### PR TITLE
Trait predicate ambiguities are not always in `Self`

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -91,17 +91,6 @@ impl<'a, 'tcx> Visitor<'tcx> for FindHirNodeVisitor<'a, 'tcx> {
         if let (None, Some(ty)) =
             (self.found_local_pattern, self.node_ty_contains_target(local.hir_id))
         {
-            // FIXME: There's a trade-off here - we can either check that our target span
-            // is contained in `local.span` or not. If we choose to check containment
-            // we can avoid some spurious suggestions (see #72690), but we lose
-            // the ability to report on things like:
-            //
-            // ```
-            // let x = vec![];
-            // ```
-            //
-            // because the target span will be in the macro expansion of `vec![]`.
-            // At present we choose not to check containment.
             self.found_local_pattern = Some(&*local.pat);
             self.found_node_ty = Some(ty);
         }
@@ -113,10 +102,8 @@ impl<'a, 'tcx> Visitor<'tcx> for FindHirNodeVisitor<'a, 'tcx> {
             if let (None, Some(ty)) =
                 (self.found_arg_pattern, self.node_ty_contains_target(param.hir_id))
             {
-                if self.target_span.contains(param.pat.span) {
-                    self.found_arg_pattern = Some(&*param.pat);
-                    self.found_node_ty = Some(ty);
-                }
+                self.found_arg_pattern = Some(&*param.pat);
+                self.found_node_ty = Some(ty);
             }
         }
         intravisit::walk_body(self, body);

--- a/src/test/ui/closure-expected-type/expect-two-infer-vars-supply-ty-with-bound-region.stderr
+++ b/src/test/ui/closure-expected-type/expect-two-infer-vars-supply-ty-with-bound-region.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/expect-two-infer-vars-supply-ty-with-bound-region.rs:8:5
+  --> $DIR/expect-two-infer-vars-supply-ty-with-bound-region.rs:8:27
    |
 LL |     with_closure(|x: u32, y| {});
-   |     ^^^^^^^^^^^^ cannot infer type for type parameter `B` declared on the function `with_closure`
+   |                           ^ consider giving this closure parameter a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23046.rs
+++ b/src/test/ui/issues/issue-23046.rs
@@ -14,7 +14,7 @@ pub fn let_<'var, VAR, F: for<'v> Fn(Expr<'v, VAR>) -> Expr<'v, VAR>>
 }
 
 fn main() {
-    let ex = |x| {
-        let_(add(x,x), |y| { //~ ERROR type annotations needed
+    let ex = |x| { //~ ERROR type annotations needed
+        let_(add(x,x), |y| {
             let_(add(x, x), |x|x)})};
 }

--- a/src/test/ui/issues/issue-23046.stderr
+++ b/src/test/ui/issues/issue-23046.stderr
@@ -1,13 +1,8 @@
-error[E0282]: type annotations needed for the closure `fn(Expr<'_, _>) -> Expr<'_, _>`
-  --> $DIR/issue-23046.rs:18:9
+error[E0282]: type annotations needed for `Expr<'_, VAR>`
+  --> $DIR/issue-23046.rs:17:15
    |
-LL |         let_(add(x,x), |y| {
-   |         ^^^^ cannot infer type for type parameter `VAR` declared on the function `let_`
-   |
-help: give this closure an explicit return type without `_` placeholders
-   |
-LL |             let_(add(x, x), |x|-> Expr<'_, _> { x })})};
-   |                                ^^^^^^^^^^^^^^^^   ^
+LL |     let ex = |x| {
+   |               ^ consider giving this closure parameter the explicit type `Expr<'_, VAR>`, where the type parameter `VAR` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-72690.stderr
+++ b/src/test/ui/issues/issue-72690.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:7:5
    |
 LL |     String::from("x".as_ref());
-   |     ^^^^^^^^^^^^ cannot infer type for struct `String`
+   |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
    = note: required by `from`
@@ -13,11 +13,13 @@ error[E0282]: type annotations needed
 LL |     |x| String::from("x".as_ref());
    |      ^ consider giving this closure parameter a type
 
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed for `&T`
   --> $DIR/issue-72690.rs:15:17
    |
 LL |     let _ = "x".as_ref();
-   |                 ^^^^^^ cannot infer type for type `str`
+   |         -       ^^^^^^ cannot infer type for type parameter `T` declared on the trait `AsRef`
+   |         |
+   |         consider giving this pattern the explicit type `&T`, where the type parameter `T` is specified
    |
    = note: cannot satisfy `str: AsRef<_>`
 
@@ -25,7 +27,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:19:5
    |
 LL |     String::from("x".as_ref());
-   |     ^^^^^^^^^^^^ cannot infer type for struct `String`
+   |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
    = note: required by `from`
@@ -34,7 +36,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:25:5
    |
 LL |     String::from("x".as_ref());
-   |     ^^^^^^^^^^^^ cannot infer type for struct `String`
+   |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
    = note: required by `from`
@@ -43,41 +45,34 @@ error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:33:5
    |
 LL |     String::from("x".as_ref());
-   |     ^^^^^^^^^^^^ cannot infer type for struct `String`
+   |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
    = note: required by `from`
 
-error[E0283]: type annotations needed for `String`
+error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:41:5
    |
 LL |     String::from("x".as_ref());
-   |     ^^^^^^^^^^^^ cannot infer type for struct `String`
-LL |     let _ = String::from("x");
-   |         - consider giving this pattern a type
+   |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
    = note: required by `from`
 
-error[E0283]: type annotations needed for `String`
+error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:47:5
    |
-LL |     let _ = String::from("x");
-   |         - consider giving this pattern a type
 LL |     String::from("x".as_ref());
-   |     ^^^^^^^^^^^^ cannot infer type for struct `String`
+   |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
    = note: required by `from`
 
-error[E0283]: type annotations needed for `String`
+error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:55:5
    |
-LL |     let _ = String::from("x");
-   |         - consider giving this pattern a type
-...
 LL |     String::from("x".as_ref());
-   |     ^^^^^^^^^^^^ cannot infer type for struct `String`
+   |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
    |
    = note: cannot satisfy `String: From<&_>`
    = note: required by `from`

--- a/src/test/ui/traits/issue-77982.rs
+++ b/src/test/ui/traits/issue-77982.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+
+fn what() {
+    let descr = String::new();
+    let mut opts = HashMap::<String, ()>::new();
+    let opt = String::new();
+
+    opts.get(opt.as_ref()); //~ ERROR type annotations needed
+}
+
+fn main() {
+    let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect();
+    //~^ ERROR type annotations needed
+}
+
+trait Foo<'a, T: ?Sized> {
+    fn foo(&self) -> Box<T> {
+        todo!()
+    }
+}
+
+trait Bar<'a, T: ?Sized> {
+    fn bar(&self) -> Box<T> {
+        todo!()
+    }
+}
+
+impl Foo<'static, u32> for () {}
+impl<'a> Foo<'a, i16> for () {}
+
+impl<'a> Bar<'static, u32> for &'a () {}
+impl<'a> Bar<'a, i16> for &'a () {}
+
+fn foo() {
+    let _ = ().foo(); //~ ERROR type annotations needed
+}
+
+fn bar() {
+    let _ = (&()).bar(); //~ ERROR type annotations needed
+}

--- a/src/test/ui/traits/issue-77982.stderr
+++ b/src/test/ui/traits/issue-77982.stderr
@@ -1,0 +1,44 @@
+error[E0283]: type annotations needed
+  --> $DIR/issue-77982.rs:8:10
+   |
+LL |     opts.get(opt.as_ref());
+   |          ^^^ ------------ this method call resolves to `&T`
+   |          |
+   |          cannot infer type for type parameter `Q` declared on the associated function `get`
+   |
+   = note: cannot satisfy `String: Borrow<_>`
+
+error[E0283]: type annotations needed
+  --> $DIR/issue-77982.rs:12:44
+   |
+LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect();
+   |                                            ^^^^^^^^^ ----------- this method call resolves to `T`
+   |                                            |
+   |                                            cannot infer type for type parameter `T` declared on the trait `From`
+   |
+   = note: cannot satisfy `u32: From<_>`
+   = note: required by `from`
+
+error[E0283]: type annotations needed for `Box<T>`
+  --> $DIR/issue-77982.rs:35:16
+   |
+LL |     let _ = ().foo();
+   |         -      ^^^ cannot infer type for type parameter `T` declared on the trait `Foo`
+   |         |
+   |         consider giving this pattern the explicit type `Box<T>`, where the type parameter `T` is specified
+   |
+   = note: cannot satisfy `(): Foo<'_, _>`
+
+error[E0283]: type annotations needed for `Box<T>`
+  --> $DIR/issue-77982.rs:39:19
+   |
+LL |     let _ = (&()).bar();
+   |         -         ^^^ cannot infer type for type parameter `T` declared on the trait `Bar`
+   |         |
+   |         consider giving this pattern the explicit type `Box<T>`, where the type parameter `T` is specified
+   |
+   = note: cannot satisfy `&(): Bar<'_, _>`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
When reporting ambiguities in trait predicates, the compiler incorrectly assumed the ambiguity was always in the type the trait should be implemented on, and never the generic parameters of the trait. This caused silly suggestions for predicates like `<KnownType as Trait<_>>`, such as giving explicit types to completely unrelated variables that happened to be of type `KnownType`.

This also reverts #73027, which worked around this issue in some cases and does not appear to be necessary any more. 

fixes #77982
fixes #78055 