### PR TITLE
Properly define va_arg and va_list for aarch64-apple-darwin

### DIFF
--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -184,8 +184,8 @@ pub(super) fn emit_va_arg(
         "aarch64" if target.options.is_like_windows => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(8).unwrap(), false)
         }
-        // iOS AArch64
-        "aarch64" if target.target_os == "ios" => {
+        // macOS / iOS AArch64
+        "aarch64" if target.options.is_like_osx => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(8).unwrap(), true)
         }
         "aarch64" => emit_aapcs_va_arg(bx, addr, target_ty),

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -173,26 +173,24 @@ pub(super) fn emit_va_arg(
     // is lacking in some instances, so we should only use it as a fallback.
     let target = &bx.cx.tcx.sess.target;
     let arch = &bx.cx.tcx.sess.target.arch;
-    match (&**arch, target.options.is_like_windows) {
+    match &**arch {
         // Windows x86
-        ("x86", true) => {
+        "x86" if target.options.is_like_windows => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(4).unwrap(), false)
         }
         // Generic x86
-        ("x86", _) => {
-            emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(4).unwrap(), true)
-        }
+        "x86" => emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(4).unwrap(), true),
         // Windows AArch64
-        ("aarch64", true) => {
+        "aarch64" if target.options.is_like_windows => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(8).unwrap(), false)
         }
         // iOS AArch64
-        ("aarch64", _) if target.target_os == "ios" => {
+        "aarch64" if target.target_os == "ios" => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(8).unwrap(), true)
         }
-        ("aarch64", _) => emit_aapcs_va_arg(bx, addr, target_ty),
+        "aarch64" => emit_aapcs_va_arg(bx, addr, target_ty),
         // Windows x86_64
-        ("x86_64", true) => {
+        "x86_64" if target.options.is_like_windows => {
             let target_ty_size = bx.cx.size_of(target_ty).bytes();
             let indirect: bool = target_ty_size > 8 || !target_ty_size.is_power_of_two();
             emit_ptr_va_arg(bx, addr, target_ty, indirect, Align::from_bytes(8).unwrap(), false)

--- a/library/core/src/ffi.rs
+++ b/library/core/src/ffi.rs
@@ -62,7 +62,7 @@ impl fmt::Debug for c_void {
 // The name is WIP, using `VaListImpl` for now.
 #[cfg(any(
     all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
-    all(target_arch = "aarch64", target_os = "ios"),
+    all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
     target_arch = "wasm32",
     target_arch = "asmjs",
     windows
@@ -85,7 +85,7 @@ pub struct VaListImpl<'f> {
 
 #[cfg(any(
     all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
-    all(target_arch = "aarch64", target_os = "ios"),
+    all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
     target_arch = "wasm32",
     target_arch = "asmjs",
     windows
@@ -107,7 +107,11 @@ impl<'f> fmt::Debug for VaListImpl<'f> {
 ///
 /// [AArch64 Procedure Call Standard]:
 /// http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf
-#[cfg(all(target_arch = "aarch64", not(target_os = "ios"), not(windows)))]
+#[cfg(all(
+    target_arch = "aarch64",
+    not(any(target_os = "macos", target_os = "ios")),
+    not(windows)
+))]
 #[repr(C)]
 #[derive(Debug)]
 #[unstable(
@@ -181,7 +185,7 @@ pub struct VaList<'a, 'f: 'a> {
             not(target_arch = "powerpc"),
             not(target_arch = "x86_64")
         ),
-        all(target_arch = "aarch64", target_os = "ios"),
+        all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
         target_arch = "wasm32",
         target_arch = "asmjs",
         windows
@@ -190,7 +194,7 @@ pub struct VaList<'a, 'f: 'a> {
 
     #[cfg(all(
         any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64"),
-        any(not(target_arch = "aarch64"), not(target_os = "ios")),
+        any(not(target_arch = "aarch64"), not(any(target_os = "macos", target_os = "ios"))),
         not(target_arch = "wasm32"),
         not(target_arch = "asmjs"),
         not(windows)
@@ -202,7 +206,7 @@ pub struct VaList<'a, 'f: 'a> {
 
 #[cfg(any(
     all(not(target_arch = "aarch64"), not(target_arch = "powerpc"), not(target_arch = "x86_64")),
-    all(target_arch = "aarch64", target_os = "ios"),
+    all(target_arch = "aarch64", any(target_os = "macos", target_os = "ios")),
     target_arch = "wasm32",
     target_arch = "asmjs",
     windows
@@ -223,7 +227,7 @@ impl<'f> VaListImpl<'f> {
 
 #[cfg(all(
     any(target_arch = "aarch64", target_arch = "powerpc", target_arch = "x86_64"),
-    any(not(target_arch = "aarch64"), not(target_os = "ios")),
+    any(not(target_arch = "aarch64"), not(any(target_os = "macos", target_os = "ios"))),
     not(target_arch = "wasm32"),
     not(target_arch = "asmjs"),
     not(windows)


### PR DESCRIPTION
From [Apple][]:

> Because of these changes, the type `va_list` is an alias for `char*`,
> and not for the struct type in the generic procedure call standard.

With this change `/x.py test --stage 1 src/test/ui/abi/variadic-ffi`
passes.

Fixes #78092

[Apple]: https://developer.apple.com/documentation/xcode/writing_arm64_code_for_apple_platforms