### PR TITLE
Initialize tracing subscriber in compiletest tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,6 @@ name = "compiletest"
 version = "0.0.0"
 dependencies = [
  "diff",
- "env_logger 0.7.1",
  "getopts",
  "glob",
  "lazy_static",
@@ -650,6 +649,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "tracing-subscriber",
  "walkdir",
  "winapi 0.3.9",
 ]

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 diff = "0.1.10"
-env_logger = { version = "0.7", default-features = false }
 getopts = "0.2"
 tracing = "0.1"
+tracing-subscriber = { version = "0.2.13", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -35,7 +35,7 @@ pub mod runtest;
 pub mod util;
 
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let config = parse_config(env::args().collect());
 


### PR DESCRIPTION
The logging in compiletest was migrated from log crate to a tracing, but
the initialization code was never changed, so logging is non-functional.

Initialize tracing subscriber using default settings.