### PR TITLE
Add built-in support for the armv5te-unknown-linux-uclibcgnueabi target

### DIFF
--- a/compiler/rustc_target/src/spec/armv5te_unknown_linux_uclibceabi.rs
+++ b/compiler/rustc_target/src/spec/armv5te_unknown_linux_uclibceabi.rs
@@ -1,0 +1,20 @@
+use crate::spec::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "armv5te-unknown-linux-uclibcgnueabi".to_string(),
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
+        arch: "arm".to_string(),
+        options: TargetOptions {
+            features: "+soft-float,+strict-align".to_string(),
+            // Atomic operations provided by compiler-builtins
+            max_atomic_width: Some(32),
+            unsupported_abis: super::arm_base::unsupported_abis(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            has_thumb_interworking: true,
+
+            ..super::linux_uclibc_base::opts()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -504,6 +504,7 @@ supported_targets! {
     ("armv4t-unknown-linux-gnueabi", armv4t_unknown_linux_gnueabi),
     ("armv5te-unknown-linux-gnueabi", armv5te_unknown_linux_gnueabi),
     ("armv5te-unknown-linux-musleabi", armv5te_unknown_linux_musleabi),
+    ("armv5te-unknown-linux-uclibceabi", armv5te_unknown_linux_uclibceabi),
     ("armv7-unknown-linux-gnueabi", armv7_unknown_linux_gnueabi),
     ("armv7-unknown-linux-gnueabihf", armv7_unknown_linux_gnueabihf),
     ("thumbv7neon-unknown-linux-gnueabihf", thumbv7neon_unknown_linux_gnueabihf),

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -162,6 +162,7 @@ target | std | host | notes
 `aarch64-uwp-windows-msvc` | ? |  |
 `aarch64-wrs-vxworks` | ? |  |
 `armv4t-unknown-linux-gnueabi` | ? |  |
+`armv5te-unknown-linux-uclibceabi` | ? |  | ARMv5TE Linux with uClibc
 `armv6-unknown-freebsd` | ✓ | ✓ | ARMv6 FreeBSD
 `armv6-unknown-netbsd-eabihf` | ? |  |
 `armv7-apple-ios` | ✓ |  | ARMv7 iOS, Cortex-a8


### PR DESCRIPTION
Hi!

I'd like to add built-in support for the `armv5te-unknown-linux-uclibcgnueabi` target. It's a pretty common target used by many devices like routers and IP cameras. It's mostly a copy-paste of `armv5te-unknown-linux-gnueabi`. I've tested it on a quite complex application that uses tokio, openssl and a lot of other stuff and everything seems to be working fine.

I'm not sure about the `post_link_args` but the point is that my linker fails when `-ldl` isn't specified. Maybe there is a better place where to put this option...

It's my first contribution to Rust itself, so feel free to wash my head :smile: 

_Note: The app mentioned above was built with this in my `.cargo/config`:_
```
[unstable]
build-std = ["core", "std", "alloc", "proc_macro", "panic_abort"]
build-std-features = ["panic_immediate_abort"]
```