### PR TITLE
Drop unneeded `mut`

### DIFF
--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -390,7 +390,7 @@ impl Printer {
         self.scan_stack.pop_front().unwrap()
     }
 
-    fn scan_top(&mut self) -> usize {
+    fn scan_top(&self) -> usize {
         *self.scan_stack.front().unwrap()
     }
 
@@ -484,7 +484,7 @@ impl Printer {
         self.pending_indentation += amount;
     }
 
-    fn get_top(&mut self) -> PrintStackElem {
+    fn get_top(&self) -> PrintStackElem {
         *self.print_stack.last().unwrap_or({
             &PrintStackElem { offset: 0, pbreak: PrintStackBreak::Broken(Breaks::Inconsistent) }
         })

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -63,7 +63,7 @@ impl<'a> Comments<'a> {
     }
 
     pub fn trailing_comment(
-        &mut self,
+        &self,
         span: rustc_span::Span,
         next_pos: Option<BytePos>,
     ) -> Option<Comment> {


### PR DESCRIPTION
These parameters don't get modified.

Note that `trailing_comment` is pub and gets exported from `rustc_ast_pretty`. Is that considered to be a stable API? If yes, and you want to reserve the right to modify `self` in `trailing_comment` in the future, that hunk would need to be dropped.