### PR TITLE
Assert that locals have storage when used

### DIFF
--- a/src/test/codegen/avr/avr-func-addrspace.rs
+++ b/src/test/codegen/avr/avr-func-addrspace.rs
@@ -23,6 +23,7 @@ pub trait Receiver { }
 pub struct Result<T, E> { _a: T, _b: E }
 
 impl Copy for usize {}
+impl Copy for &usize {}
 
 #[lang = "drop_in_place"]
 pub unsafe fn drop_in_place<T: ?Sized>(_: *mut T) {}

--- a/src/test/run-make-fulldeps/min-global-align/min_global_align.rs
+++ b/src/test/run-make-fulldeps/min-global-align/min_global_align.rs
@@ -14,6 +14,8 @@ trait Sized {}
 
 #[lang = "copy"]
 trait Copy {}
+impl Copy for bool {}
+impl Copy for &bool {}
 
 #[lang = "freeze"]
 trait Freeze {}


### PR DESCRIPTION
The validator in visit_local asserts that local has a stroage when used,
but visit_local is never called so validation is ineffective.

Use super_statement and super_terminator to ensure that locals are visited.