### PR TITLE
Disable MatchBranchSimplification

### DIFF
--- a/compiler/rustc_mir/src/transform/match_branches.rs
+++ b/compiler/rustc_mir/src/transform/match_branches.rs
@@ -38,6 +38,13 @@ pub struct MatchBranchSimplification;
 
 impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        // FIXME: This optimization can result in unsoundness, because it introduces
+        // additional uses of a place holding the discriminant value without ensuring that
+        // it is valid to do so.
+        if !tcx.sess.opts.debugging_opts.unsound_mir_opts {
+            return;
+        }
+
         let param_env = tcx.param_env(body.source.def_id());
         let bbs = body.basic_blocks_mut();
         'outer: for bb_idx in bbs.indices() {

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
@@ -2,83 +2,83 @@
 + // MIR for `bar` after MatchBranchSimplification
   
   fn bar(_1: i32) -> (bool, bool, bool, bool) {
-      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:11:8: 11:9
-      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:11:19: 11:43
-      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:12:9: 12:10
-      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:17:5: 32:6
-      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:34:9: 34:10
-      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:34:12: 34:13
-      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:34:15: 34:16
+      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:12:8: 12:9
+      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:12:19: 12:43
+      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:6: 35:7
+      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:9: 35:10
+      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:12: 35:13
+      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:35:15: 35:16
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:12:9: 12:10
-          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
           scope 2 {
-              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
               scope 3 {
-                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
                   scope 4 {
-                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:16:9: 16:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:12:9: 12:10
-          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:17:5: 32:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:18:9: 18:10
-+         _2 = Ne(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:19:13: 19:22
-+         _3 = Eq(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:21
-+         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
-+         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-+         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:9: 18:10
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
++         _2 = Ne(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
++         _3 = Eq(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
++         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:22
++         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:21
++         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
       }
   
       bb1: {
-          _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:26:13: 26:21
-          _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:27:13: 27:22
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:21
-          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:17:5: 32:6
+          _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:27:13: 27:21
+          _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:22
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:21
+          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
       }
   
       bb2: {
-          _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:19:13: 19:22
-          _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:21
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:17:5: 32:6
+          _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
+          _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:21
+          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
       }
   
       bb3: {
-          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:32:6: 32:7
-          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:9: 34:10
-          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:34:9: 34:10
-          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:12: 34:13
-          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:34:12: 34:13
-          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:34:15: 34:16
-          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:34:15: 34:16
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:35:2: 35:2
+          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:33:6: 33:7
+          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
+          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
+          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
+          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
+          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
+          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
+          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
+          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
+          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:36:2: 36:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
@@ -2,83 +2,83 @@
 + // MIR for `bar` after MatchBranchSimplification
   
   fn bar(_1: i32) -> (bool, bool, bool, bool) {
-      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:11:8: 11:9
-      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:11:19: 11:43
-      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:12:9: 12:10
-      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:17:5: 32:6
-      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:34:9: 34:10
-      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:34:12: 34:13
-      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:34:15: 34:16
+      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:12:8: 12:9
+      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:12:19: 12:43
+      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:6: 35:7
+      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:9: 35:10
+      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:12: 35:13
+      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:35:15: 35:16
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:12:9: 12:10
-          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
           scope 2 {
-              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
               scope 3 {
-                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
                   scope 4 {
-                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:16:9: 16:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:12:9: 12:10
-          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:17:5: 32:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:18:9: 18:10
-+         _2 = Ne(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:19:13: 19:22
-+         _3 = Eq(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:21
-+         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
-+         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-+         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:9: 18:10
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
+          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
++         _2 = Ne(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
++         _3 = Eq(_1, const 7_i32);        // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
++         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:22
++         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:21
++         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
       }
   
       bb1: {
-          _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:26:13: 26:21
-          _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:27:13: 27:22
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:21
-          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:17:5: 32:6
+          _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:27:13: 27:21
+          _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:22
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:21
+          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
       }
   
       bb2: {
-          _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:19:13: 19:22
-          _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:21
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
-          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:17:5: 32:6
+          _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
+          _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:21
+          goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
       }
   
       bb3: {
-          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:32:6: 32:7
-          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
-          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:9: 34:10
-          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:34:9: 34:10
-          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:12: 34:13
-          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:34:12: 34:13
-          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:34:15: 34:16
-          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:34:15: 34:16
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:34:5: 34:17
-          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:16: 34:17
-          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:35:1: 35:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:35:2: 35:2
+          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:33:6: 33:7
+          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
+          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
+          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
+          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
+          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
+          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
+          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
+          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
+          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
+          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
+          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:36:1: 36:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:36:2: 36:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
@@ -2,17 +2,17 @@
 + // MIR for `foo` after MatchBranchSimplification
   
   fn foo(_1: Option<()>) -> () {
-      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:5:8: 5:11
-      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:5:25: 5:25
+      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:6:8: 6:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:6:25: 6:25
       let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
+      let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
--         switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
+          _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
+-         switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
 +         _2 = Eq(_3, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
++         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
       }
   
       bb1: {
@@ -26,17 +26,17 @@
       }
   
       bb3: {
-          switchInt(_2) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
+          switchInt(_2) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
       }
   
       bb4: {
-          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
-          goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
+          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
+          goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
       }
   
       bb5: {
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:9:2: 9:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:10:1: 10:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:10:2: 10:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
@@ -2,17 +2,17 @@
 + // MIR for `foo` after MatchBranchSimplification
   
   fn foo(_1: Option<()>) -> () {
-      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:5:8: 5:11
-      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:5:25: 5:25
+      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:6:8: 6:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:6:25: 6:25
       let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
+      let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
--         switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
+          _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
+-         switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
 +         _2 = Eq(_3, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:6:22: 6:26
++         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
       }
   
       bb1: {
@@ -26,17 +26,17 @@
       }
   
       bb3: {
-          switchInt(_2) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
+          switchInt(_2) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
       }
   
       bb4: {
-          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
-          goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:6:5: 8:6
+          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
+          goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
       }
   
       bb5: {
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:9:1: 9:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:9:2: 9:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:10:1: 10:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:10:2: 10:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.rs
+++ b/src/test/mir-opt/matches_reduce_branches.rs
@@ -1,3 +1,4 @@
+// compile-flags: -Zunsound-mir-opts
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR matches_reduce_branches.foo.MatchBranchSimplification.diff
 // EMIT_MIR matches_reduce_branches.bar.MatchBranchSimplification.diff

--- a/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
+++ b/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
@@ -12,36 +12,57 @@
       bb0: {
           StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _3 = discriminant(_1);           // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
-          _2 = Eq(_3, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          goto -> bb4;                     // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
+          switchInt(move _3) -> [0_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
       }
   
       bb1: {
           _0 = const true;                 // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          goto -> bb4;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _5 = discriminant(_1);           // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
-          _4 = Eq(_5, const 1_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          goto -> bb5;                     // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
+          _0 = const false;                // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          goto -> bb4;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
       }
   
       bb3: {
+          StorageLive(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _5 = discriminant(_1);           // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
+          switchInt(move _5) -> [1_isize: bb9, otherwise: bb8]; // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
+      }
+  
+      bb4: {
           StorageDead(_4);                 // scope 0 at $DIR/not_equal_false.rs:4:45: 4:46
           StorageDead(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:45: 4:46
           return;                          // scope 0 at $DIR/not_equal_false.rs:5:2: 5:2
       }
   
-      bb4: {
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      bb5: {
+          _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb5: {
--         _0 = Ne(_4, const false);        // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-+         _0 = _4;                         // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      bb6: {
+          _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb7;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb7: {
+          switchInt(move _2) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      }
+  
+      bb8: {
+          _4 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb10;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb9: {
+          _4 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          goto -> bb10;                    // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb10: {
+          switchInt(move _4) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
       }
   }
   


### PR DESCRIPTION
This optimization can result in unsoundness, because it introduces
additional uses of a place holding the discriminant value without
ensuring that it is valid to do so.

Found by validation from #77369 / #78147.