### PR TITLE
Fix unreachable sub-branch detection in or-patterns

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -390,10 +390,11 @@ fn check_arms<'p, 'tcx>(
                 }
             }
             Useful(unreachables) => {
-                for set in unreachables {
-                    for span in set {
-                        unreachable_pattern(cx.tcx, span, id, None);
-                    }
+                let mut unreachables: Vec<_> = unreachables.into_iter().flatten().collect();
+                // Emit lints in the order in which they occur in the file.
+                unreachables.sort_unstable();
+                for span in unreachables {
+                    unreachable_pattern(cx.tcx, span, id, None);
                 }
             }
             UsefulWithWitness(_) => bug!(),

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -389,9 +389,11 @@ fn check_arms<'p, 'tcx>(
                     hir::MatchSource::AwaitDesugar | hir::MatchSource::TryDesugar => {}
                 }
             }
-            Useful(unreachable_subpatterns) => {
-                for span in unreachable_subpatterns {
-                    unreachable_pattern(cx.tcx, span, id, None);
+            Useful(unreachables) => {
+                for set in unreachables {
+                    for span in set {
+                        unreachable_pattern(cx.tcx, span, id, None);
+                    }
                 }
             }
             UsefulWithWitness(_) => bug!(),

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -77,10 +77,17 @@ fn main() {
         (false | true, false | true) => {}
     }
     match (true, true) {
-        (true, false) => {}
-        (false, true) => {}
+        (true, true) => {}
+        (false, false) => {}
         (false | true, false | true) => {}
     }
+    // https://github.com/rust-lang/rust/issues/76836
+    match None {
+        Some(false) => {}
+        None | Some(true
+                | false) => {} // expected unreachable warning here
+    }
+
     // A subpattern that is unreachable in all branches is overall unreachable.
     match (true, true) {
         (false, true) => {}

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.rs
@@ -85,7 +85,7 @@ fn main() {
     match None {
         Some(false) => {}
         None | Some(true
-                | false) => {} // expected unreachable warning here
+                | false) => {} //~ ERROR unreachable
     }
 
     // A subpattern that is unreachable in all branches is overall unreachable.

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -77,15 +77,15 @@ LL |         (1 | 1,) => {}
    |              ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:55:15
-   |
-LL |             | 0] => {}
-   |               ^
-
-error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:53:15
    |
 LL |             | 0
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:55:15
+   |
+LL |             | 0] => {}
    |               ^
 
 error: unreachable pattern

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -101,13 +101,13 @@ LL |         Some(0
    |              ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:89:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:96:15
    |
 LL |             | true) => {}
    |               ^^^^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:95:15
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:102:15
    |
 LL |             | true,
    |               ^^^^

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -77,15 +77,15 @@ LL |         (1 | 1,) => {}
    |              ^
 
 error: unreachable pattern
-  --> $DIR/exhaustiveness-unreachable-pattern.rs:53:15
-   |
-LL |             | 0
-   |               ^
-
-error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:55:15
    |
 LL |             | 0] => {}
+   |               ^
+
+error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:53:15
+   |
+LL |             | 0
    |               ^
 
 error: unreachable pattern
@@ -101,6 +101,12 @@ LL |         Some(0
    |              ^
 
 error: unreachable pattern
+  --> $DIR/exhaustiveness-unreachable-pattern.rs:88:19
+   |
+LL |                 | false) => {}
+   |                   ^^^^^
+
+error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:96:15
    |
 LL |             | true) => {}
@@ -112,5 +118,5 @@ error: unreachable pattern
 LL |             | true,
    |               ^^^^
 
-error: aborting due to 18 previous errors
+error: aborting due to 19 previous errors
 


### PR DESCRIPTION
The previous implementation was too eager to avoid unnecessary "unreachable pattern" warnings. I feel more confident about this implementation than I felt about the previous one.
Fixes https://github.com/rust-lang/rust/issues/76836.

@rustbot modify labels: +A-exhaustiveness-checking