### PR TITLE
Suggest adding missing braces in `const` block pattern

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1075,7 +1075,7 @@ impl<'a> Parser<'a> {
         } else if self.eat_keyword(kw::Unsafe) {
             self.parse_block_expr(None, lo, BlockCheckMode::Unsafe(ast::UserProvided), attrs)
         } else if self.eat_keyword(kw::Const) {
-            self.parse_const_block(lo.to(self.token.span))
+            self.parse_const_block(lo.to(self.prev_token.span))
         } else if self.is_do_catch_block() {
             self.recover_do_catch(attrs)
         } else if self.is_try_block() {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1074,7 +1074,7 @@ impl<'a> Parser<'a> {
             })
         } else if self.eat_keyword(kw::Unsafe) {
             self.parse_block_expr(None, lo, BlockCheckMode::Unsafe(ast::UserProvided), attrs)
-        } else if self.check_inline_const(0) {
+        } else if self.eat_keyword(kw::Const) {
             self.parse_const_block(lo.to(self.token.span))
         } else if self.is_do_catch_block() {
             self.recover_do_catch(attrs)

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -552,6 +552,15 @@ impl<'a> Parser<'a> {
         self.check_or_expected(self.token.can_begin_const_arg(), TokenType::Const)
     }
 
+    fn check_inline_const(&self, dist: usize) -> bool {
+        self.is_keyword_ahead(dist, &[kw::Const])
+            && self.look_ahead(dist + 1, |t| match t.kind {
+                token::Interpolated(ref nt) => matches!(**nt, token::NtBlock(..)),
+                token::OpenDelim(DelimToken::Brace) => true,
+                _ => false,
+            })
+    }
+
     /// Checks to see if the next token is either `+` or `+=`.
     /// Otherwise returns `false`.
     fn check_plus(&mut self) -> bool {

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -552,15 +552,6 @@ impl<'a> Parser<'a> {
         self.check_or_expected(self.token.can_begin_const_arg(), TokenType::Const)
     }
 
-    fn check_inline_const(&self, dist: usize) -> bool {
-        self.is_keyword_ahead(dist, &[kw::Const])
-            && self.look_ahead(dist + 1, |t| match t.kind {
-                token::Interpolated(ref nt) => matches!(**nt, token::NtBlock(..)),
-                token::OpenDelim(DelimToken::Brace) => true,
-                _ => false,
-            })
-    }
-
     /// Checks to see if the next token is either `+` or `+=`.
     /// Otherwise returns `false`.
     fn check_plus(&mut self) -> bool {
@@ -897,10 +888,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parses inline const expressions.
+    /// Parses inline const expressions. The `const` keyword was already eaten.
     fn parse_const_block(&mut self, span: Span) -> PResult<'a, P<Expr>> {
-        self.sess.gated_spans.gate(sym::inline_const, span);
-        self.eat_keyword(kw::Const);
         let blk = self.parse_block()?;
         let anon_const = AnonConst {
             id: DUMMY_NODE_ID,

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -890,6 +890,8 @@ impl<'a> Parser<'a> {
 
     /// Parses inline const expressions. The `const` keyword was already eaten.
     fn parse_const_block(&mut self, span: Span) -> PResult<'a, P<Expr>> {
+        self.sess.gated_spans.gate(sym::inline_const, span);
+
         let blk = self.parse_block()?;
         let anon_const = AnonConst {
             id: DUMMY_NODE_ID,

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -754,6 +754,7 @@ impl<'a> Parser<'a> {
 
     fn parse_pat_range_end(&mut self) -> PResult<'a, P<Expr>> {
         if self.check_inline_const(0) {
+            self.eat_keyword(kw::Const);
             self.parse_const_block(self.token.span)
         } else if self.check_path() {
             let lo = self.token.span;

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -339,7 +339,7 @@ impl<'a> Parser<'a> {
             PatKind::Box(pat)
         } else if self.eat_keyword(kw::Const) {
             // Parse `const { pat }`
-            let const_expr = self.parse_const_block(lo.to(self.token.span))?;
+            let const_expr = self.parse_const_block(lo.to(self.prev_token.span))?;
 
             if let Some(re) = self.parse_range_end() {
                 self.parse_pat_range_begin_with(const_expr, re)?
@@ -755,7 +755,7 @@ impl<'a> Parser<'a> {
     fn parse_pat_range_end(&mut self) -> PResult<'a, P<Expr>> {
         if self.check_inline_const(0) {
             self.eat_keyword(kw::Const);
-            self.parse_const_block(self.token.span)
+            self.parse_const_block(self.prev_token.span)
         } else if self.check_path() {
             let lo = self.token.span;
             let (qself, path) = if self.eat_lt() {

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -337,8 +337,8 @@ impl<'a> Parser<'a> {
             let pat = self.parse_pat_with_range_pat(false, None)?;
             self.sess.gated_spans.gate(sym::box_patterns, lo.to(self.prev_token.span));
             PatKind::Box(pat)
-        } else if self.check_inline_const(0) {
-            // Parse `const pat`
+        } else if self.eat_keyword(kw::Const) {
+            // Parse `const { pat }`
             let const_expr = self.parse_const_block(lo.to(self.token.span))?;
 
             if let Some(re) = self.parse_range_end() {

--- a/src/test/ui/feature-gate-inline_const.stderr
+++ b/src/test/ui/feature-gate-inline_const.stderr
@@ -2,7 +2,7 @@ error[E0658]: inline-const is experimental
   --> $DIR/feature-gate-inline_const.rs:2:13
    |
 LL |     let _ = const {
-   |             ^^^^^
+   |             ^^^^^^^
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
    = help: add `#![feature(inline_const)]` to the crate attributes to enable

--- a/src/test/ui/feature-gate-inline_const.stderr
+++ b/src/test/ui/feature-gate-inline_const.stderr
@@ -2,7 +2,7 @@ error[E0658]: inline-const is experimental
   --> $DIR/feature-gate-inline_const.rs:2:13
    |
 LL |     let _ = const {
-   |             ^^^^^^^
+   |             ^^^^^
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
    = help: add `#![feature(inline_const)]` to the crate attributes to enable

--- a/src/test/ui/parser/inline-const-pat-let.rs
+++ b/src/test/ui/parser/inline-const-pat-let.rs
@@ -1,0 +1,30 @@
+// run-pass
+
+#![allow(incomplete_features)]
+#![feature(inline_const)]
+
+fn if_let_1() -> i32 {
+    let x = 2;
+    const Y: i32 = 3;
+
+    if let const { (Y + 1) / 2 } = x {
+        x
+    } else {
+        0
+    }
+}
+
+fn if_let_2() -> i32 {
+    let x = 2;
+
+    if let const { 1 + 2 } = x {
+        const { 1 + 2 }
+    } else {
+        0
+    }
+}
+
+fn main() {
+    assert_eq!(if_let_1(), 2);
+    assert_eq!(if_let_2(), 0);
+}

--- a/src/test/ui/parser/inline-const-without-block.fixed
+++ b/src/test/ui/parser/inline-const-without-block.fixed
@@ -1,0 +1,61 @@
+// run-rustfix
+
+// See issue #78168.
+
+#![allow(incomplete_features)]
+#![feature(inline_const)]
+
+// FIXME(#78171): the lint has to be allowed because of a bug
+#[allow(dead_code)]
+const fn one() -> i32 {
+    1
+}
+
+fn foo() -> i32 {
+    let x = 2;
+
+    match x {
+        const { 2 } => {}
+        //~^ ERROR expected `{`, found `2`
+        //~| HELP try placing this code inside a block
+        _ => {}
+    }
+
+    match x {
+        const { 1 + 2 * 3 / 4 } => {}
+        //~^ ERROR expected `{`, found `1`
+        //~| HELP try placing this code inside a block
+        _ => {}
+    }
+
+    match x {
+        const { one() } => {}
+        //~^ ERROR expected `{`, found `one`
+        //~| HELP try placing this code inside a block
+        _ => {}
+    }
+
+    x
+}
+
+fn bar() -> i32 {
+    let x = const { 2 };
+    //~^ ERROR expected `{`, found `2`
+    //~| HELP try placing this code inside a block
+
+    x
+}
+
+fn baz() -> i32 {
+    let y = const { 1 + 2 * 3 / 4 };
+    //~^ ERROR expected `{`, found `1`
+    //~| HELP try placing this code inside a block
+
+    y
+}
+
+fn main() {
+    foo();
+    bar();
+    baz();
+}

--- a/src/test/ui/parser/inline-const-without-block.rs
+++ b/src/test/ui/parser/inline-const-without-block.rs
@@ -1,0 +1,61 @@
+// run-rustfix
+
+// See issue #78168.
+
+#![allow(incomplete_features)]
+#![feature(inline_const)]
+
+// FIXME(#78171): the lint has to be allowed because of a bug
+#[allow(dead_code)]
+const fn one() -> i32 {
+    1
+}
+
+fn foo() -> i32 {
+    let x = 2;
+
+    match x {
+        const 2 => {}
+        //~^ ERROR expected `{`, found `2`
+        //~| HELP try placing this code inside a block
+        _ => {}
+    }
+
+    match x {
+        const 1 + 2 * 3 / 4 => {}
+        //~^ ERROR expected `{`, found `1`
+        //~| HELP try placing this code inside a block
+        _ => {}
+    }
+
+    match x {
+        const one() => {}
+        //~^ ERROR expected `{`, found `one`
+        //~| HELP try placing this code inside a block
+        _ => {}
+    }
+
+    x
+}
+
+fn bar() -> i32 {
+    let x = const 2;
+    //~^ ERROR expected `{`, found `2`
+    //~| HELP try placing this code inside a block
+
+    x
+}
+
+fn baz() -> i32 {
+    let y = const 1 + 2 * 3 / 4;
+    //~^ ERROR expected `{`, found `1`
+    //~| HELP try placing this code inside a block
+
+    y
+}
+
+fn main() {
+    foo();
+    bar();
+    baz();
+}

--- a/src/test/ui/parser/inline-const-without-block.stderr
+++ b/src/test/ui/parser/inline-const-without-block.stderr
@@ -1,0 +1,47 @@
+error: expected `{`, found `2`
+  --> $DIR/inline-const-without-block.rs:18:15
+   |
+LL |         const 2 => {}
+   |               ^
+   |               |
+   |               expected `{`
+   |               help: try placing this code inside a block: `{ 2 }`
+
+error: expected `{`, found `1`
+  --> $DIR/inline-const-without-block.rs:25:15
+   |
+LL |         const 1 + 2 * 3 / 4 => {}
+   |               ^------------
+   |               |
+   |               expected `{`
+   |               help: try placing this code inside a block: `{ 1 + 2 * 3 / 4 }`
+
+error: expected `{`, found `one`
+  --> $DIR/inline-const-without-block.rs:32:15
+   |
+LL |         const one() => {}
+   |               ^^^--
+   |               |
+   |               expected `{`
+   |               help: try placing this code inside a block: `{ one() }`
+
+error: expected `{`, found `2`
+  --> $DIR/inline-const-without-block.rs:42:19
+   |
+LL |     let x = const 2;
+   |                   ^
+   |                   |
+   |                   expected `{`
+   |                   help: try placing this code inside a block: `{ 2 }`
+
+error: expected `{`, found `1`
+  --> $DIR/inline-const-without-block.rs:50:19
+   |
+LL |     let y = const 1 + 2 * 3 / 4;
+   |                   ^------------
+   |                   |
+   |                   expected `{`
+   |                   help: try placing this code inside a block: `{ 1 + 2 * 3 / 4 }`
+
+error: aborting due to 5 previous errors
+

--- a/src/test/ui/parser/issue-66357-unexpected-unreachable.rs
+++ b/src/test/ui/parser/issue-66357-unexpected-unreachable.rs
@@ -13,4 +13,4 @@
 
 fn f() { |[](* }
 //~^ ERROR expected one of `,` or `:`, found `(`
-//~| ERROR expected one of `&`, `(`, `)`, `-`, `...`, `..=`, `..`, `[`, `_`, `box`, `mut`, `ref`, `|`, identifier, or path, found `*`
+//~| ERROR expected one of `&`, `(`, `)`, `-`, `...`, `..=`, `..`, `[`, `_`, `box`, `const`, `mut`, `ref`, `|`, identifier, or path, found `*`

--- a/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
+++ b/src/test/ui/parser/issue-66357-unexpected-unreachable.stderr
@@ -4,7 +4,7 @@ error: expected one of `,` or `:`, found `(`
 LL | fn f() { |[](* }
    |             ^ expected one of `,` or `:`
 
-error: expected one of `&`, `(`, `)`, `-`, `...`, `..=`, `..`, `[`, `_`, `box`, `mut`, `ref`, `|`, identifier, or path, found `*`
+error: expected one of `&`, `(`, `)`, `-`, `...`, `..=`, `..`, `[`, `_`, `box`, `const`, `mut`, `ref`, `|`, identifier, or path, found `*`
   --> $DIR/issue-66357-unexpected-unreachable.rs:14:14
    |
 LL | fn f() { |[](* }

--- a/src/test/ui/parser/keyword-const-as-identifier.rs
+++ b/src/test/ui/parser/keyword-const-as-identifier.rs
@@ -1,5 +1,3 @@
-// This file was auto-generated using 'src/etc/generate-keyword-tests.py const'
-
 fn main() {
-    let const = "foo"; //~ error: expected identifier, found keyword `const`
+    let const = "foo"; //~ ERROR expected `{`, found `=`
 }

--- a/src/test/ui/parser/keyword-const-as-identifier.rs
+++ b/src/test/ui/parser/keyword-const-as-identifier.rs
@@ -1,3 +1,5 @@
 fn main() {
-    let const = "foo"; //~ ERROR expected `{`, found `=`
+    let const = "foo";
+    //~^ ERROR expected `{`, found `=`
+    //~| ERROR inline-const is experimental [E0658]
 }

--- a/src/test/ui/parser/keyword-const-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-const-as-identifier.stderr
@@ -1,13 +1,8 @@
-error: expected identifier, found keyword `const`
-  --> $DIR/keyword-const-as-identifier.rs:4:9
+error: expected `{`, found `=`
+  --> $DIR/keyword-const-as-identifier.rs:4:15
    |
 LL |     let const = "foo";
-   |         ^^^^^ expected identifier, found keyword
-   |
-help: you can escape reserved keywords to use them as identifiers
-   |
-LL |     let r#const = "foo";
-   |         ^^^^^^^
+   |               ^ expected `{`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-const-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-const-as-identifier.stderr
@@ -8,7 +8,7 @@ error[E0658]: inline-const is experimental
   --> $DIR/keyword-const-as-identifier.rs:2:9
    |
 LL |     let const = "foo";
-   |         ^^^^^^^
+   |         ^^^^^
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
    = help: add `#![feature(inline_const)]` to the crate attributes to enable

--- a/src/test/ui/parser/keyword-const-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-const-as-identifier.stderr
@@ -8,7 +8,7 @@ error[E0658]: inline-const is experimental
   --> $DIR/keyword-const-as-identifier.rs:2:9
    |
 LL |     let const = "foo";
-   |         ^^^^^
+   |         ^^^^^^^
    |
    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
    = help: add `#![feature(inline_const)]` to the crate attributes to enable

--- a/src/test/ui/parser/keyword-const-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-const-as-identifier.stderr
@@ -4,5 +4,15 @@ error: expected `{`, found `=`
 LL |     let const = "foo";
    |               ^ expected `{`
 
-error: aborting due to previous error
+error[E0658]: inline-const is experimental
+  --> $DIR/keyword-const-as-identifier.rs:2:9
+   |
+LL |     let const = "foo";
+   |         ^^^^^
+   |
+   = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information
+   = help: add `#![feature(inline_const)]` to the crate attributes to enable
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/parser/keyword-const-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-const-as-identifier.stderr
@@ -1,5 +1,5 @@
 error: expected `{`, found `=`
-  --> $DIR/keyword-const-as-identifier.rs:4:15
+  --> $DIR/keyword-const-as-identifier.rs:2:15
    |
 LL |     let const = "foo";
    |               ^ expected `{`


### PR DESCRIPTION
Fixes #78168.

Previously it would only suggest wrapping the code in braces in regular
expressions; now it does it in patterns too.

r? @spastorino
