### PR TITLE
Type hint bootstrap.py

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+allow_redefinition = True


### PR DESCRIPTION
I've looked for errors in bootstrap.py by adding type hints and running mypy over it. Untyped python code often tends to have some hidden problems.
I haven't found any bugs, only some quality problems in that the `RustBuild` class is a bit of a god class and it's hard to follow what's initialized when and where.

It may be worth it to keep the type annotations as they also act as documentation. A couple of variables have rather surprising types. I could also add `mypy` to CI, but I'd understand if you don't want to raise the requirements for Python specific tooling.