### PR TITLE
Try to not query `def_span` for every `param_env`

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -464,12 +464,12 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                     if info.is_existential() {
                         match opt_values[BoundVar::new(index)] {
                             Some(k) => k,
-                            None => self.instantiate_canonical_var(cause.span, info, |u| {
+                            None => self.instantiate_canonical_var(cause.def_span(), info, |u| {
                                 universe_map[u.as_usize()]
                             }),
                         }
                     } else {
-                        self.instantiate_canonical_var(cause.span, info, |u| {
+                        self.instantiate_canonical_var(cause.def_span(), info, |u| {
                             universe_map[u.as_usize()]
                         })
                     }
@@ -538,7 +538,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                 GenericArgKind::Const(..) => {
                     // Consts cannot outlive one another, so we don't expect to
                     // encounter this branch.
-                    span_bug!(cause.span, "unexpected const outlives {:?}", constraint);
+                    span_bug!(cause.def_span(), "unexpected const outlives {:?}", constraint);
                 }
             }
             .potentially_quantified(self.tcx, ty::PredicateKind::ForAll);

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -700,7 +700,9 @@ impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
 
         // FIXME: This is non-ideal because we don't give a
         // very descriptive origin for this region variable.
-        Ok(self.infcx.next_region_var_in_universe(MiscVariable(self.cause.span), self.for_universe))
+        Ok(self
+            .infcx
+            .next_region_var_in_universe(MiscVariable(self.cause.def_span()), self.for_universe))
     }
 
     fn consts(

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -623,7 +623,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }) => match source {
                 hir::MatchSource::IfLetDesugar { .. } => {
                     let msg = "`if let` arms have incompatible types";
-                    err.span_label(cause.span, msg);
+                    err.span_label(cause.def_span(), msg);
                     if let Some(ret_sp) = opt_suggest_box_span {
                         self.suggest_boxing_for_return_impl_trait(
                             err,
@@ -648,7 +648,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             Some(ty) if expected == ty => {
                                 let source_map = self.tcx.sess.source_map();
                                 err.span_suggestion(
-                                    source_map.end_point(cause.span),
+                                    source_map.end_point(cause.def_span()),
                                     "try removing this `?`",
                                     "".to_string(),
                                     Applicability::MachineApplicable,
@@ -665,7 +665,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         _ => last_ty,
                     });
                     let msg = "`match` arms have incompatible types";
-                    err.span_label(cause.span, msg);
+                    err.span_label(cause.def_span(), msg);
                     if prior_arms.len() <= 4 {
                         for sp in prior_arms {
                             err.span_label(*sp, format!("this is found to be of type `{}`", t));
@@ -2116,7 +2116,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         "...",
                     );
                     err.span_note(
-                        sup_trace.cause.span,
+                        sup_trace.cause.def_span(),
                         &format!("...so that the {}", sup_trace.cause.as_requirement_str()),
                     );
 

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -47,7 +47,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                     };
                     let mut err = struct_span_err!(
                         tcx.sess,
-                        cause.span,
+                        cause.def_span(),
                         E0772,
                         "{} has {} but calling `{}` introduces an implicit `'static` lifetime \
                          requirement",
@@ -62,7 +62,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                     );
                     err.span_label(param.param_ty_span, &format!("this data with {}...", lifetime));
                     err.span_label(
-                        cause.span,
+                        cause.def_span(),
                         &format!(
                             "...is captured and required to live as long as `'static` here \
                              because of an implicit lifetime bound on the {}",

--- a/compiler/rustc_infer/src/infer/error_reporting/note.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/note.rs
@@ -26,7 +26,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             infer::Subtype(ref trace) => {
                 if let Some((expected, found)) = self.values_str(&trace.values) {
                     label_or_note(
-                        trace.cause.span,
+                        trace.cause.def_span(),
                         &format!("...so that the {}", trace.cause.as_requirement_str()),
                     );
 
@@ -37,7 +37,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     // *terrible*.
 
                     label_or_note(
-                        trace.cause.span,
+                        trace.cause.def_span(),
                         &format!("...so that {}", trace.cause.as_requirement_str()),
                     );
                 }

--- a/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
+++ b/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
@@ -28,7 +28,7 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
         // please see the large comment at the end of the file in the (inlined) module
         // `doc`.
 
-        let span = self.trace.cause.span;
+        let span = self.trace.cause.def_span();
 
         self.infcx.commit_if_ok(|_| {
             // First, we instantiate each bound region in the supertype with a

--- a/compiler/rustc_infer/src/infer/lattice.rs
+++ b/compiler/rustc_infer/src/infer/lattice.rs
@@ -80,7 +80,7 @@ where
         (&ty::Infer(TyVar(..)), _) => {
             let v = infcx.next_ty_var(TypeVariableOrigin {
                 kind: TypeVariableOriginKind::LatticeVariable,
-                span: this.cause().span,
+                span: this.cause().def_span(),
             });
             this.relate_bound(v, b, a)?;
             Ok(v)
@@ -88,7 +88,7 @@ where
         (_, &ty::Infer(TyVar(..))) => {
             let v = infcx.next_ty_var(TypeVariableOrigin {
                 kind: TypeVariableOriginKind::LatticeVariable,
-                span: this.cause().span,
+                span: this.cause().def_span(),
             });
             this.relate_bound(v, a, b)?;
             Ok(v)

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -974,7 +974,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             let ty::OutlivesPredicate(r_a, r_b) =
                 self.replace_bound_vars_with_placeholders(&predicate);
             let origin = SubregionOrigin::from_obligation_cause(cause, || {
-                RelateRegionParamBound(cause.span)
+                RelateRegionParamBound(cause.def_span())
             });
             self.sub_regions(origin, r_b, r_a); // `b : a` ==> `a <= b`
             Ok(())
@@ -1692,7 +1692,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for ShallowResolver<'a, 'tcx> {
 
 impl<'tcx> TypeTrace<'tcx> {
     pub fn span(&self) -> Span {
-        self.cause.span
+        self.cause.def_span()
     }
 
     pub fn types(
@@ -1744,7 +1744,7 @@ impl<'tcx> SubregionOrigin<'tcx> {
     {
         match cause.code {
             traits::ObligationCauseCode::ReferenceOutlivesReferent(ref_type) => {
-                SubregionOrigin::ReferenceOutlivesReferent(ref_type, cause.span)
+                SubregionOrigin::ReferenceOutlivesReferent(ref_type, cause.def_span())
             }
 
             traits::ObligationCauseCode::CompareImplMethodObligation {
@@ -1752,7 +1752,7 @@ impl<'tcx> SubregionOrigin<'tcx> {
                 impl_item_def_id,
                 trait_item_def_id,
             } => SubregionOrigin::CompareImplMethodObligation {
-                span: cause.span,
+                span: cause.def_span(),
                 item_name,
                 impl_item_def_id,
                 trait_item_def_id,

--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -99,7 +99,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
         cause: &ObligationCause<'tcx>,
     ) {
         let origin = SubregionOrigin::from_obligation_cause(cause, || {
-            infer::RelateParamBound(cause.span, sup_type)
+            infer::RelateParamBound(cause.def_span(), sup_type)
         });
 
         self.register_region_obligation(

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -132,8 +132,25 @@ impl<'tcx> ObligationCause<'tcx> {
         ObligationCause { data: Some(Rc::new(ObligationCauseData { span, body_id, code })) }
     }
 
+    pub fn new_from_def_id(
+        tcx: TyCtxt<'tcx>,
+        def_id: DefId,
+        body_id: hir::HirId,
+        code: ObligationCauseCode<'tcx>,
+    ) -> ObligationCause<'tcx> {
+        ObligationCause::new(tcx.def_span(def_id), body_id, code)
+    }
+
     pub fn misc(span: Span, body_id: hir::HirId) -> ObligationCause<'tcx> {
         ObligationCause::new(span, body_id, MiscObligation)
+    }
+
+    pub fn misc_from_def_id(
+        tcx: TyCtxt<'tcx>,
+        def_id: DefId,
+        body_id: hir::HirId,
+    ) -> ObligationCause<'tcx> {
+        ObligationCause::new_from_def_id(tcx, def_id, body_id, MiscObligation)
     }
 
     pub fn dummy_with_span(span: Span) -> ObligationCause<'tcx> {

--- a/compiler/rustc_trait_selection/src/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/opaque_types.rs
@@ -1174,7 +1174,7 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
             // This also instantiates nested instances of `impl Trait`.
             let predicate = self.instantiate_opaque_types_in_map(&predicate);
 
-            let cause = traits::ObligationCause::new(span, self.body_id, traits::MiscObligation);
+            let cause = traits::ObligationCause::misc(span, self.body_id);
 
             // Require that the predicate holds for the concrete type.
             debug!("instantiate_opaque_types: predicate={:?}", predicate);

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -820,7 +820,7 @@ impl AutoTraitFinder<'tcx> {
                                 def,
                                 substs,
                                 promoted,
-                                Some(obligation.cause.span),
+                                Some(obligation.cause.def_span()),
                             ) {
                                 Ok(val) => Ok(ty::Const::from_value(select.tcx(), val, c.ty)),
                                 Err(err) => Err(err),

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/on_unimplemented.rs
@@ -43,7 +43,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         let mut fuzzy_match_impls = vec![];
 
         self.tcx.for_each_relevant_impl(trait_ref.def_id, trait_self_ty, |def_id| {
-            let impl_substs = self.fresh_substs_for_item(obligation.cause.span, def_id);
+            let impl_substs = self.fresh_substs_for_item(obligation.cause.def_span(), def_id);
             let impl_trait_ref = tcx.impl_trait_ref(def_id).unwrap().subst(tcx, impl_substs);
 
             let impl_self_ty = impl_trait_ref.self_ty();
@@ -159,7 +159,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             flags.push((sym::parent_trait, Some(t)));
         }
 
-        if let Some(k) = obligation.cause.span.desugaring_kind() {
+        if let Some(k) = obligation.cause.def_span().desugaring_kind() {
             flags.push((sym::from_desugaring, None));
             flags.push((sym::from_desugaring, Some(format!("{:?}", k))));
         }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -471,7 +471,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         }
         let param_env = obligation.param_env;
         let body_id = obligation.cause.body_id;
-        let span = obligation.cause.span;
+        let span = obligation.cause.def_span();
         let real_trait_ref = match &obligation.cause.code {
             ObligationCauseCode::ImplDerivedObligation(cause)
             | ObligationCauseCode::DerivedObligation(cause)
@@ -635,7 +635,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             // of the argument, so we can provide a suggestion. This is signaled
             // by `points_at_arg`. Otherwise, we give a more general note.
             err.span_suggestion_verbose(
-                obligation.cause.span.shrink_to_hi(),
+                obligation.cause.def_span().shrink_to_hi(),
                 &msg,
                 sugg,
                 Applicability::HasPlaceholders,
@@ -657,7 +657,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             return false;
         }
 
-        let span = obligation.cause.span;
+        let span = obligation.cause.def_span();
         let param_env = obligation.param_env;
         let trait_ref = trait_ref.skip_binder();
 
@@ -736,7 +736,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         trait_ref: &ty::Binder<ty::TraitRef<'tcx>>,
     ) {
-        let span = obligation.cause.span;
+        let span = obligation.cause.def_span();
 
         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
             let refs_number =
@@ -800,7 +800,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         trait_ref: &ty::Binder<ty::TraitRef<'tcx>>,
         points_at_arg: bool,
     ) {
-        let span = obligation.cause.span;
+        let span = obligation.cause.def_span();
         if let Ok(snippet) = self.tcx.sess.source_map().span_to_snippet(span) {
             let refs_number =
                 snippet.chars().filter(|c| !c.is_whitespace()).take_while(|c| *c == '&').count();
@@ -1271,7 +1271,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         debug!(
             "maybe_note_obligation_cause_for_async_await: obligation.predicate={:?} \
                 obligation.cause.span={:?}",
-            obligation.predicate, obligation.cause.span
+            obligation.predicate,
+            obligation.cause.def_span()
         );
         let hir = self.tcx.hir();
 

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -450,7 +450,7 @@ impl<'a, 'b, 'tcx> FulfillProcessor<'a, 'b, 'tcx> {
                         obligation.cause.body_id,
                         obligation.recursion_depth + 1,
                         arg,
-                        obligation.cause.span,
+                        obligation.cause.def_span(),
                     ) {
                         None => {
                             pending_obligation.stalled_on =
@@ -493,7 +493,7 @@ impl<'a, 'b, 'tcx> FulfillProcessor<'a, 'b, 'tcx> {
                         def_id,
                         substs,
                         obligation.param_env,
-                        obligation.cause.span,
+                        obligation.cause.def_span(),
                     ) {
                         Ok(()) => ProcessResult::Changed(vec![]),
                         Err(ErrorHandled::TooGeneric) => {
@@ -538,7 +538,7 @@ impl<'a, 'b, 'tcx> FulfillProcessor<'a, 'b, 'tcx> {
                                 def,
                                 substs,
                                 promoted,
-                                Some(obligation.cause.span),
+                                Some(obligation.cause.def_span()),
                             ) {
                                 Ok(val) => Ok(Const::from_value(self.selcx.tcx(), val, c.ty)),
                                 Err(ErrorHandled::TooGeneric) => {

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -206,7 +206,6 @@ fn do_normalize_predicates<'tcx>(
         "do_normalize_predicates(predicates={:?}, region_context={:?}, cause={:?})",
         predicates, region_context, cause,
     );
-    let span = cause.span;
     tcx.infer_ctxt().enter(|infcx| {
         // FIXME. We should really... do something with these region
         // obligations. But this call just continues the older
@@ -223,7 +222,7 @@ fn do_normalize_predicates<'tcx>(
         // we move over to lazy normalization *anyway*.
         let fulfill_cx = FulfillmentContext::new_ignoring_regions();
         let predicates =
-            match fully_normalize(&infcx, fulfill_cx, cause, elaborated_env, &predicates) {
+            match fully_normalize(&infcx, fulfill_cx, cause.clone(), elaborated_env, &predicates) {
                 Ok(predicates) => predicates,
                 Err(errors) => {
                     infcx.report_fulfillment_errors(&errors, None, false);
@@ -253,11 +252,13 @@ fn do_normalize_predicates<'tcx>(
                 // represents a legitimate failure due to some kind of
                 // unconstrained variable, and it seems better not to ICE,
                 // all things considered.
+                let span = cause.def_span();
                 tcx.sess.span_err(span, &fixup_err.to_string());
                 return Err(ErrorReported);
             }
         };
         if predicates.needs_infer() {
+            let span = cause.def_span();
             tcx.sess.delay_span_bug(span, "encountered inference variables after `fully_resolve`");
             Err(ErrorReported)
         } else {

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1103,7 +1103,7 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
             super::ImplSource::AutoImpl(..) | super::ImplSource::Builtin(..) => {
                 // These traits have no associated types.
                 selcx.tcx().sess.delay_span_bug(
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                     &format!("Cannot project an associated type from `{:?}`", impl_source),
                 );
                 return Err(());
@@ -1173,7 +1173,7 @@ fn confirm_select_candidate<'cx, 'tcx>(
         | super::ImplSource::TraitAlias(..) => {
             // we don't create Select candidates with this kind of resolution
             span_bug!(
-                obligation.cause.span,
+                obligation.cause.def_span(),
                 "Cannot project an associated type from `{:?}`",
                 impl_source
             )
@@ -1334,7 +1334,7 @@ fn confirm_param_env_candidate<'cx, 'tcx>(
     let param_env = obligation.param_env;
 
     let (cache_entry, _) = infcx.replace_bound_vars_with_fresh_vars(
-        cause.span,
+        cause.def_span(),
         LateBoundRegionConversionTime::HigherRankedType,
         &poly_cache_entry,
     );
@@ -1369,7 +1369,7 @@ fn confirm_param_env_candidate<'cx, 'tcx>(
                 obligation, poly_cache_entry, e,
             );
             debug!("confirm_param_env_candidate: {}", msg);
-            let err = infcx.tcx.ty_error_with_message(obligation.cause.span, &msg);
+            let err = infcx.tcx.ty_error_with_message(obligation.cause.def_span(), &msg);
             Progress { ty: err, obligations: vec![] }
         }
     }
@@ -1415,7 +1415,7 @@ fn confirm_impl_candidate<'cx, 'tcx>(
     let ty = tcx.type_of(assoc_ty.item.def_id);
     if substs.len() != tcx.generics_of(assoc_ty.item.def_id).count() {
         let err = tcx.ty_error_with_message(
-            obligation.cause.span,
+            obligation.cause.def_span(),
             "impl item and trait item have different parameter counts",
         );
         Progress { ty: err, obligations: nested }

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -41,7 +41,7 @@ impl<'cx, 'tcx> AtExt<'tcx> for At<'cx, 'tcx> {
 
         let mut orig_values = OriginalQueryValues::default();
         let c_ty = self.infcx.canonicalize_query(&self.param_env.and(ty), &mut orig_values);
-        let span = self.cause.span;
+        let span = self.cause.def_span();
         debug!("c_ty = {:?}", c_ty);
         if let Ok(result) = &tcx.dropck_outlives(c_ty) {
             if result.is_proven() {

--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -85,7 +85,7 @@ impl<'cx, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'cx, 'tcx> {
                 let mut selcx = SelectionContext::with_query_mode(&self, TraitQueryMode::Standard);
                 selcx.evaluate_root_obligation(obligation).unwrap_or_else(|r| {
                     span_bug!(
-                        obligation.cause.span,
+                        obligation.cause.def_span(),
                         "Overflow should be caught earlier in standard query mode: {:?}, {:?}",
                         obligation,
                         r,

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -314,7 +314,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::Projection(_) | ty::Opaque(..) => {}
             ty::Infer(ty::TyVar(_)) => {
                 span_bug!(
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                     "Self=_ should have been handled by assemble_candidates"
                 );
             }

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -383,19 +383,19 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::Dynamic(data, ..) => {
                 self.infcx
                     .replace_bound_vars_with_fresh_vars(
-                        obligation.cause.span,
+                        obligation.cause.def_span(),
                         HigherRankedType,
                         data,
                     )
                     .0
             }
-            _ => span_bug!(obligation.cause.span, "object candidate with non-object"),
+            _ => span_bug!(obligation.cause.def_span(), "object candidate with non-object"),
         };
 
         let object_trait_ref = data
             .principal()
             .unwrap_or_else(|| {
-                span_bug!(obligation.cause.span, "object candidate with no principal")
+                span_bug!(obligation.cause.def_span(), "object candidate with no principal")
             })
             .with_self_ty(self.tcx(), self_ty);
 
@@ -475,7 +475,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 // FIXME(generic_associated_types) generate placeholders to
                 // extend the trait substs.
                 tcx.sess.span_fatal(
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                     "generic associated types in trait objects are not supported yet",
                 );
             }
@@ -743,7 +743,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 // Register one obligation for 'a: 'b.
                 let cause = ObligationCause::new(
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                     obligation.cause.body_id,
                     ObjectCastObligation(target),
                 );
@@ -764,7 +764,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 }
 
                 let cause = ObligationCause::new(
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                     obligation.cause.body_id,
                     ObjectCastObligation(target),
                 );

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -480,7 +480,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     obligation.cause.body_id,
                     obligation.recursion_depth + 1,
                     arg,
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                 ) {
                     Some(mut obligations) => {
                         self.add_depth(obligations.iter_mut(), obligation.recursion_depth);
@@ -547,7 +547,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         def_id,
                         substs,
                         obligation.param_env,
-                        obligation.cause.span,
+                        obligation.cause.def_span(),
                     ) {
                         Ok(()) => Ok(EvaluatedToOk),
                         Err(ErrorHandled::TooGeneric) => Ok(EvaluatedToAmbig),
@@ -566,7 +566,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                     def,
                                     substs,
                                     promoted,
-                                    Some(obligation.cause.span),
+                                    Some(obligation.cause.def_span()),
                                 )
                                 .map(|val| ty::Const::from_value(self.tcx(), val, c.ty))
                         } else {
@@ -1157,7 +1157,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::Opaque(def_id, substs) => (def_id, substs),
             _ => {
                 span_bug!(
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                     "match_projection_obligation_against_definition_bounds() called \
                      but self-ty is not a projection: {:?}",
                     placeholder_trait_predicate.trait_ref.self_ty()
@@ -1815,7 +1815,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             self.infcx().replace_bound_vars_with_placeholders(&obligation.predicate);
         let placeholder_obligation_trait_ref = placeholder_obligation.trait_ref;
 
-        let impl_substs = self.infcx.fresh_substs_for_item(obligation.cause.span, impl_def_id);
+        let impl_substs =
+            self.infcx.fresh_substs_for_item(obligation.cause.def_span(), impl_def_id);
 
         let impl_trait_ref = impl_trait_ref.subst(self.tcx(), impl_substs);
 
@@ -2104,7 +2105,7 @@ impl<'tcx> TraitObligationExt<'tcx> for TraitObligation<'tcx> {
             parent_code: Rc::new(obligation.cause.code.clone()),
         };
         let derived_code = variant(derived_cause);
-        ObligationCause::new(obligation.cause.span, obligation.cause.body_id, derived_code)
+        ObligationCause::new(obligation.cause.def_span(), obligation.cause.body_id, derived_code)
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/structural_match.rs
+++ b/compiler/rustc_trait_selection/src/traits/structural_match.rs
@@ -75,7 +75,7 @@ fn type_marked_structural(
     let mut fulfillment_cx = traits::FulfillmentContext::new();
     // require `#[derive(PartialEq)]`
     let structural_peq_def_id =
-        infcx.tcx.require_lang_item(LangItem::StructuralPeq, Some(cause.span));
+        infcx.tcx.require_lang_item(LangItem::StructuralPeq, Some(cause.def_span()));
     fulfillment_cx.register_bound(
         infcx,
         ty::ParamEnv::empty(),
@@ -86,7 +86,7 @@ fn type_marked_structural(
     // for now, require `#[derive(Eq)]`. (Doing so is a hack to work around
     // the type `for<'a> fn(&'a ())` failing to implement `Eq` itself.)
     let structural_teq_def_id =
-        infcx.tcx.require_lang_item(LangItem::StructuralTeq, Some(cause.span));
+        infcx.tcx.require_lang_item(LangItem::StructuralTeq, Some(cause.def_span()));
     fulfillment_cx.register_bound(
         infcx,
         ty::ParamEnv::empty(),

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -221,7 +221,7 @@ fn extend_cause_with_original_assoc_item_obligation<'tcx>(
                 if let Some(impl_item_span) =
                     items.iter().find(|item| item.ident == trait_assoc_item.ident).map(fix_span)
                 {
-                    cause.make_mut().span = impl_item_span;
+                    cause.update_def_span(impl_item_span);
                 }
             }
         }
@@ -236,7 +236,7 @@ fn extend_cause_with_original_assoc_item_obligation<'tcx>(
                         items.iter().find(|i| i.ident == trait_assoc_item.ident).map(fix_span)
                     })
                 {
-                    cause.make_mut().span = impl_item_span;
+                    cause.update_def_span(impl_item_span);
                 }
             }
         }
@@ -334,7 +334,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     // The first subst is the self ty - use the correct span for it.
                     if i == 0 {
                         if let Some(hir::ItemKind::Impl { self_ty, .. }) = item.map(|i| &i.kind) {
-                            new_cause.make_mut().span = self_ty.span;
+                            new_cause.update_def_span(self_ty.span);
                         }
                     }
                     traits::Obligation::with_depth(

--- a/compiler/rustc_ty/src/ty.rs
+++ b/compiler/rustc_ty/src/ty.rs
@@ -275,7 +275,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
         .map_or(hir::CRATE_HIR_ID, |id| {
             tcx.hir().maybe_body_owned_by(id).map_or(id, |body| body.hir_id)
         });
-    let cause = traits::ObligationCause::misc(tcx.def_span(def_id), body_id);
+    let cause = traits::ObligationCause::misc_from_def_id(tcx, def_id, body_id);
     traits::normalize_param_env_or_error(tcx, def_id, unnormalized_env, cause)
 }
 

--- a/compiler/rustc_typeck/src/check/closure.rs
+++ b/compiler/rustc_typeck/src/check/closure.rs
@@ -199,7 +199,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // Given a Projection predicate, we can potentially infer
                     // the complete signature.
                     self.deduce_sig_from_projection(
-                        Some(obligation.cause.span),
+                        Some(obligation.cause.def_span()),
                         bound_predicate.rebind(proj_predicate),
                     )
                 } else {
@@ -622,7 +622,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 obligation.predicate.skip_binders()
             {
                 self.deduce_future_output_from_projection(
-                    obligation.cause.span,
+                    obligation.cause.def_span(),
                     ty::Binder::bind(proj_predicate),
                 )
             } else {

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -281,7 +281,7 @@ fn compare_predicate_entailment<'tcx>(
                 &infcx, param_env, &terr, &cause, impl_m, impl_sig, trait_m, trait_sig,
             );
 
-            cause.make_mut().span = impl_err_span;
+            cause.update_def_span(impl_err_span);
 
             let mut diag = struct_span_err!(
                 tcx.sess,
@@ -990,13 +990,13 @@ crate fn compare_const_impl<'tcx>(
 
             // Locate the Span containing just the type of the offending impl
             match tcx.hir().expect_impl_item(impl_c_hir_id).kind {
-                ImplItemKind::Const(ref ty, _) => cause.make_mut().span = ty.span,
+                ImplItemKind::Const(ref ty, _) => cause.update_def_span(ty.span),
                 _ => bug!("{:?} is not a impl const", impl_c),
             }
 
             let mut diag = struct_span_err!(
                 tcx.sess,
-                cause.span,
+                cause.def_span(),
                 E0326,
                 "implemented const `{}` has an incompatible type for \
                                              trait",

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -598,7 +598,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         &cause,
                         &mut |mut err| {
                             self.suggest_mismatched_types_on_tail(
-                                &mut err, expr, ty, e_ty, cause.span, target_id,
+                                &mut err,
+                                expr,
+                                ty,
+                                e_ty,
+                                cause.def_span(),
+                                target_id,
                             );
                             if let Some(val) = ty_kind_suggestion(ty) {
                                 let label = destination

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -904,7 +904,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Only if the cause is somewhere inside the expression we want try to point at arg.
             // Otherwise, it means that the cause is somewhere else and we should not change
             // anything because we can break the correct span.
-            if !call_sp.contains(error.obligation.cause.span) {
+            if !call_sp.contains(error.obligation.cause.def_span()) {
                 continue;
             }
 
@@ -939,7 +939,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if let (Some(ref_in), None) = (referenced_in.pop(), referenced_in.pop()) {
                     // We make sure that only *one* argument matches the obligation failure
                     // and we assign the obligation's span to its expression's.
-                    error.obligation.cause.make_mut().span = args[ref_in].span;
+                    error.obligation.cause.update_def_span(args[ref_in].span);
                     error.points_at_arg_span = true;
                 }
             }
@@ -982,7 +982,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                         let ty = AstConv::ast_ty_to_ty(self, hir_ty);
                                         let ty = self.resolve_vars_if_possible(&ty);
                                         if ty == predicate.self_ty() {
-                                            error.obligation.cause.make_mut().span = hir_ty.span;
+                                            error.obligation.cause.update_def_span(hir_ty.span);
                                         }
                                     }
                                 }

--- a/compiler/rustc_typeck/src/check/inherited.rs
+++ b/compiler/rustc_typeck/src/check/inherited.rs
@@ -132,7 +132,11 @@ impl Inherited<'a, 'tcx> {
     pub(super) fn register_predicate(&self, obligation: traits::PredicateObligation<'tcx>) {
         debug!("register_predicate({:?})", obligation);
         if obligation.has_escaping_bound_vars() {
-            span_bug!(obligation.cause.span, "escaping bound vars in predicate {:?}", obligation);
+            span_bug!(
+                obligation.cause.def_span(),
+                "escaping bound vars in predicate {:?}",
+                obligation
+            );
         }
         self.fulfillment_cx.borrow_mut().register_predicate_obligation(self, obligation);
     }

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -157,7 +157,6 @@ fn require_same_types<'tcx>(
 
 fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: LocalDefId) {
     let main_id = tcx.hir().local_def_id_to_hir_id(main_def_id);
-    let main_span = tcx.def_span(main_def_id);
     let main_t = tcx.type_of(main_def_id);
     match main_t.kind() {
         ty::FnDef(..) => {
@@ -200,6 +199,7 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: LocalDefId) {
 
                     for attr in it.attrs {
                         if tcx.sess.check_name(attr, sym::track_caller) {
+                            let main_span = tcx.def_span(main_def_id);
                             tcx.sess
                                 .struct_span_err(
                                     attr.span,
@@ -240,12 +240,18 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: LocalDefId) {
 
             require_same_types(
                 tcx,
-                &ObligationCause::new(main_span, main_id, ObligationCauseCode::MainFunctionType),
+                &ObligationCause::new_from_def_id(
+                    tcx,
+                    main_def_id.to_def_id(),
+                    main_id,
+                    ObligationCauseCode::MainFunctionType,
+                ),
                 se_ty,
                 tcx.mk_fn_ptr(actual),
             );
         }
         _ => {
+            let main_span = tcx.def_span(main_def_id);
             span_bug!(main_span, "main has a non-function type: found `{}`", main_t);
         }
     }


### PR DESCRIPTION
`param_env` only needs the span data on error paths, so let's try to make `ObligationCase` lazy. `param_env` seems to be directly responsible for about half of the `def_span` queries. I don't expect a measurable perf difference, though, because the best case in one of my profiled crates is an `0.15%` theoretical improvement, but maybe one of the benchmarks is more sensitive to it.

This change also encapsulates `span`, that can now be accessed using `def_span()` and `update_def_span()`.
