### PR TITLE
BTreeMap: let NodeRef point to the actual type of the node 

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1414,7 +1414,7 @@ impl<K, V> IntoIterator for BTreeMap<K, V> {
     fn into_iter(self) -> IntoIter<K, V> {
         let mut me = ManuallyDrop::new(self);
         if let Some(root) = me.root.take() {
-            let (f, b) = root.into_ref().full_range();
+            let (f, b) = root.full_range();
 
             IntoIter { front: Some(f), back: Some(b), length: me.length }
         } else {

--- a/library/alloc/src/collections/btree/mem.rs
+++ b/library/alloc/src/collections/btree/mem.rs
@@ -1,0 +1,34 @@
+use core::intrinsics;
+use core::mem;
+use core::ptr;
+
+/// This replaces the value behind the `v` unique reference by calling the
+/// relevant function.
+///
+/// If a panic occurs in the `change` closure, the entire process will be aborted.
+#[inline]
+pub fn take_mut<T>(v: &mut T, change: impl FnOnce(T) -> T) {
+    replace(v, |value| (change(value), ()))
+}
+
+/// This replaces the value behind the `v` unique reference by calling the
+/// relevant function, and returns a result obtained along the way.
+///
+/// If a panic occurs in the `change` closure, the entire process will be aborted.
+#[inline]
+pub fn replace<T, R>(v: &mut T, change: impl FnOnce(T) -> (T, R)) -> R {
+    struct PanicGuard;
+    impl Drop for PanicGuard {
+        fn drop(&mut self) {
+            intrinsics::abort()
+        }
+    }
+    let guard = PanicGuard;
+    let value = unsafe { ptr::read(v) };
+    let (new_value, ret) = change(value);
+    unsafe {
+        ptr::write(v, new_value);
+    }
+    mem::forget(guard);
+    ret
+}

--- a/library/alloc/src/collections/btree/mod.rs
+++ b/library/alloc/src/collections/btree/mod.rs
@@ -1,5 +1,6 @@
 mod borrow;
 pub mod map;
+mod mem;
 mod navigate;
 mod node;
 mod remove;

--- a/library/alloc/src/collections/btree/navigate.rs
+++ b/library/alloc/src/collections/btree/navigate.rs
@@ -1,7 +1,5 @@
 use core::borrow::Borrow;
 use core::cmp::Ordering;
-use core::intrinsics;
-use core::mem;
 use core::ops::Bound::{Excluded, Included, Unbounded};
 use core::ops::RangeBounds;
 use core::ptr;
@@ -304,37 +302,6 @@ macro_rules! def_next_kv_uncheched_dealloc {
 def_next_kv_uncheched_dealloc! {unsafe fn next_kv_unchecked_dealloc: right_kv}
 def_next_kv_uncheched_dealloc! {unsafe fn next_back_kv_unchecked_dealloc: left_kv}
 
-/// This replaces the value behind the `v` unique reference by calling the
-/// relevant function.
-///
-/// If a panic occurs in the `change` closure, the entire process will be aborted.
-#[inline]
-fn take_mut<T>(v: &mut T, change: impl FnOnce(T) -> T) {
-    replace(v, |value| (change(value), ()))
-}
-
-/// This replaces the value behind the `v` unique reference by calling the
-/// relevant function, and returns a result obtained along the way.
-///
-/// If a panic occurs in the `change` closure, the entire process will be aborted.
-#[inline]
-fn replace<T, R>(v: &mut T, change: impl FnOnce(T) -> (T, R)) -> R {
-    struct PanicGuard;
-    impl Drop for PanicGuard {
-        fn drop(&mut self) {
-            intrinsics::abort()
-        }
-    }
-    let guard = PanicGuard;
-    let value = unsafe { ptr::read(v) };
-    let (new_value, ret) = change(value);
-    unsafe {
-        ptr::write(v, new_value);
-    }
-    mem::forget(guard);
-    ret
-}
-
 impl<'a, K, V> Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge> {
     /// Moves the leaf edge handle to the next leaf edge and returns references to the
     /// key and value in between.
@@ -342,7 +309,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Ed
     /// # Safety
     /// There must be another KV in the direction travelled.
     pub unsafe fn next_unchecked(&mut self) -> (&'a K, &'a V) {
-        replace(self, |leaf_edge| {
+        super::mem::replace(self, |leaf_edge| {
             let kv = leaf_edge.next_kv();
             let kv = unsafe { unwrap_unchecked(kv.ok()) };
             (kv.next_leaf_edge(), kv.into_kv())
@@ -355,7 +322,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Ed
     /// # Safety
     /// There must be another KV in the direction travelled.
     pub unsafe fn next_back_unchecked(&mut self) -> (&'a K, &'a V) {
-        replace(self, |leaf_edge| {
+        super::mem::replace(self, |leaf_edge| {
             let kv = leaf_edge.next_back_kv();
             let kv = unsafe { unwrap_unchecked(kv.ok()) };
             (kv.next_back_leaf_edge(), kv.into_kv())
@@ -370,7 +337,7 @@ impl<'a, K, V> Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::E
     /// # Safety
     /// There must be another KV in the direction travelled.
     pub unsafe fn next_unchecked(&mut self) -> (&'a K, &'a mut V) {
-        let kv = replace(self, |leaf_edge| {
+        let kv = super::mem::replace(self, |leaf_edge| {
             let kv = leaf_edge.next_kv();
             let kv = unsafe { unwrap_unchecked(kv.ok()) };
             (unsafe { ptr::read(&kv) }.next_leaf_edge(), kv)
@@ -385,7 +352,7 @@ impl<'a, K, V> Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::E
     /// # Safety
     /// There must be another KV in the direction travelled.
     pub unsafe fn next_back_unchecked(&mut self) -> (&'a K, &'a mut V) {
-        let kv = replace(self, |leaf_edge| {
+        let kv = super::mem::replace(self, |leaf_edge| {
             let kv = leaf_edge.next_back_kv();
             let kv = unsafe { unwrap_unchecked(kv.ok()) };
             (unsafe { ptr::read(&kv) }.next_back_leaf_edge(), kv)
@@ -401,7 +368,7 @@ impl<'a, K, V> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge
     /// # Safety
     /// There must be another KV in the direction travelled.
     pub unsafe fn move_next_unchecked(&mut self) {
-        take_mut(self, |leaf_edge| {
+        super::mem::take_mut(self, |leaf_edge| {
             let kv = leaf_edge.next_kv();
             let kv = unsafe { unwrap_unchecked(kv.ok()) };
             kv.next_leaf_edge()
@@ -423,7 +390,7 @@ impl<K, V> Handle<NodeRef<marker::Owned, K, V, marker::Leaf>, marker::Edge> {
     /// call this method again subject to its safety conditions, or call counterpart
     /// `next_back_unchecked` subject to its safety conditions.
     pub unsafe fn next_unchecked(&mut self) -> (K, V) {
-        replace(self, |leaf_edge| {
+        super::mem::replace(self, |leaf_edge| {
             let kv = unsafe { next_kv_unchecked_dealloc(leaf_edge) };
             let k = unsafe { ptr::read(kv.reborrow().into_kv().0) };
             let v = unsafe { ptr::read(kv.reborrow().into_kv().1) };
@@ -444,7 +411,7 @@ impl<K, V> Handle<NodeRef<marker::Owned, K, V, marker::Leaf>, marker::Edge> {
     /// call this method again subject to its safety conditions, or call counterpart
     /// `next_unchecked` subject to its safety conditions.
     pub unsafe fn next_back_unchecked(&mut self) -> (K, V) {
-        replace(self, |leaf_edge| {
+        super::mem::replace(self, |leaf_edge| {
             let kv = unsafe { next_back_kv_unchecked_dealloc(leaf_edge) };
             let k = unsafe { ptr::read(kv.reborrow().into_kv().0) };
             let v = unsafe { ptr::read(kv.reborrow().into_kv().1) };

--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -158,8 +158,8 @@ fn test_partial_cmp_eq() {
     assert_eq!(top_edge_1.partial_cmp(&top_edge_2), None);
 
     root1.pop_internal_level();
-    unsafe { root1.into_ref().deallocate_and_ascend() };
-    unsafe { root2.into_ref().deallocate_and_ascend() };
+    unsafe { root1.deallocate_and_ascend() };
+    unsafe { root2.deallocate_and_ascend() };
 }
 
 #[test]

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -219,7 +219,7 @@ def children_of_node(node_ptr, height):
     keys = leaf["keys"]
     vals = leaf["vals"]
     edges = cast_to_internal(node_ptr)["edges"] if height > 0 else None
-    length = int(leaf["len"])
+    length = leaf["len"]
 
     for i in xrange(0, length + 1):
         if height > 0:

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -207,15 +207,14 @@ class StdRefCellProvider:
         yield "borrow", self.borrow
 
 
-# Yields children (in a provider's sense of the word) for a tree headed by a BoxedNode.
+# Yields children (in a provider's sense of the word) for a tree headed by a node.
 # In particular, yields each key/value pair in the node and in any child nodes.
-def children_of_node(boxed_node, height):
+def children_of_node(node_ptr, height):
     def cast_to_internal(node):
         internal_type_name = node.type.target().name.replace("LeafNode", "InternalNode", 1)
         internal_type = lookup_type(internal_type_name)
         return node.cast(internal_type.pointer())
 
-    node_ptr = unwrap_unique_or_non_null(boxed_node["ptr"])
     leaf = node_ptr.dereference()
     keys = leaf["keys"]
     vals = leaf["vals"]
@@ -225,7 +224,8 @@ def children_of_node(boxed_node, height):
     for i in xrange(0, length + 1):
         if height > 0:
             boxed_child_node = edges[i]["value"]["value"]
-            for child in children_of_node(boxed_child_node, height - 1):
+            child_node = unwrap_unique_or_non_null(boxed_child_node["ptr"])
+            for child in children_of_node(child_node, height - 1):
                 yield child
         if i < length:
             # Avoid "Cannot perform pointer math on incomplete type" on zero-sized arrays.
@@ -240,9 +240,12 @@ def children_of_map(map):
         root = map["root"]
         if root.type.name.startswith("core::option::Option<"):
             root = root.cast(gdb.lookup_type(root.type.name[21:-1]))
-        boxed_root_node = root["node"]
+        node_ptr = root["node"]
+        if node_ptr.type.name.startswith("alloc::collections::btree::node::BoxedNode<"):
+            node_ptr = node_ptr["ptr"]
+        node_ptr = unwrap_unique_or_non_null(node_ptr)
         height = root["height"]
-        for child in children_of_node(boxed_root_node, height):
+        for child in children_of_node(node_ptr, height):
             yield child
 
 

--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -101,7 +101,7 @@ fn main() {
         btree_set.insert(i);
     }
 
-    let mut empty_btree_set: BTreeSet<i32> = BTreeSet::new();
+    let empty_btree_set: BTreeSet<i32> = BTreeSet::new();
 
     // BTreeMap
     let mut btree_map = BTreeMap::new();
@@ -109,7 +109,7 @@ fn main() {
         btree_map.insert(i, i);
     }
 
-    let mut empty_btree_map: BTreeMap<i32, u32> = BTreeMap::new();
+    let empty_btree_map: BTreeMap<i32, u32> = BTreeMap::new();
 
     let mut option_btree_map: BTreeMap<bool, Option<bool>> = BTreeMap::new();
     option_btree_map.insert(false, None);


### PR DESCRIPTION
Building on #78104, it's relatively easy to confine mangled target types to the space-efficient `BoxedNode`, and let both the map's roots and node references on the fly point to the correct type. This reduces casts to two places: one for unpacking a boxed node to its actual target, and one for Global::dealloc.