### PR TITLE
min_const_generics: allow ty param in repeat expr

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -206,8 +206,10 @@ pub enum Res<Id = hir::HirId> {
     /// ```rust
     /// impl Foo { fn test() -> [u8; std::mem::size_of::<Self>()] {} }
     /// ```
+    /// We do however allow `Self` in repeat expression even if it is generic to not break code
+    /// which already works on stable while causing the `const_evaluatable_unchecked` future compat lint.
     ///
-    /// FIXME(lazy_normalization_consts): Remove this bodge once this feature is stable.
+    /// FIXME(lazy_normalization_consts): Remove this bodge once that feature is stable.
     SelfTy(Option<DefId> /* trait */, Option<(DefId, bool)> /* impl */),
     ToolMod, // e.g., `rustfmt` in `#[rustfmt::skip]`
 

--- a/src/test/ui/const-generics/issues/issue-62504.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-62504.min.stderr
@@ -1,14 +1,20 @@
-error: generic `Self` types are currently not permitted in anonymous constants
+error[E0308]: mismatched types
+  --> $DIR/issue-62504.rs:19:21
+   |
+LL |         ArrayHolder([0; Self::SIZE])
+   |                     ^^^^^^^^^^^^^^^ expected `X`, found `Self::SIZE`
+   |
+   = note: expected array `[u32; X]`
+              found array `[u32; _]`
+
+error: constant expression depends on a generic parameter
   --> $DIR/issue-62504.rs:19:25
    |
 LL |         ArrayHolder([0; Self::SIZE])
    |                         ^^^^^^^^^^
    |
-note: not a concrete type
-  --> $DIR/issue-62504.rs:17:22
-   |
-LL | impl<const X: usize> ArrayHolder<X> {
-   |                      ^^^^^^^^^^^^^^
+   = note: this may fail depending on what value the parameter takes
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/issues/issue-62504.rs
+++ b/src/test/ui/const-generics/issues/issue-62504.rs
@@ -17,8 +17,8 @@ struct ArrayHolder<const X: usize>([u32; X]);
 impl<const X: usize> ArrayHolder<X> {
     pub const fn new() -> Self {
         ArrayHolder([0; Self::SIZE])
-        //[full]~^ ERROR constant expression depends on a generic parameter
-        //[min]~^^ ERROR generic `Self` types are currently
+        //~^ ERROR constant expression depends on a generic parameter
+        //[min]~| ERROR mismatched types
     }
 }
 

--- a/src/test/ui/const-generics/issues/issue-67739.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-67739.min.stderr
@@ -1,10 +1,10 @@
-error: generic parameters may not be used in const operations
-  --> $DIR/issue-67739.rs:12:30
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-67739.rs:12:15
    |
 LL |         [0u8; mem::size_of::<Self::Associated>()];
-   |                              ^^^^^^^^^^^^^^^^ cannot perform const operation using `Self`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: type parameters may not be used in const expressions
+   = note: this may fail depending on what value the parameter takes
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-67739.rs
+++ b/src/test/ui/const-generics/issues/issue-67739.rs
@@ -10,8 +10,7 @@ pub trait Trait {
 
     fn associated_size(&self) -> usize {
         [0u8; mem::size_of::<Self::Associated>()];
-        //[full]~^ ERROR constant expression depends on a generic parameter
-        //[min]~^^ ERROR generic parameters may not be used in const operations
+        //~^ ERROR constant expression depends on a generic parameter
         0
     }
 }

--- a/src/test/ui/const-generics/min_const_generics/complex-expression.rs
+++ b/src/test/ui/const-generics/min_const_generics/complex-expression.rs
@@ -1,5 +1,7 @@
 #![feature(min_const_generics)]
 
+use std::mem::size_of;
+
 fn test<const N: usize>() {}
 
 fn ok<const M: usize>() -> [u8; M] {
@@ -21,6 +23,24 @@ fn break3<const N: usize>() {
     let _ = [0; N + 1];
     //~^ ERROR generic parameters may not be used in const operations
 }
+
+struct BreakTy0<T>(T, [u8; { size_of::<*mut T>() }]);
+//~^ ERROR generic parameters may not be used in const operations
+
+struct BreakTy1<T>(T, [u8; { { size_of::<*mut T>() } }]);
+//~^ ERROR generic parameters may not be used in const operations
+
+fn break_ty2<T>() {
+    let _: [u8; size_of::<*mut T>() + 1];
+    //~^ ERROR generic parameters may not be used in const operations
+}
+
+fn break_ty3<T>() {
+    let _ = [0; size_of::<*mut T>() + 1];
+    //~^ WARN cannot use constants which depend on generic parameters in types
+    //~| WARN this was previously accepted by the compiler but is being phased out
+}
+
 
 trait Foo {
     const ASSOC: usize;

--- a/src/test/ui/const-generics/min_const_generics/complex-expression.stderr
+++ b/src/test/ui/const-generics/min_const_generics/complex-expression.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:9:38
+  --> $DIR/complex-expression.rs:11:38
    |
 LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    |                                      ^ cannot perform const operation using `N`
@@ -7,7 +7,7 @@ LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:12:40
+  --> $DIR/complex-expression.rs:14:40
    |
 LL | struct Break1<const N: usize>([u8; { { N } }]);
    |                                        ^ cannot perform const operation using `N`
@@ -15,7 +15,7 @@ LL | struct Break1<const N: usize>([u8; { { N } }]);
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:16:17
+  --> $DIR/complex-expression.rs:18:17
    |
 LL |     let _: [u8; N + 1];
    |                 ^ cannot perform const operation using `N`
@@ -23,12 +23,46 @@ LL |     let _: [u8; N + 1];
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:21:17
+  --> $DIR/complex-expression.rs:23:17
    |
 LL |     let _ = [0; N + 1];
    |                 ^ cannot perform const operation using `N`
    |
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
-error: aborting due to 4 previous errors
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-expression.rs:27:45
+   |
+LL | struct BreakTy0<T>(T, [u8; { size_of::<*mut T>() }]);
+   |                                             ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-expression.rs:30:47
+   |
+LL | struct BreakTy1<T>(T, [u8; { { size_of::<*mut T>() } }]);
+   |                                               ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-expression.rs:34:32
+   |
+LL |     let _: [u8; size_of::<*mut T>() + 1];
+   |                                ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/complex-expression.rs:39:17
+   |
+LL |     let _ = [0; size_of::<*mut T>() + 1];
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+error: aborting due to 7 previous errors; 1 warning emitted
 

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
@@ -1,4 +1,5 @@
 // check-pass
+#![feature(min_const_generics)]
 #![allow(dead_code)]
 
 fn foo<T>() {
@@ -13,7 +14,19 @@ impl<T> Foo<T> {
     const ASSOC: usize = 4;
 
     fn test() {
-        [0; Self::ASSOC];
+        let _ = [0; Self::ASSOC];
+        //~^ WARN cannot use constants which depend on generic parameters in types
+        //~| WARN this was previously accepted by the compiler but is being phased out
+    }
+}
+
+struct Bar<const N: usize>;
+
+impl<const N: usize> Bar<N> {
+    const ASSOC: usize = 4;
+
+    fn test() {
+        let _ = [0; Self::ASSOC];
         //~^ WARN cannot use constants which depend on generic parameters in types
         //~| WARN this was previously accepted by the compiler but is being phased out
     }

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
@@ -1,0 +1,22 @@
+// check-pass
+#![allow(dead_code)]
+
+fn foo<T>() {
+    [0; std::mem::size_of::<*mut T>()];
+    //~^ WARN cannot use constants which depend on generic parameters in types
+    //~| WARN this was previously accepted by the compiler but is being phased out
+}
+
+struct Foo<T>(T);
+
+impl<T> Foo<T> {
+    const ASSOC: usize = 4;
+
+    fn test() {
+        [0; Self::ASSOC];
+        //~^ WARN cannot use constants which depend on generic parameters in types
+        //~| WARN this was previously accepted by the compiler but is being phased out
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
@@ -1,0 +1,21 @@
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/const-evaluatable-unchecked.rs:5:9
+   |
+LL |     [0; std::mem::size_of::<*mut T>()];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/const-evaluatable-unchecked.rs:16:13
+   |
+LL |         [0; Self::ASSOC];
+   |             ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
@@ -1,5 +1,5 @@
 warning: cannot use constants which depend on generic parameters in types
-  --> $DIR/const-evaluatable-unchecked.rs:5:9
+  --> $DIR/const-evaluatable-unchecked.rs:6:9
    |
 LL |     [0; std::mem::size_of::<*mut T>()];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,22 @@ LL |     [0; std::mem::size_of::<*mut T>()];
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
 
 warning: cannot use constants which depend on generic parameters in types
-  --> $DIR/const-evaluatable-unchecked.rs:16:13
+  --> $DIR/const-evaluatable-unchecked.rs:17:21
    |
-LL |         [0; Self::ASSOC];
-   |             ^^^^^^^^^^^
+LL |         let _ = [0; Self::ASSOC];
+   |                     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
 
-warning: 2 warnings emitted
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/const-evaluatable-unchecked.rs:29:21
+   |
+LL |         let _ = [0; Self::ASSOC];
+   |                     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+warning: 3 warnings emitted
 


### PR DESCRIPTION
implements https://rust-lang.zulipchat.com/#narrow/stream/260443-project-const-generics/topic/repeat.20expressions

Even with `min_const_generics` active, now keeps resulting in future compat warnings instead of hard errors.
Const parameters, for example `[0; N + 1]`, still result in hard errors during resolve.
```rust
#![allow(dead_code)]

fn foo<T>() {
    [0; std::mem::size_of::<*mut T>()];
}

struct Foo<T>(T);

impl<T> Foo<T> {
    const ASSOC: usize = 4;

    fn test() {
        [0; Self::ASSOC];
    }
}
```

r? @varkor cc @petrochenkov 