### PR TITLE
Warn using last and count to exhaust an iterator

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -240,6 +240,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     fn count(self) -> usize
     where
         Self: Sized,
@@ -272,6 +273,7 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     fn last(self) -> Option<Self::Item>
     where
         Self: Sized,

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -556,7 +556,7 @@ fn test_zip_map_rev_sideffectful() {
 
     {
         let mut it = xs.iter_mut().map(|x| *x += 1).zip(ys.iter_mut().map(|y| *y += 1));
-        (&mut it).take(5).count();
+        (&mut it).take(5).for_each(drop);
         it.next_back();
     }
     assert_eq!(&xs, &[1, 1, 1, 1, 1, 1]);
@@ -571,7 +571,7 @@ fn test_zip_nested_sideffectful() {
     {
         // test that it has the side effect nested inside enumerate
         let it = xs.iter_mut().map(|x| *x = 1).enumerate().zip(&ys);
-        it.count();
+        it.for_each(drop);
     }
     assert_eq!(&xs, &[1, 1, 1, 1, 1, 0]);
 }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -534,7 +534,7 @@ fn concurrent_recursive_mkdir() {
         }
 
         // No `Display` on result of `join()`
-        join.drain(..).map(|join| join.join().unwrap()).count();
+        join.drain(..).map(|join| join.join().unwrap()).for_each(drop);
     }
 }
 

--- a/src/test/ui/issues/issue-30081.rs
+++ b/src/test/ui/issues/issue-30081.rs
@@ -11,5 +11,5 @@ fn main() {
     instrs.into_iter()
         .map(|(_, instr)| instr)
         .map(|instr| match *instr { _other => {} })
-        .last();
+        .for_each(drop);
 }

--- a/src/test/ui/issues/issue-36053.rs
+++ b/src/test/ui/issues/issue-36053.rs
@@ -18,5 +18,5 @@ impl<'a> Iterator for Thing<'a> {
 impl<'a> FusedIterator for Thing<'a> {}
 
 fn main() {
-    Thing("test").fuse().filter(|_| true).count();
+    Thing("test").fuse().filter(|_| true).for_each(drop);
 }

--- a/src/test/ui/nll/issue-50343.rs
+++ b/src/test/ui/nll/issue-50343.rs
@@ -3,6 +3,6 @@
 #![deny(unused_mut)]
 
 fn main() {
-    vec![42].iter().map(drop).count();
-    vec![(42, 22)].iter().map(|(_x, _y)| ()).count();
+    vec![42].iter().map(drop).for_each(drop);
+    vec![(42, 22)].iter().map(|(_x, _y)| ()).for_each(drop);
 }

--- a/src/test/ui/nll/unused-mut-issue-50343.fixed
+++ b/src/test/ui/nll/unused-mut-issue-50343.fixed
@@ -4,6 +4,6 @@
 #![allow(unused_variables)] // for rustfix
 
 fn main() {
-    vec![(42, 22)].iter().map(|(x, _y)| ()).count();
+    vec![(42, 22)].iter().map(|(x, _y)| ()).for_each(drop);
     //~^ ERROR: variable does not need to be mutable
 }

--- a/src/test/ui/nll/unused-mut-issue-50343.rs
+++ b/src/test/ui/nll/unused-mut-issue-50343.rs
@@ -4,6 +4,6 @@
 #![allow(unused_variables)] // for rustfix
 
 fn main() {
-    vec![(42, 22)].iter().map(|(mut x, _y)| ()).count();
+    vec![(42, 22)].iter().map(|(mut x, _y)| ()).for_each(drop);
     //~^ ERROR: variable does not need to be mutable
 }

--- a/src/test/ui/nll/unused-mut-issue-50343.stderr
+++ b/src/test/ui/nll/unused-mut-issue-50343.stderr
@@ -1,7 +1,7 @@
 error: variable does not need to be mutable
   --> $DIR/unused-mut-issue-50343.rs:7:33
    |
-LL |     vec![(42, 22)].iter().map(|(mut x, _y)| ()).count();
+LL |     vec![(42, 22)].iter().map(|(mut x, _y)| ()).for_each(drop);
    |                                 ----^
    |                                 |
    |                                 help: remove this `mut`


### PR DESCRIPTION
This adds the same `#[must_use]` attribute as used in `collect` to `count` and `last`, as it also does not make sense to not use the result there.