### PR TITLE
Explain where the closure return type was inferred

### DIFF
--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1475,6 +1475,28 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         if let (Some(sp), Some(fn_output)) = (fcx.ret_coercion_span.borrow().as_ref(), fn_output) {
             self.add_impl_trait_explanation(&mut err, cause, fcx, expected, *sp, fn_output);
         }
+
+        if let Some(sp) = fcx.ret_coercion_span.borrow().as_ref() {
+            // If the closure has an explicit return type annotation,
+            // then a type error may occur at the first return expression we
+            // see in the closure (if it conflicts with the declared
+            // return type). Skip adding a note in this case, since it
+            // would be incorrect.
+            if !err.span.primary_spans().iter().any(|span| span == sp) {
+                let hir = fcx.tcx.hir();
+                let body_owner = hir.body_owned_by(hir.enclosing_body_owner(fcx.body_id));
+                if fcx.tcx.is_closure(hir.body_owner_def_id(body_owner).to_def_id()) {
+                    err.span_note(
+                        *sp,
+                        &format!(
+                            "return type inferred to be `{}` here",
+                            fcx.resolve_vars_if_possible(&expected)
+                        ),
+                    );
+                }
+            }
+        }
+
         err
     }
 

--- a/src/test/ui/closures/closure-return-type-mismatch.rs
+++ b/src/test/ui/closures/closure-return-type-mismatch.rs
@@ -1,0 +1,17 @@
+fn main() {
+    || {
+        if false {
+            return "test";
+        }
+        let a = true;
+        a //~ ERROR mismatched types
+    };
+
+    || -> bool {
+        if false {
+            return "hello" //~ ERROR mismatched types
+        };
+        let b = true;
+        b
+    };
+}

--- a/src/test/ui/closures/closure-return-type-mismatch.stderr
+++ b/src/test/ui/closures/closure-return-type-mismatch.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:7:9
+   |
+LL |         a
+   |         ^ expected `&str`, found `bool`
+   |
+note: return type inferred to be `&str` here
+  --> $DIR/closure-return-type-mismatch.rs:4:20
+   |
+LL |             return "test";
+   |                    ^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:12:20
+   |
+LL |             return "hello"
+   |                    ^^^^^^^ expected `bool`, found `&str`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/generator/type-mismatch-signature-deduction.stderr
+++ b/src/test/ui/generator/type-mismatch-signature-deduction.stderr
@@ -6,6 +6,11 @@ LL |         5
    |
    = note: expected type `std::result::Result<{integer}, _>`
               found type `{integer}`
+note: return type inferred to be `std::result::Result<{integer}, _>` here
+  --> $DIR/type-mismatch-signature-deduction.rs:8:20
+   |
+LL |             return Ok(6);
+   |                    ^^^^^
 
 error[E0271]: type mismatch resolving `<[generator@$DIR/type-mismatch-signature-deduction.rs:6:5: 14:6] as Generator>::Return == i32`
   --> $DIR/type-mismatch-signature-deduction.rs:5:13


### PR DESCRIPTION
Fixes #78193