### PR TITLE
Rename `overlapping_patterns` lint

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -283,7 +283,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         UNUSED_MUT,
         UNREACHABLE_CODE,
         UNREACHABLE_PATTERNS,
-        OVERLAPPING_PATTERNS,
+        OVERLAPPING_RANGE_ENDPOINTS,
         UNUSED_MUST_USE,
         UNUSED_UNSAFE,
         PATH_STATEMENTS,
@@ -335,6 +335,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
     store.register_renamed("exceeding_bitshifts", "arithmetic_overflow");
     store.register_renamed("redundant_semicolon", "redundant_semicolons");
     store.register_renamed("intra_doc_link_resolution_failure", "broken_intra_doc_links");
+    store.register_renamed("overlapping_patterns", "overlapping_range_endpoints");
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");
     store.register_removed("negate_unsigned", "cast a signed value instead");

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -283,7 +283,6 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         UNUSED_MUT,
         UNREACHABLE_CODE,
         UNREACHABLE_PATTERNS,
-        OVERLAPPING_RANGE_ENDPOINTS,
         UNUSED_MUST_USE,
         UNUSED_UNSAFE,
         PATH_STATEMENTS,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -588,8 +588,8 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `overlapping_patterns` lint detects `match` arms that have
-    /// [range patterns] that overlap.
+    /// The `overlapping_range_endpoints` lint detects `match` arms that have [range patterns] that
+    /// overlap on their endpoints.
     ///
     /// [range patterns]: https://doc.rust-lang.org/nightly/reference/patterns.html#range-patterns
     ///
@@ -607,13 +607,12 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// It is likely a mistake to have range patterns in a match expression
-    /// that overlap. Check that the beginning and end values are what you
-    /// expect, and keep in mind that with `..=` the left and right bounds are
-    /// inclusive.
-    pub OVERLAPPING_PATTERNS,
+    /// It is likely a mistake to have range patterns in a match expression that overlap in this
+    /// way. Check that the beginning and end values are what you expect, and keep in mind that
+    /// with `..=` the left and right bounds are inclusive.
+    pub OVERLAPPING_RANGE_ENDPOINTS,
     Warn,
-    "detects overlapping patterns"
+    "detects range patterns with overlapping endpoints"
 }
 
 declare_lint! {
@@ -2765,7 +2764,7 @@ declare_lint_pass! {
         DEAD_CODE,
         UNREACHABLE_CODE,
         UNREACHABLE_PATTERNS,
-        OVERLAPPING_PATTERNS,
+        OVERLAPPING_RANGE_ENDPOINTS,
         BINDINGS_WITH_VARIANT_NAME,
         UNUSED_MACROS,
         WARNINGS,

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -161,7 +161,7 @@ impl IntRange {
         // 2       --------   // 2 -------
         let (lo, hi) = self.boundaries();
         let (other_lo, other_hi) = other.boundaries();
-        lo == other_hi || hi == other_lo
+        (lo == other_hi || hi == other_lo) && !self.is_singleton() && !other.is_singleton()
     }
 
     fn to_pat<'tcx>(&self, tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Pat<'tcx> {

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -309,9 +309,7 @@ impl IntRange {
                 pcx.span,
                 |lint| {
                     let mut err = lint.build("multiple patterns overlap on their endpoints");
-                    err.span_label(pcx.span, "... with this range");
                     for (int_range, span) in overlaps {
-                        // Use the real type for user display of the ranges:
                         err.span_label(
                             span,
                             &format!(
@@ -320,7 +318,8 @@ impl IntRange {
                             ),
                         );
                     }
-                    err.note("this is likely to be a mistake");
+                    err.span_label(pcx.span, "... with this range");
+                    err.note("you likely meant to write mutually exclusive ranges");
                     err.emit();
                 },
             );

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -309,18 +309,18 @@ impl IntRange {
                 pcx.span,
                 |lint| {
                     let mut err = lint.build("multiple patterns overlap on their endpoints");
-                    err.span_label(pcx.span, "overlapping range endpoints");
+                    err.span_label(pcx.span, "... with this range");
                     for (int_range, span) in overlaps {
                         // Use the real type for user display of the ranges:
                         err.span_label(
                             span,
                             &format!(
-                                "this range overlaps on `{}`",
+                                "this range overlaps on `{}`...",
                                 int_range.to_pat(pcx.cx.tcx, pcx.ty)
                             ),
                         );
                     }
-                    // FIXME: add note
+                    err.note("this is likely to be a mistake");
                     err.emit();
                 },
             );

--- a/src/test/ui/issues/issue-21475.rs
+++ b/src/test/ui/issues/issue-21475.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(unused_imports, overlapping_patterns)]
+#![allow(unused_imports, overlapping_range_endpoints)]
 // pretty-expanded FIXME #23616
 
 use m::{START, END};

--- a/src/test/ui/issues/issue-26251.rs
+++ b/src/test/ui/issues/issue-26251.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![allow(overlapping_patterns)]
+#![allow(overlapping_range_endpoints)]
 
 fn main() {
     let x = 'a';

--- a/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.rs
@@ -1,5 +1,6 @@
 #![feature(exclusive_range_pattern)]
 #![feature(assoc_char_consts)]
+#![allow(overlapping_range_endpoints)]
 #![deny(unreachable_patterns)]
 
 macro_rules! m {

--- a/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:47:8
+  --> $DIR/exhaustiveness.rs:48:8
    |
 LL |     m!(0u8, 0..255);
    |        ^^^ pattern `u8::MAX` not covered
@@ -8,7 +8,7 @@ LL |     m!(0u8, 0..255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:48:8
+  --> $DIR/exhaustiveness.rs:49:8
    |
 LL |     m!(0u8, 0..=254);
    |        ^^^ pattern `u8::MAX` not covered
@@ -17,7 +17,7 @@ LL |     m!(0u8, 0..=254);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
-  --> $DIR/exhaustiveness.rs:49:8
+  --> $DIR/exhaustiveness.rs:50:8
    |
 LL |     m!(0u8, 1..=255);
    |        ^^^ pattern `0_u8` not covered
@@ -26,7 +26,7 @@ LL |     m!(0u8, 1..=255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `42_u8` not covered
-  --> $DIR/exhaustiveness.rs:50:8
+  --> $DIR/exhaustiveness.rs:51:8
    |
 LL |     m!(0u8, 0..42 | 43..=255);
    |        ^^^ pattern `42_u8` not covered
@@ -35,7 +35,7 @@ LL |     m!(0u8, 0..42 | 43..=255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:51:8
+  --> $DIR/exhaustiveness.rs:52:8
    |
 LL |     m!(0i8, -128..127);
    |        ^^^ pattern `i8::MAX` not covered
@@ -44,7 +44,7 @@ LL |     m!(0i8, -128..127);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:52:8
+  --> $DIR/exhaustiveness.rs:53:8
    |
 LL |     m!(0i8, -128..=126);
    |        ^^^ pattern `i8::MAX` not covered
@@ -53,7 +53,7 @@ LL |     m!(0i8, -128..=126);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
-  --> $DIR/exhaustiveness.rs:53:8
+  --> $DIR/exhaustiveness.rs:54:8
    |
 LL |     m!(0i8, -127..=127);
    |        ^^^ pattern `i8::MIN` not covered
@@ -62,7 +62,7 @@ LL |     m!(0i8, -127..=127);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `0_i8` not covered
-  --> $DIR/exhaustiveness.rs:54:11
+  --> $DIR/exhaustiveness.rs:55:11
    |
 LL |     match 0i8 {
    |           ^^^ pattern `0_i8` not covered
@@ -71,7 +71,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
-  --> $DIR/exhaustiveness.rs:59:8
+  --> $DIR/exhaustiveness.rs:60:8
    |
 LL |     m!(0u128, 0..=ALMOST_MAX);
    |        ^^^^^ pattern `u128::MAX` not covered
@@ -80,7 +80,7 @@ LL |     m!(0u128, 0..=ALMOST_MAX);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `5_u128..=u128::MAX` not covered
-  --> $DIR/exhaustiveness.rs:60:8
+  --> $DIR/exhaustiveness.rs:61:8
    |
 LL |     m!(0u128, 0..=4);
    |        ^^^^^ pattern `5_u128..=u128::MAX` not covered
@@ -89,7 +89,7 @@ LL |     m!(0u128, 0..=4);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
-  --> $DIR/exhaustiveness.rs:61:8
+  --> $DIR/exhaustiveness.rs:62:8
    |
 LL |     m!(0u128, 1..=u128::MAX);
    |        ^^^^^ pattern `0_u128` not covered
@@ -98,7 +98,7 @@ LL |     m!(0u128, 1..=u128::MAX);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `(126_u8..=127_u8, false)` not covered
-  --> $DIR/exhaustiveness.rs:69:11
+  --> $DIR/exhaustiveness.rs:70:11
    |
 LL |     match (0u8, true) {
    |           ^^^^^^^^^^^ pattern `(126_u8..=127_u8, false)` not covered

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
@@ -29,9 +29,9 @@ fn main() {
     m!(0u8, 20..=30, 25);
     m!(0u8, 20..=30, 30);
     m!(0u8, 20.. 30, 29);
-    m!(0u8, 20, 20..=30); //~ ERROR multiple patterns overlap on their endpoints
+    m!(0u8, 20, 20..=30);
     m!(0u8, 25, 20..=30);
-    m!(0u8, 30, 20..=30); //~ ERROR multiple patterns overlap on their endpoints
+    m!(0u8, 30, 20..=30);
 
     match 0u8 {
         0..=10 => {}

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
@@ -1,5 +1,5 @@
 #![feature(exclusive_range_pattern)]
-#![deny(overlapping_patterns)]
+#![deny(overlapping_range_endpoints)]
 
 macro_rules! m {
     ($s:expr, $t1:pat, $t2:pat) => {
@@ -12,31 +12,31 @@ macro_rules! m {
 }
 
 fn main() {
-    m!(0u8, 20..=30, 30..=40); //~ ERROR multiple patterns covering the same range
-    m!(0u8, 30..=40, 20..=30); //~ ERROR multiple patterns covering the same range
+    m!(0u8, 20..=30, 30..=40); //~ ERROR multiple patterns overlap on their endpoints
+    m!(0u8, 30..=40, 20..=30); //~ ERROR multiple patterns overlap on their endpoints
     m!(0u8, 20..=30, 31..=40);
     m!(0u8, 20..=30, 29..=40);
-    m!(0u8, 20.. 30, 29..=40); //~ ERROR multiple patterns covering the same range
+    m!(0u8, 20.. 30, 29..=40); //~ ERROR multiple patterns overlap on their endpoints
     m!(0u8, 20.. 30, 28..=40);
     m!(0u8, 20.. 30, 30..=40);
     m!(0u8, 20..=30, 30..=30);
-    m!(0u8, 20..=30, 30..=31); //~ ERROR multiple patterns covering the same range
+    m!(0u8, 20..=30, 30..=31); //~ ERROR multiple patterns overlap on their endpoints
     m!(0u8, 20..=30, 29..=30);
     m!(0u8, 20..=30, 20..=20);
     m!(0u8, 20..=30, 20..=21);
-    m!(0u8, 20..=30, 19..=20); //~ ERROR multiple patterns covering the same range
+    m!(0u8, 20..=30, 19..=20); //~ ERROR multiple patterns overlap on their endpoints
     m!(0u8, 20..=30, 20);
     m!(0u8, 20..=30, 25);
     m!(0u8, 20..=30, 30);
     m!(0u8, 20.. 30, 29);
-    m!(0u8, 20, 20..=30); //~ ERROR multiple patterns covering the same range
+    m!(0u8, 20, 20..=30); //~ ERROR multiple patterns overlap on their endpoints
     m!(0u8, 25, 20..=30);
-    m!(0u8, 30, 20..=30); //~ ERROR multiple patterns covering the same range
+    m!(0u8, 30, 20..=30); //~ ERROR multiple patterns overlap on their endpoints
 
     match 0u8 {
         0..=10 => {}
         20..=30 => {}
-        10..=20 => {} //~ ERROR multiple patterns covering the same range
+        10..=20 => {} //~ ERROR multiple patterns overlap on their endpoints
         _ => {}
     }
     match (0u8, true) {
@@ -47,13 +47,13 @@ fn main() {
     }
     match (true, 0u8) {
         (true, 0..=10) => {}
-        (true, 10..20) => {} //~ ERROR multiple patterns covering the same range
+        (true, 10..20) => {} //~ ERROR multiple patterns overlap on their endpoints
         (false, 10..20) => {}
         _ => {}
     }
     match Some(0u8) {
         Some(0..=10) => {}
-        Some(10..20) => {} //~ ERROR multiple patterns covering the same range
+        Some(10..20) => {} //~ ERROR multiple patterns overlap on their endpoints
         _ => {}
     }
 }

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.rs
@@ -33,6 +33,12 @@ fn main() {
     m!(0u8, 25, 20..=30);
     m!(0u8, 30, 20..=30); //~ ERROR multiple patterns covering the same range
 
+    match 0u8 {
+        0..=10 => {}
+        20..=30 => {}
+        10..=20 => {} //~ ERROR multiple patterns covering the same range
+        _ => {}
+    }
     match (0u8, true) {
         (0..=10, true) => {}
         (10..20, true) => {} // not detected

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(overlapping_range_endpoints)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:16:22
@@ -21,7 +21,7 @@ LL |     m!(0u8, 30..=40, 20..=30);
    |             |
    |             this range overlaps on `30_u8`...
    |
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:19:22
@@ -31,7 +31,7 @@ LL |     m!(0u8, 20.. 30, 29..=40);
    |             |
    |             this range overlaps on `29_u8`...
    |
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:23:22
@@ -41,7 +41,7 @@ LL |     m!(0u8, 20..=30, 30..=31);
    |             |
    |             this range overlaps on `30_u8`...
    |
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:27:22
@@ -51,7 +51,7 @@ LL |     m!(0u8, 20..=30, 19..=20);
    |             |
    |             this range overlaps on `20_u8`...
    |
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:39:9
@@ -63,7 +63,7 @@ LL |         20..=30 => {}
 LL |         10..=20 => {}
    |         ^^^^^^^ ... with this range
    |
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:50:16
@@ -73,7 +73,7 @@ LL |         (true, 0..=10) => {}
 LL |         (true, 10..20) => {}
    |                ^^^^^^ ... with this range
    |
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:56:14
@@ -83,7 +83,7 @@ LL |         Some(0..=10) => {}
 LL |         Some(10..20) => {}
    |              ^^^^^^ ... with this range
    |
-   = note: this is likely to be a mistake
+   = note: you likely meant to write mutually exclusive ranges
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
@@ -45,22 +45,6 @@ LL |     m!(0u8, 20..=30, 19..=20);
    |             this range overlaps on `20_u8`
 
 error: multiple patterns overlap on their endpoints
-  --> $DIR/overlapping_range_endpoints.rs:32:17
-   |
-LL |     m!(0u8, 20, 20..=30);
-   |             --  ^^^^^^^ overlapping range endpoints
-   |             |
-   |             this range overlaps on `20_u8`
-
-error: multiple patterns overlap on their endpoints
-  --> $DIR/overlapping_range_endpoints.rs:34:17
-   |
-LL |     m!(0u8, 30, 20..=30);
-   |             --  ^^^^^^^ overlapping range endpoints
-   |             |
-   |             this range overlaps on `30_u8`
-
-error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:39:9
    |
 LL |         0..=10 => {}
@@ -86,5 +70,5 @@ LL |         Some(0..=10) => {}
 LL |         Some(10..20) => {}
    |              ^^^^^^ overlapping range endpoints
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
@@ -61,7 +61,17 @@ LL |     m!(0u8, 30, 20..=30);
    |             this range overlaps on `30_u8`
 
 error: multiple patterns covering the same range
-  --> $DIR/overlapping_range_endpoints.rs:44:16
+  --> $DIR/overlapping_range_endpoints.rs:39:9
+   |
+LL |         0..=10 => {}
+   |         ------ this range overlaps on `10_u8`
+LL |         20..=30 => {}
+   |         ------- this range overlaps on `20_u8`
+LL |         10..=20 => {}
+   |         ^^^^^^^ overlapping patterns
+
+error: multiple patterns covering the same range
+  --> $DIR/overlapping_range_endpoints.rs:50:16
    |
 LL |         (true, 0..=10) => {}
    |                ------ this range overlaps on `10_u8`
@@ -69,12 +79,12 @@ LL |         (true, 10..20) => {}
    |                ^^^^^^ overlapping patterns
 
 error: multiple patterns covering the same range
-  --> $DIR/overlapping_range_endpoints.rs:50:14
+  --> $DIR/overlapping_range_endpoints.rs:56:14
    |
 LL |         Some(0..=10) => {}
    |              ------ this range overlaps on `10_u8`
 LL |         Some(10..20) => {}
    |              ^^^^^^ overlapping patterns
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
@@ -2,73 +2,88 @@ error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:15:22
    |
 LL |     m!(0u8, 20..=30, 30..=40);
-   |             -------  ^^^^^^^ overlapping range endpoints
+   |             -------  ^^^^^^^ ... with this range
    |             |
-   |             this range overlaps on `30_u8`
+   |             this range overlaps on `30_u8`...
    |
 note: the lint level is defined here
   --> $DIR/overlapping_range_endpoints.rs:2:9
    |
 LL | #![deny(overlapping_range_endpoints)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this is likely to be a mistake
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:16:22
    |
 LL |     m!(0u8, 30..=40, 20..=30);
-   |             -------  ^^^^^^^ overlapping range endpoints
+   |             -------  ^^^^^^^ ... with this range
    |             |
-   |             this range overlaps on `30_u8`
+   |             this range overlaps on `30_u8`...
+   |
+   = note: this is likely to be a mistake
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:19:22
    |
 LL |     m!(0u8, 20.. 30, 29..=40);
-   |             -------  ^^^^^^^ overlapping range endpoints
+   |             -------  ^^^^^^^ ... with this range
    |             |
-   |             this range overlaps on `29_u8`
+   |             this range overlaps on `29_u8`...
+   |
+   = note: this is likely to be a mistake
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:23:22
    |
 LL |     m!(0u8, 20..=30, 30..=31);
-   |             -------  ^^^^^^^ overlapping range endpoints
+   |             -------  ^^^^^^^ ... with this range
    |             |
-   |             this range overlaps on `30_u8`
+   |             this range overlaps on `30_u8`...
+   |
+   = note: this is likely to be a mistake
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:27:22
    |
 LL |     m!(0u8, 20..=30, 19..=20);
-   |             -------  ^^^^^^^ overlapping range endpoints
+   |             -------  ^^^^^^^ ... with this range
    |             |
-   |             this range overlaps on `20_u8`
+   |             this range overlaps on `20_u8`...
+   |
+   = note: this is likely to be a mistake
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:39:9
    |
 LL |         0..=10 => {}
-   |         ------ this range overlaps on `10_u8`
+   |         ------ this range overlaps on `10_u8`...
 LL |         20..=30 => {}
-   |         ------- this range overlaps on `20_u8`
+   |         ------- this range overlaps on `20_u8`...
 LL |         10..=20 => {}
-   |         ^^^^^^^ overlapping range endpoints
+   |         ^^^^^^^ ... with this range
+   |
+   = note: this is likely to be a mistake
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:50:16
    |
 LL |         (true, 0..=10) => {}
-   |                ------ this range overlaps on `10_u8`
+   |                ------ this range overlaps on `10_u8`...
 LL |         (true, 10..20) => {}
-   |                ^^^^^^ overlapping range endpoints
+   |                ^^^^^^ ... with this range
+   |
+   = note: this is likely to be a mistake
 
 error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:56:14
    |
 LL |         Some(0..=10) => {}
-   |              ------ this range overlaps on `10_u8`
+   |              ------ this range overlaps on `10_u8`...
 LL |         Some(10..20) => {}
-   |              ^^^^^^ overlapping range endpoints
+   |              ^^^^^^ ... with this range
+   |
+   = note: this is likely to be a mistake
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/overlapping_range_endpoints.stderr
@@ -1,66 +1,66 @@
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:15:22
    |
 LL |     m!(0u8, 20..=30, 30..=40);
-   |             -------  ^^^^^^^ overlapping patterns
+   |             -------  ^^^^^^^ overlapping range endpoints
    |             |
    |             this range overlaps on `30_u8`
    |
 note: the lint level is defined here
   --> $DIR/overlapping_range_endpoints.rs:2:9
    |
-LL | #![deny(overlapping_patterns)]
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL | #![deny(overlapping_range_endpoints)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:16:22
    |
 LL |     m!(0u8, 30..=40, 20..=30);
-   |             -------  ^^^^^^^ overlapping patterns
+   |             -------  ^^^^^^^ overlapping range endpoints
    |             |
    |             this range overlaps on `30_u8`
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:19:22
    |
 LL |     m!(0u8, 20.. 30, 29..=40);
-   |             -------  ^^^^^^^ overlapping patterns
+   |             -------  ^^^^^^^ overlapping range endpoints
    |             |
    |             this range overlaps on `29_u8`
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:23:22
    |
 LL |     m!(0u8, 20..=30, 30..=31);
-   |             -------  ^^^^^^^ overlapping patterns
+   |             -------  ^^^^^^^ overlapping range endpoints
    |             |
    |             this range overlaps on `30_u8`
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:27:22
    |
 LL |     m!(0u8, 20..=30, 19..=20);
-   |             -------  ^^^^^^^ overlapping patterns
+   |             -------  ^^^^^^^ overlapping range endpoints
    |             |
    |             this range overlaps on `20_u8`
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:32:17
    |
 LL |     m!(0u8, 20, 20..=30);
-   |             --  ^^^^^^^ overlapping patterns
+   |             --  ^^^^^^^ overlapping range endpoints
    |             |
    |             this range overlaps on `20_u8`
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:34:17
    |
 LL |     m!(0u8, 30, 20..=30);
-   |             --  ^^^^^^^ overlapping patterns
+   |             --  ^^^^^^^ overlapping range endpoints
    |             |
    |             this range overlaps on `30_u8`
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:39:9
    |
 LL |         0..=10 => {}
@@ -68,23 +68,23 @@ LL |         0..=10 => {}
 LL |         20..=30 => {}
    |         ------- this range overlaps on `20_u8`
 LL |         10..=20 => {}
-   |         ^^^^^^^ overlapping patterns
+   |         ^^^^^^^ overlapping range endpoints
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:50:16
    |
 LL |         (true, 0..=10) => {}
    |                ------ this range overlaps on `10_u8`
 LL |         (true, 10..20) => {}
-   |                ^^^^^^ overlapping patterns
+   |                ^^^^^^ overlapping range endpoints
 
-error: multiple patterns covering the same range
+error: multiple patterns overlap on their endpoints
   --> $DIR/overlapping_range_endpoints.rs:56:14
    |
 LL |         Some(0..=10) => {}
    |              ------ this range overlaps on `10_u8`
 LL |         Some(10..20) => {}
-   |              ^^^^^^ overlapping patterns
+   |              ^^^^^^ overlapping range endpoints
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/reachability.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/reachability.rs
@@ -1,4 +1,5 @@
 #![feature(exclusive_range_pattern)]
+#![allow(overlapping_range_endpoints)]
 #![deny(unreachable_patterns)]
 
 macro_rules! m {

--- a/src/test/ui/pattern/usefulness/integer-ranges/reachability.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/reachability.stderr
@@ -1,149 +1,149 @@
 error: unreachable pattern
-  --> $DIR/reachability.rs:16:17
+  --> $DIR/reachability.rs:17:17
    |
 LL |     m!(0u8, 42, 42);
    |                 ^^
    |
 note: the lint level is defined here
-  --> $DIR/reachability.rs:2:9
+  --> $DIR/reachability.rs:3:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:20:22
+  --> $DIR/reachability.rs:21:22
    |
 LL |     m!(0u8, 20..=30, 20);
    |                      ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:21:22
+  --> $DIR/reachability.rs:22:22
    |
 LL |     m!(0u8, 20..=30, 21);
    |                      ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:22:22
+  --> $DIR/reachability.rs:23:22
    |
 LL |     m!(0u8, 20..=30, 25);
    |                      ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:23:22
+  --> $DIR/reachability.rs:24:22
    |
 LL |     m!(0u8, 20..=30, 29);
    |                      ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:24:22
+  --> $DIR/reachability.rs:25:22
    |
 LL |     m!(0u8, 20..=30, 30);
    |                      ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:27:21
+  --> $DIR/reachability.rs:28:21
    |
 LL |     m!(0u8, 20..30, 20);
    |                     ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:28:21
+  --> $DIR/reachability.rs:29:21
    |
 LL |     m!(0u8, 20..30, 21);
    |                     ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:29:21
+  --> $DIR/reachability.rs:30:21
    |
 LL |     m!(0u8, 20..30, 25);
    |                     ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:30:21
+  --> $DIR/reachability.rs:31:21
    |
 LL |     m!(0u8, 20..30, 29);
    |                     ^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:34:22
+  --> $DIR/reachability.rs:35:22
    |
 LL |     m!(0u8, 20..=30, 20..=30);
    |                      ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:35:22
+  --> $DIR/reachability.rs:36:22
    |
 LL |     m!(0u8, 20.. 30, 20.. 30);
    |                      ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:36:22
+  --> $DIR/reachability.rs:37:22
    |
 LL |     m!(0u8, 20..=30, 20.. 30);
    |                      ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:38:22
+  --> $DIR/reachability.rs:39:22
    |
 LL |     m!(0u8, 20..=30, 21..=30);
    |                      ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:39:22
+  --> $DIR/reachability.rs:40:22
    |
 LL |     m!(0u8, 20..=30, 20..=29);
    |                      ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:41:24
+  --> $DIR/reachability.rs:42:24
    |
 LL |     m!('a', 'A'..='z', 'a'..='z');
    |                        ^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:48:9
+  --> $DIR/reachability.rs:49:9
    |
 LL |         5..=8 => {},
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:54:9
+  --> $DIR/reachability.rs:55:9
    |
 LL |         5..15 => {},
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:61:9
+  --> $DIR/reachability.rs:62:9
    |
 LL |         5..25 => {},
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:69:9
+  --> $DIR/reachability.rs:70:9
    |
 LL |         5..25 => {},
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:75:9
+  --> $DIR/reachability.rs:76:9
    |
 LL |         5..15 => {},
    |         ^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:82:9
+  --> $DIR/reachability.rs:83:9
    |
 LL |         '\u{D7FF}'..='\u{E000}' => {},
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:103:9
+  --> $DIR/reachability.rs:104:9
    |
 LL |         &FOO => {}
    |         ^^^^
 
 error: unreachable pattern
-  --> $DIR/reachability.rs:104:9
+  --> $DIR/reachability.rs:105:9
    |
 LL |         BAR => {}
    |         ^^^


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/issues/65477. I also tweaked a few things along the way.

r? @varkor 
@rustbot modify labels: +A-exhaustiveness-checking