### PR TITLE
--test-args flag description

### DIFF
--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -232,7 +232,13 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
         match subcommand.as_str() {
             "test" | "t" => {
                 opts.optflag("", "no-fail-fast", "Run all tests regardless of failure");
-                opts.optmulti("", "test-args", "extra arguments", "ARGS");
+                opts.optmulti(
+                    "",
+                    "test-args",
+                    "extra arguments to be passed for the test tool being used \
+                        (e.g. libtest, compiletest or rustdoc)",
+                    "ARGS",
+                );
                 opts.optmulti(
                     "",
                     "rustc-args",


### PR DESCRIPTION
tiny enhancement/clarification for the help description of the `--test-args` option from `x.py test` subcommand.

Edit: ...as discussed in zulip [here](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/x.2Epy.20run.20single.20unit.20test.3F/near/214107842)