### PR TITLE
Reduce diagram mess in 'match arms have incompatible types' error

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -343,6 +343,7 @@ static_assert_size!(ObligationCauseCode<'_>, 32);
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Lift)]
 pub struct MatchExpressionArmCause<'tcx> {
     pub arm_span: Span,
+    pub scrut_span: Span,
     pub semi_span: Option<Span>,
     pub source: hir::MatchSource,
     pub prior_arms: Vec<Span>,

--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -201,6 +201,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         expr.span,
                         ObligationCauseCode::MatchExpressionArm(box MatchExpressionArmCause {
                             arm_span,
+                            scrut_span: scrut.span,
                             semi_span,
                             source: match_src,
                             prior_arms: other_arms.clone(),

--- a/src/test/ui/match/match-incompat-type-semi.rs
+++ b/src/test/ui/match/match-incompat-type-semi.rs
@@ -39,4 +39,14 @@ fn main() {
         None => { //~ ERROR incompatible types
         },
     };
+
+    let _ = match Some(42) {
+        Some(x) => "rust-lang.org"
+            .chars()
+            .skip(1)
+            .chain(Some(x as u8 as char))
+            .take(10)
+            .any(char::is_alphanumeric),
+        None => {} //~ ERROR incompatible types
+    };
 }

--- a/src/test/ui/match/match-incompat-type-semi.stderr
+++ b/src/test/ui/match/match-incompat-type-semi.stderr
@@ -69,6 +69,24 @@ LL | ||         },
 LL |  |     };
    |  |_____- `match` arms have incompatible types
 
-error: aborting due to 4 previous errors
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/match-incompat-type-semi.rs:50:17
+   |
+LL |        let _ = match Some(42) {
+   |   _____________-
+LL |  |         Some(x) => "rust-lang.org"
+   |  |____________________-
+LL | ||             .chars()
+LL | ||             .skip(1)
+LL | ||             .chain(Some(x as u8 as char))
+LL | ||             .take(10)
+LL | ||             .any(char::is_alphanumeric),
+   | ||_______________________________________- this is found to be of type `bool`
+LL |  |         None => {}
+   |  |                 ^^ expected `bool`, found `()`
+LL |  |     };
+   |  |_____- `match` arms have incompatible types
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/match/match-incompat-type-semi.stderr
+++ b/src/test/ui/match/match-incompat-type-semi.stderr
@@ -56,36 +56,32 @@ LL | |     };
 error[E0308]: `match` arms have incompatible types
   --> $DIR/match-incompat-type-semi.rs:39:17
    |
-LL |        let _ = match Some(42) {
-   |   _____________-
-LL |  |         Some(x) => {
-LL |  |             x
-   |  |             - this is found to be of type `{integer}`
-LL |  |         },
-LL |  |         None => {
-   |  |_________________^
-LL | ||         },
-   | ||_________^ expected integer, found `()`
-LL |  |     };
-   |  |_____- `match` arms have incompatible types
+LL |       let _ = match Some(42) {
+   |               -------------- `match` arms have incompatible types
+LL |           Some(x) => {
+LL |               x
+   |               - this is found to be of type `{integer}`
+LL |           },
+LL |           None => {
+   |  _________________^
+LL | |         },
+   | |_________^ expected integer, found `()`
 
 error[E0308]: `match` arms have incompatible types
   --> $DIR/match-incompat-type-semi.rs:50:17
    |
-LL |        let _ = match Some(42) {
-   |   _____________-
-LL |  |         Some(x) => "rust-lang.org"
-   |  |____________________-
-LL | ||             .chars()
-LL | ||             .skip(1)
-LL | ||             .chain(Some(x as u8 as char))
-LL | ||             .take(10)
-LL | ||             .any(char::is_alphanumeric),
-   | ||_______________________________________- this is found to be of type `bool`
-LL |  |         None => {}
-   |  |                 ^^ expected `bool`, found `()`
-LL |  |     };
-   |  |_____- `match` arms have incompatible types
+LL |       let _ = match Some(42) {
+   |               -------------- `match` arms have incompatible types
+LL |           Some(x) => "rust-lang.org"
+   |  ____________________-
+LL | |             .chars()
+LL | |             .skip(1)
+LL | |             .chain(Some(x as u8 as char))
+LL | |             .take(10)
+LL | |             .any(char::is_alphanumeric),
+   | |_______________________________________- this is found to be of type `bool`
+LL |           None => {}
+   |                   ^^ expected `bool`, found `()`
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
I noticed this wild diagram in https://twitter.com/a_hoverbear/status/1318960787105353728 which I think does not benefit from the big outer vertical span.

This PR shrinks the outer span to cover just the `match` keyword and scrutinee expression *if* at least one of the highlighted match arms involved in the error is multiline.

**Before:**

<pre>
<b>error[E0308]: `match` arms have incompatible types</b>
   <b>--&gt;</b> src/topology/builder.rs:141:35
    <b>|</b>
<b>120 |</b>             let transform = match transform {
    <b>|    _________________________-</b>
<b>121 |   |</b>             Transform::Function(t) =&gt; {
    <b>|  _|_______________________________________-</b>
<b>122 | | |</b>                 filter_event_type(input_rx, input_type).compat().flat_map(|v| {
<b>123 | | |</b>                     futures::stream::iter(match v {
<b>124 | | |</b>                         Err(e) =&gt; {
<b>...   | |</b>
<b>139 | | |</b>                 .compat();
<b>140 | | |</b>             }
    <b>| |_|_____________- this is found to be of type `()`</b>
<b>141 |   |</b>             Transform::Task(t) =&gt; t
    <b>|  _|___________________________________^</b>
<b>142 | | |</b>                 .transform(filter_event_type(input_rx, input_type))
<b>143 | | |</b>                 .forward(output)
<b>144 | | |</b>                 .map(|_| debug!("Finished"))
<b>145 | | |</b>                 .compat(),
    <b>| |_|_________________________^ expected `()`, found struct `futures::compat::Compat01As03`</b>
<b>146 |   |</b>         };
    <b>|   |_________- `match` arms have incompatible types</b>
    <b>|</b>
    <b>= note:</b> expected type `<b>()</b>`
             found struct `<b>futures::compat::Compat01As03&lt;futures::Map&lt;futures::stream::Forward&lt;std::boxed::Box&lt;dyn futures::Stream&lt;Error = (), Item = event::Event&gt; + std::marker::Send&gt;, topology::fanout::Fanout&gt;, [closure@src/topology/builder.rs:144:22: 144:44]&gt;&gt;</b>`
</pre>

**After:**

<pre>
<b>error[E0308]: `match` arms have incompatible types</b>
   <b>--&gt;</b> src/topology/builder.rs:141:35
    <b>|</b>
<b>120 |</b>             let transform = match transform {
    <b>|                             --------------- `match` arms have incompatible types</b>
<b>121 |</b>                 Transform::Function(t) =&gt; {
    <b>|  _________________________________________-</b>
<b>122 | |</b>                   filter_event_type(input_rx, input_type).compat().flat_map(|v| {
<b>123 | |</b>                       futures::stream::iter(match v {
<b>124 | |</b>                           Err(e) =&gt; {
<b>...   |</b>
<b>139 | |</b>                   .compat();
<b>140 | |</b>               }
    <b>| |_______________- this is found to be of type `()`</b>
<b>141 |</b>                 Transform::Task(t) =&gt; t
    <b>|  _____________________________________^</b>
<b>142 | |</b>                   .transform(filter_event_type(input_rx, input_type))
<b>143 | |</b>                   .forward(output)
<b>144 | |</b>                   .map(|_| debug!("Finished"))
<b>145 | |</b>                   .compat(),
    <b>| |___________________________^ expected `()`, found struct `futures::compat::Compat01As03`</b>
    <b>|</b>
    <b>= note:</b> expected type `<b>()</b>`
             found struct `<b>futures::compat::Compat01As03&lt;futures::Map&lt;futures::stream::Forward&lt;std::boxed::Box&lt;dyn futures::Stream&lt;Error = (), Item = event::Event&gt; + std::marker::Send&gt;, topology::fanout::Fanout&gt;, [closure@src/topology/builder.rs:144:22: 144:44]&gt;&gt;</b>`
</pre>

FYI @Hoverbear 