### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -175,19 +175,15 @@ impl<'tcx> UnifyKey for ty::ConstVid<'tcx> {
 impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
     type Error = (&'tcx ty::Const<'tcx>, &'tcx ty::Const<'tcx>);
 
-    fn unify_values(value1: &Self, value2: &Self) -> Result<Self, Self::Error> {
-        let (val, origin) = match (value1.val, value2.val) {
+    fn unify_values(&value1: &Self, &value2: &Self) -> Result<Self, Self::Error> {
+        Ok(match (value1.val, value2.val) {
             (ConstVariableValue::Known { .. }, ConstVariableValue::Known { .. }) => {
                 bug!("equating two const variables, both of which have known values")
             }
 
             // If one side is known, prefer that one.
-            (ConstVariableValue::Known { .. }, ConstVariableValue::Unknown { .. }) => {
-                (value1.val, value1.origin)
-            }
-            (ConstVariableValue::Unknown { .. }, ConstVariableValue::Known { .. }) => {
-                (value2.val, value2.origin)
-            }
+            (ConstVariableValue::Known { .. }, ConstVariableValue::Unknown { .. }) => value1,
+            (ConstVariableValue::Unknown { .. }, ConstVariableValue::Known { .. }) => value2,
 
             // If both sides are *unknown*, it hardly matters, does it?
             (
@@ -200,11 +196,12 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
                 // universe is the minimum of the two universes, because that is
                 // the one which contains the fewest names in scope.
                 let universe = cmp::min(universe1, universe2);
-                (ConstVariableValue::Unknown { universe }, value1.origin)
+                ConstVarValue {
+                    val: ConstVariableValue::Unknown { universe },
+                    origin: value1.origin,
+                }
             }
-        };
-
-        Ok(ConstVarValue { origin, val })
+        })
     }
 }
 

--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -176,17 +176,17 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
     type Error = (&'tcx ty::Const<'tcx>, &'tcx ty::Const<'tcx>);
 
     fn unify_values(value1: &Self, value2: &Self) -> Result<Self, Self::Error> {
-        let (val, span) = match (value1.val, value2.val) {
+        let (val, origin) = match (value1.val, value2.val) {
             (ConstVariableValue::Known { .. }, ConstVariableValue::Known { .. }) => {
                 bug!("equating two const variables, both of which have known values")
             }
 
             // If one side is known, prefer that one.
             (ConstVariableValue::Known { .. }, ConstVariableValue::Unknown { .. }) => {
-                (value1.val, value1.origin.span)
+                (value1.val, value1.origin)
             }
             (ConstVariableValue::Unknown { .. }, ConstVariableValue::Known { .. }) => {
-                (value2.val, value2.origin.span)
+                (value2.val, value2.origin)
             }
 
             // If both sides are *unknown*, it hardly matters, does it?
@@ -200,17 +200,11 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
                 // universe is the minimum of the two universes, because that is
                 // the one which contains the fewest names in scope.
                 let universe = cmp::min(universe1, universe2);
-                (ConstVariableValue::Unknown { universe }, value1.origin.span)
+                (ConstVariableValue::Unknown { universe }, value1.origin)
             }
         };
 
-        Ok(ConstVarValue {
-            origin: ConstVariableOrigin {
-                kind: ConstVariableOriginKind::ConstInference,
-                span: span,
-            },
-            val,
-        })
+        Ok(ConstVarValue { origin, val })
     }
 }
 

--- a/compiler/rustc_mir/src/transform/simplify_branches.rs
+++ b/compiler/rustc_mir/src/transform/simplify_branches.rs
@@ -49,9 +49,10 @@ impl<'tcx> MirPass<'tcx> for SimplifyBranches {
                 }
                 TerminatorKind::Assert {
                     target, cond: Operand::Constant(ref c), expected, ..
-                } if (c.literal.try_eval_bool(tcx, param_env) == Some(true)) == expected => {
-                    TerminatorKind::Goto { target }
-                }
+                } => match c.literal.try_eval_bool(tcx, param_env) {
+                    Some(v) if v == expected => TerminatorKind::Goto { target },
+                    _ => continue,
+                },
                 TerminatorKind::FalseEdge { real_target, .. } => {
                     TerminatorKind::Goto { target: real_target }
                 }

--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -34,6 +34,7 @@ fn link_env_remove(arch: Arch) -> Vec<String> {
 pub fn opts(arch: Arch) -> TargetOptions {
     TargetOptions {
         cpu: target_cpu(arch),
+        dynamic_linking: false,
         executables: true,
         link_env_remove: link_env_remove(arch),
         has_elf_tls: false,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -562,10 +562,6 @@ impl<T> Option<T> {
         }
     }
 
-    /////////////////////////////////////////////////////////////////////////
-    // Setting a new value
-    /////////////////////////////////////////////////////////////////////////
-
     /// Inserts `value` into the option then returns a mutable reference to it.
     ///
     /// If the option already contains a value, the old value is dropped.

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -574,17 +574,22 @@ impl<T> Option<T> {
     /// ```
     /// #![feature(option_insert)]
     ///
-    /// let mut o = None;
-    /// let v = o.insert(3);
-    /// assert_eq!(*v, 3);
+    /// let mut opt = None;
+    /// let val = opt.insert(1);
+    /// assert_eq!(*val, 1);
+    /// assert_eq!(opt.unwrap(), 1);
+    /// let val = opt.insert(2);
+    /// assert_eq!(*val, 2);
+    /// *val = 3;
+    /// assert_eq!(opt.unwrap(), 3);
     /// ```
     #[inline]
-    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
-    pub fn insert(&mut self, v: T) -> &mut T {
-        *self = Some(v);
+    #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
+    pub fn insert(&mut self, val: T) -> &mut T {
+        *self = Some(val);
 
-        match *self {
-            Some(ref mut v) => v,
+        match self {
+            Some(v) => v,
             // SAFETY: the code above just filled the option
             None => unsafe { hint::unreachable_unchecked() },
         }
@@ -839,8 +844,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    pub fn get_or_insert(&mut self, v: T) -> &mut T {
-        self.get_or_insert_with(|| v)
+    pub fn get_or_insert(&mut self, val: T) -> &mut T {
+        self.get_or_insert_with(|| val)
     }
 
     /// Inserts a value computed from `f` into the option if it is [`None`], then
@@ -867,8 +872,8 @@ impl<T> Option<T> {
             *self = Some(f());
         }
 
-        match *self {
-            Some(ref mut v) => v,
+        match self {
+            Some(v) => v,
             // SAFETY: a `None` variant for `self` would have been replaced by a `Some`
             // variant in the code above.
             None => unsafe { hint::unreachable_unchecked() },

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -568,6 +568,8 @@ impl<T> Option<T> {
 
     /// Inserts `value` into the option then returns a mutable reference to it.
     ///
+    /// If the option already contains a value, the old value is dropped.
+    ///
     /// # Example
     ///
     /// ```

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -563,6 +563,52 @@ impl<T> Option<T> {
     }
 
     /////////////////////////////////////////////////////////////////////////
+    // Setting a new value
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Inserts `v` into the option then returns a mutable reference
+    /// to the contained value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(option_insert)]
+    ///
+    /// let mut o = None;
+    /// let v = o.insert(3);
+    /// assert_eq!(*v, 3);
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
+    pub fn insert(&mut self, v: T) -> &mut T {
+        self.insert_with(|| v)
+    }
+
+    /// Inserts a value computed from `f` into the option, then returns a
+    /// mutable reference to the contained value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(option_insert)]
+    ///
+    /// let mut o = None;
+    /// let v = o.insert_with(|| 3);
+    /// assert_eq!(*v, 3);
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
+    pub fn insert_with<F: FnOnce() -> T>(&mut self, f: F) -> &mut T {
+        *self = Some(f());
+
+        match *self {
+            Some(ref mut v) => v,
+            // SAFETY: the code above just filled the option
+            None => unsafe { hint::unreachable_unchecked() },
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
     // Iterator constructors
     /////////////////////////////////////////////////////////////////////////
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -581,25 +581,7 @@ impl<T> Option<T> {
     #[inline]
     #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
     pub fn insert(&mut self, v: T) -> &mut T {
-        self.insert_with(|| v)
-    }
-
-    /// Inserts a value computed from `f` into the option, then returns a
-    /// mutable reference to the contained value.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// #![feature(option_insert)]
-    ///
-    /// let mut o = None;
-    /// let v = o.insert_with(|| 3);
-    /// assert_eq!(*v, 3);
-    /// ```
-    #[inline]
-    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
-    pub fn insert_with<F: FnOnce() -> T>(&mut self, f: F) -> &mut T {
-        *self = Some(f());
+        *self = Some(v);
 
         match *self {
             Some(ref mut v) => v,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -566,8 +566,7 @@ impl<T> Option<T> {
     // Setting a new value
     /////////////////////////////////////////////////////////////////////////
 
-    /// Inserts `v` into the option then returns a mutable reference
-    /// to the contained value.
+    /// Inserts `value` into the option then returns a mutable reference to it.
     ///
     /// # Example
     ///
@@ -585,8 +584,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
-    pub fn insert(&mut self, val: T) -> &mut T {
-        *self = Some(val);
+    pub fn insert(&mut self, value: T) -> &mut T {
+        *self = Some(value);
 
         match self {
             Some(v) => v,
@@ -825,7 +824,7 @@ impl<T> Option<T> {
     // Entry-like operations to insert if None and return a reference
     /////////////////////////////////////////////////////////////////////////
 
-    /// Inserts `v` into the option if it is [`None`], then
+    /// Inserts `value` into the option if it is [`None`], then
     /// returns a mutable reference to the contained value.
     ///
     /// # Examples
@@ -844,12 +843,12 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    pub fn get_or_insert(&mut self, val: T) -> &mut T {
-        self.get_or_insert_with(|| val)
+    pub fn get_or_insert(&mut self, value: T) -> &mut T {
+        self.get_or_insert_with(|| value)
     }
 
-    /// Inserts a value computed from `f` into the option if it is [`None`], then
-    /// returns a mutable reference to the contained value.
+    /// Inserts a value computed from `f` into the option if it is [`None`],
+    /// then returns a mutable reference to the contained value.
     ///
     /// # Examples
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -581,7 +581,7 @@ impl<T> Option<T> {
     /// assert_eq!(opt.unwrap(), 3);
     /// ```
     #[inline]
-    #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
+    #[unstable(feature = "option_insert", reason = "newly added", issue = "78271")]
     pub fn insert(&mut self, value: T) -> &mut T {
         *self = Some(value);
 

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -346,7 +346,7 @@ mod else_keyword {}
 /// When data follows along with a variant, such as with rust's built-in [`Option`] type, the data
 /// is added as the type describes, for example `Option::Some(123)`. The same follows with
 /// struct-like variants, with things looking like `ComplexEnum::LotsOfThings { usual_struct_stuff:
-/// true, blah: "hello!".to_string(), }`. Empty Enums are similar to () in that they cannot be
+/// true, blah: "hello!".to_string(), }`. Empty Enums are similar to [`!`] in that they cannot be
 /// instantiated at all, and are used mainly to mess with the type system in interesting ways.
 ///
 /// For more information, take a look at the [Rust Book] or the [Reference]
@@ -354,6 +354,7 @@ mod else_keyword {}
 /// [ADT]: https://en.wikipedia.org/wiki/Algebraic_data_type
 /// [Rust Book]: ../book/ch06-01-defining-an-enum.html
 /// [Reference]: ../reference/items/enumerations.html
+/// [`!`]: primitive.never.html
 mod enum_keyword {}
 
 #[doc(keyword = "extern")]

--- a/src/test/ui/const-generics/infer/issue-77092.stderr
+++ b/src/test/ui/const-generics/infer/issue-77092.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-77092.rs:13:26
    |
 LL |         println!("{:?}", take_array_from_mut(&mut arr, i));
-   |                          ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `{_: usize}`
+   |                          ^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `take_array_from_mut`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/issue-77475.rs
+++ b/src/test/ui/macros/issue-77475.rs
@@ -1,0 +1,10 @@
+// check-pass
+// Regression test of #77475, this used to be ICE.
+
+#![feature(decl_macro)]
+
+use crate as _;
+
+pub macro ice(){}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #77268 (Link to "Contributing to Rust" rather than "Getting Started".)
 - #77392 (add `insert` to `Option`)
 - #77716 (Revert "Allow dynamic linking for iOS/tvOS targets.")
 - #77918 (Cleanup network tests)
 - #77920 (Avoid extraneous space between visibility kw and ident for statics)
 - #77969 (Doc formating consistency between slice sort and sort_unstable, and big O notation consistency)
 - #78098 (Clean up and improve some docs)
 - #78153 (Sync LLVM submodule if it has been initialized)
 - #78163 (Clean up lib docs)
 - #78169 (Update cargo)
 - #78198 (Simplify assert terminator only if condition evaluates to expected value)
 - #78249 (improve const infer error)
 - #78255 (Reduce diagram mess in 'match arms have incompatible types' error)
 - #78264 (Add regression test for issue-77475)
 - #78274 (Update description of Empty Enum for accuracy)

Failed merges:


r? @ghost