### PR TITLE
make `super_relate_consts` use trait objects

### DIFF
--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -564,10 +564,10 @@ impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
             // Avoid fetching the variance if we are in an invariant
             // context; no need, and it can induce dependency cycles
             // (e.g., #41849).
-            relate::relate_substs(self, None, a_subst, b_subst)
+            self.relate_substs(None, a_subst, b_subst)
         } else {
             let opt_variances = self.tcx().variances_of(item_def_id);
-            relate::relate_substs(self, Some(&opt_variances), a_subst, b_subst)
+            self.relate_substs(Some(&opt_variances), a_subst, b_subst)
         }
     }
 

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -52,8 +52,7 @@ impl TypeRelation<'tcx> for Equate<'combine, 'infcx, 'tcx> {
         // variance requires computing types which can require
         // performing trait matching (which then performs equality
         // unification).
-
-        relate::relate_substs(self, None, a_subst, b_subst)
+        self.relate_substs(None, a_subst, b_subst)
     }
 
     fn relate_with_variance<T: Relate<'tcx>>(

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -1,7 +1,7 @@
 use super::combine::{CombineFields, ConstEquateRelation, RelationDir};
 use super::Subtype;
 
-use rustc_middle::ty::relate::{self, Relate, RelateResult, TypeRelation};
+use rustc_middle::ty::relate::{Relate, RelateResult, TypeRelation};
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::TyVar;
 use rustc_middle::ty::{self, Ty, TyCtxt};


### PR DESCRIPTION
`super_relate_consts` generates quite a lot of llvm-ir considering that it is still fairly rarely used, so let's try using trait objects for that.
