### PR TITLE
Always store Rustdoc theme when it's changed

### DIFF
--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -94,6 +94,12 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
     var fullNewTheme = newTheme + resourcesSuffix + ".css";
     var newHref = mainStyleElem.href.replace(fullBasicCss, fullNewTheme);
 
+    // If this new value comes from a system setting or from the previously
+    // saved theme, no need to save it.
+    if (saveTheme === true) {
+        updateLocalStorage("rustdoc-theme", newTheme);
+    }
+
     if (styleElem.href === newHref) {
         return;
     }
@@ -112,11 +118,6 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
     });
     if (found === true) {
         styleElem.href = newHref;
-        // If this new value comes from a system setting or from the previously
-        // saved theme, no need to save it.
-        if (saveTheme === true) {
-            updateLocalStorage("rustdoc-theme", newTheme);
-        }
     }
 }
 


### PR DESCRIPTION
`switchTheme` (too) lazily updated the value of `rustdoc-theme` in `localStorage`, leading to an incorrect stored value when the system theme is the same as the default (`light`) theme.

Fixes #78273