### PR TITLE
Make the `hermit` target typecheck

### DIFF
--- a/library/std/src/sys/hermit/mutex.rs
+++ b/library/std/src/sys/hermit/mutex.rs
@@ -6,6 +6,8 @@ pub struct Mutex {
     inner: *const c_void,
 }
 
+pub type MovableMutex = Box<Mutex>;
+
 unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}
 


### PR DESCRIPTION
Currently the tier 3 Hermit targets (`x86_64-unknown-hermit` etc) have errors when building, this PR makes them at least pass `cargo check`.

Adds the missing types:
 - `std::sys::mutex::MovableMutex` (`Box<std::sys::mutex::Mutex>`)
 - `std::sys::process::CommandArgs` (`std::iter::Empty<&OsStr>`)

Adds stub implementations to `std::sys::process::Command` for the following missing methods:
 - `get_args`
 - `get_current_dir`
 - `get_program`
 - `get_envs`