### PR TITLE
Revert "Set .llvmbc and .llvmcmd sections as allocatable"

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -936,8 +936,8 @@ unsafe fn embed_bitcode(
         llvm::LLVMRustAppendModuleInlineAsm(llmod, asm.as_ptr().cast(), asm.len());
     } else {
         let asm = "
-            .section .llvmbc,\"a\"
-            .section .llvmcmd,\"a\"
+            .section .llvmbc,\"e\"
+            .section .llvmcmd,\"e\"
         ";
         llvm::LLVMRustAppendModuleInlineAsm(llmod, asm.as_ptr().cast(), asm.len());
     }


### PR DESCRIPTION
Reverts rust-lang/rust#77961, see discussion starting from https://github.com/rust-lang/rust/pull/77961#issuecomment-712313902