### PR TITLE
Use different mirror for linux headers in musl-toolchain CI script.

### DIFF
--- a/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
+++ b/src/ci/docker/host-x86_64/armhf-gnu/Dockerfile
@@ -58,7 +58,7 @@ RUN curl https://www.busybox.net/downloads/busybox-1.21.1.tar.bz2 | tar xjf - &&
 # Download the ubuntu rootfs, which we'll use as a chroot for all our tests.
 WORKDIR /tmp
 RUN mkdir rootfs/ubuntu
-RUN curl http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-base-16.04-core-armhf.tar.gz | \
+RUN curl http://cdimage.ubuntu.com/ubuntu-base/releases/16.04/release/ubuntu-base-16.04.6-base-armhf.tar.gz | \
       tar xzf - -C rootfs/ubuntu && \
       cd rootfs && mkdir proc sys dev etc etc/init.d
 

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -4,6 +4,9 @@
 # Versions of the toolchain components are configurable in `musl-cross-make/Makefile` and
 # musl unlike GLIBC is forward compatible so upgrading it shouldn't break old distributions.
 # Right now we have: Binutils 2.31.1, GCC 9.2.0, musl 1.1.24.
+
+# ignore-tidy-linelength
+
 set -ex
 
 hide_output() {
@@ -26,6 +29,9 @@ exit 1
 ARCH=$1
 TARGET=$ARCH-linux-musl
 
+# Don't depend on the mirrors of sabotage linux that musl-cross-make uses.
+LINUX_HEADERS_SITE=https://ci-mirrors.rust-lang.org/rustc/sabotage-linux-tarballs
+
 OUTPUT=/usr/local
 shift
 
@@ -38,8 +44,8 @@ cd musl-cross-make
 # A few commits ahead of v0.9.9 to include the cowpatch fix:
 git checkout a54eb56f33f255dfca60be045f12a5cfaf5a72a9
 
-hide_output make -j$(nproc) TARGET=$TARGET MUSL_VER=1.1.24
-hide_output make install TARGET=$TARGET MUSL_VER=1.1.24 OUTPUT=$OUTPUT
+hide_output make -j$(nproc) TARGET=$TARGET MUSL_VER=1.1.24 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE
+hide_output make install TARGET=$TARGET MUSL_VER=1.1.24 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE OUTPUT=$OUTPUT
 
 cd -
 


### PR DESCRIPTION
Should hopefully fix the CI failure of #78309

`musl-cross-make` Makefile for reference: https://github.com/richfelker/musl-cross-make/blob/a54eb56f33f255dfca60be045f12a5cfaf5a72a9/Makefile

r? @pietroalbini