### PR TITLE
Rollup of 15 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -936,8 +936,8 @@ unsafe fn embed_bitcode(
         llvm::LLVMRustAppendModuleInlineAsm(llmod, asm.as_ptr().cast(), asm.len());
     } else {
         let asm = "
-            .section .llvmbc,\"a\"
-            .section .llvmcmd,\"a\"
+            .section .llvmbc,\"e\"
+            .section .llvmcmd,\"e\"
         ";
         llvm::LLVMRustAppendModuleInlineAsm(llmod, asm.as_ptr().cast(), asm.len());
     }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -324,8 +324,8 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
     }
 
     #[inline]
-    pub fn coverage_context(&'a self) -> &'a coverageinfo::CrateCoverageContext<'tcx> {
-        self.coverage_cx.as_ref().unwrap()
+    pub fn coverage_context(&'a self) -> Option<&'a coverageinfo::CrateCoverageContext<'tcx>> {
+        self.coverage_cx.as_ref()
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -26,10 +26,10 @@ use tracing::debug;
 /// undocumented details in Clang's implementation (that may or may not be important) were also
 /// replicated for Rust's Coverage Map.
 pub fn finalize<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>) {
-    if cx.coverage_context().is_none() {
-        return;
-    }
-    let function_coverage_map = cx.coverage_context().unwrap().take_function_coverage_map();
+    let function_coverage_map = match cx.coverage_context() {
+        Some(ctx) => ctx.take_function_coverage_map(),
+        None => return,
+    };
     if function_coverage_map.is_empty() {
         // This module has no functions with coverage instrumentation
         return;

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mapgen.rs
@@ -26,7 +26,10 @@ use tracing::debug;
 /// undocumented details in Clang's implementation (that may or may not be important) were also
 /// replicated for Rust's Coverage Map.
 pub fn finalize<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>) {
-    let function_coverage_map = cx.coverage_context().take_function_coverage_map();
+    if cx.coverage_context().is_none() {
+        return;
+    }
+    let function_coverage_map = cx.coverage_context().unwrap().take_function_coverage_map();
     if function_coverage_map.is_empty() {
         // This module has no functions with coverage instrumentation
         return;

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -64,17 +64,22 @@ impl CoverageInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         function_source_hash: u64,
         id: CounterValueReference,
         region: CodeRegion,
-    ) {
-        debug!(
-            "adding counter to coverage_regions: instance={:?}, function_source_hash={}, id={:?}, \
-             at {:?}",
-            instance, function_source_hash, id, region,
-        );
-        let mut coverage_regions = self.coverage_context().function_coverage_map.borrow_mut();
-        coverage_regions
-            .entry(instance)
-            .or_insert_with(|| FunctionCoverage::new(self.tcx, instance))
-            .add_counter(function_source_hash, id, region);
+    ) -> bool {
+        if let Some(coverage_context) = self.coverage_context() {
+            debug!(
+                "adding counter to coverage_regions: instance={:?}, function_source_hash={}, id={:?}, \
+                at {:?}",
+                instance, function_source_hash, id, region,
+            );
+            let mut coverage_regions = coverage_context.function_coverage_map.borrow_mut();
+            coverage_regions
+                .entry(instance)
+                .or_insert_with(|| FunctionCoverage::new(self.tcx, instance))
+                .add_counter(function_source_hash, id, region);
+            true
+        } else {
+            false
+        }
     }
 
     fn add_counter_expression_region(
@@ -85,29 +90,39 @@ impl CoverageInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         op: Op,
         rhs: ExpressionOperandId,
         region: CodeRegion,
-    ) {
-        debug!(
-            "adding counter expression to coverage_regions: instance={:?}, id={:?}, {:?} {:?} {:?}, \
-             at {:?}",
-            instance, id, lhs, op, rhs, region,
-        );
-        let mut coverage_regions = self.coverage_context().function_coverage_map.borrow_mut();
-        coverage_regions
-            .entry(instance)
-            .or_insert_with(|| FunctionCoverage::new(self.tcx, instance))
-            .add_counter_expression(id, lhs, op, rhs, region);
+    ) -> bool {
+        if let Some(coverage_context) = self.coverage_context() {
+            debug!(
+                "adding counter expression to coverage_regions: instance={:?}, id={:?}, {:?} {:?} {:?}, \
+                at {:?}",
+                instance, id, lhs, op, rhs, region,
+            );
+            let mut coverage_regions = coverage_context.function_coverage_map.borrow_mut();
+            coverage_regions
+                .entry(instance)
+                .or_insert_with(|| FunctionCoverage::new(self.tcx, instance))
+                .add_counter_expression(id, lhs, op, rhs, region);
+            true
+        } else {
+            false
+        }
     }
 
-    fn add_unreachable_region(&mut self, instance: Instance<'tcx>, region: CodeRegion) {
-        debug!(
-            "adding unreachable code to coverage_regions: instance={:?}, at {:?}",
-            instance, region,
-        );
-        let mut coverage_regions = self.coverage_context().function_coverage_map.borrow_mut();
-        coverage_regions
-            .entry(instance)
-            .or_insert_with(|| FunctionCoverage::new(self.tcx, instance))
-            .add_unreachable_region(region);
+    fn add_unreachable_region(&mut self, instance: Instance<'tcx>, region: CodeRegion) -> bool {
+        if let Some(coverage_context) = self.coverage_context() {
+            debug!(
+                "adding unreachable code to coverage_regions: instance={:?}, at {:?}",
+                instance, region,
+            );
+            let mut coverage_regions = coverage_context.function_coverage_map.borrow_mut();
+            coverage_regions
+                .entry(instance)
+                .or_insert_with(|| FunctionCoverage::new(self.tcx, instance))
+                .add_unreachable_region(region);
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/mir/coverageinfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/coverageinfo.rs
@@ -10,19 +10,19 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let Coverage { kind, code_region } = coverage;
         match kind {
             CoverageKind::Counter { function_source_hash, id } => {
-                bx.add_counter_region(self.instance, function_source_hash, id, code_region);
+                if bx.add_counter_region(self.instance, function_source_hash, id, code_region) {
+                    let coverageinfo = bx.tcx().coverageinfo(self.instance.def_id());
 
-                let coverageinfo = bx.tcx().coverageinfo(self.instance.def_id());
-
-                let fn_name = bx.create_pgo_func_name_var(self.instance);
-                let hash = bx.const_u64(function_source_hash);
-                let num_counters = bx.const_u32(coverageinfo.num_counters);
-                let id = bx.const_u32(u32::from(id));
-                debug!(
-                    "codegen intrinsic instrprof.increment(fn_name={:?}, hash={:?}, num_counters={:?}, index={:?})",
-                    fn_name, hash, num_counters, id,
-                );
-                bx.instrprof_increment(fn_name, hash, num_counters, id);
+                    let fn_name = bx.create_pgo_func_name_var(self.instance);
+                    let hash = bx.const_u64(function_source_hash);
+                    let num_counters = bx.const_u32(coverageinfo.num_counters);
+                    let id = bx.const_u32(u32::from(id));
+                    debug!(
+                        "codegen intrinsic instrprof.increment(fn_name={:?}, hash={:?}, num_counters={:?}, index={:?})",
+                        fn_name, hash, num_counters, id,
+                    );
+                    bx.instrprof_increment(fn_name, hash, num_counters, id);
+                }
             }
             CoverageKind::Expression { id, lhs, op, rhs } => {
                 bx.add_counter_expression_region(self.instance, id, lhs, op, rhs, code_region);

--- a/compiler/rustc_codegen_ssa/src/traits/coverageinfo.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/coverageinfo.rs
@@ -9,14 +9,18 @@ pub trait CoverageInfoMethods: BackendTypes {
 pub trait CoverageInfoBuilderMethods<'tcx>: BackendTypes {
     fn create_pgo_func_name_var(&self, instance: Instance<'tcx>) -> Self::Value;
 
+    /// Returns true if the counter was added to the coverage map; false if `-Z instrument-coverage`
+    /// is not enabled (a coverage map is not being generated).
     fn add_counter_region(
         &mut self,
         instance: Instance<'tcx>,
         function_source_hash: u64,
         id: CounterValueReference,
         region: CodeRegion,
-    );
+    ) -> bool;
 
+    /// Returns true if the expression was added to the coverage map; false if
+    /// `-Z instrument-coverage` is not enabled (a coverage map is not being generated).
     fn add_counter_expression_region(
         &mut self,
         instance: Instance<'tcx>,
@@ -25,7 +29,9 @@ pub trait CoverageInfoBuilderMethods<'tcx>: BackendTypes {
         op: Op,
         rhs: ExpressionOperandId,
         region: CodeRegion,
-    );
+    ) -> bool;
 
-    fn add_unreachable_region(&mut self, instance: Instance<'tcx>, region: CodeRegion);
+    /// Returns true if the region was added to the coverage map; false if `-Z instrument-coverage`
+    /// is not enabled (a coverage map is not being generated).
+    fn add_unreachable_region(&mut self, instance: Instance<'tcx>, region: CodeRegion) -> bool;
 }

--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -175,19 +175,15 @@ impl<'tcx> UnifyKey for ty::ConstVid<'tcx> {
 impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
     type Error = (&'tcx ty::Const<'tcx>, &'tcx ty::Const<'tcx>);
 
-    fn unify_values(value1: &Self, value2: &Self) -> Result<Self, Self::Error> {
-        let (val, origin) = match (value1.val, value2.val) {
+    fn unify_values(&value1: &Self, &value2: &Self) -> Result<Self, Self::Error> {
+        Ok(match (value1.val, value2.val) {
             (ConstVariableValue::Known { .. }, ConstVariableValue::Known { .. }) => {
                 bug!("equating two const variables, both of which have known values")
             }
 
             // If one side is known, prefer that one.
-            (ConstVariableValue::Known { .. }, ConstVariableValue::Unknown { .. }) => {
-                (value1.val, value1.origin)
-            }
-            (ConstVariableValue::Unknown { .. }, ConstVariableValue::Known { .. }) => {
-                (value2.val, value2.origin)
-            }
+            (ConstVariableValue::Known { .. }, ConstVariableValue::Unknown { .. }) => value1,
+            (ConstVariableValue::Unknown { .. }, ConstVariableValue::Known { .. }) => value2,
 
             // If both sides are *unknown*, it hardly matters, does it?
             (
@@ -200,11 +196,12 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
                 // universe is the minimum of the two universes, because that is
                 // the one which contains the fewest names in scope.
                 let universe = cmp::min(universe1, universe2);
-                (ConstVariableValue::Unknown { universe }, value1.origin)
+                ConstVarValue {
+                    val: ConstVariableValue::Unknown { universe },
+                    origin: value1.origin,
+                }
             }
-        };
-
-        Ok(ConstVarValue { origin, val })
+        })
     }
 }
 

--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -176,17 +176,17 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
     type Error = (&'tcx ty::Const<'tcx>, &'tcx ty::Const<'tcx>);
 
     fn unify_values(value1: &Self, value2: &Self) -> Result<Self, Self::Error> {
-        let (val, span) = match (value1.val, value2.val) {
+        let (val, origin) = match (value1.val, value2.val) {
             (ConstVariableValue::Known { .. }, ConstVariableValue::Known { .. }) => {
                 bug!("equating two const variables, both of which have known values")
             }
 
             // If one side is known, prefer that one.
             (ConstVariableValue::Known { .. }, ConstVariableValue::Unknown { .. }) => {
-                (value1.val, value1.origin.span)
+                (value1.val, value1.origin)
             }
             (ConstVariableValue::Unknown { .. }, ConstVariableValue::Known { .. }) => {
-                (value2.val, value2.origin.span)
+                (value2.val, value2.origin)
             }
 
             // If both sides are *unknown*, it hardly matters, does it?
@@ -200,17 +200,11 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
                 // universe is the minimum of the two universes, because that is
                 // the one which contains the fewest names in scope.
                 let universe = cmp::min(universe1, universe2);
-                (ConstVariableValue::Unknown { universe }, value1.origin.span)
+                (ConstVariableValue::Unknown { universe }, value1.origin)
             }
         };
 
-        Ok(ConstVarValue {
-            origin: ConstVariableOrigin {
-                kind: ConstVariableOriginKind::ConstInference,
-                span: span,
-            },
-            val,
-        })
+        Ok(ConstVarValue { origin, val })
     }
 }
 

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -30,8 +30,6 @@
 //!
 //! These methods return true to indicate that the visitor has found what it is
 //! looking for, and does not need to visit anything else.
-
-use crate::ty::structural_impls::PredicateVisitor;
 use crate::ty::{self, flags::FlagComputation, Binder, Ty, TyCtxt, TypeFlags};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
@@ -210,6 +208,10 @@ pub trait TypeVisitor<'tcx>: Sized {
 
     fn visit_const(&mut self, c: &'tcx ty::Const<'tcx>) -> bool {
         c.super_visit_with(self)
+    }
+
+    fn visit_predicate(&mut self, p: ty::Predicate<'tcx>) -> bool {
+        p.super_visit_with(self)
     }
 }
 
@@ -868,9 +870,7 @@ impl<'tcx> TypeVisitor<'tcx> for HasEscapingVarsVisitor {
             _ => ct.super_visit_with(self),
         }
     }
-}
 
-impl<'tcx> PredicateVisitor<'tcx> for HasEscapingVarsVisitor {
     fn visit_predicate(&mut self, predicate: ty::Predicate<'tcx>) -> bool {
         predicate.inner.outer_exclusive_binder > self.outer_index
     }
@@ -903,9 +903,7 @@ impl<'tcx> TypeVisitor<'tcx> for HasTypeFlagsVisitor {
         debug!("HasTypeFlagsVisitor: c={:?} c.flags={:?} self.flags={:?}", c, flags, self.flags);
         flags.intersects(self.flags)
     }
-}
 
-impl<'tcx> PredicateVisitor<'tcx> for HasTypeFlagsVisitor {
     fn visit_predicate(&mut self, predicate: ty::Predicate<'tcx>) -> bool {
         debug!(
             "HasTypeFlagsVisitor: predicate={:?} predicate.flags={:?} self.flags={:?}",
@@ -914,6 +912,7 @@ impl<'tcx> PredicateVisitor<'tcx> for HasTypeFlagsVisitor {
         predicate.inner.flags.intersects(self.flags)
     }
 }
+
 /// Collects all the late-bound regions at the innermost binding level
 /// into a hash set.
 struct LateBoundRegionsCollector {

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -1040,16 +1040,6 @@ impl<'tcx> TypeFoldable<'tcx> for ty::Predicate<'tcx> {
     }
 }
 
-pub(super) trait PredicateVisitor<'tcx>: TypeVisitor<'tcx> {
-    fn visit_predicate(&mut self, predicate: ty::Predicate<'tcx>) -> bool;
-}
-
-impl<T: TypeVisitor<'tcx>> PredicateVisitor<'tcx> for T {
-    default fn visit_predicate(&mut self, predicate: ty::Predicate<'tcx>) -> bool {
-        predicate.super_visit_with(self)
-    }
-}
-
 impl<'tcx> TypeFoldable<'tcx> for &'tcx ty::List<ty::Predicate<'tcx>> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
         fold_list(*self, folder, |tcx, v| tcx.intern_predicates(v))

--- a/compiler/rustc_mir/src/transform/simplify_branches.rs
+++ b/compiler/rustc_mir/src/transform/simplify_branches.rs
@@ -49,9 +49,10 @@ impl<'tcx> MirPass<'tcx> for SimplifyBranches {
                 }
                 TerminatorKind::Assert {
                     target, cond: Operand::Constant(ref c), expected, ..
-                } if (c.literal.try_eval_bool(tcx, param_env) == Some(true)) == expected => {
-                    TerminatorKind::Goto { target }
-                }
+                } => match c.literal.try_eval_bool(tcx, param_env) {
+                    Some(v) if v == expected => TerminatorKind::Goto { target },
+                    _ => continue,
+                },
                 TerminatorKind::FalseEdge { real_target, .. } => {
                     TerminatorKind::Goto { target: real_target }
                 }

--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -34,6 +34,7 @@ fn link_env_remove(arch: Arch) -> Vec<String> {
 pub fn opts(arch: Arch) -> TargetOptions {
     TargetOptions {
         cpu: target_cpu(arch),
+        dynamic_linking: false,
         executables: true,
         link_env_remove: link_env_remove(arch),
         has_elf_tls: false,

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -118,6 +118,7 @@
 #![feature(raw_ref_op)]
 #![feature(rustc_attrs)]
 #![feature(receiver_trait)]
+#![feature(renamed_spin_loop)]
 #![feature(min_specialization)]
 #![feature(slice_ptr_get)]
 #![feature(slice_ptr_len)]

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -10,6 +10,7 @@ use core::cmp::Ordering;
 use core::convert::{From, TryFrom};
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::hint;
 use core::intrinsics::abort;
 use core::iter;
 use core::marker::{PhantomData, Unpin, Unsize};
@@ -764,6 +765,7 @@ impl<T: ?Sized> Arc<T> {
         loop {
             // check if the weak counter is currently "locked"; if so, spin.
             if cur == usize::MAX {
+                hint::spin_loop();
                 cur = this.inner().weak.load(Relaxed);
                 continue;
             }

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -529,6 +529,13 @@ mod slice_index {
             message: "out of bounds";
         }
 
+        in mod rangeinclusive_len {
+            data: "abcdef";
+            good: data[0..=5] == "abcdef";
+            bad: data[0..=6];
+            message: "out of bounds";
+        }
+
         in mod range_len_len {
             data: "abcdef";
             good: data[6..6] == "";
@@ -540,6 +547,28 @@ mod slice_index {
             data: "abcdef";
             good: data[6..=5] == "";
             bad: data[7..=6];
+            message: "out of bounds";
+        }
+    }
+
+    panic_cases! {
+        in mod rangeinclusive_exhausted {
+            data: "abcdef";
+
+            good: data[0..=5] == "abcdef";
+            good: data[{
+                let mut iter = 0..=5;
+                iter.by_ref().count(); // exhaust it
+                iter
+            }] == "";
+
+            // 0..=6 is out of bounds before exhaustion, so it
+            // stands to reason that it still would be after.
+            bad: data[{
+                let mut iter = 0..=6;
+                iter.by_ref().count(); // exhaust it
+                iter
+            }];
             message: "out of bounds";
         }
     }

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -479,13 +479,23 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
     /// assert!(!(0.0..=f32::NAN).contains(&0.0));
     /// assert!(!(f32::NAN..=1.0).contains(&1.0));
     /// ```
+    ///
+    /// This method always returns `false` after iteration has finished:
+    ///
+    /// ```
+    /// let mut r = 3..=5;
+    /// assert!(r.contains(&3) && r.contains(&5));
+    /// for _ in r.by_ref() {}
+    /// // Precise field values are unspecified here
+    /// assert!(!r.contains(&3) && !r.contains(&5));
+    /// ```
     #[stable(feature = "range_contains", since = "1.35.0")]
     pub fn contains<U>(&self, item: &U) -> bool
     where
         Idx: PartialOrd<U>,
         U: ?Sized + PartialOrd<Idx>,
     {
-        <Self as RangeBounds<Idx>>::contains(self, item)
+        !self.exhausted && <Self as RangeBounds<Idx>>::contains(self, item)
     }
 
     /// Returns `true` if the range contains no items.

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -446,6 +446,20 @@ impl<Idx> RangeInclusive<Idx> {
     }
 }
 
+impl RangeInclusive<usize> {
+    /// Converts to an exclusive `Range` for `SliceIndex` implementations.
+    /// The caller is responsible for dealing with `end == usize::MAX`.
+    #[inline]
+    pub(crate) fn into_slice_range(self) -> Range<usize> {
+        // If we're not exhausted, we want to simply slice `start..end + 1`.
+        // If we are exhausted, then slicing with `end + 1..end + 1` gives us an
+        // empty range that is still subject to bounds-checks for that endpoint.
+        let exclusive_end = self.end + 1;
+        let start = if self.exhausted { exclusive_end } else { self.start };
+        start..exclusive_end
+    }
+}
+
 #[stable(feature = "inclusive_range", since = "1.26.0")]
 impl<Idx: fmt::Debug> fmt::Debug for RangeInclusive<Idx> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/core/src/ops/range.rs
+++ b/library/core/src/ops/range.rs
@@ -495,7 +495,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
         Idx: PartialOrd<U>,
         U: ?Sized + PartialOrd<Idx>,
     {
-        !self.exhausted && <Self as RangeBounds<Idx>>::contains(self, item)
+        <Self as RangeBounds<Idx>>::contains(self, item)
     }
 
     /// Returns `true` if the range contains no items.
@@ -891,7 +891,13 @@ impl<T> RangeBounds<T> for RangeInclusive<T> {
         Included(&self.start)
     }
     fn end_bound(&self) -> Bound<&T> {
-        Included(&self.end)
+        if self.exhausted {
+            // When the iterator is exhausted, we usually have start == end,
+            // but we want the range to appear empty, containing nothing.
+            Excluded(&self.end)
+        } else {
+            Included(&self.end)
+        }
     }
 }
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -562,10 +562,6 @@ impl<T> Option<T> {
         }
     }
 
-    /////////////////////////////////////////////////////////////////////////
-    // Setting a new value
-    /////////////////////////////////////////////////////////////////////////
-
     /// Inserts `value` into the option then returns a mutable reference to it.
     ///
     /// If the option already contains a value, the old value is dropped.

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -574,17 +574,22 @@ impl<T> Option<T> {
     /// ```
     /// #![feature(option_insert)]
     ///
-    /// let mut o = None;
-    /// let v = o.insert(3);
-    /// assert_eq!(*v, 3);
+    /// let mut opt = None;
+    /// let val = opt.insert(1);
+    /// assert_eq!(*val, 1);
+    /// assert_eq!(opt.unwrap(), 1);
+    /// let val = opt.insert(2);
+    /// assert_eq!(*val, 2);
+    /// *val = 3;
+    /// assert_eq!(opt.unwrap(), 3);
     /// ```
     #[inline]
-    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
-    pub fn insert(&mut self, v: T) -> &mut T {
-        *self = Some(v);
+    #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
+    pub fn insert(&mut self, val: T) -> &mut T {
+        *self = Some(val);
 
-        match *self {
-            Some(ref mut v) => v,
+        match self {
+            Some(v) => v,
             // SAFETY: the code above just filled the option
             None => unsafe { hint::unreachable_unchecked() },
         }
@@ -839,8 +844,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    pub fn get_or_insert(&mut self, v: T) -> &mut T {
-        self.get_or_insert_with(|| v)
+    pub fn get_or_insert(&mut self, val: T) -> &mut T {
+        self.get_or_insert_with(|| val)
     }
 
     /// Inserts a value computed from `f` into the option if it is [`None`], then
@@ -867,8 +872,8 @@ impl<T> Option<T> {
             *self = Some(f());
         }
 
-        match *self {
-            Some(ref mut v) => v,
+        match self {
+            Some(v) => v,
             // SAFETY: a `None` variant for `self` would have been replaced by a `Some`
             // variant in the code above.
             None => unsafe { hint::unreachable_unchecked() },

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -568,6 +568,8 @@ impl<T> Option<T> {
 
     /// Inserts `value` into the option then returns a mutable reference to it.
     ///
+    /// If the option already contains a value, the old value is dropped.
+    ///
     /// # Example
     ///
     /// ```

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -563,6 +563,52 @@ impl<T> Option<T> {
     }
 
     /////////////////////////////////////////////////////////////////////////
+    // Setting a new value
+    /////////////////////////////////////////////////////////////////////////
+
+    /// Inserts `v` into the option then returns a mutable reference
+    /// to the contained value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(option_insert)]
+    ///
+    /// let mut o = None;
+    /// let v = o.insert(3);
+    /// assert_eq!(*v, 3);
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
+    pub fn insert(&mut self, v: T) -> &mut T {
+        self.insert_with(|| v)
+    }
+
+    /// Inserts a value computed from `f` into the option, then returns a
+    /// mutable reference to the contained value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(option_insert)]
+    ///
+    /// let mut o = None;
+    /// let v = o.insert_with(|| 3);
+    /// assert_eq!(*v, 3);
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
+    pub fn insert_with<F: FnOnce() -> T>(&mut self, f: F) -> &mut T {
+        *self = Some(f());
+
+        match *self {
+            Some(ref mut v) => v,
+            // SAFETY: the code above just filled the option
+            None => unsafe { hint::unreachable_unchecked() },
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
     // Iterator constructors
     /////////////////////////////////////////////////////////////////////////
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -581,25 +581,7 @@ impl<T> Option<T> {
     #[inline]
     #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
     pub fn insert(&mut self, v: T) -> &mut T {
-        self.insert_with(|| v)
-    }
-
-    /// Inserts a value computed from `f` into the option, then returns a
-    /// mutable reference to the contained value.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// #![feature(option_insert)]
-    ///
-    /// let mut o = None;
-    /// let v = o.insert_with(|| 3);
-    /// assert_eq!(*v, 3);
-    /// ```
-    #[inline]
-    #[unstable(feature = "option_insert", reason = "new API", issue = "none")]
-    pub fn insert_with<F: FnOnce() -> T>(&mut self, f: F) -> &mut T {
-        *self = Some(f());
+        *self = Some(v);
 
         match *self {
             Some(ref mut v) => v,

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -566,8 +566,7 @@ impl<T> Option<T> {
     // Setting a new value
     /////////////////////////////////////////////////////////////////////////
 
-    /// Inserts `v` into the option then returns a mutable reference
-    /// to the contained value.
+    /// Inserts `value` into the option then returns a mutable reference to it.
     ///
     /// # Example
     ///
@@ -585,8 +584,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
-    pub fn insert(&mut self, val: T) -> &mut T {
-        *self = Some(val);
+    pub fn insert(&mut self, value: T) -> &mut T {
+        *self = Some(value);
 
         match self {
             Some(v) => v,
@@ -825,7 +824,7 @@ impl<T> Option<T> {
     // Entry-like operations to insert if None and return a reference
     /////////////////////////////////////////////////////////////////////////
 
-    /// Inserts `v` into the option if it is [`None`], then
+    /// Inserts `value` into the option if it is [`None`], then
     /// returns a mutable reference to the contained value.
     ///
     /// # Examples
@@ -844,12 +843,12 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
-    pub fn get_or_insert(&mut self, val: T) -> &mut T {
-        self.get_or_insert_with(|| val)
+    pub fn get_or_insert(&mut self, value: T) -> &mut T {
+        self.get_or_insert_with(|| value)
     }
 
-    /// Inserts a value computed from `f` into the option if it is [`None`], then
-    /// returns a mutable reference to the contained value.
+    /// Inserts a value computed from `f` into the option if it is [`None`],
+    /// then returns a mutable reference to the contained value.
     ///
     /// # Examples
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -581,7 +581,7 @@ impl<T> Option<T> {
     /// assert_eq!(opt.unwrap(), 3);
     /// ```
     #[inline]
-    #[unstable(feature = "option_insert", reason = "newly added", issue = "none")]
+    #[unstable(feature = "option_insert", reason = "newly added", issue = "78271")]
     pub fn insert(&mut self, value: T) -> &mut T {
         *self = Some(value);
 

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -376,28 +376,24 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeInclusive<usize> {
 
     #[inline]
     fn get(self, slice: &[T]) -> Option<&[T]> {
-        if *self.end() == usize::MAX { None } else { (*self.start()..self.end() + 1).get(slice) }
+        if *self.end() == usize::MAX { None } else { self.into_slice_range().get(slice) }
     }
 
     #[inline]
     fn get_mut(self, slice: &mut [T]) -> Option<&mut [T]> {
-        if *self.end() == usize::MAX {
-            None
-        } else {
-            (*self.start()..self.end() + 1).get_mut(slice)
-        }
+        if *self.end() == usize::MAX { None } else { self.into_slice_range().get_mut(slice) }
     }
 
     #[inline]
     unsafe fn get_unchecked(self, slice: *const [T]) -> *const [T] {
         // SAFETY: the caller has to uphold the safety contract for `get_unchecked`.
-        unsafe { (*self.start()..self.end() + 1).get_unchecked(slice) }
+        unsafe { self.into_slice_range().get_unchecked(slice) }
     }
 
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: *mut [T]) -> *mut [T] {
         // SAFETY: the caller has to uphold the safety contract for `get_unchecked_mut`.
-        unsafe { (*self.start()..self.end() + 1).get_unchecked_mut(slice) }
+        unsafe { self.into_slice_range().get_unchecked_mut(slice) }
     }
 
     #[inline]
@@ -405,7 +401,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeInclusive<usize> {
         if *self.end() == usize::MAX {
             slice_end_index_overflow_fail();
         }
-        (*self.start()..self.end() + 1).index(slice)
+        self.into_slice_range().index(slice)
     }
 
     #[inline]
@@ -413,7 +409,7 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeInclusive<usize> {
         if *self.end() == usize::MAX {
             slice_end_index_overflow_fail();
         }
-        (*self.start()..self.end() + 1).index_mut(slice)
+        self.into_slice_range().index_mut(slice)
     }
 }
 

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -398,39 +398,35 @@ unsafe impl SliceIndex<str> for ops::RangeInclusive<usize> {
     type Output = str;
     #[inline]
     fn get(self, slice: &str) -> Option<&Self::Output> {
-        if *self.end() == usize::MAX { None } else { (*self.start()..self.end() + 1).get(slice) }
+        if *self.end() == usize::MAX { None } else { self.into_slice_range().get(slice) }
     }
     #[inline]
     fn get_mut(self, slice: &mut str) -> Option<&mut Self::Output> {
-        if *self.end() == usize::MAX {
-            None
-        } else {
-            (*self.start()..self.end() + 1).get_mut(slice)
-        }
+        if *self.end() == usize::MAX { None } else { self.into_slice_range().get_mut(slice) }
     }
     #[inline]
     unsafe fn get_unchecked(self, slice: *const str) -> *const Self::Output {
         // SAFETY: the caller must uphold the safety contract for `get_unchecked`.
-        unsafe { (*self.start()..self.end() + 1).get_unchecked(slice) }
+        unsafe { self.into_slice_range().get_unchecked(slice) }
     }
     #[inline]
     unsafe fn get_unchecked_mut(self, slice: *mut str) -> *mut Self::Output {
         // SAFETY: the caller must uphold the safety contract for `get_unchecked_mut`.
-        unsafe { (*self.start()..self.end() + 1).get_unchecked_mut(slice) }
+        unsafe { self.into_slice_range().get_unchecked_mut(slice) }
     }
     #[inline]
     fn index(self, slice: &str) -> &Self::Output {
         if *self.end() == usize::MAX {
             str_index_overflow_fail();
         }
-        (*self.start()..self.end() + 1).index(slice)
+        self.into_slice_range().index(slice)
     }
     #[inline]
     fn index_mut(self, slice: &mut str) -> &mut Self::Output {
         if *self.end() == usize::MAX {
             str_index_overflow_fail();
         }
-        (*self.start()..self.end() + 1).index_mut(slice)
+        self.into_slice_range().index_mut(slice)
     }
 }
 

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -1341,6 +1341,14 @@ mod slice_index {
             message: "out of range";
         }
 
+        in mod rangeinclusive_len {
+            data: [0, 1, 2, 3, 4, 5];
+
+            good: data[0..=5] == [0, 1, 2, 3, 4, 5];
+            bad: data[0..=6];
+            message: "out of range";
+        }
+
         in mod range_len_len {
             data: [0, 1, 2, 3, 4, 5];
 
@@ -1354,6 +1362,28 @@ mod slice_index {
 
             good: data[6..=5] == [];
             bad: data[7..=6];
+            message: "out of range";
+        }
+    }
+
+    panic_cases! {
+        in mod rangeinclusive_exhausted {
+            data: [0, 1, 2, 3, 4, 5];
+
+            good: data[0..=5] == [0, 1, 2, 3, 4, 5];
+            good: data[{
+                let mut iter = 0..=5;
+                iter.by_ref().count(); // exhaust it
+                iter
+            }] == [];
+
+            // 0..=6 is out of range before exhaustion, so it
+            // stands to reason that it still would be after.
+            bad: data[{
+                let mut iter = 0..=6;
+                iter.by_ref().count(); // exhaust it
+                iter
+            }];
             message: "out of range";
         }
     }

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -346,7 +346,7 @@ mod else_keyword {}
 /// When data follows along with a variant, such as with rust's built-in [`Option`] type, the data
 /// is added as the type describes, for example `Option::Some(123)`. The same follows with
 /// struct-like variants, with things looking like `ComplexEnum::LotsOfThings { usual_struct_stuff:
-/// true, blah: "hello!".to_string(), }`. Empty Enums are similar to () in that they cannot be
+/// true, blah: "hello!".to_string(), }`. Empty Enums are similar to [`!`] in that they cannot be
 /// instantiated at all, and are used mainly to mess with the type system in interesting ways.
 ///
 /// For more information, take a look at the [Rust Book] or the [Reference]
@@ -354,6 +354,7 @@ mod else_keyword {}
 /// [ADT]: https://en.wikipedia.org/wiki/Algebraic_data_type
 /// [Rust Book]: ../book/ch06-01-defining-an-enum.html
 /// [Reference]: ../reference/items/enumerations.html
+/// [`!`]: primitive.never.html
 mod enum_keyword {}
 
 #[doc(keyword = "extern")]

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -232,7 +232,13 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
         match subcommand.as_str() {
             "test" | "t" => {
                 opts.optflag("", "no-fail-fast", "Run all tests regardless of failure");
-                opts.optmulti("", "test-args", "extra arguments", "ARGS");
+                opts.optmulti(
+                    "",
+                    "test-args",
+                    "extra arguments to be passed for the test tool being used \
+                        (e.g. libtest, compiletest or rustdoc)",
+                    "ARGS",
+                );
                 opts.optmulti(
                     "",
                     "rustc-args",

--- a/src/doc/unstable-book/src/language-features/inline-const.md
+++ b/src/doc/unstable-book/src/language-features/inline-const.md
@@ -1,0 +1,45 @@
+# `inline_const`
+
+The tracking issue for this feature is: [#76001]
+
+------
+
+This feature allows you to use inline constant expressions. For example, you can
+turn this code:
+
+```rust
+# fn add_one(x: i32) -> i32 { x + 1 }
+const MY_COMPUTATION: i32 = 1 + 2 * 3 / 4;
+
+fn main() {
+    let x = add_one(MY_COMPUTATION);
+}
+```
+
+into this code:
+
+```rust
+#![feature(inline_const)]
+
+# fn add_one(x: i32) -> i32 { x + 1 }
+fn main() {
+    let x = add_one(const { 1 + 2 * 3 / 4 });
+}
+```
+
+You can also use inline constant expressions in patterns:
+
+```rust
+#![feature(inline_const)]
+
+const fn one() -> i32 { 1 }
+
+let some_int = 3;
+match some_int {
+    const { 1 + 2 } => println!("Matched 1 + 2"),
+    const { one() } => println!("Matched const fn returning 1"),
+    _ => println!("Didn't match anything :("),
+}
+```
+
+[#76001]: https://github.com/rust-lang/rust/issues/76001

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -94,6 +94,12 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
     var fullNewTheme = newTheme + resourcesSuffix + ".css";
     var newHref = mainStyleElem.href.replace(fullBasicCss, fullNewTheme);
 
+    // If this new value comes from a system setting or from the previously
+    // saved theme, no need to save it.
+    if (saveTheme === true) {
+        updateLocalStorage("rustdoc-theme", newTheme);
+    }
+
     if (styleElem.href === newHref) {
         return;
     }
@@ -112,11 +118,6 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
     });
     if (found === true) {
         styleElem.href = newHref;
-        // If this new value comes from a system setting or from the previously
-        // saved theme, no need to save it.
-        if (saveTheme === true) {
-            updateLocalStorage("rustdoc-theme", newTheme);
-        }
     }
 }
 

--- a/src/test/ui/const-generics/infer/issue-77092.stderr
+++ b/src/test/ui/const-generics/infer/issue-77092.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-77092.rs:13:26
    |
 LL |         println!("{:?}", take_array_from_mut(&mut arr, i));
-   |                          ^^^^^^^^^^^^^^^^^^^ cannot infer the value of the constant `{_: usize}`
+   |                          ^^^^^^^^^^^^^^^^^^^ cannot infer the value of const parameter `N` declared on the function `take_array_from_mut`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/issue-77475.rs
+++ b/src/test/ui/macros/issue-77475.rs
@@ -1,0 +1,10 @@
+// check-pass
+// Regression test of #77475, this used to be ICE.
+
+#![feature(decl_macro)]
+
+use crate as _;
+
+pub macro ice(){}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #76649 (Add a spin loop hint for Arc::downgrade)
 - #77392 (add `insert` to `Option`)
 - #77716 (Revert "Allow dynamic linking for iOS/tvOS targets.")
 - #78109 (Check for exhaustion in RangeInclusive::contains and slicing)
 - #78198 (Simplify assert terminator only if condition evaluates to expected value)
 - #78243 (--test-args flag description)
 - #78249 (improve const infer error)
 - #78250 (Document inline-const)
 - #78264 (Add regression test for issue-77475)
 - #78274 (Update description of Empty Enum for accuracy)
 - #78278 (move `visit_predicate` into `TypeVisitor`)
 - #78292 (Loop instead of recursion)
 - #78293 (Always store Rustdoc theme when it's changed)
 - #78300 (Make codegen coverage_context optional, and check)
 - #78307 (Revert "Set .llvmbc and .llvmcmd sections as allocatable")

Failed merges:


r? @ghost