### PR TITLE
Perform the lookahead once instead of twice in parser

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2026,14 +2026,13 @@ impl<'a> Parser<'a> {
         self.look_ahead(1, |t| t.is_ident())
             && (
                 // `{ ident, ` cannot start a block.
-                self.look_ahead(2, |t| t == &token::Comma)
-                    || self.look_ahead(2, |t| t == &token::Colon)
-                        && (
-                            // `{ ident: token, ` cannot start a block.
-                            self.look_ahead(4, |t| t == &token::Comma) ||
-                // `{ ident: ` cannot start a block unless it's a type ascription `ident: Type`.
-                self.look_ahead(3, |t| !t.can_begin_type())
-                        )
+                self.look_ahead(2, |t| t == &token::Comma || t == &token::Colon)
+                    && (
+                        // `{ ident: token, ` cannot start a block.
+                        self.look_ahead(4, |t| t == &token::Comma) ||
+                            // `{ ident: ` cannot start a block unless it's a type ascription `ident: Type`.
+                            self.look_ahead(3, |t| !t.can_begin_type())
+                    )
             )
     }
 


### PR DESCRIPTION
`is_certainly_not_a_block`  currently looks ahead twice for the same distance `2`.