### PR TITLE
Formally deprecate the constants superseded by RFC 2700

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1173,133 +1173,133 @@ extern "rust-intrinsic" {
     /// Returns the square root of an `f32`
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::sqrt`](../../std/primitive.f32.html#method.sqrt)
+    /// [`f32::sqrt`](../../std/primitive.f32.html#method.sqrt)
     pub fn sqrtf32(x: f32) -> f32;
     /// Returns the square root of an `f64`
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::sqrt`](../../std/primitive.f64.html#method.sqrt)
+    /// [`f64::sqrt`](../../std/primitive.f64.html#method.sqrt)
     pub fn sqrtf64(x: f64) -> f64;
 
     /// Raises an `f32` to an integer power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::powi`](../../std/primitive.f32.html#method.powi)
+    /// [`f32::powi`](../../std/primitive.f32.html#method.powi)
     pub fn powif32(a: f32, x: i32) -> f32;
     /// Raises an `f64` to an integer power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::powi`](../../std/primitive.f64.html#method.powi)
+    /// [`f64::powi`](../../std/primitive.f64.html#method.powi)
     pub fn powif64(a: f64, x: i32) -> f64;
 
     /// Returns the sine of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::sin`](../../std/primitive.f32.html#method.sin)
+    /// [`f32::sin`](../../std/primitive.f32.html#method.sin)
     pub fn sinf32(x: f32) -> f32;
     /// Returns the sine of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::sin`](../../std/primitive.f64.html#method.sin)
+    /// [`f64::sin`](../../std/primitive.f64.html#method.sin)
     pub fn sinf64(x: f64) -> f64;
 
     /// Returns the cosine of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::cos`](../../std/primitive.f32.html#method.cos)
+    /// [`f32::cos`](../../std/primitive.f32.html#method.cos)
     pub fn cosf32(x: f32) -> f32;
     /// Returns the cosine of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::cos`](../../std/primitive.f64.html#method.cos)
+    /// [`f64::cos`](../../std/primitive.f64.html#method.cos)
     pub fn cosf64(x: f64) -> f64;
 
     /// Raises an `f32` to an `f32` power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::powf`](../../std/primitive.f32.html#method.powf)
+    /// [`f32::powf`](../../std/primitive.f32.html#method.powf)
     pub fn powf32(a: f32, x: f32) -> f32;
     /// Raises an `f64` to an `f64` power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::powf`](../../std/primitive.f64.html#method.powf)
+    /// [`f64::powf`](../../std/primitive.f64.html#method.powf)
     pub fn powf64(a: f64, x: f64) -> f64;
 
     /// Returns the exponential of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::exp`](../../std/primitive.f32.html#method.exp)
+    /// [`f32::exp`](../../std/primitive.f32.html#method.exp)
     pub fn expf32(x: f32) -> f32;
     /// Returns the exponential of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::exp`](../../std/primitive.f64.html#method.exp)
+    /// [`f64::exp`](../../std/primitive.f64.html#method.exp)
     pub fn expf64(x: f64) -> f64;
 
     /// Returns 2 raised to the power of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::exp2`](../../std/primitive.f32.html#method.exp2)
+    /// [`f32::exp2`](../../std/primitive.f32.html#method.exp2)
     pub fn exp2f32(x: f32) -> f32;
     /// Returns 2 raised to the power of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::exp2`](../../std/primitive.f64.html#method.exp2)
+    /// [`f64::exp2`](../../std/primitive.f64.html#method.exp2)
     pub fn exp2f64(x: f64) -> f64;
 
     /// Returns the natural logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::ln`](../../std/primitive.f32.html#method.ln)
+    /// [`f32::ln`](../../std/primitive.f32.html#method.ln)
     pub fn logf32(x: f32) -> f32;
     /// Returns the natural logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::ln`](../../std/primitive.f64.html#method.ln)
+    /// [`f64::ln`](../../std/primitive.f64.html#method.ln)
     pub fn logf64(x: f64) -> f64;
 
     /// Returns the base 10 logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::log10`](../../std/primitive.f32.html#method.log10)
+    /// [`f32::log10`](../../std/primitive.f32.html#method.log10)
     pub fn log10f32(x: f32) -> f32;
     /// Returns the base 10 logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::log10`](../../std/primitive.f64.html#method.log10)
+    /// [`f64::log10`](../../std/primitive.f64.html#method.log10)
     pub fn log10f64(x: f64) -> f64;
 
     /// Returns the base 2 logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::log2`](../../std/primitive.f32.html#method.log2)
+    /// [`f32::log2`](../../std/primitive.f32.html#method.log2)
     pub fn log2f32(x: f32) -> f32;
     /// Returns the base 2 logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::log2`](../../std/primitive.f64.html#method.log2)
+    /// [`f64::log2`](../../std/primitive.f64.html#method.log2)
     pub fn log2f64(x: f64) -> f64;
 
     /// Returns `a * b + c` for `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::mul_add`](../../std/primitive.f32.html#method.mul_add)
+    /// [`f32::mul_add`](../../std/primitive.f32.html#method.mul_add)
     pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
     /// Returns `a * b + c` for `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::mul_add`](../../std/primitive.f64.html#method.mul_add)
+    /// [`f64::mul_add`](../../std/primitive.f64.html#method.mul_add)
     pub fn fmaf64(a: f64, b: f64, c: f64) -> f64;
 
     /// Returns the absolute value of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::abs`](../../std/primitive.f32.html#method.abs)
+    /// [`f32::abs`](../../std/primitive.f32.html#method.abs)
     pub fn fabsf32(x: f32) -> f32;
     /// Returns the absolute value of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::abs`](../../std/primitive.f64.html#method.abs)
+    /// [`f64::abs`](../../std/primitive.f64.html#method.abs)
     pub fn fabsf64(x: f64) -> f64;
 
     /// Returns the minimum of two `f32` values.
@@ -1326,45 +1326,45 @@ extern "rust-intrinsic" {
     /// Copies the sign from `y` to `x` for `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::copysign`](../../std/primitive.f32.html#method.copysign)
+    /// [`f32::copysign`](../../std/primitive.f32.html#method.copysign)
     pub fn copysignf32(x: f32, y: f32) -> f32;
     /// Copies the sign from `y` to `x` for `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::copysign`](../../std/primitive.f64.html#method.copysign)
+    /// [`f64::copysign`](../../std/primitive.f64.html#method.copysign)
     pub fn copysignf64(x: f64, y: f64) -> f64;
 
     /// Returns the largest integer less than or equal to an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::floor`](../../std/primitive.f32.html#method.floor)
+    /// [`f32::floor`](../../std/primitive.f32.html#method.floor)
     pub fn floorf32(x: f32) -> f32;
     /// Returns the largest integer less than or equal to an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::floor`](../../std/primitive.f64.html#method.floor)
+    /// [`f64::floor`](../../std/primitive.f64.html#method.floor)
     pub fn floorf64(x: f64) -> f64;
 
     /// Returns the smallest integer greater than or equal to an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::ceil`](../../std/primitive.f32.html#method.ceil)
+    /// [`f32::ceil`](../../std/primitive.f32.html#method.ceil)
     pub fn ceilf32(x: f32) -> f32;
     /// Returns the smallest integer greater than or equal to an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::ceil`](../../std/primitive.f64.html#method.ceil)
+    /// [`f64::ceil`](../../std/primitive.f64.html#method.ceil)
     pub fn ceilf64(x: f64) -> f64;
 
     /// Returns the integer part of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::trunc`](../../std/primitive.f32.html#method.trunc)
+    /// [`f32::trunc`](../../std/primitive.f32.html#method.trunc)
     pub fn truncf32(x: f32) -> f32;
     /// Returns the integer part of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::trunc`](../../std/primitive.f64.html#method.trunc)
+    /// [`f64::trunc`](../../std/primitive.f64.html#method.trunc)
     pub fn truncf64(x: f64) -> f64;
 
     /// Returns the nearest integer to an `f32`. May raise an inexact floating-point exception
@@ -1386,12 +1386,12 @@ extern "rust-intrinsic" {
     /// Returns the nearest integer to an `f32`. Rounds half-way cases away from zero.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::round`](../../std/primitive.f32.html#method.round)
+    /// [`f32::round`](../../std/primitive.f32.html#method.round)
     pub fn roundf32(x: f32) -> f32;
     /// Returns the nearest integer to an `f64`. Rounds half-way cases away from zero.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::round`](../../std/primitive.f64.html#method.round)
+    /// [`f64::round`](../../std/primitive.f64.html#method.round)
     pub fn roundf64(x: f64) -> f64;
 
     /// Float addition that allows optimizations based on algebraic rules.

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -1,6 +1,5 @@
 use crate::iter::{DoubleEndedIterator, FusedIterator, Iterator, TrustedLen};
 use crate::ops::Try;
-use crate::usize;
 
 /// An iterator that links two iterators together, in a chain.
 ///

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f32` floating point data type.
+//! Constants specific to the `f32` single-precision floating point type.
 //!
 //! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f32` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -29,6 +30,7 @@ use crate::num::FpCategory;
 /// let r = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `RADIX` associated constant on `f32`")]
 pub const RADIX: u32 = f32::RADIX;
 
 /// Number of significant digits in base 2.
@@ -44,6 +46,7 @@ pub const RADIX: u32 = f32::RADIX;
 /// let d = f32::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f32`")]
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -59,6 +62,7 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 /// let d = f32::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `DIGITS` associated constant on `f32`")]
 pub const DIGITS: u32 = f32::DIGITS;
 
 /// [Machine epsilon] value for `f32`.
@@ -78,6 +82,7 @@ pub const DIGITS: u32 = f32::DIGITS;
 /// let e = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `EPSILON` associated constant on `f32`")]
 pub const EPSILON: f32 = f32::EPSILON;
 
 /// Smallest finite `f32` value.
@@ -93,6 +98,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 /// let min = f32::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN` associated constant on `f32`")]
 pub const MIN: f32 = f32::MIN;
 
 /// Smallest positive normal `f32` value.
@@ -108,6 +114,7 @@ pub const MIN: f32 = f32::MIN;
 /// let min = f32::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_POSITIVE` associated constant on `f32`")]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 
 /// Largest finite `f32` value.
@@ -123,6 +130,7 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 /// let max = f32::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX` associated constant on `f32`")]
 pub const MAX: f32 = f32::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -138,6 +146,7 @@ pub const MAX: f32 = f32::MAX;
 /// let min = f32::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_EXP` associated constant on `f32`")]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -153,6 +162,7 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 /// let max = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_EXP` associated constant on `f32`")]
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -168,6 +178,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 /// let min = f32::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_10_EXP` associated constant on `f32`")]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -183,6 +194,7 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 /// let max = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_10_EXP` associated constant on `f32`")]
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -198,6 +210,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 /// let nan = f32::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `NAN` associated constant on `f32`")]
 pub const NAN: f32 = f32::NAN;
 
 /// Infinity (∞).
@@ -213,6 +226,7 @@ pub const NAN: f32 = f32::NAN;
 /// let inf = f32::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `INFINITY` associated constant on `f32`")]
 pub const INFINITY: f32 = f32::INFINITY;
 
 /// Negative infinity (−∞).
@@ -228,6 +242,7 @@ pub const INFINITY: f32 = f32::INFINITY;
 /// let ninf = f32::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `NEG_INFINITY` associated constant on `f32`")]
 pub const NEG_INFINITY: f32 = f32::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -24,6 +24,7 @@ use crate::num::FpCategory;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let r = std::f32::RADIX;
 ///
 /// // intended way
@@ -43,6 +44,7 @@ pub const RADIX: u32 = f32::RADIX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f32::MANTISSA_DIGITS;
 ///
 /// // intended way
@@ -62,6 +64,7 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f32::DIGITS;
 ///
 /// // intended way
@@ -85,6 +88,7 @@ pub const DIGITS: u32 = f32::DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let e = std::f32::EPSILON;
 ///
 /// // intended way
@@ -104,6 +108,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN;
 ///
 /// // intended way
@@ -120,6 +125,7 @@ pub const MIN: f32 = f32::MIN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN_POSITIVE;
 ///
 /// // intended way
@@ -139,6 +145,7 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f32::MAX;
 ///
 /// // intended way
@@ -155,6 +162,7 @@ pub const MAX: f32 = f32::MAX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN_EXP;
 ///
 /// // intended way
@@ -174,6 +182,7 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f32::MAX_EXP;
 ///
 /// // intended way
@@ -193,6 +202,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN_10_EXP;
 ///
 /// // intended way
@@ -212,6 +222,7 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f32::MAX_10_EXP;
 ///
 /// // intended way
@@ -231,6 +242,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let nan = std::f32::NAN;
 ///
 /// // intended way
@@ -247,6 +259,7 @@ pub const NAN: f32 = f32::NAN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let inf = std::f32::INFINITY;
 ///
 /// // intended way
@@ -266,6 +279,7 @@ pub const INFINITY: f32 = f32::INFINITY;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let ninf = std::f32::NEG_INFINITY;
 ///
 /// // intended way

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -30,7 +30,10 @@ use crate::num::FpCategory;
 /// let r = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `RADIX` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `RADIX` associated constant on `f32`"
+)]
 pub const RADIX: u32 = f32::RADIX;
 
 /// Number of significant digits in base 2.
@@ -46,7 +49,10 @@ pub const RADIX: u32 = f32::RADIX;
 /// let d = f32::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f32`"
+)]
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -62,7 +68,10 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 /// let d = f32::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `DIGITS` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `DIGITS` associated constant on `f32`"
+)]
 pub const DIGITS: u32 = f32::DIGITS;
 
 /// [Machine epsilon] value for `f32`.
@@ -82,7 +91,10 @@ pub const DIGITS: u32 = f32::DIGITS;
 /// let e = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `EPSILON` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `EPSILON` associated constant on `f32`"
+)]
 pub const EPSILON: f32 = f32::EPSILON;
 
 /// Smallest finite `f32` value.
@@ -114,7 +126,10 @@ pub const MIN: f32 = f32::MIN;
 /// let min = f32::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_POSITIVE` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MIN_POSITIVE` associated constant on `f32`"
+)]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 
 /// Largest finite `f32` value.
@@ -146,7 +161,10 @@ pub const MAX: f32 = f32::MAX;
 /// let min = f32::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_EXP` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MIN_EXP` associated constant on `f32`"
+)]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -162,7 +180,10 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 /// let max = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_EXP` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MAX_EXP` associated constant on `f32`"
+)]
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -178,7 +199,10 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 /// let min = f32::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_10_EXP` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MIN_10_EXP` associated constant on `f32`"
+)]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -194,7 +218,10 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 /// let max = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_10_EXP` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MAX_10_EXP` associated constant on `f32`"
+)]
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -226,7 +253,10 @@ pub const NAN: f32 = f32::NAN;
 /// let inf = f32::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `INFINITY` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `INFINITY` associated constant on `f32`"
+)]
 pub const INFINITY: f32 = f32::INFINITY;
 
 /// Negative infinity (−∞).
@@ -242,7 +272,10 @@ pub const INFINITY: f32 = f32::INFINITY;
 /// let ninf = f32::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `NEG_INFINITY` associated constant on `f32`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `NEG_INFINITY` associated constant on `f32`"
+)]
 pub const NEG_INFINITY: f32 = f32::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -30,7 +30,10 @@ use crate::num::FpCategory;
 /// let r = f64::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `RADIX` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `RADIX` associated constant on `f64`"
+)]
 pub const RADIX: u32 = f64::RADIX;
 
 /// Number of significant digits in base 2.
@@ -46,7 +49,10 @@ pub const RADIX: u32 = f64::RADIX;
 /// let d = f64::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f64`"
+)]
 pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -62,7 +68,10 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 /// let d = f64::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `DIGITS` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `DIGITS` associated constant on `f64`"
+)]
 pub const DIGITS: u32 = f64::DIGITS;
 
 /// [Machine epsilon] value for `f64`.
@@ -82,7 +91,10 @@ pub const DIGITS: u32 = f64::DIGITS;
 /// let e = f64::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `EPSILON` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `EPSILON` associated constant on `f64`"
+)]
 pub const EPSILON: f64 = f64::EPSILON;
 
 /// Smallest finite `f64` value.
@@ -114,7 +126,10 @@ pub const MIN: f64 = f64::MIN;
 /// let min = f64::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_POSITIVE` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MIN_POSITIVE` associated constant on `f64`"
+)]
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 
 /// Largest finite `f64` value.
@@ -146,7 +161,10 @@ pub const MAX: f64 = f64::MAX;
 /// let min = f64::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_EXP` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MIN_EXP` associated constant on `f64`"
+)]
 pub const MIN_EXP: i32 = f64::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -162,7 +180,10 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 /// let max = f64::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_EXP` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MAX_EXP` associated constant on `f64`"
+)]
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -178,7 +199,10 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 /// let min = f64::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_10_EXP` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MIN_10_EXP` associated constant on `f64`"
+)]
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -194,7 +218,10 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 /// let max = f64::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_10_EXP` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `MAX_10_EXP` associated constant on `f64`"
+)]
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -226,7 +253,10 @@ pub const NAN: f64 = f64::NAN;
 /// let inf = f64::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `INFINITY` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `INFINITY` associated constant on `f64`"
+)]
 pub const INFINITY: f64 = f64::INFINITY;
 
 /// Negative infinity (−∞).
@@ -242,7 +272,10 @@ pub const INFINITY: f64 = f64::INFINITY;
 /// let ninf = f64::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `NEG_INFINITY` associated constant on `f64`")]
+#[rustc_deprecated(
+    since = "1.49.0",
+    reason = "replaced by the `NEG_INFINITY` associated constant on `f64`"
+)]
 pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -24,6 +24,7 @@ use crate::num::FpCategory;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let r = std::f64::RADIX;
 ///
 /// // intended way
@@ -43,6 +44,7 @@ pub const RADIX: u32 = f64::RADIX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f64::MANTISSA_DIGITS;
 ///
 /// // intended way
@@ -62,6 +64,7 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f64::DIGITS;
 ///
 /// // intended way
@@ -85,6 +88,7 @@ pub const DIGITS: u32 = f64::DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let e = std::f64::EPSILON;
 ///
 /// // intended way
@@ -104,6 +108,7 @@ pub const EPSILON: f64 = f64::EPSILON;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN;
 ///
 /// // intended way
@@ -120,6 +125,7 @@ pub const MIN: f64 = f64::MIN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN_POSITIVE;
 ///
 /// // intended way
@@ -139,6 +145,7 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f64::MAX;
 ///
 /// // intended way
@@ -155,6 +162,7 @@ pub const MAX: f64 = f64::MAX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN_EXP;
 ///
 /// // intended way
@@ -174,6 +182,7 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f64::MAX_EXP;
 ///
 /// // intended way
@@ -193,6 +202,7 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN_10_EXP;
 ///
 /// // intended way
@@ -212,6 +222,7 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f64::MAX_10_EXP;
 ///
 /// // intended way
@@ -231,6 +242,7 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let nan = std::f64::NAN;
 ///
 /// // intended way
@@ -247,6 +259,7 @@ pub const NAN: f64 = f64::NAN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let inf = std::f64::INFINITY;
 ///
 /// // intended way
@@ -266,6 +279,7 @@ pub const INFINITY: f64 = f64::INFINITY;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let ninf = std::f64::NEG_INFINITY;
 ///
 /// // intended way

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f64` floating point data type.
+//! Constants specific to the `f64` double-precision floating point type.
 //!
 //! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f64` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -29,6 +30,7 @@ use crate::num::FpCategory;
 /// let r = f64::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `RADIX` associated constant on `f64`")]
 pub const RADIX: u32 = f64::RADIX;
 
 /// Number of significant digits in base 2.
@@ -44,6 +46,7 @@ pub const RADIX: u32 = f64::RADIX;
 /// let d = f64::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f64`")]
 pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -59,6 +62,7 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 /// let d = f64::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `DIGITS` associated constant on `f64`")]
 pub const DIGITS: u32 = f64::DIGITS;
 
 /// [Machine epsilon] value for `f64`.
@@ -78,6 +82,7 @@ pub const DIGITS: u32 = f64::DIGITS;
 /// let e = f64::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `EPSILON` associated constant on `f64`")]
 pub const EPSILON: f64 = f64::EPSILON;
 
 /// Smallest finite `f64` value.
@@ -93,6 +98,7 @@ pub const EPSILON: f64 = f64::EPSILON;
 /// let min = f64::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN` associated constant on `f64`")]
 pub const MIN: f64 = f64::MIN;
 
 /// Smallest positive normal `f64` value.
@@ -108,6 +114,7 @@ pub const MIN: f64 = f64::MIN;
 /// let min = f64::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_POSITIVE` associated constant on `f64`")]
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 
 /// Largest finite `f64` value.
@@ -123,6 +130,7 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 /// let max = f64::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX` associated constant on `f64`")]
 pub const MAX: f64 = f64::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -138,6 +146,7 @@ pub const MAX: f64 = f64::MAX;
 /// let min = f64::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_EXP` associated constant on `f64`")]
 pub const MIN_EXP: i32 = f64::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -153,6 +162,7 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 /// let max = f64::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_EXP` associated constant on `f64`")]
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -168,6 +178,7 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 /// let min = f64::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN_10_EXP` associated constant on `f64`")]
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -183,6 +194,7 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 /// let max = f64::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX_10_EXP` associated constant on `f64`")]
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -198,6 +210,7 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 /// let nan = f64::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `NAN` associated constant on `f64`")]
 pub const NAN: f64 = f64::NAN;
 
 /// Infinity (∞).
@@ -213,6 +226,7 @@ pub const NAN: f64 = f64::NAN;
 /// let inf = f64::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `INFINITY` associated constant on `f64`")]
 pub const INFINITY: f64 = f64::INFINITY;
 
 /// Negative infinity (−∞).
@@ -228,6 +242,7 @@ pub const INFINITY: f64 = f64::INFINITY;
 /// let ninf = f64::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.49.0", reason = "replaced by the `NEG_INFINITY` associated constant on `f64`")]
 pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2202,32 +2202,30 @@ fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT),
         }
 
         doc_comment! {
-            concat!("**This method is soft-deprecated.**
-
-Although using it won’t cause a compilation warning,
-new code should use [`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN) instead.
+            concat!("
+New code should instead use [`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN).
 
 Returns the smallest value that can be represented by this integer type."),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[inline(always)]
             #[rustc_promotable]
             #[rustc_const_stable(feature = "const_min_value", since = "1.32.0")]
+            #[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN` associated constant on this type")]
             pub const fn min_value() -> Self {
                 Self::MIN
             }
         }
 
         doc_comment! {
-            concat!("**This method is soft-deprecated.**
-
-Although using it won’t cause a compilation warning,
-new code should use [`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX) instead.
+            concat!("
+New code should instead use [`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX).
 
 Returns the largest value that can be represented by this integer type."),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[inline(always)]
             #[rustc_promotable]
             #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
+            #[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX` associated constant on this type")]
             pub const fn max_value() -> Self {
                 Self::MAX
             }

--- a/library/core/src/num/shells/i128.rs
+++ b/library/core/src/num/shells/i128.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "i128", since = "1.26.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i128`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `i128`"
+)]
 
 int_module! { i128, #[stable(feature = "i128", since="1.26.0")] }

--- a/library/core/src/num/shells/i128.rs
+++ b/library/core/src/num/shells/i128.rs
@@ -1,10 +1,10 @@
-//! The 128-bit signed integer type.
+//! Constants for the 128-bit signed integer type.
 //!
 //! *[See also the `i128` primitive type](../../std/primitive.i128.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "i128", since = "1.26.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i128`")]
 
 int_module! { i128, #[stable(feature = "i128", since="1.26.0")] }

--- a/library/core/src/num/shells/i16.rs
+++ b/library/core/src/num/shells/i16.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i16`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `i16`"
+)]
 
 int_module! { i16 }

--- a/library/core/src/num/shells/i16.rs
+++ b/library/core/src/num/shells/i16.rs
@@ -1,10 +1,10 @@
-//! The 16-bit signed integer type.
+//! Constants for the 16-bit signed integer type.
 //!
 //! *[See also the `i16` primitive type](../../std/primitive.i16.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i16`")]
 
 int_module! { i16 }

--- a/library/core/src/num/shells/i32.rs
+++ b/library/core/src/num/shells/i32.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i32`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `i32`"
+)]
 
 int_module! { i32 }

--- a/library/core/src/num/shells/i32.rs
+++ b/library/core/src/num/shells/i32.rs
@@ -1,10 +1,10 @@
-//! The 32-bit signed integer type.
+//! Constants for the 32-bit signed integer type.
 //!
 //! *[See also the `i32` primitive type](../../std/primitive.i32.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i32`")]
 
 int_module! { i32 }

--- a/library/core/src/num/shells/i64.rs
+++ b/library/core/src/num/shells/i64.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i64`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `i64`"
+)]
 
 int_module! { i64 }

--- a/library/core/src/num/shells/i64.rs
+++ b/library/core/src/num/shells/i64.rs
@@ -1,10 +1,10 @@
-//! The 64-bit signed integer type.
+//! Constants for the 64-bit signed integer type.
 //!
 //! *[See also the `i64` primitive type](../../std/primitive.i64.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i64`")]
 
 int_module! { i64 }

--- a/library/core/src/num/shells/i8.rs
+++ b/library/core/src/num/shells/i8.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i8`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `i8`"
+)]
 
 int_module! { i8 }

--- a/library/core/src/num/shells/i8.rs
+++ b/library/core/src/num/shells/i8.rs
@@ -1,10 +1,10 @@
-//! The 8-bit signed integer type.
+//! Constants for the 8-bit signed integer type.
 //!
 //! *[See also the `i8` primitive type](../../std/primitive.i8.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `i8`")]
 
 int_module! { i8 }

--- a/library/core/src/num/shells/int_macros.rs
+++ b/library/core/src/num/shells/int_macros.rs
@@ -25,6 +25,7 @@ let min = ", stringify!($T), "::MIN;
 ```
 "),
             #[$attr]
+            #[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN` associated constant on this type")]
             pub const MIN: $T = $T::MIN;
         }
 
@@ -43,6 +44,7 @@ let max = ", stringify!($T), "::MAX;
 ```
 "),
             #[$attr]
+            #[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX` associated constant on this type")]
             pub const MAX: $T = $T::MAX;
         }
     )

--- a/library/core/src/num/shells/isize.rs
+++ b/library/core/src/num/shells/isize.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `isize`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `isize`"
+)]
 
 int_module! { isize }

--- a/library/core/src/num/shells/isize.rs
+++ b/library/core/src/num/shells/isize.rs
@@ -1,10 +1,10 @@
-//! The pointer-sized signed integer type.
+//! Constants for the pointer-sized signed integer type.
 //!
 //! *[See also the `isize` primitive type](../../std/primitive.isize.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `isize`")]
 
 int_module! { isize }

--- a/library/core/src/num/shells/u128.rs
+++ b/library/core/src/num/shells/u128.rs
@@ -1,9 +1,10 @@
-//! The 128-bit unsigned integer type.
+//! Constants for the 128-bit unsigned integer type.
 //!
 //! *[See also the `u128` primitive type](../../std/primitive.u128.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "i128", since = "1.26.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u128`")]
+
 int_module! { u128, #[stable(feature = "i128", since="1.26.0")] }

--- a/library/core/src/num/shells/u128.rs
+++ b/library/core/src/num/shells/u128.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "i128", since = "1.26.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u128`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `u128`"
+)]
 
 int_module! { u128, #[stable(feature = "i128", since="1.26.0")] }

--- a/library/core/src/num/shells/u16.rs
+++ b/library/core/src/num/shells/u16.rs
@@ -1,10 +1,10 @@
-//! The 16-bit unsigned integer type.
+//! Constants for the 16-bit unsigned integer type.
 //!
 //! *[See also the `u16` primitive type](../../std/primitive.u16.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u16`")]
 
 int_module! { u16 }

--- a/library/core/src/num/shells/u16.rs
+++ b/library/core/src/num/shells/u16.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u16`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `u16`"
+)]
 
 int_module! { u16 }

--- a/library/core/src/num/shells/u32.rs
+++ b/library/core/src/num/shells/u32.rs
@@ -1,10 +1,10 @@
-//! The 32-bit unsigned integer type.
+//! Constants for the 32-bit unsigned integer type.
 //!
 //! *[See also the `u32` primitive type](../../std/primitive.u32.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u32`")]
 
 int_module! { u32 }

--- a/library/core/src/num/shells/u32.rs
+++ b/library/core/src/num/shells/u32.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u32`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `u32`"
+)]
 
 int_module! { u32 }

--- a/library/core/src/num/shells/u64.rs
+++ b/library/core/src/num/shells/u64.rs
@@ -1,10 +1,10 @@
-//! The 64-bit unsigned integer type.
+//! Constants for the 64-bit unsigned integer type.
 //!
 //! *[See also the `u64` primitive type](../../std/primitive.u64.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u64`")]
 
 int_module! { u64 }

--- a/library/core/src/num/shells/u64.rs
+++ b/library/core/src/num/shells/u64.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u64`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `u64`"
+)]
 
 int_module! { u64 }

--- a/library/core/src/num/shells/u8.rs
+++ b/library/core/src/num/shells/u8.rs
@@ -1,10 +1,10 @@
-//! The 8-bit unsigned integer type.
+//! Constants for the 8-bit unsigned integer type.
 //!
 //! *[See also the `u8` primitive type](../../std/primitive.u8.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u8`")]
 
 int_module! { u8 }

--- a/library/core/src/num/shells/u8.rs
+++ b/library/core/src/num/shells/u8.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `u8`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `u8`"
+)]
 
 int_module! { u8 }

--- a/library/core/src/num/shells/usize.rs
+++ b/library/core/src/num/shells/usize.rs
@@ -1,10 +1,10 @@
-//! The pointer-sized unsigned integer type.
+//! Constants for the pointer-sized unsigned integer type.
 //!
 //! *[See also the `usize` primitive type](../../std/primitive.usize.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `usize`")]
 
 int_module! { usize }

--- a/library/core/src/num/shells/usize.rs
+++ b/library/core/src/num/shells/usize.rs
@@ -5,6 +5,9 @@
 //! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![rustc_deprecated(since = "1.49.0", reason = "all constants in this module replaced by associated constants on `usize`")]
+#![rustc_deprecated(
+    since = "1.49.0",
+    reason = "all constants in this module replaced by associated constants on `usize`"
+)]
 
 int_module! { usize }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1960,30 +1960,28 @@ fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT),
         }
 
         doc_comment! {
-            concat!("**This method is soft-deprecated.**
-
-Although using it won’t cause compilation warning,
-new code should use [`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN) instead.
+            concat!("
+New code should instead use [`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN).
 
 Returns the smallest value that can be represented by this integer type."),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_promotable]
             #[inline(always)]
             #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
+            #[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MIN` associated constant on this type")]
             pub const fn min_value() -> Self { Self::MIN }
         }
 
         doc_comment! {
-            concat!("**This method is soft-deprecated.**
-
-Although using it won’t cause compilation warning,
-new code should use [`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX) instead.
+            concat!("
+New code should instead use [`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX).
 
 Returns the largest value that can be represented by this integer type."),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_promotable]
             #[inline(always)]
             #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
+            #[rustc_deprecated(since = "1.49.0", reason = "replaced by the `MAX` associated constant on this type")]
             pub const fn max_value() -> Self { Self::MAX }
         }
     }

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -23,21 +23,8 @@ use crate::sys::cmath;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated, deprecated_in_future)]
 pub use core::f32::{
-    consts,
-    DIGITS,
-    EPSILON,
-    MANTISSA_DIGITS,
-    RADIX,
-    INFINITY,
-    MAX_10_EXP,
-    NAN,
-    NEG_INFINITY,
-    MAX,
-    MIN,
-    MIN_POSITIVE,
-    MAX_EXP,
-    MIN_10_EXP,
-    MIN_EXP
+    consts, DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP,
+    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX,
 };
 
 #[cfg(not(test))]

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f32` floating point data type.
+//! Constants specific to the `f32` single-precision floating point type.
 //!
 //! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f32` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
@@ -20,15 +21,24 @@ use crate::intrinsics;
 use crate::sys::cmath;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::consts;
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{DIGITS, EPSILON, MANTISSA_DIGITS, RADIX};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{INFINITY, MAX_10_EXP, NAN, NEG_INFINITY};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{MAX, MIN, MIN_POSITIVE};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{MAX_EXP, MIN_10_EXP, MIN_EXP};
+#[allow(deprecated, deprecated_in_future)]
+pub use core::f32::{
+    consts,
+    DIGITS,
+    EPSILON,
+    MANTISSA_DIGITS,
+    RADIX,
+    INFINITY,
+    MAX_10_EXP,
+    NAN,
+    NEG_INFINITY,
+    MAX,
+    MIN,
+    MIN_POSITIVE,
+    MAX_EXP,
+    MIN_10_EXP,
+    MIN_EXP
+};
 
 #[cfg(not(test))]
 #[lang = "f32_runtime"]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f64` floating point data type.
+//! Constants specific to the `f64` double-precision floating point type.
 //!
 //! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f64` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
@@ -20,15 +21,24 @@ use crate::intrinsics;
 use crate::sys::cmath;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::consts;
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{DIGITS, EPSILON, MANTISSA_DIGITS, RADIX};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{INFINITY, MAX_10_EXP, NAN, NEG_INFINITY};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{MAX, MIN, MIN_POSITIVE};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{MAX_EXP, MIN_10_EXP, MIN_EXP};
+#[allow(deprecated, deprecated_in_future)]
+pub use core::f64::{
+    consts,
+    DIGITS,
+    EPSILON,
+    MANTISSA_DIGITS,
+    RADIX,
+    INFINITY,
+    MAX_10_EXP,
+    NAN,
+    NEG_INFINITY,
+    MAX,
+    MIN,
+    MIN_POSITIVE,
+    MAX_EXP,
+    MIN_10_EXP,
+    MIN_EXP
+};
 
 #[cfg(not(test))]
 #[lang = "f64_runtime"]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -23,21 +23,8 @@ use crate::sys::cmath;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated, deprecated_in_future)]
 pub use core::f64::{
-    consts,
-    DIGITS,
-    EPSILON,
-    MANTISSA_DIGITS,
-    RADIX,
-    INFINITY,
-    MAX_10_EXP,
-    NAN,
-    NEG_INFINITY,
-    MAX,
-    MIN,
-    MIN_POSITIVE,
-    MAX_EXP,
-    MIN_10_EXP,
-    MIN_EXP
+    consts, DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP,
+    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX,
 };
 
 #[cfg(not(test))]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -407,18 +407,24 @@ pub use core::hash;
 #[stable(feature = "core_hint", since = "1.27.0")]
 pub use core::hint;
 #[stable(feature = "i128", since = "1.26.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i128;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i16;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i32;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i64;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i8;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::intrinsics;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::isize;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::iter;
@@ -439,16 +445,22 @@ pub use core::raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;
 #[stable(feature = "i128", since = "1.26.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u128;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u16;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u32;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u64;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u8;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::usize;
 
 pub mod f32;

--- a/src/test/codegen/enum-discriminant-value.rs
+++ b/src/test/codegen/enum-discriminant-value.rs
@@ -4,14 +4,14 @@
 
 #[repr(i64)]
 pub enum I64 {
-    I64Min = std::i64::MIN,
-    I64Max = std::i64::MAX,
+    I64Min = i64::MIN,
+    I64Max = i64::MAX,
 }
 
 #[repr(u64)]
 pub enum U64 {
-    U64Min = std::u64::MIN,
-    U64Max = std::u64::MAX,
+    U64Min = u64::MIN,
+    U64Max = u64::MAX,
 }
 
 fn main() {

--- a/src/test/codegen/issue-56927.rs
+++ b/src/test/codegen/issue-56927.rs
@@ -1,7 +1,6 @@
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type="rlib"]
-use std::usize;
 
 #[repr(align(16))]
 pub struct S {

--- a/src/test/compile-fail/consts/issue-55878.rs
+++ b/src/test/compile-fail/consts/issue-55878.rs
@@ -3,5 +3,5 @@
 
 // error-pattern: is too big for the current architecture
 fn main() {
-    println!("Size: {}", std::mem::size_of::<[u8; std::u64::MAX as usize]>());
+    println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
 }

--- a/src/test/rustdoc/reexport-check.rs
+++ b/src/test/rustdoc/reexport-check.rs
@@ -6,6 +6,7 @@ extern crate reexport_check;
 // @!has 'foo/index.html' '//code' 'pub use self::i32;'
 // @has 'foo/index.html' '//tr[@class="module-item"]' 'i32'
 // @has 'foo/i32/index.html'
+#[allow(deprecated, deprecated_in_future)]
 pub use std::i32;
 // @!has 'foo/index.html' '//code' 'pub use self::string::String;'
 // @has 'foo/index.html' '//tr[@class="module-item"]' 'String'

--- a/src/test/rustdoc/show-const-contents.rs
+++ b/src/test/rustdoc/show-const-contents.rs
@@ -52,6 +52,7 @@ pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 pub use std::f32::consts::PI;
 
 // @has show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
+#[allow(deprecated, deprecated_in_future)]
 pub use std::i32::MAX;
 
 macro_rules! int_module {

--- a/src/test/ui/array-slice-vec/bounds-check-no-overflow.rs
+++ b/src/test/ui/array-slice-vec/bounds-check-no-overflow.rs
@@ -2,7 +2,6 @@
 // error-pattern:index out of bounds
 // ignore-emscripten no processes
 
-use std::usize;
 use std::mem::size_of;
 
 fn main() {

--- a/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.rs
+++ b/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.rs
@@ -5,8 +5,6 @@
 
 #![crate_type="lib"]
 
-use std::i32;
-
 pub trait Foo {
     const NEG: i32;
     const NEG_REV: i32;

--- a/src/test/ui/big-literals.rs
+++ b/src/test/ui/big-literals.rs
@@ -10,8 +10,8 @@ pub fn main() {
 
     assert_eq!((-2147483648i32).wrapping_sub(1), 2147483647);
 
-    assert_eq!(-3.40282356e+38_f32, ::std::f32::MIN);
-    assert_eq!(3.40282356e+38_f32, ::std::f32::MAX);
-    assert_eq!(-1.7976931348623158e+308_f64, ::std::f64::MIN);
-    assert_eq!(1.7976931348623158e+308_f64, ::std::f64::MAX);
+    assert_eq!(-3.40282356e+38_f32, f32::MIN);
+    assert_eq!(3.40282356e+38_f32, f32::MAX);
+    assert_eq!(-1.7976931348623158e+308_f64, f64::MIN);
+    assert_eq!(1.7976931348623158e+308_f64, f64::MAX);
 }

--- a/src/test/ui/const-generics/const_evaluatable_checked/fn_call.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/fn_call.rs
@@ -6,7 +6,7 @@ const fn test_me<T>(a: usize, b: usize) -> usize {
     if a < b {
         std::mem::size_of::<T>()
     } else {
-        std::usize::MAX
+        usize::MAX
     }
 }
 

--- a/src/test/ui/consts/const-err-early.rs
+++ b/src/test/ui/consts/const-err-early.rs
@@ -1,6 +1,6 @@
 #![deny(const_err)]
 
-pub const A: i8 = -std::i8::MIN; //~ ERROR const_err
+pub const A: i8 = -i8::MIN; //~ ERROR const_err
 pub const B: u8 = 200u8 + 200u8; //~ ERROR const_err
 pub const C: u8 = 200u8 * 4; //~ ERROR const_err
 pub const D: u8 = 42u8 - (42u8 + 1); //~ ERROR const_err

--- a/src/test/ui/consts/const-err-early.stderr
+++ b/src/test/ui/consts/const-err-early.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
   --> $DIR/const-err-early.rs:3:19
    |
-LL | pub const A: i8 = -std::i8::MIN;
-   | ------------------^^^^^^^^^^^^^-
+LL | pub const A: i8 = -i8::MIN;
+   | ------------------^^^^^^^^-
    |                   |
    |                   attempt to negate `i8::MIN`, which would overflow
    |

--- a/src/test/ui/consts/const-err-multi.rs
+++ b/src/test/ui/consts/const-err-multi.rs
@@ -1,6 +1,6 @@
 #![deny(const_err)]
 
-pub const A: i8 = -std::i8::MIN;
+pub const A: i8 = -i8::MIN;
 //~^ ERROR const_err
 pub const B: i8 = A;
 //~^ ERROR const_err

--- a/src/test/ui/consts/const-err-multi.stderr
+++ b/src/test/ui/consts/const-err-multi.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
   --> $DIR/const-err-multi.rs:3:19
    |
-LL | pub const A: i8 = -std::i8::MIN;
-   | ------------------^^^^^^^^^^^^^-
+LL | pub const A: i8 = -i8::MIN;
+   | ------------------^^^^^^^^-
    |                   |
    |                   attempt to negate `i8::MIN`, which would overflow
    |

--- a/src/test/ui/consts/const-err2.noopt.stderr
+++ b/src/test/ui/consts/const-err2.noopt.stderr
@@ -1,16 +1,16 @@
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
-LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
+LL |     let a = -i8::MIN;
+   |             ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
-LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
+LL |     let a_i128 = -i128::MIN;
+   |                  ^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
@@ -21,8 +21,8 @@ LL |     let b = 200u8 + 200u8 + 200u8;
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
-LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
+LL |     let b_i128 = i128::MIN - i128::MAX;
+   |                  ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13

--- a/src/test/ui/consts/const-err2.opt.stderr
+++ b/src/test/ui/consts/const-err2.opt.stderr
@@ -1,16 +1,16 @@
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
-LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
+LL |     let a = -i8::MIN;
+   |             ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
-LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
+LL |     let a_i128 = -i128::MIN;
+   |                  ^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
@@ -21,8 +21,8 @@ LL |     let b = 200u8 + 200u8 + 200u8;
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
-LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
+LL |     let b_i128 = i128::MIN - i128::MAX;
+   |                  ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13

--- a/src/test/ui/consts/const-err2.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/const-err2.opt_with_overflow_checks.stderr
@@ -1,16 +1,16 @@
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
-LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
+LL |     let a = -i8::MIN;
+   |             ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
-LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
+LL |     let a_i128 = -i128::MIN;
+   |                  ^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
@@ -21,8 +21,8 @@ LL |     let b = 200u8 + 200u8 + 200u8;
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
-LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
+LL |     let b_i128 = i128::MIN - i128::MAX;
+   |                  ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13

--- a/src/test/ui/consts/const-err2.rs
+++ b/src/test/ui/consts/const-err2.rs
@@ -16,13 +16,13 @@ fn black_box<T>(_: T) {
 }
 
 fn main() {
-    let a = -std::i8::MIN;
+    let a = -i8::MIN;
     //~^ ERROR arithmetic operation will overflow
-    let a_i128 = -std::i128::MIN;
+    let a_i128 = -i128::MIN;
     //~^ ERROR arithmetic operation will overflow
     let b = 200u8 + 200u8 + 200u8;
     //~^ ERROR arithmetic operation will overflow
-    let b_i128 = std::i128::MIN - std::i128::MAX;
+    let b_i128 = i128::MIN - i128::MAX;
     //~^ ERROR arithmetic operation will overflow
     let c = 200u8 * 4;
     //~^ ERROR arithmetic operation will overflow

--- a/src/test/ui/consts/const-negation.rs
+++ b/src/test/ui/consts/const-negation.rs
@@ -8,19 +8,19 @@ fn main() {
     const I: isize = -2147483648isize;
     #[cfg(target_pointer_width = "64")]
     const I: isize = -9223372036854775808isize;
-    assert_eq!(::std::i32::MIN as u64, 0xffffffff80000000);
+    assert_eq!(i32::MIN as u64, 0xffffffff80000000);
     assert_eq!(-2147483648isize as u64, 0xffffffff80000000);
     assert_eq!(-2147483648i32 as u64, 0xffffffff80000000);
-    assert_eq!(::std::i64::MIN as u64, 0x8000000000000000);
+    assert_eq!(i64::MIN as u64, 0x8000000000000000);
     #[cfg(target_pointer_width = "64")]
     assert_eq!(-9223372036854775808isize as u64, 0x8000000000000000);
     #[cfg(target_pointer_width = "32")]
     assert_eq!(-9223372036854775808isize as u64, 0);
     assert_eq!(-9223372036854775808i32 as u64, 0);
-    const J: usize = ::std::i32::MAX as usize;
+    const J: usize = i32::MAX as usize;
     const K: usize = -1i32 as u32 as usize;
-    const L: usize = ::std::i32::MIN as usize;
-    const M: usize = ::std::i64::MIN as usize;
+    const L: usize = i32::MIN as usize;
+    const M: usize = i64::MIN as usize;
     match 5 {
         J => {},
         K => {},

--- a/src/test/ui/consts/issue-63952.rs
+++ b/src/test/ui/consts/issue-63952.rs
@@ -1,7 +1,5 @@
 // Regression test for #63952, shouldn't hang.
 
-use std::usize;
-
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct SliceRepr {

--- a/src/test/ui/consts/promotion.rs
+++ b/src/test/ui/consts/promotion.rs
@@ -13,5 +13,5 @@ fn main() {
 
     // make sure that these do not cause trouble despite overflowing
     baz_u32(&(0-1));
-    baz_i32(&-std::i32::MIN);
+    baz_i32(&-i32::MIN);
 }

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -12,7 +12,6 @@ use std::mem::ManuallyDrop;
 use std::ops::Generator;
 use std::panic;
 use std::pin::Pin;
-use std::usize;
 
 struct InjectedFailure;
 

--- a/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.rs
+++ b/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.rs
@@ -1,10 +1,8 @@
 #![feature(exclusive_range_pattern)]
 
-use std::usize::MAX;
-
 fn main() {
     match 0usize { //~ERROR non-exhaustive patterns: `_` not covered
-        0..=MAX => {}
+        0..=usize::MAX => {}
     }
 
     match 0isize { //~ERROR non-exhaustive patterns: `_` not covered

--- a/src/test/ui/format-nan.rs
+++ b/src/test/ui/format-nan.rs
@@ -1,7 +1,6 @@
 // run-pass
 
 pub fn main() {
-    use std::f64;
     let x = "NaN".to_string();
     assert_eq!(format!("{}", f64::NAN), x);
     assert_eq!(format!("{:e}", f64::NAN), x);

--- a/src/test/ui/hashmap/hashmap-capacity-overflow.rs
+++ b/src/test/ui/hashmap/hashmap-capacity-overflow.rs
@@ -3,7 +3,6 @@
 // ignore-emscripten no processes
 
 use std::collections::hash_map::HashMap;
-use std::usize;
 use std::mem::size_of;
 
 fn main() {

--- a/src/test/ui/issues/issue-20427.rs
+++ b/src/test/ui/issues/issue-20427.rs
@@ -67,6 +67,7 @@ mod reuse {
 
 mod guard {
     pub fn check() {
+        #[allow(deprecated, deprecated_in_future)]
         use std::u8; // bring module u8 in scope
         fn f() -> u8 { // OK, resolves to primitive u8, not to std::u8
             u8::max_value() // OK, resolves to associated function <u8>::max_value,

--- a/src/test/ui/issues/issue-37686.rs
+++ b/src/test/ui/issues/issue-37686.rs
@@ -1,7 +1,7 @@
 // run-pass
 fn main() {
     match (0, 0) {
-        (std::usize::MIN, std::usize::MAX) => {}
+        (usize::MIN, usize::MAX) => {}
         _ => {}
     }
 }

--- a/src/test/ui/issues/issue-41880.rs
+++ b/src/test/ui/issues/issue-41880.rs
@@ -19,7 +19,7 @@ impl<T: Clone, F> Iterator for Iterate<T, F> where F: Fn(&T) -> T {
         Some(self.state.clone())
     }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { (std::usize::MAX, None) }
+    fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-48006.rs
+++ b/src/test/ui/issues/issue-48006.rs
@@ -6,10 +6,10 @@ use std::iter::Step;
 
 #[cfg(target_pointer_width = "16")]
 fn main() {
-    assert!(Step::steps_between(&0u32, &::std::u32::MAX).is_none());
+    assert!(Step::steps_between(&0u32, &u32::MAX).is_none());
 }
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 fn main() {
-    assert!(Step::steps_between(&0u32, &::std::u32::MAX).is_some());
+    assert!(Step::steps_between(&0u32, &u32::MAX).is_some());
 }

--- a/src/test/ui/issues/issue-50811.rs
+++ b/src/test/ui/issues/issue-50811.rs
@@ -3,7 +3,6 @@
 
 extern crate test;
 
-use std::f64::{NAN, NEG_INFINITY, INFINITY, MAX};
 use std::mem::size_of;
 use test::black_box;
 
@@ -12,7 +11,7 @@ use test::black_box;
 macro_rules! compare {
     ($op:tt) => {
         compare!(
-            [NEG_INFINITY, -MAX, -1.0, -0.0, 0.0, 1.0, MAX, INFINITY, NAN],
+            [f64::NEG_INFINITY, -f64::MAX, -1.0, -0.0, 0.0, 1.0, f64::MAX, f64::INFINITY, f64::NAN],
             $op
         );
     };
@@ -20,7 +19,7 @@ macro_rules! compare {
         $(compare!(
             $lhs,
             $op,
-            [NEG_INFINITY, -MAX, -1.0, -0.0, 0.0, 1.0, MAX, INFINITY, NAN]
+            [f64::NEG_INFINITY, -f64::MAX, -1.0, -0.0, 0.0, 1.0, f64::MAX, f64::INFINITY, f64::NAN]
         );)+
     };
     ($lhs:expr, $op:tt, [$($rhs:expr),+]) => {
@@ -44,8 +43,8 @@ macro_rules! compare {
 fn main() {
     assert_eq!(0.0/0.0 < 0.0/0.0, false);
     assert_eq!(0.0/0.0 > 0.0/0.0, false);
-    assert_eq!(NAN < NAN, false);
-    assert_eq!(NAN > NAN, false);
+    assert_eq!(f64::NAN < f64::NAN, false);
+    assert_eq!(f64::NAN > f64::NAN, false);
 
     compare!(==);
     compare!(!=);

--- a/src/test/ui/issues/issue-68010-large-zst-consts.rs
+++ b/src/test/ui/issues/issue-68010-large-zst-consts.rs
@@ -1,5 +1,5 @@
 // build-pass
 
 fn main() {
-    println!("{}", [(); std::usize::MAX].len());
+    println!("{}", [(); usize::MAX].len());
 }

--- a/src/test/ui/issues/issue-6804.rs
+++ b/src/test/ui/issues/issue-6804.rs
@@ -3,7 +3,7 @@
 #![allow(unused)]
 #![deny(illegal_floating_point_literal_pattern)]
 
-use std::f64::NAN;
+const NAN = f64::NAN;
 
 fn main() {
     let x = NAN;

--- a/src/test/ui/iterators/iter-count-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-debug.rs
@@ -4,13 +4,12 @@
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;
-use std::usize::MAX;
 
 fn main() {
-    assert_eq!((0..MAX).by_ref().count(), MAX);
+    assert_eq!((0..usize::MAX).by_ref().count(), usize::MAX);
 
     let r = panic::catch_unwind(|| {
-        (0..=MAX).by_ref().count()
+        (0..=usize::MAX).by_ref().count()
     });
     assert!(r.is_err());
 }

--- a/src/test/ui/iterators/iter-count-overflow-ndebug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-ndebug.rs
@@ -3,9 +3,8 @@
 // compile-flags: -C debug_assertions=no -C opt-level=3
 
 use std::panic;
-use std::usize::MAX;
 
 fn main() {
-    assert_eq!((0..MAX).by_ref().count(), MAX);
-    assert_eq!((0..=MAX).by_ref().count(), 0);
+    assert_eq!((0..usize::MAX).by_ref().count(), usize::MAX);
+    assert_eq!((0..=usize::MAX).by_ref().count(), 0);
 }

--- a/src/test/ui/iterators/iter-position-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-debug.rs
@@ -4,11 +4,10 @@
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;
-use std::usize::MAX;
 
 fn main() {
-    let n = MAX as u64;
-    assert_eq!((0..).by_ref().position(|i| i >= n), Some(MAX));
+    let n = usize::MAX as u64;
+    assert_eq!((0..).by_ref().position(|i| i >= n), Some(usize::MAX));
 
     let r = panic::catch_unwind(|| {
         (0..).by_ref().position(|i| i > n)

--- a/src/test/ui/iterators/iter-position-overflow-ndebug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-ndebug.rs
@@ -3,11 +3,10 @@
 // compile-flags: -C debug_assertions=no -C opt-level=3
 
 use std::panic;
-use std::usize::MAX;
 
 fn main() {
-    let n = MAX as u64;
-    assert_eq!((0..).by_ref().position(|i| i >= n), Some(MAX));
+    let n = usize::MAX as u64;
+    assert_eq!((0..).by_ref().position(|i| i >= n), Some(usize::MAX));
     assert_eq!((0..).by_ref().position(|i| i > n), Some(0));
     assert_eq!((0..=n + 1).by_ref().position(|_| false), None);
 }

--- a/src/test/ui/macros/macro-first-set.rs
+++ b/src/test/ui/macros/macro-first-set.rs
@@ -249,7 +249,7 @@ macro_rules! test_path {
 test_path!();
 test_path!(,);
 test_path!(::std);
-test_path!(std::u8,);
+test_path!(std::ops,);
 test_path!(any, super, super::super::self::path, X<Y>::Z<'a, T=U>);
 
 macro_rules! test_lifetime {

--- a/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.rs
+++ b/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.rs
@@ -1,7 +1,5 @@
 #![feature(box_syntax, unboxed_closures)]
 
-use std::usize;
-
 fn to_fn<A,F:Fn<A>>(f: F) -> F { f }
 
 fn test(_x: Box<usize>) {}

--- a/src/test/ui/numbers-arithmetic/float-nan.rs
+++ b/src/test/ui/numbers-arithmetic/float-nan.rs
@@ -1,5 +1,4 @@
 // run-pass
-use std::f64;
 
 pub fn main() {
   let nan: f64 = f64::NAN;

--- a/src/test/ui/numbers-arithmetic/overflowing-neg.rs
+++ b/src/test/ui/numbers-arithmetic/overflowing-neg.rs
@@ -6,5 +6,5 @@
 #![allow(arithmetic_overflow)]
 
 fn main() {
-    let _x = -std::i8::MIN;
+    let _x = -i8::MIN;
 }

--- a/src/test/ui/numbers-arithmetic/shift-near-oflo.rs
+++ b/src/test/ui/numbers-arithmetic/shift-near-oflo.rs
@@ -47,21 +47,21 @@ fn test_left_shift() {
     let x = 1_u8 << id(0);
     assert_eq!(x, 1);
     let x = 1_i8 << id(7);
-    assert_eq!(x, std::i8::MIN);
+    assert_eq!(x, i8::MIN);
     let x = 1_u8 << id(7);
     assert_eq!(x, 0x80);
     // high-order bits on LHS are silently discarded without panic.
     let x = 3_i8 << id(7);
-    assert_eq!(x, std::i8::MIN);
+    assert_eq!(x, i8::MIN);
     let x = 3_u8 << id(7);
     assert_eq!(x, 0x80);
 
     // above is (approximately) expanded from:
-    tests!(i8, u8, 7, std::i8::MIN, 0x80_u8);
+    tests!(i8, u8, 7, i8::MIN, 0x80_u8);
 
-    tests!(i16, u16, 15, std::i16::MIN, 0x8000_u16);
-    tests!(i32, u32, 31, std::i32::MIN, 0x8000_0000_u32);
-    tests!(i64, u64, 63, std::i64::MIN, 0x8000_0000_0000_0000_u64);
+    tests!(i16, u16, 15, i16::MIN, 0x8000_u16);
+    tests!(i32, u32, 31, i32::MIN, 0x8000_0000_u32);
+    tests!(i64, u64, 63, i64::MIN, 0x8000_0000_0000_0000_u64);
 }
 
 fn test_right_shift() {
@@ -92,9 +92,9 @@ fn test_right_shift() {
         } }
     }
 
-    tests!(i8, u8, 7, std::i8::MIN, 0x40_i8, 0x80_u8);
-    tests!(i16, u16, 15, std::i16::MIN, 0x4000_u16, 0x8000_u16);
-    tests!(i32, u32, 31, std::i32::MIN, 0x4000_0000_u32, 0x8000_0000_u32);
-    tests!(i64, u64, 63, std::i64::MIN,
+    tests!(i8, u8, 7, i8::MIN, 0x40_i8, 0x80_u8);
+    tests!(i16, u16, 15, i16::MIN, 0x4000_u16, 0x8000_u16);
+    tests!(i32, u32, 31, i32::MIN, 0x4000_0000_u32, 0x8000_0000_u32);
+    tests!(i64, u64, 63, i64::MIN,
            0x4000_0000_0000_0000_u64, 0x8000_0000_0000_0000_u64);
 }

--- a/src/test/ui/numbers-arithmetic/u128-as-f32.rs
+++ b/src/test/ui/numbers-arithmetic/u128-as-f32.rs
@@ -4,8 +4,6 @@
 #![deny(overflowing_literals)]
 extern crate test;
 
-use std::f32;
-use std::u128;
 use test::black_box;
 
 macro_rules! test {

--- a/src/test/ui/regions/regions-addr-of-upvar-self.rs
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.rs
@@ -1,5 +1,3 @@
-use std::usize;
-
 struct Dog {
     food: usize,
 }

--- a/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.rs
+++ b/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.rs
@@ -1,5 +1,3 @@
-use std::f32;
-
 #[derive(PartialEq)]
 struct Foo {
     x: u32

--- a/src/test/ui/simd/simd-intrinsic-float-minmax.rs
+++ b/src/test/ui/simd/simd-intrinsic-float-minmax.rs
@@ -20,11 +20,11 @@ fn main() {
     let y = f32x4(2.0, 1.0, 4.0, 3.0);
 
     #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
-    let nan = ::std::f32::NAN;
+    let nan = f32::NAN;
     // MIPS hardware treats f32::NAN as SNAN. Clear the signaling bit.
     // See https://github.com/rust-lang/rust/issues/52746.
     #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
-    let nan = f32::from_bits(::std::f32::NAN.to_bits() - 1);
+    let nan = f32::from_bits(f32::NAN.to_bits() - 1);
 
     let n = f32x4(nan, nan, nan, nan);
 

--- a/src/test/ui/simd/simd-intrinsic-generic-comparison.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-comparison.rs
@@ -4,8 +4,6 @@
 #![feature(repr_simd, platform_intrinsics, concat_idents)]
 #![allow(non_camel_case_types)]
 
-use std::f32::NAN;
-
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct i32x4(i32, i32, i32, i32);
@@ -94,7 +92,7 @@ fn main() {
     // NAN comparisons are special:
     // -11 (*)    13
     // -5        -100 (*)
-    let f4 = f32x4(NAN, f1.1, NAN, f2.3);
+    let f4 = f32x4(f32::NAN, f1.1, f32::NAN, f2.3);
 
     unsafe {
         tests! {

--- a/src/test/ui/sleep.rs
+++ b/src/test/ui/sleep.rs
@@ -4,7 +4,6 @@
 use std::thread::{self, sleep};
 use std::time::Duration;
 use std::sync::{Arc, Mutex};
-use std::u64;
 
 fn main() {
     let finished = Arc::new(Mutex::new(false));

--- a/src/test/ui/symbol-names/const-generics.rs
+++ b/src/test/ui/symbol-names/const-generics.rs
@@ -19,11 +19,11 @@
     // `i8`
     pub struct I8<const F: i8>;
 
-    impl I8<{std::i8::MIN}> {
+    impl I8<{i8::MIN}> {
         pub fn foo() {}
     }
 
-    impl I8<{std::i8::MAX}> {
+    impl I8<{i8::MAX}> {
         pub fn foo() {}
     }
 
@@ -34,7 +34,7 @@
     // `i16`
     pub struct I16<const F: i16>;
 
-    impl I16<{std::i16::MIN}> {
+    impl I16<{i16::MIN}> {
         pub fn foo() {}
     }
 
@@ -45,7 +45,7 @@
     // `i32`
     pub struct I32<const F: i32>;
 
-    impl I32<{std::i32::MIN}> {
+    impl I32<{i32::MIN}> {
         pub fn foo() {}
     }
 
@@ -56,7 +56,7 @@
     // `i64`
     pub struct I64<const F: i64>;
 
-    impl I64<{std::i64::MIN}> {
+    impl I64<{i64::MIN}> {
         pub fn foo() {}
     }
 
@@ -67,7 +67,7 @@
     // `i128`
     pub struct I128<const F: i128>;
 
-    impl I128<{std::i128::MIN}> {
+    impl I128<{i128::MIN}> {
         pub fn foo() {}
     }
 

--- a/src/test/ui/use-module-level-int-consts.rs
+++ b/src/test/ui/use-module-level-int-consts.rs
@@ -2,6 +2,7 @@
 
 // Make sure the module level constants are still there and accessible even after
 // the corresponding associated constants have been added, and later stabilized.
+#![allow(deprecated, deprecated_in_future)]
 use std::{u16, f32};
 
 fn main() {

--- a/src/tools/clippy/tests/ui/float_cmp_const.rs
+++ b/src/tools/clippy/tests/ui/float_cmp_const.rs
@@ -48,7 +48,7 @@ fn main() {
     v != 1.0;
 
     const ZERO_ARRAY: [f32; 3] = [0.0, 0.0, 0.0];
-    const ZERO_INF_ARRAY: [f32; 3] = [0.0, ::std::f32::INFINITY, ::std::f32::NEG_INFINITY];
+    const ZERO_INF_ARRAY: [f32; 3] = [0.0, f32::INFINITY, f32::NEG_INFINITY];
     const NON_ZERO_ARRAY: [f32; 3] = [0.0, 0.1, 0.2];
     const NON_ZERO_ARRAY2: [f32; 3] = [0.2, 0.1, 0.0];
 


### PR DESCRIPTION
Tracking issue for RFC 2700: https://github.com/rust-lang/rust/issues/68490

Previously, the new associated constants defined by RFC 2700 were stabilized for Rust 1.43. At the time it was decided not to formally deprecate the old superseded constants in the same release, in order to give stable users a chance to upgrade before being subjected to warnings. Thus the old constants were "soft deprecated", i.e. the documentation for each item strongly suggested against its use but no deprecation warnings were emitted.

This PR replaces the "soft deprecation" with, er, "actual deprecation", scheduled for Rust 1.49.