### PR TITLE
Use check-pass in single-use-lifetime ui tests

### DIFF
--- a/src/test/ui/single-use-lifetime/one-use-in-fn-return.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-return.rs
@@ -5,11 +5,12 @@
 // (Normally, using `'static` would be preferred, but there are
 // times when that is not what you want.)
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(single_use_lifetimes)]
 
-fn b<'a>() -> &'a u32 { // OK: used only in return type
+// OK: used only in return type
+fn b<'a>() -> &'a u32 {
     &22
 }
 

--- a/src/test/ui/single-use-lifetime/one-use-in-struct.rs
+++ b/src/test/ui/single-use-lifetime/one-use-in-struct.rs
@@ -2,27 +2,26 @@
 // even when they are only used once (since to not use a named
 // lifetime is illegal!)
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
 struct Foo<'f> {
-    data: &'f u32
+    data: &'f u32,
 }
 
 enum Bar<'f> {
-    Data(&'f u32)
+    Data(&'f u32),
 }
 
-trait Baz<'f> { }
+trait Baz<'f> {}
 
 // `Derive`d impls shouldn't trigger a warning, either (Issue #53738).
-
 #[derive(Debug)]
 struct Quux<'a> {
     priors: &'a u32,
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/single-use-lifetime/two-uses-in-fn-argument-and-return.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-fn-argument-and-return.rs
@@ -1,14 +1,15 @@
 // Test that we DO NOT warn when lifetime name is used in
 // both the argument and return.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
-fn c<'a>(x: &'a u32) -> &'a u32 { // OK: used twice
+// OK: used twice
+fn c<'a>(x: &'a u32) -> &'a u32 {
     &22
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/single-use-lifetime/two-uses-in-fn-arguments.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-fn-arguments.rs
@@ -1,16 +1,16 @@
 // Test that we DO NOT warn when lifetime name is used multiple
 // arguments, or more than once in a single argument.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
-fn c<'a>(x: &'a u32, y: &'a u32) { // OK: used twice
-}
+// OK: used twice
+fn c<'a>(x: &'a u32, y: &'a u32) {}
 
-fn d<'a>(x: (&'a u32, &'a u32)) { // OK: used twice
-}
+// OK: used twice
+fn d<'a>(x: (&'a u32, &'a u32)) {}
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/single-use-lifetime/two-uses-in-inherent-impl-header.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-inherent-impl-header.rs
@@ -1,18 +1,17 @@
 // Test that we DO NOT warn for a lifetime used twice in an impl.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
 struct Foo<'f> {
-    data: &'f u32
+    data: &'f u32,
 }
 
 impl<'f> Foo<'f> {
-    fn inherent_a(&self, data: &'f u32) {
-    }
+    fn inherent_a(&self, data: &'f u32) {}
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/single-use-lifetime/two-uses-in-trait-impl.rs
+++ b/src/test/ui/single-use-lifetime/two-uses-in-trait-impl.rs
@@ -1,14 +1,14 @@
 // Test that we DO NOT warn for a lifetime on an impl used in both
 // header and in an associated type.
 //
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![deny(single_use_lifetimes)]
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
 struct Foo<'f> {
-    data: &'f u32
+    data: &'f u32,
 }
 
 impl<'f> Iterator for Foo<'f> {
@@ -19,4 +19,4 @@ impl<'f> Iterator for Foo<'f> {
     }
 }
 
-fn main() { }
+fn main() {}


### PR DESCRIPTION
Rationale: the `single_use_lifetimes` lint is used during late name resolution, which is within the scope of `check-pass` and does not require codegen or linking.

Helps remove some FIXMES associated with #62277. Additionally tidies touched test files.