### PR TITLE
Qualify `panic!` as `core::panic!` in non-built-in `core` macros

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -517,15 +517,15 @@ macro_rules! unreachable {
 /// This allows your code to type-check, which is useful if you are prototyping or
 /// implementing a trait that requires multiple methods which you don't plan of using all of.
 ///
-/// The difference between `unimplemented!` and [`todo!`](macro.todo.html) is that while `todo!`
+/// The difference between `unimplemented!` and [`todo!`] is that while `todo!`
 /// conveys an intent of implementing the functionality later and the message is "not yet
 /// implemented", `unimplemented!` makes no such claims. Its message is "not implemented".
 /// Also some IDEs will mark `todo!`s.
 ///
 /// # Panics
 ///
-/// This will always [panic!](macro.panic.html) because `unimplemented!` is just a
-/// shorthand for `panic!` with a fixed, specific message.
+/// This will always [`panic!`] because `unimplemented!` is just a shorthand for `panic!` with a
+/// fixed, specific message.
 ///
 /// Like `panic!`, this macro has a second form for displaying custom values.
 ///
@@ -602,7 +602,7 @@ macro_rules! unimplemented {
 ///
 /// # Panics
 ///
-/// This will always [panic!](macro.panic.html)
+/// This will always [`panic!`].
 ///
 /// # Examples
 ///

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -45,7 +45,7 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left == right)`
+                    $crate::panic!(r#"assertion failed: `(left == right)`
   left: `{:?}`,
  right: `{:?}`"#, &*left_val, &*right_val)
                 }
@@ -59,7 +59,7 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left == right)`
+                    $crate::panic!(r#"assertion failed: `(left == right)`
   left: `{:?}`,
  right: `{:?}`: {}"#, &*left_val, &*right_val,
                            $crate::format_args!($($arg)+))
@@ -96,7 +96,7 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left != right)`
+                    $crate::panic!(r#"assertion failed: `(left != right)`
   left: `{:?}`,
  right: `{:?}`"#, &*left_val, &*right_val)
                 }
@@ -110,7 +110,7 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    panic!(r#"assertion failed: `(left != right)`
+                    $crate::panic!(r#"assertion failed: `(left != right)`
   left: `{:?}`,
  right: `{:?}`: {}"#, &*left_val, &*right_val,
                            $crate::format_args!($($arg)+))
@@ -468,7 +468,7 @@ macro_rules! writeln {
 ///
 /// # Panics
 ///
-/// This will always [`panic!`]
+/// This will always [`panic!`].
 ///
 /// # Examples
 ///
@@ -502,13 +502,13 @@ macro_rules! writeln {
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! unreachable {
     () => ({
-        panic!("internal error: entered unreachable code")
+        $crate::panic!("internal error: entered unreachable code")
     });
     ($msg:expr $(,)?) => ({
         $crate::unreachable!("{}", $msg)
     });
     ($fmt:expr, $($arg:tt)*) => ({
-        panic!($crate::concat!("internal error: entered unreachable code: ", $fmt), $($arg)*)
+        $crate::panic!($crate::concat!("internal error: entered unreachable code: ", $fmt), $($arg)*)
     });
 }
 
@@ -586,8 +586,8 @@ macro_rules! unreachable {
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! unimplemented {
-    () => (panic!("not implemented"));
-    ($($arg:tt)+) => (panic!("not implemented: {}", $crate::format_args!($($arg)+)));
+    () => ($crate::panic!("not implemented"));
+    ($($arg:tt)+) => ($crate::panic!("not implemented: {}", $crate::format_args!($($arg)+)));
 }
 
 /// Indicates unfinished code.
@@ -647,8 +647,8 @@ macro_rules! unimplemented {
 #[macro_export]
 #[stable(feature = "todo_macro", since = "1.40.0")]
 macro_rules! todo {
-    () => (panic!("not yet implemented"));
-    ($($arg:tt)+) => (panic!("not yet implemented: {}", $crate::format_args!($($arg)+)));
+    () => ($crate::panic!("not yet implemented"));
+    ($($arg:tt)+) => ($crate::panic!("not yet implemented: {}", $crate::format_args!($($arg)+)));
 }
 
 /// Definitions of built-in macros.

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -11,17 +11,16 @@
       let mut _9: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _10: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _11: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _12: &std::fmt::Arguments;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _13: std::fmt::Arguments;        // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _14: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _15: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _16: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _17: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _20: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _21: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _22: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _12: std::fmt::Arguments;    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _13: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _15: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _16: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _17: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _18: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _19: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -33,33 +32,32 @@
                   debug left_val => _7;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _8;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 5 {
-                      debug arg0 => _25;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      debug arg1 => _28;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _25;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _24;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _23: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _24: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _25: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug arg0 => _24;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug arg1 => _27;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _24;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _23;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _22: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _23: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _24: &&i32; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 7 {
                           }
                       }
-                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _28;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _27;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _26: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _27: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _28: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _27;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _26;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _25: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _26: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _27: &&i32; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
-                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _29; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug args => _31;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _29: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _30: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _31: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug pieces => (_12.0: &[&str]); // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug args => _29;   // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _28: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _29: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
@@ -114,83 +112,80 @@
       }
   
       bb2: {
-          StorageLive(_13);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _14 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _13 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &[&str; 3]
                                            // + val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &[&str; 3], val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0])) }
-          _29 = move _14 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_16);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_12.0: &[&str]) = move _13 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _17 = _7;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_16.0: &&i32) = &_17;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _18 = _7;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_17.0: &&i32) = &_18;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _20 = _8;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _19 = &_20;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_17.1: &&i32) = move _19;       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_19);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _25 = (_17.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _28 = (_17.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _24 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = _8;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _18 = &_19;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_16.1: &&i32) = move _18;       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _24 = (_16.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _27 = (_16.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _23 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _23 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _24) -> bb3; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_22);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _23) -> bb3; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb3: {
-          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _25) -> bb4; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_20.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _24) -> bb4; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb4: {
-          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _23; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _27 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _22; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _26 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _26 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_25);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _26) -> bb5; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          (_22.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _28) -> bb6; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _27) -> bb6; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          (_22.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _26; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _16 = [move _21, move _22];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _15 = &_16;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _31 = move _15 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          discriminant(_30) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_13.0: &[&str]) = move _29;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_13.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _30; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_13.2: &[std::fmt::ArgumentV1]) = move _31; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _12 = &_13;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          begin_panic_fmt(move _12);       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _25; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_25);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _15 = [move _20, move _21];      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = &_15;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _29 = move _14 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_28);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_28) = 0;           // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_12.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _28; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_12.2: &[std::fmt::ArgumentV1]) = move _29; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_28);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::panic_fmt(move _12); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(std::fmt::Arguments<'r>) -> ! {core::panicking::panic_fmt}, val: Value(Scalar(<ZST>)) }
       }
   }
   

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -11,17 +11,16 @@
       let mut _9: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _10: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _11: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _12: &std::fmt::Arguments;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _13: std::fmt::Arguments;        // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _14: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _15: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _16: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _17: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _20: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _21: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _22: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _12: std::fmt::Arguments;    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _13: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _15: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _16: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _17: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _18: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _19: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -33,33 +32,32 @@
                   debug left_val => _7;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _8;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 5 {
-                      debug arg0 => _25;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      debug arg1 => _28;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _25;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _24;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _23: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _24: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _25: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug arg0 => _24;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug arg1 => _27;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _24;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _23;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _22: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _23: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _24: &&i32; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 7 {
                           }
                       }
-                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _28;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _27;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _26: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _27: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _28: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _27;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _26;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _25: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _26: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _27: &&i32; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
-                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _29; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug args => _31;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _29: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _30: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _31: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug pieces => (_12.0: &[&str]); // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug args => _29;   // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _28: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _29: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
@@ -114,83 +112,80 @@
       }
   
       bb2: {
-          StorageLive(_13);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _14 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _13 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &[&str; 3]
                                            // + val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &[&str; 3], val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0])) }
-          _29 = move _14 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_16);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_12.0: &[&str]) = move _13 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _17 = _7;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_16.0: &&i32) = &_17;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _18 = _7;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_17.0: &&i32) = &_18;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _20 = _8;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _19 = &_20;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_17.1: &&i32) = move _19;       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_19);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _25 = (_17.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _28 = (_17.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _24 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = _8;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _18 = &_19;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_16.1: &&i32) = move _18;       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _24 = (_16.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _27 = (_16.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _23 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _23 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _24) -> bb3; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_22);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _23) -> bb3; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb3: {
-          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _25) -> bb4; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_20.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _24) -> bb4; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb4: {
-          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _23; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_23);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _27 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _22; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_22);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _26 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _26 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _27) -> bb5; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_25);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _26) -> bb5; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          (_22.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _28) -> bb6; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_21.0: &core::fmt::Opaque) = transmute::<&&i32, &core::fmt::Opaque>(move _27) -> bb6; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          (_22.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _26; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_26);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _16 = [move _21, move _22];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _15 = &_16;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _31 = move _15 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          discriminant(_30) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_13.0: &[&str]) = move _29;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_13.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _30; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_13.2: &[std::fmt::ArgumentV1]) = move _31; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_30);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _12 = &_13;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          begin_panic_fmt(move _12);       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          (_21.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _25; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_25);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _15 = [move _20, move _21];      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = &_15;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _29 = move _14 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_28);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_28) = 0;           // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_12.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _28; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_12.2: &[std::fmt::ArgumentV1]) = move _29; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_28);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::panic_fmt(move _12); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(std::fmt::Arguments<'r>) -> ! {core::panicking::panic_fmt}, val: Value(Scalar(<ZST>)) }
       }
   }
   

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -18,29 +18,27 @@
       let mut _16: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _17: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _18: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: !;                      // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _20: &std::fmt::Arguments;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _21: &std::fmt::Arguments;       // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _22: std::fmt::Arguments;        // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _23: &[&str];                // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _24: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _25: &[&str; 3];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _26: [&str; 3];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _27: &[std::fmt::ArgumentV1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _28: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _29: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _30: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _31: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _19: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: std::fmt::Arguments;    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: &[&str];                // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _22: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _23: &[&str; 3];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _24: [&str; 3];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _25: &[std::fmt::ArgumentV1]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _26: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _27: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _28: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _29: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _30: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _31: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _32: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let _33: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _34: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _35: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _38: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _39: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _40: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _41: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _42: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _43: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _36: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _37: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _38: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _39: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _40: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _41: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -48,43 +46,43 @@
               debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
               let _13: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _14: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _45: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _43: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
                   debug left_val => _13;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _14;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _36: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _37: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let mut _44: &[&str; 3]; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _34: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _35: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let mut _42: &[&str; 3]; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 5 {
-                      debug arg0 => _36;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      debug arg1 => _37;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _39;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _40;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _46: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _47: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _48: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _49: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug arg0 => _34;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug arg1 => _35;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _37;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _38;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _44: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _45: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _46: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _47: &&i32; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 7 {
                           }
                       }
-                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _42;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _43;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _50: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _51: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _52: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _53: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _40;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _41;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _48: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _49: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _50: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _51: &&i32; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
-                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _23; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug args => _27;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _54: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _55: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _56: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug pieces => _21; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug args => _25;   // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _52: &[&str]; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _53: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _54: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
@@ -126,14 +124,14 @@
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _10 = &_1;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _45 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _43 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
                                            // + val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[1]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[1])) }
-          _11 = _45;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _11 = _43;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -170,146 +168,142 @@
       }
   
       bb4: {
-          StorageLive(_19);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_20);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_21);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_22);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_23);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _44 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _42 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &[&str; 3]
                                            // + val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &[&str; 3], val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0])) }
-          _25 = _44;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _24 = _25;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _23 = move _24 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_27);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_28);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_29);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_30);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_31);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _23 = _42;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = _23;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = move _22 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_27);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_28);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_29);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_30);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_31);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _31 = _13;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = &_31;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_32);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_33);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _33 = _13;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _33 = _14;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _32 = &_33;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_29.0: &&i32) = move _30;       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_29.1: &&i32) = move _32;       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_32);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_30);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_34);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _34 = (_29.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_35);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _35 = _14;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _34 = &_35;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_31.0: &&i32) = move _32;       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_31.1: &&i32) = move _34;       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_34);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_32);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_36);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _36 = (_31.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _37 = (_31.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_38);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_39);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _39 = _36;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _40 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _35 = (_29.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _37 = _34;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _38 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _47 = _40;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _46 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb5; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_44);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_45);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _45 = _38;                       // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _44 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _45) -> bb5; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          StorageDead(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _49 = _39;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _48 = transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb6; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_45);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_46);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_47);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _47 = _37;                       // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _46 = transmute::<&&i32, &core::fmt::Opaque>(move _47) -> bb6; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          StorageDead(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_38.0: &core::fmt::Opaque) = move _48; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_38.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _46; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_40);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_39);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_41);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_42);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _42 = _37;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_43);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _43 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_47);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_36.0: &core::fmt::Opaque) = move _46; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_36.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _44; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_46);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_44);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_39);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _40 = _35;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_41);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _41 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _51 = _43;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _50 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb7; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_48);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_49);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _49 = _41;                       // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _48 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _49) -> bb7; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb7: {
-          StorageDead(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _53 = _42;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _52 = transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb8; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_49);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_50);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _51 = _40;                       // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _50 = transmute::<&&i32, &core::fmt::Opaque>(move _51) -> bb8; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb8: {
-          StorageDead(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_41.0: &core::fmt::Opaque) = move _52; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_41.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _50; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_43);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_42);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _30 = [move _38, move _41];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_41);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_38);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_37);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_36);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _29 = &_30;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _28 = _29;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _27 = move _28 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_28);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _54 = _23;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          discriminant(_55) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _56 = _27;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_22.0: &[&str]) = move _54;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_22.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _55; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_22.2: &[std::fmt::ArgumentV1]) = move _56; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_27);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_23);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _21 = &_22;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _20 = _21;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          begin_panic_fmt(move _20);       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_51);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_39.0: &core::fmt::Opaque) = move _50; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_39.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _48; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_50);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_48);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_41);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _28 = [move _36, move _39];      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_39);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_35);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_34);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _27 = &_28;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _26 = _27;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = move _26 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_52);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _52 = _21;                       // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_53);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_53) = 0;           // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_54);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _54 = _25;                       // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.0: &[&str]) = move _52;     // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _53; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.2: &[std::fmt::ArgumentV1]) = move _54; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_54);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_53);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_52);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::panic_fmt(move _20); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(std::fmt::Arguments<'r>) -> ! {core::panicking::panic_fmt}, val: Value(Scalar(<ZST>)) }
       }
   }
   

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -18,29 +18,27 @@
       let mut _16: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _17: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _18: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: !;                      // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _20: &std::fmt::Arguments;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _21: &std::fmt::Arguments;       // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _22: std::fmt::Arguments;        // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _23: &[&str];                // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _24: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _25: &[&str; 3];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _26: [&str; 3];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _27: &[std::fmt::ArgumentV1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _28: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _29: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _30: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _31: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _19: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: std::fmt::Arguments;    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: &[&str];                // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _22: &[&str; 3];             // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _23: &[&str; 3];                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _24: [&str; 3];                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _25: &[std::fmt::ArgumentV1]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _26: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _27: &[std::fmt::ArgumentV1; 2]; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _28: [std::fmt::ArgumentV1; 2];  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _29: (&&i32, &&i32);         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _30: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _31: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _32: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let _33: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _34: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _35: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _38: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _39: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _40: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _41: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _42: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _43: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _36: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _37: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _38: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _39: std::fmt::ArgumentV1;   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _40: &&i32;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _41: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -48,43 +46,43 @@
               debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
               let _13: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _14: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _45: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _43: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
                   debug left_val => _13;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _14;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _36: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _37: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let mut _44: &[&str; 3]; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _34: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _35: &&i32;          // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let mut _42: &[&str; 3]; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 5 {
-                      debug arg0 => _36;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      debug arg1 => _37;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _39;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _40;  // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _46: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _47: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _48: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _49: &&i32; // in scope 6 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      debug arg0 => _34;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug arg1 => _35;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      scope 6 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _37;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _38;  // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _44: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _45: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _46: &core::fmt::Opaque; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _47: &&i32; // in scope 6 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 7 {
                           }
                       }
-                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug x => _42;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          debug f => _43;  // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _50: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _51: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _52: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
-                          let mut _53: &&i32; // in scope 8 at $SRC_DIR/std/src/macros.rs:LL:COL
+                      scope 8 (inlined ArgumentV1::new::<&i32>) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug x => _40;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          debug f => _41;  // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _48: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _49: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _50: &core::fmt::Opaque; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                          let mut _51: &&i32; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                           scope 9 {
                           }
                       }
                   }
-                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug pieces => _23; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      debug args => _27;   // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _54: &[&str]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _55: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-                      let mut _56: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
+                  scope 10 (inlined Arguments::new_v1) { // at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug pieces => _21; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug args => _25;   // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _52: &[&str]; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _53: std::option::Option<&[std::fmt::rt::v1::Argument]>; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      let mut _54: &[std::fmt::ArgumentV1]; // in scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
@@ -126,14 +124,14 @@
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _10 = &_1;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _45 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _43 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
                                            // + val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[1]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[1])) }
-          _11 = _45;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _11 = _43;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -170,146 +168,142 @@
       }
   
       bb4: {
-          StorageLive(_19);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_20);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_21);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_22);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_23);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _44 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _42 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &[&str; 3]
                                            // + val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &[&str; 3], val: Unevaluated(WithOptConstParam { did: DefId(0:3 ~ issue_73223[317d]::main), const_param_did: None }, [], Some(promoted[0])) }
-          _25 = _44;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _24 = _25;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _23 = move _24 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_27);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_28);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_29);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_30);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_31);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _23 = _42;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = _23;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = move _22 as &[&str] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_27);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_28);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_29);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_30);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_31);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _31 = _13;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = &_31;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_32);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_33);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _33 = _13;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _33 = _14;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _32 = &_33;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_29.0: &&i32) = move _30;       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_29.1: &&i32) = move _32;       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_32);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_30);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_34);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _34 = (_29.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_35);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _35 = _14;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _34 = &_35;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_31.0: &&i32) = move _32;       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_31.1: &&i32) = move _34;       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_34);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_32);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_36);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _36 = (_31.0: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _37 = (_31.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_38);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_39);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _39 = _36;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _40 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _35 = (_29.1: &&i32);            // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _37 = _34;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _38 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _47 = _40;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _46 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _47) -> bb5; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_44);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_45);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _45 = _38;                       // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _44 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _45) -> bb5; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb5: {
-          StorageDead(_47);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _49 = _39;                       // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _48 = transmute::<&&i32, &core::fmt::Opaque>(move _49) -> bb6; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_45);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_46);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_47);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _47 = _37;                       // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _46 = transmute::<&&i32, &core::fmt::Opaque>(move _47) -> bb6; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb6: {
-          StorageDead(_49);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_38.0: &core::fmt::Opaque) = move _48; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_38.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _46; // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_48);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_46);                // scope 7 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_40);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_39);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_41);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_42);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _42 = _37;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_43);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _43 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_47);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_36.0: &core::fmt::Opaque) = move _46; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_36.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _44; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_46);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_44);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_38);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_37);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_39);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _40 = _35;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_41);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _41 = <&i32 as Debug>::fmt as for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {<&i32 as std::fmt::Debug>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _51 = _43;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _50 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _51) -> bb7; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_48);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_49);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _49 = _41;                       // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _48 = transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>(move _49) -> bb7; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> {std::intrinsics::transmute::<for<'r, 's, 't0> fn(&'r &i32, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb7: {
-          StorageDead(_51);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _53 = _42;                       // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _52 = transmute::<&&i32, &core::fmt::Opaque>(move _53) -> bb8; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_49);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_50);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_51);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _51 = _40;                       // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _50 = transmute::<&&i32, &core::fmt::Opaque>(move _51) -> bb8; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&&i32) -> &core::fmt::Opaque {std::intrinsics::transmute::<&&i32, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb8: {
-          StorageDead(_53);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_41.0: &core::fmt::Opaque) = move _52; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_41.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _50; // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_52);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_50);                // scope 9 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_43);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_42);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _30 = [move _38, move _41];      // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_41);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_38);                // scope 5 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_37);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_36);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _29 = &_30;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _28 = _29;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _27 = move _28 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_28);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _54 = _23;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          discriminant(_55) = 0;           // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _56 = _27;                       // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_22.0: &[&str]) = move _54;     // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_22.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _55; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          (_22.2: &[std::fmt::ArgumentV1]) = move _56; // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_56);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_55);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_54);                // scope 10 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_27);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_23);                // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _21 = &_22;                      // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _20 = _21;                       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
-          begin_panic_fmt(move _20);       // scope 4 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_51);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_39.0: &core::fmt::Opaque) = move _50; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_39.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _48; // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_50);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_48);                // scope 9 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_41);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_40);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _28 = [move _36, move _39];      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_39);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_35);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_34);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _27 = &_28;                      // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _26 = _27;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = move _26 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_52);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _52 = _21;                       // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_53);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_53) = 0;           // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_54);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _54 = _25;                       // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.0: &[&str]) = move _52;     // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.1: std::option::Option<&[std::fmt::rt::v1::Argument]>) = move _53; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_20.2: &[std::fmt::ArgumentV1]) = move _54; // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_54);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_53);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_52);                // scope 10 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::panic_fmt(move _20); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's> fn(&'r std::fmt::Arguments<'s>) -> ! {std::rt::begin_panic_fmt}, val: Value(Scalar(<ZST>)) }
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(std::fmt::Arguments<'r>) -> ! {core::panicking::panic_fmt}, val: Value(Scalar(<ZST>)) }
       }
   }
   

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -21,7 +21,7 @@
       let mut _19: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:54: 9:68
       let mut _20: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:70: 9:84
       let mut _21: *const T;               // in scope 0 at $DIR/issue_76432.rs:9:70: 9:84
-      let mut _22: !;                      // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _22: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug v => _2;                   // in scope 1 at $DIR/issue_76432.rs:7:9: 7:10
           let _13: &T;                     // in scope 1 at $DIR/issue_76432.rs:9:10: 9:16
@@ -64,11 +64,11 @@
       }
   
       bb1: {
-          StorageLive(_22);                // scope 1 at $SRC_DIR/std/src/macros.rs:LL:COL
-          begin_panic::<&str>(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_22);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::panic(const "internal error: entered unreachable code"); // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // + literal: Const { ty: fn(&str) -> ! {std::rt::begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(Scalar(<ZST>)) }
                                            // ty::Const
                                            // + ty: &str
                                            // + val: Value(Slice { data: Allocation { bytes: [105, 110, 116, 101, 114, 110, 97, 108, 32, 101, 114, 114, 111, 114, 58, 32, 101, 110, 116, 101, 114, 101, 100, 32, 117, 110, 114, 101, 97, 99, 104, 97, 98, 108, 101, 32, 99, 111, 100, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1099511627775], len: Size { raw: 40 } }, size: Size { raw: 40 }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 40 })

--- a/src/test/ui/hygiene/no_implicit_prelude.rs
+++ b/src/test/ui/hygiene/no_implicit_prelude.rs
@@ -1,7 +1,7 @@
 #![feature(decl_macro)]
 
 mod foo {
-    pub macro m() { Vec::new(); ().clone() }
+    pub macro m() { Vec::<i32>::new(); ().clone() }
     fn f() { ::bar::m!(); }
 }
 
@@ -13,7 +13,7 @@ mod bar {
     }
     fn f() {
         ::foo::m!();
-        assert_eq!(0, 0); //~ ERROR cannot find macro `panic` in this scope
+        assert!(true);
     }
 }
 

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -1,14 +1,3 @@
-error: cannot find macro `panic` in this scope
-  --> $DIR/no_implicit_prelude.rs:16:9
-   |
-LL |         assert_eq!(0, 0);
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = note: consider importing one of these items:
-           core::panic
-           std::panic
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0433]: failed to resolve: use of undeclared type `Vec`
   --> $DIR/no_implicit_prelude.rs:11:9
    |
@@ -38,7 +27,7 @@ LL |         ().clone()
            `use std::clone::Clone;`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0433, E0599.
 For more information about an error, try `rustc --explain E0433`.

--- a/src/test/ui/iterators/iter-count-overflow-ndebug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-ndebug.rs
@@ -2,7 +2,6 @@
 // only-32bit too impatient for 2⁶⁴ items
 // compile-flags: -C debug_assertions=no -C opt-level=3
 
-use std::panic;
 use std::usize::MAX;
 
 fn main() {

--- a/src/test/ui/iterators/iter-position-overflow-ndebug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-ndebug.rs
@@ -2,7 +2,6 @@
 // only-32bit too impatient for 2⁶⁴ items
 // compile-flags: -C debug_assertions=no -C opt-level=3
 
-use std::panic;
 use std::usize::MAX;
 
 fn main() {

--- a/src/test/ui/macros/issue-78333.rs
+++ b/src/test/ui/macros/issue-78333.rs
@@ -1,0 +1,13 @@
+// build-pass
+
+#![no_implicit_prelude]
+
+fn main() {
+    ::std::panic!();
+    ::std::todo!();
+    ::std::unimplemented!();
+    ::std::assert_eq!(0, 0);
+    ::std::assert_ne!(0, 1);
+    ::std::dbg!(123);
+    ::std::unreachable!();
+}

--- a/src/tools/clippy/tests/ui/logic_bug.rs
+++ b/src/tools/clippy/tests/ui/logic_bug.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::many_single_char_names)]
+#![allow(unused, clippy::many_single_char_names, clippy::diverging_sub_expression)]
 #![warn(clippy::logic_bug)]
 
 fn main() {

--- a/src/tools/clippy/tests/ui/nonminimal_bool.rs
+++ b/src/tools/clippy/tests/ui/nonminimal_bool.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::many_single_char_names)]
+#![allow(unused, clippy::many_single_char_names, clippy::diverging_sub_expression)]
 #![warn(clippy::nonminimal_bool)]
 
 fn main() {

--- a/src/tools/clippy/tests/ui/nonminimal_bool_methods.rs
+++ b/src/tools/clippy/tests/ui/nonminimal_bool_methods.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::many_single_char_names)]
+#![allow(unused, clippy::many_single_char_names, clippy::diverging_sub_expression)]
 #![warn(clippy::nonminimal_bool)]
 
 fn methods_with_negation() {

--- a/src/tools/clippy/tests/ui/wildcard_enum_match_arm.fixed
+++ b/src/tools/clippy/tests/ui/wildcard_enum_match_arm.fixed
@@ -7,7 +7,7 @@
     dead_code,
     clippy::single_match,
     clippy::wildcard_in_or_patterns,
-    clippy::unnested_or_patterns
+    clippy::unnested_or_patterns, clippy::diverging_sub_expression
 )]
 
 use std::io::ErrorKind;

--- a/src/tools/clippy/tests/ui/wildcard_enum_match_arm.rs
+++ b/src/tools/clippy/tests/ui/wildcard_enum_match_arm.rs
@@ -7,7 +7,7 @@
     dead_code,
     clippy::single_match,
     clippy::wildcard_in_or_patterns,
-    clippy::unnested_or_patterns
+    clippy::unnested_or_patterns, clippy::diverging_sub_expression
 )]
 
 use std::io::ErrorKind;


### PR DESCRIPTION
Fixes #78333.

-----

Otherwise code like this

    #![no_implicit_prelude]

    fn main() {
        ::std::todo!();
        ::std::unimplemented!();
    }

will fail to compile, which is unfortunate and presumably unintended.

This changes many invocations of `panic!` in a `macro_rules!` definition
to invocations of `$crate::panic!`, which makes the invocations hygienic.

Note that this does not make the built-in macro `assert!` hygienic.