### PR TITLE
Use its own `TypeckResults` to avoid ICE

### DIFF
--- a/compiler/rustc_save_analysis/src/lib.rs
+++ b/compiler/rustc_save_analysis/src/lib.rs
@@ -630,9 +630,14 @@ impl<'tcx> SaveContext<'tcx> {
             })
             | Node::Ty(&hir::Ty { kind: hir::TyKind::Path(ref qpath), .. }) => match qpath {
                 hir::QPath::Resolved(_, path) => path.res,
-                hir::QPath::TypeRelative(..) | hir::QPath::LangItem(..) => self
-                    .maybe_typeck_results
-                    .map_or(Res::Err, |typeck_results| typeck_results.qpath_res(qpath, hir_id)),
+                hir::QPath::TypeRelative(..) | hir::QPath::LangItem(..) => {
+                    // #75962: `self.typeck_results` may be different from the `hir_id`'s result.
+                    if self.tcx.has_typeck_results(hir_id.owner.to_def_id()) {
+                        self.tcx.typeck(hir_id.owner).qpath_res(qpath, hir_id)
+                    } else {
+                        Res::Err
+                    }
+                }
             },
 
             Node::Binding(&hir::Pat {

--- a/compiler/rustc_save_analysis/src/sig.rs
+++ b/compiler/rustc_save_analysis/src/sig.rs
@@ -262,7 +262,7 @@ impl<'hir> Sig for hir::Ty<'hir> {
                 } else {
                     let start = offset + prefix.len() + 5;
                     let end = start + name.len();
-                    // FIXME should put the proper path in there, not elipses.
+                    // FIXME should put the proper path in there, not ellipsis.
                     Ok(Signature {
                         text: prefix + "...::" + &name,
                         defs: vec![],
@@ -272,7 +272,7 @@ impl<'hir> Sig for hir::Ty<'hir> {
             }
             hir::TyKind::Path(hir::QPath::TypeRelative(ty, segment)) => {
                 let nested_ty = ty.make(offset + 1, id, scx)?;
-                let prefix = format!("<{}>::", nested_ty.text,);
+                let prefix = format!("<{}>::", nested_ty.text);
 
                 let name = path_segment_to_string(segment);
                 let res = scx.get_path_res(id.ok_or("Missing id for Path")?);
@@ -551,7 +551,7 @@ impl<'hir> Sig for hir::Item<'hir> {
                 // FIXME where clause
             }
             hir::ItemKind::ForeignMod(_) => Err("extern mod"),
-            hir::ItemKind::GlobalAsm(_) => Err("glboal asm"),
+            hir::ItemKind::GlobalAsm(_) => Err("global asm"),
             hir::ItemKind::ExternCrate(_) => Err("extern crate"),
             hir::ItemKind::OpaqueTy(..) => Err("opaque type"),
             // FIXME should implement this (e.g., pub use).

--- a/src/test/ui/impl-trait/bound-normalization-pass.default.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-pass.default.stderr
@@ -1,5 +1,5 @@
 warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/bound-normalization-pass.rs:5:12
+  --> $DIR/bound-normalization-pass.rs:8:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/impl-trait/bound-normalization-pass.rs
+++ b/src/test/ui/impl-trait/bound-normalization-pass.rs
@@ -1,5 +1,8 @@
 // check-pass
 // edition:2018
+// revisions: default sa
+//[sa] compile-flags: -Z save-analysis
+//-^ To make this the regression test for #75962.
 
 #![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]

--- a/src/test/ui/impl-trait/bound-normalization-pass.sa.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-pass.sa.stderr
@@ -1,0 +1,11 @@
+warning: the feature `impl_trait_in_bindings` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/bound-normalization-pass.rs:8:12
+   |
+LL | #![feature(impl_trait_in_bindings)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #75962