### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3fcd8aba10d17504c87ef12d4f62ef404c6a4703d16682a9eb5543e6cf24455"
+checksum = "7cd0782e0a7da7598164153173e5a5d4d9b1da094473c98dce0ff91406112369"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -623,7 +623,8 @@ impl HasAttrs for StmtKind {
         match *self {
             StmtKind::Local(ref local) => local.attrs(),
             StmtKind::Expr(ref expr) | StmtKind::Semi(ref expr) => expr.attrs(),
-            StmtKind::Empty | StmtKind::Item(..) => &[],
+            StmtKind::Item(ref item) => item.attrs(),
+            StmtKind::Empty => &[],
             StmtKind::MacCall(ref mac) => mac.attrs.attrs(),
         }
     }
@@ -632,7 +633,8 @@ impl HasAttrs for StmtKind {
         match self {
             StmtKind::Local(local) => local.visit_attrs(f),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.visit_attrs(f),
-            StmtKind::Empty | StmtKind::Item(..) => {}
+            StmtKind::Item(item) => item.visit_attrs(f),
+            StmtKind::Empty => {}
             StmtKind::MacCall(mac) => {
                 mac.attrs.visit_attrs(f);
             }

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -768,8 +768,13 @@ impl SyntaxExtension {
         name: Symbol,
         attrs: &[ast::Attribute],
     ) -> SyntaxExtension {
-        let allow_internal_unstable = attr::allow_internal_unstable(sess, &attrs)
-            .map(|features| features.collect::<Vec<Symbol>>().into());
+        let allow_internal_unstable = {
+            let mut feat_list = Vec::new();
+            attr::allow_internal_unstable(sess, &attrs).map(|features| feat_list.extend(features));
+            attr::rustc_allow_const_fn_unstable(sess, &attrs)
+                .map(|features| feat_list.extend(features));
+            Some(feat_list.into())
+        };
 
         let mut local_inner_macros = false;
         if let Some(macro_export) = sess.find_by_name(attrs, sym::macro_export) {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -768,13 +768,8 @@ impl SyntaxExtension {
         name: Symbol,
         attrs: &[ast::Attribute],
     ) -> SyntaxExtension {
-        let allow_internal_unstable = {
-            let mut feat_list = Vec::new();
-            attr::allow_internal_unstable(sess, &attrs).map(|features| feat_list.extend(features));
-            attr::rustc_allow_const_fn_unstable(sess, &attrs)
-                .map(|features| feat_list.extend(features));
-            Some(feat_list.into())
-        };
+        let allow_internal_unstable = attr::allow_internal_unstable(sess, &attrs)
+            .map(|features| features.collect::<Vec<Symbol>>().into());
 
         let mut local_inner_macros = false;
         if let Some(macro_export) = sess.find_by_name(attrs, sym::macro_export) {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1357,7 +1357,8 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
         // we'll expand attributes on expressions separately
         if !stmt.is_expr() {
             let (attr, derives, after_derive) = if stmt.is_item() {
-                self.classify_item(&mut stmt)
+                // FIXME: Handle custom attributes on statements (#15701)
+                (None, vec![], false)
             } else {
                 // ignore derives on non-item statements so it falls through
                 // to the unused-attributes lint

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -210,6 +210,11 @@ declare_features! (
     /// it is not on path for eventual stabilization).
     (active, no_niche, "1.42.0", None, None),
 
+    /// Allows using `#[rustc_allow_const_fn_unstable]`.
+    /// This is an attribute on `const fn` for the same
+    /// purpose as `#[allow_internal_unstable]`.
+    (active, rustc_allow_const_fn_unstable, "1.49.0", Some(69399), None),
+
     // no-tracking-issue-end
 
     // -------------------------------------------------------------------------

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -380,6 +380,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         "allow_internal_unstable side-steps feature gating and stability checks",
     ),
     gated!(
+        rustc_allow_const_fn_unstable, AssumedUsed, template!(Word, List: "feat1, feat2, ..."),
+        "rustc_allow_const_fn_unstable side-steps feature gating and stability checks"
+    ),
+    gated!(
         allow_internal_unsafe, Normal, template!(Word),
         "allow_internal_unsafe side-steps the unsafe_code lint",
     ),

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1099,11 +1099,11 @@ pub enum StmtKind<'hir> {
     Semi(&'hir Expr<'hir>),
 }
 
-impl StmtKind<'hir> {
-    pub fn attrs(&self) -> &'hir [Attribute] {
+impl<'hir> StmtKind<'hir> {
+    pub fn attrs(&self, get_item: impl FnOnce(ItemId) -> &'hir Item<'hir>) -> &'hir [Attribute] {
         match *self {
             StmtKind::Local(ref l) => &l.attrs,
-            StmtKind::Item(_) => &[],
+            StmtKind::Item(ref item_id) => &get_item(*item_id).attrs,
             StmtKind::Expr(ref e) | StmtKind::Semi(ref e) => &e.attrs,
         }
     }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -994,7 +994,8 @@ impl EarlyLintPass for UnusedDocComment {
     fn check_stmt(&mut self, cx: &EarlyContext<'_>, stmt: &ast::Stmt) {
         let kind = match stmt.kind {
             ast::StmtKind::Local(..) => "statements",
-            ast::StmtKind::Item(..) => "inner items",
+            // Disabled pending discussion in #78306
+            ast::StmtKind::Item(..) => return,
             // expressions will be reported by `check_expr`.
             ast::StmtKind::Empty
             | ast::StmtKind::Semi(_)

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -562,6 +562,13 @@ impl<'tcx> intravisit::Visitor<'tcx> for LintLevelMapBuilder<'_, 'tcx> {
         })
     }
 
+    fn visit_stmt(&mut self, e: &'tcx hir::Stmt<'tcx>) {
+        // We will call `with_lint_attrs` when we walk
+        // the `StmtKind`. The outer statement itself doesn't
+        // define the lint levels.
+        intravisit::walk_stmt(self, e);
+    }
+
     fn visit_expr(&mut self, e: &'tcx hir::Expr<'tcx>) {
         self.with_lint_attrs(e.hir_id, &e.attrs, |builder| {
             intravisit::walk_expr(builder, e);

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -8,6 +8,7 @@ use rustc_ast as ast;
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_data_structures::svh::Svh;
 use rustc_hir as hir;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_hir::definitions::{DefKey, DefPath, DefPathHash};
 use rustc_middle::hir::exports::Export;
@@ -485,6 +486,10 @@ impl CrateStore for CStore {
     /// `DefId` refers to.
     fn def_key(&self, def: DefId) -> DefKey {
         self.get_crate_data(def.krate).def_key(def.index)
+    }
+
+    fn def_kind(&self, def: DefId) -> DefKind {
+        self.get_crate_data(def.krate).def_kind(def.index)
     }
 
     fn def_path(&self, def: DefId) -> DefPath {

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -816,7 +816,7 @@ impl<'hir> Map<'hir> {
             Some(Node::Variant(ref v)) => Some(&v.attrs[..]),
             Some(Node::Field(ref f)) => Some(&f.attrs[..]),
             Some(Node::Expr(ref e)) => Some(&*e.attrs),
-            Some(Node::Stmt(ref s)) => Some(s.kind.attrs()),
+            Some(Node::Stmt(ref s)) => Some(s.kind.attrs(|id| self.item(id.id))),
             Some(Node::Arm(ref a)) => Some(&*a.attrs),
             Some(Node::GenericParam(param)) => Some(&param.attrs[..]),
             // Unit/tuple structs/variants take the attributes straight from

--- a/compiler/rustc_middle/src/middle/cstore.rs
+++ b/compiler/rustc_middle/src/middle/cstore.rs
@@ -8,6 +8,7 @@ use rustc_ast as ast;
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::{self, MetadataRef};
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_hir::definitions::{DefKey, DefPath, DefPathHash};
 use rustc_macros::HashStable;
@@ -185,6 +186,7 @@ pub trait CrateStore {
 
     // resolve
     fn def_key(&self, def: DefId) -> DefKey;
+    fn def_kind(&self, def: DefId) -> DefKind;
     fn def_path(&self, def: DefId) -> DefPath;
     fn def_path_hash(&self, def: DefId) -> DefPathHash;
     fn all_def_path_hashes_and_def_ids(&self, cnum: CrateNum) -> Vec<(DefPathHash, DefId)>;

--- a/compiler/rustc_mir/src/transform/check_consts/mod.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/mod.rs
@@ -77,7 +77,11 @@ pub fn is_lang_panic_fn(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
     Some(def_id) == tcx.lang_items().panic_fn() || Some(def_id) == tcx.lang_items().begin_panic_fn()
 }
 
-pub fn allow_internal_unstable(tcx: TyCtxt<'tcx>, def_id: DefId, feature_gate: Symbol) -> bool {
+pub fn rustc_allow_const_fn_unstable(
+    tcx: TyCtxt<'tcx>,
+    def_id: DefId,
+    feature_gate: Symbol,
+) -> bool {
     let attrs = tcx.get_attrs(def_id);
     attr::rustc_allow_const_fn_unstable(&tcx.sess, attrs)
         .map_or(false, |mut features| features.any(|name| name == feature_gate))

--- a/compiler/rustc_mir/src/transform/check_consts/mod.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/mod.rs
@@ -79,7 +79,7 @@ pub fn is_lang_panic_fn(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
 
 pub fn allow_internal_unstable(tcx: TyCtxt<'tcx>, def_id: DefId, feature_gate: Symbol) -> bool {
     let attrs = tcx.get_attrs(def_id);
-    attr::allow_internal_unstable(&tcx.sess, attrs)
+    attr::rustc_allow_const_fn_unstable(&tcx.sess, attrs)
         .map_or(false, |mut features| features.any(|name| name == feature_gate))
 }
 

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -805,7 +805,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                     }
 
                     // Calling an unstable function *always* requires that the corresponding gate
-                    // be enabled, even if the function has `#[allow_internal_unstable(the_gate)]`.
+                    // be enabled, even if the function has `#[rustc_allow_const_fn_unstable(the_gate)]`.
                     if !tcx.features().declared_lib_features.iter().any(|&(sym, _)| sym == gate) {
                         self.check_op(ops::FnCallUnstable(callee, Some(gate)));
                         return;
@@ -965,8 +965,8 @@ fn emit_unstable_in_stable_error(ccx: &ConstCx<'_, '_>, span: Span, gate: Symbol
         )
         .span_suggestion(
             attr_span,
-            "otherwise `#[allow_internal_unstable]` can be used to bypass stability checks",
-            format!("#[allow_internal_unstable({})]\n", gate),
+            "otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks",
+            format!("#[rustc_allow_const_fn_unstable({})]\n", gate),
             Applicability::MaybeIncorrect,
         )
         .emit();

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -292,7 +292,11 @@ impl Validator<'mir, 'tcx> {
 
             Status::Unstable(gate) if self.tcx.features().enabled(gate) => {
                 let unstable_in_stable = self.ccx.is_const_stable_const_fn()
-                    && !super::allow_internal_unstable(self.tcx, self.def_id().to_def_id(), gate);
+                    && !super::rustc_allow_const_fn_unstable(
+                        self.tcx,
+                        self.def_id().to_def_id(),
+                        gate,
+                    );
                 if unstable_in_stable {
                     emit_unstable_in_stable_error(self.ccx, span, gate);
                 }
@@ -819,7 +823,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
 
                     // Otherwise, we are something const-stable calling a const-unstable fn.
 
-                    if super::allow_internal_unstable(tcx, caller, gate) {
+                    if super::rustc_allow_const_fn_unstable(tcx, caller, gate) {
                         return;
                     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -88,7 +88,7 @@ impl CheckAttrVisitor<'tcx> {
             } else if self.tcx.sess.check_name(attr, sym::allow_internal_unstable) {
                 self.check_allow_internal_unstable(&attr, span, target, &attrs)
             } else if self.tcx.sess.check_name(attr, sym::rustc_allow_const_fn_unstable) {
-                self.check_rustc_allow_const_fn_unstable(&attr, span, target)
+                self.check_rustc_allow_const_fn_unstable(hir_id, &attr, span, target)
             } else {
                 // lint-only checks
                 if self.tcx.sess.check_name(attr, sym::cold) {
@@ -798,13 +798,15 @@ impl CheckAttrVisitor<'tcx> {
     /// (Allows proc_macro functions)
     fn check_rustc_allow_const_fn_unstable(
         &self,
+        hir_id: HirId,
         attr: &Attribute,
         span: &Span,
         target: Target,
     ) -> bool {
         if let Target::Fn | Target::Method(_) = target {
-            // FIXME Check that this isn't just a function, but a const fn
-            return true;
+            if self.tcx.is_const_fn_raw(self.tcx.hir().local_def_id(hir_id)) {
+                return true;
+            }
         }
         self.tcx
             .sess

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -87,7 +87,7 @@ impl<'tcx> CheckConstVisitor<'tcx> {
 
         let is_feature_allowed = |feature_gate| {
             // All features require that the corresponding gate be enabled,
-            // even if the function has `#[allow_internal_unstable(the_gate)]`.
+            // even if the function has `#[rustc_allow_const_fn_unstable(the_gate)]`.
             if !tcx.features().enabled(feature_gate) {
                 return false;
             }
@@ -105,8 +105,8 @@ impl<'tcx> CheckConstVisitor<'tcx> {
             }
 
             // However, we cannot allow stable `const fn`s to use unstable features without an explicit
-            // opt-in via `allow_internal_unstable`.
-            attr::allow_internal_unstable(&tcx.sess, &tcx.get_attrs(def_id))
+            // opt-in via `rustc_allow_const_fn_unstable`.
+            attr::rustc_allow_const_fn_unstable(&tcx.sess, &tcx.get_attrs(def_id))
                 .map_or(false, |mut features| features.any(|name| name == feature_gate))
         };
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -95,6 +95,27 @@ impl<'a> Resolver<'a> {
         }
     }
 
+    /// Walks up the tree of definitions starting at `def_id`,
+    /// stopping at the first `DefKind::Mod` encountered
+    fn nearest_mod_parent(&mut self, def_id: DefId) -> Module<'a> {
+        let def_key = self.cstore().def_key(def_id);
+
+        let mut parent_id = DefId {
+            krate: def_id.krate,
+            index: def_key.parent.expect("failed to get parent for module"),
+        };
+        // The immediate parent may not be a module
+        // (e.g. `const _: () =  { #[path = "foo.rs"] mod foo; };`)
+        // Walk up the tree until we hit a module or the crate root.
+        while parent_id.index != CRATE_DEF_INDEX
+            && self.cstore().def_kind(parent_id) != DefKind::Mod
+        {
+            let parent_def_key = self.cstore().def_key(parent_id);
+            parent_id.index = parent_def_key.parent.expect("failed to get parent for module");
+        }
+        self.get_module(parent_id)
+    }
+
     crate fn get_module(&mut self, def_id: DefId) -> Module<'a> {
         // If this is a local module, it will be in `module_map`, no need to recalculate it.
         if let Some(def_id) = def_id.as_local() {
@@ -116,11 +137,8 @@ impl<'a> Resolver<'a> {
                 .data
                 .get_opt_name()
                 .expect("given a DefId that wasn't a module");
-            // This unwrap is safe since we know this isn't the root
-            let parent = Some(self.get_module(DefId {
-                index: def_key.parent.expect("failed to get parent for module"),
-                ..def_id
-            }));
+
+            let parent = Some(self.nearest_mod_parent(def_id));
             (name, parent)
         };
 
@@ -145,8 +163,24 @@ impl<'a> Resolver<'a> {
         if let Some(id) = def_id.as_local() {
             self.local_macro_def_scopes[&id]
         } else {
-            let module_def_id = ty::DefIdTree::parent(&*self, def_id).unwrap();
-            self.get_module(module_def_id)
+            // This is not entirely correct - a `macro_rules!` macro may occur
+            // inside a 'block' module:
+            //
+            // ```rust
+            // const _: () = {
+            // #[macro_export]
+            // macro_rules! my_macro {
+            //     () => {};
+            // }
+            // `
+            // We don't record this information for external crates, so
+            // the module we compute here will be the closest 'mod' item
+            // (not necesssarily the actual parent of the `macro_rules!`
+            // macro). `macro_rules!` macros can't use def-site hygiene,
+            // so this hopefully won't be a problem.
+            //
+            // See https://github.com/rust-lang/rust/pull/77984#issuecomment-712445508
+            self.nearest_mod_parent(def_id)
         }
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -893,6 +893,7 @@ symbols! {
         rustc,
         rustc_allocator,
         rustc_allocator_nounwind,
+        rustc_allow_const_fn_unstable,
         rustc_args_required_const,
         rustc_attrs,
         rustc_builtin_macro,

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -17,6 +17,10 @@ mod entry;
 pub use entry::{Entry, OccupiedEntry, VacantEntry};
 use Entry::*;
 
+/// Minimum number of elements in nodes that are not a root.
+/// We might temporarily have fewer elements during methods.
+pub(super) const MIN_LEN: usize = node::MIN_LEN_AFTER_SPLIT;
+
 /// A map based on a B-Tree.
 ///
 /// B-Trees represent a fundamental compromise between cache-efficiency and actually minimizing
@@ -1094,13 +1098,13 @@ impl<K: Ord, V> BTreeMap<K, V> {
             // Check if right-most child is underfull.
             let mut last_edge = internal.last_edge();
             let right_child_len = last_edge.reborrow().descend().len();
-            if right_child_len < node::MIN_LEN {
+            if right_child_len < MIN_LEN {
                 // We need to steal.
                 let mut last_kv = match last_edge.left_kv() {
                     Ok(left) => left,
                     Err(_) => unreachable!(),
                 };
-                last_kv.bulk_steal_left(node::MIN_LEN - right_child_len);
+                last_kv.bulk_steal_left(MIN_LEN - right_child_len);
                 last_edge = last_kv.right_edge();
             }
 

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -38,8 +38,8 @@ use crate::alloc::{AllocRef, Global, Layout};
 use crate::boxed::Box;
 
 const B: usize = 6;
-pub const MIN_LEN: usize = B - 1;
 pub const CAPACITY: usize = 2 * B - 1;
+pub const MIN_LEN_AFTER_SPLIT: usize = B - 1;
 const KV_IDX_CENTER: usize = B - 1;
 const EDGE_IDX_LEFT_OF_CENTER: usize = B - 1;
 const EDGE_IDX_RIGHT_OF_CENTER: usize = B;

--- a/library/alloc/src/collections/btree/remove.rs
+++ b/library/alloc/src/collections/btree/remove.rs
@@ -1,4 +1,5 @@
-use super::node::{self, marker, ForceResult, Handle, NodeRef};
+use super::map::MIN_LEN;
+use super::node::{marker, ForceResult, Handle, NodeRef};
 use super::unwrap_unchecked;
 use core::mem;
 use core::ptr;
@@ -40,7 +41,7 @@ impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::LeafOrInter
         // Handle underflow
         let mut cur_node = unsafe { ptr::read(&pos).into_node().forget_type() };
         let mut at_leaf = true;
-        while cur_node.len() < node::MIN_LEN {
+        while cur_node.len() < MIN_LEN {
             match handle_underfull_node(cur_node) {
                 UnderflowResult::AtRoot => break,
                 UnderflowResult::Merged(edge, merged_with_left, offset) => {

--- a/library/alloc/src/collections/btree/split.rs
+++ b/library/alloc/src/collections/btree/split.rs
@@ -1,5 +1,6 @@
-use super::node::{self, ForceResult::*, Root};
-use super::search::{self, SearchResult::*};
+use super::map::MIN_LEN;
+use super::node::{ForceResult::*, Root};
+use super::search::{search_node, SearchResult::*};
 use core::borrow::Borrow;
 
 impl<K, V> Root<K, V> {
@@ -20,7 +21,7 @@ impl<K, V> Root<K, V> {
             let mut right_node = right_root.node_as_mut();
 
             loop {
-                let mut split_edge = match search::search_node(left_node, key) {
+                let mut split_edge = match search_node(left_node, key) {
                     // key is going to the right tree
                     Found(handle) => handle.left_edge(),
                     GoDown(handle) => handle,
@@ -65,9 +66,9 @@ impl<K, V> Root<K, V> {
                     cur_node = last_kv.merge().descend();
                 } else {
                     let right_len = last_kv.reborrow().right_edge().descend().len();
-                    // `MINLEN + 1` to avoid readjust if merge happens on the next level.
-                    if right_len < node::MIN_LEN + 1 {
-                        last_kv.bulk_steal_left(node::MIN_LEN + 1 - right_len);
+                    // `MIN_LEN + 1` to avoid readjust if merge happens on the next level.
+                    if right_len < MIN_LEN + 1 {
+                        last_kv.bulk_steal_left(MIN_LEN + 1 - right_len);
                     }
                     cur_node = last_kv.right_edge().descend();
                 }
@@ -91,8 +92,9 @@ impl<K, V> Root<K, V> {
                     cur_node = first_kv.merge().descend();
                 } else {
                     let left_len = first_kv.reborrow().left_edge().descend().len();
-                    if left_len < node::MIN_LEN + 1 {
-                        first_kv.bulk_steal_right(node::MIN_LEN + 1 - left_len);
+                    // `MIN_LEN + 1` to avoid readjust if merge happens on the next level.
+                    if left_len < MIN_LEN + 1 {
+                        first_kv.bulk_steal_right(MIN_LEN + 1 - left_len);
                     }
                     cur_node = first_kv.left_edge().descend();
                 }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -72,6 +72,7 @@
 #![allow(explicit_outlives_requirements)]
 #![allow(incomplete_features)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![cfg_attr(not(bootstrap), feature(rustc_allow_const_fn_unstable))]
 #![cfg_attr(not(test), feature(generator_trait))]
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(test, feature(new_uninit))]

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -150,7 +150,8 @@ impl<T> RawVec<T, Global> {
 impl<T, A: AllocRef> RawVec<T, A> {
     /// Like `new`, but parameterized over the choice of allocator for
     /// the returned `RawVec`.
-    #[allow_internal_unstable(const_fn)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn))]
     pub const fn new_in(alloc: A) -> Self {
         // `cap: 0` means "unallocated". zero-sized types are ignored.
         Self { ptr: Unique::dangling(), cap: 0, alloc }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -63,6 +63,7 @@
 #![warn(missing_debug_implementations)]
 #![allow(explicit_outlives_requirements)]
 #![allow(incomplete_features)]
+#![cfg_attr(not(bootstrap), feature(rustc_allow_const_fn_unstable))]
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]
 #![feature(asm)]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2045,7 +2045,8 @@ assert_eq!(
             #[rustc_const_stable(feature = "const_int_conversion", since = "1.44.0")]
             // SAFETY: const sound because integers are plain old datatypes so we can always
             // transmute them to arrays of bytes
-            #[allow_internal_unstable(const_fn_transmute)]
+            #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_transmute))]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_transmute))]
             #[inline]
             pub const fn to_ne_bytes(self) -> [u8; mem::size_of::<Self>()] {
                 // SAFETY: integers are plain old datatypes so we can always transmute them to
@@ -2193,7 +2194,8 @@ fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT),
             #[rustc_const_stable(feature = "const_int_conversion", since = "1.44.0")]
             // SAFETY: const sound because integers are plain old datatypes so we can always
             // transmute to them
-            #[allow_internal_unstable(const_fn_transmute)]
+            #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_transmute))]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_transmute))]
             #[inline]
             pub const fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
                 // SAFETY: integers are plain old datatypes so we can always transmute to them

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1803,7 +1803,8 @@ assert_eq!(
             #[rustc_const_stable(feature = "const_int_conversion", since = "1.44.0")]
             // SAFETY: const sound because integers are plain old datatypes so we can always
             // transmute them to arrays of bytes
-            #[allow_internal_unstable(const_fn_transmute)]
+            #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_transmute))]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_transmute))]
             #[inline]
             pub const fn to_ne_bytes(self) -> [u8; mem::size_of::<Self>()] {
                 // SAFETY: integers are plain old datatypes so we can always transmute them to
@@ -1951,7 +1952,8 @@ fn read_ne_", stringify!($SelfT), "(input: &mut &[u8]) -> ", stringify!($SelfT),
             #[rustc_const_stable(feature = "const_int_conversion", since = "1.44.0")]
             // SAFETY: const sound because integers are plain old datatypes so we can always
             // transmute to them
-            #[allow_internal_unstable(const_fn_transmute)]
+            #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_transmute))]
+            #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_transmute))]
             #[inline]
             pub const fn from_ne_bytes(bytes: [u8; mem::size_of::<Self>()]) -> Self {
                 // SAFETY: integers are plain old datatypes so we can always transmute to them

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -88,7 +88,8 @@ impl<T> [T] {
     #[rustc_const_stable(feature = "const_slice_len", since = "1.32.0")]
     #[inline]
     // SAFETY: const sound because we transmute out the length field as a usize (which it must be)
-    #[allow_internal_unstable(const_fn_union)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_union))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_union))]
     pub const fn len(&self) -> usize {
         // SAFETY: this is safe because `&[T]` and `FatPtr<T>` have the same layout.
         // Only `std` can make this guarantee.

--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -157,7 +157,8 @@ pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_str_from_utf8_unchecked", issue = "75196")]
-#[allow_internal_unstable(const_fn_transmute)]
+#[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_transmute))]
+#[cfg_attr(bootstrap, allow_internal_unstable(const_fn_transmute))]
 pub const unsafe fn from_utf8_unchecked(v: &[u8]) -> &str {
     // SAFETY: the caller must guarantee that the bytes `v` are valid UTF-8.
     // Also relies on `&str` and `&[u8]` having the same layout.

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -219,7 +219,8 @@ impl str {
     #[rustc_const_stable(feature = "str_as_bytes", since = "1.32.0")]
     #[inline(always)]
     #[allow(unused_attributes)]
-    #[allow_internal_unstable(const_fn_transmute)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_transmute))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_transmute))]
     pub const fn as_bytes(&self) -> &[u8] {
         // SAFETY: const sound because we transmute two types with the same layout
         unsafe { mem::transmute(self) }

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -130,7 +130,8 @@ impl RawWakerVTable {
     #[rustc_promotable]
     #[stable(feature = "futures_api", since = "1.36.0")]
     #[rustc_const_stable(feature = "futures_api", since = "1.36.0")]
-    #[allow_internal_unstable(const_fn_fn_ptr_basics)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_fn_ptr_basics))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_fn_ptr_basics))]
     pub const fn new(
         clone: unsafe fn(*const ()) -> RawWaker,
         wake: unsafe fn(*const ()),

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -401,7 +401,8 @@ fn run_client<A: for<'a, 's> DecodeMut<'a, 's, ()>, R: Encode<()>>(
 }
 
 impl Client<fn(crate::TokenStream) -> crate::TokenStream> {
-    #[allow_internal_unstable(const_fn)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn))]
     pub const fn expand1(f: fn(crate::TokenStream) -> crate::TokenStream) -> Self {
         extern "C" fn run(
             bridge: Bridge<'_>,
@@ -414,7 +415,8 @@ impl Client<fn(crate::TokenStream) -> crate::TokenStream> {
 }
 
 impl Client<fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream> {
-    #[allow_internal_unstable(const_fn)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn))]
     pub const fn expand2(
         f: fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream,
     ) -> Self {
@@ -459,7 +461,8 @@ impl ProcMacro {
         }
     }
 
-    #[allow_internal_unstable(const_fn)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn))]
     pub const fn custom_derive(
         trait_name: &'static str,
         attributes: &'static [&'static str],
@@ -468,7 +471,8 @@ impl ProcMacro {
         ProcMacro::CustomDerive { trait_name, attributes, client: Client::expand1(expand) }
     }
 
-    #[allow_internal_unstable(const_fn)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn))]
     pub const fn attr(
         name: &'static str,
         expand: fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream,
@@ -476,7 +480,8 @@ impl ProcMacro {
         ProcMacro::Attr { name, client: Client::expand2(expand) }
     }
 
-    #[allow_internal_unstable(const_fn)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn))]
     pub const fn bang(
         name: &'static str,
         expand: fn(crate::TokenStream) -> crate::TokenStream,

--- a/library/proc_macro/src/bridge/scoped_cell.rs
+++ b/library/proc_macro/src/bridge/scoped_cell.rs
@@ -35,7 +35,8 @@ impl<'a, 'b, T: LambdaL> DerefMut for RefMutL<'a, 'b, T> {
 pub struct ScopedCell<T: LambdaL>(Cell<<T as ApplyL<'static>>::Out>);
 
 impl<T: LambdaL> ScopedCell<T> {
-    #[allow_internal_unstable(const_fn)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn))]
     pub const fn new(value: <T as ApplyL<'static>>::Out) -> Self {
         ScopedCell(Cell::new(value))
     }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -18,6 +18,7 @@
     test(no_crate_inject, attr(deny(warnings))),
     test(attr(allow(dead_code, deprecated, unused_variables, unused_mut)))
 )]
+#![cfg_attr(not(bootstrap), feature(rustc_allow_const_fn_unstable))]
 #![feature(nll)]
 #![feature(staged_api)]
 #![feature(const_fn)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -206,6 +206,7 @@
 #![needs_panic_runtime]
 // std may use features in a platform-specific way
 #![allow(unused_features)]
+#![cfg_attr(not(bootstrap), feature(rustc_allow_const_fn_unstable))]
 #![cfg_attr(test, feature(print_internals, set_stdio, update_panic_count))]
 #![cfg_attr(
     all(target_vendor = "fortanix", target_env = "sgx"),

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1043,7 +1043,8 @@ impl Ipv6Addr {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_ipv6", since = "1.32.0")]
-    #[allow_internal_unstable(const_fn_transmute)]
+    #[cfg_attr(not(bootstrap), rustc_allow_const_fn_unstable(const_fn_transmute))]
+    #[cfg_attr(bootstrap, allow_internal_unstable(const_fn_transmute))]
     pub const fn new(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> Ipv6Addr {
         let addr16 = [
             a.to_be(),

--- a/src/doc/rustc/src/targets/custom.md
+++ b/src/doc/rustc/src/targets/custom.md
@@ -14,4 +14,4 @@ To see it for a different target, add the `--target` flag:
 $ rustc +nightly -Z unstable-options --target=wasm32-unknown-unknown --print target-spec-json
 ```
 
-To use a custom target, see [`xargo`](https://github.com/japaric/xargo).
+To use a custom target, see the (unstable) [`build-std` feature](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html) of `cargo`.

--- a/src/doc/rustc/src/targets/custom.md
+++ b/src/doc/rustc/src/targets/custom.md
@@ -14,4 +14,4 @@ To see it for a different target, add the `--target` flag:
 $ rustc +nightly -Z unstable-options --target=wasm32-unknown-unknown --print target-spec-json
 ```
 
-To use a custom target, see the (unstable) [`build-std` feature](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html) of `cargo`.
+To use a custom target, see the (unstable) [`build-std` feature](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std) of `cargo`.

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
@@ -1,4 +1,4 @@
-#![feature(rustc_attrs, staged_api, allow_internal_unstable)]
+#![feature(rustc_attrs, staged_api, rustc_allow_const_fn_unstable)]
 #![feature(const_fn_fn_ptr_basics)]
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -8,7 +8,7 @@ const fn error(_: fn()) {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(since="1.0.0", feature = "mep")]
-#[allow_internal_unstable(const_fn_fn_ptr_basics)]
+#[rustc_allow_const_fn_unstable(const_fn_fn_ptr_basics)]
 const fn compiles(_: fn()) {}
 
 fn main() {}

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
@@ -8,9 +8,9 @@ help: if it is not part of the public API, make this function unstably const
    |
 LL | #[rustc_const_unstable(feature = "...", issue = "...")]
    |
-help: otherwise `#[allow_internal_unstable]` can be used to bypass stability checks
+help: otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks
    |
-LL | #[allow_internal_unstable(const_fn_fn_ptr_basics)]
+LL | #[rustc_allow_const_fn_unstable(const_fn_fn_ptr_basics)]
    |
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_run_pass.rs
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_run_pass.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![feature(allow_internal_unstable)]
+#![feature(rustc_allow_const_fn_unstable)]
 #![feature(const_fn_fn_ptr_basics)]
 
 #![feature(rustc_attrs, staged_api)]
@@ -7,7 +7,7 @@
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(since="1.0.0", feature = "mep")]
-#[allow_internal_unstable(const_fn_fn_ptr_basics)]
+#[rustc_allow_const_fn_unstable(const_fn_fn_ptr_basics)]
 const fn takes_fn_ptr(_: fn()) {}
 
 const FN: fn() = || ();

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -24,9 +24,9 @@ help: if it is not part of the public API, make this function unstably const
    |
 LL | #[rustc_const_unstable(feature = "...", issue = "...")]
    |
-help: otherwise `#[allow_internal_unstable]` can be used to bypass stability checks
+help: otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks
    |
-LL | #[allow_internal_unstable(const_fn_floating_point_arithmetic)]
+LL | #[rustc_allow_const_fn_unstable(const_fn_floating_point_arithmetic)]
    |
 
 error: `foo2_gated` is not yet stable as a const fn

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -24,9 +24,9 @@ help: if it is not part of the public API, make this function unstably const
    |
 LL | #[rustc_const_unstable(feature = "...", issue = "...")]
    |
-help: otherwise `#[allow_internal_unstable]` can be used to bypass stability checks
+help: otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks
    |
-LL | #[allow_internal_unstable(const_fn_floating_point_arithmetic)]
+LL | #[rustc_allow_const_fn_unstable(const_fn_floating_point_arithmetic)]
    |
 
 error: `foo2_gated` is not yet stable as a const fn

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-struct.rs
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-struct.rs
@@ -2,6 +2,7 @@
 // this needs a different test since this is done after expansion
 
 #[allow_internal_unstable()] //~ ERROR allow_internal_unstable side-steps
+//~| ERROR attribute should
 struct S;
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
@@ -6,6 +6,15 @@ LL | #[allow_internal_unstable()]
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error: attribute should be applied to a macro
+  --> $DIR/feature-gate-allow-internal-unstable-struct.rs:4:1
+   |
+LL | #[allow_internal_unstable()]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | struct S;
+   | --------- not a macro
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.rs
+++ b/src/test/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.rs
@@ -1,0 +1,6 @@
+#![allow(unused_macros)]
+
+#[rustc_allow_const_fn_unstable()] //~ ERROR rustc_allow_const_fn_unstable side-steps
+const fn foo() { }
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-allow-const-fn-unstable.stderr
@@ -1,0 +1,12 @@
+error[E0658]: rustc_allow_const_fn_unstable side-steps feature gating and stability checks
+  --> $DIR/feature-gate-rustc-allow-const-fn-unstable.rs:3:1
+   |
+LL | #[rustc_allow_const_fn_unstable()]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #69399 <https://github.com/rust-lang/rust/issues/69399> for more information
+   = help: add `#![feature(rustc_allow_const_fn_unstable)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/lint/reasons-forbidden.rs
+++ b/src/test/ui/lint/reasons-forbidden.rs
@@ -5,6 +5,9 @@
     //~^ NOTE `forbid` level set here
     //~| NOTE `forbid` level set here
     //~| NOTE `forbid` level set here
+    //~| NOTE `forbid` level set here
+    //~| NOTE `forbid` level set here
+    //~| NOTE `forbid` level set here
     reason = "our errors & omissions insurance policy doesn't cover unsafe Rust"
 )]
 
@@ -17,9 +20,18 @@ fn main() {
     //~^ ERROR allow(unsafe_code) overruled by outer forbid(unsafe_code)
     //~| ERROR allow(unsafe_code) overruled by outer forbid(unsafe_code)
     //~| ERROR allow(unsafe_code) overruled by outer forbid(unsafe_code)
+    //~| ERROR allow(unsafe_code) overruled by outer forbid(unsafe_code)
+    //~| ERROR allow(unsafe_code) overruled by outer forbid(unsafe_code)
+    //~| ERROR allow(unsafe_code) overruled by outer forbid(unsafe_code)
     //~| NOTE overruled by previous forbid
     //~| NOTE overruled by previous forbid
     //~| NOTE overruled by previous forbid
+    //~| NOTE overruled by previous forbid
+    //~| NOTE overruled by previous forbid
+    //~| NOTE overruled by previous forbid
+    //~| NOTE our errors & omissions insurance policy doesn't cover unsafe Rust
+    //~| NOTE our errors & omissions insurance policy doesn't cover unsafe Rust
+    //~| NOTE our errors & omissions insurance policy doesn't cover unsafe Rust
     //~| NOTE our errors & omissions insurance policy doesn't cover unsafe Rust
     //~| NOTE our errors & omissions insurance policy doesn't cover unsafe Rust
     //~| NOTE our errors & omissions insurance policy doesn't cover unsafe Rust

--- a/src/test/ui/lint/reasons-forbidden.stderr
+++ b/src/test/ui/lint/reasons-forbidden.stderr
@@ -1,5 +1,5 @@
 error[E0453]: allow(unsafe_code) overruled by outer forbid(unsafe_code)
-  --> $DIR/reasons-forbidden.rs:16:13
+  --> $DIR/reasons-forbidden.rs:19:13
    |
 LL |     unsafe_code,
    |     ----------- `forbid` level set here
@@ -10,7 +10,7 @@ LL |     #[allow(unsafe_code)]
    = note: our errors & omissions insurance policy doesn't cover unsafe Rust
 
 error[E0453]: allow(unsafe_code) overruled by outer forbid(unsafe_code)
-  --> $DIR/reasons-forbidden.rs:16:13
+  --> $DIR/reasons-forbidden.rs:19:13
    |
 LL |     unsafe_code,
    |     ----------- `forbid` level set here
@@ -21,7 +21,7 @@ LL |     #[allow(unsafe_code)]
    = note: our errors & omissions insurance policy doesn't cover unsafe Rust
 
 error[E0453]: allow(unsafe_code) overruled by outer forbid(unsafe_code)
-  --> $DIR/reasons-forbidden.rs:16:13
+  --> $DIR/reasons-forbidden.rs:19:13
    |
 LL |     unsafe_code,
    |     ----------- `forbid` level set here
@@ -31,6 +31,39 @@ LL |     #[allow(unsafe_code)]
    |
    = note: our errors & omissions insurance policy doesn't cover unsafe Rust
 
-error: aborting due to 3 previous errors
+error[E0453]: allow(unsafe_code) overruled by outer forbid(unsafe_code)
+  --> $DIR/reasons-forbidden.rs:19:13
+   |
+LL |     unsafe_code,
+   |     ----------- `forbid` level set here
+...
+LL |     #[allow(unsafe_code)]
+   |             ^^^^^^^^^^^ overruled by previous forbid
+   |
+   = note: our errors & omissions insurance policy doesn't cover unsafe Rust
+
+error[E0453]: allow(unsafe_code) overruled by outer forbid(unsafe_code)
+  --> $DIR/reasons-forbidden.rs:19:13
+   |
+LL |     unsafe_code,
+   |     ----------- `forbid` level set here
+...
+LL |     #[allow(unsafe_code)]
+   |             ^^^^^^^^^^^ overruled by previous forbid
+   |
+   = note: our errors & omissions insurance policy doesn't cover unsafe Rust
+
+error[E0453]: allow(unsafe_code) overruled by outer forbid(unsafe_code)
+  --> $DIR/reasons-forbidden.rs:19:13
+   |
+LL |     unsafe_code,
+   |     ----------- `forbid` level set here
+...
+LL |     #[allow(unsafe_code)]
+   |             ^^^^^^^^^^^ overruled by previous forbid
+   |
+   = note: our errors & omissions insurance policy doesn't cover unsafe Rust
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0453`.

--- a/src/test/ui/macros/auxiliary/issue-75982.rs
+++ b/src/test/ui/macros/auxiliary/issue-75982.rs
@@ -1,0 +1,12 @@
+const _: () = {
+    #[macro_export]
+    macro_rules! first_macro {
+        () => {}
+    }
+    mod foo {
+        #[macro_export]
+        macro_rules! second_macro {
+            () => {}
+        }
+    }
+};

--- a/src/test/ui/macros/issue-75982-foreign-macro-weird-mod.rs
+++ b/src/test/ui/macros/issue-75982-foreign-macro-weird-mod.rs
@@ -1,0 +1,13 @@
+// aux-build:issue-75982.rs
+// check-pass
+
+// Regression test for issue #75982
+// Tests that don't ICE when invoking a foreign macro
+// that occurs inside a module with a weird parent.
+
+extern crate issue_75982;
+
+fn main() {
+    issue_75982::first_macro!();
+    issue_75982::second_macro!();
+}

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -130,7 +130,7 @@ impl<'tcx> LateLintPass<'tcx> for Author {
     }
 
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx hir::Stmt<'_>) {
-        if !has_attr(cx.sess(), stmt.kind.attrs()) {
+        if !has_attr(cx.sess(), stmt.kind.attrs(|id| cx.tcx.hir().item(id.id))) {
             return;
         }
         prelude();

--- a/src/tools/clippy/clippy_lints/src/utils/inspector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/inspector.rs
@@ -109,7 +109,7 @@ impl<'tcx> LateLintPass<'tcx> for DeepCodeInspector {
     }
 
     fn check_stmt(&mut self, cx: &LateContext<'tcx>, stmt: &'tcx hir::Stmt<'_>) {
-        if !has_attr(cx.sess(), stmt.kind.attrs()) {
+        if !has_attr(cx.sess(), stmt.kind.attrs(|id| cx.tcx.hir().item(id.id))) {
             return;
         }
         match stmt.kind {


### PR DESCRIPTION
Successful merges:

 - #77984 (Compute proper module parent during resolution)
 - #78085 (MIR validation should check `SwitchInt` values are valid for the type)
 - #78208 (replace `#[allow_internal_unstable]` with `#[rustc_allow_const_fn_unstable]` for `const fn`s)
 - #78209 (Update `compiler_builtins` to 0.1.36)
 - #78276 (Bump backtrace-rs to enable Mach-O support on iOS.)
 - #78320 (Link to cargo's `build-std` feature instead of `xargo` in custom target docs)
 - #78322 (BTreeMap: stop mistaking node::MIN_LEN for a node level constraint)
 - #78326 (Split out statement attributes changes from #78306)

Failed merges:


r? @ghost