### PR TITLE
Support enable/disable sanitizers/profiler per target

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -582,6 +582,15 @@ changelog-seen = 2
 # build native code.
 #android-ndk = "/path/to/ndk"
 
+# Build the sanitizer runtimes for this target.
+# This option will override the same option under [build] section.
+#sanitizers = false
+
+# Build the profiler runtime for this target(required when compiling with options that depend
+# on this runtime, such as `-C profile-generate` or `-Z instrument-coverage`).
+# This option will override the same option under [build] section.
+#profiler = false
+
 # Force static or dynamic linkage of the standard library for this target. If
 # this target is a host for rustc, this will also affect the linkage of the
 # compiler itself. This is useful for building rustc on targets that normally

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -264,7 +264,7 @@ impl<'a> ShouldRun<'a> {
     /// `all_krates` should probably be removed at some point.
     pub fn all_krates(mut self, name: &str) -> Self {
         let mut set = BTreeSet::new();
-        for krate in self.builder.in_tree_crates(name) {
+        for krate in self.builder.in_tree_crates(name, None) {
             let path = krate.local_path(self.builder);
             set.insert(path);
         }
@@ -277,7 +277,7 @@ impl<'a> ShouldRun<'a> {
     ///
     /// `make_run` will be called separately for each matching command-line path.
     pub fn krate(mut self, name: &str) -> Self {
-        for krate in self.builder.in_tree_crates(name) {
+        for krate in self.builder.in_tree_crates(name, None) {
             let path = krate.local_path(self.builder);
             self.paths.insert(PathSet::one(path));
         }

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -91,7 +91,7 @@ impl Step for Std {
             // Explicitly pass -p for all dependencies krates -- this will force cargo
             // to also check the tests/benches/examples for these crates, rather
             // than just the leaf crate.
-            for krate in builder.in_tree_crates("test") {
+            for krate in builder.in_tree_crates("test", Some(target)) {
                 cargo.arg("-p").arg(krate.name);
             }
 
@@ -155,7 +155,7 @@ impl Step for Rustc {
         // Explicitly pass -p for all compiler krates -- this will force cargo
         // to also check the tests/benches/examples for these crates, rather
         // than just the leaf crate.
-        for krate in builder.in_tree_crates("rustc-main") {
+        for krate in builder.in_tree_crates("rustc-main", Some(target)) {
             cargo.arg("-p").arg(krate.name);
         }
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -143,7 +143,7 @@ fn copy_third_party_objects(
         }
     }
 
-    if builder.config.sanitizers && compiler.stage != 0 {
+    if builder.config.sanitizers_enabled(target) && compiler.stage != 0 {
         // The sanitizers are only copied in stage1 or above,
         // to avoid creating dependency on LLVM.
         target_deps.extend(
@@ -251,7 +251,7 @@ pub fn std_cargo(builder: &Builder<'_>, target: TargetSelection, stage: u32, car
             .arg("--features")
             .arg(features);
     } else {
-        let mut features = builder.std_features();
+        let mut features = builder.std_features(target);
         features.push_str(compiler_builtins_c_feature);
 
         cargo

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -251,6 +251,8 @@ pub struct Target {
     pub ranlib: Option<PathBuf>,
     pub linker: Option<PathBuf>,
     pub ndk: Option<PathBuf>,
+    pub sanitizers: bool,
+    pub profiler: bool,
     pub crt_static: Option<bool>,
     pub musl_root: Option<PathBuf>,
     pub musl_libdir: Option<PathBuf>,
@@ -474,6 +476,8 @@ struct TomlTarget {
     llvm_config: Option<String>,
     llvm_filecheck: Option<String>,
     android_ndk: Option<String>,
+    sanitizers: Option<bool>,
+    profiler: Option<bool>,
     crt_static: Option<bool>,
     musl_root: Option<String>,
     musl_libdir: Option<String>,
@@ -857,6 +861,8 @@ impl Config {
                 target.musl_libdir = cfg.musl_libdir.map(PathBuf::from);
                 target.wasi_root = cfg.wasi_root.map(PathBuf::from);
                 target.qemu_rootfs = cfg.qemu_rootfs.map(PathBuf::from);
+                target.sanitizers = cfg.sanitizers.unwrap_or(build.sanitizers.unwrap_or_default());
+                target.profiler = cfg.profiler.unwrap_or(build.profiler.unwrap_or_default());
 
                 config.target_config.insert(TargetSelection::from_user(&triple), target);
             }
@@ -957,6 +963,22 @@ impl Config {
 
     pub fn very_verbose(&self) -> bool {
         self.verbose > 1
+    }
+
+    pub fn sanitizers_enabled(&self, target: TargetSelection) -> bool {
+        self.target_config.get(&target).map(|t| t.sanitizers).unwrap_or(self.sanitizers)
+    }
+
+    pub fn any_sanitizers_enabled(&self) -> bool {
+        self.target_config.values().any(|t| t.sanitizers) || self.sanitizers
+    }
+
+    pub fn profiler_enabled(&self, target: TargetSelection) -> bool {
+        self.target_config.get(&target).map(|t| t.profiler).unwrap_or(self.profiler)
+    }
+
+    pub fn any_profiler_enabled(&self) -> bool {
+        self.target_config.values().any(|t| t.profiler) || self.profiler
     }
 
     pub fn llvm_enabled(&self) -> bool {

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -535,8 +535,12 @@ impl Step for Rustc {
         // Find dependencies for top level crates.
         let mut compiler_crates = HashSet::new();
         for root_crate in &["rustc_driver", "rustc_codegen_llvm", "rustc_codegen_ssa"] {
-            compiler_crates
-                .extend(builder.in_tree_crates(root_crate).into_iter().map(|krate| krate.name));
+            compiler_crates.extend(
+                builder
+                    .in_tree_crates(root_crate, Some(target))
+                    .into_iter()
+                    .map(|krate| krate.name),
+            );
         }
 
         for krate in &compiler_crates {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -534,7 +534,7 @@ impl Build {
 
     /// Gets the space-separated set of activated features for the standard
     /// library.
-    fn std_features(&self) -> String {
+    fn std_features(&self, target: TargetSelection) -> String {
         let mut features = "panic-unwind".to_string();
 
         if self.config.llvm_libunwind {
@@ -543,7 +543,7 @@ impl Build {
         if self.config.backtrace {
             features.push_str(" backtrace");
         }
-        if self.config.profiler {
+        if self.config.profiler_enabled(target) {
             features.push_str(" profiler");
         }
         features
@@ -1105,7 +1105,7 @@ impl Build {
     /// Returns a Vec of all the dependencies of the given root crate,
     /// including transitive dependencies and the root itself. Only includes
     /// "local" crates (those in the local source tree, not from a registry).
-    fn in_tree_crates(&self, root: &str) -> Vec<&Crate> {
+    fn in_tree_crates(&self, root: &str, target: Option<TargetSelection>) -> Vec<&Crate> {
         let mut ret = Vec::new();
         let mut list = vec![INTERNER.intern_str(root)];
         let mut visited = HashSet::new();
@@ -1122,7 +1122,10 @@ impl Build {
                 // metadata::build.
                 if visited.insert(dep)
                     && dep != "build_helper"
-                    && (dep != "profiler_builtins" || self.config.profiler)
+                    && (dep != "profiler_builtins"
+                        || target
+                            .map(|t| self.config.profiler_enabled(t))
+                            .unwrap_or(self.config.any_profiler_enabled()))
                     && (dep != "rustc_codegen_llvm" || self.config.llvm_enabled())
                 {
                     list.push(*dep);

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -91,7 +91,7 @@ pub fn check(build: &mut Build) {
                 .unwrap_or(true)
         })
         .any(|build_llvm_ourselves| build_llvm_ourselves);
-    if building_llvm || build.config.sanitizers {
+    if building_llvm || build.config.any_sanitizers_enabled() {
         cmd_finder.must_have("cmake");
     }
 

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1265,11 +1265,11 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         cmd.env("RUSTC_BOOTSTRAP", "1");
         builder.add_rust_test_threads(&mut cmd);
 
-        if builder.config.sanitizers {
+        if builder.config.sanitizers_enabled(target) {
             cmd.env("RUSTC_SANITIZER_SUPPORT", "1");
         }
 
-        if builder.config.profiler {
+        if builder.config.profiler_enabled(target) {
             cmd.env("RUSTC_PROFILER_SUPPORT", "1");
         }
 
@@ -1585,7 +1585,7 @@ impl Step for CrateLibrustc {
         let builder = run.builder;
         let compiler = builder.compiler(builder.top_stage, run.build_triple());
 
-        for krate in builder.in_tree_crates("rustc-main") {
+        for krate in builder.in_tree_crates("rustc-main", Some(run.target)) {
             if krate.path.ends_with(&run.path) {
                 let test_kind = builder.kind.into();
 
@@ -1692,7 +1692,7 @@ impl Step for Crate {
             });
         };
 
-        for krate in builder.in_tree_crates("test") {
+        for krate in builder.in_tree_crates("test", Some(run.target)) {
             if krate.path.ends_with(&run.path) {
                 make(Mode::Std, krate);
             }


### PR DESCRIPTION
This PR add options under `[target.*]` of `config.toml` which can enable or disable sanitizers/profiler runtime for corresponding target.
If these options are empty, the global options under `[build]` will take effect.

Fix #78329