### PR TITLE
[do not merge] get build artifact for freebsd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
             env:
               CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
             os: ubuntu-latest-xl
+          - name: dist-x86_64-freebsd
+            os: ubuntu-latest-xl
+            env: {}
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:
@@ -635,7 +638,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: dist-x86_64-linux
+          - name: dist-x86_64-freebsd
             os: ubuntu-latest-xl
             env: {}
     timeout-minutes: 600

--- a/.gitmodules
+++ b/.gitmodules
@@ -46,4 +46,5 @@
 	url = https://github.com/rust-analyzer/rust-analyzer.git
 [submodule "library/backtrace"]
 	path = library/backtrace
-	url = https://github.com/rust-lang/backtrace-rs.git
+	url = https://github.com/lzutao/backtrace-rs.git
+	branch = bsd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9",
 ]
 
@@ -136,7 +136,7 @@ version = "0.3.53"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.79 (git+https://github.com/lzutao/rust-libc?branch=i78184)",
  "miniz_oxide",
  "object 0.21.1",
  "rustc-demangle",
@@ -215,7 +215,7 @@ dependencies = [
  "getopts",
  "ignore",
  "lazy_static",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "merge",
  "num_cpus",
  "opener",
@@ -325,7 +325,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "lazycell",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys",
  "log",
  "memchr",
@@ -631,7 +631,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -653,7 +653,7 @@ dependencies = [
  "getopts",
  "glob",
  "lazy_static",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.5",
  "regex",
  "rustfix",
@@ -673,7 +673,7 @@ dependencies = [
  "diff",
  "filetime",
  "getopts",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "miow 0.3.5",
  "regex",
@@ -712,7 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -866,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9447ad28eee2a5cfb031c329d46bef77487244fff6a724b378885b8691a35f78"
 dependencies = [
  "curl-sys",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe",
  "openssl-sys",
  "schannel",
@@ -881,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad4eff0be6985b7e709f64b5a541f700e9ad1407190a29f4884319eb663ed1d6"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "libnghttp2-sys",
  "libz-sys",
  "openssl-sys",
@@ -973,7 +973,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35055b1021724f4eb5262eb49130eebff23fc59fc5a14160e05faad8eeb36673"
 dependencies = [
  "compiler_builtins",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-std-workspace-core",
 ]
 
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
  "winapi 0.3.9",
 ]
@@ -1138,7 +1138,7 @@ checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -1268,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi",
 ]
 
@@ -1279,7 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi",
 ]
 
@@ -1301,7 +1301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
 dependencies = [
  "bitflags",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "libgit2-sys",
  "log",
  "openssl-probe",
@@ -1381,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "compiler_builtins",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-std-workspace-core",
 ]
 
@@ -1534,7 +1534,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1569,7 +1569,7 @@ checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 dependencies = [
  "cc",
  "fs_extra",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1715,13 +1715,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.79"
+source = "git+https://github.com/lzutao/rust-libc?branch=i78184#b58a839d02b8d0dcc6a5a78cfd88f67a8af19808"
+
+[[package]]
 name = "libgit2-sys"
 version = "0.12.14+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "libssh2-sys",
  "libz-sys",
  "openssl-sys",
@@ -1735,7 +1740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1745,7 +1750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1759,7 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config",
  "vcpkg",
 ]
@@ -1845,7 +1850,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config",
 ]
 
@@ -1990,7 +1995,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9",
 ]
 
@@ -2057,7 +2062,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "miow 0.2.1",
  "net2",
@@ -2084,7 +2089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio",
 ]
 
@@ -2119,7 +2124,7 @@ dependencies = [
  "env_logger 0.7.1",
  "getrandom 0.2.0",
  "hex 0.4.2",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "rand",
  "rustc-workspace-hack",
@@ -2134,7 +2139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9",
 ]
 
@@ -2170,7 +2175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2236,7 +2241,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys",
 ]
 
@@ -2263,7 +2268,7 @@ checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg",
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -2300,7 +2305,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2311,7 +2316,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "unwind",
 ]
 
@@ -2373,7 +2378,7 @@ checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
@@ -2388,7 +2393,7 @@ checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
  "smallvec 1.4.2",
  "winapi 0.3.9",
@@ -2403,7 +2408,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
  "smallvec 1.4.2",
  "winapi 0.3.9",
@@ -2722,7 +2727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.14",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha",
  "rand_core",
  "rand_hc",
@@ -3109,7 +3114,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 0.7.1",
  "parking_lot 0.11.0",
  "rustc-ap-rustc_graphviz",
@@ -3511,7 +3516,7 @@ name = "rustc_codegen_llvm"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 9.0.0",
  "rustc-demangle",
  "rustc_ast",
@@ -3542,7 +3547,7 @@ dependencies = [
  "bitflags",
  "cc",
  "jobserver",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap",
  "num_cpus",
  "pathdiff",
@@ -3577,7 +3582,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "measureme 9.0.0",
  "parking_lot 0.11.0",
  "rustc-hash",
@@ -3599,7 +3604,7 @@ dependencies = [
 name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_codegen_ssa",
@@ -3762,7 +3767,7 @@ dependencies = [
 name = "rustc_interface"
 version = "0.0.0"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon",
  "rustc_ast",
  "rustc_ast_lowering",
@@ -3836,7 +3841,7 @@ version = "0.0.0"
 dependencies = [
  "build_helper",
  "cc",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3853,7 +3858,7 @@ dependencies = [
 name = "rustc_metadata"
 version = "0.0.0"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap",
  "rustc_ast",
  "rustc_attr",
@@ -4537,7 +4542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4590,7 +4595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
  "winapi 0.3.9",
 ]
@@ -4609,7 +4614,7 @@ checksum = "21ccb4c06ec57bc82d0f610f1a2963d7648700e43a6f513e564b9c89f7991786"
 dependencies = [
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "psm",
  "winapi 0.3.9",
 ]
@@ -4627,7 +4632,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "hashbrown",
  "hermit-abi",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide",
  "object 0.20.0",
  "panic_abort",
@@ -4751,7 +4756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 dependencies = [
  "filetime",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall",
  "xattr",
 ]
@@ -4763,7 +4768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand",
  "redox_syscall",
  "remove_dir_all",
@@ -4814,7 +4819,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9",
 ]
 
@@ -4825,7 +4830,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "core",
  "getopts",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_abort",
  "panic_unwind",
  "proc_macro",
@@ -4840,7 +4845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee72ec31009a42b53de9a6b7d8f462b493ab3b1e4767bda1fcdbb52127f13b6c"
 dependencies = [
  "getopts",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.6.1",
 ]
 
@@ -4902,7 +4907,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9",
 ]
 
@@ -5011,7 +5016,7 @@ dependencies = [
  "crossbeam-queue 0.1.2",
  "futures",
  "lazy_static",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "mio",
  "mio-named-pipes",
@@ -5056,7 +5061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
 dependencies = [
  "futures",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio",
  "mio-uds",
  "signal-hook-registry",
@@ -5143,7 +5148,7 @@ dependencies = [
  "bytes",
  "futures",
  "iovec",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "mio",
  "mio-uds",
@@ -5367,7 +5372,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5523,7 +5528,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc",
+ "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,9 @@ dependencies = [
 name = "libc"
 version = "0.2.79"
 source = "git+https://github.com/lzutao/rust-libc?branch=i78184#b58a839d02b8d0dcc6a5a78cfd88f67a8af19808"
+dependencies = [
+ "rustc-std-workspace-core",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -4632,7 +4635,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "hashbrown",
  "hermit-abi",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79 (git+https://github.com/lzutao/rust-libc?branch=i78184)",
  "miniz_oxide",
  "object 0.20.0",
  "panic_abort",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "winapi 0.3.9",
 ]
 
@@ -136,7 +136,7 @@ version = "0.3.53"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
- "libc 0.2.79 (git+https://github.com/lzutao/rust-libc?branch=i78184)",
+ "libc 0.2.80",
  "miniz_oxide",
  "object 0.21.1",
  "rustc-demangle",
@@ -215,7 +215,7 @@ dependencies = [
  "getopts",
  "ignore",
  "lazy_static",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "merge",
  "num_cpus",
  "opener",
@@ -325,7 +325,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "lazycell",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "libgit2-sys",
  "log",
  "memchr",
@@ -631,7 +631,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -653,7 +653,7 @@ dependencies = [
  "getopts",
  "glob",
  "lazy_static",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "miow 0.3.5",
  "regex",
  "rustfix",
@@ -673,7 +673,7 @@ dependencies = [
  "diff",
  "filetime",
  "getopts",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "log",
  "miow 0.3.5",
  "regex",
@@ -712,7 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -866,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9447ad28eee2a5cfb031c329d46bef77487244fff6a724b378885b8691a35f78"
 dependencies = [
  "curl-sys",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "openssl-probe",
  "openssl-sys",
  "schannel",
@@ -881,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad4eff0be6985b7e709f64b5a541f700e9ad1407190a29f4884319eb663ed1d6"
 dependencies = [
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "libnghttp2-sys",
  "libz-sys",
  "openssl-sys",
@@ -973,7 +973,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35055b1021724f4eb5262eb49130eebff23fc59fc5a14160e05faad8eeb36673"
 dependencies = [
  "compiler_builtins",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "rustc-std-workspace-core",
 ]
 
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "redox_syscall",
  "winapi 0.3.9",
 ]
@@ -1138,7 +1138,7 @@ checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -1268,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "wasi",
 ]
 
@@ -1279,7 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "wasi",
 ]
 
@@ -1301,7 +1301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
 dependencies = [
  "bitflags",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "libgit2-sys",
  "log",
  "openssl-probe",
@@ -1381,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "compiler_builtins",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "rustc-std-workspace-core",
 ]
 
@@ -1534,7 +1534,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -1569,7 +1569,7 @@ checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 dependencies = [
  "cc",
  "fs_extra",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -1716,8 +1716,8 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.79"
-source = "git+https://github.com/lzutao/rust-libc?branch=i78184#b58a839d02b8d0dcc6a5a78cfd88f67a8af19808"
+version = "0.2.80"
+source = "git+https://github.com/lzutao/rust-libc?branch=i78184#624f53143a942e45b1f50d9690191e2543db8ef8"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -1729,7 +1729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
 dependencies = [
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "libssh2-sys",
  "libz-sys",
  "openssl-sys",
@@ -1743,7 +1743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
 dependencies = [
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
 dependencies = [
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1767,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "pkg-config",
  "vcpkg",
 ]
@@ -1853,7 +1853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
 dependencies = [
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "pkg-config",
 ]
 
@@ -1998,7 +1998,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "winapi 0.3.9",
 ]
 
@@ -2065,7 +2065,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "log",
  "miow 0.2.1",
  "net2",
@@ -2092,7 +2092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "mio",
 ]
 
@@ -2127,7 +2127,7 @@ dependencies = [
  "env_logger 0.7.1",
  "getrandom 0.2.0",
  "hex 0.4.2",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "log",
  "rand",
  "rustc-workspace-hack",
@@ -2142,7 +2142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "winapi 0.3.9",
 ]
 
@@ -2178,7 +2178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -2244,7 +2244,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "openssl-sys",
 ]
 
@@ -2271,7 +2271,7 @@ checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg",
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -2308,7 +2308,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -2319,7 +2319,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "unwind",
 ]
 
@@ -2381,7 +2381,7 @@ checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
@@ -2396,7 +2396,7 @@ checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "redox_syscall",
  "smallvec 1.4.2",
  "winapi 0.3.9",
@@ -2411,7 +2411,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "redox_syscall",
  "smallvec 1.4.2",
  "winapi 0.3.9",
@@ -2730,7 +2730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.14",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "rand_chacha",
  "rand_core",
  "rand_hc",
@@ -3117,7 +3117,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "measureme 0.7.1",
  "parking_lot 0.11.0",
  "rustc-ap-rustc_graphviz",
@@ -3519,7 +3519,7 @@ name = "rustc_codegen_llvm"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "measureme 9.0.0",
  "rustc-demangle",
  "rustc_ast",
@@ -3550,7 +3550,7 @@ dependencies = [
  "bitflags",
  "cc",
  "jobserver",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "memmap",
  "num_cpus",
  "pathdiff",
@@ -3585,7 +3585,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "measureme 9.0.0",
  "parking_lot 0.11.0",
  "rustc-hash",
@@ -3607,7 +3607,7 @@ dependencies = [
 name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_codegen_ssa",
@@ -3770,7 +3770,7 @@ dependencies = [
 name = "rustc_interface"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "rustc-rayon",
  "rustc_ast",
  "rustc_ast_lowering",
@@ -3844,7 +3844,7 @@ version = "0.0.0"
 dependencies = [
  "build_helper",
  "cc",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -3861,7 +3861,7 @@ dependencies = [
 name = "rustc_metadata"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "memmap",
  "rustc_ast",
  "rustc_attr",
@@ -4545,7 +4545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -4598,7 +4598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "redox_syscall",
  "winapi 0.3.9",
 ]
@@ -4617,7 +4617,7 @@ checksum = "21ccb4c06ec57bc82d0f610f1a2963d7648700e43a6f513e564b9c89f7991786"
 dependencies = [
  "cc",
  "cfg-if 0.1.10",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "psm",
  "winapi 0.3.9",
 ]
@@ -4635,7 +4635,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "hashbrown",
  "hermit-abi",
- "libc 0.2.79 (git+https://github.com/lzutao/rust-libc?branch=i78184)",
+ "libc 0.2.80",
  "miniz_oxide",
  "object 0.20.0",
  "panic_abort",
@@ -4759,7 +4759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 dependencies = [
  "filetime",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "redox_syscall",
  "xattr",
 ]
@@ -4771,7 +4771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "rand",
  "redox_syscall",
  "remove_dir_all",
@@ -4822,7 +4822,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "winapi 0.3.9",
 ]
 
@@ -4833,7 +4833,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "core",
  "getopts",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "panic_abort",
  "panic_unwind",
  "proc_macro",
@@ -4848,7 +4848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee72ec31009a42b53de9a6b7d8f462b493ab3b1e4767bda1fcdbb52127f13b6c"
 dependencies = [
  "getopts",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "term 0.6.1",
 ]
 
@@ -4910,7 +4910,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "winapi 0.3.9",
 ]
 
@@ -5019,7 +5019,7 @@ dependencies = [
  "crossbeam-queue 0.1.2",
  "futures",
  "lazy_static",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "log",
  "mio",
  "mio-named-pipes",
@@ -5064,7 +5064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
 dependencies = [
  "futures",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "mio",
  "mio-uds",
  "signal-hook-registry",
@@ -5151,7 +5151,7 @@ dependencies = [
  "bytes",
  "futures",
  "iovec",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
  "log",
  "mio",
  "mio-uds",
@@ -5375,7 +5375,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]
@@ -5531,7 +5531,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc 0.2.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.79",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc 0.2.79",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -136,7 +136,7 @@ version = "0.3.53"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
- "libc 0.2.80",
+ "libc",
  "miniz_oxide",
  "object 0.21.1",
  "rustc-demangle",
@@ -215,7 +215,7 @@ dependencies = [
  "getopts",
  "ignore",
  "lazy_static",
- "libc 0.2.79",
+ "libc",
  "merge",
  "num_cpus",
  "opener",
@@ -325,7 +325,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "lazycell",
- "libc 0.2.79",
+ "libc",
  "libgit2-sys",
  "log",
  "memchr",
@@ -631,7 +631,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -653,7 +653,7 @@ dependencies = [
  "getopts",
  "glob",
  "lazy_static",
- "libc 0.2.79",
+ "libc",
  "miow 0.3.5",
  "regex",
  "rustfix",
@@ -673,7 +673,7 @@ dependencies = [
  "diff",
  "filetime",
  "getopts",
- "libc 0.2.79",
+ "libc",
  "log",
  "miow 0.3.5",
  "regex",
@@ -712,7 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -866,7 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9447ad28eee2a5cfb031c329d46bef77487244fff6a724b378885b8691a35f78"
 dependencies = [
  "curl-sys",
- "libc 0.2.79",
+ "libc",
  "openssl-probe",
  "openssl-sys",
  "schannel",
@@ -881,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad4eff0be6985b7e709f64b5a541f700e9ad1407190a29f4884319eb663ed1d6"
 dependencies = [
  "cc",
- "libc 0.2.79",
+ "libc",
  "libnghttp2-sys",
  "libz-sys",
  "openssl-sys",
@@ -973,7 +973,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
- "libc 0.2.79",
+ "libc",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35055b1021724f4eb5262eb49130eebff23fc59fc5a14160e05faad8eeb36673"
 dependencies = [
  "compiler_builtins",
- "libc 0.2.79",
+ "libc",
  "rustc-std-workspace-core",
 ]
 
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79",
+ "libc",
  "redox_syscall",
  "winapi 0.3.9",
 ]
@@ -1138,7 +1138,7 @@ checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
- "libc 0.2.79",
+ "libc",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -1268,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79",
+ "libc",
  "wasi",
 ]
 
@@ -1279,7 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79",
+ "libc",
  "wasi",
 ]
 
@@ -1301,7 +1301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
 dependencies = [
  "bitflags",
- "libc 0.2.79",
+ "libc",
  "libgit2-sys",
  "log",
  "openssl-probe",
@@ -1381,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "compiler_builtins",
- "libc 0.2.79",
+ "libc",
  "rustc-std-workspace-core",
 ]
 
@@ -1534,7 +1534,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -1569,7 +1569,7 @@ checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 dependencies = [
  "cc",
  "fs_extra",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -1707,15 +1707,6 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
-dependencies = [
- "rustc-std-workspace-core",
-]
-
-[[package]]
-name = "libc"
 version = "0.2.80"
 source = "git+https://github.com/lzutao/rust-libc?branch=i78184#624f53143a942e45b1f50d9690191e2543db8ef8"
 dependencies = [
@@ -1729,7 +1720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
 dependencies = [
  "cc",
- "libc 0.2.79",
+ "libc",
  "libssh2-sys",
  "libz-sys",
  "openssl-sys",
@@ -1743,7 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
 dependencies = [
  "cc",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -1753,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
 dependencies = [
  "cc",
- "libc 0.2.79",
+ "libc",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1767,7 +1758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
- "libc 0.2.79",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1853,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
 dependencies = [
  "cc",
- "libc 0.2.79",
+ "libc",
  "pkg-config",
 ]
 
@@ -1998,7 +1989,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc 0.2.79",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -2065,7 +2056,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.79",
+ "libc",
  "log",
  "miow 0.2.1",
  "net2",
@@ -2092,7 +2083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc 0.2.79",
+ "libc",
  "mio",
 ]
 
@@ -2127,7 +2118,7 @@ dependencies = [
  "env_logger 0.7.1",
  "getrandom 0.2.0",
  "hex 0.4.2",
- "libc 0.2.79",
+ "libc",
  "log",
  "rand",
  "rustc-workspace-hack",
@@ -2142,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -2178,7 +2169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -2244,7 +2235,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
- "libc 0.2.79",
+ "libc",
  "openssl-sys",
 ]
 
@@ -2271,7 +2262,7 @@ checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg",
  "cc",
- "libc 0.2.79",
+ "libc",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -2308,7 +2299,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -2319,7 +2310,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.79",
+ "libc",
  "unwind",
 ]
 
@@ -2381,7 +2372,7 @@ checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
- "libc 0.2.79",
+ "libc",
  "redox_syscall",
  "rustc_version",
  "smallvec 0.6.13",
@@ -2396,7 +2387,7 @@ checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
- "libc 0.2.79",
+ "libc",
  "redox_syscall",
  "smallvec 1.4.2",
  "winapi 0.3.9",
@@ -2411,7 +2402,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.1.0",
  "instant",
- "libc 0.2.79",
+ "libc",
  "redox_syscall",
  "smallvec 1.4.2",
  "winapi 0.3.9",
@@ -2730,7 +2721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.14",
- "libc 0.2.79",
+ "libc",
  "rand_chacha",
  "rand_core",
  "rand_hc",
@@ -3117,7 +3108,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc 0.2.79",
+ "libc",
  "measureme 0.7.1",
  "parking_lot 0.11.0",
  "rustc-ap-rustc_graphviz",
@@ -3519,7 +3510,7 @@ name = "rustc_codegen_llvm"
 version = "0.0.0"
 dependencies = [
  "bitflags",
- "libc 0.2.79",
+ "libc",
  "measureme 9.0.0",
  "rustc-demangle",
  "rustc_ast",
@@ -3550,7 +3541,7 @@ dependencies = [
  "bitflags",
  "cc",
  "jobserver",
- "libc 0.2.79",
+ "libc",
  "memmap",
  "num_cpus",
  "pathdiff",
@@ -3585,7 +3576,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc 0.2.79",
+ "libc",
  "measureme 9.0.0",
  "parking_lot 0.11.0",
  "rustc-hash",
@@ -3607,7 +3598,7 @@ dependencies = [
 name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.79",
+ "libc",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_codegen_ssa",
@@ -3770,7 +3761,7 @@ dependencies = [
 name = "rustc_interface"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.79",
+ "libc",
  "rustc-rayon",
  "rustc_ast",
  "rustc_ast_lowering",
@@ -3844,7 +3835,7 @@ version = "0.0.0"
 dependencies = [
  "build_helper",
  "cc",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -3861,7 +3852,7 @@ dependencies = [
 name = "rustc_metadata"
 version = "0.0.0"
 dependencies = [
- "libc 0.2.79",
+ "libc",
  "memmap",
  "rustc_ast",
  "rustc_attr",
@@ -4545,7 +4536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
  "arc-swap",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -4598,7 +4589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79",
+ "libc",
  "redox_syscall",
  "winapi 0.3.9",
 ]
@@ -4617,7 +4608,7 @@ checksum = "21ccb4c06ec57bc82d0f610f1a2963d7648700e43a6f513e564b9c89f7991786"
 dependencies = [
  "cc",
  "cfg-if 0.1.10",
- "libc 0.2.79",
+ "libc",
  "psm",
  "winapi 0.3.9",
 ]
@@ -4635,7 +4626,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "hashbrown",
  "hermit-abi",
- "libc 0.2.80",
+ "libc",
  "miniz_oxide",
  "object 0.20.0",
  "panic_abort",
@@ -4759,7 +4750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 dependencies = [
  "filetime",
- "libc 0.2.79",
+ "libc",
  "redox_syscall",
  "xattr",
 ]
@@ -4771,7 +4762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
- "libc 0.2.79",
+ "libc",
  "rand",
  "redox_syscall",
  "remove_dir_all",
@@ -4822,7 +4813,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
 dependencies = [
- "libc 0.2.79",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -4833,7 +4824,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "core",
  "getopts",
- "libc 0.2.79",
+ "libc",
  "panic_abort",
  "panic_unwind",
  "proc_macro",
@@ -4848,7 +4839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee72ec31009a42b53de9a6b7d8f462b493ab3b1e4767bda1fcdbb52127f13b6c"
 dependencies = [
  "getopts",
- "libc 0.2.79",
+ "libc",
  "term 0.6.1",
 ]
 
@@ -4910,7 +4901,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.79",
+ "libc",
  "winapi 0.3.9",
 ]
 
@@ -5019,7 +5010,7 @@ dependencies = [
  "crossbeam-queue 0.1.2",
  "futures",
  "lazy_static",
- "libc 0.2.79",
+ "libc",
  "log",
  "mio",
  "mio-named-pipes",
@@ -5064,7 +5055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
 dependencies = [
  "futures",
- "libc 0.2.79",
+ "libc",
  "mio",
  "mio-uds",
  "signal-hook-registry",
@@ -5151,7 +5142,7 @@ dependencies = [
  "bytes",
  "futures",
  "iovec",
- "libc 0.2.79",
+ "libc",
  "log",
  "mio",
  "mio-uds",
@@ -5375,7 +5366,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]
@@ -5531,7 +5522,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc 0.2.79",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,13 @@ object.debug = 0
 [patch."https://github.com/rust-lang/cargo"]
 cargo = { path = "src/tools/cargo" }
 
+[patch.crates-io.libc]
+version = "0.2"
+default-features = false
+features = ['rustc-dep-of-std']
+git = "https://github.com/lzutao/rust-libc"
+branch = "i78184"
+
 [patch."https://github.com/rust-lang/rustfmt"]
 # Similar to Cargo above we want the RLS to use a vendored version of `rustfmt`
 # that we're shipping as well (to ensure that the rustfmt in RLS and the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,6 @@ object.debug = 0
 cargo = { path = "src/tools/cargo" }
 
 [patch.crates-io.libc]
-version = "0.2"
-default-features = false
-features = ['rustc-dep-of-std']
 git = "https://github.com/lzutao/rust-libc"
 branch = "i78184"
 

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,7 +16,6 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.79", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.35" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
@@ -31,6 +30,12 @@ version = "0.20"
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe']
+[dependencies.libc]
+version = "0.2"
+default-features = false
+features = ['rustc-dep-of-std']
+git = "https://github.com/lzutao/rust-libc"
+branch = "i78184"
 
 [dev-dependencies]
 rand = "0.7"

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,6 +16,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
+libc = { version = "0.2.79", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.35" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
@@ -30,12 +31,6 @@ version = "0.20"
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe']
-[dependencies.libc]
-version = "0.2"
-default-features = false
-features = ['rustc-dep-of-std']
-git = "https://github.com/lzutao/rust-libc"
-branch = "i78184"
 
 [dev-dependencies]
 rand = "0.7"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -288,6 +288,8 @@ jobs:
               CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
             <<: *job-linux-xl
 
+          - name: dist-x86_64-freebsd
+            <<: *job-linux-xl
   auto:
     <<: *base-ci-job
     name: auto
@@ -679,7 +681,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - *dist-x86_64-linux
+          - name: dist-x86_64-freebsd
+            <<: *job-linux-xl
 
   master:
     name: master

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::path::Path;
 
 /// List of allowed sources for packages.
-const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\""];
+const ALLOWED_SOURCES: &[&str] = &[
+    "\"registry+https://github.com/rust-lang/crates.io-index\"",
+    "\"git+https://github.com/lzutao/rust-libc",
+];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.
@@ -26,7 +29,14 @@ pub fn check(root: &Path, bad: &mut bool) {
         let source = line.splitn(2, '=').nth(1).unwrap().trim();
 
         // Ensure source is allowed.
-        if !ALLOWED_SOURCES.contains(&&*source) {
+        let mut matched = false;
+        for allowed in ALLOWED_SOURCES {
+            if source.starts_with(allowed) {
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
             println!("invalid source: {}", source);
             *bad = true;
         }


### PR DESCRIPTION
This PR updates backtrace-rs submodule to get the artifact for testing.
cc  #78184 .