### PR TITLE
check object safety of generic constants

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -211,6 +211,7 @@ impl AbstractConst<'tcx> {
         substs: SubstsRef<'tcx>,
     ) -> Result<Option<AbstractConst<'tcx>>, ErrorReported> {
         let inner = tcx.mir_abstract_const_opt_const_arg(def)?;
+        debug!("AbstractConst::new({:?}) = {:?}", def, inner);
         Ok(inner.map(|inner| AbstractConst { inner, substs }))
     }
 

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -85,8 +85,10 @@ pub fn is_const_evaluatable<'cx, 'tcx>(
                         } else if leaf.has_param_types_or_consts() {
                             failure_kind = cmp::min(failure_kind, FailureKind::MentionsParam);
                         }
+
+                        false
                     }
-                    Node::Binop(_, _, _) | Node::UnaryOp(_, _) | Node::FunctionCall(_, _) => (),
+                    Node::Binop(_, _, _) | Node::UnaryOp(_, _) | Node::FunctionCall(_, _) => false,
                 });
 
                 match failure_kind {
@@ -194,12 +196,12 @@ pub fn is_const_evaluatable<'cx, 'tcx>(
 ///
 /// This is only able to represent a subset of `MIR`,
 /// and should not leak any information about desugarings.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct AbstractConst<'tcx> {
     // FIXME: Consider adding something like `IndexSlice`
     // and use this here.
-    inner: &'tcx [Node<'tcx>],
-    substs: SubstsRef<'tcx>,
+    pub inner: &'tcx [Node<'tcx>],
+    pub substs: SubstsRef<'tcx>,
 }
 
 impl AbstractConst<'tcx> {
@@ -210,6 +212,17 @@ impl AbstractConst<'tcx> {
     ) -> Result<Option<AbstractConst<'tcx>>, ErrorReported> {
         let inner = tcx.mir_abstract_const_opt_const_arg(def)?;
         Ok(inner.map(|inner| AbstractConst { inner, substs }))
+    }
+
+    pub fn from_const(
+        tcx: TyCtxt<'tcx>,
+        ct: &ty::Const<'tcx>,
+    ) -> Result<Option<AbstractConst<'tcx>>, ErrorReported> {
+        match ct.val {
+            ty::ConstKind::Unevaluated(def, substs, None) => AbstractConst::new(tcx, def, substs),
+            ty::ConstKind::Error(_) => Err(ErrorReported),
+            _ => Ok(None),
+        }
     }
 
     #[inline]
@@ -550,31 +563,32 @@ pub(super) fn try_unify_abstract_consts<'tcx>(
     // on `ErrorReported`.
 }
 
-fn walk_abstract_const<'tcx, F>(tcx: TyCtxt<'tcx>, ct: AbstractConst<'tcx>, mut f: F)
+// FIXME: Use `std::ops::ControlFlow` instead of `bool` here.
+pub fn walk_abstract_const<'tcx, F>(tcx: TyCtxt<'tcx>, ct: AbstractConst<'tcx>, mut f: F) -> bool
 where
-    F: FnMut(Node<'tcx>),
+    F: FnMut(Node<'tcx>) -> bool,
 {
-    recurse(tcx, ct, &mut f);
-    fn recurse<'tcx>(tcx: TyCtxt<'tcx>, ct: AbstractConst<'tcx>, f: &mut dyn FnMut(Node<'tcx>)) {
+    fn recurse<'tcx>(
+        tcx: TyCtxt<'tcx>,
+        ct: AbstractConst<'tcx>,
+        f: &mut dyn FnMut(Node<'tcx>) -> bool,
+    ) -> bool {
         let root = ct.root();
-        f(root);
-        match root {
-            Node::Leaf(_) => (),
-            Node::Binop(_, l, r) => {
-                recurse(tcx, ct.subtree(l), f);
-                recurse(tcx, ct.subtree(r), f);
-            }
-            Node::UnaryOp(_, v) => {
-                recurse(tcx, ct.subtree(v), f);
-            }
-            Node::FunctionCall(func, args) => {
-                recurse(tcx, ct.subtree(func), f);
-                for &arg in args {
-                    recurse(tcx, ct.subtree(arg), f);
+        f(root)
+            || match root {
+                Node::Leaf(_) => false,
+                Node::Binop(_, l, r) => {
+                    recurse(tcx, ct.subtree(l), f) || recurse(tcx, ct.subtree(r), f)
+                }
+                Node::UnaryOp(_, v) => recurse(tcx, ct.subtree(v), f),
+                Node::FunctionCall(func, args) => {
+                    recurse(tcx, ct.subtree(func), f)
+                        || args.iter().any(|&arg| recurse(tcx, ct.subtree(arg), f))
                 }
             }
-        }
     }
+
+    recurse(tcx, ct, &mut f)
 }
 
 /// Tries to unify two abstract constants using structural equality.

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2090,25 +2090,25 @@ fn const_evaluatable_predicates_of<'tcx>(
     if let hir::Node::Item(item) = node {
         if let hir::ItemKind::Impl { ref of_trait, ref self_ty, .. } = item.kind {
             if let Some(of_trait) = of_trait {
-                warn!("const_evaluatable_predicates_of({:?}): visit impl trait_ref", def_id);
+                debug!("const_evaluatable_predicates_of({:?}): visit impl trait_ref", def_id);
                 collector.visit_trait_ref(of_trait);
             }
 
-            warn!("const_evaluatable_predicates_of({:?}): visit_self_ty", def_id);
+            debug!("const_evaluatable_predicates_of({:?}): visit_self_ty", def_id);
             collector.visit_ty(self_ty);
         }
     }
 
     if let Some(generics) = node.generics() {
-        warn!("const_evaluatable_predicates_of({:?}): visit_generics", def_id);
+        debug!("const_evaluatable_predicates_of({:?}): visit_generics", def_id);
         collector.visit_generics(generics);
     }
 
     if let Some(fn_sig) = tcx.hir().fn_sig_by_hir_id(hir_id) {
-        warn!("const_evaluatable_predicates_of({:?}): visit_fn_decl", def_id);
+        debug!("const_evaluatable_predicates_of({:?}): visit_fn_decl", def_id);
         collector.visit_fn_decl(fn_sig.decl);
     }
-    warn!("const_evaluatable_predicates_of({:?}) = {:?}", def_id, collector.preds);
+    debug!("const_evaluatable_predicates_of({:?}) = {:?}", def_id, collector.preds);
 
     collector.preds
 }

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-ret.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-ret.rs
@@ -1,0 +1,21 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+
+const fn bar<T: ?Sized>() -> usize { 7 }
+
+trait Foo {
+    fn test(&self) -> [u8; bar::<Self>()];
+}
+
+impl Foo for () {
+    fn test(&self) -> [u8; bar::<Self>()] {
+        [0; bar::<Self>()]
+    }
+}
+
+fn use_dyn(v: &dyn Foo) { //~ERROR the trait `Foo` cannot be made into an object
+    v.test();
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-ret.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-ret.stderr
@@ -1,0 +1,18 @@
+error[E0038]: the trait `Foo` cannot be made into an object
+  --> $DIR/object-safety-err-ret.rs:17:15
+   |
+LL | fn use_dyn(v: &dyn Foo) {
+   |               ^^^^^^^^ `Foo` cannot be made into an object
+   |
+   = help: consider moving `test` to another trait
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-err-ret.rs:8:23
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     fn test(&self) -> [u8; bar::<Self>()];
+   |                       ^^^^^^^^^^^^^^^^^^^ ...because method `test` references the `Self` type in its return type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-where-bounds.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-where-bounds.rs
@@ -1,0 +1,22 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+#![deny(where_clauses_object_safety)]
+
+
+const fn bar<T: ?Sized>() -> usize { 7 }
+
+trait Foo {
+    fn test(&self) where [u8; bar::<Self>()]: Sized;
+    //~^ ERROR the trait `Foo` cannot be made into an object
+    //~| WARN this was previously accepted by the compiler but is being phased out
+}
+
+impl Foo for () {
+    fn test(&self) where [u8; bar::<Self>()]: Sized {}
+}
+
+fn use_dyn(v: &dyn Foo) {
+    v.test();
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-where-bounds.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-where-bounds.stderr
@@ -1,0 +1,24 @@
+error: the trait `Foo` cannot be made into an object
+  --> $DIR/object-safety-err-where-bounds.rs:9:8
+   |
+LL |     fn test(&self) where [u8; bar::<Self>()]: Sized;
+   |        ^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/object-safety-err-where-bounds.rs:3:9
+   |
+LL | #![deny(where_clauses_object_safety)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/object-safety-err-where-bounds.rs:9:8
+   |
+LL | trait Foo {
+   |       --- this trait cannot be made into an object...
+LL |     fn test(&self) where [u8; bar::<Self>()]: Sized;
+   |        ^^^^ ...because method `test` references the `Self` type in its `where` clause
+   = help: consider moving `test` to another trait
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.rs
@@ -16,6 +16,7 @@ fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
 }
 
 fn main() {
+    // FIXME(const_evaluatable_checked): Improve the error message here.
     use_dyn(&());
     //~^ ERROR type annotations needed
 }

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.rs
@@ -1,0 +1,21 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+trait Foo<const N: usize> {
+    fn test(&self) -> [u8; N + 1];
+}
+
+impl<const N: usize> Foo<N> for () {
+    fn test(&self) -> [u8; N + 1] {
+        [0; N + 1]
+    }
+}
+
+fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
+    assert_eq!(v.test(), [0; N + 1]);
+}
+
+fn main() {
+    use_dyn(&());
+    //~^ ERROR type annotations needed
+}

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.stderr
@@ -1,5 +1,5 @@
 error[E0284]: type annotations needed: cannot satisfy `the constant `use_dyn::<{_: usize}>::{constant#0}` can be evaluated`
-  --> $DIR/object-safety-ok-infer-err.rs:19:5
+  --> $DIR/object-safety-ok-infer-err.rs:20:5
    |
 LL | fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
    |                                                       ----- required by this bound in `use_dyn`

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok-infer-err.stderr
@@ -1,0 +1,12 @@
+error[E0284]: type annotations needed: cannot satisfy `the constant `use_dyn::<{_: usize}>::{constant#0}` can be evaluated`
+  --> $DIR/object-safety-ok-infer-err.rs:19:5
+   |
+LL | fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
+   |                                                       ----- required by this bound in `use_dyn`
+...
+LL |     use_dyn(&());
+   |     ^^^^^^^ cannot satisfy `the constant `use_dyn::<{_: usize}>::{constant#0}` can be evaluated`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0284`.

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-ok.rs
@@ -1,0 +1,21 @@
+// run-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+trait Foo<const N: usize> {
+    fn test(&self) -> [u8; N + 1];
+}
+
+impl<const N: usize> Foo<N> for () {
+    fn test(&self) -> [u8; N + 1] {
+        [0; N + 1]
+    }
+}
+
+fn use_dyn<const N: usize>(v: &dyn Foo<N>) where [u8; N + 1]: Sized {
+    assert_eq!(v.test(), [0; N + 1]);
+}
+
+fn main() {
+    use_dyn::<3>(&());
+}


### PR DESCRIPTION
As `Self` can only be effectively used in constants with `const_evaluatable_checked` this should not matter outside of it.

Implements the first item of #72219

> Object safety interactions with constants

r? @oli-obk for now cc @nikomatsakis