### PR TITLE
Treat trailing semicolon as a statement in macro call

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -905,6 +905,13 @@ pub struct Stmt {
 }
 
 impl Stmt {
+    pub fn has_trailing_semicolon(&self) -> bool {
+        match &self.kind {
+            StmtKind::Semi(_) => true,
+            StmtKind::MacCall(mac) => matches!(mac.style, MacStmtStyle::Semicolon),
+            _ => false,
+        }
+    }
     pub fn add_trailing_semicolon(mut self) -> Self {
         self.kind = match self.kind {
             StmtKind::Expr(expr) => StmtKind::Semi(expr),

--- a/compiler/rustc_lint/src/redundant_semicolon.rs
+++ b/compiler/rustc_lint/src/redundant_semicolon.rs
@@ -42,6 +42,11 @@ impl EarlyLintPass for RedundantSemicolons {
 
 fn maybe_lint_redundant_semis(cx: &EarlyContext<'_>, seq: &mut Option<(Span, bool)>) {
     if let Some((span, multiple)) = seq.take() {
+        // FIXME: Find a better way of ignoring the trailing
+        // semicolon from macro expansion
+        if span == rustc_span::DUMMY_SP {
+            return;
+        }
         cx.struct_span_lint(REDUNDANT_SEMICOLONS, span, |lint| {
             let (msg, rem) = if multiple {
                 ("unnecessary trailing semicolons", "remove these semicolons")

--- a/src/test/ui/macros/empty-trailing-stmt.rs
+++ b/src/test/ui/macros/empty-trailing-stmt.rs
@@ -1,0 +1,10 @@
+macro_rules! empty {
+    () => { }
+}
+
+fn foo() -> bool { //~ ERROR mismatched
+    { true } //~ ERROR mismatched
+    empty!();
+}
+
+fn main() {}

--- a/src/test/ui/macros/empty-trailing-stmt.stderr
+++ b/src/test/ui/macros/empty-trailing-stmt.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/empty-trailing-stmt.rs:6:7
+   |
+LL |     { true }
+   |       ^^^^ expected `()`, found `bool`
+
+error[E0308]: mismatched types
+  --> $DIR/empty-trailing-stmt.rs:5:13
+   |
+LL | fn foo() -> bool {
+   |    ---      ^^^^ expected `bool`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.stdout
@@ -40,7 +40,7 @@ macro_rules! produce_it
     }
 }
 
-fn main /* 0#0 */() { }
+fn main /* 0#0 */() { ; }
 
 /*
 Expansions:


### PR DESCRIPTION
See #61733 (comment)

We now preserve the trailing semicolon in a macro invocation, even if
the macro expands to nothing. As a result, the following code no longer
compiles:

```rust
macro_rules! empty {
    () => { }
}

fn foo() -> bool { //~ ERROR mismatched
    { true } //~ ERROR mismatched
    empty!();
}
```

Previously, `{ true }` would be considered the trailing expression, even
though there's a semicolon in `empty!();`

This makes macro expansion more token-based.