### PR TITLE
Tweak invalid `fn` header and body parsing

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1550,14 +1550,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub(super) fn expected_semi_or_open_brace<T>(&mut self) -> PResult<'a, T> {
-        let token_str = super::token_descr(&self.token);
-        let msg = &format!("expected `;` or `{{`, found {}", token_str);
-        let mut err = self.struct_span_err(self.token.span, msg);
-        err.span_label(self.token.span, "expected `;` or `{`");
-        Err(err)
-    }
-
     pub(super) fn eat_incorrect_doc_comment_for_param_type(&mut self) {
         if let token::DocComment(..) = self.token.kind {
             self.struct_span_err(

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1538,7 +1538,7 @@ impl<'a> Parser<'a> {
         generics.where_clause = self.parse_where_clause()?; // `where T: Ord`
 
         let mut sig_hi = self.prev_token.span;
-        let body = self.parse_fn_body(attrs, &mut sig_hi)?; // `;` or `{ ... }`.
+        let body = self.parse_fn_body(attrs, &ident, &mut sig_hi)?; // `;` or `{ ... }`.
         let fn_sig_span = sig_lo.to(sig_hi);
         Ok((ident, FnSig { header, decl, span: fn_sig_span }, generics, body))
     }
@@ -1549,6 +1549,7 @@ impl<'a> Parser<'a> {
     fn parse_fn_body(
         &mut self,
         attrs: &mut Vec<Attribute>,
+        ident: &Ident,
         sig_hi: &mut Span,
     ) -> PResult<'a, Option<P<Block>>> {
         let (inner_attrs, body) = if self.eat(&token::Semi) {
@@ -1573,9 +1574,21 @@ impl<'a> Parser<'a> {
                 .emit();
             (Vec::new(), Some(self.mk_block_err(span)))
         } else {
-            return self
-                .expected_one_of_not_found(&[], &[token::Semi, token::OpenDelim(token::Brace)])
-                .map(|_| None);
+            if let Err(mut err) =
+                self.expected_one_of_not_found(&[], &[token::Semi, token::OpenDelim(token::Brace)])
+            {
+                if self.token.kind == token::CloseDelim(token::Brace) {
+                    // The enclosing `mod`, `trait` or `impl` is being closed, so keep the `fn` in
+                    // the AST for typechecking.
+                    err.span_label(ident.span, "while parsing this `fn`");
+                    err.emit();
+                    (Vec::new(), None)
+                } else {
+                    return Err(err);
+                }
+            } else {
+                unreachable!()
+            }
         };
         attrs.extend(inner_attrs);
         Ok(body)
@@ -1653,10 +1666,19 @@ impl<'a> Parser<'a> {
         req_name: ReqName,
         ret_allow_plus: AllowPlus,
     ) -> PResult<'a, P<FnDecl>> {
-        Ok(P(FnDecl {
-            inputs: self.parse_fn_params(req_name)?,
-            output: self.parse_ret_ty(ret_allow_plus, RecoverQPath::Yes)?,
-        }))
+        let inputs = self.parse_fn_params(req_name)?;
+        let output = self.parse_ret_ty(ret_allow_plus, RecoverQPath::Yes)?;
+
+        if let ast::FnRetTy::Ty(ty) = &output {
+            if let TyKind::Path(_, Path { segments, .. }) = &ty.kind {
+                if let [.., last] = &segments[..] {
+                    // Detect and recover `fn foo() -> Vec<i32>> {}`
+                    self.check_trailing_angle_brackets(last, &[&token::OpenDelim(token::Brace)]);
+                }
+            }
+        }
+
+        Ok(P(FnDecl { inputs, output }))
     }
 
     /// Parses the parameter list of a function, including the `(` and `)` delimiters.

--- a/src/test/ui/issues/issue-39616.rs
+++ b/src/test/ui/issues/issue-39616.rs
@@ -1,4 +1,4 @@
 fn foo(a: [0; 1]) {} //~ ERROR expected type, found `0`
-//~| ERROR expected `;` or `{`, found `]`
+//~| ERROR expected one of `)`, `,`, `->`, `;`, `where`, or `{`, found `]`
 
 fn main() {}

--- a/src/test/ui/issues/issue-39616.rs
+++ b/src/test/ui/issues/issue-39616.rs
@@ -1,4 +1,3 @@
 fn foo(a: [0; 1]) {} //~ ERROR expected type, found `0`
-//~| ERROR expected one of `)`, `,`, `->`, `;`, `where`, or `{`, found `]`
 
 fn main() {}

--- a/src/test/ui/issues/issue-39616.stderr
+++ b/src/test/ui/issues/issue-39616.stderr
@@ -4,11 +4,11 @@ error: expected type, found `0`
 LL | fn foo(a: [0; 1]) {}
    |            ^ expected type
 
-error: expected `;` or `{`, found `]`
+error: expected one of `)`, `,`, `->`, `;`, `where`, or `{`, found `]`
   --> $DIR/issue-39616.rs:1:16
    |
 LL | fn foo(a: [0; 1]) {}
-   |                ^ expected `;` or `{`
+   |                ^ expected one of `)`, `,`, `->`, `;`, `where`, or `{`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-39616.stderr
+++ b/src/test/ui/issues/issue-39616.stderr
@@ -4,11 +4,5 @@ error: expected type, found `0`
 LL | fn foo(a: [0; 1]) {}
    |            ^ expected type
 
-error: expected one of `)`, `,`, `->`, `;`, `where`, or `{`, found `]`
-  --> $DIR/issue-39616.rs:1:16
-   |
-LL | fn foo(a: [0; 1]) {}
-   |                ^ expected one of `)`, `,`, `->`, `;`, `where`, or `{`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-58856-1.rs
+++ b/src/test/ui/issues/issue-58856-1.rs
@@ -2,7 +2,7 @@ impl A {
     //~^ ERROR cannot find type `A` in this scope
     fn b(self>
     //~^ ERROR expected one of `)`, `,`, or `:`, found `>`
-    //~| ERROR expected `;` or `{`, found `>`
+    //~| ERROR expected one of `->`, `;`, `where`, or `{`, found `>`
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-58856-1.stderr
+++ b/src/test/ui/issues/issue-58856-1.stderr
@@ -6,14 +6,14 @@ LL |     fn b(self>
    |         |
    |         unclosed delimiter
 
-error: expected `;` or `{`, found `>`
+error: expected one of `->`, `;`, `where`, or `{`, found `>`
   --> $DIR/issue-58856-1.rs:3:14
    |
 LL | impl A {
    |        - while parsing this item list starting here
 LL |
 LL |     fn b(self>
-   |              ^ expected `;` or `{`
+   |              ^ expected one of `->`, `;`, `where`, or `{`
 ...
 LL | }
    | - the item list ends here

--- a/src/test/ui/parser/fn-colon-return-type.rs
+++ b/src/test/ui/parser/fn-colon-return-type.rs
@@ -1,0 +1,5 @@
+fn foo(x: i32): i32 { //~ ERROR expected one of `->`, `;`, `where`, or `{`, found `:`
+    x
+}
+
+fn main() {}

--- a/src/test/ui/parser/fn-colon-return-type.stderr
+++ b/src/test/ui/parser/fn-colon-return-type.stderr
@@ -1,0 +1,8 @@
+error: expected one of `->`, `;`, `where`, or `{`, found `:`
+  --> $DIR/fn-colon-return-type.rs:1:15
+   |
+LL | fn foo(x: i32): i32 {
+   |               ^ expected one of `->`, `;`, `where`, or `{`
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/issue-24780.rs
+++ b/src/test/ui/parser/issue-24780.rs
@@ -3,6 +3,6 @@
 // expected one of ..., `>`, ... found `>`
 
 fn foo() -> Vec<usize>> {
-    //~^ ERROR expected `;` or `{`, found `>`
+    //~^ ERROR expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
     Vec::new()
 }

--- a/src/test/ui/parser/issue-24780.rs
+++ b/src/test/ui/parser/issue-24780.rs
@@ -1,8 +1,9 @@
 // Verify that '>' is not both expected and found at the same time, as it used
 // to happen in #24780. For example, following should be an error:
-// expected one of ..., `>`, ... found `>`
+// expected one of ..., `>`, ... found `>`. No longer exactly this, but keeping for posterity.
 
-fn foo() -> Vec<usize>> {
-    //~^ ERROR expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
+fn foo() -> Vec<usize>> { //~ ERROR unmatched angle bracket
     Vec::new()
 }
+
+fn main() {}

--- a/src/test/ui/parser/issue-24780.stderr
+++ b/src/test/ui/parser/issue-24780.stderr
@@ -1,8 +1,8 @@
-error: expected `;` or `{`, found `>`
+error: expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
   --> $DIR/issue-24780.rs:5:23
    |
 LL | fn foo() -> Vec<usize>> {
-   |                       ^ expected `;` or `{`
+   |                       ^ expected one of `!`, `+`, `::`, `;`, `where`, or `{`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-24780.stderr
+++ b/src/test/ui/parser/issue-24780.stderr
@@ -1,8 +1,8 @@
-error: expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
+error: unmatched angle bracket
   --> $DIR/issue-24780.rs:5:23
    |
 LL | fn foo() -> Vec<usize>> {
-   |                       ^ expected one of `!`, `+`, `::`, `;`, `where`, or `{`
+   |                       ^^ help: remove extra angle bracket
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-6610.rs
+++ b/src/test/ui/parser/issue-6610.rs
@@ -1,3 +1,3 @@
-trait Foo { fn a() } //~ ERROR expected `;` or `{`, found `}`
+trait Foo { fn a() } //~ ERROR expected one of `->`, `;`, `where`, or `{`, found `}`
 
 fn main() {}

--- a/src/test/ui/parser/issue-6610.stderr
+++ b/src/test/ui/parser/issue-6610.stderr
@@ -2,11 +2,9 @@ error: expected one of `->`, `;`, `where`, or `{`, found `}`
   --> $DIR/issue-6610.rs:1:20
    |
 LL | trait Foo { fn a() }
-   |           -        ^
-   |           |        |
-   |           |        expected one of `->`, `;`, `where`, or `{`
-   |           |        the item list ends here
-   |           while parsing this item list starting here
+   |                -   ^ expected one of `->`, `;`, `where`, or `{`
+   |                |
+   |                while parsing this `fn`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-6610.stderr
+++ b/src/test/ui/parser/issue-6610.stderr
@@ -1,10 +1,10 @@
-error: expected `;` or `{`, found `}`
+error: expected one of `->`, `;`, `where`, or `{`, found `}`
   --> $DIR/issue-6610.rs:1:20
    |
 LL | trait Foo { fn a() }
    |           -        ^
    |           |        |
-   |           |        expected `;` or `{`
+   |           |        expected one of `->`, `;`, `where`, or `{`
    |           |        the item list ends here
    |           while parsing this item list starting here
 

--- a/src/test/ui/parser/missing_right_paren.stderr
+++ b/src/test/ui/parser/missing_right_paren.stderr
@@ -22,11 +22,11 @@ error: expected one of `:` or `|`, found `)`
 LL | fn main((ؼ
    |           ^ expected one of `:` or `|`
 
-error: expected `;` or `{`, found `<eof>`
+error: expected one of `->`, `;`, `where`, or `{`, found `<eof>`
   --> $DIR/missing_right_paren.rs:3:11
    |
 LL | fn main((ؼ
-   |           ^ expected `;` or `{`
+   |           ^ expected one of `->`, `;`, `where`, or `{`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/not-a-pred.rs
+++ b/src/test/ui/parser/not-a-pred.rs
@@ -1,6 +1,5 @@
-// error-pattern: lt
-
 fn f(a: isize, b: isize) : lt(a, b) { }
+//~^ ERROR expected one of `->`, `;`, `where`, or `{`, found `:`
 
 fn lt(a: isize, b: isize) { }
 

--- a/src/test/ui/parser/not-a-pred.stderr
+++ b/src/test/ui/parser/not-a-pred.stderr
@@ -1,8 +1,8 @@
-error: expected `;` or `{`, found `:`
-  --> $DIR/not-a-pred.rs:3:26
+error: expected one of `->`, `;`, `where`, or `{`, found `:`
+  --> $DIR/not-a-pred.rs:1:26
    |
 LL | fn f(a: isize, b: isize) : lt(a, b) { }
-   |                          ^ expected `;` or `{`
+   |                          ^ expected one of `->`, `;`, `where`, or `{`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
* Rely on regular "expected"/"found" parser error for `fn`, fix #77115
* Recover empty `fn` bodies when encountering `}`
* Recover trailing `>` in return types
* Recover from non-type in array type `[<BAD TOKEN>; LEN]`