### PR TITLE
Update tests to remove old numeric constants

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1173,133 +1173,133 @@ extern "rust-intrinsic" {
     /// Returns the square root of an `f32`
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::sqrt`](../../std/primitive.f32.html#method.sqrt)
+    /// [`f32::sqrt`](../../std/primitive.f32.html#method.sqrt)
     pub fn sqrtf32(x: f32) -> f32;
     /// Returns the square root of an `f64`
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::sqrt`](../../std/primitive.f64.html#method.sqrt)
+    /// [`f64::sqrt`](../../std/primitive.f64.html#method.sqrt)
     pub fn sqrtf64(x: f64) -> f64;
 
     /// Raises an `f32` to an integer power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::powi`](../../std/primitive.f32.html#method.powi)
+    /// [`f32::powi`](../../std/primitive.f32.html#method.powi)
     pub fn powif32(a: f32, x: i32) -> f32;
     /// Raises an `f64` to an integer power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::powi`](../../std/primitive.f64.html#method.powi)
+    /// [`f64::powi`](../../std/primitive.f64.html#method.powi)
     pub fn powif64(a: f64, x: i32) -> f64;
 
     /// Returns the sine of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::sin`](../../std/primitive.f32.html#method.sin)
+    /// [`f32::sin`](../../std/primitive.f32.html#method.sin)
     pub fn sinf32(x: f32) -> f32;
     /// Returns the sine of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::sin`](../../std/primitive.f64.html#method.sin)
+    /// [`f64::sin`](../../std/primitive.f64.html#method.sin)
     pub fn sinf64(x: f64) -> f64;
 
     /// Returns the cosine of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::cos`](../../std/primitive.f32.html#method.cos)
+    /// [`f32::cos`](../../std/primitive.f32.html#method.cos)
     pub fn cosf32(x: f32) -> f32;
     /// Returns the cosine of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::cos`](../../std/primitive.f64.html#method.cos)
+    /// [`f64::cos`](../../std/primitive.f64.html#method.cos)
     pub fn cosf64(x: f64) -> f64;
 
     /// Raises an `f32` to an `f32` power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::powf`](../../std/primitive.f32.html#method.powf)
+    /// [`f32::powf`](../../std/primitive.f32.html#method.powf)
     pub fn powf32(a: f32, x: f32) -> f32;
     /// Raises an `f64` to an `f64` power.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::powf`](../../std/primitive.f64.html#method.powf)
+    /// [`f64::powf`](../../std/primitive.f64.html#method.powf)
     pub fn powf64(a: f64, x: f64) -> f64;
 
     /// Returns the exponential of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::exp`](../../std/primitive.f32.html#method.exp)
+    /// [`f32::exp`](../../std/primitive.f32.html#method.exp)
     pub fn expf32(x: f32) -> f32;
     /// Returns the exponential of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::exp`](../../std/primitive.f64.html#method.exp)
+    /// [`f64::exp`](../../std/primitive.f64.html#method.exp)
     pub fn expf64(x: f64) -> f64;
 
     /// Returns 2 raised to the power of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::exp2`](../../std/primitive.f32.html#method.exp2)
+    /// [`f32::exp2`](../../std/primitive.f32.html#method.exp2)
     pub fn exp2f32(x: f32) -> f32;
     /// Returns 2 raised to the power of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::exp2`](../../std/primitive.f64.html#method.exp2)
+    /// [`f64::exp2`](../../std/primitive.f64.html#method.exp2)
     pub fn exp2f64(x: f64) -> f64;
 
     /// Returns the natural logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::ln`](../../std/primitive.f32.html#method.ln)
+    /// [`f32::ln`](../../std/primitive.f32.html#method.ln)
     pub fn logf32(x: f32) -> f32;
     /// Returns the natural logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::ln`](../../std/primitive.f64.html#method.ln)
+    /// [`f64::ln`](../../std/primitive.f64.html#method.ln)
     pub fn logf64(x: f64) -> f64;
 
     /// Returns the base 10 logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::log10`](../../std/primitive.f32.html#method.log10)
+    /// [`f32::log10`](../../std/primitive.f32.html#method.log10)
     pub fn log10f32(x: f32) -> f32;
     /// Returns the base 10 logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::log10`](../../std/primitive.f64.html#method.log10)
+    /// [`f64::log10`](../../std/primitive.f64.html#method.log10)
     pub fn log10f64(x: f64) -> f64;
 
     /// Returns the base 2 logarithm of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::log2`](../../std/primitive.f32.html#method.log2)
+    /// [`f32::log2`](../../std/primitive.f32.html#method.log2)
     pub fn log2f32(x: f32) -> f32;
     /// Returns the base 2 logarithm of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::log2`](../../std/primitive.f64.html#method.log2)
+    /// [`f64::log2`](../../std/primitive.f64.html#method.log2)
     pub fn log2f64(x: f64) -> f64;
 
     /// Returns `a * b + c` for `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::mul_add`](../../std/primitive.f32.html#method.mul_add)
+    /// [`f32::mul_add`](../../std/primitive.f32.html#method.mul_add)
     pub fn fmaf32(a: f32, b: f32, c: f32) -> f32;
     /// Returns `a * b + c` for `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::mul_add`](../../std/primitive.f64.html#method.mul_add)
+    /// [`f64::mul_add`](../../std/primitive.f64.html#method.mul_add)
     pub fn fmaf64(a: f64, b: f64, c: f64) -> f64;
 
     /// Returns the absolute value of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::abs`](../../std/primitive.f32.html#method.abs)
+    /// [`f32::abs`](../../std/primitive.f32.html#method.abs)
     pub fn fabsf32(x: f32) -> f32;
     /// Returns the absolute value of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::abs`](../../std/primitive.f64.html#method.abs)
+    /// [`f64::abs`](../../std/primitive.f64.html#method.abs)
     pub fn fabsf64(x: f64) -> f64;
 
     /// Returns the minimum of two `f32` values.
@@ -1326,45 +1326,45 @@ extern "rust-intrinsic" {
     /// Copies the sign from `y` to `x` for `f32` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::copysign`](../../std/primitive.f32.html#method.copysign)
+    /// [`f32::copysign`](../../std/primitive.f32.html#method.copysign)
     pub fn copysignf32(x: f32, y: f32) -> f32;
     /// Copies the sign from `y` to `x` for `f64` values.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::copysign`](../../std/primitive.f64.html#method.copysign)
+    /// [`f64::copysign`](../../std/primitive.f64.html#method.copysign)
     pub fn copysignf64(x: f64, y: f64) -> f64;
 
     /// Returns the largest integer less than or equal to an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::floor`](../../std/primitive.f32.html#method.floor)
+    /// [`f32::floor`](../../std/primitive.f32.html#method.floor)
     pub fn floorf32(x: f32) -> f32;
     /// Returns the largest integer less than or equal to an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::floor`](../../std/primitive.f64.html#method.floor)
+    /// [`f64::floor`](../../std/primitive.f64.html#method.floor)
     pub fn floorf64(x: f64) -> f64;
 
     /// Returns the smallest integer greater than or equal to an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::ceil`](../../std/primitive.f32.html#method.ceil)
+    /// [`f32::ceil`](../../std/primitive.f32.html#method.ceil)
     pub fn ceilf32(x: f32) -> f32;
     /// Returns the smallest integer greater than or equal to an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::ceil`](../../std/primitive.f64.html#method.ceil)
+    /// [`f64::ceil`](../../std/primitive.f64.html#method.ceil)
     pub fn ceilf64(x: f64) -> f64;
 
     /// Returns the integer part of an `f32`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::trunc`](../../std/primitive.f32.html#method.trunc)
+    /// [`f32::trunc`](../../std/primitive.f32.html#method.trunc)
     pub fn truncf32(x: f32) -> f32;
     /// Returns the integer part of an `f64`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::trunc`](../../std/primitive.f64.html#method.trunc)
+    /// [`f64::trunc`](../../std/primitive.f64.html#method.trunc)
     pub fn truncf64(x: f64) -> f64;
 
     /// Returns the nearest integer to an `f32`. May raise an inexact floating-point exception
@@ -1386,12 +1386,12 @@ extern "rust-intrinsic" {
     /// Returns the nearest integer to an `f32`. Rounds half-way cases away from zero.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f32::round`](../../std/primitive.f32.html#method.round)
+    /// [`f32::round`](../../std/primitive.f32.html#method.round)
     pub fn roundf32(x: f32) -> f32;
     /// Returns the nearest integer to an `f64`. Rounds half-way cases away from zero.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::f64::round`](../../std/primitive.f64.html#method.round)
+    /// [`f64::round`](../../std/primitive.f64.html#method.round)
     pub fn roundf64(x: f64) -> f64;
 
     /// Float addition that allows optimizations based on algebraic rules.

--- a/library/core/tests/num/nan.rs
+++ b/library/core/tests/num/nan.rs
@@ -1,6 +1,5 @@
 #[test]
 fn test_nan() {
-    use core::f64;
     let x = "NaN".to_string();
     assert_eq!(format!("{}", f64::NAN), x);
     assert_eq!(format!("{:e}", f64::NAN), x);

--- a/src/test/codegen/enum-discriminant-value.rs
+++ b/src/test/codegen/enum-discriminant-value.rs
@@ -4,14 +4,14 @@
 
 #[repr(i64)]
 pub enum I64 {
-    I64Min = std::i64::MIN,
-    I64Max = std::i64::MAX,
+    I64Min = i64::MIN,
+    I64Max = i64::MAX,
 }
 
 #[repr(u64)]
 pub enum U64 {
-    U64Min = std::u64::MIN,
-    U64Max = std::u64::MAX,
+    U64Min = u64::MIN,
+    U64Max = u64::MAX,
 }
 
 fn main() {

--- a/src/test/codegen/issue-56927.rs
+++ b/src/test/codegen/issue-56927.rs
@@ -1,7 +1,6 @@
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type="rlib"]
-use std::usize;
 
 #[repr(align(16))]
 pub struct S {

--- a/src/test/compile-fail/consts/issue-55878.rs
+++ b/src/test/compile-fail/consts/issue-55878.rs
@@ -3,5 +3,5 @@
 
 // error-pattern: are too big for the current architecture
 fn main() {
-    println!("Size: {}", std::mem::size_of::<[u8; std::u64::MAX as usize]>());
+    println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
 }

--- a/src/test/rustdoc/reexport-check.rs
+++ b/src/test/rustdoc/reexport-check.rs
@@ -6,6 +6,7 @@ extern crate reexport_check;
 // @!has 'foo/index.html' '//code' 'pub use self::i32;'
 // @has 'foo/index.html' '//tr[@class="module-item"]' 'i32'
 // @has 'foo/i32/index.html'
+#[allow(deprecated, deprecated_in_future)]
 pub use std::i32;
 // @!has 'foo/index.html' '//code' 'pub use self::string::String;'
 // @has 'foo/index.html' '//tr[@class="module-item"]' 'String'

--- a/src/test/rustdoc/show-const-contents.rs
+++ b/src/test/rustdoc/show-const-contents.rs
@@ -52,6 +52,7 @@ pub const MY_TYPE_WITH_STR: MyTypeWithStr = MyTypeWithStr("show this");
 pub use std::f32::consts::PI;
 
 // @has show_const_contents/constant.MAX.html '= i32::MAX; // 2_147_483_647i32'
+#[allow(deprecated, deprecated_in_future)]
 pub use std::i32::MAX;
 
 macro_rules! int_module {

--- a/src/test/ui/array-slice-vec/bounds-check-no-overflow.rs
+++ b/src/test/ui/array-slice-vec/bounds-check-no-overflow.rs
@@ -2,7 +2,6 @@
 // error-pattern:index out of bounds
 // ignore-emscripten no processes
 
-use std::usize;
 use std::mem::size_of;
 
 fn main() {

--- a/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.noopt.stderr
+++ b/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.noopt.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:27:22
    |
 LL |     const NEG: i32 = -i32::MIN + T::NEG;
    |                      ^^^^^^^^^ attempt to negate `i32::MIN`, which would overflow
@@ -7,25 +7,25 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:31:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:35
    |
 LL |     const NEG_REV: i32 = T::NEG + (-i32::MIN);
    |                                   ^^^^^^^^^^^ attempt to negate `i32::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:32:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:36:36
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:36
    |
 LL |     const ADD_REV: i32 =  T::ADD + (i32::MAX+1);
    |                                    ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:37:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      ^^^^^ attempt to divide `1_i32` by zero
@@ -33,19 +33,19 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:41:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:35
    |
 LL |     const DIV_REV: i32 = T::DIV + (1/0);
    |                                   ^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:42:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:46:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:35
    |
 LL |     const OOB_REV: i32 = T::OOB + [1][1];
    |                                   ^^^^^^ index out of bounds: the length is 1 but the index is 1

--- a/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.opt.stderr
+++ b/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.opt.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:27:22
    |
 LL |     const NEG: i32 = -i32::MIN + T::NEG;
    |                      ^^^^^^^^^ attempt to negate `i32::MIN`, which would overflow
@@ -7,25 +7,25 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:31:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:35
    |
 LL |     const NEG_REV: i32 = T::NEG + (-i32::MIN);
    |                                   ^^^^^^^^^^^ attempt to negate `i32::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:32:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:36:36
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:36
    |
 LL |     const ADD_REV: i32 =  T::ADD + (i32::MAX+1);
    |                                    ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:37:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      ^^^^^ attempt to divide `1_i32` by zero
@@ -33,19 +33,19 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:41:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:35
    |
 LL |     const DIV_REV: i32 = T::DIV + (1/0);
    |                                   ^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:42:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:46:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:35
    |
 LL |     const OOB_REV: i32 = T::OOB + [1][1];
    |                                   ^^^^^^ index out of bounds: the length is 1 but the index is 1

--- a/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.opt_with_overflow_checks.stderr
+++ b/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.opt_with_overflow_checks.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:27:22
    |
 LL |     const NEG: i32 = -i32::MIN + T::NEG;
    |                      ^^^^^^^^^ attempt to negate `i32::MIN`, which would overflow
@@ -7,25 +7,25 @@ LL |     const NEG: i32 = -i32::MIN + T::NEG;
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:31:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:29:35
    |
 LL |     const NEG_REV: i32 = T::NEG + (-i32::MIN);
    |                                   ^^^^^^^^^^^ attempt to negate `i32::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:32:22
    |
 LL |     const ADD: i32 = (i32::MAX+1) + T::ADD;
    |                      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:36:36
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:34:36
    |
 LL |     const ADD_REV: i32 =  T::ADD + (i32::MAX+1);
    |                                    ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:37:22
    |
 LL |     const DIV: i32 = (1/0) + T::DIV;
    |                      ^^^^^ attempt to divide `1_i32` by zero
@@ -33,19 +33,19 @@ LL |     const DIV: i32 = (1/0) + T::DIV;
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:41:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:39:35
    |
 LL |     const DIV_REV: i32 = T::DIV + (1/0);
    |                                   ^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:22
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:42:22
    |
 LL |     const OOB: i32 = [1][1] + T::OOB;
    |                      ^^^^^^ index out of bounds: the length is 1 but the index is 1
 
 error: this operation will panic at runtime
-  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:46:35
+  --> $DIR/issue-69020-assoc-const-arith-overflow.rs:44:35
    |
 LL |     const OOB_REV: i32 = T::OOB + [1][1];
    |                                   ^^^^^^ index out of bounds: the length is 1 but the index is 1

--- a/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.rs
+++ b/src/test/ui/associated-consts/issue-69020-assoc-const-arith-overflow.rs
@@ -5,8 +5,6 @@
 
 #![crate_type="lib"]
 
-use std::i32;
-
 pub trait Foo {
     const NEG: i32;
     const NEG_REV: i32;

--- a/src/test/ui/big-literals.rs
+++ b/src/test/ui/big-literals.rs
@@ -10,8 +10,8 @@ pub fn main() {
 
     assert_eq!((-2147483648i32).wrapping_sub(1), 2147483647);
 
-    assert_eq!(-3.40282356e+38_f32, ::std::f32::MIN);
-    assert_eq!(3.40282356e+38_f32, ::std::f32::MAX);
-    assert_eq!(-1.7976931348623158e+308_f64, ::std::f64::MIN);
-    assert_eq!(1.7976931348623158e+308_f64, ::std::f64::MAX);
+    assert_eq!(-3.40282356e+38_f32, f32::MIN);
+    assert_eq!(3.40282356e+38_f32, f32::MAX);
+    assert_eq!(-1.7976931348623158e+308_f64, f64::MIN);
+    assert_eq!(1.7976931348623158e+308_f64, f64::MAX);
 }

--- a/src/test/ui/const-generics/const_evaluatable_checked/fn_call.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/fn_call.rs
@@ -6,7 +6,7 @@ const fn test_me<T>(a: usize, b: usize) -> usize {
     if a < b {
         std::mem::size_of::<T>()
     } else {
-        std::usize::MAX
+        usize::MAX
     }
 }
 

--- a/src/test/ui/const-generics/issues/issue-72819-generic-in-const-eval.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-72819-generic-in-const-eval.full.stderr
@@ -1,8 +1,8 @@
 error: constant expression depends on a generic parameter
-  --> $DIR/issue-72819-generic-in-const-eval.rs:9:47
+  --> $DIR/issue-72819-generic-in-const-eval.rs:9:39
    |
-LL | where Assert::<{N < usize::max_value() / 2}>: IsTrue,
-   |                                               ^^^^^^
+LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
+   |                                       ^^^^^^
    |
    = note: this may fail depending on what value the parameter takes
 

--- a/src/test/ui/const-generics/issues/issue-72819-generic-in-const-eval.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-72819-generic-in-const-eval.min.stderr
@@ -1,7 +1,7 @@
 error: generic parameters may not be used in const operations
   --> $DIR/issue-72819-generic-in-const-eval.rs:9:17
    |
-LL | where Assert::<{N < usize::max_value() / 2}>: IsTrue,
+LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
    |                 ^ cannot perform const operation using `N`
    |
    = help: const parameters may only be used as standalone arguments, i.e. `N`

--- a/src/test/ui/const-generics/issues/issue-72819-generic-in-const-eval.rs
+++ b/src/test/ui/const-generics/issues/issue-72819-generic-in-const-eval.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(min, feature(min_const_generics))]
 
 struct Arr<const N: usize>
-where Assert::<{N < usize::max_value() / 2}>: IsTrue,
+where Assert::<{N < usize::MAX / 2}>: IsTrue,
 //[full]~^ ERROR constant expression depends on a generic parameter
 //[min]~^^ ERROR generic parameters may not be used in const operations
 {
@@ -19,5 +19,5 @@ trait IsTrue {}
 impl IsTrue for Assert<true> {}
 
 fn main() {
-    let x: Arr<{usize::max_value()}> = Arr {};
+    let x: Arr<{usize::MAX}> = Arr {};
 }

--- a/src/test/ui/const-generics/issues/issue-73260.rs
+++ b/src/test/ui/const-generics/issues/issue-73260.rs
@@ -3,7 +3,7 @@
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 struct Arr<const N: usize>
-where Assert::<{N < usize::max_value() / 2}>: IsTrue, //~ ERROR constant expression
+where Assert::<{N < usize::MAX / 2}>: IsTrue, //~ ERROR constant expression
 {
 }
 
@@ -14,7 +14,7 @@ trait IsTrue {}
 impl IsTrue for Assert<true> {}
 
 fn main() {
-    let x: Arr<{usize::max_value()}> = Arr {};
+    let x: Arr<{usize::MAX}> = Arr {};
     //~^ ERROR mismatched types
     //~| ERROR mismatched types
 }

--- a/src/test/ui/const-generics/issues/issue-73260.stderr
+++ b/src/test/ui/const-generics/issues/issue-73260.stderr
@@ -1,25 +1,25 @@
 error: constant expression depends on a generic parameter
-  --> $DIR/issue-73260.rs:6:47
+  --> $DIR/issue-73260.rs:6:39
    |
-LL | where Assert::<{N < usize::max_value() / 2}>: IsTrue,
-   |                                               ^^^^^^
+LL | where Assert::<{N < usize::MAX / 2}>: IsTrue,
+   |                                       ^^^^^^
    |
    = note: this may fail depending on what value the parameter takes
 
 error[E0308]: mismatched types
   --> $DIR/issue-73260.rs:17:12
    |
-LL |     let x: Arr<{usize::max_value()}> = Arr {};
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `false`, found `true`
+LL |     let x: Arr<{usize::MAX}> = Arr {};
+   |            ^^^^^^^^^^^^^^^^^ expected `false`, found `true`
    |
    = note: expected type `false`
               found type `true`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-73260.rs:17:40
+  --> $DIR/issue-73260.rs:17:32
    |
-LL |     let x: Arr<{usize::max_value()}> = Arr {};
-   |                                        ^^^ expected `false`, found `true`
+LL |     let x: Arr<{usize::MAX}> = Arr {};
+   |                                ^^^ expected `false`, found `true`
    |
    = note: expected type `false`
               found type `true`

--- a/src/test/ui/consts/const-err-early.rs
+++ b/src/test/ui/consts/const-err-early.rs
@@ -1,6 +1,6 @@
 #![deny(const_err)]
 
-pub const A: i8 = -std::i8::MIN; //~ ERROR const_err
+pub const A: i8 = -i8::MIN; //~ ERROR const_err
 pub const B: u8 = 200u8 + 200u8; //~ ERROR const_err
 pub const C: u8 = 200u8 * 4; //~ ERROR const_err
 pub const D: u8 = 42u8 - (42u8 + 1); //~ ERROR const_err

--- a/src/test/ui/consts/const-err-early.stderr
+++ b/src/test/ui/consts/const-err-early.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
   --> $DIR/const-err-early.rs:3:19
    |
-LL | pub const A: i8 = -std::i8::MIN;
-   | ------------------^^^^^^^^^^^^^-
+LL | pub const A: i8 = -i8::MIN;
+   | ------------------^^^^^^^^-
    |                   |
    |                   attempt to negate `i8::MIN`, which would overflow
    |

--- a/src/test/ui/consts/const-err-multi.rs
+++ b/src/test/ui/consts/const-err-multi.rs
@@ -1,6 +1,6 @@
 #![deny(const_err)]
 
-pub const A: i8 = -std::i8::MIN;
+pub const A: i8 = -i8::MIN;
 //~^ ERROR const_err
 pub const B: i8 = A;
 //~^ ERROR const_err

--- a/src/test/ui/consts/const-err-multi.stderr
+++ b/src/test/ui/consts/const-err-multi.stderr
@@ -1,8 +1,8 @@
 error: any use of this value will cause an error
   --> $DIR/const-err-multi.rs:3:19
    |
-LL | pub const A: i8 = -std::i8::MIN;
-   | ------------------^^^^^^^^^^^^^-
+LL | pub const A: i8 = -i8::MIN;
+   | ------------------^^^^^^^^-
    |                   |
    |                   attempt to negate `i8::MIN`, which would overflow
    |

--- a/src/test/ui/consts/const-err2.noopt.stderr
+++ b/src/test/ui/consts/const-err2.noopt.stderr
@@ -1,16 +1,16 @@
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
-LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
+LL |     let a = -i8::MIN;
+   |             ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
-LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
+LL |     let a_i128 = -i128::MIN;
+   |                  ^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
@@ -21,8 +21,8 @@ LL |     let b = 200u8 + 200u8 + 200u8;
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
-LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
+LL |     let b_i128 = i128::MIN - i128::MAX;
+   |                  ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13

--- a/src/test/ui/consts/const-err2.opt.stderr
+++ b/src/test/ui/consts/const-err2.opt.stderr
@@ -1,16 +1,16 @@
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
-LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
+LL |     let a = -i8::MIN;
+   |             ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
-LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
+LL |     let a_i128 = -i128::MIN;
+   |                  ^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
@@ -21,8 +21,8 @@ LL |     let b = 200u8 + 200u8 + 200u8;
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
-LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
+LL |     let b_i128 = i128::MIN - i128::MAX;
+   |                  ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13

--- a/src/test/ui/consts/const-err2.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/const-err2.opt_with_overflow_checks.stderr
@@ -1,16 +1,16 @@
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:19:13
    |
-LL |     let a = -std::i8::MIN;
-   |             ^^^^^^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
+LL |     let a = -i8::MIN;
+   |             ^^^^^^^^ attempt to negate `i8::MIN`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:21:18
    |
-LL |     let a_i128 = -std::i128::MIN;
-   |                  ^^^^^^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
+LL |     let a_i128 = -i128::MIN;
+   |                  ^^^^^^^^^^ attempt to negate `i128::MIN`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:23:13
@@ -21,8 +21,8 @@ LL |     let b = 200u8 + 200u8 + 200u8;
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:25:18
    |
-LL |     let b_i128 = std::i128::MIN - std::i128::MAX;
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
+LL |     let b_i128 = i128::MIN - i128::MAX;
+   |                  ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i128::MIN - i128::MAX`, which would overflow
 
 error: this arithmetic operation will overflow
   --> $DIR/const-err2.rs:27:13

--- a/src/test/ui/consts/const-err2.rs
+++ b/src/test/ui/consts/const-err2.rs
@@ -16,13 +16,13 @@ fn black_box<T>(_: T) {
 }
 
 fn main() {
-    let a = -std::i8::MIN;
+    let a = -i8::MIN;
     //~^ ERROR arithmetic operation will overflow
-    let a_i128 = -std::i128::MIN;
+    let a_i128 = -i128::MIN;
     //~^ ERROR arithmetic operation will overflow
     let b = 200u8 + 200u8 + 200u8;
     //~^ ERROR arithmetic operation will overflow
-    let b_i128 = std::i128::MIN - std::i128::MAX;
+    let b_i128 = i128::MIN - i128::MAX;
     //~^ ERROR arithmetic operation will overflow
     let c = 200u8 * 4;
     //~^ ERROR arithmetic operation will overflow

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3.rs
@@ -12,8 +12,6 @@
 #![allow(unused_imports)]
 
 use std::fmt;
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
 
 const A_I8_I
     : [u32; (i8::MAX as usize) + 1]

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-eval-overflow-3.rs:20:11
+  --> $DIR/const-eval-overflow-3.rs:18:11
    |
 LL |     = [0; (i8::MAX + 1) as usize];
    |           ^^^^^^^^^^^^^ attempt to compute `i8::MAX + 1_i8`, which would overflow

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3b.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3b.rs
@@ -10,8 +10,6 @@
 #![allow(unused_imports)]
 
 use std::fmt;
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
 
 const A_I8_I
     : [u32; (i8::MAX as usize) + 1]

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3b.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/const-eval-overflow-3b.rs:18:22
+  --> $DIR/const-eval-overflow-3b.rs:16:22
    |
 LL |     = [0; (i8::MAX + 1u8) as usize];
    |                      ^^^ expected `i8`, found `u8`
 
 error[E0277]: cannot add `u8` to `i8`
-  --> $DIR/const-eval-overflow-3b.rs:18:20
+  --> $DIR/const-eval-overflow-3b.rs:16:20
    |
 LL |     = [0; (i8::MAX + 1u8) as usize];
    |                    ^ no implementation for `i8 + u8`

--- a/src/test/ui/consts/const-eval/const-eval-overflow-4.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-4.rs
@@ -6,8 +6,6 @@
 #![allow(unused_imports)]
 
 use std::fmt;
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
 
 const A_I8_T
     : [u32; (i8::MAX as i8 + 1i8) as usize]

--- a/src/test/ui/consts/const-eval/const-eval-overflow-4.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-4.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-eval-overflow-4.rs:13:13
+  --> $DIR/const-eval-overflow-4.rs:11:13
    |
 LL |     : [u32; (i8::MAX as i8 + 1i8) as usize]
    |             ^^^^^^^^^^^^^^^^^^^^^ attempt to compute `i8::MAX + 1_i8`, which would overflow

--- a/src/test/ui/consts/const-eval/const-eval-overflow-4b.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-4b.rs
@@ -5,9 +5,6 @@
 
 #![allow(unused_imports)]
 
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
-
 const A_I8_T
     : [u32; (i8::MAX as i8 + 1u8) as usize]
     //~^ ERROR mismatched types

--- a/src/test/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/const-eval-overflow-4b.rs:12:30
+  --> $DIR/const-eval-overflow-4b.rs:9:30
    |
 LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |                              ^^^ expected `i8`, found `u8`
 
 error[E0277]: cannot add `u8` to `i8`
-  --> $DIR/const-eval-overflow-4b.rs:12:28
+  --> $DIR/const-eval-overflow-4b.rs:9:28
    |
 LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |                            ^ no implementation for `i8 + u8`
@@ -13,7 +13,7 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    = help: the trait `Add<u8>` is not implemented for `i8`
 
 error[E0604]: only `u8` can be cast as `char`, not `i8`
-  --> $DIR/const-eval-overflow-4b.rs:25:13
+  --> $DIR/const-eval-overflow-4b.rs:22:13
    |
 LL |     : [u32; 5i8 as char as usize]
    |             ^^^^^^^^^^^ invalid cast

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.rs
@@ -8,8 +8,6 @@
 #![deny(const_err)]
 
 use std::fmt;
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
 
 const VALS_I8: (i8,) =
     (

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
@@ -1,5 +1,5 @@
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:16:6
+  --> $DIR/const-eval-overflow2.rs:14:6
    |
 LL | / const VALS_I8: (i8,) =
 LL | |     (
@@ -15,7 +15,7 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:22:6
+  --> $DIR/const-eval-overflow2.rs:20:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
@@ -25,7 +25,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:28:6
+  --> $DIR/const-eval-overflow2.rs:26:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
@@ -35,7 +35,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:34:6
+  --> $DIR/const-eval-overflow2.rs:32:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
@@ -45,7 +45,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:40:6
+  --> $DIR/const-eval-overflow2.rs:38:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
@@ -55,7 +55,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:45:6
+  --> $DIR/const-eval-overflow2.rs:43:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MIN - 1,
@@ -64,7 +64,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:50:6
+  --> $DIR/const-eval-overflow2.rs:48:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MIN - 1,
@@ -73,7 +73,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:56:6
+  --> $DIR/const-eval-overflow2.rs:54:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.rs
@@ -8,8 +8,6 @@
 #![deny(const_err)]
 
 use std::fmt;
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
 
 const VALS_I8: (i8,) =
     (

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
@@ -1,5 +1,5 @@
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:16:6
+  --> $DIR/const-eval-overflow2b.rs:14:6
    |
 LL | / const VALS_I8: (i8,) =
 LL | |     (
@@ -15,7 +15,7 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:22:6
+  --> $DIR/const-eval-overflow2b.rs:20:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
@@ -25,7 +25,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:28:6
+  --> $DIR/const-eval-overflow2b.rs:26:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
@@ -35,7 +35,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:34:6
+  --> $DIR/const-eval-overflow2b.rs:32:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
@@ -45,7 +45,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:40:6
+  --> $DIR/const-eval-overflow2b.rs:38:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
@@ -55,7 +55,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:45:6
+  --> $DIR/const-eval-overflow2b.rs:43:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX + 1,
@@ -64,7 +64,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:50:6
+  --> $DIR/const-eval-overflow2b.rs:48:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX + 1,
@@ -73,7 +73,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:56:6
+  --> $DIR/const-eval-overflow2b.rs:54:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.rs
@@ -8,8 +8,6 @@
 #![deny(const_err)]
 
 use std::fmt;
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
 
 const VALS_I8: (i8,) =
     (

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
@@ -1,5 +1,5 @@
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:16:6
+  --> $DIR/const-eval-overflow2c.rs:14:6
    |
 LL | / const VALS_I8: (i8,) =
 LL | |     (
@@ -15,7 +15,7 @@ LL | #![deny(const_err)]
    |         ^^^^^^^^^
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:22:6
+  --> $DIR/const-eval-overflow2c.rs:20:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
@@ -25,7 +25,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:28:6
+  --> $DIR/const-eval-overflow2c.rs:26:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
@@ -35,7 +35,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:34:6
+  --> $DIR/const-eval-overflow2c.rs:32:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
@@ -45,7 +45,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:40:6
+  --> $DIR/const-eval-overflow2c.rs:38:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
@@ -55,7 +55,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:45:6
+  --> $DIR/const-eval-overflow2c.rs:43:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX * 2,
@@ -64,7 +64,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:50:6
+  --> $DIR/const-eval-overflow2c.rs:48:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX * 2,
@@ -73,7 +73,7 @@ LL | |      );
    | |_______-
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:56:6
+  --> $DIR/const-eval-overflow2c.rs:54:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (

--- a/src/test/ui/consts/const-eval/dangling.rs
+++ b/src/test/ui/consts/const-eval/dangling.rs
@@ -1,6 +1,6 @@
 #![feature(const_raw_ptr_deref)]
 
-use std::{mem, usize};
+use std::mem;
 
 // Make sure we error with the right kind of error on a too large slice.
 const TEST: () = { unsafe { //~ NOTE

--- a/src/test/ui/consts/const-int-arithmetic.rs
+++ b/src/test/ui/consts/const-int-arithmetic.rs
@@ -5,8 +5,6 @@
 #![feature(const_overflowing_int_methods)]
 #![feature(const_wrapping_int_methods)]
 
-use std::{i8, i128};
-
 macro_rules! suite {
     ($(
         $fn:ident -> $ty:ty { $( $label:ident : $expr:expr, $result:expr; )* }

--- a/src/test/ui/consts/const-int-overflowing-rpass.rs
+++ b/src/test/ui/consts/const-int-overflowing-rpass.rs
@@ -16,7 +16,7 @@ const SHR_A: (u32, bool) = 0x10u32.overflowing_shr(4);
 const SHR_B: (u32, bool) = 0x10u32.overflowing_shr(132);
 
 const NEG_A: (u32, bool) = 0u32.overflowing_neg();
-const NEG_B: (u32, bool) = core::u32::MAX.overflowing_neg();
+const NEG_B: (u32, bool) = u32::MAX.overflowing_neg();
 
 const ABS_POS: (i32, bool) = 10i32.overflowing_abs();
 const ABS_NEG: (i32, bool) = (-10i32).overflowing_abs();

--- a/src/test/ui/consts/const-negation.rs
+++ b/src/test/ui/consts/const-negation.rs
@@ -8,19 +8,19 @@ fn main() {
     const I: isize = -2147483648isize;
     #[cfg(target_pointer_width = "64")]
     const I: isize = -9223372036854775808isize;
-    assert_eq!(::std::i32::MIN as u64, 0xffffffff80000000);
+    assert_eq!(i32::MIN as u64, 0xffffffff80000000);
     assert_eq!(-2147483648isize as u64, 0xffffffff80000000);
     assert_eq!(-2147483648i32 as u64, 0xffffffff80000000);
-    assert_eq!(::std::i64::MIN as u64, 0x8000000000000000);
+    assert_eq!(i64::MIN as u64, 0x8000000000000000);
     #[cfg(target_pointer_width = "64")]
     assert_eq!(-9223372036854775808isize as u64, 0x8000000000000000);
     #[cfg(target_pointer_width = "32")]
     assert_eq!(-9223372036854775808isize as u64, 0);
     assert_eq!(-9223372036854775808i32 as u64, 0);
-    const J: usize = ::std::i32::MAX as usize;
+    const J: usize = i32::MAX as usize;
     const K: usize = -1i32 as u32 as usize;
-    const L: usize = ::std::i32::MIN as usize;
-    const M: usize = ::std::i64::MIN as usize;
+    const L: usize = i32::MIN as usize;
+    const M: usize = i64::MIN as usize;
     match 5 {
         J => {},
         K => {},

--- a/src/test/ui/consts/issue-63952.rs
+++ b/src/test/ui/consts/issue-63952.rs
@@ -1,7 +1,5 @@
 // Regression test for #63952, shouldn't hang.
 
-use std::usize;
-
 #[repr(C)]
 #[derive(Copy, Clone)]
 struct SliceRepr {

--- a/src/test/ui/consts/issue-63952.stderr
+++ b/src/test/ui/consts/issue-63952.stderr
@@ -1,5 +1,5 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-63952.rs:18:1
+  --> $DIR/issue-63952.rs:16:1
    |
 LL | / const SLICE_WAY_TOO_LONG: &[u8] = unsafe {
 LL | |     SliceTransmute {

--- a/src/test/ui/consts/promote_fn_calls_std.rs
+++ b/src/test/ui/consts/promote_fn_calls_std.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated, deprecated_in_future)] // can be removed if different fns are chosen
 // build-pass (FIXME(62277): could be check-pass?)
 
 fn main() {

--- a/src/test/ui/consts/promotion.rs
+++ b/src/test/ui/consts/promotion.rs
@@ -13,5 +13,5 @@ fn main() {
 
     // make sure that these do not cause trouble despite overflowing
     baz_u32(&(0-1));
-    baz_i32(&-std::i32::MIN);
+    baz_i32(&-i32::MIN);
 }

--- a/src/test/ui/discrim/discrim-ill-typed.rs
+++ b/src/test/ui/discrim/discrim-ill-typed.rs
@@ -7,8 +7,6 @@
 
 #![allow(dead_code, unused_variables, unused_imports)]
 
-use std::{i8,u8,i16,u16,i32,u32,i64, u64};
-
 fn f_i8() {
     #[repr(i8)]
     enum A {

--- a/src/test/ui/discrim/discrim-ill-typed.stderr
+++ b/src/test/ui/discrim/discrim-ill-typed.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:17:16
+  --> $DIR/discrim-ill-typed.rs:15:16
    |
 LL |         OhNo = 0_u8,
    |                ^^^^ expected `i8`, found `u8`
@@ -10,7 +10,7 @@ LL |         OhNo = 0_i8,
    |                ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:30:16
+  --> $DIR/discrim-ill-typed.rs:28:16
    |
 LL |         OhNo = 0_i8,
    |                ^^^^ expected `u8`, found `i8`
@@ -21,7 +21,7 @@ LL |         OhNo = 0_u8,
    |                ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:43:16
+  --> $DIR/discrim-ill-typed.rs:41:16
    |
 LL |         OhNo = 0_u16,
    |                ^^^^^ expected `i16`, found `u16`
@@ -32,7 +32,7 @@ LL |         OhNo = 0_i16,
    |                ^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:56:16
+  --> $DIR/discrim-ill-typed.rs:54:16
    |
 LL |         OhNo = 0_i16,
    |                ^^^^^ expected `u16`, found `i16`
@@ -43,7 +43,7 @@ LL |         OhNo = 0_u16,
    |                ^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:69:16
+  --> $DIR/discrim-ill-typed.rs:67:16
    |
 LL |         OhNo = 0_u32,
    |                ^^^^^ expected `i32`, found `u32`
@@ -54,7 +54,7 @@ LL |         OhNo = 0_i32,
    |                ^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:82:16
+  --> $DIR/discrim-ill-typed.rs:80:16
    |
 LL |         OhNo = 0_i32,
    |                ^^^^^ expected `u32`, found `i32`
@@ -65,7 +65,7 @@ LL |         OhNo = 0_u32,
    |                ^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:95:16
+  --> $DIR/discrim-ill-typed.rs:93:16
    |
 LL |         OhNo = 0_u64,
    |                ^^^^^ expected `i64`, found `u64`
@@ -76,7 +76,7 @@ LL |         OhNo = 0_i64,
    |                ^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/discrim-ill-typed.rs:108:16
+  --> $DIR/discrim-ill-typed.rs:106:16
    |
 LL |         OhNo = 0_i64,
    |                ^^^^^ expected `u64`, found `i64`

--- a/src/test/ui/discrim/discrim-overflow-2.rs
+++ b/src/test/ui/discrim/discrim-overflow-2.rs
@@ -5,8 +5,6 @@
 // See also run-pass/discrim-explicit-23030.rs where the suggested
 // workaround is tested.
 
-use std::{i8,u8,i16,u16,i32,u32,i64, u64};
-
 fn f_i8() {
     #[repr(i8)]
     enum A {

--- a/src/test/ui/discrim/discrim-overflow-2.stderr
+++ b/src/test/ui/discrim/discrim-overflow-2.stderr
@@ -1,5 +1,5 @@
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:15:9
+  --> $DIR/discrim-overflow-2.rs:13:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 127
@@ -7,7 +7,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -128` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:24:9
+  --> $DIR/discrim-overflow-2.rs:22:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 255
@@ -15,7 +15,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:33:9
+  --> $DIR/discrim-overflow-2.rs:31:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 32767
@@ -23,7 +23,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -32768` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:42:9
+  --> $DIR/discrim-overflow-2.rs:40:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 65535
@@ -31,7 +31,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:51:9
+  --> $DIR/discrim-overflow-2.rs:49:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 2147483647
@@ -39,7 +39,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -2147483648` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:60:9
+  --> $DIR/discrim-overflow-2.rs:58:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 4294967295
@@ -47,7 +47,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:69:9
+  --> $DIR/discrim-overflow-2.rs:67:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 9223372036854775807
@@ -55,7 +55,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -9223372036854775808` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow-2.rs:78:9
+  --> $DIR/discrim-overflow-2.rs:76:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 18446744073709551615

--- a/src/test/ui/discrim/discrim-overflow.rs
+++ b/src/test/ui/discrim/discrim-overflow.rs
@@ -3,8 +3,6 @@
 // See also run-pass/discrim-explicit-23030.rs where the suggested
 // workaround is tested.
 
-use std::{i8,u8,i16,u16,i32,u32,i64, u64};
-
 fn f_i8() {
     #[repr(i8)]
     enum A {

--- a/src/test/ui/discrim/discrim-overflow.stderr
+++ b/src/test/ui/discrim/discrim-overflow.stderr
@@ -1,5 +1,5 @@
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:13:9
+  --> $DIR/discrim-overflow.rs:11:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 127
@@ -7,7 +7,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -128` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:24:9
+  --> $DIR/discrim-overflow.rs:22:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 255
@@ -15,7 +15,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:35:9
+  --> $DIR/discrim-overflow.rs:33:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 32767
@@ -23,7 +23,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -32768` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:46:9
+  --> $DIR/discrim-overflow.rs:44:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 65535
@@ -31,7 +31,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:58:9
+  --> $DIR/discrim-overflow.rs:56:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 2147483647
@@ -39,7 +39,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -2147483648` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:70:9
+  --> $DIR/discrim-overflow.rs:68:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 4294967295
@@ -47,7 +47,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = 0` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:82:9
+  --> $DIR/discrim-overflow.rs:80:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 9223372036854775807
@@ -55,7 +55,7 @@ LL |         OhNo,
    = note: explicitly set `OhNo = -9223372036854775808` if that is desired outcome
 
 error[E0370]: enum discriminant overflowed
-  --> $DIR/discrim-overflow.rs:94:9
+  --> $DIR/discrim-overflow.rs:92:9
    |
 LL |         OhNo,
    |         ^^^^ overflowed on value after 18446744073709551615

--- a/src/test/ui/drop/dynamic-drop-async.rs
+++ b/src/test/ui/drop/dynamic-drop-async.rs
@@ -18,7 +18,6 @@ use std::{
     ptr,
     rc::Rc,
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
-    usize,
 };
 
 struct InjectedFailure;

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -12,7 +12,6 @@ use std::mem::ManuallyDrop;
 use std::ops::Generator;
 use std::panic;
 use std::pin::Pin;
-use std::usize;
 
 struct InjectedFailure;
 

--- a/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.rs
+++ b/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.rs
@@ -1,5 +1,3 @@
-use std::{isize, usize};
-
 fn main() {
     match 0usize {
         //~^ ERROR non-exhaustive patterns: `_` not covered

--- a/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
+++ b/src/test/ui/feature-gates/feature-gate-precise_pointer_size_matching.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/feature-gate-precise_pointer_size_matching.rs:4:11
+  --> $DIR/feature-gate-precise_pointer_size_matching.rs:2:11
    |
 LL |     match 0usize {
    |           ^^^^^^ pattern `_` not covered
@@ -10,7 +10,7 @@ LL |     match 0usize {
    = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/feature-gate-precise_pointer_size_matching.rs:12:11
+  --> $DIR/feature-gate-precise_pointer_size_matching.rs:10:11
    |
 LL |     match 0isize {
    |           ^^^^^^ pattern `_` not covered

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.rs
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.rs
@@ -13,8 +13,8 @@ macro_rules! m {
 }
 
 fn floats() {
-    m!(0f32, core::f32::NEG_INFINITY..); //~ ERROR non-exhaustive patterns: `_` not covered
-    m!(0f32, ..core::f32::INFINITY); //~ ERROR non-exhaustive patterns: `_` not covered
+    m!(0f32, f32::NEG_INFINITY..); //~ ERROR non-exhaustive patterns: `_` not covered
+    m!(0f32, ..f32::INFINITY); //~ ERROR non-exhaustive patterns: `_` not covered
 }
 
 fn khar() {
@@ -33,12 +33,12 @@ fn khar() {
 
 mod unsigned {
     fn u8() {
-        const ALMOST_MAX: u8 = core::u8::MAX - 1;
-        const ALMOST_MIN: u8 = core::u8::MIN + 1;
+        const ALMOST_MAX: u8 = u8::MAX - 1;
+        const ALMOST_MIN: u8 = u8::MIN + 1;
         const VAL: u8 = 42;
         const VAL_1: u8 = VAL + 1;
         const VAL_2: u8 = VAL + 2;
-        m!(0, ..core::u8::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..u8::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -46,12 +46,12 @@ mod unsigned {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn u16() {
-        const ALMOST_MAX: u16 = core::u16::MAX - 1;
-        const ALMOST_MIN: u16 = core::u16::MIN + 1;
+        const ALMOST_MAX: u16 = u16::MAX - 1;
+        const ALMOST_MIN: u16 = u16::MIN + 1;
         const VAL: u16 = 42;
         const VAL_1: u16 = VAL + 1;
         const VAL_2: u16 = VAL + 2;
-        m!(0, ..core::u16::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..u16::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -59,12 +59,12 @@ mod unsigned {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn u32() {
-        const ALMOST_MAX: u32 = core::u32::MAX - 1;
-        const ALMOST_MIN: u32 = core::u32::MIN + 1;
+        const ALMOST_MAX: u32 = u32::MAX - 1;
+        const ALMOST_MIN: u32 = u32::MIN + 1;
         const VAL: u32 = 42;
         const VAL_1: u32 = VAL + 1;
         const VAL_2: u32 = VAL + 2;
-        m!(0, ..core::u32::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..u32::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -72,12 +72,12 @@ mod unsigned {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn u64() {
-        const ALMOST_MAX: u64 = core::u64::MAX - 1;
-        const ALMOST_MIN: u64 = core::u64::MIN + 1;
+        const ALMOST_MAX: u64 = u64::MAX - 1;
+        const ALMOST_MIN: u64 = u64::MIN + 1;
         const VAL: u64 = 42;
         const VAL_1: u64 = VAL + 1;
         const VAL_2: u64 = VAL + 2;
-        m!(0, ..core::u64::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..u64::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -85,12 +85,12 @@ mod unsigned {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn u128() {
-        const ALMOST_MAX: u128 = core::u128::MAX - 1;
-        const ALMOST_MIN: u128 = core::u128::MIN + 1;
+        const ALMOST_MAX: u128 = u128::MAX - 1;
+        const ALMOST_MIN: u128 = u128::MIN + 1;
         const VAL: u128 = 42;
         const VAL_1: u128 = VAL + 1;
         const VAL_2: u128 = VAL + 2;
-        m!(0, ..core::u128::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..u128::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -101,12 +101,12 @@ mod unsigned {
 
 mod signed {
     fn i8() {
-        const ALMOST_MAX: i8 = core::i8::MAX - 1;
-        const ALMOST_MIN: i8 = core::i8::MIN + 1;
+        const ALMOST_MAX: i8 = i8::MAX - 1;
+        const ALMOST_MIN: i8 = i8::MIN + 1;
         const VAL: i8 = 42;
         const VAL_1: i8 = VAL + 1;
         const VAL_2: i8 = VAL + 2;
-        m!(0, ..core::i8::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..i8::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -114,12 +114,12 @@ mod signed {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn i16() {
-        const ALMOST_MAX: i16 = core::i16::MAX - 1;
-        const ALMOST_MIN: i16 = core::i16::MIN + 1;
+        const ALMOST_MAX: i16 = i16::MAX - 1;
+        const ALMOST_MIN: i16 = i16::MIN + 1;
         const VAL: i16 = 42;
         const VAL_1: i16 = VAL + 1;
         const VAL_2: i16 = VAL + 2;
-        m!(0, ..core::i16::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..i16::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -127,12 +127,12 @@ mod signed {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn i32() {
-        const ALMOST_MAX: i32 = core::i32::MAX - 1;
-        const ALMOST_MIN: i32 = core::i32::MIN + 1;
+        const ALMOST_MAX: i32 = i32::MAX - 1;
+        const ALMOST_MIN: i32 = i32::MIN + 1;
         const VAL: i32 = 42;
         const VAL_1: i32 = VAL + 1;
         const VAL_2: i32 = VAL + 2;
-        m!(0, ..core::i32::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..i32::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -140,12 +140,12 @@ mod signed {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn i64() {
-        const ALMOST_MAX: i64 = core::i64::MAX - 1;
-        const ALMOST_MIN: i64 = core::i64::MIN + 1;
+        const ALMOST_MAX: i64 = i64::MAX - 1;
+        const ALMOST_MIN: i64 = i64::MIN + 1;
         const VAL: i64 = 42;
         const VAL_1: i64 = VAL + 1;
         const VAL_2: i64 = VAL + 2;
-        m!(0, ..core::i64::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..i64::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns
@@ -153,12 +153,12 @@ mod signed {
         m!(0, ..VAL_1 | VAL_2..); //~ ERROR non-exhaustive patterns
     }
     fn i128() {
-        const ALMOST_MAX: i128 = core::i128::MAX - 1;
-        const ALMOST_MIN: i128 = core::i128::MIN + 1;
+        const ALMOST_MAX: i128 = i128::MAX - 1;
+        const ALMOST_MIN: i128 = i128::MIN + 1;
         const VAL: i128 = 42;
         const VAL_1: i128 = VAL + 1;
         const VAL_2: i128 = VAL + 2;
-        m!(0, ..core::i128::MAX); //~ ERROR non-exhaustive patterns
+        m!(0, ..i128::MAX); //~ ERROR non-exhaustive patterns
         m!(0, ..ALMOST_MAX); //~ ERROR non-exhaustive patterns
         m!(0, ALMOST_MIN..); //~ ERROR non-exhaustive patterns
         m!(0, ..=ALMOST_MAX); //~ ERROR non-exhaustive patterns

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -1,7 +1,7 @@
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:16:8
    |
-LL |     m!(0f32, core::f32::NEG_INFINITY..);
+LL |     m!(0f32, f32::NEG_INFINITY..);
    |        ^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -10,7 +10,7 @@ LL |     m!(0f32, core::f32::NEG_INFINITY..);
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:17:8
    |
-LL |     m!(0f32, ..core::f32::INFINITY);
+LL |     m!(0f32, ..f32::INFINITY);
    |        ^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -73,7 +73,7 @@ LL |     m!('a', ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:41:12
    |
-LL |         m!(0, ..core::u8::MAX);
+LL |         m!(0, ..u8::MAX);
    |            ^ pattern `u8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -127,7 +127,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:54:12
    |
-LL |         m!(0, ..core::u16::MAX);
+LL |         m!(0, ..u16::MAX);
    |            ^ pattern `u16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -181,7 +181,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:67:12
    |
-LL |         m!(0, ..core::u32::MAX);
+LL |         m!(0, ..u32::MAX);
    |            ^ pattern `u32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -235,7 +235,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:80:12
    |
-LL |         m!(0, ..core::u64::MAX);
+LL |         m!(0, ..u64::MAX);
    |            ^ pattern `u64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -289,7 +289,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:93:12
    |
-LL |         m!(0, ..core::u128::MAX);
+LL |         m!(0, ..u128::MAX);
    |            ^ pattern `u128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -343,7 +343,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:109:12
    |
-LL |         m!(0, ..core::i8::MAX);
+LL |         m!(0, ..i8::MAX);
    |            ^ pattern `i8::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -397,7 +397,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:122:12
    |
-LL |         m!(0, ..core::i16::MAX);
+LL |         m!(0, ..i16::MAX);
    |            ^ pattern `i16::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -451,7 +451,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:135:12
    |
-LL |         m!(0, ..core::i32::MAX);
+LL |         m!(0, ..i32::MAX);
    |            ^ pattern `i32::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -505,7 +505,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:148:12
    |
-LL |         m!(0, ..core::i64::MAX);
+LL |         m!(0, ..i64::MAX);
    |            ^ pattern `i64::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
@@ -559,7 +559,7 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
 error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:161:12
    |
-LL |         m!(0, ..core::i128::MAX);
+LL |         m!(0, ..i128::MAX);
    |            ^ pattern `i128::MAX` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-pass.rs
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-pass.rs
@@ -26,19 +26,19 @@ macro_rules! test_int {
 }
 
 fn unsigned_int() {
-    test_int!(0u8, core::u8::MIN, core::u8::MAX);
-    test_int!(0u16, core::u16::MIN, core::u16::MAX);
-    test_int!(0u32, core::u32::MIN, core::u32::MAX);
-    test_int!(0u64, core::u64::MIN, core::u64::MAX);
-    test_int!(0u128, core::u128::MIN, core::u128::MAX);
+    test_int!(0u8, u8::MIN, u8::MAX);
+    test_int!(0u16, u16::MIN, u16::MAX);
+    test_int!(0u32, u32::MIN, u32::MAX);
+    test_int!(0u64, u64::MIN, u64::MAX);
+    test_int!(0u128, u128::MIN, u128::MAX);
 }
 
 fn signed_int() {
-    test_int!(0i8, core::i8::MIN, core::i8::MAX);
-    test_int!(0i16, core::i16::MIN, core::i16::MAX);
-    test_int!(0i32, core::i32::MIN, core::i32::MAX);
-    test_int!(0i64, core::i64::MIN, core::i64::MAX);
-    test_int!(0i128, core::i128::MIN, core::i128::MAX);
+    test_int!(0i8, i8::MIN, i8::MAX);
+    test_int!(0i16, i16::MIN, i16::MAX);
+    test_int!(0i32, i32::MIN, i32::MAX);
+    test_int!(0i64, i64::MIN, i64::MAX);
+    test_int!(0i128, i128::MIN, i128::MAX);
 }
 
 fn khar() {

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-semantics.rs
@@ -24,15 +24,15 @@ fn range_to_inclusive() {
     //---------------------------------------
 
     // u8; `..=X`
-    assert!(yes!(core::u8::MIN, ..=core::u8::MIN));
-    assert!(yes!(core::u8::MIN, ..=5));
+    assert!(yes!(u8::MIN, ..=u8::MIN));
+    assert!(yes!(u8::MIN, ..=5));
     assert!(yes!(5u8, ..=5));
     assert!(!yes!(6u8, ..=5));
 
     // i16; `..=X`
-    assert!(yes!(core::i16::MIN, ..=core::i16::MIN));
-    assert!(yes!(core::i16::MIN, ..=0));
-    assert!(yes!(core::i16::MIN, ..=-5));
+    assert!(yes!(i16::MIN, ..=i16::MIN));
+    assert!(yes!(i16::MIN, ..=0));
+    assert!(yes!(i16::MIN, ..=-5));
     assert!(yes!(-5, ..=-5));
     assert!(!yes!(-4, ..=-5));
 
@@ -43,14 +43,14 @@ fn range_to_inclusive() {
     assert!(!yes!('b', ..='a'));
 
     // f32; `..=X`
-    assert!(yes!(core::f32::NEG_INFINITY, ..=core::f32::NEG_INFINITY));
-    assert!(yes!(core::f32::NEG_INFINITY, ..=1.0f32));
+    assert!(yes!(f32::NEG_INFINITY, ..=f32::NEG_INFINITY));
+    assert!(yes!(f32::NEG_INFINITY, ..=1.0f32));
     assert!(yes!(1.5f32, ..=1.5f32));
     assert!(!yes!(1.6f32, ..=-1.5f32));
 
     // f64; `..=X`
-    assert!(yes!(core::f64::NEG_INFINITY, ..=core::f64::NEG_INFINITY));
-    assert!(yes!(core::f64::NEG_INFINITY, ..=1.0f64));
+    assert!(yes!(f64::NEG_INFINITY, ..=f64::NEG_INFINITY));
+    assert!(yes!(f64::NEG_INFINITY, ..=1.0f64));
     assert!(yes!(1.5f64, ..=1.5f64));
     assert!(!yes!(1.6f64, ..=-1.5f64));
 }
@@ -66,16 +66,16 @@ fn range_to() {
     assert!(!yes!(6u8, ..5));
 
     // u8; `..X`
-    const NU8: u8 = core::u8::MIN + 1;
-    assert!(yes!(core::u8::MIN, ..NU8));
+    const NU8: u8 = u8::MIN + 1;
+    assert!(yes!(u8::MIN, ..NU8));
     assert!(yes!(0u8, ..5));
     assert!(!yes!(5u8, ..5));
     assert!(!yes!(6u8, ..5));
 
     // i16; `..X`
-    const NI16: i16 = core::i16::MIN + 1;
-    assert!(yes!(core::i16::MIN, ..NI16));
-    assert!(yes!(core::i16::MIN, ..5));
+    const NI16: i16 = i16::MIN + 1;
+    assert!(yes!(i16::MIN, ..NI16));
+    assert!(yes!(i16::MIN, ..5));
     assert!(yes!(-6, ..-5));
     assert!(!yes!(-5, ..-5));
 
@@ -87,16 +87,16 @@ fn range_to() {
     assert!(!yes!('b', ..'a'));
 
     // f32; `..X`
-    assert!(yes!(core::f32::NEG_INFINITY, ..1.0f32));
+    assert!(yes!(f32::NEG_INFINITY, ..1.0f32));
     assert!(!yes!(1.5f32, ..1.5f32));
-    const E32: f32 = 1.5f32 + core::f32::EPSILON;
+    const E32: f32 = 1.5f32 + f32::EPSILON;
     assert!(yes!(1.5f32, ..E32));
     assert!(!yes!(1.6f32, ..1.5f32));
 
     // f64; `..X`
-    assert!(yes!(core::f64::NEG_INFINITY, ..1.0f64));
+    assert!(yes!(f64::NEG_INFINITY, ..1.0f64));
     assert!(!yes!(1.5f64, ..1.5f64));
-    const E64: f64 = 1.5f64 + core::f64::EPSILON;
+    const E64: f64 = 1.5f64 + f64::EPSILON;
     assert!(yes!(1.5f64, ..E64));
     assert!(!yes!(1.6f64, ..1.5f64));
 }
@@ -106,23 +106,23 @@ fn range_from() {
     //--------------------------------
 
     // u8; `X..`
-    assert!(yes!(core::u8::MIN, core::u8::MIN..));
-    assert!(yes!(core::u8::MAX, core::u8::MIN..));
-    assert!(!yes!(core::u8::MIN, 1..));
+    assert!(yes!(u8::MIN, u8::MIN..));
+    assert!(yes!(u8::MAX, u8::MIN..));
+    assert!(!yes!(u8::MIN, 1..));
     assert!(!yes!(4, 5..));
     assert!(yes!(5, 5..));
     assert!(yes!(6, 5..));
-    assert!(yes!(core::u8::MAX, core::u8::MAX..));
+    assert!(yes!(u8::MAX, u8::MAX..));
 
     // i16; `X..`
-    assert!(yes!(core::i16::MIN, core::i16::MIN..));
-    assert!(yes!(core::i16::MAX, core::i16::MIN..));
-    const NI16: i16 = core::i16::MIN + 1;
-    assert!(!yes!(core::i16::MIN, NI16..));
+    assert!(yes!(i16::MIN, i16::MIN..));
+    assert!(yes!(i16::MAX, i16::MIN..));
+    const NI16: i16 = i16::MIN + 1;
+    assert!(!yes!(i16::MIN, NI16..));
     assert!(!yes!(-4, 5..));
     assert!(yes!(-4, -4..));
     assert!(yes!(-3, -4..));
-    assert!(yes!(core::i16::MAX, core::i16::MAX..));
+    assert!(yes!(i16::MAX, i16::MAX..));
 
     // char; `X..`
     assert!(yes!('\u{0}', '\u{0}'..));
@@ -133,24 +133,24 @@ fn range_from() {
     assert!(yes!(core::char::MAX, core::char::MAX..));
 
     // f32; `X..`
-    assert!(yes!(core::f32::NEG_INFINITY, core::f32::NEG_INFINITY..));
-    assert!(yes!(core::f32::INFINITY, core::f32::NEG_INFINITY..));
-    assert!(!yes!(core::f32::NEG_INFINITY, 1.0f32..));
-    assert!(yes!(core::f32::INFINITY, 1.0f32..));
-    assert!(!yes!(1.0f32 - core::f32::EPSILON, 1.0f32..));
+    assert!(yes!(f32::NEG_INFINITY, f32::NEG_INFINITY..));
+    assert!(yes!(f32::INFINITY, f32::NEG_INFINITY..));
+    assert!(!yes!(f32::NEG_INFINITY, 1.0f32..));
+    assert!(yes!(f32::INFINITY, 1.0f32..));
+    assert!(!yes!(1.0f32 - f32::EPSILON, 1.0f32..));
     assert!(yes!(1.0f32, 1.0f32..));
-    assert!(yes!(core::f32::INFINITY, 1.0f32..));
-    assert!(yes!(core::f32::INFINITY, core::f32::INFINITY..));
+    assert!(yes!(f32::INFINITY, 1.0f32..));
+    assert!(yes!(f32::INFINITY, f32::INFINITY..));
 
     // f64; `X..`
-    assert!(yes!(core::f64::NEG_INFINITY, core::f64::NEG_INFINITY..));
-    assert!(yes!(core::f64::INFINITY, core::f64::NEG_INFINITY..));
-    assert!(!yes!(core::f64::NEG_INFINITY, 1.0f64..));
-    assert!(yes!(core::f64::INFINITY, 1.0f64..));
-    assert!(!yes!(1.0f64 - core::f64::EPSILON, 1.0f64..));
+    assert!(yes!(f64::NEG_INFINITY, f64::NEG_INFINITY..));
+    assert!(yes!(f64::INFINITY, f64::NEG_INFINITY..));
+    assert!(!yes!(f64::NEG_INFINITY, 1.0f64..));
+    assert!(yes!(f64::INFINITY, 1.0f64..));
+    assert!(!yes!(1.0f64 - f64::EPSILON, 1.0f64..));
     assert!(yes!(1.0f64, 1.0f64..));
-    assert!(yes!(core::f64::INFINITY, 1.0f64..));
-    assert!(yes!(core::f64::INFINITY, core::f64::INFINITY..));
+    assert!(yes!(f64::INFINITY, 1.0f64..));
+    assert!(yes!(f64::INFINITY, f64::INFINITY..));
 }
 
 fn main() {

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.rs
@@ -9,42 +9,42 @@ macro_rules! m {
 }
 
 fn main() {
-    m!(0, ..core::u8::MIN);
+    m!(0, ..u8::MIN);
     //~^ ERROR lower range bound must be less than upper
     //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::u16::MIN);
+    m!(0, ..u16::MIN);
     //~^ ERROR lower range bound must be less than upper
     //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::u32::MIN);
+    m!(0, ..u32::MIN);
     //~^ ERROR lower range bound must be less than upper
     //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::u64::MIN);
+    m!(0, ..u64::MIN);
     //~^ ERROR lower range bound must be less than upper
     //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::u128::MIN);
-    //~^ ERROR lower range bound must be less than upper
-    //~| ERROR lower range bound must be less than upper
-
-    m!(0, ..core::i8::MIN);
-    //~^ ERROR lower range bound must be less than upper
-    //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::i16::MIN);
-    //~^ ERROR lower range bound must be less than upper
-    //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::i32::MIN);
-    //~^ ERROR lower range bound must be less than upper
-    //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::i64::MIN);
-    //~^ ERROR lower range bound must be less than upper
-    //~| ERROR lower range bound must be less than upper
-    m!(0, ..core::i128::MIN);
+    m!(0, ..u128::MIN);
     //~^ ERROR lower range bound must be less than upper
     //~| ERROR lower range bound must be less than upper
 
-    m!(0f32, ..core::f32::NEG_INFINITY);
+    m!(0, ..i8::MIN);
     //~^ ERROR lower range bound must be less than upper
     //~| ERROR lower range bound must be less than upper
-    m!(0f64, ..core::f64::NEG_INFINITY);
+    m!(0, ..i16::MIN);
+    //~^ ERROR lower range bound must be less than upper
+    //~| ERROR lower range bound must be less than upper
+    m!(0, ..i32::MIN);
+    //~^ ERROR lower range bound must be less than upper
+    //~| ERROR lower range bound must be less than upper
+    m!(0, ..i64::MIN);
+    //~^ ERROR lower range bound must be less than upper
+    //~| ERROR lower range bound must be less than upper
+    m!(0, ..i128::MIN);
+    //~^ ERROR lower range bound must be less than upper
+    //~| ERROR lower range bound must be less than upper
+
+    m!(0f32, ..f32::NEG_INFINITY);
+    //~^ ERROR lower range bound must be less than upper
+    //~| ERROR lower range bound must be less than upper
+    m!(0f64, ..f64::NEG_INFINITY);
     //~^ ERROR lower range bound must be less than upper
     //~| ERROR lower range bound must be less than upper
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-thir-lower-empty.stderr
@@ -1,74 +1,74 @@
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:12:11
    |
-LL |     m!(0, ..core::u8::MIN);
-   |           ^^^^^^^^^^^^^^^
+LL |     m!(0, ..u8::MIN);
+   |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:15:11
    |
-LL |     m!(0, ..core::u16::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u16::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:18:11
    |
-LL |     m!(0, ..core::u32::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u32::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:21:11
    |
-LL |     m!(0, ..core::u64::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u64::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:24:11
    |
-LL |     m!(0, ..core::u128::MIN);
-   |           ^^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u128::MIN);
+   |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:28:11
    |
-LL |     m!(0, ..core::i8::MIN);
-   |           ^^^^^^^^^^^^^^^
+LL |     m!(0, ..i8::MIN);
+   |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:31:11
    |
-LL |     m!(0, ..core::i16::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i16::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:34:11
    |
-LL |     m!(0, ..core::i32::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i32::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:37:11
    |
-LL |     m!(0, ..core::i64::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i64::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:40:11
    |
-LL |     m!(0, ..core::i128::MIN);
-   |           ^^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i128::MIN);
+   |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:44:14
    |
-LL |     m!(0f32, ..core::f32::NEG_INFINITY);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     m!(0f32, ..f32::NEG_INFINITY);
+   |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:47:14
    |
-LL |     m!(0f64, ..core::f64::NEG_INFINITY);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     m!(0f64, ..f64::NEG_INFINITY);
+   |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:51:13
@@ -79,74 +79,74 @@ LL |     m!('a', ..'\u{0}');
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:12:11
    |
-LL |     m!(0, ..core::u8::MIN);
-   |           ^^^^^^^^^^^^^^^
+LL |     m!(0, ..u8::MIN);
+   |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:15:11
    |
-LL |     m!(0, ..core::u16::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u16::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:18:11
    |
-LL |     m!(0, ..core::u32::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u32::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:21:11
    |
-LL |     m!(0, ..core::u64::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u64::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:24:11
    |
-LL |     m!(0, ..core::u128::MIN);
-   |           ^^^^^^^^^^^^^^^^^
+LL |     m!(0, ..u128::MIN);
+   |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:28:11
    |
-LL |     m!(0, ..core::i8::MIN);
-   |           ^^^^^^^^^^^^^^^
+LL |     m!(0, ..i8::MIN);
+   |           ^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:31:11
    |
-LL |     m!(0, ..core::i16::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i16::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:34:11
    |
-LL |     m!(0, ..core::i32::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i32::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:37:11
    |
-LL |     m!(0, ..core::i64::MIN);
-   |           ^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i64::MIN);
+   |           ^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:40:11
    |
-LL |     m!(0, ..core::i128::MIN);
-   |           ^^^^^^^^^^^^^^^^^
+LL |     m!(0, ..i128::MIN);
+   |           ^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:44:14
    |
-LL |     m!(0f32, ..core::f32::NEG_INFINITY);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     m!(0f32, ..f32::NEG_INFINITY);
+   |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:47:14
    |
-LL |     m!(0f64, ..core::f64::NEG_INFINITY);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     m!(0f64, ..f64::NEG_INFINITY);
+   |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0579]: lower range bound must be less than upper
   --> $DIR/half-open-range-pats-thir-lower-empty.rs:51:13

--- a/src/test/ui/hashmap/hashmap-capacity-overflow.rs
+++ b/src/test/ui/hashmap/hashmap-capacity-overflow.rs
@@ -3,7 +3,6 @@
 // ignore-emscripten no processes
 
 use std::collections::hash_map::HashMap;
-use std::usize;
 use std::mem::size_of;
 
 fn main() {

--- a/src/test/ui/issues/issue-20427.rs
+++ b/src/test/ui/issues/issue-20427.rs
@@ -4,6 +4,7 @@
 #![allow(unused_imports)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
+#![allow(deprecated, deprecated_in_future)]
 
 // aux-build:i8.rs
 // ignore-pretty issue #37201

--- a/src/test/ui/issues/issue-23833.rs
+++ b/src/test/ui/issues/issue-23833.rs
@@ -1,8 +1,6 @@
 // run-pass
 #![allow(unused_imports)]
 use std::fmt;
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
 
 const A_I8_T
     : [u32; (i8::MAX as i8 - 1i8) as usize]

--- a/src/test/ui/issues/issue-37686.rs
+++ b/src/test/ui/issues/issue-37686.rs
@@ -1,7 +1,7 @@
 // run-pass
 fn main() {
     match (0, 0) {
-        (std::usize::MIN, std::usize::MAX) => {}
+        (usize::MIN, usize::MAX) => {}
         _ => {}
     }
 }

--- a/src/test/ui/issues/issue-41880.rs
+++ b/src/test/ui/issues/issue-41880.rs
@@ -19,7 +19,7 @@ impl<T: Clone, F> Iterator for Iterate<T, F> where F: Fn(&T) -> T {
         Some(self.state.clone())
     }
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) { (std::usize::MAX, None) }
+    fn size_hint(&self) -> (usize, Option<usize>) { (usize::MAX, None) }
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-48006.rs
+++ b/src/test/ui/issues/issue-48006.rs
@@ -6,10 +6,10 @@ use std::iter::Step;
 
 #[cfg(target_pointer_width = "16")]
 fn main() {
-    assert!(Step::steps_between(&0u32, &::std::u32::MAX).is_none());
+    assert!(Step::steps_between(&0u32, &u32::MAX).is_none());
 }
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 fn main() {
-    assert!(Step::steps_between(&0u32, &::std::u32::MAX).is_some());
+    assert!(Step::steps_between(&0u32, &u32::MAX).is_some());
 }

--- a/src/test/ui/issues/issue-50811.rs
+++ b/src/test/ui/issues/issue-50811.rs
@@ -3,7 +3,6 @@
 
 extern crate test;
 
-use std::f64::{NAN, NEG_INFINITY, INFINITY, MAX};
 use std::mem::size_of;
 use test::black_box;
 
@@ -12,7 +11,7 @@ use test::black_box;
 macro_rules! compare {
     ($op:tt) => {
         compare!(
-            [NEG_INFINITY, -MAX, -1.0, -0.0, 0.0, 1.0, MAX, INFINITY, NAN],
+            [f64::NEG_INFINITY, -f64::MAX, -1.0, -0.0, 0.0, 1.0, f64::MAX, f64::INFINITY, f64::NAN],
             $op
         );
     };
@@ -20,7 +19,7 @@ macro_rules! compare {
         $(compare!(
             $lhs,
             $op,
-            [NEG_INFINITY, -MAX, -1.0, -0.0, 0.0, 1.0, MAX, INFINITY, NAN]
+            [f64::NEG_INFINITY, -f64::MAX, -1.0, -0.0, 0.0, 1.0, f64::MAX, f64::INFINITY, f64::NAN]
         );)+
     };
     ($lhs:expr, $op:tt, [$($rhs:expr),+]) => {
@@ -44,8 +43,8 @@ macro_rules! compare {
 fn main() {
     assert_eq!(0.0/0.0 < 0.0/0.0, false);
     assert_eq!(0.0/0.0 > 0.0/0.0, false);
-    assert_eq!(NAN < NAN, false);
-    assert_eq!(NAN > NAN, false);
+    assert_eq!(f64::NAN < f64::NAN, false);
+    assert_eq!(f64::NAN > f64::NAN, false);
 
     compare!(==);
     compare!(!=);

--- a/src/test/ui/issues/issue-68010-large-zst-consts.rs
+++ b/src/test/ui/issues/issue-68010-large-zst-consts.rs
@@ -1,5 +1,5 @@
 // build-pass
 
 fn main() {
-    println!("{}", [(); std::usize::MAX].len());
+    println!("{}", [(); usize::MAX].len());
 }

--- a/src/test/ui/issues/issue-6804.rs
+++ b/src/test/ui/issues/issue-6804.rs
@@ -3,7 +3,7 @@
 #![allow(unused)]
 #![deny(illegal_floating_point_literal_pattern)]
 
-use std::f64::NAN;
+const NAN: f64 = f64::NAN;
 
 fn main() {
     let x = NAN;

--- a/src/test/ui/issues/issue-8460-const.noopt.stderr
+++ b/src/test/ui/issues/issue-8460-const.noopt.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:14:36
+  --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
@@ -7,37 +7,37 @@ LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:16:36
+  --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:18:36
+  --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:20:36
+  --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:22:36
+  --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:24:36
+  --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:26:36
+  --> $DIR/issue-8460-const.rs:25:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
@@ -45,103 +45,103 @@ LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:28:36
+  --> $DIR/issue-8460-const.rs:27:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:30:36
+  --> $DIR/issue-8460-const.rs:29:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:32:36
+  --> $DIR/issue-8460-const.rs:31:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:34:36
+  --> $DIR/issue-8460-const.rs:33:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:36:36
+  --> $DIR/issue-8460-const.rs:35:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:38:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:40:36
+  --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:42:36
+  --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:44:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:46:36
+  --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:48:36
+  --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute the remainder of `i128::MIN % -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:50:36
+  --> $DIR/issue-8460-const.rs:49:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:52:36
+  --> $DIR/issue-8460-const.rs:51:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:54:36
+  --> $DIR/issue-8460-const.rs:53:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:56:36
+  --> $DIR/issue-8460-const.rs:55:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:58:36
+  --> $DIR/issue-8460-const.rs:57:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:60:36
+  --> $DIR/issue-8460-const.rs:59:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero

--- a/src/test/ui/issues/issue-8460-const.opt.stderr
+++ b/src/test/ui/issues/issue-8460-const.opt.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:14:36
+  --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
@@ -7,37 +7,37 @@ LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:16:36
+  --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:18:36
+  --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:20:36
+  --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:22:36
+  --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:24:36
+  --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:26:36
+  --> $DIR/issue-8460-const.rs:25:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
@@ -45,103 +45,103 @@ LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:28:36
+  --> $DIR/issue-8460-const.rs:27:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:30:36
+  --> $DIR/issue-8460-const.rs:29:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:32:36
+  --> $DIR/issue-8460-const.rs:31:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:34:36
+  --> $DIR/issue-8460-const.rs:33:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:36:36
+  --> $DIR/issue-8460-const.rs:35:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:38:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:40:36
+  --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:42:36
+  --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:44:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:46:36
+  --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:48:36
+  --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute the remainder of `i128::MIN % -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:50:36
+  --> $DIR/issue-8460-const.rs:49:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:52:36
+  --> $DIR/issue-8460-const.rs:51:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:54:36
+  --> $DIR/issue-8460-const.rs:53:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:56:36
+  --> $DIR/issue-8460-const.rs:55:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:58:36
+  --> $DIR/issue-8460-const.rs:57:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:60:36
+  --> $DIR/issue-8460-const.rs:59:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero

--- a/src/test/ui/issues/issue-8460-const.opt_with_overflow_checks.stderr
+++ b/src/test/ui/issues/issue-8460-const.opt_with_overflow_checks.stderr
@@ -1,5 +1,5 @@
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:14:36
+  --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
@@ -7,37 +7,37 @@ LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    = note: `#[deny(arithmetic_overflow)]` on by default
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:16:36
+  --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:18:36
+  --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:20:36
+  --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:22:36
+  --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:24:36
+  --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute `i128::MIN / -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:26:36
+  --> $DIR/issue-8460-const.rs:25:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
@@ -45,103 +45,103 @@ LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:28:36
+  --> $DIR/issue-8460-const.rs:27:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to divide `1_i8` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:30:36
+  --> $DIR/issue-8460-const.rs:29:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i16` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:32:36
+  --> $DIR/issue-8460-const.rs:31:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i32` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:34:36
+  --> $DIR/issue-8460-const.rs:33:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 / 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to divide `1_i64` by zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:36:36
+  --> $DIR/issue-8460-const.rs:35:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:38:36
+  --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:40:36
+  --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:42:36
+  --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:44:36
+  --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:46:36
+  --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64`, which would overflow
 
 error: this arithmetic operation will overflow
-  --> $DIR/issue-8460-const.rs:48:36
+  --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^ attempt to compute the remainder of `i128::MIN % -1_i128`, which would overflow
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:50:36
+  --> $DIR/issue-8460-const.rs:49:36
    |
 LL |     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to calculate the remainder of `1_isize` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:52:36
+  --> $DIR/issue-8460-const.rs:51:36
    |
 LL |     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());
    |                                    ^^^^^^^ attempt to calculate the remainder of `1_i8` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:54:36
+  --> $DIR/issue-8460-const.rs:53:36
    |
 LL |     assert!(thread::spawn(move|| { 1i16 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i16` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:56:36
+  --> $DIR/issue-8460-const.rs:55:36
    |
 LL |     assert!(thread::spawn(move|| { 1i32 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i32` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:58:36
+  --> $DIR/issue-8460-const.rs:57:36
    |
 LL |     assert!(thread::spawn(move|| { 1i64 % 0; }).join().is_err());
    |                                    ^^^^^^^^ attempt to calculate the remainder of `1_i64` with a divisor of zero
 
 error: this operation will panic at runtime
-  --> $DIR/issue-8460-const.rs:60:36
+  --> $DIR/issue-8460-const.rs:59:36
    |
 LL |     assert!(thread::spawn(move|| { 1i128 % 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to calculate the remainder of `1_i128` with a divisor of zero

--- a/src/test/ui/issues/issue-8460-const.rs
+++ b/src/test/ui/issues/issue-8460-const.rs
@@ -7,7 +7,6 @@
 
 #![deny(const_err)]
 
-use std::{isize, i8, i16, i32, i64, i128};
 use std::thread;
 
 fn main() {

--- a/src/test/ui/iterators/iter-count-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-debug.rs
@@ -4,13 +4,12 @@
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;
-use std::usize::MAX;
 
 fn main() {
-    assert_eq!((0..MAX).by_ref().count(), MAX);
+    assert_eq!((0..usize::MAX).by_ref().count(), usize::MAX);
 
     let r = panic::catch_unwind(|| {
-        (0..=MAX).by_ref().count()
+        (0..=usize::MAX).by_ref().count()
     });
     assert!(r.is_err());
 }

--- a/src/test/ui/iterators/iter-count-overflow-ndebug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-ndebug.rs
@@ -2,9 +2,7 @@
 // only-32bit too impatient for 2⁶⁴ items
 // compile-flags: -C debug_assertions=no -C opt-level=3
 
-use std::usize::MAX;
-
 fn main() {
-    assert_eq!((0..MAX).by_ref().count(), MAX);
-    assert_eq!((0..=MAX).by_ref().count(), 0);
+    assert_eq!((0..usize::MAX).by_ref().count(), usize::MAX);
+    assert_eq!((0..=usize::MAX).by_ref().count(), 0);
 }

--- a/src/test/ui/iterators/iter-position-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-debug.rs
@@ -4,11 +4,10 @@
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 
 use std::panic;
-use std::usize::MAX;
 
 fn main() {
-    let n = MAX as u64;
-    assert_eq!((0..).by_ref().position(|i| i >= n), Some(MAX));
+    let n = usize::MAX as u64;
+    assert_eq!((0..).by_ref().position(|i| i >= n), Some(usize::MAX));
 
     let r = panic::catch_unwind(|| {
         (0..).by_ref().position(|i| i > n)

--- a/src/test/ui/iterators/iter-position-overflow-ndebug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-ndebug.rs
@@ -2,11 +2,9 @@
 // only-32bit too impatient for 2⁶⁴ items
 // compile-flags: -C debug_assertions=no -C opt-level=3
 
-use std::usize::MAX;
-
 fn main() {
-    let n = MAX as u64;
-    assert_eq!((0..).by_ref().position(|i| i >= n), Some(MAX));
+    let n = usize::MAX as u64;
+    assert_eq!((0..).by_ref().position(|i| i >= n), Some(usize::MAX));
     assert_eq!((0..).by_ref().position(|i| i > n), Some(0));
     assert_eq!((0..=n + 1).by_ref().position(|_| false), None);
 }

--- a/src/test/ui/macros/macro-first-set.rs
+++ b/src/test/ui/macros/macro-first-set.rs
@@ -249,7 +249,7 @@ macro_rules! test_path {
 test_path!();
 test_path!(,);
 test_path!(::std);
-test_path!(std::u8,);
+test_path!(std::ops,);
 test_path!(any, super, super::super::self::path, X<Y>::Z<'a, T=U>);
 
 macro_rules! test_lifetime {

--- a/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.rs
+++ b/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.rs
@@ -1,7 +1,5 @@
 #![feature(box_syntax, unboxed_closures)]
 
-use std::usize;
-
 fn to_fn<A,F:Fn<A>>(f: F) -> F { f }
 
 fn test(_x: Box<usize>) {}

--- a/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.stderr
+++ b/src/test/ui/moves/moves-based-on-type-move-out-of-closure-env-issue-1965.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of `i`, a captured variable in an `Fn` closure
-  --> $DIR/moves-based-on-type-move-out-of-closure-env-issue-1965.rs:11:28
+  --> $DIR/moves-based-on-type-move-out-of-closure-env-issue-1965.rs:9:28
    |
 LL |     let i = box 3;
    |         - captured outer variable

--- a/src/test/ui/numbers-arithmetic/float-int-invalid-const-cast.rs
+++ b/src/test/ui/numbers-arithmetic/float-int-invalid-const-cast.rs
@@ -2,8 +2,6 @@
 
 #![deny(const_err)]
 
-use std::{f32, f64};
-
 // Forces evaluation of constants, triggering hard error
 fn force<T>(_: T) {}
 

--- a/src/test/ui/numbers-arithmetic/float-nan.rs
+++ b/src/test/ui/numbers-arithmetic/float-nan.rs
@@ -1,5 +1,4 @@
 // run-pass
-use std::f64;
 
 pub fn main() {
   let nan: f64 = f64::NAN;

--- a/src/test/ui/numbers-arithmetic/num-wrapping.rs
+++ b/src/test/ui/numbers-arithmetic/num-wrapping.rs
@@ -21,7 +21,8 @@ macro_rules! int_modules {
     ($(($name:ident, $size:expr),)*) => ($(
         mod $name {
             pub const BITS: usize = $size;
-            pub use std::$name::*;
+            pub const MAX: $name = $name::MAX;
+            pub const MIN: $name = $name::MIN;
         }
     )*)
 }

--- a/src/test/ui/numbers-arithmetic/overflowing-neg.rs
+++ b/src/test/ui/numbers-arithmetic/overflowing-neg.rs
@@ -6,5 +6,5 @@
 #![allow(arithmetic_overflow)]
 
 fn main() {
-    let _x = -std::i8::MIN;
+    let _x = -i8::MIN;
 }

--- a/src/test/ui/numbers-arithmetic/saturating-float-casts-impl.rs
+++ b/src/test/ui/numbers-arithmetic/saturating-float-casts-impl.rs
@@ -11,10 +11,6 @@
 extern crate test;
 
 use self::test::black_box;
-use std::{f32, f64};
-#[cfg(not(target_os = "emscripten"))]
-use std::{i128, u128};
-use std::{i16, i32, i64, i8, u16, u32, u64, u8};
 
 macro_rules! test {
     ($val:expr, $src_ty:ident -> $dest_ty:ident, $expected:expr) => (

--- a/src/test/ui/numbers-arithmetic/shift-near-oflo.rs
+++ b/src/test/ui/numbers-arithmetic/shift-near-oflo.rs
@@ -47,21 +47,21 @@ fn test_left_shift() {
     let x = 1_u8 << id(0);
     assert_eq!(x, 1);
     let x = 1_i8 << id(7);
-    assert_eq!(x, std::i8::MIN);
+    assert_eq!(x, i8::MIN);
     let x = 1_u8 << id(7);
     assert_eq!(x, 0x80);
     // high-order bits on LHS are silently discarded without panic.
     let x = 3_i8 << id(7);
-    assert_eq!(x, std::i8::MIN);
+    assert_eq!(x, i8::MIN);
     let x = 3_u8 << id(7);
     assert_eq!(x, 0x80);
 
     // above is (approximately) expanded from:
-    tests!(i8, u8, 7, std::i8::MIN, 0x80_u8);
+    tests!(i8, u8, 7, i8::MIN, 0x80_u8);
 
-    tests!(i16, u16, 15, std::i16::MIN, 0x8000_u16);
-    tests!(i32, u32, 31, std::i32::MIN, 0x8000_0000_u32);
-    tests!(i64, u64, 63, std::i64::MIN, 0x8000_0000_0000_0000_u64);
+    tests!(i16, u16, 15, i16::MIN, 0x8000_u16);
+    tests!(i32, u32, 31, i32::MIN, 0x8000_0000_u32);
+    tests!(i64, u64, 63, i64::MIN, 0x8000_0000_0000_0000_u64);
 }
 
 fn test_right_shift() {
@@ -92,9 +92,9 @@ fn test_right_shift() {
         } }
     }
 
-    tests!(i8, u8, 7, std::i8::MIN, 0x40_i8, 0x80_u8);
-    tests!(i16, u16, 15, std::i16::MIN, 0x4000_u16, 0x8000_u16);
-    tests!(i32, u32, 31, std::i32::MIN, 0x4000_0000_u32, 0x8000_0000_u32);
-    tests!(i64, u64, 63, std::i64::MIN,
+    tests!(i8, u8, 7, i8::MIN, 0x40_i8, 0x80_u8);
+    tests!(i16, u16, 15, i16::MIN, 0x4000_u16, 0x8000_u16);
+    tests!(i32, u32, 31, i32::MIN, 0x4000_0000_u32, 0x8000_0000_u32);
+    tests!(i64, u64, 63, i64::MIN,
            0x4000_0000_0000_0000_u64, 0x8000_0000_0000_0000_u64);
 }

--- a/src/test/ui/numbers-arithmetic/u128-as-f32.rs
+++ b/src/test/ui/numbers-arithmetic/u128-as-f32.rs
@@ -4,8 +4,6 @@
 #![deny(overflowing_literals)]
 extern crate test;
 
-use std::f32;
-use std::u128;
 use test::black_box;
 
 macro_rules! test {

--- a/src/test/ui/regions/regions-addr-of-upvar-self.nll.stderr
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/regions-addr-of-upvar-self.rs:10:20
+  --> $DIR/regions-addr-of-upvar-self.rs:8:20
    |
 LL |         let _f = || {
    |                  -- lifetime `'1` represents this closure's body
@@ -9,7 +9,7 @@ LL |             let p: &'static mut usize = &mut self.food;
    = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 
 error: lifetime may not live long enough
-  --> $DIR/regions-addr-of-upvar-self.rs:10:20
+  --> $DIR/regions-addr-of-upvar-self.rs:8:20
    |
 LL |     pub fn chase_cat(&mut self) {
    |                      - let's call the lifetime of this reference `'1`
@@ -18,7 +18,7 @@ LL |             let p: &'static mut usize = &mut self.food;
    |                    ^^^^^^^^^^^^^^^^^^ type annotation requires that `'1` must outlive `'static`
 
 error[E0597]: `self` does not live long enough
-  --> $DIR/regions-addr-of-upvar-self.rs:10:46
+  --> $DIR/regions-addr-of-upvar-self.rs:8:46
    |
 LL |         let _f = || {
    |                  -- value captured here

--- a/src/test/ui/regions/regions-addr-of-upvar-self.rs
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.rs
@@ -1,5 +1,3 @@
-use std::usize;
-
 struct Dog {
     food: usize,
 }

--- a/src/test/ui/regions/regions-addr-of-upvar-self.stderr
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.stderr
@@ -1,22 +1,22 @@
 error[E0495]: cannot infer an appropriate lifetime for borrow expression due to conflicting requirements
-  --> $DIR/regions-addr-of-upvar-self.rs:10:41
+  --> $DIR/regions-addr-of-upvar-self.rs:8:41
    |
 LL |             let p: &'static mut usize = &mut self.food;
    |                                         ^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the lifetime `'_` as defined on the body at 9:18...
-  --> $DIR/regions-addr-of-upvar-self.rs:9:18
+note: first, the lifetime cannot outlive the lifetime `'_` as defined on the body at 7:18...
+  --> $DIR/regions-addr-of-upvar-self.rs:7:18
    |
 LL |         let _f = || {
    |                  ^^
 note: ...so that closure can access `self`
-  --> $DIR/regions-addr-of-upvar-self.rs:10:41
+  --> $DIR/regions-addr-of-upvar-self.rs:8:41
    |
 LL |             let p: &'static mut usize = &mut self.food;
    |                                         ^^^^^^^^^^^^^^
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/regions-addr-of-upvar-self.rs:10:41
+  --> $DIR/regions-addr-of-upvar-self.rs:8:41
    |
 LL |             let p: &'static mut usize = &mut self.food;
    |                                         ^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.rs
+++ b/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.rs
@@ -1,5 +1,3 @@
-use std::f32;
-
 #[derive(PartialEq)]
 struct Foo {
     x: u32

--- a/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.stderr
@@ -1,11 +1,11 @@
 error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated with `#[derive(PartialEq, Eq)]`
-  --> $DIR/match-forbidden-without-eq.rs:13:9
+  --> $DIR/match-forbidden-without-eq.rs:11:9
    |
 LL |         FOO => { }
    |         ^^^
 
 warning: floating-point types cannot be used in patterns
-  --> $DIR/match-forbidden-without-eq.rs:20:9
+  --> $DIR/match-forbidden-without-eq.rs:18:9
    |
 LL |         f32::INFINITY => { }
    |         ^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |         f32::INFINITY => { }
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 warning: floating-point types cannot be used in patterns
-  --> $DIR/match-forbidden-without-eq.rs:20:9
+  --> $DIR/match-forbidden-without-eq.rs:18:9
    |
 LL |         f32::INFINITY => { }
    |         ^^^^^^^^^^^^^

--- a/src/test/ui/simd/simd-intrinsic-float-minmax.rs
+++ b/src/test/ui/simd/simd-intrinsic-float-minmax.rs
@@ -20,11 +20,11 @@ fn main() {
     let y = f32x4(2.0, 1.0, 4.0, 3.0);
 
     #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
-    let nan = ::std::f32::NAN;
+    let nan = f32::NAN;
     // MIPS hardware treats f32::NAN as SNAN. Clear the signaling bit.
     // See https://github.com/rust-lang/rust/issues/52746.
     #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
-    let nan = f32::from_bits(::std::f32::NAN.to_bits() - 1);
+    let nan = f32::from_bits(f32::NAN.to_bits() - 1);
 
     let n = f32x4(nan, nan, nan, nan);
 

--- a/src/test/ui/simd/simd-intrinsic-generic-comparison.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-comparison.rs
@@ -4,8 +4,6 @@
 #![feature(repr_simd, platform_intrinsics, concat_idents)]
 #![allow(non_camel_case_types)]
 
-use std::f32::NAN;
-
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct i32x4(i32, i32, i32, i32);
@@ -94,7 +92,7 @@ fn main() {
     // NAN comparisons are special:
     // -11 (*)    13
     // -5        -100 (*)
-    let f4 = f32x4(NAN, f1.1, NAN, f2.3);
+    let f4 = f32x4(f32::NAN, f1.1, f32::NAN, f2.3);
 
     unsafe {
         tests! {

--- a/src/test/ui/sleep.rs
+++ b/src/test/ui/sleep.rs
@@ -4,7 +4,6 @@
 use std::thread::{self, sleep};
 use std::time::Duration;
 use std::sync::{Arc, Mutex};
-use std::u64;
 
 fn main() {
     let finished = Arc::new(Mutex::new(false));

--- a/src/test/ui/structs-enums/discrim-explicit-23030.rs
+++ b/src/test/ui/structs-enums/discrim-explicit-23030.rs
@@ -5,8 +5,6 @@
 // See also compile-fail/overflow-discrim.rs, which shows what
 // happens if you leave the OhNo explicit cases out here.
 
-use std::{i8,u8,i16,u16,i32,u32,i64,u64,isize,usize};
-
 fn f_i8() {
     #[repr(i8)]
     enum A {

--- a/src/test/ui/symbol-names/const-generics.rs
+++ b/src/test/ui/symbol-names/const-generics.rs
@@ -19,11 +19,11 @@
     // `i8`
     pub struct I8<const F: i8>;
 
-    impl I8<{std::i8::MIN}> {
+    impl I8<{i8::MIN}> {
         pub fn foo() {}
     }
 
-    impl I8<{std::i8::MAX}> {
+    impl I8<{i8::MAX}> {
         pub fn foo() {}
     }
 
@@ -34,7 +34,7 @@
     // `i16`
     pub struct I16<const F: i16>;
 
-    impl I16<{std::i16::MIN}> {
+    impl I16<{i16::MIN}> {
         pub fn foo() {}
     }
 
@@ -45,7 +45,7 @@
     // `i32`
     pub struct I32<const F: i32>;
 
-    impl I32<{std::i32::MIN}> {
+    impl I32<{i32::MIN}> {
         pub fn foo() {}
     }
 
@@ -56,7 +56,7 @@
     // `i64`
     pub struct I64<const F: i64>;
 
-    impl I64<{std::i64::MIN}> {
+    impl I64<{i64::MIN}> {
         pub fn foo() {}
     }
 
@@ -67,7 +67,7 @@
     // `i128`
     pub struct I128<const F: i128>;
 
-    impl I128<{std::i128::MIN}> {
+    impl I128<{i128::MIN}> {
         pub fn foo() {}
     }
 

--- a/src/test/ui/union/union-transmute.rs
+++ b/src/test/ui/union/union-transmute.rs
@@ -1,8 +1,5 @@
 // run-pass
 
-extern crate core;
-use core::f32;
-
 union U {
     a: (u8, u8),
     b: u16,

--- a/src/test/ui/use-module-level-int-consts.rs
+++ b/src/test/ui/use-module-level-int-consts.rs
@@ -2,6 +2,7 @@
 
 // Make sure the module level constants are still there and accessible even after
 // the corresponding associated constants have been added, and later stabilized.
+#![allow(deprecated, deprecated_in_future)]
 use std::{u16, f32};
 
 fn main() {

--- a/src/test/ui/wrapping-int-api.rs
+++ b/src/test/ui/wrapping-int-api.rs
@@ -4,9 +4,6 @@
 // Don't warn about overflowing ops on 32-bit platforms
 #![cfg_attr(target_pointer_width = "32", allow(const_err))]
 
-use std::{i8, i16, i32, i64, isize};
-use std::{u8, u16, u32, u64, usize};
-
 fn main() {
     assert_eq!(   i8::MAX.wrapping_add(1),    i8::MIN);
     assert_eq!(  i16::MAX.wrapping_add(1),   i16::MIN);

--- a/src/tools/clippy/tests/ui/float_cmp_const.rs
+++ b/src/tools/clippy/tests/ui/float_cmp_const.rs
@@ -48,7 +48,7 @@ fn main() {
     v != 1.0;
 
     const ZERO_ARRAY: [f32; 3] = [0.0, 0.0, 0.0];
-    const ZERO_INF_ARRAY: [f32; 3] = [0.0, ::std::f32::INFINITY, ::std::f32::NEG_INFINITY];
+    const ZERO_INF_ARRAY: [f32; 3] = [0.0, f32::INFINITY, f32::NEG_INFINITY];
     const NON_ZERO_ARRAY: [f32; 3] = [0.0, 0.1, 0.2];
     const NON_ZERO_ARRAY2: [f32; 3] = [0.2, 0.1, 0.0];
 


### PR DESCRIPTION
Part of #68490.

Care has been taken to leave the old consts where appropriate, for testing backcompat regressions, module shadowing, etc. The intrinsics docs were accidentally referring to some methods on f64 as std::f64, which I changed due to being contrary with how we normally disambiguate the shadow module from the primitive. In one other place I changed std::u8 to std::ops since it was just testing path handling in macros.

For places which have legitimate uses of the old consts, deprecated attributes have been optimistically inserted. Although currently unnecessary, they exist to emphasize to any future deprecation effort the necessity of these specific symbols and prevent them from being accidentally removed.