### PR TITLE
Add const_fn in generics test

### DIFF
--- a/src/test/ui/const-generics/min_const_generics/const_fn_in_generics.rs
+++ b/src/test/ui/const-generics/min_const_generics/const_fn_in_generics.rs
@@ -1,0 +1,17 @@
+// run-pass
+
+#![feature(min_const_generics)]
+
+const fn identity<const T: u32>() -> u32 { T }
+
+#[derive(Eq, PartialEq, Debug)]
+pub struct ConstU32<const U: u32>;
+
+pub fn new() -> ConstU32<{ identity::<3>() }> {
+  ConstU32::<{ identity::<3>() }>
+}
+
+fn main() {
+  let v = new();
+  assert_eq!(v, ConstU32::<3>);
+}


### PR DESCRIPTION
Adds a test that constant functions in generic parameters work properly. I was surprised this works, but I also to turbofish the constant in main, otherwise it didn't infer properly:
```
let v: ConstU32<3> = ...
```
Did not work as I expected, which I can highlight in the test if that's the intended behaviour.

r? @lcnr 
