### PR TITLE
Ensure no type errors when calling Closure/Generator upvars_ty

### DIFF
--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -104,7 +104,9 @@ impl FlagComputation {
                 self.add_ty(substs.return_ty());
                 self.add_ty(substs.witness());
                 self.add_ty(substs.yield_ty());
-                self.add_ty(substs.tupled_upvars_ty());
+                if let Ok(tupled_ty) = substs.tupled_upvars_ty() {
+                    self.add_ty(tupled_ty);
+                }
             }
 
             &ty::GeneratorWitness(ts) => {
@@ -122,7 +124,9 @@ impl FlagComputation {
 
                 self.add_ty(substs.sig_as_fn_ptr_ty());
                 self.add_ty(substs.kind_ty());
-                self.add_ty(substs.tupled_upvars_ty());
+                if let Ok(tupled_ty) = substs.tupled_upvars_ty() {
+                    self.add_ty(tupled_ty);
+                }
             }
 
             &ty::Bound(debruijn, _) => {

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -506,9 +506,9 @@ fn polymorphize<'tcx>(
     // the unpolymorphized upvar closure would result in a polymorphized closure producing
     // multiple mono items (and eventually symbol clashes).
     let upvars_ty = if tcx.is_closure(def_id) {
-        Some(substs.as_closure().tupled_upvars_ty())
+        substs.as_closure().tupled_upvars_ty().ok()
     } else if tcx.type_of(def_id).is_generator() {
-        Some(substs.as_generator().tupled_upvars_ty())
+        substs.as_generator().tupled_upvars_ty().ok()
     } else {
         None
     };

--- a/compiler/rustc_middle/src/ty/outlives.rs
+++ b/compiler/rustc_middle/src/ty/outlives.rs
@@ -96,14 +96,16 @@ fn compute_components(
             }
 
             ty::Closure(_, ref substs) => {
-                let tupled_ty = substs.as_closure().tupled_upvars_ty();
-                compute_components(tcx, tupled_ty, out, visited);
+                if let Ok(tupled_ty) = substs.as_closure().tupled_upvars_ty() {
+                    compute_components(tcx, tupled_ty, out, visited);
+                }
             }
 
             ty::Generator(_, ref substs, _) => {
                 // Same as the closure case
-                let tupled_ty = substs.as_generator().tupled_upvars_ty();
-                compute_components(tcx, tupled_ty, out, visited);
+                if let Ok(tupled_ty) = substs.as_generator().tupled_upvars_ty() {
+                    compute_components(tcx, tupled_ty, out, visited);
+                }
 
                 // We ignore regions in the generator interior as we don't
                 // want these to affect region inference

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -664,7 +664,11 @@ pub trait PrettyPrinter<'tcx>:
                     p!(print_def_path(did, substs));
                     p!(" upvar_tys=(");
                     if !substs.as_generator().is_valid() {
-                        p!("unavailable");
+                        if substs.as_generator().tupled_upvars_ty().is_err() {
+                            p!("err");
+                        } else {
+                            p!("unavailable");
+                        }
                     } else {
                         self = self.comma_sep(substs.as_generator().upvar_tys())?;
                     }
@@ -699,7 +703,13 @@ pub trait PrettyPrinter<'tcx>:
                 } else {
                     p!(print_def_path(did, substs));
                     if !substs.as_closure().is_valid() {
-                        p!(" closure_substs=(unavailable)");
+                        p!(" closure_substs=(");
+                        if substs.as_closure().tupled_upvars_ty().is_err() {
+                            p!("err");
+                        } else {
+                            p!("unavailable");
+                        }
+                        p!(")");
                     } else {
                         p!(" closure_kind_ty=", print(substs.as_closure().kind_ty()));
                         p!(

--- a/compiler/rustc_mir/src/util/elaborate_drops.rs
+++ b/compiler/rustc_mir/src/util/elaborate_drops.rs
@@ -850,7 +850,12 @@ where
         let ty = self.place_ty(self.place);
         match ty.kind() {
             ty::Closure(_, substs) => {
-                let tys: Vec<_> = substs.as_closure().upvar_tys().collect();
+                let substs = substs.as_closure();
+                let tys: Vec<_> = if substs.tupled_upvars_ty().is_ok() {
+                    substs.upvar_tys().collect()
+                } else {
+                    vec![]
+                };
                 self.open_drop_for_tuple(&tys)
             }
             // Note that `elaborate_drops` only drops the upvars of a generator,
@@ -860,7 +865,12 @@ where
             // It effetively only contains upvars until the generator transformation runs.
             // See librustc_body/transform/generator.rs for more details.
             ty::Generator(_, substs, _) => {
-                let tys: Vec<_> = substs.as_generator().upvar_tys().collect();
+                let substs = substs.as_generator();
+                let tys: Vec<_> = if substs.tupled_upvars_ty().is_ok() {
+                    substs.upvar_tys().collect()
+                } else {
+                    vec![]
+                };
                 self.open_drop_for_tuple(&tys)
             }
             ty::Tuple(..) => {

--- a/compiler/rustc_trait_selection/src/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/opaque_types.rs
@@ -717,10 +717,12 @@ where
             ty::Closure(_, ref substs) => {
                 // Skip lifetime parameters of the enclosing item(s)
 
-                substs.as_closure().tupled_upvars_ty().visit_with(self);
+                if let Ok(tupled_ty) = substs.as_closure().tupled_upvars_ty() {
+                    tupled_ty.visit_with(self);
 
-                for upvar_ty in substs.as_closure().upvar_tys() {
-                    upvar_ty.visit_with(self);
+                    for upvar_ty in substs.as_closure().upvar_tys() {
+                        upvar_ty.visit_with(self);
+                    }
                 }
 
                 substs.as_closure().sig_as_fn_ptr_ty().visit_with(self);
@@ -730,10 +732,12 @@ where
                 // Skip lifetime parameters of the enclosing item(s)
                 // Also skip the witness type, because that has no free regions.
 
-                substs.as_generator().tupled_upvars_ty().visit_with(self);
+                if let Ok(tupled_ty) = substs.as_generator().tupled_upvars_ty() {
+                    tupled_ty.visit_with(self);
 
-                for upvar_ty in substs.as_generator().upvar_tys() {
-                    upvar_ty.visit_with(self);
+                    for upvar_ty in substs.as_closure().upvar_tys() {
+                        upvar_ty.visit_with(self);
+                    }
                 }
 
                 substs.as_generator().return_ty().visit_with(self);

--- a/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/dropck_outlives.rs
@@ -110,7 +110,12 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         // check if *any* of those are trivial.
         ty::Tuple(ref tys) => tys.iter().all(|t| trivial_dropck_outlives(tcx, t.expect_ty())),
         ty::Closure(_, ref substs) => {
-            trivial_dropck_outlives(tcx, substs.as_closure().tupled_upvars_ty())
+            if let Ok(tupled_tys) = substs.as_closure().tupled_upvars_ty() {
+                trivial_dropck_outlives(tcx, tupled_tys)
+            } else {
+                // Same as the error case above
+                true
+            }
         }
 
         ty::Adt(def, _) => {

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -593,7 +593,9 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                     // only inspects the upvar types).
                     walker.skip_current_subtree(); // subtree handled below
                     // FIXME(eddyb) add the type to `walker` instead of recursing.
-                    self.compute(substs.as_closure().tupled_upvars_ty().into());
+                    if let Ok(tupled_tys) = substs.as_closure().tupled_upvars_ty() {
+                        self.compute(tupled_tys.into());
+                    }
                 }
 
                 ty::FnPtr(_) => {

--- a/compiler/rustc_ty/src/needs_drop.rs
+++ b/compiler/rustc_ty/src/needs_drop.rs
@@ -94,15 +94,20 @@ where
                     _ if component.is_copy_modulo_regions(tcx.at(DUMMY_SP), self.param_env) => (),
 
                     ty::Closure(_, substs) => {
-                        for upvar_ty in substs.as_closure().upvar_tys() {
-                            queue_type(self, upvar_ty);
+                        let substs = substs.as_closure();
+                        if substs.tupled_upvars_ty().is_ok() {
+                            for upvar_ty in substs.upvar_tys() {
+                                queue_type(self, upvar_ty);
+                            }
                         }
                     }
 
                     ty::Generator(def_id, substs, _) => {
                         let substs = substs.as_generator();
-                        for upvar_ty in substs.upvar_tys() {
-                            queue_type(self, upvar_ty);
+                        if substs.tupled_upvars_ty().is_ok() {
+                            for upvar_ty in substs.upvar_tys() {
+                                queue_type(self, upvar_ty);
+                            }
                         }
 
                         let witness = substs.witness();

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -206,7 +206,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Build a tuple (U0..Un) of the final upvar types U0..Un
         // and unify the upvar tupe type in the closure with it:
         let final_tupled_upvars_type = self.tcx.mk_tup(final_upvar_tys.iter());
-        self.demand_suptype(span, substs.tupled_upvars_ty(), final_tupled_upvars_type);
+        if let Ok(tupled_upvars) = substs.tupled_upvars_ty() {
+            self.demand_suptype(span, tupled_upvars, final_tupled_upvars_type);
+        }
 
         // If we are also inferred the closure kind here,
         // process any deferred resolutions.

--- a/src/test/ui/issues/issue-77993-1.rs
+++ b/src/test/ui/issues/issue-77993-1.rs
@@ -1,0 +1,12 @@
+#[derive(Clone)]
+struct InGroup<F> {
+    it: It,
+    //~^ ERROR cannot find type `It` in this scope
+    f: F,
+}
+fn dates_in_year() -> impl Clone {
+    InGroup { f: |d| d }
+    //~^ ERROR missing field `it` in initializer of `InGroup<_>`
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-77993-1.stderr
+++ b/src/test/ui/issues/issue-77993-1.stderr
@@ -1,0 +1,16 @@
+error[E0412]: cannot find type `It` in this scope
+  --> $DIR/issue-77993-1.rs:3:9
+   |
+LL |     it: It,
+   |         ^^ not found in this scope
+
+error[E0063]: missing field `it` in initializer of `InGroup<_>`
+  --> $DIR/issue-77993-1.rs:8:5
+   |
+LL |     InGroup { f: |d| d }
+   |     ^^^^^^^ missing `it`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0063, E0412.
+For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-77993-2.rs
+++ b/src/test/ui/issues/issue-77993-2.rs
@@ -1,0 +1,9 @@
+// edition:2018
+
+async fn test() -> Result<(), Box<dyn std::error::Error>> {
+    macro!();
+    //~^ ERROR expected identifier, found `!`
+    Ok(())
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-77993-2.stderr
+++ b/src/test/ui/issues/issue-77993-2.stderr
@@ -1,0 +1,8 @@
+error: expected identifier, found `!`
+  --> $DIR/issue-77993-2.rs:4:10
+   |
+LL |     macro!();
+   |          ^ expected identifier
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #77993

Places with ungaurded calls to `upvars_ty` would already throw a bug in case of Ty::Error, or we were working with MIR / building MIR exprs. 

r? @nikomatsakis 