### PR TITLE
Always record reference to binding in match if guards

### DIFF
--- a/src/test/ui/generator/yielding-in-match-guards.rs
+++ b/src/test/ui/generator/yielding-in-match-guards.rs
@@ -1,4 +1,4 @@
-// check-pass
+// build-pass
 // edition:2018
 
 // This test is derived from
@@ -11,6 +11,7 @@
 // of the underlying generator.
 
 async fn f() -> u8 { 1 }
+async fn foo() -> [bool; 10] { [false; 10] }
 
 pub async fn g(x: u8) {
     match x {
@@ -19,6 +20,24 @@ pub async fn g(x: u8) {
     }
 }
 
+// #78366: check the reference to the binding is recorded even if the binding is not autorefed
+
+async fn h(x: usize) {
+    match x {
+        y if foo().await[y] => (),
+        _ => (),
+    }
+}
+
+async fn i(x: u8) {
+    match x {
+        y if f().await == y + 1 => (),
+        _ => (),
+    }
+}
+
 fn main() {
     let _ = g(10);
+    let _ = h(9);
+    let _ = i(8);
 }


### PR DESCRIPTION
When encountering a binding from a `match` pattern in its `if` guard when computing a generator's interior types, we must always record the type of a reference to the binding because of how `if` guards are lowered to MIR. This was missed in #75213 because the binding in that test case was autorefed and we recorded that adjusted type anyway.

Fixes #78366