### PR TITLE
fix(docs): typo in BufWriter documentation

### DIFF
--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -15,7 +15,7 @@ use crate::io::{
 /// *repeated* write calls to the same file or network socket. It does not
 /// help when writing very large amounts at once, or writing just one or a few
 /// times. It also provides no advantage when writing to a destination that is
-/// in memory, like a [`Vec`]<u8>`.
+/// in memory, like a [`Vec`]`<u8>`.
 ///
 /// It is critical to call [`flush`] before `BufWriter<W>` is dropped. Though
 /// dropping will attempt to flush the contents of the buffer, any errors


### PR DESCRIPTION
This PR fixes a small typo in the BufWriter documentation. The current documentation looks like this:

![2020-10-26-111501_438x83_scrot](https://user-images.githubusercontent.com/238549/97160357-83d3a000-177c-11eb-8a35-3cdd3a7d89de.png)

The `<u8>` at the end is mangled by Markdown. This PR makes the `BufWriter` documentation like the `BufReader` one:

https://github.com/rust-lang/rust/blob/master/library/std/src/io/buffered/bufreader.rs#L16

I'm tagging Steve as per the Rustc dev guide.

r? @steveklabnik