### PR TITLE
Add compiler support for LLVM's x86_64 ERMSB feature

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -63,6 +63,7 @@ const X86_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("bmi1", None),
     ("bmi2", None),
     ("cmpxchg16b", Some(sym::cmpxchg16b_target_feature)),
+    ("ermsb", Some(sym::ermsb_target_feature)),
     ("f16c", Some(sym::f16c_target_feature)),
     ("fma", None),
     ("fxsr", None),

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -238,6 +238,7 @@ declare_features! (
     (active, rtm_target_feature, "1.35.0", Some(44839), None),
     (active, f16c_target_feature, "1.36.0", Some(44839), None),
     (active, riscv_target_feature, "1.45.0", Some(44839), None),
+    (active, ermsb_target_feature, "1.49.0", Some(44839), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates (target features)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -467,6 +467,7 @@ symbols! {
         encode,
         env,
         eq,
+        ermsb_target_feature,
         err,
         exact_div,
         except,

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2414,6 +2414,7 @@ fn from_target_feature(
                 Some(sym::movbe_target_feature) => rust_features.movbe_target_feature,
                 Some(sym::rtm_target_feature) => rust_features.rtm_target_feature,
                 Some(sym::f16c_target_feature) => rust_features.f16c_target_feature,
+                Some(sym::ermsb_target_feature) => rust_features.ermsb_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/test/ui/target-feature/gate.rs
+++ b/src/test/ui/target-feature/gate.rs
@@ -26,6 +26,7 @@
 // gate-test-rtm_target_feature
 // gate-test-f16c_target_feature
 // gate-test-riscv_target_feature
+// gate-test-ermsb_target_feature
 
 #[target_feature(enable = "avx512bw")]
 //~^ ERROR: currently unstable

--- a/src/test/ui/target-feature/gate.stderr
+++ b/src/test/ui/target-feature/gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable
-  --> $DIR/gate.rs:30:18
+  --> $DIR/gate.rs:31:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This change is needed for compiler-builtins to check for this feature
when implementing memcpy/memset. See:
  https://github.com/rust-lang/compiler-builtins/pull/365

Without this change, the following code compiles, but does nothing:
```rust
#[cfg(target_feature = "ermsb")]
pub unsafe fn ermsb_memcpy() { ... }
```

The change just does compile-time detection. I think that runtime
detection will have to come in a follow-up CL to std-detect.

Like all the CPU feature flags, this just references #44839

Signed-off-by: Joe Richey <joerichey@google.com>