### PR TITLE
resolve: private fields in tuple struct ctor diag

### DIFF
--- a/src/test/ui/issues/issue-38412.rs
+++ b/src/test/ui/issues/issue-38412.rs
@@ -1,6 +1,6 @@
 fn main() {
     let Box(a) = loop { };
-    //~^ ERROR expected tuple struct or tuple variant, found struct `Box`
+    //~^ ERROR cannot match against a tuple struct which contains private fields
 
     // (The below is a trick to allow compiler to infer a type for
     // variable `a` without attempting to ascribe a type to the

--- a/src/test/ui/issues/issue-38412.stderr
+++ b/src/test/ui/issues/issue-38412.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found struct `Box`
+error[E0532]: cannot match against a tuple struct which contains private fields
   --> $DIR/issue-38412.rs:2:9
    |
 LL |     let Box(a) = loop { };

--- a/src/test/ui/issues/issue-42944.rs
+++ b/src/test/ui/issues/issue-42944.rs
@@ -7,7 +7,7 @@ mod bar {
 
     fn foo() {
         Bx(());
-        //~^ ERROR expected function, tuple struct or tuple variant, found struct `Bx` [E0423]
+        //~^ ERROR cannot initialize a tuple struct which contains private fields [E0423]
     }
 }
 

--- a/src/test/ui/issues/issue-42944.stderr
+++ b/src/test/ui/issues/issue-42944.stderr
@@ -1,8 +1,14 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `Bx`
+error[E0423]: cannot initialize a tuple struct which contains private fields
   --> $DIR/issue-42944.rs:9:9
    |
 LL |         Bx(());
-   |         ^^ constructor is not visible here due to private fields
+   |         ^^
+   |
+note: constructor is not visible here due to private fields
+  --> $DIR/issue-42944.rs:2:19
+   |
+LL |     pub struct Bx(());
+   |                   ^^ private field
 
 error[E0425]: cannot find function, tuple struct or tuple variant `Bx` in this scope
   --> $DIR/issue-42944.rs:16:9

--- a/src/test/ui/issues/issue-75906.rs
+++ b/src/test/ui/issues/issue-75906.rs
@@ -1,0 +1,13 @@
+mod m {
+    pub struct Foo { x: u8 }
+
+    pub struct Bar(u8);
+}
+
+use m::{Foo, Bar};
+
+fn main() {
+    let x = Foo { x: 12 };
+    let y = Bar(12);
+    //~^ ERROR cannot initialize a tuple struct which contains private fields [E0423]
+}

--- a/src/test/ui/issues/issue-75906.stderr
+++ b/src/test/ui/issues/issue-75906.stderr
@@ -1,0 +1,15 @@
+error[E0423]: cannot initialize a tuple struct which contains private fields
+  --> $DIR/issue-75906.rs:11:13
+   |
+LL |     let y = Bar(12);
+   |             ^^^
+   |
+note: constructor is not visible here due to private fields
+  --> $DIR/issue-75906.rs:4:20
+   |
+LL |     pub struct Bar(u8);
+   |                    ^^ private field
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/issues/issue-75907.rs
+++ b/src/test/ui/issues/issue-75907.rs
@@ -13,6 +13,6 @@ use foo::{make_bar, Bar, Foo};
 
 fn main() {
     let Bar(x, y, Foo(z)) = make_bar();
-    //~^ ERROR expected tuple struct
-    //~| ERROR expected tuple struct
+    //~^ ERROR cannot match against a tuple struct which contains private fields
+    //~| ERROR cannot match against a tuple struct which contains private fields
 }

--- a/src/test/ui/issues/issue-75907.stderr
+++ b/src/test/ui/issues/issue-75907.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found struct `Bar`
+error[E0532]: cannot match against a tuple struct which contains private fields
   --> $DIR/issue-75907.rs:15:9
    |
 LL |     let Bar(x, y, Foo(z)) = make_bar();
@@ -12,7 +12,7 @@ LL |     let Bar(x, y, Foo(z)) = make_bar();
    |                |
    |                private field
 
-error[E0532]: expected tuple struct or tuple variant, found struct `Foo`
+error[E0532]: cannot match against a tuple struct which contains private fields
   --> $DIR/issue-75907.rs:15:19
    |
 LL |     let Bar(x, y, Foo(z)) = make_bar();

--- a/src/test/ui/issues/issue-75907_b.rs
+++ b/src/test/ui/issues/issue-75907_b.rs
@@ -7,5 +7,5 @@ use a::{make_bar, Bar};
 
 fn main() {
     let Bar(x, y, z) = make_bar();
-    //~^ ERROR expected tuple struct
+    //~^ ERROR cannot match against a tuple struct which contains private fields
 }

--- a/src/test/ui/issues/issue-75907_b.stderr
+++ b/src/test/ui/issues/issue-75907_b.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found struct `Bar`
+error[E0532]: cannot match against a tuple struct which contains private fields
   --> $DIR/issue-75907_b.rs:9:9
    |
 LL |     let Bar(x, y, z) = make_bar();

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.rs
@@ -18,7 +18,7 @@ fn main() {
     //~^ ERROR `..` required with struct marked as non-exhaustive
 
     let ts = TupleStruct(640, 480);
-    //~^ ERROR expected function, tuple struct or tuple variant, found struct `TupleStruct` [E0423]
+    //~^ ERROR cannot initialize a tuple struct which contains private fields [E0423]
 
     let ts_explicit = structs::TupleStruct(640, 480);
     //~^ ERROR tuple struct constructor `TupleStruct` is private [E0603]

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, tuple struct or tuple variant, found struct `TupleStruct`
+error[E0423]: cannot initialize a tuple struct which contains private fields
   --> $DIR/struct.rs:20:14
    |
 LL |     let ts = TupleStruct(640, 480);


### PR DESCRIPTION
Fixes #75906.

This PR improves the diagnostic emitted when a tuple struct is being constructed which has private fields so that private fields are labelled and the message is improved.

r? @estebank