### PR TITLE
Add a description of `rust_ast::ast::ItemKind`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2635,6 +2635,7 @@ impl Default for FnHeader {
     }
 }
 
+/// Represents a concrete type and contains information specific to the type of the item.
 #[derive(Clone, Encodable, Decodable, Debug)]
 pub enum ItemKind {
     /// An `extern crate` item, with the optional *original* crate name if the crate was renamed.


### PR DESCRIPTION
Add a descriptive doc comment adapted from the [module docs](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_ast/ast/index.html).