### PR TITLE
Move f64::NAN ui tests into `library`

### DIFF
--- a/library/core/tests/num/mod.rs
+++ b/library/core/tests/num/mod.rs
@@ -27,6 +27,8 @@ mod bignum;
 mod dec2flt;
 mod flt2dec;
 
+mod nan;
+
 /// Adds the attribute to all items in the block.
 macro_rules! cfg_block {
     ($(#[$attr:meta]{$($it:item)*})*) => {$($(

--- a/library/core/tests/num/nan.rs
+++ b/library/core/tests/num/nan.rs
@@ -1,8 +1,8 @@
 #[test]
 fn test_nan() {
-  use core::f64;
-  let x = "NaN".to_string();
-  assert_eq!(format!("{}", f64::NAN), x);
-  assert_eq!(format!("{:e}", f64::NAN), x);
-  assert_eq!(format!("{:E}", f64::NAN), x);
+    use core::f64;
+    let x = "NaN".to_string();
+    assert_eq!(format!("{}", f64::NAN), x);
+    assert_eq!(format!("{:e}", f64::NAN), x);
+    assert_eq!(format!("{:E}", f64::NAN), x);
 }

--- a/library/core/tests/num/nan.rs
+++ b/library/core/tests/num/nan.rs
@@ -1,0 +1,8 @@
+#[test]
+fn test_nan() {
+  use core::f64;
+  let x = "NaN".to_string();
+  assert_eq!(format!("{}", f64::NAN), x);
+  assert_eq!(format!("{:e}", f64::NAN), x);
+  assert_eq!(format!("{:E}", f64::NAN), x);
+}

--- a/src/test/ui/format-nan.rs
+++ b/src/test/ui/format-nan.rs
@@ -1,9 +1,0 @@
-// run-pass
-
-pub fn main() {
-    use std::f64;
-    let x = "NaN".to_string();
-    assert_eq!(format!("{}", f64::NAN), x);
-    assert_eq!(format!("{:e}", f64::NAN), x);
-    assert_eq!(format!("{:E}", f64::NAN), x);
-}


### PR DESCRIPTION
This is a partial fix of #76268.

r? @matklad