### PR TITLE
MinConstGenerics UI test for invalid values for bool & char

### DIFF
--- a/src/test/ui/const-generics/min_const_generics/invalid-patterns.rs
+++ b/src/test/ui/const-generics/min_const_generics/invalid-patterns.rs
@@ -1,0 +1,45 @@
+#![feature(min_const_generics)]
+use std::mem::transmute;
+
+fn get_flag<const FlagSet: bool, const ShortName: char>() -> Option<char> {
+  if FlagSet {
+    Some(ShortName)
+  } else {
+    None
+  }
+}
+
+union CharRaw {
+  byte: u8,
+  character: char,
+}
+
+union BoolRaw {
+  byte: u8,
+  boolean: bool,
+}
+
+const char_raw: CharRaw = CharRaw { byte: 0xFF };
+const bool_raw: BoolRaw = BoolRaw { byte: 0x42 };
+
+fn main() {
+  // Test that basic cases don't work
+  assert!(get_flag::<true, 'c'>().is_some());
+  assert!(get_flag::<false, 'x'>().is_none());
+  get_flag::<false, 0xFF>();
+  //~^ ERROR mismatched types
+  get_flag::<7, 'c'>();
+  //~^ ERROR mismatched types
+  get_flag::<42, 0x5ad>();
+  //~^ ERROR mismatched types
+  //~| ERROR mismatched types
+
+
+  get_flag::<false, { unsafe { char_raw.character } }>();
+  //~^ ERROR it is undefined behavior
+  get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
+  //~^ ERROR it is undefined behavior
+  get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
+  //~^ ERROR it is undefined behavior
+  //~| ERROR it is undefined behavior
+}

--- a/src/test/ui/const-generics/min_const_generics/invalid-patterns.stderr
+++ b/src/test/ui/const-generics/min_const_generics/invalid-patterns.stderr
@@ -1,0 +1,60 @@
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:29:21
+   |
+LL |   get_flag::<false, 0xFF>();
+   |                     ^^^^ expected `char`, found `u8`
+
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:31:14
+   |
+LL |   get_flag::<7, 'c'>();
+   |              ^ expected `bool`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:33:14
+   |
+LL |   get_flag::<42, 0x5ad>();
+   |              ^^ expected `bool`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:33:18
+   |
+LL |   get_flag::<42, 0x5ad>();
+   |                  ^^^^^ expected `char`, found `u8`
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:38:21
+   |
+LL |   get_flag::<false, { unsafe { char_raw.character } }>();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:40:14
+   |
+LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:42:14
+   |
+LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:42:47
+   |
+LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0080, E0308.
+For more information about an error, try `rustc --explain E0080`.


### PR DESCRIPTION
This adds a test for `feature(min_const_generics)` with some invalid values for bools and chars and ensures that they do not ICE and error with understandable messages.

r? @lcnr 