### PR TITLE
Clarify main code paths in exhaustiveness checking

### DIFF
--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(control_flow_enum)]
 #![feature(crate_visibility_modifier)]
 #![feature(bool_to_option)]
+#![feature(once_cell)]
 #![feature(or_patterns)]
 #![recursion_limit = "256"]
 

--- a/src/test/ui/issues/issue-30240.rs
+++ b/src/test/ui/issues/issue-30240.rs
@@ -1,9 +1,9 @@
 fn main() {
-    match "world" { //~ ERROR non-exhaustive patterns: `&_`
+    match "world" { //~ ERROR non-exhaustive patterns: `_`
         "hello" => {}
     }
 
-    match "world" { //~ ERROR non-exhaustive patterns: `&_`
+    match "world" { //~ ERROR non-exhaustive patterns: `_`
         ref _x if false => {}
         "hello" => {}
     }

--- a/src/test/ui/issues/issue-30240.stderr
+++ b/src/test/ui/issues/issue-30240.stderr
@@ -1,17 +1,17 @@
-error[E0004]: non-exhaustive patterns: `&_` not covered
+error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/issue-30240.rs:2:11
    |
 LL |     match "world" {
-   |           ^^^^^^^ pattern `&_` not covered
+   |           ^^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&str`
 
-error[E0004]: non-exhaustive patterns: `&_` not covered
+error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/issue-30240.rs:6:11
    |
 LL |     match "world" {
-   |           ^^^^^^^ pattern `&_` not covered
+   |           ^^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&str`


### PR DESCRIPTION
This PR massively clarifies the main code paths of exhaustiveness checking, by using the `Constructor` enum to a fuller extent. I've been itching to write it for more than a year, but the complexity of matching consts had prevented me. Behold a massive simplification :D.
This in particular removes a fair amount of duplication between various parts, localizes code into methods of relevant types when applicable, makes some implicit assumptions explicit, and overall improves legibility a lot (or so I hope). Additionally, after my changes, undoing #76918 turned out to be a noticeable perf gain.

As usual I tried my best to make the commits self-contained and easy to follow. I've also tried to keep the code well-commented, but I tend to forget how complex this file is; I'm happy to clarify things as needed.
My measurements show good perf improvements on the two match-heavy benchmarks (-18.0% on `unicode_normalization-check`! :D); I'd like a perf run to check the overall impact.

r? @varkor 
@rustbot modify labels: +A-exhaustiveness-checking