### PR TITLE
Remove semicolon from internal `err` macro

### DIFF
--- a/library/core/src/str/validations.rs
+++ b/library/core/src/str/validations.rs
@@ -125,7 +125,7 @@ pub(super) fn run_utf8_validation(v: &[u8]) -> Result<(), Utf8Error> {
         let old_offset = index;
         macro_rules! err {
             ($error_len: expr) => {
-                return Err(Utf8Error { valid_up_to: old_offset, error_len: $error_len });
+                return Err(Utf8Error { valid_up_to: old_offset, error_len: $error_len })
             };
         }
 

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -19,7 +19,7 @@ rustc: beta
 # bootstrapping issues with use of new syntax in this repo. If you're looking at
 # the beta/stable branch, this key should be omitted, as we don't want to depend
 # on rustfmt from nightly there.
-rustfmt: nightly-2020-10-12
+rustfmt: nightly-2020-11-19
 
 # When making a stable release the process currently looks like:
 #


### PR DESCRIPTION
This macro is used in expression position (a match arm), and only
compiles because of #33953

Regardless of what happens with that issue, this makes the
usage of the macro less confusing at the call site.