### PR TITLE
Adjust turbofish help message for const generics

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -678,8 +678,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
     pub fn unsolved_variables(&self) -> Vec<Ty<'tcx>> {
         let mut inner = self.inner.borrow_mut();
-        // FIXME(const_generics): should there be an equivalent function for const variables?
-
         let mut vars: Vec<Ty<'_>> = inner
             .type_variables()
             .unsolved_variables()

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -20,7 +20,8 @@ use rustc_span::{MultiSpan, Span, SpanSnippetError, DUMMY_SP};
 
 use tracing::{debug, trace};
 
-const TURBOFISH: &str = "use `::<...>` instead of `<...>` to specify type arguments";
+const TURBOFISH_SUGGESTION_STR: &str =
+    "use `::<...>` instead of `<...>` to specify type or const arguments";
 
 /// Creates a placeholder argument.
 pub(super) fn dummy_arg(ident: Ident) -> Param {
@@ -659,7 +660,7 @@ impl<'a> Parser<'a> {
                                 Ok(_) => {
                                     e.span_suggestion_verbose(
                                         binop.span.shrink_to_lo(),
-                                        "use `::<...>` instead of `<...>` to specify type arguments",
+                                        TURBOFISH_SUGGESTION_STR,
                                         "::".to_string(),
                                         Applicability::MaybeIncorrect,
                                     );
@@ -814,7 +815,7 @@ impl<'a> Parser<'a> {
                 let suggest = |err: &mut DiagnosticBuilder<'_>| {
                     err.span_suggestion_verbose(
                         op.span.shrink_to_lo(),
-                        TURBOFISH,
+                        TURBOFISH_SUGGESTION_STR,
                         "::".to_string(),
                         Applicability::MaybeIncorrect,
                     );
@@ -888,7 +889,7 @@ impl<'a> Parser<'a> {
                         {
                             // All we know is that this is `foo < bar >` and *nothing* else. Try to
                             // be helpful, but don't attempt to recover.
-                            err.help(TURBOFISH);
+                            err.help(TURBOFISH_SUGGESTION_STR);
                             err.help("or use `(...)` if you meant to specify fn arguments");
                         }
 

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces-without-turbofish.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces-without-turbofish.stderr
@@ -4,7 +4,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR + 3>();
    |        ^       ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR + 3>();
    |        ^^
@@ -15,7 +15,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR + BAR>();
    |        ^         ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR + BAR>();
    |        ^^
@@ -26,7 +26,7 @@ error: comparison operators cannot be chained
 LL |     foo<3 + 3>();
    |        ^     ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<3 + 3>();
    |        ^^
@@ -37,7 +37,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - 3>();
    |        ^       ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - 3>();
    |        ^^
@@ -48,7 +48,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - BAR>();
    |        ^         ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - BAR>();
    |        ^^
@@ -59,7 +59,7 @@ error: comparison operators cannot be chained
 LL |     foo<100 - BAR>();
    |        ^         ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<100 - BAR>();
    |        ^^
@@ -70,7 +70,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar<i32>()>();
    |        ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar<i32>()>();
    |        ^^
@@ -87,7 +87,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar::<i32>()>();
    |        ^            ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar::<i32>()>();
    |        ^^
@@ -98,7 +98,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar::<i32>() + BAR>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar::<i32>() + BAR>();
    |        ^^
@@ -109,7 +109,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar::<i32>() - BAR>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar::<i32>() - BAR>();
    |        ^^
@@ -120,7 +120,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - bar::<i32>()>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |        ^^
@@ -131,7 +131,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - bar::<i32>()>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |        ^^

--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -4,7 +4,7 @@ error: comparison operators cannot be chained
 LL |     (0..13).collect<Vec<i32>>();
    |                    ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     (0..13).collect::<Vec<i32>>();
    |                    ^^
@@ -15,7 +15,7 @@ error: comparison operators cannot be chained
 LL |     Vec<i32>::new();
    |        ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     Vec::<i32>::new();
    |        ^^
@@ -26,7 +26,7 @@ error: comparison operators cannot be chained
 LL |     (0..13).collect<Vec<i32>();
    |                    ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     (0..13).collect::<Vec<i32>();
    |                    ^^
@@ -37,7 +37,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
 LL |     let x = std::collections::HashMap<i128, i128>::new();
    |                                           ^ expected one of 7 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     let x = std::collections::HashMap::<i128, i128>::new();
    |                                      ^^
@@ -48,7 +48,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 LL |         std::collections::HashMap<i128, i128>::new()
    |                                       ^ expected one of 8 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |         std::collections::HashMap::<i128, i128>::new()
    |                                  ^^
@@ -59,7 +59,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 LL |         std::collections::HashMap<i128, i128>::new();
    |                                       ^ expected one of 8 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |         std::collections::HashMap::<i128, i128>::new();
    |                                  ^^
@@ -70,7 +70,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 LL |         std::collections::HashMap<i128, i128>::new(1, 2);
    |                                       ^ expected one of 8 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |         std::collections::HashMap::<i128, i128>::new(1, 2);
    |                                  ^^

--- a/src/test/ui/parser/require-parens-for-chained-comparison.rs
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.rs
@@ -12,15 +12,15 @@ fn main() {
 
     f<X>();
     //~^ ERROR comparison operators cannot be chained
-    //~| HELP use `::<...>` instead of `<...>` to specify type arguments
+    //~| HELP use `::<...>` instead of `<...>` to specify type or const arguments
 
     f<Result<Option<X>, Option<Option<X>>>(1, 2);
     //~^ ERROR comparison operators cannot be chained
-    //~| HELP use `::<...>` instead of `<...>` to specify type arguments
+    //~| HELP use `::<...>` instead of `<...>` to specify type or const arguments
 
     use std::convert::identity;
     let _ = identity<u8>;
     //~^ ERROR comparison operators cannot be chained
-    //~| HELP use `::<...>` instead of `<...>` to specify type arguments
+    //~| HELP use `::<...>` instead of `<...>` to specify type or const arguments
     //~| HELP or use `(...)` if you meant to specify fn arguments
 }

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -26,7 +26,7 @@ error: comparison operators cannot be chained
 LL |     f<X>();
    |      ^ ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     f::<X>();
    |      ^^
@@ -37,7 +37,7 @@ error: comparison operators cannot be chained
 LL |     f<Result<Option<X>, Option<Option<X>>>(1, 2);
    |      ^      ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     f::<Result<Option<X>, Option<Option<X>>>(1, 2);
    |      ^^
@@ -48,7 +48,7 @@ error: comparison operators cannot be chained
 LL |     let _ = identity<u8>;
    |                     ^  ^
    |
-   = help: use `::<...>` instead of `<...>` to specify type arguments
+   = help: use `::<...>` instead of `<...>` to specify type or const arguments
    = help: or use `(...)` if you meant to specify fn arguments
 
 error: aborting due to 5 previous errors


### PR DESCRIPTION
Types are no longer special. (This message arguably only makes sense with `min_const_generics` or more, but we'll be there soon.)

r? @lcnr 
