### PR TITLE
Add support for custom allocators in `Vec`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1336,9 +1336,10 @@ impl<I> FromIterator<I> for Box<[I]> {
 }
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<T: Clone> Clone for Box<[T]> {
+impl<T: Clone, A: AllocRef + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {
-        self.to_vec().into_boxed_slice()
+        let alloc = Box::alloc_ref(self).clone();
+        self.to_vec_in(alloc).into_boxed_slice()
     }
 
     fn clone_from(&mut self, other: &Self) {

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -233,13 +233,8 @@ impl<T, A: AllocRef> RawVec<T, A> {
     }
 
     /// Returns a shared reference to the allocator backing this `RawVec`.
-    pub fn alloc(&self) -> &A {
+    pub fn alloc_ref(&self) -> &A {
         &self.alloc
-    }
-
-    /// Returns a mutable reference to the allocator backing this `RawVec`.
-    pub fn alloc_mut(&mut self) -> &mut A {
-        &mut self.alloc
     }
 
     fn current_memory(&self) -> Option<(NonNull<u8>, Layout)> {

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -13,7 +13,7 @@
 // gdb-check:$1 = &[i32](len: 4) = {0, 1, 2, 3}
 
 // gdb-command: print vec
-// gdb-check:$2 = Vec<u64>(len: 4, cap: [...]) = {4, 5, 6, 7}
+// gdb-check:$2 = Vec<u64, alloc::alloc::Global>(len: 4, cap: [...]) = {4, 5, 6, 7}
 
 // gdb-command: print str_slice
 // gdb-check:$3 = "IAMA string slice!"
@@ -74,7 +74,7 @@
 // NOTE: While slices have a .natvis entry that works in VS & VS Code, it fails in CDB 10.0.18362.1
 
 // cdb-command: dx vec,d
-// cdb-check:vec,d [...] : { size=4 } [Type: [...]::Vec<u64>]
+// cdb-check:vec,d [...] : { size=4 } [Type: [...]::Vec<u64, alloc::alloc::Global>]
 // cdb-check:    [size]           : 4 [Type: [...]]
 // cdb-check:    [capacity]       : [...] [Type: [...]]
 // cdb-check:    [0]              : 4 [Type: unsigned __int64]

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -1,10 +1,11 @@
 // aux-build:impl_trait_aux.rs
 // edition:2018
+// ignore-tidy-linelength
 
 extern crate impl_trait_aux;
 
 // @has impl_trait/fn.func.html
-// @has - '//pre[@class="rust fn"]' "pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
+// @has - '//pre[@class="rust fn"]' "pub fn func<'a>(_x: impl Clone + Into<Vec<u8, Global>> + 'a)"
 // @!has - '//pre[@class="rust fn"]' 'where'
 pub use impl_trait_aux::func;
 
@@ -31,7 +32,7 @@ pub use impl_trait_aux::func4;
 pub use impl_trait_aux::async_fn;
 
 // @has impl_trait/struct.Foo.html
-// @has - '//*[@id="method.method"]//code' "pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
+// @has - '//*[@id="method.method"]//code' "pub fn method<'a>(_x: impl Clone + Into<Vec<u8, Global>> + 'a)"
 // @!has - '//*[@id="method.method"]//code' 'where'
 pub use impl_trait_aux::Foo;
 

--- a/src/test/ui/associated-types/defaults-wf.stderr
+++ b/src/test/ui/associated-types/defaults-wf.stderr
@@ -6,7 +6,7 @@ LL |     type Ty = Vec<[u8]>;
    | 
   ::: $SRC_DIR/alloc/src/vec.rs:LL:COL
    |
-LL | pub struct Vec<T> {
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global> {
    |                - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `[u8]`

--- a/src/test/ui/bad/bad-sized.stderr
+++ b/src/test/ui/bad/bad-sized.stderr
@@ -17,7 +17,7 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    | 
   ::: $SRC_DIR/alloc/src/vec.rs:LL:COL
    |
-LL | pub struct Vec<T> {
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global> {
    |                - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`

--- a/src/test/ui/const-generics/invalid-constant-in-args.rs
+++ b/src/test/ui/const-generics/invalid-constant-in-args.rs
@@ -1,4 +1,6 @@
+use std::cell::Cell;
+
 fn main() {
-    let _: Vec<&str, "a"> = Vec::new();
+    let _: Cell<&str, "a"> = Cell::new("");
     //~^ ERROR wrong number of generic arguments
 }

--- a/src/test/ui/const-generics/invalid-constant-in-args.stderr
+++ b/src/test/ui/const-generics/invalid-constant-in-args.stderr
@@ -1,8 +1,8 @@
 error[E0107]: wrong number of generic arguments: expected 1, found 2
-  --> $DIR/invalid-constant-in-args.rs:2:22
+  --> $DIR/invalid-constant-in-args.rs:4:23
    |
-LL |     let _: Vec<&str, "a"> = Vec::new();
-   |                      ^^^ unexpected const argument
+LL |     let _: Cell<&str, "a"> = Cell::new("");
+   |                       ^^^ unexpected const argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20433.stderr
+++ b/src/test/ui/issues/issue-20433.stderr
@@ -6,7 +6,7 @@ LL |     fn iceman(c: Vec<[i32]>) {}
    | 
   ::: $SRC_DIR/alloc/src/vec.rs:LL:COL
    |
-LL | pub struct Vec<T> {
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global> {
    |                - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `[i32]`

--- a/src/test/ui/type/ascription/issue-34255-1.rs
+++ b/src/test/ui/type/ascription/issue-34255-1.rs
@@ -7,7 +7,7 @@ impl Reactor {
         input_cells: Vec::new()
         //~^ ERROR cannot find value `input_cells` in this scope
         //~| ERROR parenthesized type parameters may only be used with a `Fn` trait
-        //~| ERROR wrong number of type arguments: expected 1, found 0
+        //~| ERROR wrong number of type arguments: expected at least 1, found 0
     }
 }
 

--- a/src/test/ui/type/ascription/issue-34255-1.stderr
+++ b/src/test/ui/type/ascription/issue-34255-1.stderr
@@ -10,11 +10,11 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
 LL |         input_cells: Vec::new()
    |                           ^^^^^ only `Fn` traits may use parentheses
 
-error[E0107]: wrong number of type arguments: expected 1, found 0
+error[E0107]: wrong number of type arguments: expected at least 1, found 0
   --> $DIR/issue-34255-1.rs:7:22
    |
 LL |         input_cells: Vec::new()
-   |                      ^^^^^^^^^^ expected 1 type argument
+   |                      ^^^^^^^^^^ expected at least 1 type argument
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This follows the [roadmap](https://github.com/rust-lang/wg-allocators/issues/7) of the allocator WG to add custom allocators to collections.

r? @Amanieu 

This pull request requires a crater run.

### Prior work:
- #71873: Crater-test to solve rust-lang/wg-allocators#1
- [`alloc-wg`](https://github.com/TimDiekmann/alloc-wg)-crate