### PR TITLE
Change as_str → to_string in proc_macro::Ident::span() docs

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -881,7 +881,7 @@ impl Ident {
     }
 
     /// Returns the span of this `Ident`, encompassing the entire string returned
-    /// by `as_str`.
+    /// by [`to_string`](Self::to_string).
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn span(&self) -> Span {
         Span(self.0.span())


### PR DESCRIPTION
There is no `as_str` function on Ident any more.

Also change it to an intra doc link while we're at it.