### PR TITLE
add options to use optimized and mangled compiler builtins

### DIFF
--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -31,3 +31,5 @@ harness = false
 [features]
 compiler-builtins-mem = ['compiler_builtins/mem']
 compiler-builtins-c = ["compiler_builtins/c"]
+compiler-builtins-asm = ["compiler_builtins/asm"]
+compiler-builtins-mangled-names = ["compiler_builtins/mangled-names"]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -60,6 +60,8 @@ panic-unwind = ["panic_unwind"]
 profiler = ["profiler_builtins"]
 compiler-builtins-c = ["alloc/compiler-builtins-c"]
 compiler-builtins-mem = ["alloc/compiler-builtins-mem"]
+compiler-builtins-asm = ["alloc/compiler-builtins-asm"]
+compiler-builtins-mangled-names = ["alloc/compiler-builtins-mangled-names"]
 llvm-libunwind = ["unwind/llvm-libunwind"]
 system-llvm-libunwind = ["unwind/system-llvm-libunwind"]
 


### PR DESCRIPTION
In principle the compiler builtin features are also offered to alloc and std.