### PR TITLE
BTreeMap: fix pointer provenance rules

### DIFF
--- a/library/alloc/src/collections/btree/search.rs
+++ b/library/alloc/src/collections/btree/search.rs
@@ -72,7 +72,7 @@ where
     // is an index -- not a reference.
     let len = node.len();
     for i in 0..len {
-        let k = unsafe { node.key_at(i) };
+        let k = unsafe { node.reborrow().key_at(i) };
         match key.cmp(k.borrow()) {
             Ordering::Greater => {}
             Ordering::Equal => return (i, true),

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -78,6 +78,7 @@
 #![cfg_attr(test, feature(new_uninit))]
 #![feature(allocator_api)]
 #![feature(array_chunks)]
+#![feature(array_methods)]
 #![feature(array_value_iter)]
 #![feature(array_windows)]
 #![feature(allow_internal_unstable)]


### PR DESCRIPTION
Fixes #78477 and includes #78476

r? @Mark-Simulacrum 