### PR TITLE
sip hasher: fix pointer provenance problem

### DIFF
--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -111,7 +111,7 @@ macro_rules! load_int_le {
         debug_assert!($i + mem::size_of::<$int_ty>() <= $buf.len());
         let mut data = 0 as $int_ty;
         ptr::copy_nonoverlapping(
-            $buf.get_unchecked($i),
+            $buf.as_ptr().add($i),
             &mut data as *mut _ as *mut u8,
             mem::size_of::<$int_ty>(),
         );


### PR DESCRIPTION
The sip hasher code uses `get_unchecked` to get a reference to a particular element, but then turns that into a raw pointer and also accesses neighboring elements. Use `as_ptr().add` instead to avoid restricting the resulting raw pointer to a single element.