### PR TITLE
Inline NonZeroN::from(n)

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -92,6 +92,7 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 doc_comment! {
                     concat!(
 "Converts a `", stringify!($Ty), "` into an `", stringify!($Int), "`"),
+                    #[inline]
                     fn from(nonzero: $Ty) -> Self {
                         nonzero.0
                     }


### PR DESCRIPTION
Currently this results in the generated assembly having a function call for this trivial conversion.