### PR TITLE
Rollup of 16 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "chalk-ir",
+ "either",
  "measureme 9.0.0",
  "polonius-engine",
  "rustc-rayon-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,7 +3883,6 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "chalk-ir",
- "either",
  "measureme 9.0.0",
  "polonius-engine",
  "rustc-rayon-core",

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -206,8 +206,10 @@ pub enum Res<Id = hir::HirId> {
     /// ```rust
     /// impl Foo { fn test() -> [u8; std::mem::size_of::<Self>()] {} }
     /// ```
+    /// We do however allow `Self` in repeat expression even if it is generic to not break code
+    /// which already works on stable while causing the `const_evaluatable_unchecked` future compat lint.
     ///
-    /// FIXME(lazy_normalization_consts): Remove this bodge once this feature is stable.
+    /// FIXME(lazy_normalization_consts): Remove this bodge once that feature is stable.
     SelfTy(Option<DefId> /* trait */, Option<(DefId, bool)> /* impl */),
     ToolMod, // e.g., `rustfmt` in `#[rustfmt::skip]`
 

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -678,8 +678,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
     pub fn unsolved_variables(&self) -> Vec<Ty<'tcx>> {
         let mut inner = self.inner.borrow_mut();
-        // FIXME(const_generics): should there be an equivalent function for const variables?
-
         let mut vars: Vec<Ty<'_>> = inner
             .type_variables()
             .unsolved_variables()

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -439,7 +439,7 @@ fn lint_literal<'tcx>(
                 cx.struct_span_lint(OVERFLOWING_LITERALS, e.span, |lint| {
                     lint.build(&format!("literal out of range for `{}`", t.name_str()))
                         .note(&format!(
-                            "the literal `{}` does not fit into the type `{}` and will be converted to `std::{}::INFINITY`",
+                            "the literal `{}` does not fit into the type `{}` and will be converted to `{}::INFINITY`",
                             cx.sess()
                                 .source_map()
                                 .span_to_snippet(lit.span)

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -765,7 +765,7 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateTypedef(
     LLVMMetadataRef File, unsigned LineNo, LLVMMetadataRef Scope) {
   return wrap(Builder->createTypedef(
     unwrap<DIType>(Type), StringRef(Name, NameLen), unwrap<DIFile>(File),
-    LineNo, unwrap<DIScope>(Scope)));
+    LineNo, unwrapDIPtr<DIScope>(Scope)));
 }
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreatePointerType(

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-either = "1.5.0"
 rustc_arena = { path = "../rustc_arena" }
 bitflags = "1.2.1"
 tracing = "0.1"

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 doctest = false
 
 [dependencies]
+either = "1.5.0"
 rustc_arena = { path = "../rustc_arena" }
 bitflags = "1.2.1"
 tracing = "0.1"

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -5,6 +5,8 @@
 use self::InferTy::*;
 use self::TyKind::*;
 
+use either::Either;
+
 use crate::infer::canonical::Canonical;
 use crate::ty::subst::{GenericArg, InternalSubsts, Subst, SubstsRef};
 use crate::ty::{
@@ -388,9 +390,17 @@ impl<'tcx> ClosureSubsts<'tcx> {
         self.split().parent_substs
     }
 
+    /// Returns an iterator over the list of types of captured paths by the closure.
+    /// In case there was a type error in figuring out the types of the captured path, an
+    /// empty iterator is returned.
     #[inline]
     pub fn upvar_tys(self) -> impl Iterator<Item = Ty<'tcx>> + 'tcx {
-        self.tupled_upvars_ty().tuple_fields()
+        match self.tupled_upvars_ty().kind() {
+            TyKind::Error(_) => Either::Left(std::iter::empty()),
+            TyKind::Tuple(..) => Either::Right(self.tupled_upvars_ty().tuple_fields()),
+            TyKind::Infer(_) => bug!("upvar_tys called before capture types are inferred"),
+            ty => bug!("Unexpected representation of upvar types tuple {:?}", ty),
+        }
     }
 
     /// Returns the tuple type representing the upvars for this closure.
@@ -515,9 +525,17 @@ impl<'tcx> GeneratorSubsts<'tcx> {
         self.split().witness.expect_ty()
     }
 
+    /// Returns an iterator over the list of types of captured paths by the generator.
+    /// In case there was a type error in figuring out the types of the captured path, an
+    /// empty iterator is returned.
     #[inline]
     pub fn upvar_tys(self) -> impl Iterator<Item = Ty<'tcx>> + 'tcx {
-        self.tupled_upvars_ty().tuple_fields()
+        match self.tupled_upvars_ty().kind() {
+            TyKind::Error(_) => Either::Left(std::iter::empty()),
+            TyKind::Tuple(..) => Either::Right(self.tupled_upvars_ty().tuple_fields()),
+            TyKind::Infer(_) => bug!("upvar_tys called before capture types are inferred"),
+            ty => bug!("Unexpected representation of upvar types tuple {:?}", ty),
+        }
     }
 
     /// Returns the tuple type representing the upvars for this generator.
@@ -660,13 +678,15 @@ pub enum UpvarSubsts<'tcx> {
 }
 
 impl<'tcx> UpvarSubsts<'tcx> {
+    /// Returns an iterator over the list of types of captured paths by the closure/generator.
+    /// In case there was a type error in figuring out the types of the captured path, an
+    /// empty iterator is returned.
     #[inline]
     pub fn upvar_tys(self) -> impl Iterator<Item = Ty<'tcx>> + 'tcx {
-        let tupled_upvars_ty = match self {
-            UpvarSubsts::Closure(substs) => substs.as_closure().split().tupled_upvars_ty,
-            UpvarSubsts::Generator(substs) => substs.as_generator().split().tupled_upvars_ty,
-        };
-        tupled_upvars_ty.expect_ty().tuple_fields()
+        match self {
+            UpvarSubsts::Closure(substs) => Either::Left(substs.as_closure().upvar_tys()),
+            UpvarSubsts::Generator(substs) => Either::Right(substs.as_generator().upvar_tys()),
+        }
     }
 
     #[inline]

--- a/compiler/rustc_mir/src/dataflow/impls/borrows.rs
+++ b/compiler/rustc_mir/src/dataflow/impls/borrows.rs
@@ -177,7 +177,7 @@ impl<'a, 'tcx> Borrows<'a, 'tcx> {
         //
         // We are careful always to call this function *before* we
         // set up the gen-bits for the statement or
-        // termanator. That way, if the effect of the statement or
+        // terminator. That way, if the effect of the statement or
         // terminator *does* introduce a new loan of the same
         // region, then setting that gen-bit will override any
         // potential kill introduced here.

--- a/compiler/rustc_mir/src/dataflow/impls/liveness.rs
+++ b/compiler/rustc_mir/src/dataflow/impls/liveness.rs
@@ -8,7 +8,7 @@ use crate::dataflow::{AnalysisDomain, Backward, GenKill, GenKillAnalysis};
 ///
 /// This analysis considers references as being used only at the point of the
 /// borrow. In other words, this analysis does not track uses because of references that already
-/// exist. See [this `mir-datalow` test][flow-test] for an example. You almost never want to use
+/// exist. See [this `mir-dataflow` test][flow-test] for an example. You almost never want to use
 /// this analysis without also looking at the results of [`MaybeBorrowedLocals`].
 ///
 /// [`MaybeBorrowedLocals`]: ../struct.MaybeBorrowedLocals.html
@@ -134,7 +134,7 @@ impl DefUse {
 
             // `MutatingUseContext::Call` and `MutatingUseContext::Yield` indicate that this is the
             // destination place for a `Call` return or `Yield` resume respectively. Since this is
-            // only a `Def` when the function returns succesfully, we handle this case separately
+            // only a `Def` when the function returns successfully, we handle this case separately
             // in `call_return_effect` above.
             PlaceContext::MutatingUse(MutatingUseContext::Call | MutatingUseContext::Yield) => None,
 

--- a/compiler/rustc_mir/src/interpret/validity.rs
+++ b/compiler/rustc_mir/src/interpret/validity.rs
@@ -559,9 +559,8 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
                 // Nothing to check.
                 Ok(true)
             }
-            // The above should be all the (inhabited) primitive types. The rest is compound, we
+            // The above should be all the primitive types. The rest is compound, we
             // check them by visiting their fields/variants.
-            // (`Str` UTF-8 check happens in `visit_aggregate`, too.)
             ty::Adt(..)
             | ty::Tuple(..)
             | ty::Array(..)

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -20,7 +20,8 @@ use rustc_span::{MultiSpan, Span, SpanSnippetError, DUMMY_SP};
 
 use tracing::{debug, trace};
 
-const TURBOFISH: &str = "use `::<...>` instead of `<...>` to specify type arguments";
+const TURBOFISH_SUGGESTION_STR: &str =
+    "use `::<...>` instead of `<...>` to specify type or const arguments";
 
 /// Creates a placeholder argument.
 pub(super) fn dummy_arg(ident: Ident) -> Param {
@@ -659,7 +660,7 @@ impl<'a> Parser<'a> {
                                 Ok(_) => {
                                     e.span_suggestion_verbose(
                                         binop.span.shrink_to_lo(),
-                                        "use `::<...>` instead of `<...>` to specify type arguments",
+                                        TURBOFISH_SUGGESTION_STR,
                                         "::".to_string(),
                                         Applicability::MaybeIncorrect,
                                     );
@@ -814,7 +815,7 @@ impl<'a> Parser<'a> {
                 let suggest = |err: &mut DiagnosticBuilder<'_>| {
                     err.span_suggestion_verbose(
                         op.span.shrink_to_lo(),
-                        TURBOFISH,
+                        TURBOFISH_SUGGESTION_STR,
                         "::".to_string(),
                         Applicability::MaybeIncorrect,
                     );
@@ -888,7 +889,7 @@ impl<'a> Parser<'a> {
                         {
                             // All we know is that this is `foo < bar >` and *nothing* else. Try to
                             // be helpful, but don't attempt to recover.
-                            err.help(TURBOFISH);
+                            err.help(TURBOFISH_SUGGESTION_STR);
                             err.help("or use `(...)` if you meant to specify fn arguments");
                         }
 

--- a/compiler/rustc_span/src/caching_source_map_view.rs
+++ b/compiler/rustc_span/src/caching_source_map_view.rs
@@ -1,13 +1,25 @@
 use crate::source_map::SourceMap;
 use crate::{BytePos, SourceFile};
 use rustc_data_structures::sync::Lrc;
+use std::ops::Range;
 
 #[derive(Clone)]
 struct CacheEntry {
     time_stamp: usize,
     line_number: usize,
-    line_start: BytePos,
-    line_end: BytePos,
+    // The line's byte position range in the `SourceMap`. This range will fail to contain a valid
+    // position in certain edge cases. Spans often start/end one past something, and when that
+    // something is the last character of a file (this can happen when a file doesn't end in a
+    // newline, for example), we'd still like for the position to be considered within the last
+    // line. However, it isn't according to the exclusive upper bound of this range. We cannot
+    // change the upper bound to be inclusive, because for most lines, the upper bound is the same
+    // as the lower bound of the next line, so there would be an ambiguity.
+    //
+    // Since the containment aspect of this range is only used to see whether or not the cache
+    // entry contains a position, the only ramification of the above is that we will get cache
+    // misses for these rare positions. A line lookup for the position via `SourceMap::lookup_line`
+    // after a cache miss will produce the last line number, as desired.
+    line: Range<BytePos>,
     file: Lrc<SourceFile>,
     file_index: usize,
 }
@@ -26,8 +38,7 @@ impl<'sm> CachingSourceMapView<'sm> {
         let entry = CacheEntry {
             time_stamp: 0,
             line_number: 0,
-            line_start: BytePos(0),
-            line_end: BytePos(0),
+            line: BytePos(0)..BytePos(0),
             file: first_file,
             file_index: 0,
         };
@@ -47,13 +58,13 @@ impl<'sm> CachingSourceMapView<'sm> {
 
         // Check if the position is in one of the cached lines
         for cache_entry in self.line_cache.iter_mut() {
-            if line_contains((cache_entry.line_start, cache_entry.line_end), pos) {
+            if cache_entry.line.contains(&pos) {
                 cache_entry.time_stamp = self.time_stamp;
 
                 return Some((
                     cache_entry.file.clone(),
                     cache_entry.line_number,
-                    pos - cache_entry.line_start,
+                    pos - cache_entry.line.start,
                 ));
             }
         }
@@ -95,28 +106,11 @@ impl<'sm> CachingSourceMapView<'sm> {
         let line_bounds = cache_entry.file.line_bounds(line_index);
 
         cache_entry.line_number = line_index + 1;
-        cache_entry.line_start = line_bounds.0;
-        cache_entry.line_end = line_bounds.1;
+        cache_entry.line = line_bounds;
         cache_entry.time_stamp = self.time_stamp;
 
-        Some((cache_entry.file.clone(), cache_entry.line_number, pos - cache_entry.line_start))
+        Some((cache_entry.file.clone(), cache_entry.line_number, pos - cache_entry.line.start))
     }
-}
-
-#[inline]
-fn line_contains(line_bounds: (BytePos, BytePos), pos: BytePos) -> bool {
-    // This condition will be false in one case where we'd rather it wasn't. Spans often start/end
-    // one past something, and when that something is the last character of a file (this can happen
-    // when a file doesn't end in a newline, for example), we'd still like for the position to be
-    // considered within the last line. However, it isn't according to the exclusive upper bound
-    // below. We cannot change the upper bound to be inclusive, because for most lines, the upper
-    // bound is the same as the lower bound of the next line, so there would be an ambiguity.
-    //
-    // Supposing we only use this function to check whether or not the line cache entry contains
-    // a position, the only ramification of the above is that we will get cache misses for these
-    // rare positions. A line lookup for the position via `SourceMap::lookup_line` after a cache
-    // miss will produce the last line number, as desired.
-    line_bounds.0 <= pos && pos < line_bounds.1
 }
 
 #[inline]

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1427,7 +1427,7 @@ impl SourceFile {
     }
 
     pub fn line_bounds(&self, line_index: usize) -> (BytePos, BytePos) {
-        if self.start_pos == self.end_pos {
+        if self.is_empty() {
             return (self.start_pos, self.end_pos);
         }
 
@@ -1439,9 +1439,18 @@ impl SourceFile {
         }
     }
 
+    /// Returns whether or not the file contains the given `SourceMap` byte
+    /// position. The position one past the end of the file is considered to be
+    /// contained by the file. This implies that files for which `is_empty`
+    /// returns true still contain one byte position according to this function.
     #[inline]
     pub fn contains(&self, byte_pos: BytePos) -> bool {
         byte_pos >= self.start_pos && byte_pos <= self.end_pos
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.start_pos == self.end_pos
     }
 
     /// Calculates the original byte position relative to the start of the file

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -52,7 +52,7 @@ use std::cell::RefCell;
 use std::cmp::{self, Ordering};
 use std::fmt;
 use std::hash::Hash;
-use std::ops::{Add, Sub};
+use std::ops::{Add, Range, Sub};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -1426,16 +1426,16 @@ impl SourceFile {
         if line_index >= 0 { Some(line_index as usize) } else { None }
     }
 
-    pub fn line_bounds(&self, line_index: usize) -> (BytePos, BytePos) {
+    pub fn line_bounds(&self, line_index: usize) -> Range<BytePos> {
         if self.is_empty() {
-            return (self.start_pos, self.end_pos);
+            return self.start_pos..self.end_pos;
         }
 
         assert!(line_index < self.lines.len());
         if line_index == (self.lines.len() - 1) {
-            (self.lines[line_index], self.end_pos)
+            self.lines[line_index]..self.end_pos
         } else {
-            (self.lines[line_index], self.lines[line_index + 1])
+            self.lines[line_index]..self.lines[line_index + 1]
         }
     }
 

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -92,6 +92,7 @@ assert_eq!(size_of::<Option<core::num::", stringify!($Ty), ">>(), size_of::<", s
                 doc_comment! {
                     concat!(
 "Converts a `", stringify!($Ty), "` into an `", stringify!($Int), "`"),
+                    #[inline]
                     fn from(nonzero: $Ty) -> Self {
                         nonzero.0
                     }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -881,7 +881,7 @@ impl Ident {
     }
 
     /// Returns the span of this `Ident`, encompassing the entire string returned
-    /// by `as_str`.
+    /// by [to_string](Self::to_string).
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     pub fn span(&self) -> Span {
         Span(self.0.span())

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -446,7 +446,7 @@ impl Hash for PrefixComponent<'_> {
 /// (`/` or `\`).
 ///
 /// This `enum` is created by iterating over [`Components`], which in turn is
-/// created by the [`components`][`Path::components`] method on [`Path`].
+/// created by the [`components`](Path::components) method on [`Path`].
 ///
 /// # Examples
 ///
@@ -1319,7 +1319,7 @@ impl PathBuf {
         self.inner
     }
 
-    /// Converts this `PathBuf` into a [boxed][`Box`] [`Path`].
+    /// Converts this `PathBuf` into a [boxed](Box) [`Path`].
     #[stable(feature = "into_boxed_path", since = "1.20.0")]
     pub fn into_boxed_path(self) -> Box<Path> {
         let rw = Box::into_raw(self.inner.into_boxed_os_str()) as *mut Path;
@@ -1686,8 +1686,7 @@ pub struct Path {
     inner: OsStr,
 }
 
-/// An error returned from [`Path::strip_prefix`][`strip_prefix`] if the prefix
-/// was not found.
+/// An error returned from [`Path::strip_prefix`] if the prefix was not found.
 ///
 /// This `struct` is created by the [`strip_prefix`] method on [`Path`].
 /// See its documentation for more.
@@ -2470,7 +2469,7 @@ impl Path {
         fs::metadata(self).map(|m| m.is_dir()).unwrap_or(false)
     }
 
-    /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or
+    /// Converts a [`Box<Path>`](Box) into a [`PathBuf`] without copying or
     /// allocating.
     #[stable(feature = "into_boxed_path", since = "1.20.0")]
     pub fn into_path_buf(self: Box<Path>) -> PathBuf {
@@ -2498,7 +2497,7 @@ impl fmt::Debug for Path {
 ///
 /// A [`Path`] might contain non-Unicode data. This `struct` implements the
 /// [`Display`] trait in a way that mitigates that. It is created by the
-/// [`display`][`Path::display`] method on [`Path`].
+/// [`display`](Path::display) method on [`Path`].
 ///
 /// # Examples
 ///

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -348,7 +348,7 @@ Using this flag looks like this:
 $ rustdoc src/lib.rs -Z unstable-options --enable-per-target-ignores
 ```
 
-This flag allows you to tag doctests with compiltest style `ignore-foo` filters that prevent
+This flag allows you to tag doctests with compiletest style `ignore-foo` filters that prevent
 rustdoc from running that test if the target triple string contains foo. For example:
 
 ```rust

--- a/src/test/ui/const-generics/dyn-supertraits.rs
+++ b/src/test/ui/const-generics/dyn-supertraits.rs
@@ -1,0 +1,58 @@
+// check-pass
+// revisions: full min
+
+#![cfg_attr(full, feature(const_generics))]
+#![cfg_attr(full, allow(incomplete_features))]
+#![cfg_attr(min, feature(min_const_generics))]
+
+trait Foo<const N: usize> {}
+trait Bar<const N: usize> : Foo<N> {}
+trait Baz: Foo<3> {}
+
+struct FooType<const N: usize> {}
+struct BarType<const N: usize> {}
+struct BazType {}
+
+impl<const N: usize> Foo<N> for FooType<N> {}
+impl<const N: usize> Foo<N> for BarType<N> {}
+impl<const N: usize> Bar<N> for BarType<N> {}
+impl Foo<3> for BazType {}
+impl Baz for BazType {}
+
+trait Foz {}
+trait Boz: Foo<3> + Foz {}
+trait Bok<const N: usize>: Foo<N> + Foz {}
+
+struct FozType {}
+struct BozType {}
+struct BokType<const N: usize> {}
+
+impl Foz for FozType {}
+
+impl Foz for BozType {}
+impl Foo<3> for BozType {}
+impl Boz for BozType {}
+
+impl<const N: usize> Foz for BokType<N> {}
+impl<const N: usize> Foo<N> for BokType<N> {}
+impl<const N: usize> Bok<N> for BokType<N> {}
+
+fn a<const N: usize>(x: &dyn Foo<N>) {}
+fn b(x: &dyn Foo<3>) {}
+
+fn main() {
+    let foo = FooType::<3> {};
+    a(&foo); b(&foo);
+
+    let bar = BarType::<3> {};
+    a(&bar); b(&bar);
+
+    let baz = BazType {};
+    a(&baz); b(&baz);
+
+    let boz = BozType {};
+    a(&boz); b(&boz);
+
+    let bok = BokType::<3> {};
+    a(&bok); b(&bok);
+}

--- a/src/test/ui/const-generics/dyn-supertraits.rs
+++ b/src/test/ui/const-generics/dyn-supertraits.rs
@@ -1,58 +1,82 @@
-// check-pass
+// run-pass
 // revisions: full min
 
 #![cfg_attr(full, feature(const_generics))]
 #![cfg_attr(full, allow(incomplete_features))]
 #![cfg_attr(min, feature(min_const_generics))]
 
-trait Foo<const N: usize> {}
+trait Foo<const N: usize> {
+    fn myfun(&self) -> usize;
+}
 trait Bar<const N: usize> : Foo<N> {}
 trait Baz: Foo<3> {}
 
-struct FooType<const N: usize> {}
-struct BarType<const N: usize> {}
-struct BazType {}
+struct FooType<const N: usize>;
+struct BarType<const N: usize>;
+struct BazType;
 
-impl<const N: usize> Foo<N> for FooType<N> {}
-impl<const N: usize> Foo<N> for BarType<N> {}
+impl<const N: usize> Foo<N> for FooType<N> {
+    fn myfun(&self) -> usize { N }
+}
+impl<const N: usize> Foo<N> for BarType<N> {
+    fn myfun(&self) -> usize { N + 1 }
+}
 impl<const N: usize> Bar<N> for BarType<N> {}
-impl Foo<3> for BazType {}
+impl Foo<3> for BazType {
+    fn myfun(&self) -> usize { 999 }
+}
 impl Baz for BazType {}
 
 trait Foz {}
 trait Boz: Foo<3> + Foz {}
 trait Bok<const N: usize>: Foo<N> + Foz {}
 
-struct FozType {}
-struct BozType {}
-struct BokType<const N: usize> {}
+struct FozType;
+struct BozType;
+struct BokType<const N: usize>;
 
 impl Foz for FozType {}
 
 impl Foz for BozType {}
-impl Foo<3> for BozType {}
+impl Foo<3> for BozType {
+    fn myfun(&self) -> usize { 9999 }
+}
 impl Boz for BozType {}
 
 impl<const N: usize> Foz for BokType<N> {}
-impl<const N: usize> Foo<N> for BokType<N> {}
+impl<const N: usize> Foo<N> for BokType<N> {
+    fn myfun(&self) -> usize { N + 2 }
+}
 impl<const N: usize> Bok<N> for BokType<N> {}
 
-fn a<const N: usize>(x: &dyn Foo<N>) {}
-fn b(x: &dyn Foo<3>) {}
+fn a<const N: usize>(_: &dyn Foo<N>) {}
+fn b(_: &dyn Foo<3>) {}
+fn c<T: Bok<N>, const N: usize>(x: T) { a::<N>(&x); }
+fn d<T: ?Sized + Foo<3>>(_: &T) {}
+fn e(x: &dyn Bar<3>) { d(x); }
+
+fn get_myfun<const N: usize>(x: &dyn Foo<N>) -> usize { x.myfun() }
 
 fn main() {
     let foo = FooType::<3> {};
-    a(&foo); b(&foo);
+    a(&foo); b(&foo); d(&foo);
+    assert!(get_myfun(&foo) == 3);
 
     let bar = BarType::<3> {};
-    a(&bar); b(&bar);
+    a(&bar); b(&bar); d(&bar); e(&bar);
+    assert!(get_myfun(&bar) == 4);
 
     let baz = BazType {};
-    a(&baz); b(&baz);
+    a(&baz); b(&baz); d(&baz);
+    assert!(get_myfun(&baz) == 999);
 
     let boz = BozType {};
-    a(&boz); b(&boz);
+    a(&boz); b(&boz); d(&boz);
+    assert!(get_myfun(&boz) == 9999);
 
     let bok = BokType::<3> {};
-    a(&bok); b(&bok);
+    a(&bok); b(&bok); d(&bok);
+    assert!(get_myfun(&bok) == 5);
+    
+    c(BokType::<3> {});
 }

--- a/src/test/ui/const-generics/dyn-supertraits.rs
+++ b/src/test/ui/const-generics/dyn-supertraits.rs
@@ -49,34 +49,37 @@ impl<const N: usize> Foo<N> for BokType<N> {
 }
 impl<const N: usize> Bok<N> for BokType<N> {}
 
-fn a<const N: usize>(_: &dyn Foo<N>) {}
-fn b(_: &dyn Foo<3>) {}
-fn c<T: Bok<N>, const N: usize>(x: T) { a::<N>(&x); }
-fn d<T: ?Sized + Foo<3>>(_: &T) {}
-fn e(x: &dyn Bar<3>) { d(x); }
-
-fn get_myfun<const N: usize>(x: &dyn Foo<N>) -> usize { x.myfun() }
+fn a<const N: usize>(x: &dyn Foo<N>) -> usize { x.myfun() }
+fn b(x: &dyn Foo<3>) -> usize { x.myfun() }
+fn c<T: Bok<N>, const N: usize>(x: T) -> usize { a::<N>(&x) }
+fn d<T: ?Sized + Foo<3>>(x: &T) -> usize { x.myfun() }
+fn e(x: &dyn Bar<3>) -> usize { d(x) }
 
 fn main() {
     let foo = FooType::<3> {};
-    a(&foo); b(&foo); d(&foo);
-    assert!(get_myfun(&foo) == 3);
+    assert!(a(&foo) == 3);
+    assert!(b(&foo) == 3);
+    assert!(d(&foo) == 3);
 
     let bar = BarType::<3> {};
-    a(&bar); b(&bar); d(&bar); e(&bar);
-    assert!(get_myfun(&bar) == 4);
+    assert!(a(&bar) == 4);
+    assert!(b(&bar) == 4);
+    assert!(d(&bar) == 4);
+    assert!(e(&bar) == 4);
 
     let baz = BazType {};
-    a(&baz); b(&baz); d(&baz);
-    assert!(get_myfun(&baz) == 999);
+    assert!(a(&baz) == 999);
+    assert!(b(&baz) == 999);
+    assert!(d(&baz) == 999);
 
     let boz = BozType {};
-    a(&boz); b(&boz); d(&boz);
-    assert!(get_myfun(&boz) == 9999);
+    assert!(a(&boz) == 9999);
+    assert!(b(&boz) == 9999);
+    assert!(d(&boz) == 9999);
 
     let bok = BokType::<3> {};
-    a(&bok); b(&bok); d(&bok);
-    assert!(get_myfun(&bok) == 5);
-    
-    c(BokType::<3> {});
+    assert!(a(&bok) == 5);
+    assert!(b(&bok) == 5);
+    assert!(d(&bok) == 5);
+    assert!(c(BokType::<3> {}) == 5);
 }

--- a/src/test/ui/const-generics/issues/issue-62504.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-62504.min.stderr
@@ -1,14 +1,20 @@
-error: generic `Self` types are currently not permitted in anonymous constants
+error[E0308]: mismatched types
+  --> $DIR/issue-62504.rs:19:21
+   |
+LL |         ArrayHolder([0; Self::SIZE])
+   |                     ^^^^^^^^^^^^^^^ expected `X`, found `Self::SIZE`
+   |
+   = note: expected array `[u32; X]`
+              found array `[u32; _]`
+
+error: constant expression depends on a generic parameter
   --> $DIR/issue-62504.rs:19:25
    |
 LL |         ArrayHolder([0; Self::SIZE])
    |                         ^^^^^^^^^^
    |
-note: not a concrete type
-  --> $DIR/issue-62504.rs:17:22
-   |
-LL | impl<const X: usize> ArrayHolder<X> {
-   |                      ^^^^^^^^^^^^^^
+   = note: this may fail depending on what value the parameter takes
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/issues/issue-62504.rs
+++ b/src/test/ui/const-generics/issues/issue-62504.rs
@@ -17,8 +17,8 @@ struct ArrayHolder<const X: usize>([u32; X]);
 impl<const X: usize> ArrayHolder<X> {
     pub const fn new() -> Self {
         ArrayHolder([0; Self::SIZE])
-        //[full]~^ ERROR constant expression depends on a generic parameter
-        //[min]~^^ ERROR generic `Self` types are currently
+        //~^ ERROR constant expression depends on a generic parameter
+        //[min]~| ERROR mismatched types
     }
 }
 

--- a/src/test/ui/const-generics/issues/issue-67739.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-67739.min.stderr
@@ -1,10 +1,10 @@
-error: generic parameters may not be used in const operations
-  --> $DIR/issue-67739.rs:12:30
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-67739.rs:12:15
    |
 LL |         [0u8; mem::size_of::<Self::Associated>()];
-   |                              ^^^^^^^^^^^^^^^^ cannot perform const operation using `Self`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: type parameters may not be used in const expressions
+   = note: this may fail depending on what value the parameter takes
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-67739.rs
+++ b/src/test/ui/const-generics/issues/issue-67739.rs
@@ -10,8 +10,7 @@ pub trait Trait {
 
     fn associated_size(&self) -> usize {
         [0u8; mem::size_of::<Self::Associated>()];
-        //[full]~^ ERROR constant expression depends on a generic parameter
-        //[min]~^^ ERROR generic parameters may not be used in const operations
+        //~^ ERROR constant expression depends on a generic parameter
         0
     }
 }

--- a/src/test/ui/const-generics/min_const_generics/complex-expression.rs
+++ b/src/test/ui/const-generics/min_const_generics/complex-expression.rs
@@ -1,5 +1,7 @@
 #![feature(min_const_generics)]
 
+use std::mem::size_of;
+
 fn test<const N: usize>() {}
 
 fn ok<const M: usize>() -> [u8; M] {
@@ -21,6 +23,24 @@ fn break3<const N: usize>() {
     let _ = [0; N + 1];
     //~^ ERROR generic parameters may not be used in const operations
 }
+
+struct BreakTy0<T>(T, [u8; { size_of::<*mut T>() }]);
+//~^ ERROR generic parameters may not be used in const operations
+
+struct BreakTy1<T>(T, [u8; { { size_of::<*mut T>() } }]);
+//~^ ERROR generic parameters may not be used in const operations
+
+fn break_ty2<T>() {
+    let _: [u8; size_of::<*mut T>() + 1];
+    //~^ ERROR generic parameters may not be used in const operations
+}
+
+fn break_ty3<T>() {
+    let _ = [0; size_of::<*mut T>() + 1];
+    //~^ WARN cannot use constants which depend on generic parameters in types
+    //~| WARN this was previously accepted by the compiler but is being phased out
+}
+
 
 trait Foo {
     const ASSOC: usize;

--- a/src/test/ui/const-generics/min_const_generics/complex-expression.stderr
+++ b/src/test/ui/const-generics/min_const_generics/complex-expression.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:9:38
+  --> $DIR/complex-expression.rs:11:38
    |
 LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    |                                      ^ cannot perform const operation using `N`
@@ -7,7 +7,7 @@ LL | struct Break0<const N: usize>([u8; { N + 1 }]);
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:12:40
+  --> $DIR/complex-expression.rs:14:40
    |
 LL | struct Break1<const N: usize>([u8; { { N } }]);
    |                                        ^ cannot perform const operation using `N`
@@ -15,7 +15,7 @@ LL | struct Break1<const N: usize>([u8; { { N } }]);
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:16:17
+  --> $DIR/complex-expression.rs:18:17
    |
 LL |     let _: [u8; N + 1];
    |                 ^ cannot perform const operation using `N`
@@ -23,12 +23,46 @@ LL |     let _: [u8; N + 1];
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-expression.rs:21:17
+  --> $DIR/complex-expression.rs:23:17
    |
 LL |     let _ = [0; N + 1];
    |                 ^ cannot perform const operation using `N`
    |
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
-error: aborting due to 4 previous errors
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-expression.rs:27:45
+   |
+LL | struct BreakTy0<T>(T, [u8; { size_of::<*mut T>() }]);
+   |                                             ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-expression.rs:30:47
+   |
+LL | struct BreakTy1<T>(T, [u8; { { size_of::<*mut T>() } }]);
+   |                                               ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-expression.rs:34:32
+   |
+LL |     let _: [u8; size_of::<*mut T>() + 1];
+   |                                ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/complex-expression.rs:39:17
+   |
+LL |     let _ = [0; size_of::<*mut T>() + 1];
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+error: aborting due to 7 previous errors; 1 warning emitted
 

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
@@ -1,4 +1,5 @@
 // check-pass
+#![feature(min_const_generics)]
 #![allow(dead_code)]
 
 fn foo<T>() {
@@ -13,7 +14,19 @@ impl<T> Foo<T> {
     const ASSOC: usize = 4;
 
     fn test() {
-        [0; Self::ASSOC];
+        let _ = [0; Self::ASSOC];
+        //~^ WARN cannot use constants which depend on generic parameters in types
+        //~| WARN this was previously accepted by the compiler but is being phased out
+    }
+}
+
+struct Bar<const N: usize>;
+
+impl<const N: usize> Bar<N> {
+    const ASSOC: usize = 4;
+
+    fn test() {
+        let _ = [0; Self::ASSOC];
         //~^ WARN cannot use constants which depend on generic parameters in types
         //~| WARN this was previously accepted by the compiler but is being phased out
     }

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.rs
@@ -1,0 +1,22 @@
+// check-pass
+#![allow(dead_code)]
+
+fn foo<T>() {
+    [0; std::mem::size_of::<*mut T>()];
+    //~^ WARN cannot use constants which depend on generic parameters in types
+    //~| WARN this was previously accepted by the compiler but is being phased out
+}
+
+struct Foo<T>(T);
+
+impl<T> Foo<T> {
+    const ASSOC: usize = 4;
+
+    fn test() {
+        [0; Self::ASSOC];
+        //~^ WARN cannot use constants which depend on generic parameters in types
+        //~| WARN this was previously accepted by the compiler but is being phased out
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
@@ -1,0 +1,21 @@
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/const-evaluatable-unchecked.rs:5:9
+   |
+LL |     [0; std::mem::size_of::<*mut T>()];
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(const_evaluatable_unchecked)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/const-evaluatable-unchecked.rs:16:13
+   |
+LL |         [0; Self::ASSOC];
+   |             ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-evaluatable-unchecked.stderr
@@ -1,5 +1,5 @@
 warning: cannot use constants which depend on generic parameters in types
-  --> $DIR/const-evaluatable-unchecked.rs:5:9
+  --> $DIR/const-evaluatable-unchecked.rs:6:9
    |
 LL |     [0; std::mem::size_of::<*mut T>()];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,22 @@ LL |     [0; std::mem::size_of::<*mut T>()];
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
 
 warning: cannot use constants which depend on generic parameters in types
-  --> $DIR/const-evaluatable-unchecked.rs:16:13
+  --> $DIR/const-evaluatable-unchecked.rs:17:21
    |
-LL |         [0; Self::ASSOC];
-   |             ^^^^^^^^^^^
+LL |         let _ = [0; Self::ASSOC];
+   |                     ^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
 
-warning: 2 warnings emitted
+warning: cannot use constants which depend on generic parameters in types
+  --> $DIR/const-evaluatable-unchecked.rs:29:21
+   |
+LL |         let _ = [0; Self::ASSOC];
+   |                     ^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
+
+warning: 3 warnings emitted
 

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces-without-turbofish.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces-without-turbofish.stderr
@@ -4,7 +4,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR + 3>();
    |        ^       ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR + 3>();
    |        ^^
@@ -15,7 +15,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR + BAR>();
    |        ^         ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR + BAR>();
    |        ^^
@@ -26,7 +26,7 @@ error: comparison operators cannot be chained
 LL |     foo<3 + 3>();
    |        ^     ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<3 + 3>();
    |        ^^
@@ -37,7 +37,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - 3>();
    |        ^       ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - 3>();
    |        ^^
@@ -48,7 +48,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - BAR>();
    |        ^         ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - BAR>();
    |        ^^
@@ -59,7 +59,7 @@ error: comparison operators cannot be chained
 LL |     foo<100 - BAR>();
    |        ^         ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<100 - BAR>();
    |        ^^
@@ -70,7 +70,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar<i32>()>();
    |        ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar<i32>()>();
    |        ^^
@@ -87,7 +87,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar::<i32>()>();
    |        ^            ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar::<i32>()>();
    |        ^^
@@ -98,7 +98,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar::<i32>() + BAR>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar::<i32>() + BAR>();
    |        ^^
@@ -109,7 +109,7 @@ error: comparison operators cannot be chained
 LL |     foo<bar::<i32>() - BAR>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<bar::<i32>() - BAR>();
    |        ^^
@@ -120,7 +120,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - bar::<i32>()>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |        ^^
@@ -131,7 +131,7 @@ error: comparison operators cannot be chained
 LL |     foo<BAR - bar::<i32>()>();
    |        ^                  ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |        ^^

--- a/src/test/ui/const-generics/min_const_generics/invalid-patterns.rs
+++ b/src/test/ui/const-generics/min_const_generics/invalid-patterns.rs
@@ -1,0 +1,45 @@
+#![feature(min_const_generics)]
+use std::mem::transmute;
+
+fn get_flag<const FlagSet: bool, const ShortName: char>() -> Option<char> {
+  if FlagSet {
+    Some(ShortName)
+  } else {
+    None
+  }
+}
+
+union CharRaw {
+  byte: u8,
+  character: char,
+}
+
+union BoolRaw {
+  byte: u8,
+  boolean: bool,
+}
+
+const char_raw: CharRaw = CharRaw { byte: 0xFF };
+const bool_raw: BoolRaw = BoolRaw { byte: 0x42 };
+
+fn main() {
+  // Test that basic cases don't work
+  assert!(get_flag::<true, 'c'>().is_some());
+  assert!(get_flag::<false, 'x'>().is_none());
+  get_flag::<false, 0xFF>();
+  //~^ ERROR mismatched types
+  get_flag::<7, 'c'>();
+  //~^ ERROR mismatched types
+  get_flag::<42, 0x5ad>();
+  //~^ ERROR mismatched types
+  //~| ERROR mismatched types
+
+
+  get_flag::<false, { unsafe { char_raw.character } }>();
+  //~^ ERROR it is undefined behavior
+  get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
+  //~^ ERROR it is undefined behavior
+  get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
+  //~^ ERROR it is undefined behavior
+  //~| ERROR it is undefined behavior
+}

--- a/src/test/ui/const-generics/min_const_generics/invalid-patterns.stderr
+++ b/src/test/ui/const-generics/min_const_generics/invalid-patterns.stderr
@@ -1,0 +1,60 @@
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:29:21
+   |
+LL |   get_flag::<false, 0xFF>();
+   |                     ^^^^ expected `char`, found `u8`
+
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:31:14
+   |
+LL |   get_flag::<7, 'c'>();
+   |              ^ expected `bool`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:33:14
+   |
+LL |   get_flag::<42, 0x5ad>();
+   |              ^^ expected `bool`, found integer
+
+error[E0308]: mismatched types
+  --> $DIR/invalid-patterns.rs:33:18
+   |
+LL |   get_flag::<42, 0x5ad>();
+   |                  ^^^^^ expected `char`, found `u8`
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:38:21
+   |
+LL |   get_flag::<false, { unsafe { char_raw.character } }>();
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:40:14
+   |
+LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:42:14
+   |
+LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/invalid-patterns.rs:42:47
+   |
+LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0080, E0308.
+For more information about an error, try `rustc --explain E0080`.

--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -4,7 +4,7 @@ error: comparison operators cannot be chained
 LL |     (0..13).collect<Vec<i32>>();
    |                    ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     (0..13).collect::<Vec<i32>>();
    |                    ^^
@@ -15,7 +15,7 @@ error: comparison operators cannot be chained
 LL |     Vec<i32>::new();
    |        ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     Vec::<i32>::new();
    |        ^^
@@ -26,7 +26,7 @@ error: comparison operators cannot be chained
 LL |     (0..13).collect<Vec<i32>();
    |                    ^   ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     (0..13).collect::<Vec<i32>();
    |                    ^^
@@ -37,7 +37,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
 LL |     let x = std::collections::HashMap<i128, i128>::new();
    |                                           ^ expected one of 7 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     let x = std::collections::HashMap::<i128, i128>::new();
    |                                      ^^
@@ -48,7 +48,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 LL |         std::collections::HashMap<i128, i128>::new()
    |                                       ^ expected one of 8 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |         std::collections::HashMap::<i128, i128>::new()
    |                                  ^^
@@ -59,7 +59,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 LL |         std::collections::HashMap<i128, i128>::new();
    |                                       ^ expected one of 8 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |         std::collections::HashMap::<i128, i128>::new();
    |                                  ^^
@@ -70,7 +70,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 LL |         std::collections::HashMap<i128, i128>::new(1, 2);
    |                                       ^ expected one of 8 possible tokens
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |         std::collections::HashMap::<i128, i128>::new(1, 2);
    |                                  ^^

--- a/src/test/ui/issues/issue-77993-1.rs
+++ b/src/test/ui/issues/issue-77993-1.rs
@@ -1,0 +1,12 @@
+#[derive(Clone)]
+struct InGroup<F> {
+    it: It,
+    //~^ ERROR cannot find type `It` in this scope
+    f: F,
+}
+fn dates_in_year() -> impl Clone {
+    InGroup { f: |d| d }
+    //~^ ERROR missing field `it` in initializer of `InGroup<_>`
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-77993-1.stderr
+++ b/src/test/ui/issues/issue-77993-1.stderr
@@ -1,0 +1,16 @@
+error[E0412]: cannot find type `It` in this scope
+  --> $DIR/issue-77993-1.rs:3:9
+   |
+LL |     it: It,
+   |         ^^ not found in this scope
+
+error[E0063]: missing field `it` in initializer of `InGroup<_>`
+  --> $DIR/issue-77993-1.rs:8:5
+   |
+LL |     InGroup { f: |d| d }
+   |     ^^^^^^^ missing `it`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0063, E0412.
+For more information about an error, try `rustc --explain E0063`.

--- a/src/test/ui/issues/issue-77993-2.rs
+++ b/src/test/ui/issues/issue-77993-2.rs
@@ -1,0 +1,9 @@
+// edition:2018
+
+async fn test() -> Result<(), Box<dyn std::error::Error>> {
+    macro!();
+    //~^ ERROR expected identifier, found `!`
+    Ok(())
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-77993-2.stderr
+++ b/src/test/ui/issues/issue-77993-2.stderr
@@ -1,0 +1,8 @@
+error: expected identifier, found `!`
+  --> $DIR/issue-77993-2.rs:4:10
+   |
+LL |     macro!();
+   |          ^ expected identifier
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-type-overflow2.stderr
+++ b/src/test/ui/lint/lint-type-overflow2.stderr
@@ -17,7 +17,7 @@ error: literal out of range for `f32`
 LL |     let x = -3.40282357e+38_f32;
    |              ^^^^^^^^^^^^^^^^^^
    |
-   = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `std::f32::INFINITY`
+   = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `f32::INFINITY`
 
 error: literal out of range for `f32`
   --> $DIR/lint-type-overflow2.rs:10:14
@@ -25,7 +25,7 @@ error: literal out of range for `f32`
 LL |     let x =  3.40282357e+38_f32;
    |              ^^^^^^^^^^^^^^^^^^
    |
-   = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `std::f32::INFINITY`
+   = note: the literal `3.40282357e+38_f32` does not fit into the type `f32` and will be converted to `f32::INFINITY`
 
 error: literal out of range for `f64`
   --> $DIR/lint-type-overflow2.rs:11:14
@@ -33,7 +33,7 @@ error: literal out of range for `f64`
 LL |     let x = -1.7976931348623159e+308_f64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `std::f64::INFINITY`
+   = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `f64::INFINITY`
 
 error: literal out of range for `f64`
   --> $DIR/lint-type-overflow2.rs:12:14
@@ -41,7 +41,7 @@ error: literal out of range for `f64`
 LL |     let x =  1.7976931348623159e+308_f64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `std::f64::INFINITY`
+   = note: the literal `1.7976931348623159e+308_f64` does not fit into the type `f64` and will be converted to `f64::INFINITY`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/parser/require-parens-for-chained-comparison.rs
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.rs
@@ -12,15 +12,15 @@ fn main() {
 
     f<X>();
     //~^ ERROR comparison operators cannot be chained
-    //~| HELP use `::<...>` instead of `<...>` to specify type arguments
+    //~| HELP use `::<...>` instead of `<...>` to specify type or const arguments
 
     f<Result<Option<X>, Option<Option<X>>>(1, 2);
     //~^ ERROR comparison operators cannot be chained
-    //~| HELP use `::<...>` instead of `<...>` to specify type arguments
+    //~| HELP use `::<...>` instead of `<...>` to specify type or const arguments
 
     use std::convert::identity;
     let _ = identity<u8>;
     //~^ ERROR comparison operators cannot be chained
-    //~| HELP use `::<...>` instead of `<...>` to specify type arguments
+    //~| HELP use `::<...>` instead of `<...>` to specify type or const arguments
     //~| HELP or use `(...)` if you meant to specify fn arguments
 }

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -26,7 +26,7 @@ error: comparison operators cannot be chained
 LL |     f<X>();
    |      ^ ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     f::<X>();
    |      ^^
@@ -37,7 +37,7 @@ error: comparison operators cannot be chained
 LL |     f<Result<Option<X>, Option<Option<X>>>(1, 2);
    |      ^      ^
    |
-help: use `::<...>` instead of `<...>` to specify type arguments
+help: use `::<...>` instead of `<...>` to specify type or const arguments
    |
 LL |     f::<Result<Option<X>, Option<Option<X>>>(1, 2);
    |      ^^
@@ -48,7 +48,7 @@ error: comparison operators cannot be chained
 LL |     let _ = identity<u8>;
    |                     ^  ^
    |
-   = help: use `::<...>` instead of `<...>` to specify type arguments
+   = help: use `::<...>` instead of `<...>` to specify type or const arguments
    = help: or use `(...)` if you meant to specify fn arguments
 
 error: aborting due to 5 previous errors


### PR DESCRIPTION
Successful merges:

 - #78224 (min_const_generics: allow ty param in repeat expr)
 - #78423 (rustc_span: improve bounds checks in byte_pos_to_line_and_col)
 - #78428 (MinConstGenerics UI test for invalid values for bool & char)
 - #78431 (Prefer new associated numeric consts in float error messages)
 - #78432 (Handle type errors in closure/generator upvar_tys)
 - #78460 (Adjust turbofish help message for const generics)
 - #78462 (Use unwrapDIPtr because the Scope may be null.)
 - #78465 (Change as_str → to_string in proc_macro::Ident::span() docs)
 - #78470 (Clean up intra-doc links in `std::path`)
 - #78475 (fix a comment in validity check)
 - #78478 (Add const generics tests for supertraits + dyn traits.)
 - #78487 (Fix typo "compiltest")
 - #78491 (Inline NonZeroN::from(n))
 - #78492 (Update books)
 - #78493 (Update cargo)
 - #78494 (Fix typos)

Failed merges:


r? @ghost