### PR TITLE
Infer the default host target from the host toolchain if possible

### DIFF
--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `x.py check` needs opt-in to check tests (--all-targets) [#77473](https://github.com/rust-lang/rust/pull/77473)
 - The default bootstrap profiles are now located at `bootstrap/defaults/config.$PROFILE.toml` (previously they were located at `bootstrap/defaults/config.toml.$PROFILE`) [#77558](https://github.com/rust-lang/rust/pull/77558)
+- If you have Rust already installed, `x.py` will now infer the host target
+  from the default rust toolchain. [#78513](https://github.com/rust-lang/rust/pull/78513)
 
 
 ## [Version 2] - 2020-09-25

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -266,7 +266,7 @@ config = {}
 def build():
     if 'build' in known_args:
         return known_args['build'][-1][1]
-    return bootstrap.default_build_triple()
+    return bootstrap.default_build_triple(verbose=False)
 
 
 def set(key, value):


### PR DESCRIPTION
- `beta-x86_64-unknown-linux-gnu` has beta stripped
- `rustc2` is ignored

This fixes ongoing issues where x.py will detect the wrong host triple
between MSVC and GNU.

I don't think this will break anyone's workflow - I'd be very surprised if you a) had no `[build]` section in `config.toml`, b) had rustc installed, and c) expected the default target to be something other than the default target used by `rustc`. But I could be wrong - I'm happy to hear user stories :)

Fixes https://github.com/rust-lang/rust/issues/78150.

r? @Mark-Simulacrum
cc @Lokathor