### PR TITLE
Switchable buffering for Stdout

### DIFF
--- a/library/std/src/io/buffered/mod.rs
+++ b/library/std/src/io/buffered/mod.rs
@@ -4,6 +4,7 @@ mod bufreader;
 mod bufwriter;
 mod linewriter;
 mod linewritershim;
+mod switchwriter;
 
 #[cfg(test)]
 mod tests;
@@ -18,6 +19,9 @@ use linewritershim::LineWriterShim;
 
 #[stable(feature = "bufwriter_into_parts", since = "1.56.0")]
 pub use bufwriter::WriterPanicked;
+
+#[unstable(feature = "stdout_switchable_buffering", issue = "78515")]
+pub use switchwriter::{BufferMode, SwitchWriter};
 
 /// An error returned by [`BufWriter::into_inner`] which combines an error that
 /// happened while writing out the buffer, and the buffered writer object

--- a/library/std/src/io/buffered/switchwriter.rs
+++ b/library/std/src/io/buffered/switchwriter.rs
@@ -1,0 +1,117 @@
+use crate::fmt::Arguments;
+use crate::io::{self, buffered::LineWriterShim, BufWriter, IoSlice, Write};
+/// Different buffering modes a writer can use
+#[unstable(feature = "stdout_switchable_buffering", issue = "78515")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BufferMode {
+    /// Immediate: forward writes directly to the underlying writer. In some
+    /// cases, a writer may buffer temporarily to reduce the number of
+    /// underlying writes (for instance, when processing a formatted write!(),
+    /// which makes several tiny writes), but even in this case the formatted
+    /// buffer will always be forwarded immediately.
+    Immediate,
+
+    /// Block buffering: buffer writes until the buffer is full, then forward
+    /// to the underlying writer
+    Block,
+
+    /// Line buffering: same as block buffering, except that it immediately
+    /// forwards the buffered content when it encounters a newline.
+    Line,
+}
+
+/// Wraps a writer and provides a switchable buffering mode for its output
+#[unstable(feature = "stdout_switchable_buffering", issue = "78515")]
+#[derive(Debug)]
+pub struct SwitchWriter<W: Write> {
+    buffer: BufWriter<W>,
+    mode: BufferMode,
+}
+
+impl<W: Write> SwitchWriter<W> {
+    #[unstable(feature = "stdout_switchable_buffering", issue = "78515")]
+    pub fn new(writer: W, mode: BufferMode) -> Self {
+        Self { buffer: BufWriter::new(writer), mode }
+    }
+
+    // Don't forget to add with_capacity if this type ever becomes public
+
+    #[unstable(feature = "stdout_switchable_buffering", issue = "78515")]
+    pub fn mode(&self) -> BufferMode {
+        self.mode
+    }
+
+    /// Set the buffering mode. This will not attempt any io; it only changes
+    /// the mode used for subsequent writes.
+    #[unstable(feature = "stdout_switchable_buffering", issue = "78515")]
+    pub fn set_mode(&mut self, mode: BufferMode) {
+        self.mode = mode
+    }
+}
+
+/// Shared logic for io methods that need to switch over the buffering mode
+macro_rules! use_correct_writer {
+    ($this:ident, |$writer:ident| $usage:expr) => {
+        match $this.mode {
+            BufferMode::Immediate => {
+                $this.buffer.flush_buf()?;
+                let $writer = $this.buffer.get_mut();
+                $usage
+            }
+            BufferMode::Block => {
+                let $writer = &mut $this.buffer;
+                $usage
+            }
+            BufferMode::Line => {
+                let mut $writer = LineWriterShim::new(&mut $this.buffer);
+                $usage
+            }
+        }
+    };
+}
+
+impl<W: Write> Write for SwitchWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        use_correct_writer!(self, |writer| writer.write(buf))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buffer.flush()
+    }
+
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        use_correct_writer!(self, |writer| writer.write_vectored(bufs))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.buffer.is_write_vectored()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        use_correct_writer!(self, |writer| writer.write_all(buf))
+    }
+
+    fn write_all_vectored(&mut self, bufs: &mut [IoSlice<'_>]) -> io::Result<()> {
+        use_correct_writer!(self, |writer| writer.write_all_vectored(bufs))
+    }
+
+    fn write_fmt(&mut self, fmt: Arguments<'_>) -> io::Result<()> {
+        match self.mode {
+            BufferMode::Immediate => {
+                // write_fmt is usually going to be very numerous tiny writes
+                // from the constituent fmt calls, so even though we're in
+                // unbuffered mode we still collect it to the buffer so that
+                // we can flush it in a single write.
+                self.buffer.flush_buf()?;
+                self.buffer.write_fmt(fmt)?;
+                self.buffer.flush_buf()
+            }
+            BufferMode::Block => self.buffer.write_fmt(fmt),
+            BufferMode::Line => {
+                let mut shim = LineWriterShim::new(&mut self.buffer);
+                shim.write_fmt(fmt)
+            }
+        }
+    }
+}

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -260,6 +260,8 @@ use crate::str;
 use crate::sys;
 use crate::sys_common::memchr;
 
+#[unstable(feature = "stdout_switchable_buffering", issue = "78515")]
+pub use self::buffered::BufferMode;
 #[stable(feature = "bufwriter_into_parts", since = "1.56.0")]
 pub use self::buffered::WriterPanicked;
 #[unstable(feature = "internal_output_capture", issue = "none")]

--- a/library/std/src/sys/hermit/stdio.rs
+++ b/library/std/src/sys/hermit/stdio.rs
@@ -1,5 +1,4 @@
-use crate::io;
-use crate::io::{IoSlice, IoSliceMut};
+use crate::io::{self, BufferMode, IoSlice, IoSliceMut};
 use crate::sys::hermit::abi;
 
 pub struct Stdin;
@@ -117,4 +116,8 @@ pub fn is_ebadf(_err: &io::Error) -> bool {
 
 pub fn panic_output() -> Option<impl io::Write> {
     Some(Stderr::new())
+}
+
+pub fn default_stdout_buffer_mode() -> BufferMode {
+    BufferMode::Line
 }

--- a/library/std/src/sys/sgx/stdio.rs
+++ b/library/std/src/sys/sgx/stdio.rs
@@ -1,6 +1,6 @@
 use fortanix_sgx_abi as abi;
 
-use crate::io;
+use crate::io::{self, BufferMode};
 #[cfg(not(test))]
 use crate::slice;
 #[cfg(not(test))]
@@ -71,6 +71,10 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 
 pub fn panic_output() -> Option<impl io::Write> {
     super::abi::panic::SgxPanicOutput::new()
+}
+
+pub fn default_stdout_buffer_mode() -> BufferMode {
+    BufferMode::Line
 }
 
 // This function is needed by libunwind. The symbol is named in pre-link args

--- a/library/std/src/sys/unix/stdio.rs
+++ b/library/std/src/sys/unix/stdio.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoSlice, IoSliceMut};
+use crate::io::{self, BufferMode, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
 use crate::os::unix::io::{AsFd, BorrowedFd, FromRawFd};
 use crate::sys::fd::FileDesc;
@@ -138,4 +138,10 @@ impl<'a> AsFd for io::StderrLock<'a> {
     fn as_fd(&self) -> BorrowedFd<'_> {
         unsafe { BorrowedFd::borrow_raw(libc::STDERR_FILENO) }
     }
+}
+
+/// Get the default stdout buffermode. In the future, this should be determined
+/// via `isatty` or some similar check on stdout
+pub fn default_stdout_buffer_mode() -> BufferMode {
+    BufferMode::Line
 }

--- a/library/std/src/sys/unsupported/stdio.rs
+++ b/library/std/src/sys/unsupported/stdio.rs
@@ -1,4 +1,4 @@
-use crate::io;
+use crate::io::{self, BufferMode};
 
 pub struct Stdin;
 pub struct Stdout;
@@ -56,4 +56,8 @@ pub fn is_ebadf(_err: &io::Error) -> bool {
 
 pub fn panic_output() -> Option<Vec<u8>> {
     None
+}
+
+pub fn default_stdout_buffer_mode() -> BufferMode {
+    BufferMode::Line
 }

--- a/library/std/src/sys/wasi/stdio.rs
+++ b/library/std/src/sys/wasi/stdio.rs
@@ -1,7 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use super::fd::WasiFd;
-use crate::io::{self, IoSlice, IoSliceMut};
+use crate::io::{self, BufferMode, IoSlice, IoSliceMut};
 use crate::mem::ManuallyDrop;
 use crate::os::raw;
 use crate::os::wasi::io::{AsRawFd, FromRawFd};
@@ -109,4 +109,8 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 
 pub fn panic_output() -> Option<impl io::Write> {
     Some(Stderr::new())
+}
+
+pub fn default_stdout_buffer_mode() -> BufferMode {
+    BufferMode::Line
 }

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -2,7 +2,7 @@
 
 use crate::char::decode_utf16;
 use crate::cmp;
-use crate::io;
+use crate::io::{self, BufferMode};
 use crate::os::windows::io::{FromRawHandle, IntoRawHandle};
 use crate::ptr;
 use crate::str;
@@ -419,4 +419,8 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 
 pub fn panic_output() -> Option<impl io::Write> {
     Some(Stderr::new())
+}
+
+pub fn default_stdout_buffer_mode() -> BufferMode {
+    BufferMode::Line
 }


### PR DESCRIPTION
# Summary

This PR adds "switchable" buffering to Stdout. Instead of being unconditionally line-buffered, stdout can now be put in one of 3 modes: line buffering, which is the current behavior; block buffering, which mirrors `BufWriter`; and unbuffered, which (with one small exception, see **Design Notes**) forwards all writes directly to the underlying device.

~~This PR additionally contains some proposed implementation updates to `BufWriter`, with a focus on reducing total device `write` calls in the average case. These updates are based on [lessons learned](https://github.com/rust-lang/rust/pull/72808#discussion_r475911543) from the design of `LineWriterShim`, as well as some discussions with @workingjubilee on this topic. This could be considered "out of scope" for this PR, so at the discretion of the reviewers I'm happy to move it to a separate PR, but I was "in the neighborhood", so to speak. See **Design Notes** for details about these changes.~~ Moved to #78551

This PR moves us another step closer to #60673, which calls for `stdout` to use block buffering when appropriate (ie, when stdout is a not a tty). This PR does *not* change any current startup behavior; `stdout` is still unconditionally line buffered by default. Instead, this PR creates only an implementation of switchable buffering (which lives in the `SwitchWriter` type), which future PRs (probably individual ones for different platforms) can use to select an appropriate startup default for their launch environment.

## Side note on terminology

Throughout this proposal I'll be referring to writers flushing / buffers being flushed; unless I specify otherwise, I always mean that the data is being flushed *one level*, to the wrapped `io::Write` writer. "Full" flushing (ie, forwarding all the way though the stack to the underlying sink) is assumed to only happen on an explicit user call to `flush`.

# Design notes

## `SwitchWriter`

The core of this PR is the `SwitchWriter` type. It's fairly simple; it has a current mode, and delegates all write operations to its `BufWriter` as follows:

- In block buffered mode, it forwards directly to the `BufWriter`.
- In line buffered mode, it creates a `LineWriterShim` (a wrapper around `&mut BufWriter`, implementing line buffering logic) and forwards to it. Treatment of existing buffered data is entirely deferred to `LineWriterShim`.
- In unbuffered mode, it ensures the `BufWriter` is flushed, then forwards directly to the `io::Write` contained by the `BufWriter`.
    - A small exception: because `write_fmt` tends to be a lot of very short writes, it is buffered into the `BufWriter` and immediately flushed. The write still completes immediately, but we assume in practice that a caller of `write_fmt` on an unbuffered `SwitchWriter` doesn't care if *every* individual write that entails is forwarded directly to the writer, as much as they care that the write is forwarded *immediately*.

Changing the buffering mode never performs any synchronous i/o operations; it only changes the behavior of subsequent writes. The treatment of buffered content during a mode shift is left deliberately unspecified; in practice it's treated by whatever the behavior of the current mode is. For instance, when switching from block buffering to line buffering, any previously buffered content will (usually) remain buffered until a new line is written by the user. `SwitchWriter` does not retroactively scan the buffer for newlines to flush after such a mode switch. Conversely, it's possible (though unlikely) for partial writes from the underlying device to cause lines in line buffering mode to be buffered without being flushed.  `LineWriter` is designed to retry these writes ASAP (on subsequent write calls), but switching to block buffered mode will cause this content to remain buffered. It is assumed that, in cases where precision is needed, the user would `flush` *before* switching modes.

Strictly speaking, it isn't necessary for the fulfillment of #60673 for `stdout` to be *switchable*, only that the mode is set based on some environmental factors at startup. In practice, however, this means that the *implementation* needs to be able to switch over the current mode, so it's a trivial addition to make it further switchable at runtime. This has the side benefit of making it easy to break #60673 into different parts; without this public interface, the PR fails the "unused code" checks, and would require an implementation of `isatty` to be added immediately. Because this new API is unstable, I figure we can always remove it after #60673 is complete if we find it isn't justifying its inclusion. 

## `stdout` interface changes

This change adds `buffer_mode` and `set_buffer_mode` to `StdoutLock`, which cause the buffering mode to be globally switched. There's not much else to talk about here. Currently `SwitchWriter` is *not* exported publicly (though it could be someday), so this API is the only way right now for any of this behavior to be accessed.

# Follow up items

The functional aspects of this PR are complete, but there are still several open tasks that need to be completed. Some are code related (write comprehensive tests & docs), which others are publishing related (this PR adds new public methods to `StdoutLock`, which need to be discussed and approved).

## Tasks

- [ ] `SwitchWriter` tests
- [ ] `stdout` switching tests
   - Is `stdout` tested specifically as a write target? I see tests for panic consistency / recovery, and extensive tests for `BufWriter`, `LineWriter`, etc., but didn't immediately see tests for "writing to stdout".
- [ ] Comprehensive documentation of new public API
- [ ] Comprehensive documentation of `SwitchWriter`; even though it's not exported publicly, we still want it to be documented for developers reading it.

## Open questions

While I've made assumptions about these, and described my rationale as much as possible above, I wanted to call out the specific things that I wanted to be sure are addressed in review.

- [x] Should stdout be made runtime switchable by standard library clients at all?
    - Emphatically yes.
    - [ ] If so, approve my naming scheme, or come up with a preferable one.
    - [ ] if so, do we like the trivial get/set interface, or is another design warrented?
    - [ ] Should the buffer switching interface be available on `Stdout`, as well as `StdoutLock`?
- [ ] Do we like these buffer mode choices? I was torn about whether to expose unbuffered, or just stick to Block / Line buffering. We need an unbuffered mode internally (for stdout cleanup at program shutdown) but we don't necessarily have to expose it.

# Next steps

Assuming this PR gets merged (or, at least, the `SwitchWriter` part), the only remaining step is to actually create an interface for the platform to report its preferred stdout configuration based on the startup environment. This would be nearly identical to the way `stdout_raw` or `is_ebadf` are handled today: a standard interface is implemented in the various `sys` crates and consumed via a uniform interface in `io`. My envisioned interface looks like:

```rust
/// Get the stdout buffering mode based on the startup
/// environment. For instance, on unix platforms, this will
/// enable line-buffering if stdout is a tty and block-buffering
/// otherwise. Also returns the default buffer size.
fn get_default_stdout_mode() -> (BufferMode, usize) { ... }
```

This will, of course, be discussed in more detail in that future PR.
