### PR TITLE
Revert invalid `fn` return type parsing change

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1666,19 +1666,10 @@ impl<'a> Parser<'a> {
         req_name: ReqName,
         ret_allow_plus: AllowPlus,
     ) -> PResult<'a, P<FnDecl>> {
-        let inputs = self.parse_fn_params(req_name)?;
-        let output = self.parse_ret_ty(ret_allow_plus, RecoverQPath::Yes)?;
-
-        if let ast::FnRetTy::Ty(ty) = &output {
-            if let TyKind::Path(_, Path { segments, .. }) = &ty.kind {
-                if let [.., last] = &segments[..] {
-                    // Detect and recover `fn foo() -> Vec<i32>> {}`
-                    self.check_trailing_angle_brackets(last, &[&token::OpenDelim(token::Brace)]);
-                }
-            }
-        }
-
-        Ok(P(FnDecl { inputs, output }))
+        Ok(P(FnDecl {
+            inputs: self.parse_fn_params(req_name)?,
+            output: self.parse_ret_ty(ret_allow_plus, RecoverQPath::Yes)?,
+        }))
     }
 
     /// Parses the parameter list of a function, including the `(` and `)` delimiters.

--- a/src/test/ui/parser/fn-returns-fn-pointer.rs
+++ b/src/test/ui/parser/fn-returns-fn-pointer.rs
@@ -1,0 +1,6 @@
+// check-pass
+// Regression test for #78507.
+fn foo() -> Option<fn() -> Option<bool>> {
+    Some(|| Some(true))
+}
+fn main() {}

--- a/src/test/ui/parser/issue-24780.rs
+++ b/src/test/ui/parser/issue-24780.rs
@@ -1,8 +1,8 @@
 // Verify that '>' is not both expected and found at the same time, as it used
 // to happen in #24780. For example, following should be an error:
-// expected one of ..., `>`, ... found `>`. No longer exactly this, but keeping for posterity.
+// expected one of ..., `>`, ... found `>`.
 
-fn foo() -> Vec<usize>> { //~ ERROR unmatched angle bracket
+fn foo() -> Vec<usize>> { //~ ERROR expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
     Vec::new()
 }
 

--- a/src/test/ui/parser/issue-24780.stderr
+++ b/src/test/ui/parser/issue-24780.stderr
@@ -1,8 +1,8 @@
-error: unmatched angle bracket
+error: expected one of `!`, `+`, `::`, `;`, `where`, or `{`, found `>`
   --> $DIR/issue-24780.rs:5:23
    |
 LL | fn foo() -> Vec<usize>> {
-   |                       ^^ help: remove extra angle bracket
+   |                       ^ expected one of `!`, `+`, `::`, `;`, `where`, or `{`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Revert one of the changes in #78379.

Fix #78507.