### PR TITLE
rustc_llvm: unwrap LLVMMetadataRef before casting

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -936,7 +936,7 @@ extern "C" LLVMValueRef LLVMRustDIBuilderInsertDeclareAtEnd(
   return wrap(Builder->insertDeclare(
       unwrap(V), unwrap<DILocalVariable>(VarInfo),
       Builder->createExpression(llvm::ArrayRef<int64_t>(AddrOps, AddrOpsCount)),
-      DebugLoc(cast<MDNode>(DL)),
+      DebugLoc(cast<MDNode>(unwrap(DL))),
       unwrap(InsertAtEnd)));
 }
 


### PR DESCRIPTION
Directly casting the opaque pointer was [reported] to cause an
"incomplete type" error with GCC 9.3:

```
llvm-wrapper/RustWrapper.cpp:939:31:   required from here
/usr/include/c++/9.3/type_traits:1301:12: error: invalid use of incomplete type 'struct LLVMOpaqueMetadata'
 1301 |     struct is_base_of
      |            ^~~~~~~~~~
In file included from [...]/rust/src/llvm-project/llvm/include/llvm-c/BitReader.h:23,
                 from llvm-wrapper/LLVMWrapper.h:1,
                 from llvm-wrapper/RustWrapper.cpp:1:
[...]/rust/src/llvm-project/llvm/include/llvm-c/Types.h:89:16: note: forward declaration of 'struct LLVMOpaqueMetadata'
   89 | typedef struct LLVMOpaqueMetadata *LLVMMetadataRef;
      |                ^~~~~~~~~~~~~~~~~~
```

[reported]: https://zulip-archive.rust-lang.org/182449tcompilerhelp/12215halprustcllvmbuildfail.html#214915124

A simple `unwrap` fixes the issue.

r? @eddyb 