### PR TITLE
Implementation changes to BufWriter

### DIFF
--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -399,6 +399,8 @@ impl<W: Write> Write for BufWriter<W> {
         } else if written > 0 {
             0
         } else {
+            // It's guaranteed at this point that the buffer is empty, because
+            // if wasn't, it would have been flushed earlier in this function.
             self.get_mut().write(tail)?
         };
 
@@ -490,7 +492,7 @@ impl<W: Write> Write for BufWriter<W> {
                         self.flush_buf()?;
                     }
 
-                    if buf.len() >= self.available() {
+                    if buf.len() >= self.capacity() && self.buf.is_empty() {
                         // If an individual buffer exceeds our *total* capacity
                         // and we haven't buffered anything yet, just forward
                         // it to the underlying device

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -549,10 +549,9 @@ impl<W: Write + Seek> Seek for BufWriter<W> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<W: Write> Drop for BufWriter<W> {
     fn drop(&mut self) {
-        if !self.panicked {
-            if self.inner.is_some() {
-                let _ = self.flush_buf();
-            }
+        if self.inner.is_some() && !self.panicked {
+            // dtors should not panic, so we ignore a failed flush
+            let _r = self.flush_buf();
         }
     }
 }

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -240,7 +240,7 @@ impl<W: Write> BufWriter<W> {
                             return Err(Error::new(
                                 ErrorKind::WriteZero,
                                 "failed to write the buffered data",
-                            ))
+                            ));
                         }
                         Ok(n) => guard.consume(n),
                         Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -562,15 +562,15 @@ impl<W: Write> Drop for BufWriter<W> {
 /// buffer in a list input to write_vectored.
 ///
 /// FIXME: delete this function and replace it with slice::trim if that becomes
-/// a things (https://github.com/rust-lang/rfcs/issues/2547)
-fn only_one<I, T>(iter: I, filter: impl FnMut(&T) -> bool) -> Option<T>
+/// a thing (https://github.com/rust-lang/rfcs/issues/2547)
+fn only_one<I>(iter: I, filter: impl Fn(&I::Item) -> bool) -> Option<I::Item>
 where
-    I: IntoIterator<Item = T>,
+    I: IntoIterator,
     I::IntoIter: FusedIterator,
 {
     let mut iter = iter.into_iter().filter(filter);
-    match (iter.next(), iter.count()) {
-        (Some(item), 0) => Some(item),
+    match (iter.next(), iter.next()) {
+        (Some(item), None) => Some(item),
         _ => None,
     }
 }

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -2,6 +2,7 @@ use crate::fmt;
 use crate::io::{
     self, Error, ErrorKind, IntoInnerError, IoSlice, Seek, SeekFrom, Write, DEFAULT_BUF_SIZE,
 };
+use crate::iter::FusedIterator;
 
 /// Helper macro for a common write pattern. Write a buffer using the given
 /// function call, then use the returned usize to get the unwritten tail of

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -561,7 +561,7 @@ impl<W: Write> Drop for BufWriter<W> {
 /// matching that predicate. Used to check if there is exactly one non-empty
 /// buffer in a list input to write_vectored.
 ///
-/// TODO: delete this function and replace it with slice::trim if that becomes
+/// FIXME: delete this function and replace it with slice::trim if that becomes
 /// a things (https://github.com/rust-lang/rfcs/issues/2547)
 fn only_one<I, T>(iter: I, filter: impl FnMut(&T) -> bool) -> Option<T>
 where

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -18,15 +18,15 @@ use crate::iter::FusedIterator;
 /// let tail = tail!(self.write_to_buffer(buf));
 /// ```
 macro_rules! tail {
-    ($this:ident $(. $write:ident)+ ($buf:expr)) => {{
+    ($($write:ident).+ ($buf:expr)) => {{
         let buf = $buf;
-        let written = $this $(. $write)+ (buf);
+        let written = $($write).+ (buf);
         &buf[written..]
     }};
 
-    ($this:ident $(. $write:ident)+ ($buf:expr) ? ) => {{
+    ($($write:ident).+ ($buf:expr) ? ) => {{
         let buf = $buf;
-        let written = $this $(. $write)+ (buf)?;
+        let written = $($write).+ (buf)?;
         &buf[written..]
     }};
 }

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -488,7 +488,10 @@ impl<W: Write> Write for BufWriter<W> {
                     }
                 }
 
-                // Buffer as much as possible until we reach full capacity
+                // Buffer as much as possible until we reach full capacity.
+                // Once we've buffered at least 1 byte, we're obligated to
+                // return Ok(..) before attempting any fallible i/o operations,
+                // so once the buffer is full we immediately return.
                 total_buffered += self.write_to_buf(buf);
                 if self.buffer().len() == self.capacity() {
                     break;

--- a/library/std/src/io/buffered/linewritershim.rs
+++ b/library/std/src/io/buffered/linewritershim.rs
@@ -170,7 +170,7 @@ impl<'a, W: Write> Write for LineWriterShim<'a, W> {
     /// get the benefits of more granular partial-line handling without losing
     /// anything in efficiency
     fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        // TODO: BufWriter recently received some optimized handling of
+        // FIXME: BufWriter recently received some optimized handling of
         // vectored writes; update this method to take advantage of those
         // updates. In particular, BufWriter::is_write_vectored is always true,
         // because BufWriter::write_vectored takes special care to buffer

--- a/library/std/src/io/buffered/tests.rs
+++ b/library/std/src/io/buffered/tests.rs
@@ -9,11 +9,10 @@ pub struct ShortReader {
     lengths: Vec<usize>,
 }
 
-// FIXME: rustfmt and tidy disagree about the correct formatting of this
-// function. This leads to issues for users with editors configured to
-// rustfmt-on-save.
 impl Read for ShortReader {
     fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        // Note for developers: if your editor is fighting you about the
+        // correct rustfmt here, make sure you're using nightly
         if self.lengths.is_empty() { Ok(0) } else { Ok(self.lengths.remove(0)) }
     }
 }

--- a/library/std/src/io/buffered/tests.rs
+++ b/library/std/src/io/buffered/tests.rs
@@ -14,11 +14,7 @@ pub struct ShortReader {
 // rustfmt-on-save.
 impl Read for ShortReader {
     fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
-        if self.lengths.is_empty() {
-            Ok(0)
-        } else {
-            Ok(self.lengths.remove(0))
-        }
+        if self.lengths.is_empty() { Ok(0) } else { Ok(self.lengths.remove(0)) }
     }
 }
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -279,6 +279,7 @@
 #![feature(maybe_uninit_extra)]
 #![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_slice)]
+#![feature(min_const_generics)]
 #![feature(min_specialization)]
 #![feature(needs_panic_runtime)]
 #![feature(negative_impls)]


### PR DESCRIPTION
This PR contains some proposed implementation updates to `BufWriter`, with a focus on reducing total device `write` calls in the average case. These updates are based on [lessons learned](https://github.com/rust-lang/rust/pull/72808#discussion_r475911543) from the design of `LineWriterShim`, as well as some discussions with @workingjubilee on this topic.

There are three main changes to how `BufWriter` works:

- `write_all` now fully fills the buffer before flushing. Previously, it would fill the buffer as much as possible without splitting any incoming writes. However, we assume that a caller of `write_all` is foremost interested in minimizing write calls to the underlying device, which we can best achieve by maximizing the size of buffers we flush. Of course, incoming data that exceeds the *total* size of the buffer is still forwarded directly to the underlying device.
    - Conversely, we assume that a caller of `write` would prefer to have unbroken writes if possible (that is, would prefer `Ok(n)` where `n == buf.len()`). The implementation of `write` is therefore left unchanged with regard to buffer filling.
- `write_vectored` is unchanged when `inner.is_write_vectored()`. However, in the case where the underlying device doesn't offer any specialization, we now take care to buffer together all the incoming sub-bufs, even if the *total* size exceeds our buffer, and only fall back to directly forwarded writes in the case that an *individual* slice exceeds our buffer size. As a result, `BufWriter` now also unconditionally returns `true` for `is_write_vectored`.
- Added `flush_buf_vectored()`, a new internal method that is similar to `flush_buf`, but additionally attempts to use vectored operations to send the new incoming data along with the existing buffered data in a single operation. I took care to ensure that this never results in more system calls than it would have already; in particular, it immediately stops forwarding as soon as the existing buffer is fully forwarded, even if 0 new bytes have been sent. `write` and `write_all` were refactored to take advantage of it, and `write_vectored` was slightly modified to forward to `write` if exactly 1 buffer is being written.
- Additionally, as a much more minor change, removed several unnecessary uses of the `self.panicked` guard fences. `BufWriter::panicked` is about preventing duplicate writes of buffered data, so it isn't necessary to fence writes to the underlying device when the buffer is known to be empty.

# Follow up items

## Tasks

- [x] Test the new behavior

## Open questions

Stuff I want to call out and ensure is addressed in review:

- [x] Do the assumptions underpinning the `BufWriter` changes make sense.
- [x] Would it make sense for `BufWriter` to unconditionally return `true` for `is_write_buffered`, since it specializes vectored writes by buffering them together, even when the underlying device offers no such specialization?

This was split off to a separate PR from #78515