### PR TITLE
Improve wording of `core::ptr::drop_in_place` docs

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -99,9 +99,9 @@ mod mut_ptr;
 ///   dropped normally.
 ///
 /// * It is friendlier to the optimizer to do this over [`ptr::read`] when
-///   dropping manually allocated memory (e.g., when writing Box/Rc/Vec),
-///   as the compiler doesn't need to prove that it's sound to elide the
-///   copy.
+///   dropping manually allocated memory (e.g., in the implementations of
+///   `Box`/`Rc`/`Vec`), as the compiler doesn't need to prove that it's
+///   sound to elide the copy.
 ///
 /// * It can be used to drop [pinned] data when `T` is not `repr(packed)`
 ///   (pinned data must not be moved before it is dropped).

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -1,7 +1,7 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f32` floating point data type.
 //!
-//! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
+//! *[See also the `f32` primitive type](primitive@f32).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -1,7 +1,7 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f64` floating point data type.
 //!
-//! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
+//! *[See also the `f64` primitive type](primitive@f64).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!


### PR DESCRIPTION
And two small intra-doc link conversions in `std::{f32, f64}`.
