### PR TITLE
Link to pass docs from NRVO module docs

### DIFF
--- a/compiler/rustc_mir/src/transform/nrvo.rs
+++ b/compiler/rustc_mir/src/transform/nrvo.rs
@@ -1,3 +1,5 @@
+//! See the docs for [`RenameReturnPlace`].
+
 use rustc_hir::Mutability;
 use rustc_index::bit_set::HybridBitSet;
 use rustc_middle::mir::visit::{MutVisitor, NonUseContext, PlaceContext, Visitor};


### PR DESCRIPTION
It can be easy to miss that this is documented on the pass's struct if you are
looking at the module docs.

Cc https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/what.20is.20NRVO.3F
