### PR TITLE
Use check-pass instead of build-pass in regions ui test suite

### DIFF
--- a/src/test/ui/regions/region-bound-extra-bound-in-inherent-impl.rs
+++ b/src/test/ui/regions/region-bound-extra-bound-in-inherent-impl.rs
@@ -1,7 +1,7 @@
 // Test related to #22779. In this case, the impl is an inherent impl,
 // so it doesn't have to match any trait, so no error results.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 struct MySlice<'a, T:'a>(&'a mut [T]);

--- a/src/test/ui/regions/region-bound-same-bounds-in-trait-and-impl.rs
+++ b/src/test/ui/regions/region-bound-same-bounds-in-trait-and-impl.rs
@@ -1,7 +1,7 @@
 // Test related to #22779, but where the `'a:'b` relation
 // appears in the trait too. No error here.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 trait Tr<'a, T> {
     fn renew<'b: 'a>(self) -> &'b mut [T] where 'a: 'b;

--- a/src/test/ui/regions/region-object-lifetime-1.rs
+++ b/src/test/ui/regions/region-object-lifetime-1.rs
@@ -1,7 +1,7 @@
 // Various tests related to testing how region inference works
 // with respect to the object receivers.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(warnings)]
 
 trait Foo {

--- a/src/test/ui/regions/region-object-lifetime-3.rs
+++ b/src/test/ui/regions/region-object-lifetime-3.rs
@@ -1,7 +1,7 @@
 // Various tests related to testing how region inference works
 // with respect to the object receivers.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(warnings)]
 
 trait Foo {

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-2.rs
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-2.rs
@@ -2,7 +2,7 @@
 // "projection gap": in this test, we know that `T: 'x`, and that is
 // enough to conclude that `T::Foo: 'x`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-3.rs
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-3.rs
@@ -2,7 +2,7 @@
 // "projection gap": in this test, we know that `T::Foo: 'x`, and that
 // is (naturally) enough to conclude that `T::Foo: 'x`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-4.rs
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-4.rs
@@ -2,7 +2,7 @@
 // "projection gap": in this test, we know that `T: 'x`, and that
 // is (naturally) enough to conclude that `T: 'x`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-region-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-region-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-region.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-region.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-type-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-type-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-type.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-type.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-region-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-region-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-region.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-region.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-type-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-type-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-type.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-type.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-projection-hrtype.rs
+++ b/src/test/ui/regions/regions-outlives-projection-hrtype.rs
@@ -5,7 +5,7 @@
 // `'r` is bound, that leads to badness. This test checks that
 // everything works.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 trait TheTrait {

--- a/src/test/ui/regions/regions-outlives-projection-trait-def.rs
+++ b/src/test/ui/regions/regions-outlives-projection-trait-def.rs
@@ -1,7 +1,7 @@
 // Test that `<F as Foo<'a>>::Type: 'b`, where `trait Foo<'a> { Type:
 // 'a; }`, does not require that `F: 'b`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 trait SomeTrait<'a> {

--- a/src/test/ui/regions/regions-outlives-scalar.rs
+++ b/src/test/ui/regions/regions-outlives-scalar.rs
@@ -1,7 +1,7 @@
 // Test that scalar values outlive all regions.
 // Rule OutlivesScalar from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 struct Foo<'a> {


### PR DESCRIPTION
## Overview

Helps with #62277 

Region inference have nothing to do with codegen because they are erased before codegen. 
Ref: https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Is.20region.20inference.20.20nothing.20to.20do.20with.20codegen.20process.3F/near/215956759

