### PR TITLE
Constantify more BTreeMap and BTreeSet functions

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -2188,7 +2188,8 @@ impl<K, V> BTreeMap<K, V> {
     /// assert_eq!(a.len(), 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn len(&self) -> usize {
+    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    pub const fn len(&self) -> usize {
         self.length
     }
 
@@ -2207,7 +2208,8 @@ impl<K, V> BTreeMap<K, V> {
     /// assert!(!a.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -1527,6 +1527,13 @@ fn test_send() {
     }
 }
 
+#[allow(dead_code)]
+fn test_const() {
+    const MAP: &'static BTreeMap<(), ()> = &BTreeMap::new();
+    const LEN: usize = MAP.len();
+    const IS_EMPTY: bool = MAP.is_empty();
+}
+
 #[test]
 fn test_occupied_entry_key() {
     let mut a = BTreeMap::new();

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -950,7 +950,8 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(v.len(), 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn len(&self) -> usize {
+    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    pub const fn len(&self) -> usize {
         self.map.len()
     }
 
@@ -967,7 +968,8 @@ impl<T> BTreeSet<T> {
     /// assert!(!v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_btree_new", issue = "71835")]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -15,6 +15,13 @@ fn test_clone_eq() {
     assert_eq!(m.clone(), m);
 }
 
+#[allow(dead_code)]
+fn test_const() {
+    const SET: &'static BTreeSet<()> = &BTreeSet::new();
+    const LEN: usize = SET.len();
+    const IS_EMPTY: bool = SET.is_empty();
+}
+
 #[test]
 fn test_iter_min_max() {
     let mut a = BTreeSet::new();


### PR DESCRIPTION
Just because we can:

- `BTreeMap::len`
- `BTreeMap::is_empty`
- `BTreeSet::len`
- `BTreeSet::is_empty`

Note that I put the `const` under `const_btree_new`, because I don't think their is a need to create another feature flag for that.

cc #71835