### PR TITLE
Add keyboard handling to the theme picker menu

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -79,12 +79,12 @@ pub fn render<T: Print, S: Print>(
         {sidebar}\
     </nav>\
     <div class=\"theme-picker\">\
-        <button id=\"theme-picker\" aria-label=\"Pick another theme!\">\
+        <button id=\"theme-picker\" aria-label=\"Pick another theme!\" aria-haspopup=\"menu\">\
             <img src=\"{static_root_path}brush{suffix}.svg\" \
                  width=\"18\" \
                  alt=\"Pick another theme!\">\
         </button>\
-        <div id=\"theme-choices\"></div>\
+        <div id=\"theme-choices\" role=\"menu\"></div>\
     </div>\
     <script src=\"{static_root_path}theme{suffix}.js\"></script>\
     <nav class=\"sub\">\

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -798,17 +798,61 @@ function handleThemeButtonsBlur(e) {{
     var active = document.activeElement;
     var related = e.relatedTarget;
 
-    if (active.id !== "themePicker" &&
+    if (active.id !== "theme-picker" &&
         (!active.parentNode || active.parentNode.id !== "theme-choices") &&
         (!related ||
-         (related.id !== "themePicker" &&
+         (related.id !== "theme-picker" &&
           (!related.parentNode || related.parentNode.id !== "theme-choices")))) {{
         hideThemeButtonState();
     }}
 }}
 
+function handleThemeKeyPress(e) {{
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {{ return; }}
+    if (!themePicker.parentNode.contains(e.target)) {{ return; }}
+    var active = document.activeElement;
+    switch (e.key) {{
+        case "ArrowUp":
+            e.preventDefault();
+            if (active.previousElementSibling && e.target.id !== "theme-picker") {{
+                active.previousElementSibling.focus();
+            }} else {{
+                showThemeButtonState();
+                themes.lastElementChild.focus();
+            }}
+            break;
+        case "ArrowDown":
+            e.preventDefault();
+            if (active.nextElementSibling && e.target.id !== "theme-picker") {{
+                active.nextElementSibling.focus();
+            }} else {{
+                showThemeButtonState();
+                themes.firstElementChild.focus();
+            }}
+            break;
+        case "Enter":
+        case "Return":
+        case "Space":
+            if (e.target.id === "theme-picker" && themes.style.display === "none") {{
+                e.preventDefault();
+                showThemeButtonState();
+                themes.firstElementChild.focus();
+            }}
+            break;
+        case "Home":
+            e.preventDefault();
+            themes.firstElementChild.focus();
+            break;
+        case "End":
+            e.preventDefault();
+            themes.lastElementChild.focus();
+            break;
+    }}
+}};
+
 themePicker.onclick = switchThemeButtonState;
 themePicker.onblur = handleThemeButtonsBlur;
+document.addEventListener("keydown", handleThemeKeyPress);
 {}.forEach(function(item) {{
     var but = document.createElement("button");
     but.textContent = item;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -807,58 +807,8 @@ function handleThemeButtonsBlur(e) {{
     }}
 }}
 
-function handleThemeKeyDown(e) {{
-    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {{ return; }}
-    if (!themePicker.parentNode.contains(e.target)) {{ return; }}
-    var active = document.activeElement;
-    switch (e.key) {{
-        case "ArrowUp":
-            e.preventDefault();
-            if (active.previousElementSibling && e.target.id !== "theme-picker") {{
-                active.previousElementSibling.focus();
-            }} else {{
-                showThemeButtonState();
-                themes.lastElementChild.focus();
-            }}
-            break;
-        case "ArrowDown":
-            e.preventDefault();
-            if (active.nextElementSibling && e.target.id !== "theme-picker") {{
-                active.nextElementSibling.focus();
-            }} else {{
-                showThemeButtonState();
-                themes.firstElementChild.focus();
-            }}
-            break;
-        case "Enter":
-        case "Return":
-        case "Space":
-            if (e.target.id === "theme-picker" && themes.style.display === "none") {{
-                e.preventDefault();
-                showThemeButtonState();
-                themes.firstElementChild.focus();
-            }}
-            break;
-        case "Home":
-            e.preventDefault();
-            themes.firstElementChild.focus();
-            break;
-        case "End":
-            e.preventDefault();
-            themes.lastElementChild.focus();
-            break;
-        // The escape key is handled in main.js, instead of here, for two reasons:
-        //
-        // 1 Escape should close the menu, even if it's not focused.
-        // 2 The escape event handler is bound to both keydown and keypress, to work
-        //   around browser inconsistencies. That sort of logic doesn't apply to the
-        //   rest of these keybindings.
-    }}
-}};
-
 themePicker.onclick = switchThemeButtonState;
 themePicker.onblur = handleThemeButtonsBlur;
-document.addEventListener("keydown", handleThemeKeyDown);
 {}.forEach(function(item) {{
     var but = document.createElement("button");
     but.textContent = item;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -807,7 +807,7 @@ function handleThemeButtonsBlur(e) {{
     }}
 }}
 
-function handleThemeKeyPress(e) {{
+function handleThemeKeyDown(e) {{
     if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {{ return; }}
     if (!themePicker.parentNode.contains(e.target)) {{ return; }}
     var active = document.activeElement;
@@ -847,12 +847,18 @@ function handleThemeKeyPress(e) {{
             e.preventDefault();
             themes.lastElementChild.focus();
             break;
+        // The escape key is handled in main.js, instead of here, for two reasons:
+        //
+        // 1 Escape should close the menu, even if it's not focused.
+        // 2 The escape event handler is bound to both keydown and keypress, to work
+        //   around browser inconsistencies. That sort of logic doesn't apply to the
+        //   rest of these keybindings.
     }}
 }};
 
 themePicker.onclick = switchThemeButtonState;
 themePicker.onblur = handleThemeButtonsBlur;
-document.addEventListener("keydown", handleThemeKeyPress);
+document.addEventListener("keydown", handleThemeKeyDown);
 {}.forEach(function(item) {{
     var but = document.createElement("button");
     but.textContent = item;

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -4,6 +4,7 @@
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass */
 /* global onEachLazy, hasOwnProperty, removeClass, updateLocalStorage */
+/* global hideThemeButtonState */
 
 if (!String.prototype.startsWith) {
     String.prototype.startsWith = function(searchString, position) {
@@ -137,10 +138,6 @@ function defocusSearchBar() {
                 sidebar.appendChild(div);
             }
         }
-        var themePickers = document.getElementsByClassName("theme-picker");
-        if (themePickers && themePickers.length > 0) {
-            themePickers[0].style.display = "none";
-        }
     }
 
     function hideSidebar() {
@@ -155,10 +152,6 @@ function defocusSearchBar() {
             filler.remove();
         }
         document.getElementsByTagName("body")[0].style.marginTop = "";
-        var themePickers = document.getElementsByClassName("theme-picker");
-        if (themePickers && themePickers.length > 0) {
-            themePickers[0].style.display = null;
-        }
     }
 
     function showSearchResults(search) {
@@ -376,6 +369,7 @@ function defocusSearchBar() {
             document.title = titleBeforeSearch;
         }
         defocusSearchBar();
+        hideThemeButtonState();
     }
 
     function handleShortcut(ev) {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -4,7 +4,7 @@
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass */
 /* global onEachLazy, hasOwnProperty, removeClass, updateLocalStorage */
-/* global hideThemeButtonState */
+/* global hideThemeButtonState, showThemeButtonState */
 
 if (!String.prototype.startsWith) {
     String.prototype.startsWith = function(searchString, position) {
@@ -46,6 +46,14 @@ function getSearchInput() {
 
 function getSearchElement() {
     return document.getElementById("search");
+}
+
+function getThemesElement() {
+    return document.getElementById("theme-choices");
+}
+
+function getThemePickerElement() {
+    return document.getElementById("theme-picker");
 }
 
 // Sets the focus on the search bar at the top of the page
@@ -406,7 +414,57 @@ function defocusSearchBar() {
             case "?":
                 displayHelp(true, ev);
                 break;
+
+            default:
+                var themePicker = getThemePickerElement();
+                if (themePicker.parentNode.contains(ev.target)) {
+                    handleThemeKeyDown(ev);
+                }
             }
+        }
+    }
+
+    function handleThemeKeyDown(ev) {
+        var active = document.activeElement;
+        var themes = getThemesElement();
+        switch (getVirtualKey(ev)) {
+        case "ArrowUp":
+            ev.preventDefault();
+            if (active.previousElementSibling && ev.target.id !== "theme-picker") {
+                active.previousElementSibling.focus();
+            } else {
+                showThemeButtonState();
+                themes.lastElementChild.focus();
+            }
+            break;
+        case "ArrowDown":
+            ev.preventDefault();
+            if (active.nextElementSibling && ev.target.id !== "theme-picker") {
+                active.nextElementSibling.focus();
+            } else {
+                showThemeButtonState();
+                themes.firstElementChild.focus();
+            }
+            break;
+        case "Enter":
+        case "Return":
+        case "Space":
+            if (ev.target.id === "theme-picker" && themes.style.display === "none") {
+                ev.preventDefault();
+                showThemeButtonState();
+                themes.firstElementChild.focus();
+            }
+            break;
+        case "Home":
+            ev.preventDefault();
+            themes.firstElementChild.focus();
+            break;
+        case "End":
+            ev.preventDefault();
+            themes.lastElementChild.focus();
+            break;
+        // The escape key is handled in handleEscape, not here,
+        // so that pressing escape will close the menu even if it isn't focused
         }
     }
 


### PR DESCRIPTION
This PR is mostly designed to bring the theme picker closer to feature parity with the menu bar from docs.rs. Though the rustdoc theme picker is technically already usable from the keyboard, it's really weird that arrow keys work on some of the menus, but not all of them, in the exact same page.
