### PR TITLE
parser: Cleanup `LazyTokenStream` and avoid some clones

### DIFF
--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -22,7 +22,7 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_span::{Span, DUMMY_SP};
 use smallvec::{smallvec, SmallVec};
 
-use std::{iter, mem};
+use std::{fmt, iter, mem};
 
 /// When the main rust parser encounters a syntax-extension invocation, it
 /// parses the arguments to the invocation as a token-tree. This is a very
@@ -120,72 +120,51 @@ where
     }
 }
 
-// A cloneable callback which produces a `TokenStream`. Each clone
-// of this should produce the same `TokenStream`
-pub trait CreateTokenStream: sync::Send + sync::Sync + FnOnce() -> TokenStream {
-    // Workaround for the fact that `Clone` is not object-safe
-    fn clone_it(&self) -> Box<dyn CreateTokenStream>;
+pub trait CreateTokenStream: sync::Send + sync::Sync {
+    fn create_token_stream(&self) -> TokenStream;
 }
 
-impl<F: 'static + Clone + sync::Send + sync::Sync + FnOnce() -> TokenStream> CreateTokenStream
-    for F
-{
-    fn clone_it(&self) -> Box<dyn CreateTokenStream> {
-        Box::new(self.clone())
+impl CreateTokenStream for TokenStream {
+    fn create_token_stream(&self) -> TokenStream {
+        self.clone()
     }
 }
 
-impl Clone for Box<dyn CreateTokenStream> {
-    fn clone(&self) -> Self {
-        let val: &(dyn CreateTokenStream) = &**self;
-        val.clone_it()
-    }
-}
-
-/// A lazy version of `TokenStream`, which may defer creation
+/// A lazy version of `TokenStream`, which defers creation
 /// of an actual `TokenStream` until it is needed.
-pub type LazyTokenStream = Lrc<LazyTokenStreamInner>;
-
+/// `Box` is here only to reduce the structure size.
 #[derive(Clone)]
-pub enum LazyTokenStreamInner {
-    Lazy(Box<dyn CreateTokenStream>),
-    Ready(TokenStream),
-}
+pub struct LazyTokenStream(Lrc<Box<dyn CreateTokenStream>>);
 
-impl std::fmt::Debug for LazyTokenStreamInner {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LazyTokenStreamInner::Lazy(..) => f.debug_struct("LazyTokenStream::Lazy").finish(),
-            LazyTokenStreamInner::Ready(..) => f.debug_struct("LazyTokenStream::Ready").finish(),
-        }
+impl LazyTokenStream {
+    pub fn new(inner: impl CreateTokenStream + 'static) -> LazyTokenStream {
+        LazyTokenStream(Lrc::new(Box::new(inner)))
+    }
+
+    pub fn create_token_stream(&self) -> TokenStream {
+        self.0.create_token_stream()
     }
 }
 
-impl LazyTokenStreamInner {
-    pub fn into_token_stream(&self) -> TokenStream {
-        match self {
-            // Note that we do not cache this. If this ever becomes a performance
-            // problem, we should investigate wrapping `LazyTokenStreamInner`
-            // in a lock
-            LazyTokenStreamInner::Lazy(cb) => (cb.clone())(),
-            LazyTokenStreamInner::Ready(stream) => stream.clone(),
-        }
+impl fmt::Debug for LazyTokenStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt("LazyTokenStream", f)
     }
 }
 
-impl<S: Encoder> Encodable<S> for LazyTokenStreamInner {
+impl<S: Encoder> Encodable<S> for LazyTokenStream {
     fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
         panic!("Attempted to encode LazyTokenStream");
     }
 }
 
-impl<D: Decoder> Decodable<D> for LazyTokenStreamInner {
+impl<D: Decoder> Decodable<D> for LazyTokenStream {
     fn decode(_d: &mut D) -> Result<Self, D::Error> {
         panic!("Attempted to decode LazyTokenStream");
     }
 }
 
-impl<CTX> HashStable<CTX> for LazyTokenStreamInner {
+impl<CTX> HashStable<CTX> for LazyTokenStream {
     fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
         panic!("Attempted to compute stable hash for LazyTokenStream");
     }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -16,8 +16,8 @@ pub use path::PathStyle;
 
 use rustc_ast::ptr::P;
 use rustc_ast::token::{self, DelimToken, Token, TokenKind};
-use rustc_ast::tokenstream::{self, DelimSpan, LazyTokenStream, LazyTokenStreamInner, Spacing};
-use rustc_ast::tokenstream::{TokenStream, TokenTree};
+use rustc_ast::tokenstream::{self, DelimSpan, LazyTokenStream, Spacing};
+use rustc_ast::tokenstream::{CreateTokenStream, TokenStream, TokenTree};
 use rustc_ast::DUMMY_NODE_ID;
 use rustc_ast::{self as ast, AnonConst, AttrStyle, AttrVec, Const, CrateSugar, Extern, Unsafe};
 use rustc_ast::{Async, Expr, ExprKind, MacArgs, MacDelimiter, Mutability, StrLit};
@@ -1199,15 +1199,12 @@ impl<'a> Parser<'a> {
         f: impl FnOnce(&mut Self) -> PResult<'a, R>,
     ) -> PResult<'a, (R, Option<LazyTokenStream>)> {
         let start_token = (self.token.clone(), self.token_spacing);
-        let mut cursor_snapshot = self.token_cursor.clone();
+        let cursor_snapshot = self.token_cursor.clone();
 
         let ret = f(self)?;
 
-        let new_calls = self.token_cursor.num_next_calls;
-        let num_calls = new_calls - cursor_snapshot.num_next_calls;
-        let desugar_doc_comments = self.desugar_doc_comments;
-
         // We didn't capture any tokens
+        let num_calls = self.token_cursor.num_next_calls - cursor_snapshot.num_next_calls;
         if num_calls == 0 {
             return Ok((ret, None));
         }
@@ -1220,27 +1217,41 @@ impl<'a> Parser<'a> {
         //
         // This also makes `Parser` very cheap to clone, since
         // there is no intermediate collection buffer to clone.
-        let lazy_cb = move || {
-            // The token produced by the final call to `next` or `next_desugared`
-            // was not actually consumed by the callback. The combination
-            // of chaining the initial token and using `take` produces the desired
-            // result - we produce an empty `TokenStream` if no calls were made,
-            // and omit the final token otherwise.
-            let tokens = std::iter::once(start_token)
-                .chain((0..num_calls).map(|_| {
-                    if desugar_doc_comments {
-                        cursor_snapshot.next_desugared()
-                    } else {
-                        cursor_snapshot.next()
-                    }
-                }))
-                .take(num_calls);
+        struct LazyTokenStreamImpl {
+            start_token: (Token, Spacing),
+            cursor_snapshot: TokenCursor,
+            num_calls: usize,
+            desugar_doc_comments: bool,
+        }
+        impl CreateTokenStream for LazyTokenStreamImpl {
+            fn create_token_stream(&self) -> TokenStream {
+                // The token produced by the final call to `next` or `next_desugared`
+                // was not actually consumed by the callback. The combination
+                // of chaining the initial token and using `take` produces the desired
+                // result - we produce an empty `TokenStream` if no calls were made,
+                // and omit the final token otherwise.
+                let mut cursor_snapshot = self.cursor_snapshot.clone();
+                let tokens = std::iter::once(self.start_token.clone())
+                    .chain((0..self.num_calls).map(|_| {
+                        if self.desugar_doc_comments {
+                            cursor_snapshot.next_desugared()
+                        } else {
+                            cursor_snapshot.next()
+                        }
+                    }))
+                    .take(self.num_calls);
 
-            make_token_stream(tokens)
+                make_token_stream(tokens)
+            }
+        }
+
+        let lazy_impl = LazyTokenStreamImpl {
+            start_token,
+            cursor_snapshot,
+            num_calls,
+            desugar_doc_comments: self.desugar_doc_comments,
         };
-        let stream = LazyTokenStream::new(LazyTokenStreamInner::Lazy(Box::new(lazy_cb)));
-
-        Ok((ret, Some(stream)))
+        Ok((ret, Some(LazyTokenStream::new(lazy_impl))))
     }
 
     /// `::{` or `::*`


### PR DESCRIPTION
by using a named struct instead of a closure.

r? @Aaron1011 