### PR TITLE
Add note to process::arg[s] that args shouldn't be escaped or quoted

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -557,6 +557,9 @@ impl Command {
     ///
     /// [`args`]: Command::args
     ///
+    /// Note that the argument is passed to the program directly as is, so you shouldn't wrap it in quotes
+    /// or escape special characters the same way you would do that when running the program from terminal.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -581,6 +584,9 @@ impl Command {
     /// To pass a single argument see [`arg`].
     ///
     /// [`arg`]: Command::arg
+    ///
+    /// Note that each argument is passed to the program directly as is, so you shouldn't wrap it in quotes
+    /// or escape special characters the same way you would do that when running the program from terminal directly.
     ///
     /// # Examples
     ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -557,8 +557,10 @@ impl Command {
     ///
     /// [`args`]: Command::args
     ///
-    /// Note that the argument is passed to the program directly as is, so you shouldn't wrap it in quotes
-    /// or escape special characters the same way you would do that when running the program from terminal.
+    /// Note that the argument is not passed through a shell, but given
+    /// literally to the program. This means that shell syntax like quotes,
+    /// escaped characters, word splitting, glob patterns, substitution, etc.
+    /// have no effect.
     ///
     /// # Examples
     ///
@@ -585,8 +587,10 @@ impl Command {
     ///
     /// [`arg`]: Command::arg
     ///
-    /// Note that each argument is passed to the program directly as is, so you shouldn't wrap it in quotes
-    /// or escape special characters the same way you would do that when running the program from terminal directly.
+    /// Note that the arguments are not passed through a shell, but given
+    /// literally to the program. This means that shell syntax like quotes,
+    /// escaped characters, word splitting, glob patterns, substitution, etc.
+    /// have no effect.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This came out of discussion on [forum](https://users.rust-lang.org/t/how-to-get-full-output-from-command/50626), where I recently asked a question and it turned out that the problem was redundant quotation:

```rust
 Command::new("rg")
        .arg("\"pattern\"") // this will look for "pattern" with quotes included
```

This is something that has bitten me few times already (in multiple languages actually), so It'd be grateful to have it in the docs, even though it's not sctrictly Rust specific problem. Other users also agreed. 

This can be really annoying to debug, because in many cases (inluding mine), quotes can be legal part of the argument, so the command doesn't fail, it just behaves unexpectedly. Not everybody (including me) knows that quotes around arguments are part of the shell and not part of the called program. Coincidentally, somoene had the same problem [yesterday](https://www.reddit.com/r/rust/comments/jkxelc/going_crazy_over_running_a_curl_process_from_rust/) on reddit.

I am not a native speaker, so I welcome any corrections or better formulation, I don't expect this to be merged as is. I was also reminded that this is platform/shell specific behaviour, but I didn't find a good way to formulate that briefly, any ideas welcome.

 It's also my first PR here, so I am not sure I did everything correctly, I did this just from Github UI.