### PR TITLE
Update Android API level to 21 in CI

### DIFF
--- a/src/ci/docker/host-x86_64/arm-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/arm-android/Dockerfile
@@ -5,7 +5,7 @@ RUN sh /scripts/android-base-apt-get.sh
 
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
-    download_and_make_toolchain android-ndk-r15c-linux-x86_64.zip arm 14
+    download_and_make_toolchain android-ndk-r15c-linux-x86_64.zip arm 21
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
@@ -29,7 +29,7 @@ ENV PATH=$PATH:/android/sdk/platform-tools
 
 ENV TARGETS=arm-linux-androideabi
 
-ENV RUST_CONFIGURE_ARGS --arm-linux-androideabi-ndk=/android/ndk/arm-14
+ENV RUST_CONFIGURE_ARGS --arm-linux-androideabi-ndk=/android/ndk/arm-21
 
 ENV SCRIPT python3 ../x.py --stage 2 test --host='' --target $TARGETS
 

--- a/src/ci/docker/host-x86_64/dist-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-android/Dockerfile
@@ -7,8 +7,8 @@ RUN sh /scripts/android-base-apt-get.sh
 COPY scripts/android-ndk.sh /scripts/
 RUN . /scripts/android-ndk.sh && \
     download_ndk android-ndk-r15c-linux-x86_64.zip && \
-    make_standalone_toolchain arm 14 && \
-    make_standalone_toolchain x86 14 && \
+    make_standalone_toolchain arm 21 && \
+    make_standalone_toolchain x86 21 && \
     make_standalone_toolchain arm64 21 && \
     make_standalone_toolchain x86_64 21 && \
     remove_ndk
@@ -24,10 +24,10 @@ ENV TARGETS=$TARGETS,x86_64-linux-android
 ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-profiler \
-      --arm-linux-androideabi-ndk=/android/ndk/arm-14 \
-      --armv7-linux-androideabi-ndk=/android/ndk/arm-14 \
-      --thumbv7neon-linux-androideabi-ndk=/android/ndk/arm-14 \
-      --i686-linux-android-ndk=/android/ndk/x86-14 \
+      --arm-linux-androideabi-ndk=/android/ndk/arm-21 \
+      --armv7-linux-androideabi-ndk=/android/ndk/arm-21 \
+      --thumbv7neon-linux-androideabi-ndk=/android/ndk/arm-21 \
+      --i686-linux-android-ndk=/android/ndk/x86-21 \
       --aarch64-linux-android-ndk=/android/ndk/arm64-21 \
       --x86_64-linux-android-ndk=/android/ndk/x86_64-21 \
       --disable-docs


### PR DESCRIPTION
I ran into a problem with #78572 because the Android API level in CI is pretty old. The `accept4()` function is exposed by the `libc` crate, but it is added in Android 5.0 with API level 21 (released in June 2014). Currently, the CI is still on API level 14 in most cases.

So I was wondering: should we just update the API level in CI to 21? I think the alternative would be to remove the `accept4()` function from the `libc` crate for Android, but that would break crates that use it.

