### PR TITLE
Clarify handling of final line ending in str::lines()

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -843,8 +843,8 @@ impl str {
     /// a line feed (`\r\n`).
     ///
     /// The final line ending is optional. A string that ends with a final line
-    /// ending (carriage return or line feed) will return the same lines as an
-    /// otherwise identical string without a final line ending.
+    /// ending will return the same lines as an otherwise identical string
+    /// without a final line ending.
     ///
     /// # Examples
     ///

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -842,7 +842,9 @@ impl str {
     /// Lines are ended with either a newline (`\n`) or a carriage return with
     /// a line feed (`\r\n`).
     ///
-    /// The final line ending is optional.
+    /// The final line ending is optional. A string that ends with a final line
+    /// ending (carriage return or line feed) will return the same lines as an
+    /// otherwise identical string without a final line ending.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
I found the description as it stands a bit confusing. I've added a bit more explanation to make it clear that a trailing line ending does not produce a final empty line.