### PR TITLE
[WIP] Distinguish between links on inner and outer attributes

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2388,7 +2388,7 @@ impl UseTree {
 /// Distinguishes between `Attribute`s that decorate items and Attributes that
 /// are contained as statements within items. These two cases need to be
 /// distinguished for pretty-printing.
-#[derive(Clone, PartialEq, Encodable, Decodable, Debug, Copy, HashStable_Generic)]
+#[derive(Clone, PartialEq, Eq, Hash, Encodable, Decodable, Debug, Copy, HashStable_Generic)]
 pub enum AttrStyle {
     Outer,
     Inner,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -385,6 +385,7 @@ pub struct DocFragment {
     pub parent_module: Option<DefId>,
     pub doc: String,
     pub kind: DocFragmentKind,
+    pub style: AttrStyle,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -421,7 +422,6 @@ pub struct Attributes {
     pub span: Option<rustc_span::Span>,
     /// map from Rust paths to resolved defs and potential URL fragments
     pub links: Vec<ItemLink>,
-    pub inner_docs: bool,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -559,6 +559,7 @@ impl Attributes {
                     doc: value,
                     kind,
                     parent_module,
+                    style: attr.style,
                 });
 
                 if sp.is_none() {
@@ -584,6 +585,7 @@ impl Attributes {
                                 doc: contents,
                                 kind: DocFragmentKind::Include { filename },
                                 parent_module: parent_module,
+                                style: attr.style,
                             });
                         }
                     }
@@ -618,18 +620,12 @@ impl Attributes {
             }
         }
 
-        let inner_docs = attrs
-            .iter()
-            .find(|a| a.doc_str().is_some())
-            .map_or(true, |a| a.style == AttrStyle::Inner);
-
         Attributes {
             doc_strings,
             other_attrs,
             cfg: if cfg == Cfg::True { None } else { Some(Arc::new(cfg)) },
             span: sp,
             links: vec![],
-            inner_docs,
         }
     }
 

--- a/src/librustdoc/passes/collapse_docs.rs
+++ b/src/librustdoc/passes/collapse_docs.rs
@@ -39,7 +39,9 @@ fn collapse(doc_strings: &mut Vec<DocFragment>) {
             if matches!(*curr_kind, DocFragmentKind::Include { .. })
                 || curr_kind != new_kind
                 || curr_frag.parent_module != frag.parent_module
+                || curr_frag.style != frag.style
             {
+                // Keep these as two separate attributes
                 if *curr_kind == DocFragmentKind::SugaredDoc
                     || *curr_kind == DocFragmentKind::RawDoc
                 {
@@ -49,6 +51,7 @@ fn collapse(doc_strings: &mut Vec<DocFragment>) {
                 docs.push(curr_frag);
                 last_frag = Some(frag);
             } else {
+                // Combine both attributes into one
                 curr_frag.doc.push('\n');
                 curr_frag.doc.push_str(&frag.doc);
                 curr_frag.span = curr_frag.span.to(frag.span);

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -179,7 +179,9 @@ crate fn source_span_for_markdown_range(
         return None;
     }
 
+    trace!("markdown is {}", markdown);
     let snippet = cx.sess().source_map().span_to_snippet(span_of_attrs(attrs)?).ok()?;
+    trace!("snippet is {}", snippet);
 
     let starting_line = markdown[..md_range.start].matches('\n').count();
     let ending_line = starting_line + markdown[md_range.start..md_range.end].matches('\n').count();
@@ -196,7 +198,9 @@ crate fn source_span_for_markdown_range(
 
     'outer: for (line_no, md_line) in md_lines.enumerate() {
         loop {
-            let source_line = src_lines.next().expect("could not find markdown in source");
+            let source_line = src_lines.next().unwrap_or_else(|| {
+                panic!("could not find markdown range {:?} in source", md_range)
+            });
             match source_line.find(md_line) {
                 Some(offset) => {
                     if line_no == starting_line {

--- a/src/test/rustdoc-ui/intra-link-inner-outer.rs
+++ b/src/test/rustdoc-ui/intra-link-inner-outer.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+pub enum A {}
+
+/// Links to [outer][A] and [outer][B]
+//~^ WARNING: unresolved link to `B`
+pub mod M {
+    //! Links to [inner][A] and [inner][B]
+    //~^ WARNING: unresolved link to `A`
+
+    pub struct B;
+}

--- a/src/test/rustdoc/intra-link-inner-outer.rs
+++ b/src/test/rustdoc/intra-link-inner-outer.rs
@@ -1,0 +1,24 @@
+#![crate_name = "foo"]
+
+pub enum A {}
+
+/// Links to [outer A][A] and [outer B][B]
+// @has foo/M/index.html '//*[@href="../foo/enum.A.html"]' 'outer A'
+// @!has foo/M/index.html '//*[@href="../foo/struct.B.html"]' 'outer B'
+// doesn't resolve unknown links
+pub mod M {
+    //! Links to [inner A][A] and [inner B][B]
+    // @!has foo/M/index.html '//*[@href="../foo/enum.A.html"]' 'inner A'
+    // @has foo/M/index.html '//*[@href="../foo/struct.B.html"]' 'inner B'
+    pub struct B;
+}
+
+// distinguishes between links to inner and outer attributes
+/// Links to [outer A][A]
+// @has foo/N/index.html '//*[@href="../foo/enum.A.html"]' 'outer A'
+pub mod N {
+    //! Links to [inner A][A]
+    // @has foo/N/index.html '//*[@href="../foo/struct.A.html"]' 'inner A'
+
+    pub struct A;
+}


### PR DESCRIPTION
Normally, rustdoc will resolve `//!` docs in the scope inside the module
and `///` in the scope of the parent. But if there are modules with
inner docs, it would previously resolve _all_ of the links inside the module.

This now distinguishes between links that came from inside the module
and links that came from outside. The intra-doc links part works, but
unfortunately the rest of rustdoc assumes there is only one canonical
resolution for a link and won't look for more than one on the same item.

- Store the attribute style on each DocFragment
- Don't combine attributes with different styles
- Calculate the parent module in only one place
- Remove outdated and fixed FIXME comments

This came from a failed attempt to work on https://github.com/rust-lang/rust/issues/78591 and there's some debugging for that left over. Let me know if I should remove it.

r? @GuillaumeGomez - do you have suggestions for how to pass this information to the rest of rustdoc? For context, the issue is that given a list of links like
```rust
vec![ItemLink { link: "a", did: Some(DefId(0)) }, ItemLink { link: "a", did: Some(DefId(1)) }]
```
`rustdoc::html` will always pick the first resolution in the array. Maybe the link should also say whether it's an inner or outer link, and have `html` distinguish too?

cc @Manishearth - technically this is a breaking change, but I consider the old behavior a bug.