### PR TITLE
[perf] rustc_ast: Remove one level of indirection from `LazyTokenStream`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1054,7 +1054,7 @@ pub struct Expr {
 
 // `Expr` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(Expr, 112);
+rustc_data_structures::static_assert_size!(Expr, 128);
 
 impl Expr {
     /// Returns `true` if this expression would be valid somewhere that expects a value;

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -698,7 +698,7 @@ pub enum Nonterminal {
 
 // `Nonterminal` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(Nonterminal, 48);
+rustc_data_structures::static_assert_size!(Nonterminal, 56);
 
 #[derive(Debug, Copy, Clone, PartialEq, Encodable, Decodable)]
 pub enum NonterminalKind {

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -134,11 +134,11 @@ impl CreateTokenStream for TokenStream {
 /// of an actual `TokenStream` until it is needed.
 /// `Box` is here only to reduce the structure size.
 #[derive(Clone)]
-pub struct LazyTokenStream(Lrc<Box<dyn CreateTokenStream>>);
+pub struct LazyTokenStream(Lrc<dyn CreateTokenStream>);
 
 impl LazyTokenStream {
     pub fn new(inner: impl CreateTokenStream + 'static) -> LazyTokenStream {
-        LazyTokenStream(Lrc::new(Box::new(inner)))
+        LazyTokenStream(Lrc::new(inner))
     }
 
     pub fn create_token_stream(&self) -> TokenStream {


### PR DESCRIPTION
It makes `Expr` and `Nonterminal` larger due to a fat pointer, but both of those structures live lonely under `P` and `Lrc` respectively, so it shouldn't have much effect until the size crosses some power of two boundary, I guess?