### PR TITLE
Trivial fixes to bitwise operator documentation

### DIFF
--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -109,10 +109,12 @@ not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///     fn bitand(self, Self(rhs): Self) -> Self::Output {
 ///         let Self(lhs) = self;
 ///         assert_eq!(lhs.len(), rhs.len());
-///         Self(lhs.iter()
+///         Self(
+///             lhs.iter()
 ///                 .zip(rhs.iter())
 ///                 .map(|(x, y)| *x & *y)
-///                 .collect())
+///                 .collect()
+///         )
 ///     }
 /// }
 ///
@@ -207,10 +209,12 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///     fn bitor(self, Self(rhs): Self) -> Self::Output {
 ///         let Self(lhs) = self;
 ///         assert_eq!(lhs.len(), rhs.len());
-///         Self(lhs.iter()
+///         Self(
+///             lhs.iter()
 ///                 .zip(rhs.iter())
 ///                 .map(|(x, y)| *x | *y)
-///                 .collect())
+///                 .collect()
+///         )
 ///     }
 /// }
 ///
@@ -305,10 +309,12 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///     fn bitxor(self, Self(rhs): Self) -> Self::Output {
 ///         let Self(lhs) = self;
 ///         assert_eq!(lhs.len(), rhs.len());
-///         Self(lhs.iter()
+///         Self(
+///             lhs.iter()
 ///                 .zip(rhs.iter())
 ///                 .map(|(x, y)| *x ^ *y)
-///                 .collect())
+///                 .collect()
+///         )
 ///     }
 /// }
 ///
@@ -646,11 +652,13 @@ shr_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 ///     // `rhs` is the "right-hand side" of the expression `a &= b`.
 ///     fn bitand_assign(&mut self, rhs: Self) {
 ///         assert_eq!(self.0.len(), rhs.0.len());
-///         *self = Self(self.0
-///                          .iter()
-///                          .zip(rhs.0.iter())
-///                          .map(|(x, y)| *x & *y)
-///                          .collect());
+///         *self = Self(
+///             self.0
+///                 .iter()
+///                 .zip(rhs.0.iter())
+///                 .map(|(x, y)| *x & *y)
+///                 .collect()
+///         );
 ///     }
 /// }
 ///

--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -111,7 +111,7 @@ not_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///         assert_eq!(lhs.len(), rhs.len());
 ///         Self(lhs.iter()
 ///                 .zip(rhs.iter())
-///                 .map(|(x, y)| *x && *y)
+///                 .map(|(x, y)| *x & *y)
 ///                 .collect())
 ///     }
 /// }
@@ -207,7 +207,10 @@ bitand_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///     fn bitor(self, Self(rhs): Self) -> Self::Output {
 ///         let Self(lhs) = self;
 ///         assert_eq!(lhs.len(), rhs.len());
-///         Self(lhs.iter().zip(rhs.iter()).map(|(x, y)| *x || *y).collect())
+///         Self(lhs.iter()
+///                 .zip(rhs.iter())
+///                 .map(|(x, y)| *x | *y)
+///                 .collect())
 ///     }
 /// }
 ///
@@ -304,7 +307,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///         assert_eq!(lhs.len(), rhs.len());
 ///         Self(lhs.iter()
 ///                 .zip(rhs.iter())
-///                 .map(|(x, y)| (*x || *y) && !(*x && *y))
+///                 .map(|(x, y)| *x ^ *y))
 ///                 .collect())
 ///     }
 /// }
@@ -646,7 +649,7 @@ shr_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 i128 isize }
 ///         *self = Self(self.0
 ///                          .iter()
 ///                          .zip(rhs.0.iter())
-///                          .map(|(x, y)| *x && *y)
+///                          .map(|(x, y)| *x & *y)
 ///                          .collect());
 ///     }
 /// }

--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -307,7 +307,7 @@ bitor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///         assert_eq!(lhs.len(), rhs.len());
 ///         Self(lhs.iter()
 ///                 .zip(rhs.iter())
-///                 .map(|(x, y)| *x ^ *y))
+///                 .map(|(x, y)| *x ^ *y)
 ///                 .collect())
 ///     }
 /// }


### PR DESCRIPTION
Added fixes to documentation of `BitAnd`, `BitOr`, `BitXor` and
`BitAndAssign`, where the documentation for implementation on
`Vector<bool>` was using logical operators in place of the bitwise
operators.

r? @steveklabnik
Closes #78619