### PR TITLE
Inline Default::default() for atomics

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -155,6 +155,7 @@ pub struct AtomicBool {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for AtomicBool {
     /// Creates an `AtomicBool` initialized to `false`.
+    #[inline]
     fn default() -> Self {
         Self::new(false)
     }
@@ -1212,6 +1213,7 @@ macro_rules! atomic_int {
 
         #[$stable]
         impl Default for $atomic_type {
+            #[inline]
             fn default() -> Self {
                 Self::new(Default::default())
             }


### PR DESCRIPTION
Functions like `AtomicUsize::default()` are not cross-crate inlineable before this PR ([see assembly output here](https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=e353321766418f759c69fb141d3732f8)), which can lead to unexpected performance issues when initializing a large array using this function, e.g. as seen [here](https://github.com/spacejam/sled/blob/d513996a85875be8c813fd0e30a548b89682289a/src/histogram.rs#L53) which should turn into a simple loop writing zeroes but doesn't.

r? @m-ou-se 