### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -232,17 +232,19 @@ pub(super) fn transcribe<'a>(
                 // the meta-var.
                 let ident = MacroRulesNormalizedIdent::new(orignal_ident);
                 if let Some(cur_matched) = lookup_cur_matched(ident, interp, &repeats) {
-                    if let MatchedNonterminal(ref nt) = cur_matched {
-                        // FIXME #2887: why do we apply a mark when matching a token tree meta-var
-                        // (e.g. `$x:tt`), but not when we are matching any other type of token
-                        // tree?
-                        if let NtTT(ref tt) = **nt {
-                            result.push(tt.clone().into());
+                    if let MatchedNonterminal(nt) = cur_matched {
+                        let token = if let NtTT(tt) = &**nt {
+                            // `tt`s are emitted into the output stream directly as "raw tokens",
+                            // without wrapping them into groups.
+                            tt.clone()
                         } else {
+                            // Other variables are emitted into the output stream as groups with
+                            // `Delimiter::None` to maintain parsing priorities.
+                            // `Interpolated` is currenty used for such groups in rustc parser.
                             marker.visit_span(&mut sp);
-                            let token = TokenTree::token(token::Interpolated(nt.clone()), sp);
-                            result.push(token.into());
-                        }
+                            TokenTree::token(token::Interpolated(nt.clone()), sp)
+                        };
+                        result.push(token.into());
                     } else {
                         // We were unable to descend far enough. This is an error.
                         return Err(cx.struct_span_err(

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -1036,8 +1036,9 @@ impl<'a, T> Hole<'a, T> {
         debug_assert!(index != self.pos);
         debug_assert!(index < self.data.len());
         unsafe {
-            let index_ptr: *const _ = self.data.get_unchecked(index);
-            let hole_ptr = self.data.get_unchecked_mut(self.pos);
+            let ptr = self.data.as_mut_ptr();
+            let index_ptr: *const _ = ptr.add(index);
+            let hole_ptr = ptr.add(self.pos);
             ptr::copy_nonoverlapping(index_ptr, hole_ptr, 1);
         }
         self.pos = index;

--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -71,7 +71,7 @@ macro_rules! vec {
 ///
 /// Additional parameters passed to `format!` replace the `{}`s within the
 /// formatting string in the order given unless named or positional parameters
-/// are used; see [`std::fmt`][fmt] for more information.
+/// are used; see [`std::fmt`] for more information.
 ///
 /// A common use for `format!` is concatenation and interpolation of strings.
 /// The same convention is used with [`print!`] and [`write!`] macros,
@@ -80,7 +80,7 @@ macro_rules! vec {
 /// To convert a single value to a string, use the [`to_string`] method. This
 /// will use the [`Display`] formatting trait.
 ///
-/// [fmt]: core::fmt
+/// [`std::fmt`]: ../std/fmt/index.html
 /// [`print!`]: ../std/macro.print.html
 /// [`write!`]: core::write
 /// [`to_string`]: crate::string::ToString

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -111,7 +111,7 @@ macro_rules! load_int_le {
         debug_assert!($i + mem::size_of::<$int_ty>() <= $buf.len());
         let mut data = 0 as $int_ty;
         ptr::copy_nonoverlapping(
-            $buf.get_unchecked($i),
+            $buf.as_ptr().add($i),
             &mut data as *mut _ as *mut u8,
             mem::size_of::<$int_ty>(),
         );

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -327,7 +327,7 @@ macro_rules! r#try {
 ///
 /// See [`std::fmt`] for more information on the format string syntax.
 ///
-/// [`std::fmt`]: crate::fmt
+/// [`std::fmt`]: ../std/fmt/index.html
 /// [`fmt::Write`]: crate::fmt::Write
 /// [`io::Write`]: ../std/io/trait.Write.html
 /// [`fmt::Result`]: crate::fmt::Result

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -842,13 +842,13 @@ impl<T> MaybeUninit<T> {
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
     pub fn slice_as_ptr(this: &[MaybeUninit<T>]) -> *const T {
-        this as *const [MaybeUninit<T>] as *const T
+        this.as_ptr() as *const T
     }
 
     /// Gets a mutable pointer to the first element of the array.
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
     pub fn slice_as_mut_ptr(this: &mut [MaybeUninit<T>]) -> *mut T {
-        this as *mut [MaybeUninit<T>] as *mut T
+        this.as_mut_ptr() as *mut T
     }
 }

--- a/library/core/src/str/error.rs
+++ b/library/core/src/str/error.rs
@@ -72,6 +72,7 @@ impl Utf8Error {
     /// assert_eq!(1, error.valid_up_to());
     /// ```
     #[stable(feature = "utf8_error", since = "1.5.0")]
+    #[inline]
     pub fn valid_up_to(&self) -> usize {
         self.valid_up_to
     }
@@ -92,6 +93,7 @@ impl Utf8Error {
     ///
     /// [U+FFFD]: ../../std/char/constant.REPLACEMENT_CHARACTER.html
     #[stable(feature = "utf8_error_error_len", since = "1.20.0")]
+    #[inline]
     pub fn error_len(&self) -> Option<usize> {
         self.error_len.map(|len| len as usize)
     }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -326,6 +326,7 @@ unsafe impl TrustedLen for Bytes<'_> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl TrustedRandomAccess for Bytes<'_> {
+    #[inline]
     fn may_have_side_effect() -> bool {
         false
     }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2431,6 +2431,7 @@ impl AsRef<[u8]> for str {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for &str {
     /// Creates an empty str
+    #[inline]
     fn default() -> Self {
         ""
     }
@@ -2439,6 +2440,7 @@ impl Default for &str {
 #[stable(feature = "default_mut_str", since = "1.28.0")]
 impl Default for &mut str {
     /// Creates an empty mutable str
+    #[inline]
     fn default() -> Self {
         // SAFETY: The empty string is valid UTF-8.
         unsafe { from_utf8_unchecked_mut(&mut []) }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1711,6 +1711,7 @@ impl str {
     ///
     /// assert_eq!("Hello\tworld", s.trim());
     /// ```
+    #[inline]
     #[must_use = "this returns the trimmed string as a slice, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1748,6 +1749,7 @@ impl str {
     /// let s = "  עברית  ";
     /// assert!(Some('ע') == s.trim_start().chars().next());
     /// ```
+    #[inline]
     #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
@@ -1785,6 +1787,7 @@ impl str {
     /// let s = "  עברית  ";
     /// assert!(Some('ת') == s.trim_end().chars().rev().next());
     /// ```
+    #[inline]
     #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
@@ -1823,6 +1826,7 @@ impl str {
     /// let s = "  עברית";
     /// assert!(Some('ע') == s.trim_left().chars().next());
     /// ```
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_deprecated(
         since = "1.33.0",
@@ -1864,6 +1868,7 @@ impl str {
     /// let s = "עברית  ";
     /// assert!(Some('ת') == s.trim_right().chars().rev().next());
     /// ```
+    #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_deprecated(
         since = "1.33.0",
@@ -2261,6 +2266,7 @@ impl str {
     /// assert_eq!("GRüßE, JüRGEN ❤", s);
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[inline]
     pub fn make_ascii_uppercase(&mut self) {
         // SAFETY: safe because we transmute two types with the same layout.
         let me = unsafe { self.as_bytes_mut() };
@@ -2287,6 +2293,7 @@ impl str {
     /// assert_eq!("grÜße, jÜrgen ❤", s);
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[inline]
     pub fn make_ascii_lowercase(&mut self) {
         // SAFETY: safe because we transmute two types with the same layout.
         let me = unsafe { self.as_bytes_mut() };

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -155,6 +155,7 @@ pub struct AtomicBool {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Default for AtomicBool {
     /// Creates an `AtomicBool` initialized to `false`.
+    #[inline]
     fn default() -> Self {
         Self::new(false)
     }
@@ -1212,6 +1213,7 @@ macro_rules! atomic_int {
 
         #[$stable]
         impl Default for $atomic_type {
+            #[inline]
             fn default() -> Self {
                 Self::new(Default::default())
             }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -557,6 +557,9 @@ impl Command {
     ///
     /// [`args`]: Command::args
     ///
+    /// Note that the argument is passed to the program directly as is, so you shouldn't wrap it in quotes
+    /// or escape special characters the same way you would do that when running the program from terminal.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -581,6 +584,9 @@ impl Command {
     /// To pass a single argument see [`arg`].
     ///
     /// [`arg`]: Command::arg
+    ///
+    /// Note that each argument is passed to the program directly as is, so you shouldn't wrap it in quotes
+    /// or escape special characters the same way you would do that when running the program from terminal directly.
     ///
     /// # Examples
     ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -557,8 +557,10 @@ impl Command {
     ///
     /// [`args`]: Command::args
     ///
-    /// Note that the argument is passed to the program directly as is, so you shouldn't wrap it in quotes
-    /// or escape special characters the same way you would do that when running the program from terminal.
+    /// Note that the argument is not passed through a shell, but given
+    /// literally to the program. This means that shell syntax like quotes,
+    /// escaped characters, word splitting, glob patterns, substitution, etc.
+    /// have no effect.
     ///
     /// # Examples
     ///
@@ -585,8 +587,10 @@ impl Command {
     ///
     /// [`arg`]: Command::arg
     ///
-    /// Note that each argument is passed to the program directly as is, so you shouldn't wrap it in quotes
-    /// or escape special characters the same way you would do that when running the program from terminal directly.
+    /// Note that the arguments are not passed through a shell, but given
+    /// literally to the program. This means that shell syntax like quotes,
+    /// escaped characters, word splitting, glob patterns, substitution, etc.
+    /// have no effect.
     ///
     /// # Examples
     ///

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -178,7 +178,8 @@ impl Thread {
                     tv_nsec: nsecs,
                 };
                 secs -= ts.tv_sec as u64;
-                if libc::nanosleep(&ts, &mut ts) == -1 {
+                let ts_ptr = &mut ts as *mut _;
+                if libc::nanosleep(ts_ptr, ts_ptr) == -1 {
                     assert_eq!(os::errno(), libc::EINTR);
                     secs += ts.tv_sec as u64;
                     nsecs = ts.tv_nsec;


### PR DESCRIPTION
Successful merges:

 - #78073 (Add #[inline] to some functions in core::str.)
 - #78596 (Fix doc links to std::fmt)
 - #78599 (Add note to process::arg[s] that args shouldn't be escaped or quoted)
 - #78602 (fix various aliasing issues in the standard library)
 - #78603 (expand: Tweak a comment in implementation of `macro_rules`)
 - #78621 (Inline Default::default() for atomics)

Failed merges:


r? @ghost