### PR TITLE
Implement PartialEq for proc_macro::Ident == strings

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -513,6 +513,9 @@ impl server::Ident for Rustc<'_> {
     fn new(&mut self, string: &str, span: Self::Span, is_raw: bool) -> Self::Ident {
         Ident::new(self.sess, Symbol::intern(string), is_raw, span)
     }
+    fn eq(&mut self, ident: Self::Ident, rhs: &str) -> bool {
+        ident.sym.as_str() == rhs
+    }
     fn span(&mut self, ident: Self::Ident) -> Self::Span {
         ident.span
     }

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -101,6 +101,7 @@ macro_rules! with_api {
             },
             Ident {
                 fn new(string: &str, span: $S::Span, is_raw: bool) -> $S::Ident;
+                fn eq($self: $S::Ident, rhs: &str) -> bool;
                 fn span($self: $S::Ident) -> $S::Span;
                 fn with_span($self: $S::Ident, span: $S::Span) -> $S::Ident;
             },

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -923,6 +923,31 @@ impl fmt::Debug for Ident {
     }
 }
 
+#[stable(feature = "proc_macro_ident_eq", since = "1.49.0")]
+impl PartialEq<str> for Ident {
+    fn eq(&self, rhs: &str) -> bool {
+        self.0.eq(rhs)
+    }
+}
+
+#[stable(feature = "proc_macro_ident_eq", since = "1.49.0")]
+impl PartialEq<String> for Ident {
+    fn eq(&self, rhs: &String) -> bool {
+        <Self as PartialEq<str>>::eq(self, rhs.as_str())
+    }
+}
+
+#[stable(feature = "proc_macro_ident_eq", since = "1.49.0")]
+impl<'a, T> PartialEq<&'a T> for Ident
+where
+    T: ?Sized,
+    Ident: PartialEq<T>,
+{
+    fn eq(&self, rhs: &&T) -> bool {
+        <Self as PartialEq<T>>::eq(self, *rhs)
+    }
+}
+
 /// A literal string (`"hello"`), byte string (`b"hello"`),
 /// character (`'a'`), byte character (`b'a'`), an integer or floating point number
 /// with or without a suffix (`1`, `1u8`, `2.3`, `2.3f32`).

--- a/library/proc_macro/tests/test.rs
+++ b/library/proc_macro/tests/test.rs
@@ -1,6 +1,6 @@
 #![feature(proc_macro_span)]
 
-use proc_macro::LineColumn;
+use proc_macro::{Ident, LineColumn};
 
 #[test]
 fn test_line_column_ord() {
@@ -9,4 +9,15 @@ fn test_line_column_ord() {
     let line1_column0 = LineColumn { line: 1, column: 0 };
     assert!(line0_column0 < line0_column1);
     assert!(line0_column1 < line1_column0);
+}
+
+#[test]
+fn test_ident_eq() {
+    // Good enough if it typechecks, since proc_macro::Ident can't exist in a test.
+    fn _check(ident: &Ident, string: String) {
+        let _ = ident == "serde";
+        let _ = *ident == "serde";
+        let _ = *ident == string;
+        let _ = *ident == &&&string;
+    }
 }


### PR DESCRIPTION
```rust
impl PartialEq<str> for Ident
```

```rust
impl PartialEq<String> for Ident
```

```rust
impl<'a, T> PartialEq<&'a T> for Ident
where
    T: ?Sized,
    Ident: PartialEq<T>
```

Closes https://github.com/rust-lang/rust/issues/51074.

We avoid implementing PartialEq\<Ident\> because *"comparison in vacuum doesn't generally make sense in presence of hygiene and it became a source of bugs"* --- see https://github.com/rust-lang/rust/issues/51074#issuecomment-392253878. However, comparing an Ident to a string is *"probably explicit enough"* --- see https://github.com/rust-lang/rust/issues/51074#issuecomment-392388309.

The use case is to support attribute parsing, among other things. For example parsing #\[serde(rename = "...")\] might involve `if ident == "serde"` and `if ident == "rename"`.