### PR TITLE
Add PartialEq<char> for proc_macro::Punct

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -842,6 +842,13 @@ impl fmt::Debug for Punct {
     }
 }
 
+#[stable(feature = "proc_macro_punct_eq", since = "1.49.0")]
+impl PartialEq<char> for Punct {
+    fn eq(&self, rhs: &char) -> bool {
+        self.as_char() == *rhs
+    }
+}
+
 /// An identifier (`ident`).
 #[derive(Clone)]
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]

--- a/library/proc_macro/tests/test.rs
+++ b/library/proc_macro/tests/test.rs
@@ -1,6 +1,6 @@
 #![feature(proc_macro_span)]
 
-use proc_macro::LineColumn;
+use proc_macro::{LineColumn, Punct};
 
 #[test]
 fn test_line_column_ord() {
@@ -9,4 +9,12 @@ fn test_line_column_ord() {
     let line1_column0 = LineColumn { line: 1, column: 0 };
     assert!(line0_column0 < line0_column1);
     assert!(line0_column1 < line1_column0);
+}
+
+#[test]
+fn test_punct_eq() {
+    // Good enough if it typechecks, since proc_macro::Punct can't exist in a test.
+    fn _check(punct: Punct) {
+        let _ = punct == ':';
+    }
 }


### PR DESCRIPTION
`punct.as_char() == '░'` is pervasive when parsing anything involving punct. I think `punct == '░'` is sufficiently unambiguous that it makes sense to provide the impl.

https://github.com/rust-lang/rust/blob/1899c489d4c30b2640d30b77ac04f0a548834d81/library/proc_macro/src/quote.rs#L79
https://github.com/rust-lang/rust/blob/1899c489d4c30b2640d30b77ac04f0a548834d81/library/proc_macro/src/quote.rs#L83
https://github.com/rust-lang/rust/blob/1899c489d4c30b2640d30b77ac04f0a548834d81/src/test/ui/suggestions/auxiliary/issue-61963.rs#L26
https://github.com/rust-lang/rust/blob/1899c489d4c30b2640d30b77ac04f0a548834d81/src/test/ui/proc-macro/auxiliary/three-equals.rs#L23