### PR TITLE
Do not ICE on invalid const param in an invalid path

### DIFF
--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -79,7 +79,13 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                         let _tables = tcx.typeck(body_owner);
                         &*path
                     }
-                    _ => span_bug!(DUMMY_SP, "unexpected const parent path {:?}", parent_node),
+                    _ => {
+                        tcx.sess.delay_span_bug(
+                            DUMMY_SP,
+                            &format!("unexpected const parent path {:?}", parent_node),
+                        );
+                        return None;
+                    }
                 };
 
                 // We've encountered an `AnonConst` in some path, so we need to

--- a/src/test/ui/issues/issue-78622.rs
+++ b/src/test/ui/issues/issue-78622.rs
@@ -1,0 +1,5 @@
+struct S;
+fn f() {
+    S::A::<f> {} //~ ERROR ambiguous associated type
+}
+fn main() {}

--- a/src/test/ui/issues/issue-78622.stderr
+++ b/src/test/ui/issues/issue-78622.stderr
@@ -1,0 +1,9 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/issue-78622.rs:3:5
+   |
+LL |     S::A::<f> {}
+   |     ^^^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
Fix #78622.