### PR TITLE
Make Vec::len() and Vec::is_empty() const

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -1362,7 +1362,8 @@ impl<T> Vec<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn len(&self) -> usize {
+    #[rustc_const_stable(feature = "const_vec_len", since = "1.49.0")]
+    pub const fn len(&self) -> usize {
         self.len
     }
 
@@ -1378,7 +1379,8 @@ impl<T> Vec<T> {
     /// assert!(!v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    #[rustc_const_stable(feature = "const_vec_len", since = "1.49.0")]
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 


### PR DESCRIPTION
Since these can trivially be const, I applied `rustc_const_stable` right away. Is this okay?