### PR TITLE
Fix intrinsic size_of stable link

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -764,7 +764,7 @@ extern "rust-intrinsic" {
     /// More specifically, this is the offset in bytes between successive
     /// items of the same type, including alignment padding.
     ///
-    /// The stabilized version of this intrinsic is [`size_of`].
+    /// The stabilized version of this intrinsic is [`crate::mem::size_of`].
     #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
     pub fn size_of<T>() -> usize;
 


### PR DESCRIPTION
I noticed that it is pointing to the same link when I was reading
https://github.com/rust-lang/rust-clippy/issues/2997