### PR TITLE
Try running lldb_batchmode.py with PYTHONUNBUFFERED

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1166,6 +1166,7 @@ impl<'test> TestCx<'test> {
                 .arg(&lldb_script_path)
                 .arg(test_executable)
                 .arg(debugger_script)
+                .env("PYTHONUNBUFFERED", "1") // Help debugging #78665
                 .env("PYTHONPATH", self.config.lldb_python_dir.as_ref().unwrap()),
         )
     }


### PR DESCRIPTION
When reporting fatal errors, LLVM calls abort() to exit the program. There is a chance that might interfere with Python printing stuff to stdout, as by default it relies on buffering to increase performance.

This commit tries to disable Python buffering, to hopefully get useful logs while debugging #78665.