### PR TITLE
Use check-pass instead of build-pass in some consts ui test suits

### DIFF
--- a/src/test/ui/consts/const-block-non-item-statement.rs
+++ b/src/test/ui/consts/const-block-non-item-statement.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 enum Foo {
     Bar = { let x = 1; 3 }

--- a/src/test/ui/consts/const-fn-destructuring-arg.rs
+++ b/src/test/ui/consts/const-fn-destructuring-arg.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 const fn i((a, b): (u32, u32)) -> u32 {
     a + b

--- a/src/test/ui/consts/const_let_assign.rs
+++ b/src/test/ui/consts/const_let_assign.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 struct S(i32);
 

--- a/src/test/ui/consts/const_let_assign2.rs
+++ b/src/test/ui/consts/const_let_assign2.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub struct AA {
     pub data: [u8; 10],


### PR DESCRIPTION
Helps with #62277 

Changed tests modified by https://github.com/rust-lang/rust/pull/57175 because of the stabilization `#![feature(const_let)]`.
They should be compile-fail because the feature gate checking disallow the feature before stabilization. So the feature gate checking have nothing to do with codegen according to https://rustc-dev-guide.rust-lang.org/feature-gate-ck.html.