### PR TITLE
Remove FIXME comment in some incremental test suite

### DIFF
--- a/src/test/incremental/add_private_fn_at_krate_root_cc/struct_point.rs
+++ b/src/test/incremental/add_private_fn_at_krate_root_cc/struct_point.rs
@@ -5,7 +5,7 @@
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
 // aux-build:point.rs
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]

--- a/src/test/incremental/change_add_field/struct_point.rs
+++ b/src/test/incremental/change_add_field/struct_point.rs
@@ -5,7 +5,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]

--- a/src/test/incremental/change_private_impl_method/struct_point.rs
+++ b/src/test/incremental/change_private_impl_method/struct_point.rs
@@ -3,7 +3,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![feature(rustc_attrs)]
 #![feature(stmt_expr_attributes)]

--- a/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_body/struct_point.rs
@@ -2,7 +2,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
+++ b/src/test/incremental/change_pub_inherent_method_sig/struct_point.rs
@@ -2,7 +2,7 @@
 
 // revisions:cfail1 cfail2
 // compile-flags: -Z query-dep-graph
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/issue-49595/issue-49595.rs
+++ b/src/test/incremental/issue-49595/issue-49595.rs
@@ -1,6 +1,6 @@
 // revisions:cfail1 cfail2 cfail3
 // compile-flags: -Z query-dep-graph --test
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 #![feature(rustc_attrs)]
 #![crate_type = "rlib"]


### PR DESCRIPTION
Helps with #62277 

I removed FIXME comment in some incremental tests with [rustc_partition_codegened](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_incremental/assert_module_sources/index.html). This seems using codegen process. So it uses intentionally `build-pass`