### PR TITLE
add mipsel-unknown-none target

### DIFF
--- a/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
@@ -1,5 +1,6 @@
-// Bare MIPS32r2, little endian, softfloat
-// can be used for MIPS M4K core (e.g. on PIC32MX devices)
+//! Bare MIPS32r2, little endian, softfloat
+//!
+//! Can be used for MIPS M4K core (e.g. on PIC32MX devices)
 
 use crate::spec::abi::Abi;
 use crate::spec::{LinkerFlavor, LldFlavor, RelocModel};

--- a/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
@@ -1,4 +1,4 @@
-//! Bare MIPS32r2, little endian, softfloat
+//! Bare MIPS32r2, little endian, softfloat, O32 calling convention
 //!
 //! Can be used for MIPS M4K core (e.g. on PIC32MX devices)
 

--- a/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
@@ -1,0 +1,32 @@
+// Bare MIPS32r2, little endian, softfloat
+// can be used for MIPS M4K core (e.g. on PIC32MX devices)
+
+use crate::spec::{LinkerFlavor, LldFlavor, RelocModel};
+use crate::spec::{PanicStrategy, Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "mipsel-unknown-none".to_string(),
+        target_endian: "little".to_string(),
+        pointer_width: 32,
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
+        arch: "mips".to_string(),
+        target_os: "none".to_string(),
+        target_env: String::new(),
+        target_vendor: String::new(),
+        linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
+
+        options: TargetOptions {
+            cpu: "mips32r2".to_string(),
+            features: "+mips32r2,+soft-float,+noabicalls".to_string(),
+            max_atomic_width: Some(32),
+            executables: true,
+            linker: Some("rust-lld".to_owned()),
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            emit_debug_gdb_scripts: false,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
@@ -1,6 +1,7 @@
 // Bare MIPS32r2, little endian, softfloat
 // can be used for MIPS M4K core (e.g. on PIC32MX devices)
 
+use crate::spec::abi::Abi;
 use crate::spec::{LinkerFlavor, LldFlavor, RelocModel};
 use crate::spec::{PanicStrategy, Target, TargetOptions};
 
@@ -25,6 +26,14 @@ pub fn target() -> Target {
             linker: Some("rust-lld".to_owned()),
             panic_strategy: PanicStrategy::Abort,
             relocation_model: RelocModel::Static,
+            unsupported_abis: vec![
+                Abi::Stdcall,
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall,
+                Abi::Win64,
+                Abi::SysV64,
+            ],
             emit_debug_gdb_scripts: false,
             ..Default::default()
         },

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -653,6 +653,7 @@ supported_targets! {
     ("powerpc64-wrs-vxworks", powerpc64_wrs_vxworks),
 
     ("mipsel-sony-psp", mipsel_sony_psp),
+    ("mipsel-unknown-none", mipsel_unknown_none),
     ("thumbv4t-none-eabi", thumbv4t_none_eabi),
 }
 

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -180,6 +180,7 @@ target | std | host | notes
 `i686-wrs-vxworks` | ? |  |
 `mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
 `mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc
+`mipsel-unknown-none` | * |  | Bare MIPS (LE) softfloat
 `mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP)
 `mipsisa32r6-unknown-linux-gnu` | ? |  |
 `mipsisa32r6el-unknown-linux-gnu` | ? |  |


### PR DESCRIPTION
This adds a target for bare MIPS32r2, little endian, softfloat. This target can be used for PIC32 microcontrollers (or possibly for other devices that have a MIPS MCU core such as the M4K core).

Tried to find a name for the target that is in line with the naming scheme apparently used for the other MIPS targets.

r? @jonas-schievink 