### PR TITLE
Use reparsed `TokenStream` if we captured any inner attributes

### DIFF
--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -611,11 +611,11 @@ fn prepend_attrs(
     }
     let mut builder = tokenstream::TokenStreamBuilder::new();
     for attr in attrs {
-        assert_eq!(
-            attr.style,
-            ast::AttrStyle::Outer,
-            "inner attributes should prevent cached tokens from existing"
-        );
+        // FIXME: Correctly handle tokens for inner attributes.
+        // For now, we fall back to reparsing the original AST node
+        if attr.style == ast::AttrStyle::Inner {
+            return None;
+        }
         builder.push(
             attr.tokens
                 .as_ref()

--- a/src/test/ui/proc-macro/issue-78675-captured-inner-attrs.rs
+++ b/src/test/ui/proc-macro/issue-78675-captured-inner-attrs.rs
@@ -1,0 +1,32 @@
+// check-pass
+// edition:2018
+// compile-flags: -Z span-debug
+// aux-build:test-macros.rs
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use] extern crate test_macros;
+
+macro_rules! foo {(
+    #[fake_attr]
+    $item:item
+) => (
+    $item
+)}
+
+macro_rules! outer {($item:item) => (
+    print_bang! { // Identity proc-macro
+        foo! {
+            #[fake_attr]
+            $item
+        }
+    }
+)}
+outer! {
+    mod bar {
+        //! Foo
+    }
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
+++ b/src/test/ui/proc-macro/issue-78675-captured-inner-attrs.stdout
@@ -1,0 +1,86 @@
+PRINT-BANG INPUT (DISPLAY): foo ! { #[fake_attr] mod bar {
+    #![doc = r" Foo"]
+} }
+PRINT-BANG INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "foo",
+        span: $DIR/issue-78675-captured-inner-attrs.rs:20:9: 20:12 (#4),
+    },
+    Punct {
+        ch: '!',
+        spacing: Alone,
+        span: $DIR/issue-78675-captured-inner-attrs.rs:20:12: 20:13 (#4),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Alone,
+                span: $DIR/issue-78675-captured-inner-attrs.rs:21:13: 21:14 (#4),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "fake_attr",
+                        span: $DIR/issue-78675-captured-inner-attrs.rs:21:15: 21:24 (#4),
+                    },
+                ],
+                span: $DIR/issue-78675-captured-inner-attrs.rs:21:14: 21:25 (#4),
+            },
+            Group {
+                delimiter: None,
+                stream: TokenStream [
+                    Ident {
+                        ident: "mod",
+                        span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                    },
+                    Ident {
+                        ident: "bar",
+                        span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Punct {
+                                ch: '#',
+                                spacing: Joint,
+                                span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                            },
+                            Punct {
+                                ch: '!',
+                                spacing: Alone,
+                                span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "doc",
+                                        span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Alone,
+                                        span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                                    },
+                                    Literal {
+                                        kind: StrRaw(0),
+                                        symbol: " Foo",
+                                        suffix: None,
+                                        span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                                    },
+                                ],
+                                span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                            },
+                        ],
+                        span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+                    },
+                ],
+                span: $DIR/issue-78675-captured-inner-attrs.rs:22:13: 22:18 (#4),
+            },
+        ],
+        span: $DIR/issue-78675-captured-inner-attrs.rs:20:14: 23:10 (#4),
+    },
+]


### PR DESCRIPTION
Fixes #78675

We now bail out of `prepend_attrs` if we ended up capturing any inner
attributes (which can happen in several places, due to token capturing
for `macro_rules!` arguments.