### PR TITLE
Do not inline finish_grow

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -471,6 +471,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
 // above `RawVec::grow_amortized` for details. (The `A` parameter isn't
 // significant, because the number of different `A` types seen in practice is
 // much smaller than the number of `T` types.)
+#[inline(never)]
 fn finish_grow<A>(
     new_layout: Result<Layout, LayoutError>,
     current_memory: Option<(NonNull<u8>, Layout)>,

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2103,7 +2103,10 @@ where
     I: TrustedLen<Item = T>,
 {
     fn from_iter(iterator: I) -> Self {
-        let mut vector = Vec::new();
+        let mut vector = match iterator.size_hint() {
+            (_, Some(upper)) => Vec::with_capacity(upper),
+            _ => Vec::new(),
+        };
         // must delegate to spec_extend() since extend() itself delegates
         // to spec_from for empty Vecs
         vector.spec_extend(iterator);


### PR DESCRIPTION
Fixes #78471.

Looking at libgkrust.a in Firefox, the sizes for the `gkrust.*.o` file is:
- 18584816 (text) 582418 (data) with unmodified master
- 17937659 (text) 582554 (data) with #72227 reverted
- 17968228 (text) 582858 (data) with `#[inline(never)]` on `grow_amortized` and `grow_exact`, but that has some performance consequences
- 17927760 (text) 582322 (data) with this change

So in terms of size, at least in the case of Firefox, this patch more than undoes the regression. I don't think it should affect performance, but we'll see.