### PR TITLE
Suggest library/std when running all stage 0 tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -970,7 +970,8 @@ impl Step for Compiletest {
         if builder.top_stage == 0 && env::var("COMPILETEST_FORCE_STAGE0").is_err() {
             eprintln!("\
 error: `--stage 0` runs compiletest on the beta compiler, not your local changes, and will almost always cause tests to fail
-help: use `--stage 1` instead
+help: to test the compiler, use `--stage 1` instead
+help: to test the standard library, use `--stage 0 library/std` instead
 note: if you're sure you want to do this, please open an issue as to why. In the meantime, you can override this with `COMPILETEST_FORCE_STAGE0=1`."
             );
             std::process::exit(1);


### PR DESCRIPTION
r? @Mark-Simulacrum 
cc @ijackson 

For context, this came out of a discord conversation where @ijackson was running `test --stage 1` when they were only adding doc-tests to the standard library.