### PR TITLE
std: IntoInnerError into_parts, NoStorageSpace

### DIFF
--- a/library/std/src/io/buffered/mod.rs
+++ b/library/std/src/io/buffered/mod.rs
@@ -126,6 +126,29 @@ impl<W> IntoInnerError<W> {
     pub fn into_inner(self) -> W {
         self.0
     }
+
+    #[doc(test(attr(cfg(os = "linux"))))]
+    /// Consumes the [`IntoInnerError`] and returns the error which caused the call to
+    /// [`BufWriter::into_inner()`] to fail, and the underlying writer.
+    ///
+    /// This can be used to simply obtain ownership of the underlying error; it can also be used for
+    /// advanced error recovery.
+    ///
+    /// # Example (requires `/dev/full`, which is available on Linux)
+    /// ```
+    /// use std::io::{BufWriter, ErrorKind, Write};
+    /// use std::fs::File;
+    ///
+    /// let mut stream = BufWriter::new(File::create("/dev/full").unwrap());
+    /// write!(stream, "this cannot be actually written").unwrap();
+    /// let into_inner_err = stream.into_inner().expect_err("now we discover the ENOSPC");
+    /// let (err, _writer) = into_inner_err.into_parts();
+    /// assert_eq!(err.kind(), ErrorKind::NoStorageSpace);
+    /// ```
+    #[stable(feature = "std_io_into_inner_error_into_inner_parts", since = "1.51.0")]
+    pub fn into_parts(self) -> (Error, W) {
+        (self.1, self.0)
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -156,6 +156,11 @@ pub enum ErrorKind {
     /// [`Ok(0)`]: Ok
     #[stable(feature = "rust1", since = "1.0.0")]
     WriteZero,
+    /// The underlying storage (typically, a filesystem) is full.
+    ///
+    /// This does not include out of quota errors.
+    #[stable(feature = "io_error_no_storage_space", since = "1.51.0")]
+    NoStorageSpace,
     /// This operation was interrupted.
     ///
     /// Interrupted operations can typically be retried.
@@ -199,6 +204,7 @@ impl ErrorKind {
             ErrorKind::TimedOut => "timed out",
             ErrorKind::WriteZero => "write zero",
             ErrorKind::Interrupted => "operation interrupted",
+            ErrorKind::NoStorageSpace => "no storage space",
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
         }

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -174,6 +174,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::EADDRNOTAVAIL => ErrorKind::AddrNotAvailable,
         libc::EADDRINUSE => ErrorKind::AddrInUse,
         libc::ENOENT => ErrorKind::NotFound,
+        libc::ENOSPC => ErrorKind::NoStorageSpace,
         libc::EINTR => ErrorKind::Interrupted,
         libc::EINVAL => ErrorKind::InvalidInput,
         libc::ETIMEDOUT => ErrorKind::TimedOut,


### PR DESCRIPTION
Hi.  I was doing something with std and `BufWriterr` and I discovered that after getting an `IntoInnerError` I wasn't able to get an owned copy of the contained `io::Error`.  That seemed wrong, so I set about making an MR to fix it.  That is the 2nd commit here.

While doing this I wanted to write a doctest.  I wasn't able to think of a reliable portable way of provoking a convenient io error but on Linux at least we have `/dev/full` so I used that.  I think I have marked the doctest with the appropriate attribute.  I guess I'll see what the CI says.

But the doctest wants to say something about the actual error, and unaccountably `ErrorKind` lacks a variant corresponding to `ENOSPC`.  Given that the docs say that existing errors of kind `Other` may change into specific errors, I thought this was not a breaking change.

I have made both of these things insta-stable.  That will definitely need an fcp at least, and also this is my first attempt to (1) do a platform-specific doctest and (2) provide an insta-stable method on something in std, so it will need some review from appropriate people!

Additionally, since I know nothing about Windows I have not added anything to do with `ErrorKind::NoStorageSpace` there.  I don't know if this ought to be a blocker.  My git grep also found some stuff to do with vxworks; I don't know if that has `ENOSPC`.

Thanks for your attention.