### PR TITLE
Use  `is_sep_byte`, instead of `is_verbatim_sep` when parsing `Prefix::DeviceNS`

### DIFF
--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -873,12 +873,12 @@ pub fn test_decompositions_windows() {
     );
 
     t!("\\\\.\\foo/bar",
-    iter: ["\\\\.\\foo/bar", "\\"],
+    iter: ["\\\\.\\foo", "\\", "bar"],
     has_root: true,
     is_absolute: true,
-    parent: None,
-    file_name: None,
-    file_stem: None,
+    parent: Some("\\\\.\\foo/"),
+    file_name: Some("bar"),
+    file_stem: Some("bar"),
     extension: None
     );
 

--- a/library/std/src/sys/windows/path.rs
+++ b/library/std/src/sys/windows/path.rs
@@ -62,7 +62,8 @@ pub fn parse_prefix(path: &OsStr) -> Option<Prefix<'_>> {
                     }
                     // \\?\cat_pics
                     _ => {
-                        let idx = path.iter().position(|&b| b == b'\\').unwrap_or(path.len());
+                        let idx =
+                            path.iter().position(|&b| is_verbatim_sep(b)).unwrap_or(path.len());
                         let slice = &path[..idx];
                         return Some(Verbatim(unsafe { u8_slice_as_os_str(slice) }));
                     }
@@ -70,7 +71,7 @@ pub fn parse_prefix(path: &OsStr) -> Option<Prefix<'_>> {
             }
         } else if let Some(path) = path.strip_prefix(b".\\") {
             // \\.\COM42
-            let idx = path.iter().position(|&b| b == b'\\').unwrap_or(path.len());
+            let idx = path.iter().position(|&b| is_sep_byte(b)).unwrap_or(path.len());
             let slice = &path[..idx];
             return Some(DeviceNS(unsafe { u8_slice_as_os_str(slice) }));
         }


### PR DESCRIPTION
Currently on Windows, when parsing the prefix of a path in the device namespace, e.g. `\\.\C:\foo.txt`, only `\` is recognized as a separator. This means that for the path `\\.\C:/foo.txt`, the entire path is parsed as the prefix, instead of only `\\.\C:`. This is also inconsistent because `/` is recognized as a separator in the rest of the path, e.g. `\\.\C:\foo/bar.txt`, just not in the prefix. 

The [documentation](https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats) mentions no such restriction on the prefix, and prefixes delimited by `/` are handled fine on Windows:

```rust
use std::fs::File;
use std::io::prelude::*;

fn main() -> std::io::Result<()> {
    let mut file = File::create(r"\\.\C:/foo.txt")?;
    write!(file, "12345")?;
    drop(file);

    let mut file = File::open(r"C:\foo.txt")?;
    let mut contents = String::new();
    file.read_to_string(&mut contents)?;

    assert_eq!("12345", contents);

    Ok(())
}
```

Therefore it is my belief that the current behavior is a bug, which this PR addresses.
