### PR TITLE
Move codegen backend dylibs to a more sensible place

### DIFF
--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -134,8 +134,8 @@ pub fn get_or_default_sysroot() -> PathBuf {
     }
 }
 
-// The name of the directory rustc expects libraries to be located.
-fn find_libdir(sysroot: &Path) -> Cow<'static, str> {
+/// The name of the directory rustc expects libraries to be located.
+pub fn find_libdir(sysroot: &Path) -> Cow<'static, str> {
     // FIXME: This is a quick hack to make the rustc binary able to locate
     // Rust libraries in Linux environments where libraries might be installed
     // to lib64/lib32. This would be more foolproof by basing the sysroot off

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -637,7 +637,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn sysroot_codegen_backends(&self, compiler: Compiler) -> PathBuf {
-        self.sysroot_libdir(compiler, compiler.host).with_file_name("codegen-backends")
+        self.rustc_libdir(compiler).with_file_name("codegen-backends")
     }
 
     /// Returns the compiler's libdir where it stores the dynamic libraries that

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -509,7 +509,7 @@ impl Step for Rustc {
             let backends_rel = backends_src
                 .strip_prefix(&src)
                 .unwrap()
-                .strip_prefix(builder.sysroot_libdir_relative(compiler))
+                .strip_prefix(builder.libdir_relative(compiler))
                 .unwrap();
             // Don't use custom libdir here because ^lib/ will be resolved again with installer
             let backends_dst = image.join("lib").join(&backends_rel);


### PR DESCRIPTION
They used to be located at `lib/rustlib/$HOST_TRIPLE/codegen-backends`. Now they are at `lib/codegen-backends`.

cc @khyperia (https://github.com/EmbarkStudios/rust-gpu/issues/48#issuecomment-721127274)

@rustbot modify labels: +A-driver +T-compiler