### PR TITLE
Fix panic in bootstrap for non-workspace path dependencies.

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1119,6 +1119,10 @@ impl Build {
             let krate = &self.crates[&krate];
             ret.push(krate);
             for dep in &krate.deps {
+                if !self.crates.contains_key(dep) {
+                    // Ignore non-workspace members.
+                    continue;
+                }
                 // Don't include optional deps if their features are not
                 // enabled. Ideally this would be computed from `cargo
                 // metadata --features …`, but that is somewhat slow. Just


### PR DESCRIPTION
If you add a `path` dependency to a `Cargo.toml` that is located outside of the workspace, then the `in_tree_crates` function can panic because it finds a path dependency that is not defined (since it uses `cargo metadata --no-deps`).  This fixes it by skipping over those entries, which are usually not things you select on the command-line.

Fixes #78617