### PR TITLE
Add #[must_bind] attribute and lint

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -205,6 +205,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(allow, Normal, template!(List: r#"lint1, lint2, ..., /*opt*/ reason = "...""#)),
     ungated!(forbid, Normal, template!(List: r#"lint1, lint2, ..., /*opt*/ reason = "...""#)),
     ungated!(deny, Normal, template!(List: r#"lint1, lint2, ..., /*opt*/ reason = "...""#)),
+    ungated!(must_bind, AssumedUsed, template!(Word, NameValueStr: "reason")),
     ungated!(must_use, AssumedUsed, template!(Word, NameValueStr: "reason")),
     // FIXME(#14407)
     ungated!(

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -702,6 +702,7 @@ symbols! {
         mul,
         mul_assign,
         mul_with_overflow,
+        must_bind,
         must_use,
         mut_ptr,
         mut_slice_ptr,


### PR DESCRIPTION
Prototype implementation of https://internals.rust-lang.org/t/pre-rfc-must-bind/12658

Like `#[must_use]`, but also catches `let _ =`.

Intended to be used on semaphore guards and similar things where RAII guard is detached from the protected resource.
Beginner users often think that `_` is just a funny variable name and the guard will be dropped at the end of block instead of immediately. This may introduce silent logic error into the code.

TODO:

* Require `#[feature]` instead of insta-stable
* Proper test
* Add section to reference
* Probably refactor the code
* Decide on a specific lint text and attribute name
* Detecting `#[must_bind]` without `#[must_use]` as error.
* Automatically suggest an edit for `cargo fix`

---

Is this idea worth pursuing further or it's unlikely to go through even with the TODOs resolved?