### PR TITLE
Array trait impl comment/doc fixes

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -353,8 +353,9 @@ impl<T: Ord, const N: usize> Ord for [T; N] {
     }
 }
 
-// The Default impls cannot be generated using the array_impls! macro because
-// they require array literals.
+// The Default impls cannot be done with const generics because `[T; 0]` doesn't
+// require Default to be implemented, and having different impl blocks for
+// different numbers isn't supported yet.
 
 macro_rules! array_impl_default {
     {$n:expr, $t:ident $($ts:ident)*} => {

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -491,6 +491,8 @@ mod prim_pointer {}
 ///
 /// Arrays of *any* size implement the following traits if the element type allows it:
 ///
+/// - [`Copy`]
+/// - [`Clone`]
 /// - [`Debug`]
 /// - [`IntoIterator`] (implemented for `&[T; N]` and `&mut [T; N]`)
 /// - [`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]
@@ -498,14 +500,9 @@ mod prim_pointer {}
 /// - [`AsRef`], [`AsMut`]
 /// - [`Borrow`], [`BorrowMut`]
 ///
-/// Arrays of sizes from 0 to 32 (inclusive) implement [`Default`] trait
+/// Arrays of sizes from 0 to 32 (inclusive) implement the [`Default`] trait
 /// if the element type allows it. As a stopgap, trait implementations are
 /// statically generated up to size 32.
-///
-/// Arrays of *any* size are [`Copy`] if the element type is [`Copy`]
-/// and [`Clone`] if the element type is [`Clone`]. This works
-/// because [`Copy`] and [`Clone`] traits are specially known
-/// to the compiler.
 ///
 /// Arrays coerce to [slices (`[T]`)][slice], so a slice method may be called on
 /// an array. Indeed, this provides most of the API for working with arrays.


### PR DESCRIPTION
Two small doc/comment fixes regarding trait implementations on arrays.