### PR TITLE
Add link to rust website

### DIFF
--- a/src/doc/index.md
+++ b/src/doc/index.md
@@ -26,7 +26,7 @@ h2 {
 }
 </style>
 
-Welcome to an overview of the documentation provided by the Rust project.
+Welcome to an overview of the documentation provided by the [Rust project].
 All of these projects are managed by the Docs Team; there are other
 unofficial documentation resources as well!
 
@@ -139,3 +139,4 @@ When developing for Bare Metal or Embedded Linux systems, you may find these res
 [The Embedded Rust Book] is targeted at developers familiar with embedded development and familiar with Rust, but have not used Rust for embedded development.
 
 [The Embedded Rust Book]: embedded-book/index.html
+[Rust project]: https://www.rust-lang.org


### PR DESCRIPTION
Fixes #30838

This doesn't fix the issue as suggested but it at least adds a link to allow to go back to the rust website.

r? @steveklabnik 