### PR TITLE
(rustdoc) fix test for trait impl display

### DIFF
--- a/src/test/rustdoc/impl-everywhere.rs
+++ b/src/test/rustdoc/impl-everywhere.rs
@@ -8,23 +8,23 @@ pub struct Bar;
 impl Foo for Bar {}
 impl Foo2 for Bar {}
 
-// @!has foo/fn.foo.html '//section[@id="main"]//pre' "x: &\'x impl Foo"
-// @!has foo/fn.foo.html '//section[@id="main"]//pre' "-> &\'x impl Foo {"
+// @has foo/fn.foo.html '//section[@id="main"]//pre' "x: &'x impl Foo"
+// @has foo/fn.foo.html '//section[@id="main"]//pre' "-> &'x impl Foo"
 pub fn foo<'x>(x: &'x impl Foo) -> &'x impl Foo {
     x
 }
 
-// @!has foo/fn.foo2.html '//section[@id="main"]//pre' "x: &\'x impl Foo"
-// @!has foo/fn.foo2.html '//section[@id="main"]//pre' '-> impl Foo2 {'
+// @has foo/fn.foo2.html '//section[@id="main"]//pre' "x: &'x impl Foo"
+// @has foo/fn.foo2.html '//section[@id="main"]//pre' '-> impl Foo2'
 pub fn foo2<'x>(_x: &'x impl Foo) -> impl Foo2 {
     Bar
 }
 
-// @!has foo/fn.foo_foo.html '//section[@id="main"]//pre' '-> impl Foo + Foo2 {'
+// @has foo/fn.foo_foo.html '//section[@id="main"]//pre' '-> impl Foo + Foo2'
 pub fn foo_foo() -> impl Foo + Foo2 {
     Bar
 }
 
-// @!has foo/fn.foo2.html '//section[@id="main"]//pre' "x: &'x (impl Foo + Foo2)"
+// @has foo/fn.foo_foo_foo.html '//section[@id="main"]//pre' "x: &'x impl Foo + Foo2"
 pub fn foo_foo_foo<'x>(_x: &'x (impl Foo + Foo2)) {
 }


### PR DESCRIPTION
The test checks that parameters and return values with `impl Trait` types are correctly generated in rustdoc's output.

In essence, the previous version of the test checked the absence of values that would never be generated by rustdoc, so it could basically never fail. These values were adjusted to the expected output and are now required to exist in rustdoc's output. See https://github.com/rust-lang/rust/issues/55201#issuecomment-716182474 for a detailed explanation of the reasoning behind the changes. 

Note that the output of rustdoc for `impl Trait`s in parameters and return values did not change since the inital test creation, so this PR only modifies the test.

Closes #55201 