### PR TITLE
Constantify `UnsafeCell::into_inner` and related

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -406,7 +406,7 @@ impl<T> Cell<T> {
     /// assert_eq!(five, 5);
     /// ```
     #[stable(feature = "move_cell", since = "1.17.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
     pub const fn into_inner(self) -> T {
         self.value.into_inner()
     }
@@ -669,7 +669,7 @@ impl<T> RefCell<T> {
     /// let five = c.into_inner();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
     #[inline]
     pub const fn into_inner(self) -> T {
         // Since this function takes `self` (the `RefCell`) by value, the
@@ -1682,7 +1682,7 @@ impl<T> UnsafeCell<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
     pub const fn into_inner(self) -> T {
         self.value
     }

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -406,7 +406,8 @@ impl<T> Cell<T> {
     /// assert_eq!(five, 5);
     /// ```
     #[stable(feature = "move_cell", since = "1.17.0")]
-    pub fn into_inner(self) -> T {
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    pub const fn into_inner(self) -> T {
         self.value.into_inner()
     }
 }
@@ -668,12 +669,11 @@ impl<T> RefCell<T> {
     /// let five = c.into_inner();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
     #[inline]
-    pub fn into_inner(self) -> T {
+    pub const fn into_inner(self) -> T {
         // Since this function takes `self` (the `RefCell`) by value, the
         // compiler statically verifies that it is not currently borrowed.
-        // Therefore the following assertion is just a `debug_assert!`.
-        debug_assert!(self.borrow.get() == UNUSED);
         self.value.into_inner()
     }
 
@@ -1682,7 +1682,8 @@ impl<T> UnsafeCell<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn into_inner(self) -> T {
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    pub const fn into_inner(self) -> T {
         self.value
     }
 }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -70,6 +70,7 @@
 #![feature(cfg_target_has_atomic)]
 #![feature(const_alloc_layout)]
 #![feature(const_discriminant)]
+#![feature(const_cell_into_inner)]
 #![feature(const_checked_int_methods)]
 #![feature(const_euclidean_int_methods)]
 #![feature(const_float_classify)]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -365,7 +365,7 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
     pub const fn into_inner(self) -> bool {
         self.v.into_inner() != 0
     }
@@ -942,7 +942,7 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
     pub const fn into_inner(self) -> *mut T {
         self.p.into_inner()
     }
@@ -1464,7 +1464,7 @@ assert_eq!(some_var.into_inner(), 5);
 ```"),
                 #[inline]
                 #[$stable_access]
-                #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+                #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
                 pub const fn into_inner(self) -> $int_type {
                     self.v.into_inner()
                 }

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -365,7 +365,8 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    pub fn into_inner(self) -> bool {
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    pub const fn into_inner(self) -> bool {
         self.v.into_inner() != 0
     }
 
@@ -941,7 +942,8 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    pub fn into_inner(self) -> *mut T {
+    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+    pub const fn into_inner(self) -> *mut T {
         self.p.into_inner()
     }
 
@@ -1462,7 +1464,8 @@ assert_eq!(some_var.into_inner(), 5);
 ```"),
                 #[inline]
                 #[$stable_access]
-                pub fn into_inner(self) -> $int_type {
+                #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "none")]
+                pub const fn into_inner(self) -> $int_type {
                     self.v.into_inner()
                 }
             }

--- a/library/core/tests/cell.rs
+++ b/library/core/tests/cell.rs
@@ -422,3 +422,15 @@ fn refcell_format() {
     let msg = format!("{name} {}", &*what.borrow(), name = &*name.borrow());
     assert_eq!(msg, "rust rocks".to_string());
 }
+
+#[allow(dead_code)]
+fn const_cells() {
+    const UNSAFE_CELL: UnsafeCell<i32> = UnsafeCell::new(3);
+    const _: i32 = UNSAFE_CELL.into_inner();
+
+    const REF_CELL: RefCell<i32> = RefCell::new(3);
+    const _: i32 = REF_CELL.into_inner();
+
+    const CELL: Cell<i32> = Cell::new(3);
+    const _: i32 = CELL.into_inner();
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -9,6 +9,7 @@
 #![feature(box_syntax)]
 #![feature(cell_update)]
 #![feature(const_assume)]
+#![feature(const_cell_into_inner)]
 #![feature(core_intrinsics)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]


### PR DESCRIPTION
Tracking issue: #78729 

This PR constantifies:
- `UnsafeCell::into_inner`
- `Cell::into_inner`
- `RefCell::into_inner`
- `Atomic*::into_inner`

r? @dtolnay 