### PR TITLE
Implement PartialEq for more combinations of arrays vs array references

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -223,6 +223,66 @@ where
     }
 }
 
+#[stable(feature = "array_ref_equality", since = "1.49.0")]
+impl<A, B, const N: usize> PartialEq<[A; N]> for &[B; N]
+where
+    B: PartialEq<A>,
+{
+    #[inline]
+    fn eq(&self, other: &[A; N]) -> bool {
+        self[..] == other[..]
+    }
+    #[inline]
+    fn ne(&self, other: &[A; N]) -> bool {
+        self[..] != other[..]
+    }
+}
+
+#[stable(feature = "array_ref_equality", since = "1.49.0")]
+impl<A, B, const N: usize> PartialEq<&[A; N]> for [B; N]
+where
+    B: PartialEq<A>,
+{
+    #[inline]
+    fn eq(&self, other: &&[A; N]) -> bool {
+        self[..] == other[..]
+    }
+    #[inline]
+    fn ne(&self, other: &&[A; N]) -> bool {
+        self[..] != other[..]
+    }
+}
+
+#[stable(feature = "array_ref_equality", since = "1.49.0")]
+impl<A, B, const N: usize> PartialEq<[A; N]> for &mut [B; N]
+where
+    B: PartialEq<A>,
+{
+    #[inline]
+    fn eq(&self, other: &[A; N]) -> bool {
+        self[..] == other[..]
+    }
+    #[inline]
+    fn ne(&self, other: &[A; N]) -> bool {
+        self[..] != other[..]
+    }
+}
+
+#[stable(feature = "array_ref_equality", since = "1.49.0")]
+impl<A, B, const N: usize> PartialEq<&mut [A; N]> for [B; N]
+where
+    B: PartialEq<A>,
+{
+    #[inline]
+    fn eq(&self, other: &&mut [A; N]) -> bool {
+        self[..] == other[..]
+    }
+    #[inline]
+    fn ne(&self, other: &&mut [A; N]) -> bool {
+        self[..] != other[..]
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<A, B, const N: usize> PartialEq<[B]> for [A; N]
 where
@@ -312,10 +372,6 @@ where
         self[..] != other[..]
     }
 }
-
-// NOTE: some less important impls are omitted to reduce code bloat
-// __impl_slice_eq2! { [A; $N], &'b [B; $N] }
-// __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Eq, const N: usize> Eq for [T; N] {}

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -374,3 +374,19 @@ fn cell_allows_array_cycle() {
     b3.a[0].set(Some(&b1));
     b3.a[1].set(Some(&b2));
 }
+
+#[test]
+fn array_ref_equality() {
+    let v_ref: &[_; 42] = &[0; 42];
+    let v_mut: &mut [_; 42] = &mut [0; 42];
+    let v: [_; 42] = [0; 42];
+    assert_eq!(v_ref, v_ref);
+    assert_eq!(v_ref, v_mut);
+    assert_eq!(v_ref, v);
+    assert_eq!(v_mut, v_ref);
+    assert_eq!(v_mut, v_mut);
+    assert_eq!(v_mut, v);
+    assert_eq!(v, v_ref);
+    assert_eq!(v, v_mut);
+    assert_eq!(v, v);
+}


### PR DESCRIPTION
Previously, this code would error in the noted places:

```Rust
    let v_ref: &[_; 42] = &[0; 42];
    let v_mut: &mut [_; 42] = &mut [0; 42];
    let v: [_; 42] = [0; 42];
    assert_eq!(v_ref, v_ref);
    assert_eq!(v_ref, v_mut);
    assert_eq!(v_ref, v); //~ ERROR
    assert_eq!(v_mut, v_ref);
    assert_eq!(v_mut, v_mut);
    assert_eq!(v_mut, v); //~ ERROR
    assert_eq!(v, v_ref); //~ ERROR
    assert_eq!(v, v_mut); //~ ERROR
    assert_eq!(v, v);
```

This PR makes it compile. Originally these implementations were omitted
to reduce bloat but now one can add them thanks to const generics.