### PR TITLE
Remove legacy promote-release support from build-manifestg

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -469,7 +469,6 @@ impl<'a> Builder<'a> {
                 dist::RustDev,
                 dist::Extended,
                 dist::BuildManifest,
-                dist::HashSign
             ),
             Kind::Install => describe!(
                 install::Docs,


### PR DESCRIPTION
Now that we're not running the [legacy `promote-release`](https://github.com/rust-lang/rust-central-station/tree/master/promote-release) anymore, this PR removes support from it from `bootstrap` and `build-manifest`.

r? @Mark-Simulacrum 