### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "arc-swap"


### PR DESCRIPTION
7 commits in becb4c282b8f37469efb8f5beda45a5501f9d367..d5556aeb8405b1fe696adb6e297ad7a1f2989b62
2020-10-28 16:41:55 +0000 to 2020-11-04 22:20:36 +0000
- Implement weak dependency features. (rust-lang/cargo#8818)
- Avoid some extra downloads with new feature resolver. (rust-lang/cargo#8823)
- fix: remove install command `$`, for copying friendly (rust-lang/cargo#8828)
- Bump `anyhow` dependency to `1.0.34` in `crates-io` crate (rust-lang/cargo#8826)
- Normalize SourceID in `cargo metadata`. (rust-lang/cargo#8824)
- vendor: correct the path to cargo config (rust-lang/cargo#8822)
- Make host_root return host.root(), not host.dest() (rust-lang/cargo#8819)