### PR TITLE
The renumber pass is long gone

### DIFF
--- a/compiler/rustc_ast/src/node_id.rs
+++ b/compiler/rustc_ast/src/node_id.rs
@@ -13,8 +13,8 @@ rustc_data_structures::define_id_collections!(NodeMap, NodeSet, NodeId);
 pub const CRATE_NODE_ID: NodeId = NodeId::from_u32(0);
 
 /// When parsing and doing expansions, we initially give all AST nodes this AST
-/// node value. Then later, in the renumber pass, we renumber them to have
-/// small, positive ids.
+/// node value. Then later, during expansion, we renumber them to have small,
+/// positive ids.
 pub const DUMMY_NODE_ID: NodeId = NodeId::MAX;
 
 impl NodeId {


### PR DESCRIPTION
Originally, there has been a dedicated pass for renumbering
AST NodeIds to have actual values. This pass had been added by
commit a5ad4c379466519a0bf977864a5cdc50a7ade385.

Then, later, this step was moved to where it resides now,
macro expansion. See commit c86c8d41a26b2037e80c9fd028a59313a78b3a66
or PR #36438.

The comment snippet, added by the original commit, has
survived the times without any change, becoming outdated
at removal of the dedicated pass.

Nowadays, grepping for the next_node_id function will show up
multiple places in the compiler that call it, but the main
rewriting that the comment talks about is still done in the
expansion step, inside an innocious looking visit_id function
that's called during macro invocation collection.