### PR TITLE
Implement network primitives with ideal Rust layout, not C system layout

### DIFF
--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -12,7 +12,7 @@ use crate::option;
 use crate::slice;
 use crate::sys::net::netc as c;
 use crate::sys_common::net::LookupHost;
-use crate::sys_common::{AsInner, FromInner, IntoInner};
+use crate::sys_common::{FromInner, IntoInner};
 use crate::vec;
 
 /// An internet socket address, either IPv4 or IPv6.
@@ -528,17 +528,14 @@ impl SocketAddrV6 {
 
 impl FromInner<c::sockaddr_in> for SocketAddrV4 {
     fn from_inner(addr: c::sockaddr_in) -> SocketAddrV4 {
-        SocketAddrV4 {
-            ip: unsafe { *(&addr.sin_addr as *const c::in_addr as *const Ipv4Addr) },
-            port: ntohs(addr.sin_port),
-        }
+        SocketAddrV4 { ip: Ipv4Addr::from_inner(addr.sin_addr), port: ntohs(addr.sin_port) }
     }
 }
 
 impl FromInner<c::sockaddr_in6> for SocketAddrV6 {
     fn from_inner(addr: c::sockaddr_in6) -> SocketAddrV6 {
         SocketAddrV6 {
-            ip: unsafe { *(&addr.sin6_addr as *const c::in6_addr as *const Ipv6Addr) },
+            ip: Ipv6Addr::from_inner(addr.sin6_addr),
             port: ntohs(addr.sin6_port),
             flowinfo: addr.sin6_flowinfo,
             scope_id: addr.sin6_scope_id,
@@ -562,7 +559,7 @@ impl IntoInner<c::sockaddr_in6> for SocketAddrV6 {
         c::sockaddr_in6 {
             sin6_family: c::AF_INET6 as c::sa_family_t,
             sin6_port: htons(self.port),
-            sin6_addr: *self.ip.as_inner(),
+            sin6_addr: self.ip.into_inner(),
             sin6_flowinfo: self.flowinfo,
             sin6_scope_id: self.scope_id,
             ..unsafe { mem::zeroed() }

--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -7,7 +7,7 @@ use crate::hash;
 use crate::io::{self, Write};
 use crate::iter;
 use crate::mem;
-use crate::net::{htons, ntohs, IpAddr, Ipv4Addr, Ipv6Addr};
+use crate::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use crate::option;
 use crate::slice;
 use crate::sys::net::netc as c;
@@ -528,7 +528,7 @@ impl SocketAddrV6 {
 
 impl FromInner<c::sockaddr_in> for SocketAddrV4 {
     fn from_inner(addr: c::sockaddr_in) -> SocketAddrV4 {
-        SocketAddrV4 { ip: Ipv4Addr::from_inner(addr.sin_addr), port: ntohs(addr.sin_port) }
+        SocketAddrV4 { ip: Ipv4Addr::from_inner(addr.sin_addr), port: u16::from_be(addr.sin_port) }
     }
 }
 
@@ -536,7 +536,7 @@ impl FromInner<c::sockaddr_in6> for SocketAddrV6 {
     fn from_inner(addr: c::sockaddr_in6) -> SocketAddrV6 {
         SocketAddrV6 {
             ip: Ipv6Addr::from_inner(addr.sin6_addr),
-            port: ntohs(addr.sin6_port),
+            port: u16::from_be(addr.sin6_port),
             flowinfo: addr.sin6_flowinfo,
             scope_id: addr.sin6_scope_id,
         }
@@ -547,7 +547,7 @@ impl IntoInner<c::sockaddr_in> for SocketAddrV4 {
     fn into_inner(self) -> c::sockaddr_in {
         c::sockaddr_in {
             sin_family: c::AF_INET as c::sa_family_t,
-            sin_port: htons(self.port),
+            sin_port: self.port.to_be(),
             sin_addr: self.ip.into_inner(),
             ..unsafe { mem::zeroed() }
         }
@@ -558,7 +558,7 @@ impl IntoInner<c::sockaddr_in6> for SocketAddrV6 {
     fn into_inner(self) -> c::sockaddr_in6 {
         c::sockaddr_in6 {
             sin6_family: c::AF_INET6 as c::sa_family_t,
-            sin6_port: htons(self.port),
+            sin6_port: self.port.to_be(),
             sin6_addr: self.ip.into_inner(),
             sin6_flowinfo: self.flowinfo,
             sin6_scope_id: self.scope_id,

--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -131,7 +131,7 @@ impl SocketAddr {
     /// ```
     #[stable(feature = "ip_addr", since = "1.7.0")]
     #[must_use]
-    #[rustc_const_unstable(feature = "const_socketaddr", issue = "none")]
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
     pub const fn new(ip: IpAddr, port: u16) -> SocketAddr {
         match ip {
             IpAddr::V4(a) => SocketAddr::V4(SocketAddrV4::new(a, port)),
@@ -278,7 +278,7 @@ impl SocketAddrV4 {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
-    #[rustc_const_unstable(feature = "const_socketaddr", issue = "none")]
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
     pub const fn new(ip: Ipv4Addr, port: u16) -> SocketAddrV4 {
         SocketAddrV4 { ip, port }
     }
@@ -369,7 +369,7 @@ impl SocketAddrV6 {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
-    #[rustc_const_unstable(feature = "const_socketaddr", issue = "none")]
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
     pub const fn new(ip: Ipv6Addr, port: u16, flowinfo: u32, scope_id: u32) -> SocketAddrV6 {
         SocketAddrV6 { ip, port, flowinfo, scope_id }
     }

--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -596,37 +596,6 @@ impl<I: Into<IpAddr>> From<(I, u16)> for SocketAddr {
     }
 }
 
-/// A type with the same memory layout as `c::sockaddr`. Used in converting Rust level
-/// SocketAddr* types into their system representation. The benefit of this specific
-/// type over using `c::sockaddr_storage` is that this type is exactly as large as it
-/// needs to be and not a lot larger. And it can be initialized more cleanly from Rust.
-#[repr(C)]
-pub(crate) union SocketAddrCRepr {
-    v4: c::sockaddr_in,
-    v6: c::sockaddr_in6,
-}
-
-impl SocketAddrCRepr {
-    pub fn as_ptr(&self) -> *const c::sockaddr {
-        self as *const _ as *const c::sockaddr
-    }
-}
-
-impl<'a> IntoInner<(SocketAddrCRepr, c::socklen_t)> for &'a SocketAddr {
-    fn into_inner(self) -> (SocketAddrCRepr, c::socklen_t) {
-        match *self {
-            SocketAddr::V4(ref a) => {
-                let sockaddr = SocketAddrCRepr { v4: a.into_inner() };
-                (sockaddr, mem::size_of::<c::sockaddr_in>() as c::socklen_t)
-            }
-            SocketAddr::V6(ref a) => {
-                let sockaddr = SocketAddrCRepr { v6: a.into_inner() };
-                (sockaddr, mem::size_of::<c::sockaddr_in6>() as c::socklen_t)
-            }
-        }
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for SocketAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -14,9 +14,6 @@ use crate::sys_common::{FromInner, IntoInner};
 /// This enum can contain either an [`Ipv4Addr`] or an [`Ipv6Addr`], see their
 /// respective documentation for more details.
 ///
-/// The size of an `IpAddr` instance may vary depending on the target operating
-/// system.
-///
 /// # Examples
 ///
 /// ```
@@ -48,9 +45,6 @@ pub enum IpAddr {
 /// They are usually represented as four octets.
 ///
 /// See [`IpAddr`] for a type encompassing both IPv4 and IPv6 addresses.
-///
-/// The size of an `Ipv4Addr` struct may vary depending on the target operating
-/// system.
 ///
 /// [IETF RFC 791]: https://tools.ietf.org/html/rfc791
 ///
@@ -86,9 +80,6 @@ pub struct Ipv4Addr {
 ///
 /// IPv6 addresses are defined as 128-bit integers in [IETF RFC 4291].
 /// They are usually represented as eight 16-bit segments.
-///
-/// The size of an `Ipv6Addr` struct may vary depending on the target operating
-/// system.
 ///
 /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
 ///

--- a/library/std/src/net/ip/tests.rs
+++ b/library/std/src/net/ip/tests.rs
@@ -944,3 +944,26 @@ fn ip_const() {
     const IS_IP_V6: bool = IP_ADDRESS.is_ipv6();
     assert!(!IS_IP_V6);
 }
+
+#[test]
+fn structural_match() {
+    // test that all IP types can be structurally matched upon
+
+    const IPV4: Ipv4Addr = Ipv4Addr::LOCALHOST;
+    match IPV4 {
+        Ipv4Addr::LOCALHOST => {}
+        _ => unreachable!(),
+    }
+
+    const IPV6: Ipv6Addr = Ipv6Addr::LOCALHOST;
+    match IPV6 {
+        Ipv6Addr::LOCALHOST => {}
+        _ => unreachable!(),
+    }
+
+    const IP: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    match IP {
+        IpAddr::V4(Ipv4Addr::LOCALHOST) => {}
+        _ => unreachable!(),
+    }
+}

--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -69,15 +69,6 @@ pub enum Shutdown {
     Both,
 }
 
-#[inline]
-const fn htons(i: u16) -> u16 {
-    i.to_be()
-}
-#[inline]
-const fn ntohs(i: u16) -> u16 {
-    u16::from_be(i)
-}
-
 fn each_addr<A: ToSocketAddrs, F, T>(addr: A, mut f: F) -> io::Result<T>
 where
     F: FnMut(io::Result<&SocketAddr>) -> io::Result<T>,

--- a/library/std/src/sys/sgx/net.rs
+++ b/library/std/src/sys/sgx/net.rs
@@ -538,6 +538,4 @@ pub mod netc {
 
     #[derive(Copy, Clone)]
     pub struct sockaddr {}
-
-    pub type socklen_t = usize;
 }

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -139,8 +139,8 @@ impl Socket {
     pub fn connect_timeout(&self, addr: &SocketAddr, timeout: Duration) -> io::Result<()> {
         self.set_nonblocking(true)?;
         let r = unsafe {
-            let (addrp, len) = addr.into_inner();
-            cvt(libc::connect(self.as_raw_fd(), addrp, len))
+            let (addr, len) = addr.into_inner();
+            cvt(libc::connect(self.as_raw_fd(), addr.as_ptr(), len))
         };
         self.set_nonblocking(false)?;
 

--- a/library/std/src/sys/unsupported/net.rs
+++ b/library/std/src/sys/unsupported/net.rs
@@ -363,6 +363,4 @@ pub mod netc {
 
     #[derive(Copy, Clone)]
     pub struct sockaddr {}
-
-    pub type socklen_t = usize;
 }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -524,6 +524,4 @@ pub mod netc {
 
     #[derive(Copy, Clone)]
     pub struct sockaddr {}
-
-    pub type socklen_t = usize;
 }

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -143,8 +143,8 @@ impl Socket {
     pub fn connect_timeout(&self, addr: &SocketAddr, timeout: Duration) -> io::Result<()> {
         self.set_nonblocking(true)?;
         let result = {
-            let (addrp, len) = addr.into_inner();
-            let result = unsafe { c::connect(self.as_raw_socket(), addrp, len) };
+            let (addr, len) = addr.into_inner();
+            let result = unsafe { c::connect(self.as_raw_socket(), addr.as_ptr(), len) };
             cvt(result).map(drop)
         };
         self.set_nonblocking(false)?;

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -10,7 +10,7 @@ use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use crate::ptr;
 use crate::sys::net::netc as c;
 use crate::sys::net::{cvt, cvt_gai, cvt_r, init, wrlen_t, Socket};
-use crate::sys_common::{AsInner, FromInner, IntoInner};
+use crate::sys_common::{FromInner, IntoInner};
 use crate::time::Duration;
 
 use libc::{c_int, c_void};
@@ -621,7 +621,7 @@ impl UdpSocket {
 
     pub fn join_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         let mreq = c::ipv6_mreq {
-            ipv6mr_multiaddr: *multiaddr.as_inner(),
+            ipv6mr_multiaddr: multiaddr.into_inner(),
             ipv6mr_interface: to_ipv6mr_interface(interface),
         };
         setsockopt(&self.inner, c::IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, mreq)
@@ -637,7 +637,7 @@ impl UdpSocket {
 
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         let mreq = c::ipv6_mreq {
-            ipv6mr_multiaddr: *multiaddr.as_inner(),
+            ipv6mr_multiaddr: multiaddr.into_inner(),
             ipv6mr_interface: to_ipv6mr_interface(interface),
         };
         setsockopt(&self.inner, c::IPPROTO_IPV6, IPV6_DROP_MEMBERSHIP, mreq)


### PR DESCRIPTION
This PR is the result of this internals forum thread: https://internals.rust-lang.org/t/why-are-socketaddrv4-socketaddrv6-based-on-low-level-sockaddr-in-6/13321.

Instead of basing `std:::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6}` on system (C) structs, they are encoded in a more optimal and idiomatic Rust way.

This changes the public API of std by introducing structural equality impls for all four types here, which means that `match ipv4addr { SOME_CONSTANT => ... }` will now compile, whereas previously this was an error. No other intentional changes are introduced to public API.

It's possible to observe the current layout of these types (e.g., by pointer casting); most but not all libraries which were found by Crater to do this have had updates issued and affected versions yanked. See report below.

### Benefits of this change

- It will become possible to move these fundamental network types from `std` into `core` ([RFC](https://github.com/rust-lang/rfcs/pull/2832)).
- Some methods that can't be made `const fn`s today can be made `const fn`s with this change.
- `SocketAddrV4` only occupies 6 bytes instead of 16 bytes.
- These simple primitives become easier to read and uses less `unsafe`.
- Makes these types support structural equality, which means you can now (for instance) match an `Ipv4Addr` against a constant

### ~Remaining~ Previous problems

This change obviously changes the memory layout of the types. And it turns out some libraries invalidly assumes the memory layout and does very dangerous pointer casts to convert them. These libraries will have undefined behaviour and perform invalid memory access until patched.

- [x] - `mio` - Issue: https://github.com/tokio-rs/mio/issues/1386.
  - [x] `0.7` branch https://github.com/tokio-rs/mio/pull/1388
  - [x] `0.7.6` published https://github.com/tokio-rs/mio/pull/1398
  - [x] Yank all `0.7` versions older than `0.7.6`
  - [x] Report `<0.7.6` to RustSec Advisory Database https://rustsec.org/advisories/RUSTSEC-2020-0081.html
- [x] - `socket2` - Issue: https://github.com/rust-lang/socket2-rs/issues/119.
  - [x] `0.3.x` branch https://github.com/rust-lang/socket2-rs/pull/120
  - [x] `0.3.16` published
  - [x] `master` branch https://github.com/rust-lang/socket2-rs/pull/122
  - [x] Yank all `0.3` versions older than `0.3.16`
  - [x] Report `<0.3.16` to RustSec Advisory Database https://rustsec.org/advisories/RUSTSEC-2020-0079.html
- [x] - `net2` - Issue: https://github.com/deprecrated/net2-rs/issues/105
  - [x] https://github.com/deprecrated/net2-rs/pull/106
  - [x] `0.2.36` published
  - [x] Yank all `0.2` versions older than `0.2.36`
  - [x] Report `<0.2.36` to RustSec Advisory Database https://rustsec.org/advisories/RUSTSEC-2020-0078.html
- [x] - `miow` - Issue: https://github.com/yoshuawuyts/miow/issues/38
  - [x] `0.3.x` - https://github.com/yoshuawuyts/miow/pull/39
  - [x] `0.3.6` published
  - [x] `0.2.x` - https://github.com/yoshuawuyts/miow/pull/40
  - [x] `0.2.2` published
  - [x] Yanked all `0.2` versions older than `0.2.2`
  - [x] Yanked all `0.3` versions older than `0.3.6`
  - [x] Report `<0.2.2` and `<0.3.6` to RustSec Advisory Database https://rustsec.org/advisories/RUSTSEC-2020-0080.html
- [x] - `quinn master` (aka what became 0.7) - https://github.com/quinn-rs/quinn/issues/968 https://github.com/quinn-rs/quinn/pull/987
  - [x] - `quinn 0.6` - https://github.com/quinn-rs/quinn/pull/1045
  - [x] - `quinn 0.5` - https://github.com/quinn-rs/quinn/pull/1046
  - [x] - Release `0.7.0`, `0.6.2` and `0.5.4`
- [x] - `nb-connect` - https://github.com/smol-rs/nb-connect/issues/1
  - [x] - Release `1.0.3`
  - [x] - Yank all versions older than `1.0.3`
- [x] - `shadowsocks-rust` - https://github.com/shadowsocks/shadowsocks-rust/issues/462
- [ ] - `rio` - https://github.com/spacejam/rio/issues/44
- [ ] - `seaslug` - https://github.com/spacejam/seaslug/issues/1

#### Fixed crate versions

All crates I have found that assumed the memory layout have been fixed and published. The crates and versions that will continue working even as/if this PR is merged is (please upgrade these to help unblock this PR):

* `net2 0.2.36`
* `socket2 0.3.16`
* `miow 0.2.2`
* `miow 0.3.6`
* `mio 0.7.6`
* `mio 0.6.23` - Never had the invalid assumption itself, but has now been bumped to only allow fixed dependencies (`net2` + `miow`)
* `nb-connect 1.0.3`
* `quinn 0.5.4`
* `quinn 0.6.2`

### Release notes draft

This release changes the memory layout of `Ipv4Addr`, `Ipv6Addr`, `SocketAddrV4` and `SocketAddrV6`. The standard library no longer implements these as the corresponding `libc` structs (`sockaddr_in`, `sockaddr_in6` etc.). This internal representation was never exposed, but some crates relied on it anyway by unsafely transmuting. This change will cause those crates to make invalid memory accesses. Notably `net2 <0.2.36`, `socket2 <0.3.16`, `mio <0.7.6`, `miow <0.3.6` and a few other crates are affected. All known affected crates have been patched and have had fixed versions published over a year ago. If any affected crate is still in your dependency tree, you need to upgrade them before using this version of Rust.
