### PR TITLE
add error_occured field to ConstQualifs, 

### DIFF
--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -233,14 +233,15 @@ pub struct BorrowCheckResult<'tcx> {
 
 /// The result of the `mir_const_qualif` query.
 ///
-/// Each field corresponds to an implementer of the `Qualif` trait in
-/// `librustc_mir/transform/check_consts/qualifs.rs`. See that file for more information on each
+/// Each field (except `error_occured`) corresponds to an implementer of the `Qualif` trait in
+/// `rustc_mir/src/transform/check_consts/qualifs.rs`. See that file for more information on each
 /// `Qualif`.
 #[derive(Clone, Copy, Debug, Default, TyEncodable, TyDecodable, HashStable)]
 pub struct ConstQualifs {
     pub has_mut_interior: bool,
     pub needs_drop: bool,
     pub custom_eq: bool,
+    pub error_occured: bool,
 }
 
 /// After we borrow check a closure, we are left with various

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -241,7 +241,7 @@ pub struct ConstQualifs {
     pub has_mut_interior: bool,
     pub needs_drop: bool,
     pub custom_eq: bool,
-    pub error_occured: bool,
+    pub error_occured: Option<ErrorReported>,
 }
 
 /// After we borrow check a closure, we are left with various

--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -282,9 +282,8 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
             );
             return Err(ErrorHandled::Reported(ErrorReported {}));
         }
-        let qualif = tcx.mir_const_qualif_opt_const_arg(def);
-        if qualif.error_occured {
-            return Err(ErrorHandled::Reported(ErrorReported {}));
+        if let Some(error_reported) = tcx.mir_const_qualif_opt_const_arg(def).error_occured {
+            return Err(ErrorHandled::Reported(error_reported));
         }
     }
 

--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -6,10 +6,10 @@ use crate::interpret::{
     ScalarMaybeUninit, StackPopCleanup,
 };
 
+use rustc_errors::ErrorReported;
 use rustc_hir::def::DefKind;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::ErrorHandled;
-use rustc_errors::ErrorReported;
 use rustc_middle::traits::Reveal;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, subst::Subst, TyCtxt};

--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -9,6 +9,7 @@ use crate::interpret::{
 use rustc_hir::def::DefKind;
 use rustc_middle::mir;
 use rustc_middle::mir::interpret::ErrorHandled;
+use rustc_errors::ErrorReported;
 use rustc_middle::traits::Reveal;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, subst::Subst, TyCtxt};
@@ -273,6 +274,10 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
             if let Some(error_reported) = tcx.typeck_opt_const_arg(def).tainted_by_errors {
                 return Err(ErrorHandled::Reported(error_reported));
             }
+        }
+        let qualif = tcx.mir_const_qualif_opt_const_arg(def);
+        if qualif.error_occured {
+            return Err(ErrorHandled::Reported(ErrorReported {}));
         }
     }
 

--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -275,6 +275,13 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
                 return Err(ErrorHandled::Reported(error_reported));
             }
         }
+        if !tcx.is_mir_available(def.did) {
+            tcx.sess.delay_span_bug(
+                tcx.def_span(def.did),
+                &format!("no MIR body is available for {:?}", def.did),
+            );
+            return Err(ErrorHandled::Reported(ErrorReported {}));
+        }
         let qualif = tcx.mir_const_qualif_opt_const_arg(def);
         if qualif.error_occured {
             return Err(ErrorHandled::Reported(ErrorReported {}));

--- a/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
@@ -9,11 +9,12 @@ use rustc_trait_selection::traits;
 
 use super::ConstCx;
 
-pub fn in_any_value_of_ty(cx: &ConstCx<'_, 'tcx>, ty: Ty<'tcx>) -> ConstQualifs {
+pub fn in_any_value_of_ty(cx: &ConstCx<'_, 'tcx>, ty: Ty<'tcx>, error_occured: bool) -> ConstQualifs {
     ConstQualifs {
         has_mut_interior: HasMutInterior::in_any_value_of_ty(cx, ty),
         needs_drop: NeedsDrop::in_any_value_of_ty(cx, ty),
         custom_eq: CustomEq::in_any_value_of_ty(cx, ty),
+        error_occured,
     }
 }
 

--- a/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
@@ -2,6 +2,7 @@
 //!
 //! See the `Qualif` trait for more info.
 
+use rustc_errors::ErrorReported;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, subst::SubstsRef, AdtDef, Ty};
 use rustc_span::DUMMY_SP;
@@ -12,7 +13,7 @@ use super::ConstCx;
 pub fn in_any_value_of_ty(
     cx: &ConstCx<'_, 'tcx>,
     ty: Ty<'tcx>,
-    error_occured: bool,
+    error_occured: Option<ErrorReported>,
 ) -> ConstQualifs {
     ConstQualifs {
         has_mut_interior: HasMutInterior::in_any_value_of_ty(cx, ty),

--- a/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
@@ -9,7 +9,11 @@ use rustc_trait_selection::traits;
 
 use super::ConstCx;
 
-pub fn in_any_value_of_ty(cx: &ConstCx<'_, 'tcx>, ty: Ty<'tcx>, error_occured: bool) -> ConstQualifs {
+pub fn in_any_value_of_ty(
+    cx: &ConstCx<'_, 'tcx>,
+    ty: Ty<'tcx>,
+    error_occured: bool,
+) -> ConstQualifs {
     ConstQualifs {
         has_mut_interior: HasMutInterior::in_any_value_of_ty(cx, ty),
         needs_drop: NeedsDrop::in_any_value_of_ty(cx, ty),

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -123,7 +123,11 @@ impl Qualifs<'mir, 'tcx> {
         has_mut_interior.get().contains(local) || self.indirectly_mutable(ccx, local, location)
     }
 
-    fn in_return_place(&mut self, ccx: &'mir ConstCx<'mir, 'tcx>, error_occured: bool) -> ConstQualifs {
+    fn in_return_place(
+        &mut self,
+        ccx: &'mir ConstCx<'mir, 'tcx>,
+        error_occured: bool,
+    ) -> ConstQualifs {
         // Find the `Return` terminator if one exists.
         //
         // If no `Return` terminator exists, this MIR is divergent. Just return the conservative

--- a/src/test/compile-fail/issue-52443.rs
+++ b/src/test/compile-fail/issue-52443.rs
@@ -11,5 +11,4 @@ fn main() {
     //~| ERROR calls in constants are limited to constant functions
     //~| ERROR mutable references are not allowed in constants
     //~| ERROR calls in constants are limited to constant functions
-    //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/const-generics/nested-type.full.stderr
+++ b/src/test/ui/const-generics/nested-type.full.stderr
@@ -4,13 +4,6 @@ error[E0015]: calls in constants are limited to constant functions, tuple struct
 LL |     Foo::<17>::value()
    |     ^^^^^^^^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/nested-type.rs:16:5
-   |
-LL |     Foo::<17>::value()
-   |     ^^^^^^^^^^^^^^^^^^ calling non-const function `Foo::{constant#0}::Foo::<17_usize>::value`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0015, E0080.
-For more information about an error, try `rustc --explain E0015`.
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/const-generics/nested-type.min.stderr
+++ b/src/test/ui/const-generics/nested-type.min.stderr
@@ -20,13 +20,6 @@ error[E0015]: calls in constants are limited to constant functions, tuple struct
 LL |     Foo::<17>::value()
    |     ^^^^^^^^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/nested-type.rs:16:5
-   |
-LL |     Foo::<17>::value()
-   |     ^^^^^^^^^^^^^^^^^^ calling non-const function `Foo::{constant#0}::Foo::<17_usize>::value`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0015, E0080.
-For more information about an error, try `rustc --explain E0015`.
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/const-generics/nested-type.rs
+++ b/src/test/ui/const-generics/nested-type.rs
@@ -15,7 +15,6 @@ struct Foo<const N: [u8; { //[min]~ ERROR `[u8; _]` is forbidden
 
     Foo::<17>::value()
     //~^ ERROR calls in constants are limited to constant functions
-    //~| ERROR evaluation of constant value failed
 }]>;
 
 fn main() {}

--- a/src/test/ui/consts/const-call.rs
+++ b/src/test/ui/consts/const-call.rs
@@ -5,5 +5,4 @@ fn f(x: usize) -> usize {
 fn main() {
     let _ = [0; f(2)];
     //~^ ERROR calls in constants are limited to constant functions
-    //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/consts/const-call.stderr
+++ b/src/test/ui/consts/const-call.stderr
@@ -4,13 +4,6 @@ error[E0015]: calls in constants are limited to constant functions, tuple struct
 LL |     let _ = [0; f(2)];
    |                 ^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/const-call.rs:6:17
-   |
-LL |     let _ = [0; f(2)];
-   |                 ^^^^ calling non-const function `f`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0015, E0080.
-For more information about an error, try `rustc --explain E0015`.
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/consts/const-eval/issue-52442.rs
+++ b/src/test/ui/consts/const-eval/issue-52442.rs
@@ -1,5 +1,4 @@
 fn main() {
     [();  { &loop { break } as *const _ as usize } ];
     //~^ ERROR casting pointers to integers in constants is unstable
-    //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/consts/const-eval/issue-52442.stderr
+++ b/src/test/ui/consts/const-eval/issue-52442.stderr
@@ -7,13 +7,6 @@ LL |     [();  { &loop { break } as *const _ as usize } ];
    = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-52442.rs:2:13
-   |
-LL |     [();  { &loop { break } as *const _ as usize } ];
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0080, E0658.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.rs
@@ -5,7 +5,6 @@ fn main() {
     let _: [u8; 0] = [4; {
         match &1 as *const i32 as usize {
             //~^ ERROR casting pointers to integers in constants
-            //~| ERROR evaluation of constant value failed
             0 => 42,
             n => n,
         }

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -7,13 +7,6 @@ LL |         match &1 as *const i32 as usize {
    = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/match-test-ptr-null.rs:6:15
-   |
-LL |         match &1 as *const i32 as usize {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0080, E0658.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.rs
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.rs
@@ -4,7 +4,6 @@
 
 struct Bug {
     a: [(); (|| { 0 })()] //~ ERROR calls in constants are limited to
-    //~^ ERROR evaluation of constant value failed
 }
 
 fn main() {}

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
@@ -4,13 +4,6 @@ error[E0015]: calls in constants are limited to constant functions, tuple struct
 LL |     a: [(); (|| { 0 })()]
    |             ^^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-68542-closure-in-array-len.rs:6:13
-   |
-LL |     a: [(); (|| { 0 })()]
-   |             ^^^^^^^^^^^^ calling non-const function `Bug::a::{constant#0}::{closure#0}`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0015, E0080.
-For more information about an error, try `rustc --explain E0015`.
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/consts/issue-76064.rs
+++ b/src/test/ui/consts/issue-76064.rs
@@ -1,0 +1,3 @@
+struct Bug([u8; panic!(1)]); //~ ERROR panicking in constants is unstable
+
+fn main() {}

--- a/src/test/ui/consts/issue-76064.stderr
+++ b/src/test/ui/consts/issue-76064.stderr
@@ -1,0 +1,13 @@
+error[E0658]: panicking in constants is unstable
+  --> $DIR/issue-76064.rs:1:17
+   |
+LL | struct Bug([u8; panic!(1)]);
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
+   = help: add `#![feature(const_panic)]` to the crate attributes to enable
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/issues/issue-39559-2.rs
+++ b/src/test/ui/issues/issue-39559-2.rs
@@ -13,8 +13,6 @@ impl Dim for Dim3 {
 fn main() {
     let array: [usize; Dim3::dim()]
     //~^ ERROR E0015
-    //~| ERROR E0080
         = [0; Dim3::dim()];
         //~^ ERROR E0015
-        //~| ERROR E0080
 }

--- a/src/test/ui/issues/issue-39559-2.stderr
+++ b/src/test/ui/issues/issue-39559-2.stderr
@@ -4,25 +4,12 @@ error[E0015]: calls in constants are limited to constant functions, tuple struct
 LL |     let array: [usize; Dim3::dim()]
    |                        ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-39559-2.rs:14:24
-   |
-LL |     let array: [usize; Dim3::dim()]
-   |                        ^^^^^^^^^^^ calling non-const function `<Dim3 as Dim>::dim`
-
 error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/issue-39559-2.rs:17:15
+  --> $DIR/issue-39559-2.rs:16:15
    |
 LL |         = [0; Dim3::dim()];
    |               ^^^^^^^^^^^
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-39559-2.rs:17:15
-   |
-LL |         = [0; Dim3::dim()];
-   |               ^^^^^^^^^^^ calling non-const function `<Dim3 as Dim>::dim`
+error: aborting due to 2 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0015, E0080.
-For more information about an error, try `rustc --explain E0015`.
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/issues/issue-43105.rs
+++ b/src/test/ui/issues/issue-43105.rs
@@ -2,7 +2,6 @@ fn xyz() -> u8 { 42 }
 
 const NUM: u8 = xyz();
 //~^ ERROR calls in constants are limited to constant functions, tuple structs and tuple variants
-//~| ERROR any use of this value will cause an error [const_err]
 
 fn main() {
     match 1 {

--- a/src/test/ui/issues/issue-43105.stderr
+++ b/src/test/ui/issues/issue-43105.stderr
@@ -4,28 +4,18 @@ error[E0015]: calls in constants are limited to constant functions, tuple struct
 LL | const NUM: u8 = xyz();
    |                 ^^^^^
 
-error: any use of this value will cause an error
-  --> $DIR/issue-43105.rs:3:17
-   |
-LL | const NUM: u8 = xyz();
-   | ----------------^^^^^-
-   |                 |
-   |                 calling non-const function `xyz`
-   |
-   = note: `#[deny(const_err)]` on by default
-
 error: could not evaluate constant pattern
-  --> $DIR/issue-43105.rs:9:9
+  --> $DIR/issue-43105.rs:8:9
    |
 LL |         NUM => unimplemented!(),
    |         ^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/issue-43105.rs:9:9
+  --> $DIR/issue-43105.rs:8:9
    |
 LL |         NUM => unimplemented!(),
    |         ^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
@@ -1,4 +1,3 @@
 fn main() {
     let _ = [0; (&0 as *const i32) as usize]; //~ ERROR casting pointers to integers in constants
-    //~^ ERROR evaluation of constant value failed
 }

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
@@ -7,13 +7,6 @@ LL |     let _ = [0; (&0 as *const i32) as usize];
    = note: see issue #51910 <https://github.com/rust-lang/rust/issues/51910> for more information
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-52023-array-size-pointer-cast.rs:2:17
-   |
-LL |     let _ = [0; (&0 as *const i32) as usize];
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0080, E0658.
-For more information about an error, try `rustc --explain E0080`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/issues/issue-52060.rs
+++ b/src/test/ui/issues/issue-52060.rs
@@ -3,6 +3,5 @@
 static A: &'static [u32] = &[1];
 static B: [u32; 1] = [0; A.len()];
 //~^ ERROR [E0013]
-//~| ERROR evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/issues/issue-52060.stderr
+++ b/src/test/ui/issues/issue-52060.stderr
@@ -6,13 +6,6 @@ LL | static B: [u32; 1] = [0; A.len()];
    |
    = help: consider extracting the value of the `static` to a `const`, and referring to that
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-52060.rs:4:26
-   |
-LL | static B: [u32; 1] = [0; A.len()];
-   |                          ^ constant accesses static
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0013, E0080.
-For more information about an error, try `rustc --explain E0013`.
+For more information about this error, try `rustc --explain E0013`.

--- a/src/test/ui/issues/issue-77919.rs
+++ b/src/test/ui/issues/issue-77919.rs
@@ -1,8 +1,8 @@
 fn main() {
-    [1; <Multiply<Five, Five>>::VAL]; //~ ERROR evaluation of constant value failed
+    [1; <Multiply<Five, Five>>::VAL];
 }
 trait TypeVal<T> {
-    const VAL: T; //~ ERROR any use of this value will cause an error
+    const VAL: T;
 }
 struct Five;
 struct Multiply<N, M> {

--- a/src/test/ui/issues/issue-77919.stderr
+++ b/src/test/ui/issues/issue-77919.stderr
@@ -26,21 +26,7 @@ LL |     const VAL: T;
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
-error: any use of this value will cause an error
-  --> $DIR/issue-77919.rs:5:5
-   |
-LL |     const VAL: T;
-   |     ^^^^^^^^^^^^^ no MIR body is available for DefId(0:7 ~ issue_77919[317d]::TypeVal::VAL)
-   |
-   = note: `#[deny(const_err)]` on by default
+error: aborting due to 3 previous errors
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-77919.rs:2:9
-   |
-LL |     [1; <Multiply<Five, Five>>::VAL];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0046, E0080, E0412.
+Some errors have detailed explanations: E0046, E0412.
 For more information about an error, try `rustc --explain E0046`.

--- a/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6252.stderr
@@ -26,21 +26,7 @@ LL |     const VAL: T;
 LL | impl<N, M> TypeVal<usize> for Multiply<N, M> where N: TypeVal<VAL> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `VAL` in implementation
 
-error: any use of this value will cause an error
-  --> $DIR/ice-6252.rs:5:5
-   |
-LL |     const VAL: T;
-   |     ^^^^^^^^^^^^^ no MIR body is available for DefId(0:5 ~ ice_6252[317d]::TypeVal::VAL)
-   |
-   = note: `#[deny(const_err)]` on by default
+error: aborting due to 3 previous errors
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/ice-6252.rs:14:9
-   |
-LL |     [1; <Multiply<Five, Five>>::VAL];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0046, E0080, E0412.
+Some errors have detailed explanations: E0046, E0412.
 For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
fix #76064

I wasn't sure what `in_return_place` actually did and not sure why it returns `ConstQualifs` while it's sibling functions return `bool`. So I tried to make as minimal changes to the structure as possible. Please point out whether I have to refactor it or not.

r? @oli-obk 
cc @RalfJung 