### PR TITLE
Make some std::io functions `const`

### DIFF
--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -94,7 +94,8 @@ impl<T> Cursor<T> {
     /// # force_inference(&buff);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn new(inner: T) -> Cursor<T> {
+    #[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+    pub const fn new(inner: T) -> Cursor<T> {
         Cursor { pos: 0, inner }
     }
 
@@ -130,7 +131,8 @@ impl<T> Cursor<T> {
     /// let reference = buff.get_ref();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn get_ref(&self) -> &T {
+    #[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+    pub const fn get_ref(&self) -> &T {
         &self.inner
     }
 
@@ -175,7 +177,8 @@ impl<T> Cursor<T> {
     /// assert_eq!(buff.position(), 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn position(&self) -> u64 {
+    #[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+    pub const fn position(&self) -> u64 {
         self.pos
     }
 

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -94,7 +94,7 @@ impl<T> Cursor<T> {
     /// # force_inference(&buff);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+    #[rustc_const_unstable(feature = "const_io_structs", issue = "78812")]
     pub const fn new(inner: T) -> Cursor<T> {
         Cursor { pos: 0, inner }
     }
@@ -131,7 +131,7 @@ impl<T> Cursor<T> {
     /// let reference = buff.get_ref();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+    #[rustc_const_unstable(feature = "const_io_structs", issue = "78812")]
     pub const fn get_ref(&self) -> &T {
         &self.inner
     }
@@ -177,7 +177,7 @@ impl<T> Cursor<T> {
     /// assert_eq!(buff.position(), 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+    #[rustc_const_unstable(feature = "const_io_structs", issue = "78812")]
     pub const fn position(&self) -> u64 {
         self.pos
     }

--- a/library/std/src/io/cursor/tests.rs
+++ b/library/std/src/io/cursor/tests.rs
@@ -514,3 +514,10 @@ fn test_eq() {
 
     let _: AssertEq<Cursor<Vec<u8>>> = AssertEq(Cursor::new(Vec::new()));
 }
+
+#[allow(dead_code)]
+fn const_cursor() {
+    const CURSOR: Cursor<&[u8]> = Cursor::new(&[0]);
+    const _: &&[u8] = CURSOR.get_ref();
+    const _: u64 = CURSOR.position();
+}

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -102,7 +102,7 @@ pub struct Empty {
 /// assert!(buffer.is_empty());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+#[rustc_const_unstable(feature = "const_io_structs", issue = "78812")]
 pub const fn empty() -> Empty {
     Empty { _priv: () }
 }
@@ -160,7 +160,7 @@ pub struct Repeat {
 /// assert_eq!(buffer, [0b101, 0b101, 0b101]);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+#[rustc_const_unstable(feature = "const_io_structs", issue = "78812")]
 pub const fn repeat(byte: u8) -> Repeat {
     Repeat { byte }
 }
@@ -228,7 +228,7 @@ pub struct Sink {
 /// assert_eq!(num_bytes, 5);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+#[rustc_const_unstable(feature = "const_io_structs", issue = "78812")]
 pub const fn sink() -> Sink {
     Sink { _priv: () }
 }

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -102,7 +102,8 @@ pub struct Empty {
 /// assert!(buffer.is_empty());
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn empty() -> Empty {
+#[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+pub const fn empty() -> Empty {
     Empty { _priv: () }
 }
 
@@ -159,7 +160,8 @@ pub struct Repeat {
 /// assert_eq!(buffer, [0b101, 0b101, 0b101]);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn repeat(byte: u8) -> Repeat {
+#[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+pub const fn repeat(byte: u8) -> Repeat {
     Repeat { byte }
 }
 
@@ -226,7 +228,8 @@ pub struct Sink {
 /// assert_eq!(num_bytes, 5);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-pub fn sink() -> Sink {
+#[rustc_const_unstable(feature = "const_io_structs", issue = "none")]
+pub const fn sink() -> Sink {
     Sink { _priv: () }
 }
 

--- a/library/std/src/io/util/tests.rs
+++ b/library/std/src/io/util/tests.rs
@@ -1,5 +1,5 @@
 use crate::io::prelude::*;
-use crate::io::{copy, empty, repeat, sink};
+use crate::io::{copy, empty, repeat, sink, Empty, Repeat, Sink};
 
 #[test]
 fn copy_copies() {
@@ -42,4 +42,11 @@ fn take_some_bytes() {
     assert_eq!(repeat(4).take(100).bytes().count(), 100);
     assert_eq!(repeat(4).take(100).bytes().next().unwrap().unwrap(), 4);
     assert_eq!(repeat(1).take(10).chain(repeat(2).take(10)).bytes().count(), 20);
+}
+
+#[allow(dead_code)]
+fn const_utils() {
+    const _: Empty = empty();
+    const _: Repeat = repeat(b'c');
+    const _: Sink = sink();
 }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -242,6 +242,7 @@
 #![feature(const_fn_transmute)]
 #![feature(const_fn)]
 #![feature(const_fn_fn_ptr_basics)]
+#![feature(const_io_structs)]
 #![feature(const_ip)]
 #![feature(const_ipv6)]
 #![feature(const_raw_ptr_deref)]


### PR DESCRIPTION
Tracking issue: #78812 

Make the following functions `const`:
- `io::Cursor::new`
- `io::Cursor::get_ref`
- `io::Cursor::position`
- `io::empty`
- `io::repeat`
- `io::sink`

r? @dtolnay 