### PR TITLE
./x.py: add --only lint1,lint2 flag to ./x.py clippy which only runs specified lints and ignores all others

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -20,9 +20,9 @@ fn args(builder: &Builder<'_>) -> Vec<String> {
         arr.iter().copied().map(String::from)
     }
 
-    if let Subcommand::Clippy { fix, .. } = builder.config.cmd {
+    if let Subcommand::Clippy { fix, only, .. } = &builder.config.cmd {
         let mut args = vec![];
-        if fix {
+        if *fix {
             #[rustfmt::skip]
             args.extend(strings(&[
                 "--fix", "-Zunstable-options",
@@ -33,6 +33,14 @@ fn args(builder: &Builder<'_>) -> Vec<String> {
             ]));
         }
         args.extend(strings(&["--", "--cap-lints", "warn"]));
+        // only run specified lints
+        if let Some(only) = only {
+            args.push("-Aclippy::all".into());
+            let allow_lints: Vec<_> =
+                only.split(",").map(|lintname| format!("-Wclippy::{}", lintname)).collect();
+
+            args.extend(allow_lints);
+        }
         args
     } else {
         vec![]

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -57,6 +57,7 @@ pub enum Subcommand {
     Clippy {
         fix: bool,
         paths: Vec<PathBuf>,
+        only: Option<String>,
     },
     Fix {
         paths: Vec<PathBuf>,
@@ -276,6 +277,7 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`",
             }
             "clippy" => {
                 opts.optflag("", "fix", "automatically apply lint suggestions");
+                opts.optopt("", "only", "only run specified clippy lints", "clippy_lint_name");
             }
             "doc" => {
                 opts.optflag("", "open", "open the docs in a browser");
@@ -517,7 +519,11 @@ Arguments:
             "check" | "c" => {
                 Subcommand::Check { paths, all_targets: matches.opt_present("all-targets") }
             }
-            "clippy" => Subcommand::Clippy { paths, fix: matches.opt_present("fix") },
+            "clippy" => Subcommand::Clippy {
+                paths,
+                fix: matches.opt_present("fix"),
+                only: matches.opt_str("only"),
+            },
             "fix" => Subcommand::Fix { paths },
             "test" | "t" => Subcommand::Test {
                 paths,


### PR DESCRIPTION
for example:
 ./x.py clippy --only or_fun_call,type_complexity
will only run these two clippy lints.