### PR TITLE
look at assoc ct, check the type of nodes

### DIFF
--- a/src/test/ui/const-generics/const_evaluatable_checked/associated-consts.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/associated-consts.rs
@@ -1,0 +1,31 @@
+// run-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+pub trait BlockCipher {
+    const BLOCK_SIZE: usize;
+}
+
+struct FooCipher;
+impl BlockCipher for FooCipher {
+    const BLOCK_SIZE: usize = 64;
+}
+
+struct BarCipher;
+impl BlockCipher for BarCipher {
+    const BLOCK_SIZE: usize = 32;
+}
+
+pub struct Block<C>(C);
+
+pub fn test<C: BlockCipher, const M: usize>()
+where
+    [u8; M - C::BLOCK_SIZE]: Sized,
+{
+    let _ = [0; M - C::BLOCK_SIZE];
+}
+
+fn main() {
+    test::<FooCipher, 128>();
+    test::<BarCipher, 64>();
+}

--- a/src/test/ui/const-generics/const_evaluatable_checked/different-fn.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/different-fn.rs
@@ -1,0 +1,16 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+use std::mem::size_of;
+use std::marker::PhantomData;
+
+struct Foo<T>(PhantomData<T>);
+
+fn test<T>() -> [u8; size_of::<T>()] {
+    [0; size_of::<Foo<T>>()]
+    //~^ ERROR unconstrained generic constant
+}
+
+fn main() {
+    test::<u32>();
+}

--- a/src/test/ui/const-generics/const_evaluatable_checked/different-fn.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/different-fn.stderr
@@ -1,0 +1,14 @@
+error: unconstrained generic constant
+  --> $DIR/different-fn.rs:10:9
+   |
+LL |     [0; size_of::<Foo<T>>()]
+   |         ^^^^^^^^^^^^^^^^^^^
+   |
+help: consider adding a `where` bound for this expression
+  --> $DIR/different-fn.rs:10:9
+   |
+LL |     [0; size_of::<Foo<T>>()]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
an example where types matter are function objects, see the added test which previously passed.

Now does a shallow comparison of unevaluated constants.

r? @oli-obk 