### PR TITLE
Bump minimal supported LLVM version to 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           - name: mingw-check
             os: ubuntu-latest-xl
             env: {}
-          - name: x86_64-gnu-llvm-8
+          - name: x86_64-gnu-llvm-9
             os: ubuntu-latest-xl
             env: {}
           - name: x86_64-gnu-tools
@@ -265,7 +265,7 @@ jobs:
           - name: x86_64-gnu-distcheck
             os: ubuntu-latest-xl
             env: {}
-          - name: x86_64-gnu-llvm-8
+          - name: x86_64-gnu-llvm-9
             env:
               RUST_BACKTRACE: 1
             os: ubuntu-latest-xl

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -147,17 +147,9 @@ fn set_probestack(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
 fn translate_obsolete_target_features(feature: &str) -> &str {
     const LLVM9_FEATURE_CHANGES: &[(&str, &str)] =
         &[("+fp-only-sp", "-fp64"), ("-fp-only-sp", "+fp64"), ("+d16", "-d32"), ("-d16", "+d32")];
-    if llvm_util::get_major_version() >= 9 {
-        for &(old, new) in LLVM9_FEATURE_CHANGES {
-            if feature == old {
-                return new;
-            }
-        }
-    } else {
-        for &(old, new) in LLVM9_FEATURE_CHANGES {
-            if feature == new {
-                return old;
-            }
+    for &(old, new) in LLVM9_FEATURE_CHANGES {
+        if feature == old {
+            return new;
         }
     }
     feature

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -153,11 +153,7 @@ pub fn llvm_target_features(sess: &Session) -> impl Iterator<Item = &str> {
         .target_feature
         .split(',')
         .filter(|f| !RUSTC_SPECIFIC_FEATURES.iter().any(|s| f.contains(s)));
-    sess.target
-        .features
-        .split(',')
-        .chain(cmdline)
-        .filter(|l| !l.is_empty())
+    sess.target.features.split(',').chain(cmdline).filter(|l| !l.is_empty())
 }
 
 pub fn apply_target_cpu_attr(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -144,17 +144,6 @@ fn set_probestack(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
     );
 }
 
-fn translate_obsolete_target_features(feature: &str) -> &str {
-    const LLVM9_FEATURE_CHANGES: &[(&str, &str)] =
-        &[("+fp-only-sp", "-fp64"), ("-fp-only-sp", "+fp64"), ("+d16", "-d32"), ("-d16", "+d32")];
-    for &(old, new) in LLVM9_FEATURE_CHANGES {
-        if feature == old {
-            return new;
-        }
-    }
-    feature
-}
-
 pub fn llvm_target_features(sess: &Session) -> impl Iterator<Item = &str> {
     const RUSTC_SPECIFIC_FEATURES: &[&str] = &["crt-static"];
 
@@ -169,7 +158,6 @@ pub fn llvm_target_features(sess: &Session) -> impl Iterator<Item = &str> {
         .split(',')
         .chain(cmdline)
         .filter(|l| !l.is_empty())
-        .map(translate_obsolete_target_features)
 }
 
 pub fn apply_target_cpu_attr(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -377,11 +377,6 @@ fn get_pgo_use_path(config: &ModuleConfig) -> Option<CString> {
 }
 
 pub(crate) fn should_use_new_llvm_pass_manager(config: &ModuleConfig) -> bool {
-    // We only support the new pass manager starting with LLVM 9.
-    if llvm_util::get_major_version() < 9 {
-        return false;
-    }
-
     // The new pass manager is disabled by default.
     config.new_llvm_pass_manager
 }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -100,11 +100,6 @@ fn to_llvm_tls_model(tls_model: TlsModel) -> llvm::ThreadLocalMode {
     }
 }
 
-fn strip_function_ptr_alignment(data_layout: String) -> String {
-    // FIXME: Make this more general.
-    data_layout.replace("-Fi8-", "-")
-}
-
 fn strip_x86_address_spaces(data_layout: String) -> String {
     data_layout.replace("-p270:32:32-p271:32:32-p272:64:64-", "-")
 }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -119,9 +119,6 @@ pub unsafe fn create_module(
     let llmod = llvm::LLVMModuleCreateWithNameInContext(mod_name.as_ptr(), llcx);
 
     let mut target_data_layout = sess.target.data_layout.clone();
-    if llvm_util::get_major_version() < 9 {
-        target_data_layout = strip_function_ptr_alignment(target_data_layout);
-    }
     if llvm_util::get_major_version() < 10
         && (sess.target.arch == "x86" || sess.target.arch == "x86_64")
     {

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -104,7 +104,7 @@ unsafe fn configure_llvm(sess: &Session) {
         }
     }
 
-    if sess.opts.debugging_opts.llvm_time_trace && get_major_version() >= 9 {
+    if sess.opts.debugging_opts.llvm_time_trace {
         // time-trace is not thread safe and running it in parallel will cause seg faults.
         if !sess.opts.debugging_opts.no_parallel_llvm {
             bug!("`-Z llvm-time-trace` requires `-Z no-parallel-llvm")
@@ -122,10 +122,8 @@ unsafe fn configure_llvm(sess: &Session) {
 
 pub fn time_trace_profiler_finish(file_name: &str) {
     unsafe {
-        if get_major_version() >= 9 {
-            let file_name = CString::new(file_name).unwrap();
-            llvm::LLVMTimeTraceProfilerFinish(file_name.as_ptr());
-        }
+        let file_name = CString::new(file_name).unwrap();
+        llvm::LLVMTimeTraceProfilerFinish(file_name.as_ptr());
     }
 }
 

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -124,9 +124,7 @@ extern "C" LLVMValueRef LLVMRustGetOrInsertFunction(LLVMModuleRef M,
   return wrap(unwrap(M)
                   ->getOrInsertFunction(StringRef(Name, NameLen),
                                         unwrap<FunctionType>(FunctionTy))
-#if LLVM_VERSION_GE(9, 0)
                   .getCallee()
-#endif
   );
 }
 
@@ -251,11 +249,7 @@ extern "C" void LLVMRustAddDereferenceableOrNullCallSiteAttr(LLVMValueRef Instr,
 extern "C" void LLVMRustAddByValCallSiteAttr(LLVMValueRef Instr, unsigned Index,
                                              LLVMTypeRef Ty) {
   CallBase *Call = unwrap<CallBase>(Instr);
-#if LLVM_VERSION_GE(9, 0)
   Attribute Attr = Attribute::getWithByValType(Call->getContext(), unwrap(Ty));
-#else
-  Attribute Attr = Attribute::get(Call->getContext(), Attribute::ByVal);
-#endif
   Call->addAttribute(Index, Attr);
 }
 
@@ -296,11 +290,7 @@ extern "C" void LLVMRustAddDereferenceableOrNullAttr(LLVMValueRef Fn,
 extern "C" void LLVMRustAddByValAttr(LLVMValueRef Fn, unsigned Index,
                                      LLVMTypeRef Ty) {
   Function *F = unwrap<Function>(Fn);
-#if LLVM_VERSION_GE(9, 0)
   Attribute Attr = Attribute::getWithByValType(F->getContext(), unwrap(Ty));
-#else
-  Attribute Attr = Attribute::get(F->getContext(), Attribute::ByVal);
-#endif
   F->addAttribute(Index, Attr);
 }
 
@@ -616,11 +606,9 @@ static DISubprogram::DISPFlags fromRust(LLVMRustDISPFlags SPFlags) {
   if (isSet(SPFlags & LLVMRustDISPFlags::SPFlagOptimized)) {
     Result |= DISubprogram::DISPFlags::SPFlagOptimized;
   }
-#if LLVM_VERSION_GE(9, 0)
   if (isSet(SPFlags & LLVMRustDISPFlags::SPFlagMainSubprogram)) {
     Result |= DISubprogram::DISPFlags::SPFlagMainSubprogram;
   }
-#endif
 
   return Result;
 }
@@ -744,10 +732,6 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateFunction(
       DITemplateParameterArray(unwrap<MDTuple>(TParam));
   DISubprogram::DISPFlags llvmSPFlags = fromRust(SPFlags);
   DINode::DIFlags llvmFlags = fromRust(Flags);
-#if LLVM_VERSION_LT(9, 0)
-  if (isSet(SPFlags & LLVMRustDISPFlags::SPFlagMainSubprogram))
-    llvmFlags |= DINode::DIFlags::FlagMainSubprogram;
-#endif
   DISubprogram *Sub = Builder->createFunction(
       unwrapDI<DIScope>(Scope),
       StringRef(Name, NameLen),

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -348,11 +348,11 @@ fn check_llvm_version(builder: &Builder<'_>, llvm_config: &Path) {
     let version = output(cmd.arg("--version"));
     let mut parts = version.split('.').take(2).filter_map(|s| s.parse::<u32>().ok());
     if let (Some(major), Some(_minor)) = (parts.next(), parts.next()) {
-        if major >= 8 {
+        if major >= 9 {
             return;
         }
     }
-    panic!("\n\nbad LLVM version: {}, need >=8.0\n\n", version)
+    panic!("\n\nbad LLVM version: {}, need >=9.0\n\n", version)
 }
 
 fn configure_cmake(

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-9/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-9/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   sudo \
   gdb \
   llvm-9-tools \
+  llvm-9-dev \
   libedit-dev \
   libssl-dev \
   pkg-config \

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-9/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-9/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   sudo \
   gdb \
-  llvm-8-tools \
+  llvm-9-tools \
   libedit-dev \
   libssl-dev \
   pkg-config \
@@ -27,7 +27,7 @@ RUN sh /scripts/sccache.sh
 # using llvm-link-shared due to libffi issues -- see #34486
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
-      --llvm-root=/usr/lib/llvm-8 \
+      --llvm-root=/usr/lib/llvm-9 \
       --enable-llvm-link-shared \
       --set rust.thin-lto-import-instr-limit=10
 

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -280,7 +280,7 @@ jobs:
           - name: mingw-check
             <<: *job-linux-xl
 
-          - name: x86_64-gnu-llvm-8
+          - name: x86_64-gnu-llvm-9
             <<: *job-linux-xl
 
           - name: x86_64-gnu-tools
@@ -412,7 +412,7 @@ jobs:
           - name: x86_64-gnu-distcheck
             <<: *job-linux-xl
 
-          - name: x86_64-gnu-llvm-8
+          - name: x86_64-gnu-llvm-9
             env:
               RUST_BACKTRACE: 1
             <<: *job-linux-xl

--- a/src/test/codegen/abi-efiapi.rs
+++ b/src/test/codegen/abi-efiapi.rs
@@ -1,7 +1,6 @@
 // Checks if the correct annotation for the efiapi ABI is passed to llvm.
 
 // revisions:x86_64 i686 aarch64 arm riscv
-// min-llvm-version: 9.0
 // needs-llvm-components: aarch64 arm riscv
 
 //[x86_64] compile-flags: --target x86_64-unknown-uefi

--- a/src/test/codegen/force-unwind-tables.rs
+++ b/src/test/codegen/force-unwind-tables.rs
@@ -1,4 +1,3 @@
-// min-llvm-version: 8.0
 // compile-flags: -C no-prepopulate-passes -C force-unwind-tables=y
 
 #![crate_type="lib"]

--- a/src/test/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
+++ b/src/test/ui/sanitize/new-llvm-pass-manager-thin-lto.rs
@@ -2,7 +2,6 @@
 // being run when compiling with new LLVM pass manager and ThinLTO.
 // Note: The issue occurred only on non-zero opt-level.
 //
-// min-llvm-version: 9.0
 // needs-sanitizer-support
 // needs-sanitizer-address
 //


### PR DESCRIPTION
This bumps the minimal tested llvm version to 9.
This should enable supporting newer LLVM features (and CPU extensions).

This was motived by #78361 having to drop features because of LLVM 8 not supporting certain CPU extensions yet.
This was declared relatively uncontroversial on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Min.20Supported.20LLVM.20Upgrade.20Process.3F/near/215957859).

Paging @eddyb because there was a comment in the [dockerfile](https://github.com/rust-lang/rust/blob/master/src/ci/docker/host-x86_64/x86_64-gnu-llvm-8/Dockerfile#L42) describing a hack (which I don't quite understand) which was also blocked by not having LLVM 9.