### PR TITLE
rustc_parse: fix ConstBlock expr span

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -873,7 +873,8 @@ impl<'a> Parser<'a> {
             id: DUMMY_NODE_ID,
             value: self.mk_expr(blk.span, ExprKind::Block(blk, None), AttrVec::new()),
         };
-        Ok(self.mk_expr(span, ExprKind::ConstBlock(anon_const), AttrVec::new()))
+        let blk_span = anon_const.value.span;
+        Ok(self.mk_expr(span.to(blk_span), ExprKind::ConstBlock(anon_const), AttrVec::new()))
     }
 
     /// Parses mutability (`mut` or nothing).


### PR DESCRIPTION
The span for a ConstBlock expression should presumably run through the end of the block it contains and not stop at the keyword, just like is done with similar block-containing expression kinds, such as a TryBlock 