### PR TITLE
Workaround for "could not fully normalize" ICE 

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2136,10 +2136,8 @@ impl<T> InPlaceDrop<T> {
 impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
-        if mem::needs_drop::<T>() {
-            unsafe {
-                ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
-            }
+        unsafe {
+            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
         }
     }
 }
@@ -2871,10 +2869,8 @@ impl<T> IntoIter<T> {
     }
 
     fn drop_remaining(&mut self) {
-        if mem::needs_drop::<T>() {
-            unsafe {
-                ptr::drop_in_place(self.as_mut_slice());
-            }
+        unsafe {
+            ptr::drop_in_place(self.as_mut_slice());
         }
         self.ptr = self.end;
     }


### PR DESCRIPTION
Workaround for "could not fully normalize" ICE (#78139) by removing the `needs_drop::<T>()` calls triggering it.
Corresponding beta PR: #78845

Fixes #78139 -- the underlying bug is likely not fixed but we don't have another test case isolated for now, so closing.