### PR TITLE
Clean copyright as per rustc-dev-guide.

### DIFF
--- a/src/test/rustdoc/auxiliary/enum-primitive.rs
+++ b/src/test/rustdoc/auxiliary/enum-primitive.rs
@@ -1,24 +1,3 @@
-// Copyright (c) 2015 Anders Kaseorg <andersk@mit.edu>
-
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// “Software”), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 //! This crate exports a macro `enum_from_primitive!` that wraps an
 //! `enum` declaration and automatically adds an implementation of
 //! `num::FromPrimitive` (reexported here), to allow conversion from
@@ -58,8 +37,8 @@ pub mod num_traits {
     }
 }
 
-pub use std::option::Option;
 pub use num_traits::FromPrimitive;
+pub use std::option::Option;
 
 /// Helper macro for internal use by `enum_from_primitive!`.
 #[macro_export]

--- a/src/test/ui/auxiliary/kinds_in_metadata.rs
+++ b/src/test/ui/auxiliary/kinds_in_metadata.rs
@@ -1,8 +1,5 @@
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
-
 // Tests that metadata serialization works for the `Copy` kind.
 
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
-pub fn f<T:Copy>() {}
+pub fn f<T: Copy>() {}

--- a/src/test/ui/can-copy-pod.rs
+++ b/src/test/ui/can-copy-pod.rs
@@ -1,14 +1,11 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
-
 // Tests that type parameters with the `Copy` are implicitly copyable.
 
 #![allow(dead_code)]
 
-fn can_copy_copy<T:Copy>(v: T) {
+fn can_copy_copy<T: Copy>(v: T) {
     let _a = v;
     let _b = v;
 }

--- a/src/test/ui/closures/closure-reform-bad.rs
+++ b/src/test/ui/closures/closure-reform-bad.rs
@@ -1,6 +1,3 @@
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
-
 fn call_bare(f: fn(&str)) {
     f("Hello ");
 }
@@ -8,5 +5,5 @@ fn call_bare(f: fn(&str)) {
 fn main() {
     let string = "world!";
     let f = |s: &str| println!("{}{}", s, string);
-    call_bare(f)    //~ ERROR mismatched types
+    call_bare(f) //~ ERROR mismatched types
 }

--- a/src/test/ui/closures/closure-reform-bad.stderr
+++ b/src/test/ui/closures/closure-reform-bad.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/closure-reform-bad.rs:11:15
+  --> $DIR/closure-reform-bad.rs:8:15
    |
 LL |     let f = |s: &str| println!("{}{}", s, string);
    |             ------------------------------------- the found closure
@@ -7,7 +7,7 @@ LL |     call_bare(f)
    |               ^ expected fn pointer, found closure
    |
    = note: expected fn pointer `for<'r> fn(&'r str)`
-                 found closure `[closure@$DIR/closure-reform-bad.rs:10:13: 10:50]`
+                 found closure `[closure@$DIR/closure-reform-bad.rs:7:13: 7:50]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-wrong-kind.rs
+++ b/src/test/ui/closures/closure-wrong-kind.rs
@@ -1,12 +1,9 @@
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
-
 struct X;
 fn foo<T>(_: T) {}
 fn bar<T: Fn(u32)>(_: T) {}
 
 fn main() {
     let x = X;
-    let closure = |_| foo(x);  //~ ERROR E0525
+    let closure = |_| foo(x); //~ ERROR E0525
     bar(closure);
 }

--- a/src/test/ui/closures/closure-wrong-kind.stderr
+++ b/src/test/ui/closures/closure-wrong-kind.stderr
@@ -1,5 +1,5 @@
 error[E0525]: expected a closure that implements the `Fn` trait, but this closure only implements `FnOnce`
-  --> $DIR/closure-wrong-kind.rs:10:19
+  --> $DIR/closure-wrong-kind.rs:7:19
    |
 LL |     let closure = |_| foo(x);
    |                   ^^^^^^^^-^

--- a/src/test/ui/functions-closures/closure-reform.rs
+++ b/src/test/ui/functions-closures/closure-reform.rs
@@ -1,19 +1,24 @@
 // run-pass
 #![allow(unused_variables)]
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 fn call_it<F>(f: F)
-    where F : FnOnce(String) -> String
+where
+    F: FnOnce(String) -> String,
 {
     println!("{}", f("Fred".to_string()))
 }
 
-fn call_a_thunk<F>(f: F) where F: FnOnce() {
+fn call_a_thunk<F>(f: F)
+where
+    F: FnOnce(),
+{
     f();
 }
 
-fn call_this<F>(f: F) where F: FnOnce(&str) + Send {
+fn call_this<F>(f: F)
+where
+    F: FnOnce(&str) + Send,
+{
     f("Hello!");
 }
 
@@ -21,7 +26,7 @@ fn call_bare(f: fn(&str)) {
     f("Hello world!")
 }
 
-fn call_bare_again(f: extern "Rust" fn(&str)) {
+fn call_bare_again(f: fn(&str)) {
     f("Goodbye world!")
 }
 
@@ -29,17 +34,13 @@ pub fn main() {
     // Procs
 
     let greeting = "Hello ".to_string();
-    call_it(|s| {
-        format!("{}{}", greeting, s)
-    });
+    call_it(|s| format!("{}{}", greeting, s));
 
     let greeting = "Goodbye ".to_string();
     call_it(|s| format!("{}{}", greeting, s));
 
     let greeting = "How's life, ".to_string();
-    call_it(|s: String| -> String {
-        format!("{}{}", greeting, s)
-    });
+    call_it(|s: String| -> String { format!("{}{}", greeting, s) });
 
     // Closures
 

--- a/src/test/ui/kinds-in-metadata.rs
+++ b/src/test/ui/kinds-in-metadata.rs
@@ -3,9 +3,6 @@
 
 // pretty-expanded FIXME #23616
 
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
-
 // Tests that metadata serialization works for the `Copy` kind.
 
 extern crate kinds_in_metadata;

--- a/src/test/ui/new-box-syntax.rs
+++ b/src/test/ui/new-box-syntax.rs
@@ -1,9 +1,6 @@
 // run-pass
 // pretty-expanded FIXME #23616
 
-/* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
-
 #![allow(dead_code, unused_variables)]
 #![feature(box_syntax)]
 
@@ -21,8 +18,5 @@ pub fn main() {
     let b: Box<isize> = box (1 + 2);
     let c = box (3 + 4);
 
-    let s: Box<Structure> = box Structure {
-        x: 3,
-        y: 4,
-    };
+    let s: Box<Structure> = box Structure { x: 3, y: 4 };
 }


### PR DESCRIPTION
As per rustc-dev-guide copyrights should be only in main folders and not in headers of .rs files. Where needed, .stderr was updated to reflect rustfmt guidelines (automatically applied).