### PR TITLE
Nicer hunk headers for rust files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 * text=auto eol=lf
 *.cpp rust
 *.h rust
-*.rs rust
+*.rs rust diff=rust
 *.fixed linguist-language=Rust
 src/etc/installer/gfx/* binary
 *.woff binary


### PR DESCRIPTION
I found this trick at <https://tekin.co.uk/2020/10/better-git-diff-output-for-ruby-python-elixir-and-more>

Before the hunk headers for changes in methods would refer to the impl:

```diff
diff --git a/compiler/rustc_middle/src/ty/context.rs b/compiler/rustc_middle/src/ty/context.rs
index 1c6937e685c..fa4264d729b 100644
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -678,7 +678,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             ref closure_captures,
             ref generator_interior_types,
         } = *self;
-
+        // foo
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
             type_dependent_defs.hash_stable(hcx, hasher);
             field_indices.hash_stable(hcx, hasher);
```

After the hunk headers refer to the actual function signature:

```diff
diff --git a/compiler/rustc_middle/src/ty/context.rs b/compiler/rustc_middle/src/ty/context.rs
index 1c6937e685c..fa4264d729b 100644
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -678,7 +678,7 @@ fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHas
             ref closure_captures,
             ref generator_interior_types,
         } = *self;
-
+        // foo
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
             type_dependent_defs.hash_stable(hcx, hasher);
             field_indices.hash_stable(hcx, hasher);
```

When the function signature is visible, it will use the function
signature of the previous method as hunk header:

```diff
diff --git a/compiler/rustc_middle/src/ty/context.rs b/compiler/rustc_middle/src/ty/context.rs
index 1c6937e685c..63058dfc837 100644
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -992,6 +992,7 @@ pub fn typeck_opt_const_arg(
     }

     pub fn alloc_steal_mir(self, mir: Body<'tcx>) -> &'tcx Steal<Body<'tcx>> {
+        // foo
         self.arena.alloc(Steal::new(mir))
     }
```