### PR TITLE
Avoid no-op when truncating a vector to same size.

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -716,7 +716,7 @@ impl<T> Vec<T> {
     /// assert_eq!(vec, [1, 2]);
     /// ```
     ///
-    /// No truncation occurs when `len` is greater than the vector's current
+    /// No truncation occurs when `len` is greater than or equal to the vector's current
     /// length:
     ///
     /// ```
@@ -746,7 +746,7 @@ impl<T> Vec<T> {
         //   such that no value will be dropped twice in case `drop_in_place`
         //   were to panic once (if it panics twice, the program aborts).
         unsafe {
-            if len > self.len {
+            if len >= self.len {
                 return;
             }
             let remaining_len = self.len - len;


### PR DESCRIPTION
I noticed that `Vec::truncate()` will actually execute unnecessary operations if the target `len` is the same as the current `len`, even though it should do nothing. The method already checks whether the target `len` is _greater_ than the current `len`, so I simply changed this check to a `>=` and updated the wording of the associated doc comment to reflect this.

While the lack of the `=` incurs a nearly negligible amount of unnecessary overhead, this does happen when `clear()`ing an empty vector or string, which happens fairly commonly.