### PR TITLE
Fix and re-enable two coverage tests on MacOS

### DIFF
--- a/src/test/run-make-fulldeps/coverage-reports-base/Makefile
+++ b/src/test/run-make-fulldeps/coverage-reports-base/Makefile
@@ -13,15 +13,13 @@
 BASEDIR=../coverage-reports-base
 SOURCEDIR=../coverage
 
-ifeq ($(UNAME),Darwin)
-# FIXME(richkadel): It appears that --debug is not available on MacOS even when not running
-# under CI.
-NO_LLVM_ASSERTIONS=1
-endif
-
 # The `llvm-cov show` flag `--debug`, used to generate the `counters` output files, is only enabled
-# if LLVM assertions are enabled. Some CI builds disable debug assertions.
-ifndef NO_LLVM_ASSERTIONS
+# if LLVM assertions are enabled. Requires Rust config `llvm/optimize` and not
+# `llvm/release_debuginfo`. Note that some CI builds disable debug assertions (by setting
+# `NO_LLVM_ASSERTIONS=1`), so it is not OK to fail the test, but `bless`ed test results cannot be
+# generated without debug assertions.
+LLVM_COV_DEBUG := $(shell "$(LLVM_BIN_DIR)"/llvm-cov show --debug 2>&1 | grep -q "Unknown command line argument '--debug'"; echo $$?)
+ifeq ($(LLVM_COV_DEBUG), 1)
 DEBUG_FLAG=--debug
 endif
 

--- a/src/test/run-make-fulldeps/coverage-spanview-base/Makefile
+++ b/src/test/run-make-fulldeps/coverage-spanview-base/Makefile
@@ -9,9 +9,20 @@
 BASEDIR=../coverage-spanview-base
 SOURCEDIR=../coverage
 
-ifeq ($(UNAME),Darwin)
-SED_HAS_ISSUES=1
-endif
+define SPANVIEW_HEADER
+<!DOCTYPE html>
+<!--
+
+Preview this file as rendered HTML from the github source at:
+https://htmlpreview.github.io/?https://github.com/rust-lang/rust/blob/master/src/test/run-make-fulldeps/coverage-spanview-base/expected_mir_dump.%s/%s
+
+For revisions in Pull Requests (PR):
+  * Replace "rust-lang" with the github PR author
+  * Replace "master" with the PR branch name
+
+-->
+endef
+export SPANVIEW_HEADER
 
 all: $(patsubst $(SOURCEDIR)/%.rs,%,$(wildcard $(SOURCEDIR)/*.rs))
 
@@ -33,31 +44,12 @@ endif
 			-Zdump-mir-spanview \
 			-Zdump-mir-dir="$(TMPDIR)"/mir_dump.$@
 
-ifdef SED_HAS_ISSUES
-	# FIXME(richkadel): MacOS's default sed has some significant limitations. Until I've come up
-	# with a better workaround, I'm disabling this test for MacOS.
-	#
-	# For future reference, see if `gsed` is available as an alternative.
-	which gsed || echo "no gsed"
-else
-
 	for path in "$(TMPDIR)"/mir_dump.$@/*; do \
-		echo $$path; \
 		file="$$(basename "$$path")"; \
-		echo $$file; \
 		urlescaped="$$("$(PYTHON)" $(BASEDIR)/escape_url.py $$file)" || exit $$?; \
-		echo $$urlescaped; \
-		sed -i -e '1a\
-<!--\
-\
-Preview this file as rendered HTML from the github source at:\
-https://htmlpreview.github.io/?https://github.com/rust-lang/rust/blob/master/src/test/run-make-fulldeps/coverage-spanview-base/expected_mir_dump.$@/'"$$urlescaped"'\
-\
-For revisions in Pull Requests (PR):\
-  * Replace "rust-lang" with the github PR author\
-  * Replace "master" with the PR branch name\
-\
--->' "$$path"; \
+		printf "$$SPANVIEW_HEADER\n" "$@" "$$urlescaped" > "$$path".modified; \
+		tail -n +2 "$$path" >> "$$path".modified; \
+		mv "$$path".modified "$$path"; \
 	done && true # for/done ends in non-zero status
 
 ifdef RUSTC_BLESS_TEST
@@ -69,6 +61,4 @@ else
 	rm -f "$(TMPDIR)"/actual_mir_dump.$@/*
 	cp "$(TMPDIR)"/mir_dump.$@/*InstrumentCoverage.0.html "$(TMPDIR)"/actual_mir_dump.$@/
 	$(DIFF) -r expected_mir_dump.$@/ "$(TMPDIR)"/actual_mir_dump.$@/
-endif
-
 endif


### PR DESCRIPTION
Note, in the coverage-reports test, the comment about MacOS was wrong.
The setting is based on config.toml llvm `optimize` setting. There
doesn't appear to be any environment variable I can check, and I
don't think we should add one. Testing the binary itself is a more
reliable way to check anyway.

For the coverage-spanview test, I removed the dependency on sed
altogether, which is much less ugly than trying to work around the
MacOS sed differences.

I tested these changes on Linux, Windows, and Mac.

r? @tmandry 
FYI @wesleywiser 