### PR TITLE
Clarified description of write! macro

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -318,7 +318,7 @@ macro_rules! r#try {
 
 /// Writes formatted data into a buffer.
 ///
-/// This macro accepts a format string, a list of arguments, and a 'writer'. Arguments will be
+/// This macro accepts a 'writer', a format string, a list of arguments. Arguments will be
 /// formatted according to the specified format string and the result will be passed to the writer.
 /// The writer may be any value with a `write_fmt` method; generally this comes from an
 /// implementation of either the [`fmt::Write`] or the [`io::Write`] trait. The macro

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -318,7 +318,7 @@ macro_rules! r#try {
 
 /// Writes formatted data into a buffer.
 ///
-/// This macro accepts a 'writer', a format string, a list of arguments. Arguments will be
+/// This macro accepts a 'writer', a format string, and a list of arguments. Arguments will be
 /// formatted according to the specified format string and the result will be passed to the writer.
 /// The writer may be any value with a `write_fmt` method; generally this comes from an
 /// implementation of either the [`fmt::Write`] or the [`io::Write`] trait. The macro


### PR DESCRIPTION
Reordered the list of arguments in the description to match that in the actual macro.

Suggested and discussed [here](https://discord.com/channels/442252698964721669/443492145567891458/774341262609219624).