### PR TITLE
Change --extern-html-root-url to use crate source path as key

### DIFF
--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -250,14 +250,14 @@ details.
 Using this flag looks like this:
 
 ```bash
-$ rustdoc src/lib.rs -Z unstable-options --extern-html-root-url some-crate=https://example.com/some-crate/1.0.1
+$ rustdoc src/lib.rs -Z unstable-options --extern-html-root-url libsome_crate.rlib=https://example.com/some-crate/1.0.1
 ```
 
 Ordinarily, when rustdoc wants to link to a type from a different crate, it looks in two places:
 docs that already exist in the output directory, or the `#![doc(doc_html_root)]` set in the other
 crate. However, if you want to link to docs that exist in neither of those places, you can use these
-flags to control that behavior. When the `--extern-html-root-url` flag is given with a name matching
-one of your dependencies, rustdoc use that URL for those docs. Keep in mind that if those docs exist
+flags to control that behavior. When the `--extern-html-root-url` flag is given with a filename matching
+one of your dependencies, rustdoc will use that URL for those docs. Keep in mind that if those docs exist
 in the output directory, those local docs will still override this flag.
 
 ### `-Z force-unstable-if-unmarked`

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -14,7 +14,7 @@ use rustc_attr as attr;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, DefKind, Res};
-use rustc_hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX};
+use rustc_hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_infer::infer::region_constraints::{Constraint, RegionConstraintData};
 use rustc_middle::bug;
@@ -211,9 +211,13 @@ impl Clean<ExternalCrate> for CrateNum {
             cx.tcx.item_children(root).iter().map(|item| item.res).filter_map(as_keyword).collect()
         };
 
+        let extern_paths =
+            if *self == LOCAL_CRATE { vec![] } else { cx.tcx.crate_extern_paths(*self) };
+
         ExternalCrate {
             name: cx.tcx.crate_name(*self).to_string(),
             src: krate_src,
+            extern_paths,
             attrs: cx.tcx.get_attrs(root).clean(cx),
             primitives,
             keywords,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1,10 +1,10 @@
 use std::cell::RefCell;
 use std::default::Default;
+use std::ffi::OsString;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
 use std::lazy::SyncOnceCell as OnceCell;
-use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{slice, vec};
@@ -67,7 +67,7 @@ pub struct Crate {
 pub struct ExternalCrate {
     pub name: String,
     pub src: FileName,
-    pub extern_paths: Vec<PathBuf>,
+    pub extern_files: Vec<OsString>,
     pub attrs: Attributes,
     pub primitives: Vec<(DefId, PrimitiveType, Attributes)>,
     pub keywords: Vec<(DefId, String, Attributes)>,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
 use std::lazy::SyncOnceCell as OnceCell;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::{slice, vec};
@@ -66,6 +67,7 @@ pub struct Crate {
 pub struct ExternalCrate {
     pub name: String,
     pub src: FileName,
+    pub extern_paths: Vec<PathBuf>,
     pub attrs: Attributes,
     pub primitives: Vec<(DefId, PrimitiveType, Attributes)>,
     pub keywords: Vec<(DefId, String, Attributes)>,

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
-use std::ffi::OsStr;
+use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::path::PathBuf;
 
@@ -214,8 +214,8 @@ pub struct RenderOptions {
     pub themes: Vec<StylePath>,
     /// If present, CSS file that contains rules to add to the default CSS.
     pub extension_css: Option<PathBuf>,
-    /// A map of crate sources to the URL to use instead of querying the crate's `html_root_url`.
-    pub extern_html_root_urls: BTreeMap<PathBuf, String>,
+    /// A map of crate source filenames to the URL to use instead of querying the crate's `html_root_url`.
+    pub extern_html_root_urls: BTreeMap<OsString, String>,
     /// A map of the default settings (values are as for DOM storage API). Keys should lack the
     /// `rustdoc-` prefix.
     pub default_settings: HashMap<String, String>,
@@ -690,7 +690,7 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Han
 /// describing the issue.
 fn parse_extern_html_roots(
     matches: &getopts::Matches,
-) -> Result<BTreeMap<PathBuf, String>, &'static str> {
+) -> Result<BTreeMap<OsString, String>, &'static str> {
     let mut externs = BTreeMap::new();
     for arg in &matches.opt_strs("extern-html-root-url") {
         let mut parts = arg.splitn(2, '=');

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -214,8 +214,8 @@ pub struct RenderOptions {
     pub themes: Vec<StylePath>,
     /// If present, CSS file that contains rules to add to the default CSS.
     pub extension_css: Option<PathBuf>,
-    /// A map of crate names to the URL to use instead of querying the crate's `html_root_url`.
-    pub extern_html_root_urls: BTreeMap<String, String>,
+    /// A map of crate sources to the URL to use instead of querying the crate's `html_root_url`.
+    pub extern_html_root_urls: BTreeMap<PathBuf, String>,
     /// A map of the default settings (values are as for DOM storage API). Keys should lack the
     /// `rustdoc-` prefix.
     pub default_settings: HashMap<String, String>,
@@ -690,13 +690,13 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Han
 /// describing the issue.
 fn parse_extern_html_roots(
     matches: &getopts::Matches,
-) -> Result<BTreeMap<String, String>, &'static str> {
+) -> Result<BTreeMap<PathBuf, String>, &'static str> {
     let mut externs = BTreeMap::new();
     for arg in &matches.opt_strs("extern-html-root-url") {
         let mut parts = arg.splitn(2, '=');
         let name = parts.next().ok_or("--extern-html-root-url must not be empty")?;
         let url = parts.next().ok_or("--extern-html-root-url must be of the form name=url")?;
-        externs.insert(name.to_string(), url.to_string());
+        externs.insert(name.into(), url.to_string());
     }
 
     Ok(externs)

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -128,7 +129,7 @@ impl Cache {
     pub fn from_krate(
         render_info: RenderInfo,
         document_private: bool,
-        extern_html_root_urls: &BTreeMap<PathBuf, String>,
+        extern_html_root_urls: &BTreeMap<OsString, String>,
         dst: &Path,
         mut krate: clean::Crate,
     ) -> (clean::Crate, Cache) {
@@ -174,9 +175,9 @@ impl Cache {
                 _ => PathBuf::new(),
             };
             let extern_url = e
-                .extern_paths
+                .extern_files
                 .iter()
-                .filter_map(|path| extern_html_root_urls.get(&*path))
+                .filter_map(|file_name| extern_html_root_urls.get(file_name))
                 .next()
                 .map(|u| &**u);
             cache

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -128,7 +128,7 @@ impl Cache {
     pub fn from_krate(
         render_info: RenderInfo,
         document_private: bool,
-        extern_html_root_urls: &BTreeMap<String, String>,
+        extern_html_root_urls: &BTreeMap<PathBuf, String>,
         dst: &Path,
         mut krate: clean::Crate,
     ) -> (clean::Crate, Cache) {
@@ -173,7 +173,12 @@ impl Cache {
                 },
                 _ => PathBuf::new(),
             };
-            let extern_url = extern_html_root_urls.get(&e.name).map(|u| &**u);
+            let extern_url = e
+                .extern_paths
+                .iter()
+                .filter_map(|path| extern_html_root_urls.get(&*path))
+                .next()
+                .map(|u| &**u);
             cache
                 .extern_locations
                 .insert(n, (e.name.clone(), src_root, extern_location(e, extern_url, &dst)));

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -13,6 +13,7 @@ use crate::html::render::{plain_text_summary, shorten};
 use crate::html::render::{Generic, IndexItem, IndexItemFunctionType, RenderType, TypeWithKind};
 
 /// Indicates where an external crate can be found.
+#[derive(Debug)]
 pub enum ExternalLocation {
     /// Remote URL root of the external crate
     Remote(String),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -146,7 +146,7 @@ fn opts() -> Vec<RustcOptGroup> {
         stable("cfg", |o| o.optmulti("", "cfg", "pass a --cfg to rustc", "")),
         stable("extern", |o| o.optmulti("", "extern", "pass an --extern to rustc", "NAME[=PATH]")),
         unstable("extern-html-root-url", |o| {
-            o.optmulti("", "extern-html-root-url", "base URL to use for dependencies", "NAME=URL")
+            o.optmulti("", "extern-html-root-url", "base URL to use for dependencies", "PATH=URL")
         }),
         stable("plugin-path", |o| o.optmulti("", "plugin-path", "removed", "DIR")),
         stable("C", |o| {

--- a/src/test/rustdoc/auxiliary/extern-html-root-url.rs
+++ b/src/test/rustdoc/auxiliary/extern-html-root-url.rs
@@ -1,0 +1,2 @@
+// compile-flags: -C metadata=1
+pub mod iter {}

--- a/src/test/rustdoc/auxiliary/issue-76296-1.rs
+++ b/src/test/rustdoc/auxiliary/issue-76296-1.rs
@@ -1,0 +1,6 @@
+// compile-flags: -C metadata=1
+// compile-flags: -C extra-filename=-1
+#![crate_name="foo"]
+#![doc(html_root_url="https://example.com/foo/v1")]
+
+pub struct Foo1;

--- a/src/test/rustdoc/auxiliary/issue-76296-2.rs
+++ b/src/test/rustdoc/auxiliary/issue-76296-2.rs
@@ -1,0 +1,6 @@
+// compile-flags: -C metadata=2
+// compile-flags: -C extra-filename=-2
+#![crate_name = "foo"]
+#![doc(html_root_url="https://example.com/foo/v2")]
+
+pub struct Foo2;

--- a/src/test/rustdoc/extern-html-root-url.rs
+++ b/src/test/rustdoc/extern-html-root-url.rs
@@ -1,8 +1,7 @@
-// ignore-tidy-linelength
 // aux-crate: priv:extern_html_root_url=extern-html-root-url.rs
 // compile-flags: -Z unstable-options
 // compile-flags: --edition 2018
-// compile-flags: --extern-html-root-url {{build-base}}/extern-html-root-url/auxiliary/libextern_html_root_url.so=https://example.com/core/0.1.0
+// compile-flags: --extern-html-root-url libextern_html_root_url.so=https://example.com/core/0.1.0
 
 // @has extern_html_root_url/index.html
 // @has - '//a/@href' 'https://example.com/core/0.1.0/extern_html_root_url/iter/index.html'

--- a/src/test/rustdoc/extern-html-root-url.rs
+++ b/src/test/rustdoc/extern-html-root-url.rs
@@ -1,6 +1,10 @@
-// compile-flags:-Z unstable-options --extern-html-root-url core=https://example.com/core/0.1.0
+// ignore-tidy-linelength
+// aux-crate: priv:extern_html_root_url=extern-html-root-url.rs
+// compile-flags: -Z unstable-options
+// compile-flags: --edition 2018
+// compile-flags: --extern-html-root-url {{build-base}}/extern-html-root-url/auxiliary/libextern_html_root_url.so=https://example.com/core/0.1.0
 
 // @has extern_html_root_url/index.html
-// @has - '//a/@href' 'https://example.com/core/0.1.0/core/iter/index.html'
+// @has - '//a/@href' 'https://example.com/core/0.1.0/extern_html_root_url/iter/index.html'
 #[doc(no_inline)]
-pub use std::iter;
+pub use extern_html_root_url::iter;

--- a/src/test/rustdoc/issue-76296-override.rs
+++ b/src/test/rustdoc/issue-76296-override.rs
@@ -1,11 +1,12 @@
+// ignore-tidy-linelength
 // aux-build: issue-76296-1.rs
 // aux-build: issue-76296-2.rs
 // compile-flags: -Z unstable-options
 // compile-flags: --edition 2018
 // compile-flags: --extern priv:foo1={{build-base}}/issue-76296-override/auxiliary/libfoo-1.so
 // compile-flags: --extern priv:foo2={{build-base}}/issue-76296-override/auxiliary/libfoo-2.so
-// compile-flags: --extern-html-root-url foo=https://example.com/override/v1
-// compile-flags: --extern-html-root-url foo=https://example.com/override/v2
+// compile-flags: --extern-html-root-url {{build-base}}/issue-76296-override/auxiliary/libfoo-1.so=https://example.com/override/v1
+// compile-flags: --extern-html-root-url {{build-base}}/issue-76296-override/auxiliary/libfoo-2.so=https://example.com/override/v2
 
 // @has 'issue_76296_override/index.html'
 // @matches - '//a[@href="https://example.com/override/v1/foo/struct.Foo1.html"]' '^Foo1$'

--- a/src/test/rustdoc/issue-76296-override.rs
+++ b/src/test/rustdoc/issue-76296-override.rs
@@ -1,12 +1,11 @@
-// ignore-tidy-linelength
 // aux-build: issue-76296-1.rs
 // aux-build: issue-76296-2.rs
 // compile-flags: -Z unstable-options
 // compile-flags: --edition 2018
 // compile-flags: --extern priv:foo1={{build-base}}/issue-76296-override/auxiliary/libfoo-1.so
 // compile-flags: --extern priv:foo2={{build-base}}/issue-76296-override/auxiliary/libfoo-2.so
-// compile-flags: --extern-html-root-url {{build-base}}/issue-76296-override/auxiliary/libfoo-1.so=https://example.com/override/v1
-// compile-flags: --extern-html-root-url {{build-base}}/issue-76296-override/auxiliary/libfoo-2.so=https://example.com/override/v2
+// compile-flags: --extern-html-root-url libfoo-1.so=https://example.com/override/v1
+// compile-flags: --extern-html-root-url libfoo-2.so=https://example.com/override/v2
 
 // @has 'issue_76296_override/index.html'
 // @matches - '//a[@href="https://example.com/override/v1/foo/struct.Foo1.html"]' '^Foo1$'

--- a/src/test/rustdoc/issue-76296-override.rs
+++ b/src/test/rustdoc/issue-76296-override.rs
@@ -1,0 +1,32 @@
+// aux-build: issue-76296-1.rs
+// aux-build: issue-76296-2.rs
+// compile-flags: -Z unstable-options
+// compile-flags: --edition 2018
+// compile-flags: --extern priv:foo1={{build-base}}/issue-76296-override/auxiliary/libfoo-1.so
+// compile-flags: --extern priv:foo2={{build-base}}/issue-76296-override/auxiliary/libfoo-2.so
+// compile-flags: --extern-html-root-url foo=https://example.com/override/v1
+// compile-flags: --extern-html-root-url foo=https://example.com/override/v2
+
+// @has 'issue_76296_override/index.html'
+// @matches - '//a[@href="https://example.com/override/v1/foo/struct.Foo1.html"]' '^Foo1$'
+// @matches - '//a[@href="https://example.com/override/v2/foo/struct.Foo2.html"]' '^Foo2$'
+
+#[doc(no_inline)]
+pub use foo1::Foo1;
+
+#[doc(no_inline)]
+pub use foo2::Foo2;
+
+// @has 'issue_76296_override/fn.foo1.html'
+// @matches - '//a[@href="https://example.com/override/v1/foo/struct.Foo1.html"]' '^foo1::Foo1$'
+// @matches - '//a[@href="https://example.com/override/v1/foo/struct.Foo1.html"]' '^Foo1$'
+
+/// Makes a [`foo1::Foo1`]
+pub fn foo1() -> Foo1 { foo1::Foo1 }
+
+// @has 'issue_76296_override/fn.foo2.html'
+// @matches - '//a[@href="https://example.com/override/v2/foo/struct.Foo2.html"]' '^foo2::Foo2$'
+// @matches - '//a[@href="https://example.com/override/v2/foo/struct.Foo2.html"]' '^Foo2$'
+
+/// Makes a [`foo2::Foo2`]
+pub fn foo2() -> Foo2 { foo2::Foo2 }

--- a/src/test/rustdoc/issue-76296.rs
+++ b/src/test/rustdoc/issue-76296.rs
@@ -1,0 +1,30 @@
+// aux-build: issue-76296-1.rs
+// aux-build: issue-76296-2.rs
+// compile-flags: -Z unstable-options
+// compile-flags: --edition 2018
+// compile-flags: --extern priv:foo1={{build-base}}/issue-76296/auxiliary/libfoo-1.so
+// compile-flags: --extern priv:foo2={{build-base}}/issue-76296/auxiliary/libfoo-2.so
+
+// @has 'issue_76296/index.html'
+// @matches - '//a[@href="https://example.com/foo/v1/foo/struct.Foo1.html"]' '^Foo1$'
+// @matches - '//a[@href="https://example.com/foo/v2/foo/struct.Foo2.html"]' '^Foo2$'
+
+#[doc(no_inline)]
+pub use foo1::Foo1;
+
+#[doc(no_inline)]
+pub use foo2::Foo2;
+
+// @has 'issue_76296/fn.foo1.html'
+// @matches - '//a[@href="https://example.com/foo/v1/foo/struct.Foo1.html"]' '^foo1::Foo1$'
+// @matches - '//a[@href="https://example.com/foo/v1/foo/struct.Foo1.html"]' '^Foo1$'
+
+/// Makes a [`foo1::Foo1`]
+pub fn foo1() -> Foo1 { foo1::Foo1 }
+
+// @has 'issue_76296/fn.foo2.html'
+// @matches - '//a[@href="https://example.com/foo/v2/foo/struct.Foo2.html"]' '^foo2::Foo2$'
+// @matches - '//a[@href="https://example.com/foo/v2/foo/struct.Foo2.html"]' '^Foo2$'
+
+/// Makes a [`foo2::Foo2`]
+pub fn foo2() -> Foo2 { foo2::Foo2 }


### PR DESCRIPTION
This is the most correct solution I see to #76296, this allows setting the html-root-url for all crates in the dependency tree, no matter how many duplicates of a specific crate name exist.

I have prototyped the associated docs.rs changes in my script that builds in the same fashion as it: <https://github.com/Nemo157/dotfiles/commit/d452627d1a5649cf3baaefa29be35e57a7f4929a>. Before this is merged we would want to do the same for docs.rs itself (I'll make a PR for this shortly), it's forwards-compatible to start emitting both sets of flags and remove the current ones later, extra unused flags are just ignored.

fixes #76296 