### PR TITLE
Add macro test for min-const-generics

### DIFF
--- a/src/test/ui/const-generics/min_const_generics/macro-fail.rs
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.rs
@@ -1,0 +1,48 @@
+#![feature(min_const_generics)]
+
+struct Example<const N: usize>;
+
+macro_rules! external_macro {
+  () => {{
+    //~^ ERROR expected type
+    const X: usize = 1337;
+    X
+  }}
+}
+
+trait Marker<const N: usize> {}
+impl<const N: usize> Marker<N> for Example<N> {}
+
+fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+  Example::<gimme_a_const!(marker)>
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+}
+
+fn from_marker(_: impl Marker<{
+    #[macro_export]
+    macro_rules! inline { () => {{ 3 }} }; inline!()
+}>) {}
+
+fn main() {
+  let _ok = Example::<{
+    #[macro_export]
+    macro_rules! gimme_a_const {
+      ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+      //~^ ERROR expected type
+      //~| ERROR expected type
+    };
+    gimme_a_const!(run)
+  }>;
+
+  let _fail = Example::<external_macro!()>;
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+
+  let _fail = Example::<gimme_a_const!()>;
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+  //~| ERROR unexpected end of macro invocation
+}

--- a/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -1,0 +1,107 @@
+error: expected type, found `{`
+  --> $DIR/macro-fail.rs:33:27
+   |
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                                 ----------------------
+   |                                 |
+   |                                 this macro call doesn't expand to a type
+   |                                 in this macro invocation
+...
+LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected type, found `{`
+  --> $DIR/macro-fail.rs:33:27
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ----------------------
+   |             |
+   |             this macro call doesn't expand to a type
+   |             in this macro invocation
+...
+LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected type, found `{`
+  --> $DIR/macro-fail.rs:6:10
+   |
+LL |     () => {{
+   |  __________^
+LL | |
+LL | |     const X: usize = 1337;
+LL | |     X
+LL | |   }}
+   | |___^ expected type
+...
+LL |     let _fail = Example::<external_macro!()>;
+   |                           -----------------
+   |                           |
+   |                           this macro call doesn't expand to a type
+   |                           in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of macro invocation
+  --> $DIR/macro-fail.rs:44:25
+   |
+LL |     macro_rules! gimme_a_const {
+   |     -------------------------- when calling this macro
+...
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:16:26
+   |
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:16:33
+   |
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ unexpected type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:19:3
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:19:13
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ^^^^^^^^^^^^^^^^^^^^^^ unexpected type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:40:15
+   |
+LL |   let _fail = Example::<external_macro!()>;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:40:25
+   |
+LL |   let _fail = Example::<external_macro!()>;
+   |                         ^^^^^^^^^^^^^^^^^ unexpected type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:44:15
+   |
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:44:25
+   |
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |                         ^^^^^^^^^^^^^^^^ unexpected type argument
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/min_const_generics/macro.rs
+++ b/src/test/ui/const-generics/min_const_generics/macro.rs
@@ -1,0 +1,57 @@
+// run-pass
+#![feature(min_const_generics)]
+
+struct Example<const N: usize>;
+
+macro_rules! external_macro {
+  () => {{
+    const X: usize = 1337;
+    X
+  }}
+}
+
+trait Marker<const N: usize> {}
+impl<const N: usize> Marker<N> for Example<N> {}
+
+fn make_marker() -> impl Marker<{
+    #[macro_export]
+    macro_rules! const_macro { () => {{ 3 }} }; inline!()
+}> {
+  Example::<{ const_macro!() }>
+}
+
+fn from_marker(_: impl Marker<{
+    #[macro_export]
+    macro_rules! inline { () => {{ 3 }} }; inline!()
+}>) {}
+
+fn main() {
+  let _ok = Example::<{
+    #[macro_export]
+    macro_rules! gimme_a_const {
+      ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+    };
+    gimme_a_const!(run)
+  }>;
+
+  let _ok = Example::<{ external_macro!() }>;
+
+  let _ok: [_; gimme_a_const!(blah)] = [0,0,0];
+  let _ok: [[u8; gimme_a_const!(blah)]; gimme_a_const!(blah)];
+  let _ok: [u8; gimme_a_const!(blah)];
+
+  let _ok: [u8; {
+    #[macro_export]
+    macro_rules! const_two { () => {{ 2 }} };
+    const_two!()
+  }];
+
+  let _ok = [0; {
+    #[macro_export]
+    macro_rules! const_three { () => {{ 3 }} };
+    const_three!()
+  }];
+  let _ok = [0; const_three!()];
+
+  from_marker(make_marker());
+}


### PR DESCRIPTION
Adds a test which uses a macro inside a block for a const-expression, as per #78433

r? @lcnr  