### PR TITLE
Improve wording of error for lifetime that is too short

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/diagnostics/region_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/region_errors.rs
@@ -514,7 +514,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         } = errci;
 
         let mut diag =
-            self.infcx.tcx.sess.struct_span_err(*span, "lifetime may not live long enough");
+            self.infcx.tcx.sess.struct_span_err(*span, "lifetime may not be long enough");
 
         let (_, mir_def_name) =
             self.infcx.tcx.article_and_description(self.mir_def_id().to_def_id());

--- a/src/test/ui/associated-type-bounds/implied-region-constraints.nll.stderr
+++ b/src/test/ui/associated-type-bounds/implied-region-constraints.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/implied-region-constraints.rs:17:56
    |
 LL | fn _bad_st<'a, 'b, T>(x: St<'a, 'b, T>)
@@ -11,7 +11,7 @@ LL |     let _failure_proves_not_implied_outlives_region_b: &'b T = &x.f0;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/implied-region-constraints.rs:38:64
    |
 LL | fn _bad_en7<'a, 'b, T>(x: En7<'a, 'b, T>)

--- a/src/test/ui/associated-types/associated-types-project-from-hrtb-in-fn-body.nll.stderr
+++ b/src/test/ui/associated-types/associated-types-project-from-hrtb-in-fn-body.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/associated-types-project-from-hrtb-in-fn-body.rs:22:29
    |
 LL | fn bar<'a, 'b, I : for<'x> Foo<&'x isize>>(
@@ -11,7 +11,7 @@ LL |     let z: I::A = if cond { x } else { y };
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/associated-types-project-from-hrtb-in-fn-body.rs:22:40
    |
 LL | fn bar<'a, 'b, I : for<'x> Foo<&'x isize>>(

--- a/src/test/ui/associated-types/associated-types-subtyping-1.nll.stderr
+++ b/src/test/ui/associated-types/associated-types-subtyping-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/associated-types-subtyping-1.rs:24:12
    |
 LL | fn method2<'a,'b,T>(x: &'a T, y: &'b T)
@@ -11,7 +11,7 @@ LL |     let a: <T as Trait<'a>>::Type = make_any();
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/associated-types-subtyping-1.rs:35:13
    |
 LL | fn method3<'a,'b,T>(x: &'a T, y: &'b T)

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.krisskross.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.krisskross.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-contravariant.rs:45:4
    |
 LL | fn transmute<'a,'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {
@@ -11,7 +11,7 @@ LL |    (a, b)
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-contravariant.rs:45:4
    |
 LL | fn transmute<'a,'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {

--- a/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-contravariant.transmute.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-contravariant.rs:38:4
    |
 LL | fn baz<'a,'b>(x: &'a u32) -> &'static u32 {

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.krisskross.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.krisskross.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-invariant.rs:56:5
    |
 LL | fn transmute<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
@@ -11,7 +11,7 @@ LL |     (a, b)
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-invariant.rs:56:5
    |
 LL | fn transmute<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.oneuse.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.oneuse.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-invariant.rs:39:13
    |
 LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {
@@ -11,7 +11,7 @@ LL |     let a = bar(f, x);
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-invariant.rs:40:13
    |
 LL | fn baz<'a, 'b>(x: Type<'a>, y: Type<'b>) -> (Type<'a>, Type<'b>) {

--- a/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
+++ b/src/test/ui/associated-types/cache/project-fn-ret-invariant.transmute.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/project-fn-ret-invariant.rs:49:5
    |
 LL | fn baz<'a, 'b>(x: Type<'a>) -> Type<'static> {

--- a/src/test/ui/async-await/issues/issue-63388-1.nll.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-63388-1.rs:13:5
    |
 LL |       async fn do_sth<'a>(

--- a/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.nll.stderr
+++ b/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ret-impl-trait-one.rs:12:80
    |
 LL |   async fn async_ret_impl_trait1<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a> {

--- a/src/test/ui/borrowck/borrowck-reborrow-from-shorter-lived-andmut.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-reborrow-from-shorter-lived-andmut.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/borrowck-reborrow-from-shorter-lived-andmut.rs:9:5
    |
 LL | fn copy_borrowed_ptr<'a,'b>(p: &'a mut S<'b>) -> S<'b> {

--- a/src/test/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.rs
+++ b/src/test/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.rs
@@ -2,6 +2,6 @@ fn main() {
     let f = move || {};
     let _action = move || {
         || f() // The `nested` closure
-        //~^ ERROR lifetime may not live long enough
+        //~^ ERROR lifetime may not be long enough
     };
 }

--- a/src/test/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.stderr
+++ b/src/test/ui/borrowck/issue-53432-nested-closure-outlives-borrowed-value.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-53432-nested-closure-outlives-borrowed-value.rs:4:9
    |
 LL |     let _action = move || {

--- a/src/test/ui/c-variadic/variadic-ffi-4.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-4.rs
@@ -6,33 +6,33 @@ use core::ffi::{VaList, VaListImpl};
 
 pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
     ap
-    //~^ ERROR: lifetime may not live long enough
-    //~| ERROR: lifetime may not live long enough
+    //~^ ERROR: lifetime may not be long enough
+    //~| ERROR: lifetime may not be long enough
 }
 
 pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
-    ap //~ ERROR: lifetime may not live long enough
+    ap //~ ERROR: lifetime may not be long enough
 }
 
 pub unsafe extern "C" fn no_escape2(_: usize, ap: ...) {
-    let _ = ap.with_copy(|ap| ap); //~ ERROR: lifetime may not live long enough
+    let _ = ap.with_copy(|ap| ap); //~ ERROR: lifetime may not be long enough
 }
 
 pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
     *ap0 = ap1;
-    //~^ ERROR: lifetime may not live long enough
-    //~| ERROR: lifetime may not live long enough
+    //~^ ERROR: lifetime may not be long enough
+    //~| ERROR: lifetime may not be long enough
 }
 
 pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
     ap0 = &mut ap1;
     //~^ ERROR: `ap1` does not live long enough
-    //~| ERROR: lifetime may not live long enough
-    //~| ERROR: lifetime may not live long enough
+    //~| ERROR: lifetime may not be long enough
+    //~| ERROR: lifetime may not be long enough
 }
 
 pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
     *ap0 = ap1.clone();
-    //~^ ERROR: lifetime may not live long enough
-    //~| ERROR: lifetime may not live long enough
+    //~^ ERROR: lifetime may not be long enough
+    //~| ERROR: lifetime may not be long enough
 }

--- a/src/test/ui/c-variadic/variadic-ffi-4.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:8:5
    |
 LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
@@ -8,7 +8,7 @@ LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f
 LL |     ap
    |     ^^ function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'f`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:8:5
    |
 LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
@@ -18,7 +18,7 @@ LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f
 LL |     ap
    |     ^^ returning this value requires that `'1` must outlive `'f`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:14:5
    |
 LL | pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
@@ -26,7 +26,7 @@ LL | pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'stati
 LL |     ap
    |     ^^ returning this value requires that `'1` must outlive `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:18:31
    |
 LL |     let _ = ap.with_copy(|ap| ap);
@@ -35,7 +35,7 @@ LL |     let _ = ap.with_copy(|ap| ap);
    |                           | return type of closure is VaList<'2, '_>
    |                           has type `VaList<'1, '_>`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:22:5
    |
 LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -45,7 +45,7 @@ LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut
 LL |     *ap0 = ap1;
    |     ^^^^ assignment requires that `'1` must outlive `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:22:5
    |
 LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -55,7 +55,7 @@ LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut
 LL |     *ap0 = ap1;
    |     ^^^^ assignment requires that `'2` must outlive `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:28:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -65,7 +65,7 @@ LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut
 LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ assignment requires that `'1` must outlive `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:28:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -89,7 +89,7 @@ LL |     ap0 = &mut ap1;
 LL | }
    | - `ap1` dropped here while still borrowed
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:35:12
    |
 LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -99,7 +99,7 @@ LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut
 LL |     *ap0 = ap1.clone();
    |            ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variadic-ffi-4.rs:35:12
    |
 LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/expect-fn-supply-fn.rs:16:49
    |
 LL | fn expect_free_supply_free_from_fn<'x>(x: &'x u32) {
@@ -10,7 +10,7 @@ LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
    |                                                 has type `fn(&'1 u32)`
    |                                                 requires that `'1` must outlive `'x`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/expect-fn-supply-fn.rs:16:49
    |
 LL | fn expect_free_supply_free_from_fn<'x>(x: &'x u32) {

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.nll.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/expect-region-supply-region-2.rs:14:30
    |
 LL | fn expect_bound_supply_named<'x>() {
@@ -9,7 +9,7 @@ LL |     closure_expecting_bound(|x: &'x u32| {
    |                              |
    |                              requires that `'1` must outlive `'x`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/expect-region-supply-region-2.rs:14:30
    |
 LL | fn expect_bound_supply_named<'x>() {

--- a/src/test/ui/closures/closure-expected-type/expect-region-supply-region.polonius.stderr
+++ b/src/test/ui/closures/closure-expected-type/expect-region-supply-region.polonius.stderr
@@ -18,7 +18,7 @@ LL |     closure_expecting_bound(|x: &u32| {
 LL |         f = Some(x);
    |         ^^^^^^^^^^^ `x` escapes the closure body here
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/expect-region-supply-region.rs:37:30
    |
 LL | fn expect_bound_supply_named<'x>() {
@@ -41,7 +41,7 @@ LL |     closure_expecting_bound(|x: &'x u32| {
 LL |         f = Some(x);
    |         ^^^^^^^^^^^ `x` escapes the closure body here
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/expect-region-supply-region.rs:37:30
    |
 LL | fn expect_bound_supply_named<'x>() {

--- a/src/test/ui/error-codes/E0490.nll.stderr
+++ b/src/test/ui/error-codes/E0490.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/E0490.rs:2:12
    |
 LL | fn f<'a, 'b>(y: &'b ()) {

--- a/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.rs
+++ b/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.rs
@@ -10,7 +10,7 @@ where F: FnOnce(&'a i32, &i32) -> &'a i32
 }
 
 fn foo<'a>(x: &'a i32) {
-    invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR lifetime may not live long enough
+    invoke(&x, |a, b| if a > b { a } else { b }); //~ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.stderr
+++ b/src/test/ui/error-codes/E0621-does-not-trigger-for-closures.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/E0621-does-not-trigger-for-closures.rs:13:45
    |
 LL |     invoke(&x, |a, b| if a > b { a } else { b });

--- a/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.nll.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/hr-subtype.rs:39:13
    |
 LL |           fn subtype<'x, 'y: 'x, 'z: 'y>() {
@@ -15,7 +15,7 @@ LL | | fn(Inv<'y>)) }
    = help: consider adding the following bound: `'x: 'y`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/hr-subtype.rs:45:13
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {

--- a/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.nll.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/hr-subtype.rs:45:13
    |
 LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {

--- a/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.nll.stderr
@@ -4,7 +4,7 @@ error: higher-ranked subtype error
 LL |     want_hrtb::<StaticInt>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/hrtb-just-for-static.rs:30:5
    |
 LL | fn give_some<'a>() {

--- a/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-perfect-forwarding.nll.stderr
@@ -45,7 +45,7 @@ LL | | }
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/hrtb-perfect-forwarding.rs:46:5
    |
 LL | fn foo_hrtb_bar_not<'b,T>(mut t: T)

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.polonius.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.polonius.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/error-handling.rs:23:16
    |
 LL | fn foo<'a, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.rs
@@ -21,7 +21,7 @@ fn foo<'a, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
     let _: *mut &'a i32 = u.1;
     unsafe {
         let _: &'b i32 = *u.0;
-        //~^ ERROR lifetime may not live long enough
+        //~^ ERROR lifetime may not be long enough
     }
     u.0
 }

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/error-handling.rs:23:16
    |
 LL | fn foo<'a, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:3:23
    |
 LL | fn elided(x: &i32) -> impl Copy { x }
@@ -11,7 +11,7 @@ help: to allow this `impl Trait` to capture borrowed data with lifetime `'1`, ad
 LL | fn elided(x: &i32) -> impl Copy + '_ { x }
    |                       ^^^^^^^^^^^^^^
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:5:32
    |
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy { x }
@@ -25,7 +25,7 @@ help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, ad
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy + 'a { x }
    |                                ^^^^^^^^^^^^^^
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:7:46
    |
 LL | fn elided2(x: &i32) -> impl Copy + 'static { x }
@@ -35,7 +35,7 @@ LL | fn elided2(x: &i32) -> impl Copy + 'static { x }
    |
    = help: consider replacing `'1` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:9:55
    |
 LL | fn explicit2<'a>(x: &'a i32) -> impl Copy + 'static { x }
@@ -52,7 +52,7 @@ LL | fn foo<'a>(x: &i32) -> impl Copy + 'a { x }
    |               |
    |               help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:22:24
    |
 LL | fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug) { (Box::new(x), x) }
@@ -60,7 +60,7 @@ LL | fn elided5(x: &i32) -> (Box<dyn Debug>, impl Debug) { (Box::new(x), x) }
    |               |
    |               let's call the lifetime of this reference `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:28:69
    |
 LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
@@ -69,7 +69,7 @@ LL | fn with_bound<'a>(x: &'a i32) -> impl LifetimeTrait<'a> + 'static { x }
    = help: consider replacing `'a` with `'static`
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/must_outlive_least_region_or_bound.rs:32:61
    |
 LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32) {

--- a/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
+++ b/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/static-return-lifetime-infered.rs:6:35
    |
 LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> {
@@ -11,7 +11,7 @@ help: to allow this `impl Trait` to capture borrowed data with lifetime `'1`, ad
 LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> + '_ {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/static-return-lifetime-infered.rs:9:37
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {

--- a/src/test/ui/in-band-lifetimes/mismatched.nll.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched.nll.stderr
@@ -6,7 +6,7 @@ LL | fn foo(x: &'a u32, y: &u32) -> &'a u32 { y }
    |                       |
    |                       help: add explicit lifetime `'a` to the type of `y`: `&'a u32`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/mismatched.rs:6:46
    |
 LL | fn foo2(x: &'a u32, y: &'b u32) -> &'a u32 { y }

--- a/src/test/ui/issues/issue-10291.nll.stderr
+++ b/src/test/ui/issues/issue-10291.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-10291.rs:3:9
    |
 LL | fn test<'x>(x: &'x isize) {

--- a/src/test/ui/issues/issue-16922.nll.stderr
+++ b/src/test/ui/issues/issue-16922.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-16922.rs:4:5
    |
 LL | fn foo<T: Any>(value: &T) -> Box<dyn Any> {

--- a/src/test/ui/issues/issue-26217.nll.stderr
+++ b/src/test/ui/issues/issue-26217.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-26217.rs:4:5
    |
 LL | fn bar<'a>() {

--- a/src/test/ui/issues/issue-28848.nll.stderr
+++ b/src/test/ui/issues/issue-28848.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-28848.rs:10:5
    |
 LL | pub fn foo<'a, 'b>(u: &'b ()) -> &'a () {

--- a/src/test/ui/issues/issue-52213.nll.stderr
+++ b/src/test/ui/issues/issue-52213.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-52213.rs:3:20
    |
 LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {

--- a/src/test/ui/issues/issue-52533-1.nll.stderr
+++ b/src/test/ui/issues/issue-52533-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-52533-1.rs:9:18
    |
 LL |     gimme(|x, y| y)

--- a/src/test/ui/issues/issue-52533.nll.stderr
+++ b/src/test/ui/issues/issue-52533.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-52533.rs:5:16
    |
 LL |     foo(|a, b| b)

--- a/src/test/ui/issues/issue-54943.nll.stderr
+++ b/src/test/ui/issues/issue-54943.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-54943.rs:6:13
    |
 LL | fn boo<'a>() {

--- a/src/test/ui/issues/issue-55796.nll.stderr
+++ b/src/test/ui/issues/issue-55796.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-55796.rs:18:9
    |
 LL | pub trait Graph<'a> {
@@ -9,7 +9,7 @@ LL |         Box::new(self.out_edges(u).map(|e| e.target()))
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-55796.rs:23:9
    |
 LL | pub trait Graph<'a> {

--- a/src/test/ui/issues/issue-75777.nll.stderr
+++ b/src/test/ui/issues/issue-75777.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-75777.rs:13:5
    |
 LL | fn inject<'a, Env: 'a, A: 'a + Send>(v: A) -> Box<dyn FnOnce(&'a Env) -> BoxFuture<'a, A>> {

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex1-return-one-existing-name-if-else-using-impl.rs:11:20
    |
 LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex1-return-one-existing-name-return-type-is-anon.rs:8:5
    |
 LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex1-return-one-existing-name-self-is-anon.rs:8:30
    |
 LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {

--- a/src/test/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2b-push-no-existing-names.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex2b-push-no-existing-names.rs:6:5
    |
 LL | fn foo(x: &mut Vec<Ref<i32>>, y: Ref<i32>) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2c-push-inference-variable.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex2c-push-inference-variable.rs:7:5
    |
 LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex2d-push-inference-variable-2.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2d-push-inference-variable-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex2d-push-inference-variable-2.rs:8:5
    |
 LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex2e-push-inference-variable-3.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex2e-push-inference-variable-3.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex2e-push-inference-variable-3.rs:8:5
    |
 LL | fn foo<'a, 'b, 'c>(x: &'a mut Vec<Ref<'b, i32>>, y: Ref<'c, i32>) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-2.rs:2:5
    |
 LL | fn foo(&mut (ref mut v, w): &mut (&u8, &u8), x: &u8) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-3.rs:2:5
    |
 LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
@@ -8,7 +8,7 @@ LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
 LL |     z.push((x,y));
    |     ^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-3.rs:2:5
    |
 LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-both-are-structs-2.rs:7:5
    |
 LL | fn foo(mut x: Ref, y: Ref) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-both-are-structs-3.rs:7:5
    |
 LL | fn foo(mut x: Ref) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-earlybound-regions.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-both-are-structs-earlybound-regions.rs:9:5
    |
 LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>)

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-latebound-regions.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-both-are-structs-latebound-regions.rs:6:5
    |
 LL | fn foo<'a, 'b>(mut x: Vec<Ref<'a>>, y: Ref<'b>) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-both-are-structs.rs:6:5
    |
 LL | fn foo(mut x: Vec<Ref>, y: Ref) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-latebound-regions.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-latebound-regions.rs:2:5
    |
 LL | fn foo<'a,'b>(x: &mut Vec<&'a u8>, y: &'b u8) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:4:5
    |
 LL | fn foo(mut x: Ref, y: &u32) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-3.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-one-is-struct-3.rs:4:5
    |
 LL | fn foo(mut y: Ref, x: &u32) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-4.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-one-is-struct-4.rs:4:5
    |
 LL | fn foo(mut y: Ref, x: &u32) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-one-is-struct.rs:7:5
    |
 LL | fn foo(mut x: Ref, y: &u32) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-return-type-is-anon.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-return-type-is-anon.rs:7:5
    |
 LL |   fn foo<'a>(&self, x: &i32) -> &i32 {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-self-is-anon.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-self-is-anon.rs:7:19
    |
 LL |     fn foo<'a>(&self, x: &Foo) -> &Foo {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.nll.stderr
@@ -6,7 +6,7 @@ LL | fn foo(x:fn(&u8, &u8), y: Vec<&u8>, z: &u8) {
 LL |   y.push(z);
    |   ^ cannot borrow as mutable
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
    |
 LL | fn foo(x:fn(&u8, &u8), y: Vec<&u8>, z: &u8) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-impl-items.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-using-impl-items.rs:6:9
    |
 LL |     fn foo(x: &mut Vec<&u8>, y: &u8) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.nll.stderr
@@ -6,7 +6,7 @@ LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&u8>, z: &u8) {
 LL |   y.push(z);
    |   ^ cannot borrow as mutable
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
    |
 LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&u8>, z: &u8) {

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ex3-both-anon-regions.rs:2:5
    |
 LL | fn foo(x: &mut Vec<&u8>, y: &u8) {

--- a/src/test/ui/lub-if.nll.stderr
+++ b/src/test/ui/lub-if.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lub-if.rs:28:9
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
@@ -9,7 +9,7 @@ LL |         s
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lub-if.rs:35:9
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {

--- a/src/test/ui/lub-match.nll.stderr
+++ b/src/test/ui/lub-match.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lub-match.rs:30:13
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
@@ -9,7 +9,7 @@ LL |             s
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lub-match.rs:39:13
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {

--- a/src/test/ui/match/match-ref-mut-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-invariance.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/match-ref-mut-invariance.rs:10:9
    |
 LL | impl<'b> S<'b> {

--- a/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/match-ref-mut-let-invariance.rs:11:9
    |
 LL | impl<'b> S<'b> {

--- a/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument-callee.stderr
@@ -10,7 +10,7 @@ LL |         let mut closure = expect_sig(|p, y| *p = y);
                (),
            ]
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/escape-argument-callee.rs:26:45
    |
 LL |         let mut closure = expect_sig(|p, y| *p = y);

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-fail-no-postdom.stderr
@@ -17,7 +17,7 @@ LL | |         },
    = note: late-bound region is '_#5r
    = note: late-bound region is '_#6r
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/propagate-approximated-fail-no-postdom.rs:46:13
    |
 LL |         |_outlives1, _outlives2, _outlives3, x, y| {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-ref.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-ref.rs
@@ -43,7 +43,7 @@ fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {
         // Only works if 'x: 'y:
         demand_y(x, y, x.get())
-        //~^ ERROR lifetime may not live long enough
+        //~^ ERROR lifetime may not be long enough
     });
 }
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-ref.stderr
@@ -33,7 +33,7 @@ LL | | }
    |
    = note: defining type: supply
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/propagate-approximated-ref.rs:45:9
    |
 LL | fn supply<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-val.rs
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-val.rs
@@ -36,7 +36,7 @@ fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {
     establish_relationships(cell_a, cell_b, |outlives1, outlives2, x, y| {
         // Only works if 'x: 'y:
         demand_y(outlives1, outlives2, x.get())
-        //~^ ERROR lifetime may not live long enough
+        //~^ ERROR lifetime may not be long enough
     });
 }
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-val.stderr
@@ -33,7 +33,7 @@ LL | | }
    |
    = note: defining type: test
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/propagate-approximated-val.rs:38:9
    |
 LL | fn test<'a, 'b>(cell_a: Cell<&'a u32>, cell_b: Cell<&'b u32>) {

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-no-bounds.stderr
@@ -17,7 +17,7 @@ LL | |     });
    = note: late-bound region is '_#2r
    = note: late-bound region is '_#3r
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/propagate-fail-to-approximate-longer-no-bounds.rs:37:9
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives, x, y| {

--- a/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-fail-to-approximate-longer-wrong-bounds.stderr
@@ -17,7 +17,7 @@ LL | |     });
    = note: late-bound region is '_#3r
    = note: late-bound region is '_#4r
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/propagate-fail-to-approximate-longer-wrong-bounds.rs:41:9
    |
 LL |     establish_relationships(&cell_a, &cell_b, |_outlives1, _outlives2, x, y| {

--- a/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr-named-does-not-outlive-static.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-lbr-named-does-not-outlive-static.rs:9:5
    |
 LL | fn foo<'a>(x: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.rs
+++ b/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.rs
@@ -7,7 +7,7 @@
 
 fn foo<'a, 'b>(x: &'a u32, y: &'b u32) -> &'b u32 {
     &*x
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.stderr
+++ b/src/test/ui/nll/closure-requirements/region-lbr1-does-not-outlive-ebr2.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-lbr1-does-not-outlive-ebr2.rs:9:5
    |
 LL | fn foo<'a, 'b>(x: &'a u32, y: &'b u32) -> &'b u32 {

--- a/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
+++ b/src/test/ui/nll/closure-requirements/return-wrong-bound-region.stderr
@@ -10,7 +10,7 @@ LL |     expect_sig(|a, b| b); // ought to return `a`
                (),
            ]
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/return-wrong-bound-region.rs:11:23
    |
 LL |     expect_sig(|a, b| b); // ought to return `a`

--- a/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.rs
+++ b/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.rs
@@ -6,7 +6,7 @@
 
 fn doit(data: &'static mut ()) {
     || doit(data);
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
     //~| ERROR `data` does not live long enough
 }
 

--- a/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.stderr
+++ b/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-42574-diagnostic-in-nested-closure.rs:8:8
    |
 LL |     || doit(data);

--- a/src/test/ui/nll/issue-48238.stderr
+++ b/src/test/ui/nll/issue-48238.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-48238.rs:9:13
    |
 LL |     move || use_val(&orig);

--- a/src/test/ui/nll/issue-50716.nll.stderr
+++ b/src/test/ui/nll/issue-50716.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-50716.rs:14:14
    |
 LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)

--- a/src/test/ui/nll/issue-52113.rs
+++ b/src/test/ui/nll/issue-52113.rs
@@ -31,7 +31,7 @@ fn produce_err<'a, 'b: 'a>(data: &'b mut Vec<&'b u32>, value: &'a u32) -> impl B
         let value: &'a u32 = value;
         data.push(value);
     };
-    x //~ ERROR lifetime may not live long enough
+    x //~ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/issue-52113.stderr
+++ b/src/test/ui/nll/issue-52113.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-52113.rs:34:5
    |
 LL | fn produce_err<'a, 'b: 'a>(data: &'b mut Vec<&'b u32>, value: &'a u32) -> impl Bazinga + 'b {

--- a/src/test/ui/nll/issue-52742.nll.stderr
+++ b/src/test/ui/nll/issue-52742.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-52742.rs:14:9
    |
 LL |     fn take_bar(&mut self, b: Bar<'_>) {

--- a/src/test/ui/nll/issue-55394.nll.stderr
+++ b/src/test/ui/nll/issue-55394.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-55394.rs:9:9
    |
 LL |     fn new(bar: &mut Bar) -> Self {

--- a/src/test/ui/nll/issue-55401.nll.stderr
+++ b/src/test/ui/nll/issue-55401.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-55401.rs:3:5
    |
 LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/issue-58053.rs
+++ b/src/test/ui/nll/issue-58053.rs
@@ -4,10 +4,10 @@ fn main() {
     let i = &3;
 
     let f = |x: &i32| -> &i32 { x };
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
     let j = f(i);
 
     let g = |x: &i32| { x };
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
     let k = g(i);
 }

--- a/src/test/ui/nll/issue-58053.stderr
+++ b/src/test/ui/nll/issue-58053.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-58053.rs:6:33
    |
 LL |     let f = |x: &i32| -> &i32 { x };
@@ -7,7 +7,7 @@ LL |     let f = |x: &i32| -> &i32 { x };
    |                 |        return type of closure is &'2 i32
    |                 let's call the lifetime of this reference `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-58053.rs:10:25
    |
 LL |     let g = |x: &i32| { x };

--- a/src/test/ui/nll/issue-58299.rs
+++ b/src/test/ui/nll/issue-58299.rs
@@ -13,7 +13,7 @@ impl Y for A<'static> {
 fn foo<'a>(x: i32) {
     match x {
         // This uses <A<'a> as Y>::X, but `A<'a>` does not implement `Y`.
-        A::<'a>::X..=A::<'static>::X => (), //~ ERROR lifetime may not live long enough
+        A::<'a>::X..=A::<'static>::X => (), //~ ERROR lifetime may not be long enough
         _ => (),
     }
 }
@@ -21,7 +21,7 @@ fn foo<'a>(x: i32) {
 fn bar<'a>(x: i32) {
     match x {
         // This uses <A<'a> as Y>::X, but `A<'a>` does not implement `Y`.
-        A::<'static>::X..=A::<'a>::X => (), //~ ERROR lifetime may not live long enough
+        A::<'static>::X..=A::<'a>::X => (), //~ ERROR lifetime may not be long enough
         _ => (),
     }
 }

--- a/src/test/ui/nll/issue-58299.stderr
+++ b/src/test/ui/nll/issue-58299.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-58299.rs:16:9
    |
 LL | fn foo<'a>(x: i32) {
@@ -9,7 +9,7 @@ LL |         A::<'a>::X..=A::<'static>::X => (),
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-58299.rs:24:27
    |
 LL | fn bar<'a>(x: i32) {

--- a/src/test/ui/nll/mir_check_cast_closure.rs
+++ b/src/test/ui/nll/mir_check_cast_closure.rs
@@ -5,7 +5,7 @@
 fn bar<'a, 'b>() -> fn(&'a u32, &'b u32) -> &'a u32 {
     let g: fn(_, _) -> _ = |_x, y| y;
     g
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/mir_check_cast_closure.stderr
+++ b/src/test/ui/nll/mir_check_cast_closure.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/mir_check_cast_closure.rs:7:5
    |
 LL | fn bar<'a, 'b>() -> fn(&'a u32, &'b u32) -> &'a u32 {

--- a/src/test/ui/nll/mir_check_cast_reify.rs
+++ b/src/test/ui/nll/mir_check_cast_reify.rs
@@ -35,7 +35,7 @@ fn bar<'a>(x: &'a u32) -> &'static u32 {
     // as part of checking the `ReifyFnPointer`.
     let f: fn(_) -> _ = foo;
     f(x)
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/mir_check_cast_reify.stderr
+++ b/src/test/ui/nll/mir_check_cast_reify.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/mir_check_cast_reify.rs:37:5
    |
 LL | fn bar<'a>(x: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/mir_check_cast_unsafe_fn.rs
+++ b/src/test/ui/nll/mir_check_cast_unsafe_fn.rs
@@ -7,7 +7,7 @@ fn bar<'a>(input: &'a u32, f: fn(&'a u32) -> &'a u32) -> &'static u32 {
     // in `g`. These are related via the `UnsafeFnPointer` cast.
     let g: unsafe fn(_) -> _ = f;
     unsafe { g(input) }
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsafe_fn.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/mir_check_cast_unsafe_fn.rs:9:14
    |
 LL | fn bar<'a>(input: &'a u32, f: fn(&'a u32) -> &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/mir_check_cast_unsize.rs
+++ b/src/test/ui/nll/mir_check_cast_unsize.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 fn bar<'a>(x: &'a u32) -> &'static dyn Debug {
     x
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/mir_check_cast_unsize.stderr
+++ b/src/test/ui/nll/mir_check_cast_unsize.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/mir_check_cast_unsize.rs:8:5
    |
 LL | fn bar<'a>(x: &'a u32) -> &'static dyn Debug {

--- a/src/test/ui/nll/outlives-suggestion-more.rs
+++ b/src/test/ui/nll/outlives-suggestion-more.rs
@@ -4,14 +4,14 @@
 
 // Should suggest: 'a: 'c, 'b: 'd
 fn foo1<'a, 'b, 'c, 'd>(x: &'a usize, y: &'b usize) -> (&'c usize, &'d usize) {
-    (x, y) //~ERROR lifetime may not live long enough
-           //~^ERROR lifetime may not live long enough
+    (x, y) //~ERROR lifetime may not be long enough
+           //~^ERROR lifetime may not be long enough
 }
 
 // Should suggest: 'a: 'c and use 'static instead of 'b
 fn foo2<'a, 'b, 'c>(x: &'a usize, y: &'b usize) -> (&'c usize, &'static usize) {
-    (x, y) //~ERROR lifetime may not live long enough
-           //~^ERROR lifetime may not live long enough
+    (x, y) //~ERROR lifetime may not be long enough
+           //~^ERROR lifetime may not be long enough
 }
 
 // Should suggest: 'a and 'b are the same and use 'static instead of 'c
@@ -20,9 +20,9 @@ fn foo3<'a, 'b, 'c, 'd, 'e>(
     y: &'b usize,
     z: &'c usize,
 ) -> (&'b usize, &'a usize, &'static usize) {
-    (x, y, z) //~ERROR lifetime may not live long enough
-              //~^ERROR lifetime may not live long enough
-              //~^^ERROR lifetime may not live long enough
+    (x, y, z) //~ERROR lifetime may not be long enough
+              //~^ERROR lifetime may not be long enough
+              //~^^ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/outlives-suggestion-more.stderr
+++ b/src/test/ui/nll/outlives-suggestion-more.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-more.rs:7:5
    |
 LL | fn foo1<'a, 'b, 'c, 'd>(x: &'a usize, y: &'b usize) -> (&'c usize, &'d usize) {
@@ -10,7 +10,7 @@ LL |     (x, y)
    |
    = help: consider adding the following bound: `'a: 'c`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-more.rs:7:5
    |
 LL | fn foo1<'a, 'b, 'c, 'd>(x: &'a usize, y: &'b usize) -> (&'c usize, &'d usize) {
@@ -27,7 +27,7 @@ help: the following changes may resolve your lifetime errors
    = help: add bound `'a: 'c`
    = help: add bound `'b: 'd`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-more.rs:13:5
    |
 LL | fn foo2<'a, 'b, 'c>(x: &'a usize, y: &'b usize) -> (&'c usize, &'static usize) {
@@ -39,7 +39,7 @@ LL |     (x, y)
    |
    = help: consider adding the following bound: `'a: 'c`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-more.rs:13:5
    |
 LL | fn foo2<'a, 'b, 'c>(x: &'a usize, y: &'b usize) -> (&'c usize, &'static usize) {
@@ -54,7 +54,7 @@ help: the following changes may resolve your lifetime errors
    = help: add bound `'a: 'c`
    = help: replace `'b` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-more.rs:23:5
    |
 LL | fn foo3<'a, 'b, 'c, 'd, 'e>(
@@ -67,7 +67,7 @@ LL |     (x, y, z)
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-more.rs:23:5
    |
 LL | fn foo3<'a, 'b, 'c, 'd, 'e>(
@@ -80,7 +80,7 @@ LL |     (x, y, z)
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-more.rs:23:5
    |
 LL | fn foo3<'a, 'b, 'c, 'd, 'e>(

--- a/src/test/ui/nll/outlives-suggestion-simple.polonius.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.polonius.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:6:5
    |
 LL | fn foo1<'a, 'b>(x: &'a usize) -> &'b usize {
@@ -10,7 +10,7 @@ LL |     x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:10:5
    |
 LL | fn foo2<'a>(x: &'a usize) -> &'static usize {
@@ -20,7 +20,7 @@ LL |     x
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:14:5
    |
 LL | fn foo3<'a, 'b>(x: &'a usize, y: &'b usize) -> (&'b usize, &'a usize) {
@@ -32,7 +32,7 @@ LL |     (x, y)
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:14:5
    |
 LL | fn foo3<'a, 'b>(x: &'a usize, y: &'b usize) -> (&'b usize, &'a usize) {
@@ -46,7 +46,7 @@ LL |     (x, y)
 
 help: `'a` and `'b` must be the same: replace one with the other
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:22:5
    |
 LL | fn foo4<'a, 'b, 'c>(x: &'a usize) -> (&'b usize, &'c usize) {
@@ -59,7 +59,7 @@ LL |     (x, x)
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:22:5
    |
 LL | fn foo4<'a, 'b, 'c>(x: &'a usize) -> (&'b usize, &'c usize) {
@@ -74,7 +74,7 @@ LL |     (x, x)
 
 help: add bound `'a: 'b + 'c`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:31:9
    |
 LL |     pub fn foo<'a>(x: &'a usize) -> Self {
@@ -84,7 +84,7 @@ LL |         Foo { x }
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:41:9
    |
 LL | impl<'a> Bar<'a> {
@@ -96,7 +96,7 @@ LL |         self.x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:52:9
    |
 LL | impl<'a> Baz<'a> {

--- a/src/test/ui/nll/outlives-suggestion-simple.rs
+++ b/src/test/ui/nll/outlives-suggestion-simple.rs
@@ -3,23 +3,23 @@
 #![feature(nll)]
 
 fn foo1<'a, 'b>(x: &'a usize) -> &'b usize {
-    x //~ERROR lifetime may not live long enough
+    x //~ERROR lifetime may not be long enough
 }
 
 fn foo2<'a>(x: &'a usize) -> &'static usize {
-    x //~ERROR lifetime may not live long enough
+    x //~ERROR lifetime may not be long enough
 }
 
 fn foo3<'a, 'b>(x: &'a usize, y: &'b usize) -> (&'b usize, &'a usize) {
-    (x, y) //~ERROR lifetime may not live long enough
-           //~^ERROR lifetime may not live long enough
+    (x, y) //~ERROR lifetime may not be long enough
+           //~^ERROR lifetime may not be long enough
 }
 
 fn foo4<'a, 'b, 'c>(x: &'a usize) -> (&'b usize, &'c usize) {
     // FIXME: ideally, we suggest 'a: 'b + 'c, but as of today (may 04, 2019), the null error
     // reporting stops after the first error in a MIR def so as not to produce too many errors, so
     // currently we only report 'a: 'b. The user would then re-run and get another error.
-    (x, x) //~ERROR lifetime may not live long enough
+    (x, x) //~ERROR lifetime may not be long enough
 }
 
 struct Foo<'a> {
@@ -28,7 +28,7 @@ struct Foo<'a> {
 
 impl Foo<'static> {
     pub fn foo<'a>(x: &'a usize) -> Self {
-        Foo { x } //~ERROR lifetime may not live long enough
+        Foo { x } //~ERROR lifetime may not be long enough
     }
 }
 
@@ -38,7 +38,7 @@ struct Bar<'a> {
 
 impl<'a> Bar<'a> {
     pub fn get<'b>(&self) -> &'b usize {
-        self.x //~ERROR lifetime may not live long enough
+        self.x //~ERROR lifetime may not be long enough
     }
 }
 
@@ -49,7 +49,7 @@ struct Baz<'a> {
 
 impl<'a> Baz<'a> {
     fn get<'b>(&'b self) -> &'a i32 {
-        self.x //~ERROR lifetime may not live long enough
+        self.x //~ERROR lifetime may not be long enough
     }
 }
 

--- a/src/test/ui/nll/outlives-suggestion-simple.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:6:5
    |
 LL | fn foo1<'a, 'b>(x: &'a usize) -> &'b usize {
@@ -10,7 +10,7 @@ LL |     x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:10:5
    |
 LL | fn foo2<'a>(x: &'a usize) -> &'static usize {
@@ -20,7 +20,7 @@ LL |     x
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:14:5
    |
 LL | fn foo3<'a, 'b>(x: &'a usize, y: &'b usize) -> (&'b usize, &'a usize) {
@@ -32,7 +32,7 @@ LL |     (x, y)
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:14:5
    |
 LL | fn foo3<'a, 'b>(x: &'a usize, y: &'b usize) -> (&'b usize, &'a usize) {
@@ -46,7 +46,7 @@ LL |     (x, y)
 
 help: `'a` and `'b` must be the same: replace one with the other
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:22:5
    |
 LL | fn foo4<'a, 'b, 'c>(x: &'a usize) -> (&'b usize, &'c usize) {
@@ -59,7 +59,7 @@ LL |     (x, x)
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:31:9
    |
 LL |     pub fn foo<'a>(x: &'a usize) -> Self {
@@ -69,7 +69,7 @@ LL |         Foo { x }
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:41:9
    |
 LL | impl<'a> Bar<'a> {
@@ -81,7 +81,7 @@ LL |         self.x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/outlives-suggestion-simple.rs:52:9
    |
 LL | impl<'a> Baz<'a> {

--- a/src/test/ui/nll/polonius/subset-relations.stderr
+++ b/src/test/ui/nll/polonius/subset-relations.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/subset-relations.rs:11:5
    |
 LL | fn missing_subset<'a, 'b>(x: &'a u32, y: &'b u32) -> &'a u32 {

--- a/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-closure.stderr
@@ -36,7 +36,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: 'a`...
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/projection-one-region-closure.rs:45:39
    |
 LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -86,7 +86,7 @@ LL |     with_signature(cell, t, |cell, t| require(cell, t));
    |
    = help: consider adding an explicit lifetime bound `T: 'a`...
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/projection-one-region-closure.rs:56:39
    |
 LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)

--- a/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-one-region-trait-bound-closure.stderr
@@ -27,7 +27,7 @@ LL | | }
    |
    = note: defining type: no_relationships_late::<'_#1r, T>
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/projection-one-region-trait-bound-closure.rs:37:39
    |
 LL | fn no_relationships_late<'a, 'b, T>(cell: Cell<&'a ()>, t: T)
@@ -68,7 +68,7 @@ LL | | }
    |
    = note: defining type: no_relationships_early::<'_#1r, '_#2r, T>
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/projection-one-region-trait-bound-closure.rs:47:39
    |
 LL | fn no_relationships_early<'a, 'b, T>(cell: Cell<&'a ()>, t: T)

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.rs
@@ -85,7 +85,7 @@ where
     T: Anything<'b, 'b>,
 {
     with_signature(cell, t, |cell, t| require(cell, t));
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 #[rustc_regions]

--- a/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
+++ b/src/test/ui/nll/ty-outlives/projection-two-region-trait-bound-closure.stderr
@@ -184,7 +184,7 @@ LL | | }
    |
    = note: defining type: two_regions::<'_#1r, T>
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/projection-two-region-trait-bound-closure.rs:87:29
    |
 LL | fn two_regions<'a, 'b, T>(cell: Cell<&'a ()>, t: T)

--- a/src/test/ui/nll/ty-outlives/wf-unreachable.rs
+++ b/src/test/ui/nll/ty-outlives/wf-unreachable.rs
@@ -5,37 +5,37 @@
 
 fn uninit<'a>() {
     return;
-    let x: &'static &'a ();                         //~ ERROR lifetime may not live long enough
+    let x: &'static &'a ();                         //~ ERROR lifetime may not be long enough
 }
 
 fn var_type<'a>() {
     return;
-    let x: &'static &'a () = &&();                  //~ ERROR lifetime may not live long enough
+    let x: &'static &'a () = &&();                  //~ ERROR lifetime may not be long enough
 }
 
 fn uninit_infer<'a>() {
-    let x: &'static &'a _;                          //~ ERROR lifetime may not live long enough
+    let x: &'static &'a _;                          //~ ERROR lifetime may not be long enough
     x = && ();
 }
 
 fn infer<'a>() {
     return;
-    let x: &'static &'a _ = &&();                   //~ ERROR lifetime may not live long enough
+    let x: &'static &'a _ = &&();                   //~ ERROR lifetime may not be long enough
 }
 
 fn uninit_no_var<'a>() {
     return;
-    let _: &'static &'a ();                         //~ ERROR lifetime may not live long enough
+    let _: &'static &'a ();                         //~ ERROR lifetime may not be long enough
 }
 
 fn no_var<'a>() {
     return;
-    let _: &'static &'a () = &&();                  //~ ERROR lifetime may not live long enough
+    let _: &'static &'a () = &&();                  //~ ERROR lifetime may not be long enough
 }
 
 fn infer_no_var<'a>() {
     return;
-    let _: &'static &'a _ = &&();                   //~ ERROR lifetime may not live long enough
+    let _: &'static &'a _ = &&();                   //~ ERROR lifetime may not be long enough
 }
 
 trait X<'a, 'b> {}
@@ -48,7 +48,7 @@ impl<'a> X<'a, 'a> for () {}
 // This type annotation is not well-formed because we substitute `()` for `_`.
 fn required_substs<'a>() {
     return;
-    let _: C<'static, 'a, _> = C((), &(), &());     //~ ERROR lifetime may not live long enough
+    let _: C<'static, 'a, _> = C((), &(), &());     //~ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/ty-outlives/wf-unreachable.stderr
+++ b/src/test/ui/nll/ty-outlives/wf-unreachable.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:8:12
    |
 LL | fn uninit<'a>() {
@@ -9,7 +9,7 @@ LL |     let x: &'static &'a ();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:13:12
    |
 LL | fn var_type<'a>() {
@@ -20,7 +20,7 @@ LL |     let x: &'static &'a () = &&();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:17:12
    |
 LL | fn uninit_infer<'a>() {
@@ -30,7 +30,7 @@ LL |     let x: &'static &'a _;
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:23:12
    |
 LL | fn infer<'a>() {
@@ -41,7 +41,7 @@ LL |     let x: &'static &'a _ = &&();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:28:12
    |
 LL | fn uninit_no_var<'a>() {
@@ -52,7 +52,7 @@ LL |     let _: &'static &'a ();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:33:12
    |
 LL | fn no_var<'a>() {
@@ -63,7 +63,7 @@ LL |     let _: &'static &'a () = &&();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:38:12
    |
 LL | fn infer_no_var<'a>() {
@@ -74,7 +74,7 @@ LL |     let _: &'static &'a _ = &&();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-unreachable.rs:51:12
    |
 LL | fn required_substs<'a>() {

--- a/src/test/ui/nll/type-alias-free-regions.nll.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-alias-free-regions.rs:17:9
    |
 LL | impl<'a> FromBox<'a> for C<'a> {
@@ -8,7 +8,7 @@ LL |     fn from_box(b: Box<B>) -> Self {
 LL |         C { f: b }
    |         ^^^^^^^^^^ returning this value requires that `'1` must outlive `'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-alias-free-regions.rs:27:9
    |
 LL | impl<'a> FromTuple<'a> for C<'a> {

--- a/src/test/ui/nll/type-check-pointer-coercions.stderr
+++ b/src/test/ui/nll/type-check-pointer-coercions.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:4:5
    |
 LL | fn shared_to_const<'a, 'b>(x: &&'a i32) -> *const &'b i32 {
@@ -10,7 +10,7 @@ LL |     x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:8:5
    |
 LL | fn unique_to_const<'a, 'b>(x: &mut &'a i32) -> *const &'b i32 {
@@ -22,7 +22,7 @@ LL |     x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:13:5
    |
 LL | fn unique_to_mut<'a, 'b>(x: &mut &'a i32) -> *mut &'b i32 {
@@ -35,7 +35,7 @@ LL |     x
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:13:5
    |
 LL | fn unique_to_mut<'a, 'b>(x: &mut &'a i32) -> *mut &'b i32 {
@@ -50,7 +50,7 @@ LL |     x
 
 help: `'b` and `'a` must be the same: replace one with the other
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:18:5
    |
 LL | fn mut_to_const<'a, 'b>(x: *mut &'a i32) -> *const &'b i32 {
@@ -62,7 +62,7 @@ LL |     x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:24:5
    |
 LL | fn array_elem<'a, 'b>(x: &'a i32) -> *const &'b i32 {
@@ -75,7 +75,7 @@ LL |     y
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:30:5
    |
 LL | fn array_coerce<'a, 'b>(x: &'a i32) -> *const [&'b i32; 3] {
@@ -88,7 +88,7 @@ LL |     y
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-coercions.rs:36:5
    |
 LL | fn nested_array<'a, 'b>(x: &'a i32) -> *const [&'b i32; 2] {

--- a/src/test/ui/nll/type-check-pointer-comparisons.rs
+++ b/src/test/ui/nll/type-check-pointer-comparisons.rs
@@ -4,20 +4,20 @@
 
 fn compare_const<'a, 'b>(x: *const &mut &'a i32, y: *const &mut &'b i32) {
     x == y;
-    //~^ ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
+    //~| ERROR lifetime may not be long enough
 }
 
 fn compare_mut<'a, 'b>(x: *mut &'a i32, y: *mut &'b i32) {
     x == y;
-    //~^ ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
+    //~| ERROR lifetime may not be long enough
 }
 
 fn compare_fn_ptr<'a, 'b, 'c>(f: fn(&'c mut &'a i32), g: fn(&'c mut &'b i32)) {
     f == g;
-    //~^ ERROR lifetime may not live long enough
-    //~| ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
+    //~| ERROR lifetime may not be long enough
 }
 
 fn compare_hr_fn_ptr<'a>(f: fn(&'a i32), g: fn(&i32)) {

--- a/src/test/ui/nll/type-check-pointer-comparisons.stderr
+++ b/src/test/ui/nll/type-check-pointer-comparisons.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-comparisons.rs:6:5
    |
 LL | fn compare_const<'a, 'b>(x: *const &mut &'a i32, y: *const &mut &'b i32) {
@@ -10,7 +10,7 @@ LL |     x == y;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-comparisons.rs:6:10
    |
 LL | fn compare_const<'a, 'b>(x: *const &mut &'a i32, y: *const &mut &'b i32) {
@@ -24,7 +24,7 @@ LL |     x == y;
 
 help: `'a` and `'b` must be the same: replace one with the other
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-comparisons.rs:12:5
    |
 LL | fn compare_mut<'a, 'b>(x: *mut &'a i32, y: *mut &'b i32) {
@@ -36,7 +36,7 @@ LL |     x == y;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-comparisons.rs:12:10
    |
 LL | fn compare_mut<'a, 'b>(x: *mut &'a i32, y: *mut &'b i32) {
@@ -50,7 +50,7 @@ LL |     x == y;
 
 help: `'a` and `'b` must be the same: replace one with the other
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-comparisons.rs:18:5
    |
 LL | fn compare_fn_ptr<'a, 'b, 'c>(f: fn(&'c mut &'a i32), g: fn(&'c mut &'b i32)) {
@@ -62,7 +62,7 @@ LL |     f == g;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/type-check-pointer-comparisons.rs:18:10
    |
 LL | fn compare_fn_ptr<'a, 'b, 'c>(f: fn(&'c mut &'a i32), g: fn(&'c mut &'b i32)) {

--- a/src/test/ui/nll/user-annotations/closure-substs.polonius.stderr
+++ b/src/test/ui/nll/user-annotations/closure-substs.polonius.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/closure-substs.rs:8:16
    |
 LL | fn foo<'a>() {
@@ -9,7 +9,7 @@ LL |         return x;
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/closure-substs.rs:15:16
    |
 LL |     |x: &i32| -> &'static i32 {
@@ -17,7 +17,7 @@ LL |     |x: &i32| -> &'static i32 {
 LL |         return x;
    |                ^ returning this value requires that `'1` must outlive `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/closure-substs.rs:15:16
    |
 LL |     |x: &i32| -> &'static i32 {
@@ -27,7 +27,7 @@ LL |     |x: &i32| -> &'static i32 {
 LL |         return x;
    |                ^ returning this value requires that `'1` must outlive `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/closure-substs.rs:22:9
    |
 LL | fn bar<'a>() {

--- a/src/test/ui/nll/user-annotations/closure-substs.rs
+++ b/src/test/ui/nll/user-annotations/closure-substs.rs
@@ -5,21 +5,21 @@
 fn foo<'a>() {
     // Here `x` is free in the closure sig:
     |x: &'a i32| -> &'static i32 {
-        return x; //~ ERROR lifetime may not live long enough
+        return x; //~ ERROR lifetime may not be long enough
     };
 }
 
 fn foo1() {
     // Here `x` is bound in the closure sig:
     |x: &i32| -> &'static i32 {
-        return x; //~ ERROR lifetime may not live long enough
+        return x; //~ ERROR lifetime may not be long enough
     };
 }
 
 fn bar<'a>() {
     // Here `x` is free in the closure sig:
     |x: &'a i32, b: fn(&'static i32)| {
-        b(x); //~ ERROR lifetime may not live long enough
+        b(x); //~ ERROR lifetime may not be long enough
     };
 }
 

--- a/src/test/ui/nll/user-annotations/closure-substs.stderr
+++ b/src/test/ui/nll/user-annotations/closure-substs.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/closure-substs.rs:8:16
    |
 LL | fn foo<'a>() {
@@ -9,7 +9,7 @@ LL |         return x;
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/closure-substs.rs:15:16
    |
 LL |     |x: &i32| -> &'static i32 {
@@ -17,7 +17,7 @@ LL |     |x: &i32| -> &'static i32 {
 LL |         return x;
    |                ^ returning this value requires that `'1` must outlive `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/closure-substs.rs:22:9
    |
 LL | fn bar<'a>() {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/constant-in-expr-inherent-1.rs:8:5
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/constant-in-expr-normalize.rs:18:5
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/constant-in-expr-trait-item-1.rs:10:5
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/constant-in-expr-trait-item-2.rs:10:5
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/constant-in-expr-trait-item-3.rs:10:5
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/inherent-associated-constants.rs
+++ b/src/test/ui/nll/user-annotations/inherent-associated-constants.rs
@@ -7,7 +7,7 @@ impl A<'static> {
 }
 
 fn non_wf_associated_const<'a>(x: i32) {
-    A::<'a>::IC; //~ ERROR lifetime may not live long enough
+    A::<'a>::IC; //~ ERROR lifetime may not be long enough
 }
 
 fn wf_associated_const<'a>(x: i32) {

--- a/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
+++ b/src/test/ui/nll/user-annotations/inherent-associated-constants.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/inherent-associated-constants.rs:10:5
    |
 LL | fn non_wf_associated_const<'a>(x: i32) {

--- a/src/test/ui/nll/user-annotations/issue-54124.rs
+++ b/src/test/ui/nll/user-annotations/issue-54124.rs
@@ -1,8 +1,8 @@
 #![feature(nll)]
 
 fn test<'a>() {
-    let _:fn(&()) = |_:&'a ()| {}; //~ ERROR lifetime may not live long enough
-    //~^ ERROR lifetime may not live long enough
+    let _:fn(&()) = |_:&'a ()| {}; //~ ERROR lifetime may not be long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {

--- a/src/test/ui/nll/user-annotations/issue-54124.stderr
+++ b/src/test/ui/nll/user-annotations/issue-54124.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-54124.rs:4:22
    |
 LL | fn test<'a>() {
@@ -8,7 +8,7 @@ LL |     let _:fn(&()) = |_:&'a ()| {};
    |                      |
    |                      requires that `'1` must outlive `'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-54124.rs:4:22
    |
 LL | fn test<'a>() {

--- a/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.rs
+++ b/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.rs
@@ -32,7 +32,7 @@ fn coupled_regions_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
     // swap_regions((y, _z));
 
     // ... but the ascribed type also invalidates this use of `y`
-    y //~ ERROR lifetime may not live long enough
+    y //~ ERROR lifetime may not be long enough
 }
 
 fn swap_types((mut y, mut _z): PairCoupledTypes<&u32>) {
@@ -46,7 +46,7 @@ fn coupled_types_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
     // swap_types((y, _z));
 
     // ... but the ascribed type also invalidates this use of `y`
-    y //~ ERROR lifetime may not live long enough
+    y //~ ERROR lifetime may not be long enough
 }
 
 fn swap_wilds((mut y, mut _z): PairCoupledTypes<&u32>) {
@@ -59,7 +59,7 @@ fn coupled_wilds_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
     // swap_wilds((y, _z));
 
     // ... but the ascribed type also invalidates this use of `y`
-    y //~ ERROR lifetime may not live long enough
+    y //~ ERROR lifetime may not be long enough
 }
 
 fn main() {

--- a/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
+++ b/src/test/ui/nll/user-annotations/issue-55748-pat-types-constrain-bindings.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-55748-pat-types-constrain-bindings.rs:35:5
    |
 LL | fn coupled_regions_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
@@ -9,7 +9,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-55748-pat-types-constrain-bindings.rs:49:5
    |
 LL | fn coupled_types_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
@@ -20,7 +20,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-55748-pat-types-constrain-bindings.rs:62:5
    |
 LL | fn coupled_wilds_lhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.rs
+++ b/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.rs
@@ -14,12 +14,12 @@ fn uncoupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 
 fn coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
     let ((y, _z),) = ((s, _x),): (PairCoupledTypes<_>,);
-    y //~ ERROR lifetime may not live long enough
+    y //~ ERROR lifetime may not be long enough
 }
 
 fn coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
     let ((y, _z),) = ((s, _x),): (PairCoupledRegions<_>,);
-    y //~ ERROR lifetime may not live long enough
+    y //~ ERROR lifetime may not be long enough
 }
 
 fn cast_uncoupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
@@ -29,12 +29,12 @@ fn cast_uncoupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
 
 fn cast_coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
     let ((y, _z),) = ((s, _x),) as (PairCoupledTypes<_>,);
-    y //~ ERROR lifetime may not live long enough
+    y //~ ERROR lifetime may not be long enough
 }
 
 fn cast_coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
     let ((y, _z),) = ((s, _x),) as (PairCoupledRegions<_>,);
-    y //~ ERROR lifetime may not live long enough
+    y //~ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.stderr
+++ b/src/test/ui/nll/user-annotations/issue-57731-ascibed-coupled-types.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:17:5
    |
 LL | fn coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
@@ -9,7 +9,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:22:5
    |
 LL | fn coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
@@ -20,7 +20,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:32:5
    |
 LL | fn cast_coupled_wilds_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {
@@ -31,7 +31,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/issue-57731-ascibed-coupled-types.rs:37:5
    |
 LL | fn cast_coupled_regions_rhs<'a>(_x: &'a u32, s: &'static u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/patterns.stderr
+++ b/src/test/ui/nll/user-annotations/patterns.stderr
@@ -148,7 +148,7 @@ LL |         value1: &x,
 LL | }
    | - `x` dropped here while still borrowed
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/patterns.rs:113:5
    |
 LL | fn static_to_a_to_static_through_variable<'a>(x: &'a u32) -> &'static u32 {
@@ -159,7 +159,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/patterns.rs:125:5
    |
 LL | fn static_to_a_to_static_through_tuple<'a>(x: &'a u32) -> &'static u32 {
@@ -170,7 +170,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/patterns.rs:130:5
    |
 LL | fn static_to_a_to_static_through_struct<'a>(_x: &'a u32) -> &'static u32 {
@@ -181,7 +181,7 @@ LL |     y
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/patterns.rs:134:18
    |
 LL | fn a_to_static_then_static<'a>(x: &'a u32) -> &'static u32 {

--- a/src/test/ui/nll/user-annotations/wf-self-type.rs
+++ b/src/test/ui/nll/user-annotations/wf-self-type.rs
@@ -9,7 +9,7 @@ impl<'a, 'b> Foo<'a, 'b> {
 }
 
 pub fn foo<'a, 'b>(u: &'b ()) -> &'a () {
-    Foo::xmute(u) //~ ERROR lifetime may not live long enough
+    Foo::xmute(u) //~ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/user-annotations/wf-self-type.stderr
+++ b/src/test/ui/nll/user-annotations/wf-self-type.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-self-type.rs:12:5
    |
 LL | pub fn foo<'a, 'b>(u: &'b ()) -> &'a () {

--- a/src/test/ui/nll/where_clauses_in_functions.rs
+++ b/src/test/ui/nll/where_clauses_in_functions.rs
@@ -11,7 +11,7 @@ where
 
 fn bar<'a, 'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {
     foo(x, y)
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/where_clauses_in_functions.stderr
+++ b/src/test/ui/nll/where_clauses_in_functions.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/where_clauses_in_functions.rs:13:5
    |
 LL | fn bar<'a, 'b>(x: &'a u32, y: &'b u32) -> (&'a u32, &'b u32) {

--- a/src/test/ui/nll/where_clauses_in_structs.rs
+++ b/src/test/ui/nll/where_clauses_in_structs.rs
@@ -11,7 +11,7 @@ struct Foo<'a: 'b, 'b> {
 
 fn bar<'a, 'b>(x: Cell<&'a u32>, y: Cell<&'b u32>) {
     Foo { x, y };
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/nll/where_clauses_in_structs.stderr
+++ b/src/test/ui/nll/where_clauses_in_structs.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/where_clauses_in_structs.rs:13:11
    |
 LL | fn bar<'a, 'b>(x: Cell<&'a u32>, y: Cell<&'b u32>) {

--- a/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/object-lifetime-default-elision.rs:71:5
    |
 LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-box-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-box-error.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/object-lifetime-default-from-box-error.rs:18:5
    |
 LL | fn load(ss: &mut SomeStruct) -> Box<dyn SomeTrait> {

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-box-error.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/object-lifetime-default-from-rptr-box-error.rs:15:5
    |
 LL | fn c<'a>(t: &'a Box<dyn Test+'a>, mut ss: SomeStruct<'a>) {

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:21:5
    |
 LL | fn c<'a>(t: &'a MyBox<dyn Test+'a>, mut ss: SomeStruct<'a>) {

--- a/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-mybox.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/object-lifetime-default-mybox.rs:27:5
    |
 LL | fn load1<'a,'b>(a: &'a MyBox<dyn SomeTrait>,

--- a/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.nll.stderr
+++ b/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:8:5
    |
 LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
@@ -11,7 +11,7 @@ LL |     *x = *y;
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:14:5
    |
 LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {

--- a/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.nll.stderr
+++ b/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:9:5
    |
 LL | fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
@@ -11,7 +11,7 @@ LL |     *x = *y;
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:16:5
    |
 LL | fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {

--- a/src/test/ui/regions/region-object-lifetime-2.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-object-lifetime-2.rs:10:5
    |
 LL | fn borrowed_receiver_different_lifetimes<'a,'b>(x: &'a dyn Foo) -> &'b () {

--- a/src/test/ui/regions/region-object-lifetime-4.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-4.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-object-lifetime-4.rs:12:5
    |
 LL | fn borrowed_receiver_related_lifetimes2<'a,'b>(x: &'a (dyn Foo + 'b)) -> &'b () {

--- a/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-object-lifetime-in-coercion.rs:8:12
    |
 LL | fn a(v: &[u8]) -> Box<dyn Foo + 'static> {
@@ -6,7 +6,7 @@ LL | fn a(v: &[u8]) -> Box<dyn Foo + 'static> {
 LL |     let x: Box<dyn Foo + 'static> = Box::new(v);
    |            ^^^^^^^^^^^^^^^^^^^^^^ type annotation requires that `'1` must outlive `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-object-lifetime-in-coercion.rs:13:5
    |
 LL | fn b(v: &[u8]) -> Box<dyn Foo + 'static> {
@@ -14,7 +14,7 @@ LL | fn b(v: &[u8]) -> Box<dyn Foo + 'static> {
 LL |     Box::new(v)
    |     ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-object-lifetime-in-coercion.rs:19:5
    |
 LL | fn c(v: &[u8]) -> Box<dyn Foo> {
@@ -23,7 +23,7 @@ LL | fn c(v: &[u8]) -> Box<dyn Foo> {
 LL |     Box::new(v)
    |     ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/region-object-lifetime-in-coercion.rs:23:5
    |
 LL | fn d<'a,'b>(v: &'a [u8]) -> Box<dyn Foo+'b> {

--- a/src/test/ui/regions/regions-addr-of-self.nll.stderr
+++ b/src/test/ui/regions/regions-addr-of-self.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-addr-of-self.rs:7:16
    |
 LL |     pub fn chase_cat(&mut self) {

--- a/src/test/ui/regions/regions-addr-of-upvar-self.nll.stderr
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-addr-of-upvar-self.rs:10:20
    |
 LL |         let _f = || {
@@ -8,7 +8,7 @@ LL |             let p: &'static mut usize = &mut self.food;
    |
    = note: closure implements `FnMut`, so references to captured variables can't escape the closure
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-addr-of-upvar-self.rs:10:20
    |
 LL |     pub fn chase_cat(&mut self) {

--- a/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.migrate.nll.stderr
+++ b/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.migrate.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-assoc-type-in-supertrait-outlives-container.rs:39:12
    |
 LL | fn with_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.nll.stderr
+++ b/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-assoc-type-in-supertrait-outlives-container.rs:39:12
    |
 LL | fn with_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.rs
+++ b/src/test/ui/regions/regions-assoc-type-in-supertrait-outlives-container.rs
@@ -38,7 +38,7 @@ fn with_assoc<'a,'b>() {
 
     let _: &'a WithAssoc<TheType<'b>> = loop { };
     //[migrate]~^ ERROR reference has a longer lifetime
-    //[nll]~^^ ERROR lifetime may not live long enough
+    //[nll]~^^ ERROR lifetime may not be long enough
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-by-trait-requiring-static.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:22:5
    |
 LL | fn param_not_ok<'a>(x: &'a isize) {
@@ -8,7 +8,7 @@ LL |     assert_send::<&'a isize>();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:26:5
    |
 LL | fn param_not_ok1<'a>(_: &'a isize) {
@@ -18,7 +18,7 @@ LL |     assert_send::<&'a str>();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:30:5
    |
 LL | fn param_not_ok2<'a>(_: &'a isize) {
@@ -28,7 +28,7 @@ LL |     assert_send::<&'a [isize]>();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:44:5
    |
 LL | fn box_with_region_not_ok<'a>() {
@@ -38,7 +38,7 @@ LL |     assert_send::<Box<&'a isize>>();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:55:5
    |
 LL | fn unsafe_ok2<'a>(_: &'a isize) {
@@ -48,7 +48,7 @@ LL |     assert_send::<*const &'a isize>();
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-by-trait-requiring-static.rs:59:5
    |
 LL | fn unsafe_ok3<'a>(_: &'a isize) {

--- a/src/test/ui/regions/regions-bounded-method-type-parameters-cross-crate.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters-cross-crate.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-method-type-parameters-cross-crate.rs:20:5
    |
 LL | fn call_bigger_region<'x, 'y>(a: Inv<'x>, b: Inv<'y>) {

--- a/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounded-method-type-parameters.rs:12:9
    |
 LL | fn caller<'a>(x: &isize) {

--- a/src/test/ui/regions/regions-bounds.nll.stderr
+++ b/src/test/ui/regions/regions-bounds.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounds.rs:9:12
    |
 LL | fn a_fn1<'a,'b>(e: TupleStruct<'a>) -> TupleStruct<'b> {
@@ -10,7 +10,7 @@ LL |     return e;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-bounds.rs:13:12
    |
 LL | fn a_fn3<'a,'b>(e: Struct<'a>) -> Struct<'b> {

--- a/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-close-object-into-object-2.rs:10:5
    |
 LL | fn g<'a, T: 'static>(v: Box<dyn A<T> + 'a>) -> Box<dyn X + 'static> {

--- a/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-4.nll.stderr
@@ -6,7 +6,7 @@ LL |     box B(&*v) as Box<dyn X>
    |
    = help: consider adding an explicit lifetime bound `U: 'static`...
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-close-object-into-object-4.rs:10:5
    |
 LL | fn i<'a, T, U>(v: Box<dyn A<U>+'a>) -> Box<dyn X + 'static> {

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-close-over-type-parameter-multiple.rs:20:5
    |
 LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait + 'c> {

--- a/src/test/ui/regions/regions-creating-enums3.nll.stderr
+++ b/src/test/ui/regions/regions-creating-enums3.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-creating-enums3.rs:7:5
    |
 LL | fn mk_add_bad1<'a,'b>(x: &'a Ast<'a>, y: &'b Ast<'b>) -> Ast<'a> {

--- a/src/test/ui/regions/regions-creating-enums4.nll.stderr
+++ b/src/test/ui/regions/regions-creating-enums4.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-creating-enums4.rs:7:5
    |
 LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {

--- a/src/test/ui/regions/regions-early-bound-error-method.nll.stderr
+++ b/src/test/ui/regions/regions-early-bound-error-method.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-early-bound-error-method.rs:20:9
    |
 LL | impl<'a> Box<'a> {

--- a/src/test/ui/regions/regions-early-bound-error.nll.stderr
+++ b/src/test/ui/regions/regions-early-bound-error.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-early-bound-error.rs:19:5
    |
 LL | fn get<'a,'b,G:GetRef<'a, isize>>(g1: G, b: &'b isize) -> &'b isize {

--- a/src/test/ui/regions/regions-escape-method.rs
+++ b/src/test/ui/regions/regions-escape-method.rs
@@ -12,5 +12,5 @@ impl S {
 
 fn main() {
     let s = S;
-    s.f(|p| p) //~ ERROR lifetime may not live long enough
+    s.f(|p| p) //~ ERROR lifetime may not be long enough
 }

--- a/src/test/ui/regions/regions-escape-method.stderr
+++ b/src/test/ui/regions/regions-escape-method.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-escape-method.rs:15:13
    |
 LL |     s.f(|p| p)

--- a/src/test/ui/regions/regions-escape-via-trait-or-not.rs
+++ b/src/test/ui/regions/regions-escape-via-trait-or-not.rs
@@ -15,7 +15,7 @@ fn with<R:Deref, F>(f: F) -> isize where F: FnOnce(&isize) -> R {
 }
 
 fn return_it() -> isize {
-    with(|o| o) //~ ERROR lifetime may not live long enough
+    with(|o| o) //~ ERROR lifetime may not be long enough
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-escape-via-trait-or-not.stderr
+++ b/src/test/ui/regions/regions-escape-via-trait-or-not.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-escape-via-trait-or-not.rs:18:14
    |
 LL |     with(|o| o)

--- a/src/test/ui/regions/regions-free-region-ordering-callee.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-callee.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-callee.rs:13:5
    |
 LL | fn ordering2<'a, 'b>(x: &'a &'b usize, y: &'a usize) -> &'b usize {
@@ -11,7 +11,7 @@ LL |     &*y
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-callee.rs:18:12
    |
 LL | fn ordering3<'a, 'b>(x: &'a usize, y: &'b usize) -> &'a &'b usize {

--- a/src/test/ui/regions/regions-free-region-ordering-caller.migrate.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-caller.migrate.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-caller.rs:11:12
    |
 LL | fn call2<'a, 'b>(a: &'a usize, b: &'b usize) {
@@ -10,7 +10,7 @@ LL |     let z: Option<&'b &'a usize> = None;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-caller.rs:17:12
    |
 LL | fn call3<'a, 'b>(a: &'a usize, b: &'b usize) {
@@ -23,7 +23,7 @@ LL |     let z: Option<&'b Paramd<'a>> = None;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-caller.rs:22:12
    |
 LL | fn call4<'a, 'b>(a: &'a usize, b: &'b usize) {

--- a/src/test/ui/regions/regions-free-region-ordering-caller.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-caller.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-caller.rs:11:12
    |
 LL | fn call2<'a, 'b>(a: &'a usize, b: &'b usize) {
@@ -10,7 +10,7 @@ LL |     let z: Option<&'b &'a usize> = None;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-caller.rs:17:12
    |
 LL | fn call3<'a, 'b>(a: &'a usize, b: &'b usize) {
@@ -23,7 +23,7 @@ LL |     let z: Option<&'b Paramd<'a>> = None;
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-caller.rs:22:12
    |
 LL | fn call4<'a, 'b>(a: &'a usize, b: &'b usize) {

--- a/src/test/ui/regions/regions-free-region-ordering-caller.rs
+++ b/src/test/ui/regions/regions-free-region-ordering-caller.rs
@@ -9,18 +9,18 @@ struct Paramd<'a> { x: &'a usize }
 
 fn call2<'a, 'b>(a: &'a usize, b: &'b usize) {
     let z: Option<&'b &'a usize> = None;//[migrate]~ ERROR E0491
-    //[nll]~^ ERROR lifetime may not live long enough
+    //[nll]~^ ERROR lifetime may not be long enough
 }
 
 fn call3<'a, 'b>(a: &'a usize, b: &'b usize) {
     let y: Paramd<'a> = Paramd { x: a };
     let z: Option<&'b Paramd<'a>> = None;//[migrate]~ ERROR E0491
-    //[nll]~^ ERROR lifetime may not live long enough
+    //[nll]~^ ERROR lifetime may not be long enough
 }
 
 fn call4<'a, 'b>(a: &'a usize, b: &'b usize) {
     let z: Option<&'a &'b usize> = None;//[migrate]~ ERROR E0491
-    //[nll]~^ ERROR lifetime may not live long enough
+    //[nll]~^ ERROR lifetime may not be long enough
 }
 
 fn main() {}

--- a/src/test/ui/regions/regions-free-region-ordering-incorrect.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-incorrect.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-free-region-ordering-incorrect.rs:15:9
    |
 LL |   impl<'b, T> Node<'b, T> {

--- a/src/test/ui/regions/regions-infer-call-3.rs
+++ b/src/test/ui/regions/regions-infer-call-3.rs
@@ -6,7 +6,7 @@ fn with<T, F>(f: F) -> T where F: FnOnce(&isize) -> T {
 
 fn manip<'a>(x: &'a isize) -> isize {
     let z = with(|y| { select(x, y) });
-    //~^ ERROR lifetime may not live long enough
+    //~^ ERROR lifetime may not be long enough
     *z
 }
 

--- a/src/test/ui/regions/regions-infer-call-3.stderr
+++ b/src/test/ui/regions/regions-infer-call-3.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-call-3.rs:8:24
    |
 LL |     let z = with(|y| { select(x, y) });

--- a/src/test/ui/regions/regions-infer-contravariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-contravariance-due-to-decl.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-contravariance-due-to-decl.rs:25:12
    |
 LL | fn use_<'short,'long>(c: Contravariant<'short>,

--- a/src/test/ui/regions/regions-infer-covariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-covariance-due-to-decl.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-covariance-due-to-decl.rs:22:12
    |
 LL | fn use_<'short,'long>(c: Covariant<'long>,

--- a/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-decl.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-invariance-due-to-decl.rs:12:5
    |
 LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-3.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-invariance-due-to-mutability-3.rs:10:5
    |
 LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {

--- a/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
+++ b/src/test/ui/regions/regions-infer-invariance-due-to-mutability-4.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-invariance-due-to-mutability-4.rs:10:5
    |
 LL | fn to_longer_lifetime<'r>(b_isize: Invariant<'r>) -> Invariant<'static> {

--- a/src/test/ui/regions/regions-infer-not-param.nll.stderr
+++ b/src/test/ui/regions/regions-infer-not-param.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-not-param.rs:15:54
    |
 LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p }
@@ -8,7 +8,7 @@ LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p }
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-not-param.rs:19:63
    |
 LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
@@ -18,7 +18,7 @@ LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-not-param.rs:19:63
    |
 LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }

--- a/src/test/ui/regions/regions-infer-paramd-indirect.nll.stderr
+++ b/src/test/ui/regions/regions-infer-paramd-indirect.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-infer-paramd-indirect.rs:22:9
    |
 LL | impl<'a> SetF<'a> for C<'a> {

--- a/src/test/ui/regions/regions-lifetime-bounds-on-fns.nll.stderr
+++ b/src/test/ui/regions/regions-lifetime-bounds-on-fns.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-lifetime-bounds-on-fns.rs:8:5
    |
 LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
@@ -11,7 +11,7 @@ LL |     *x = *y;
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-lifetime-bounds-on-fns.rs:14:5
    |
 LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {

--- a/src/test/ui/regions/regions-nested-fns.nll.stderr
+++ b/src/test/ui/regions/regions-nested-fns.nll.stderr
@@ -37,7 +37,7 @@ LL |         if false { return ay; }
 LL | }
    | - `y` dropped here while still borrowed
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-nested-fns.rs:14:27
    |
 LL | fn nested<'x>(x: &'x isize) {

--- a/src/test/ui/regions/regions-outlives-projection-container-hrtb.migrate.nll.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container-hrtb.migrate.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container-hrtb.rs:30:12
    |
 LL | fn with_assoc<'a,'b>() {
@@ -11,7 +11,7 @@ LL |     let _: &'a WithHrAssoc<TheType<'b>> = loop { };
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container-hrtb.rs:50:12
    |
 LL | fn with_assoc_sub<'a,'b>() {

--- a/src/test/ui/regions/regions-outlives-projection-container-hrtb.nll.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container-hrtb.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container-hrtb.rs:30:12
    |
 LL | fn with_assoc<'a,'b>() {
@@ -11,7 +11,7 @@ LL |     let _: &'a WithHrAssoc<TheType<'b>> = loop { };
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container-hrtb.rs:50:12
    |
 LL | fn with_assoc_sub<'a,'b>() {

--- a/src/test/ui/regions/regions-outlives-projection-container-hrtb.rs
+++ b/src/test/ui/regions/regions-outlives-projection-container-hrtb.rs
@@ -29,7 +29,7 @@ fn with_assoc<'a,'b>() {
 
     let _: &'a WithHrAssoc<TheType<'b>> = loop { };
     //[migrate]~^ ERROR reference has a longer lifetime
-    //[nll]~^^ ERROR lifetime may not live long enough
+    //[nll]~^^ ERROR lifetime may not be long enough
 }
 
 pub trait TheSubTrait : for<'a> TheTrait<'a> {
@@ -49,7 +49,7 @@ fn with_assoc_sub<'a,'b>() {
 
     let _: &'a WithHrAssocSub<TheType<'b>> = loop { };
     //[migrate]~^ ERROR reference has a longer lifetime
-    //[nll]~^^ ERROR lifetime may not live long enough
+    //[nll]~^^ ERROR lifetime may not be long enough
 }
 
 

--- a/src/test/ui/regions/regions-outlives-projection-container-wc.migrate.nll.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container-wc.migrate.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container-wc.rs:33:12
    |
 LL | fn with_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-outlives-projection-container-wc.nll.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container-wc.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container-wc.rs:33:12
    |
 LL | fn with_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-outlives-projection-container-wc.rs
+++ b/src/test/ui/regions/regions-outlives-projection-container-wc.rs
@@ -32,7 +32,7 @@ fn with_assoc<'a,'b>() {
 
     let _: &'a WithAssoc<TheType<'b>> = loop { };
     //[migrate]~^ ERROR reference has a longer lifetime
-    //[nll]~^^ ERROR lifetime may not live long enough
+    //[nll]~^^ ERROR lifetime may not be long enough
 }
 
 fn main() {

--- a/src/test/ui/regions/regions-outlives-projection-container.nll.stderr
+++ b/src/test/ui/regions/regions-outlives-projection-container.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container.rs:36:13
    |
 LL | fn with_assoc<'a,'b>() {
@@ -11,7 +11,7 @@ LL |     let _x: &'a WithAssoc<TheType<'b>> = loop { };
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container.rs:54:13
    |
 LL | fn without_assoc<'a,'b>() {
@@ -24,7 +24,7 @@ LL |     let _x: &'a WithoutAssoc<TheType<'b>> = loop { };
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container.rs:63:5
    |
 LL | fn call_with_assoc<'a,'b>() {
@@ -37,7 +37,7 @@ LL |     call::<&'a WithAssoc<TheType<'b>>>();
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-outlives-projection-container.rs:70:5
    |
 LL | fn call_without_assoc<'a,'b>() {

--- a/src/test/ui/regions/regions-proc-bound-capture.nll.stderr
+++ b/src/test/ui/regions/regions-proc-bound-capture.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-proc-bound-capture.rs:9:5
    |
 LL | fn static_proc(x: &isize) -> Box<dyn FnMut() -> (isize) + 'static> {

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.nll.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref-mut-ref.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-reborrow-from-shorter-mut-ref-mut-ref.rs:4:5
    |
 LL | fn copy_borrowed_ptr<'a, 'b, 'c>(p: &'a mut &'b mut &'c mut isize) -> &'b mut isize {

--- a/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.nll.stderr
+++ b/src/test/ui/regions/regions-reborrow-from-shorter-mut-ref.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-reborrow-from-shorter-mut-ref.rs:6:5
    |
 LL | fn copy_borrowed_ptr<'a, 'b>(p: &'a mut &'b mut isize) -> &'b mut isize {

--- a/src/test/ui/regions/regions-ret-borrowed-1.nll.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-ret-borrowed-1.rs:10:14
    |
 LL |     with(|o| o)

--- a/src/test/ui/regions/regions-ret-borrowed.nll.stderr
+++ b/src/test/ui/regions/regions-ret-borrowed.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-ret-borrowed.rs:13:14
    |
 LL |     with(|o| o)

--- a/src/test/ui/regions/regions-static-bound.ll.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.ll.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-static-bound.rs:9:5
    |
 LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {

--- a/src/test/ui/regions/regions-static-bound.migrate.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.migrate.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-static-bound.rs:9:5
    |
 LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {

--- a/src/test/ui/regions/regions-static-bound.nll.stderr
+++ b/src/test/ui/regions/regions-static-bound.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-static-bound.rs:9:5
    |
 LL | fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {

--- a/src/test/ui/regions/regions-static-bound.rs
+++ b/src/test/ui/regions/regions-static-bound.rs
@@ -7,7 +7,7 @@ fn static_id_indirect<'a,'b>(t: &'a ()) -> &'static ()
     where 'a: 'b, 'b: 'static { t }
 fn static_id_wrong_way<'a>(t: &'a ()) -> &'static () where 'static: 'a {
     t //[migrate]~ ERROR E0312
-        //[nll]~^ ERROR lifetime may not live long enough
+        //[nll]~^ ERROR lifetime may not be long enough
 }
 
 fn error(u: &(), v: &()) {

--- a/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
+++ b/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-trait-object-subtyping.rs:15:5
    |
 LL | fn foo3<'a,'b>(x: &'a mut dyn Dummy) -> &'b mut dyn Dummy {
@@ -11,7 +11,7 @@ LL |     x
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-trait-object-subtyping.rs:22:5
    |
 LL | fn foo4<'a:'b,'b>(x: Wrapper<&'a mut dyn Dummy>) -> Wrapper<&'b mut dyn Dummy> {

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.nll.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-variance-contravariant-use-covariant-in-second-position.rs:25:12
    |
 LL | fn use_<'short,'long>(c: S<'long, 'short>,

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-variance-contravariant-use-covariant.rs:23:12
    |
 LL | fn use_<'short,'long>(c: Contravariant<'short>,

--- a/src/test/ui/regions/regions-variance-covariant-use-contravariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-covariant-use-contravariant.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-variance-covariant-use-contravariant.rs:23:12
    |
 LL | fn use_<'short,'long>(c: Covariant<'long>,

--- a/src/test/ui/regions/regions-variance-invariant-use-contravariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-contravariant.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-variance-invariant-use-contravariant.rs:20:12
    |
 LL | fn use_<'short,'long>(c: Invariant<'long>,

--- a/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
+++ b/src/test/ui/regions/regions-variance-invariant-use-covariant.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/regions-variance-invariant-use-covariant.rs:17:12
    |
 LL | fn use_<'b>(c: Invariant<'b>) {

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait-async.rs:8:48
    |
 LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait.rs:6:31
    |
 LL |     fn f(self: Pin<&Self>) -> impl Clone { self }

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
@@ -7,7 +7,7 @@ LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
    |                          |         let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:75
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
@@ -16,7 +16,7 @@ LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (
    |                          |          let's call the lifetime of this reference `'1`
    |                          let's call the lifetime of this reference `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:6:46
    |
 LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
@@ -7,7 +7,7 @@ LL |     fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
    |                    |         let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:8:69
    |
 LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
@@ -16,7 +16,7 @@ LL |     fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, 
    |                    |          let's call the lifetime of this reference `'1`
    |                    let's call the lifetime of this reference `'2`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch.rs:13:58
    |
 LL |     fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }

--- a/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self-async.rs:13:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     async fn ref_self(&self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
@@ -48,7 +48,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self-async.rs:35:9
    |
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {

--- a/src/test/ui/self/elision/lt-ref-self.nll.stderr
+++ b/src/test/ui/self/elision/lt-ref-self.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self.rs:11:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     fn ref_self(&self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self.rs:17:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self.rs:21:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self.rs:25:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self.rs:29:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
@@ -48,7 +48,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/lt-ref-self.rs:33:9
    |
 LL |     fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {

--- a/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self-async.rs:13:9
    |
 LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
@@ -48,7 +48,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self-async.rs:35:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {

--- a/src/test/ui/self/elision/ref-mut-self.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-self.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self.rs:11:9
    |
 LL |     fn ref_self(&mut self, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     fn ref_self(&mut self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self.rs:17:9
    |
 LL |     fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self.rs:21:9
    |
 LL |     fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self.rs:25:9
    |
 LL |     fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self.rs:29:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
@@ -48,7 +48,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-self.rs:33:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {

--- a/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct-async.rs:13:9
    |
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct-async.rs:29:9
    |
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {

--- a/src/test/ui/self/elision/ref-mut-struct.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct.rs:11:9
    |
 LL |     fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct.rs:15:9
    |
 LL |     fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct.rs:19:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct.rs:23:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-mut-struct.rs:27:9
    |
 LL |     fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {

--- a/src/test/ui/self/elision/ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-self-async.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self-async.rs:23:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     async fn ref_self(&self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self-async.rs:29:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self-async.rs:33:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self-async.rs:37:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self-async.rs:41:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
@@ -48,7 +48,7 @@ LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self-async.rs:45:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
@@ -58,7 +58,7 @@ LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self-async.rs:49:9
    |
 LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {

--- a/src/test/ui/self/elision/ref-self.nll.stderr
+++ b/src/test/ui/self/elision/ref-self.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self.rs:21:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     fn ref_self(&self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self.rs:27:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self.rs:31:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self.rs:35:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self.rs:39:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
@@ -48,7 +48,7 @@ LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self.rs:43:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
@@ -58,7 +58,7 @@ LL |     fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-self.rs:47:9
    |
 LL |     fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {

--- a/src/test/ui/self/elision/ref-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct-async.rs:13:9
    |
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct-async.rs:29:9
    |
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {

--- a/src/test/ui/self/elision/ref-struct.nll.stderr
+++ b/src/test/ui/self/elision/ref-struct.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct.rs:11:9
    |
 LL |     fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
@@ -8,7 +8,7 @@ LL |     fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct.rs:15:9
    |
 LL |     fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
@@ -18,7 +18,7 @@ LL |     fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct.rs:19:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
@@ -28,7 +28,7 @@ LL |     fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct.rs:23:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
@@ -38,7 +38,7 @@ LL |     fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
 LL |         f
    |         ^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/ref-struct.rs:27:9
    |
 LL |     fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
@@ -6,7 +6,7 @@ LL | fn baz<G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
    |        |
    |        help: consider introducing lifetime `'a` here: `'a,`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/missing-lifetimes-in-signature.rs:15:37
    |
 LL | fn foo<G, T>(g: G, dest: &mut T) -> impl FnOnce()

--- a/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/trait-object-nested-in-impl-trait.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/trait-object-nested-in-impl-trait.rs:27:23
    |
 LL |     fn iter(&self) -> impl Iterator<Item = Box<dyn Foo>> {
@@ -11,7 +11,7 @@ help: to allow this `impl Trait` to capture borrowed data with lifetime `'1`, ad
 LL |     fn iter(&self) -> impl Iterator<Item = Box<dyn Foo>> + '_ {
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/trait-object-nested-in-impl-trait.rs:39:9
    |
 LL |       fn iter(&self) -> impl Iterator<Item = Box<dyn Foo>> + '_ {
@@ -22,7 +22,7 @@ LL | |             remaining: self.0.iter(),
 LL | |         }
    | |_________^ returning this value requires that `'1` must outlive `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/trait-object-nested-in-impl-trait.rs:50:9
    |
 LL |       fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> + 'a {
@@ -35,7 +35,7 @@ LL | |         }
    |
    = help: consider replacing `'a` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/trait-object-nested-in-impl-trait.rs:60:30
    |
 LL |     fn iter<'a>(&'a self) -> impl Iterator<Item = Box<dyn Foo>> {

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:17:9
    |
 LL |     doit(0, &|x, y| {

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/dyn-trait-underscore.rs:8:5
    |
 LL | fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.nll.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/underscore-lifetime-elison-mismatch.rs:1:42
    |
 LL | fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); }

--- a/src/test/ui/variance/variance-associated-types2.nll.stderr
+++ b/src/test/ui/variance/variance-associated-types2.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-associated-types2.rs:13:12
    |
 LL | fn take<'a>(_: &'a u32) {

--- a/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:4:5
    |
 LL | fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
@@ -8,7 +8,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:7:5
    |
 LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
@@ -18,7 +18,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:10:5
    |
 LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
@@ -28,7 +28,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:13:5
    |
 LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
@@ -38,7 +38,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:18:5
    |
 LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
@@ -49,7 +49,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:22:5
    |
 LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
@@ -60,7 +60,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:26:5
    |
 LL | fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
@@ -71,7 +71,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:30:5
    |
 LL | fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
@@ -82,7 +82,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:35:5
    |
 LL | fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
@@ -93,7 +93,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:39:5
    |
 LL | fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
@@ -104,7 +104,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:43:5
    |
 LL | fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
@@ -115,7 +115,7 @@ LL |     v
    |
    = help: consider replacing `'new` with `'static`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-btree-invariant-types.rs:47:5
    |
 LL | fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)

--- a/src/test/ui/variance/variance-cell-is-invariant.nll.stderr
+++ b/src/test/ui/variance/variance-cell-is-invariant.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-cell-is-invariant.rs:14:12
    |
 LL | fn use_<'short,'long>(c: Foo<'short>,

--- a/src/test/ui/variance/variance-contravariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-object.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-contravariant-arg-object.rs:14:5
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
@@ -11,7 +11,7 @@ LL |     v
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-contravariant-arg-object.rs:22:5
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-contravariant-arg-trait-match.rs:13:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -11,7 +11,7 @@ LL |     impls_get::<G,&'min i32>()
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-contravariant-arg-trait-match.rs:21:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-contravariant-self-trait-match.rs:13:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -11,7 +11,7 @@ LL |     impls_get::<&'min G>();
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-contravariant-self-trait-match.rs:22:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-covariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-object.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-covariant-arg-object.rs:15:5
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
@@ -11,7 +11,7 @@ LL |     v
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-covariant-arg-object.rs:22:5
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-covariant-arg-trait-match.rs:14:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -11,7 +11,7 @@ LL |     impls_get::<G,&'min i32>()
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-covariant-arg-trait-match.rs:20:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-covariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-covariant-self-trait-match.rs:14:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -11,7 +11,7 @@ LL |     impls_get::<&'min G>();
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-covariant-self-trait-match.rs:20:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-invariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-object.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-invariant-arg-object.rs:11:5
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
@@ -11,7 +11,7 @@ LL |     v
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-invariant-arg-object.rs:18:5
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-invariant-arg-trait-match.rs:10:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -11,7 +11,7 @@ LL |     impls_get::<G,&'min i32>()
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-invariant-arg-trait-match.rs:16:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-invariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-invariant-self-trait-match.rs:10:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
@@ -11,7 +11,7 @@ LL |     impls_get::<&'min G>();
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-invariant-self-trait-match.rs:16:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()

--- a/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-use-contravariant-struct-1.rs:12:5
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)

--- a/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-use-covariant-struct-1.rs:10:5
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)

--- a/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-use-invariant-struct-1.rs:12:5
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
@@ -11,7 +11,7 @@ LL |     v
    |
    = help: consider adding the following bound: `'min: 'max`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/variance-use-invariant-struct-1.rs:19:5
    |
 LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)

--- a/src/test/ui/wf/wf-static-method.nll.stderr
+++ b/src/test/ui/wf/wf-static-method.nll.stderr
@@ -1,4 +1,4 @@
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-static-method.rs:17:9
    |
 LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
@@ -11,7 +11,7 @@ LL |         u
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-static-method.rs:26:18
    |
 LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
@@ -24,7 +24,7 @@ LL |         let me = Self::make_me();
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-static-method.rs:33:9
    |
 LL | impl<'a, 'b> Evil<'a, 'b> {
@@ -37,7 +37,7 @@ LL |         u
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-static-method.rs:41:5
    |
 LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
@@ -49,7 +49,7 @@ LL |     <()>::static_evil(b)
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-static-method.rs:45:5
    |
 LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
@@ -61,7 +61,7 @@ LL |     <IndirectEvil>::static_evil(b)
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error: lifetime may not live long enough
+error: lifetime may not be long enough
   --> $DIR/wf-static-method.rs:50:5
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {


### PR DESCRIPTION
"lifetime may not live long enough" -> "lifetime may not be long enough"

Saying "lifetime may not live long enough" is kind of redundant and also
confusing. It's not that the lifetime isn't *living* long enough, it's
that the lifetime isn't long enough: A lifetime doesn't have its own
lifetime!
