### PR TITLE
Rollup of 14 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -796,7 +796,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
 
     fn visit_expr(&mut self, expr: &'a Expr) {
         match &expr.kind {
-            ExprKind::LlvmInlineAsm(..) if !self.session.target.options.allow_asm => {
+            ExprKind::LlvmInlineAsm(..) if !self.session.target.allow_asm => {
                 struct_span_err!(
                     self.session,
                     expr.span,

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -37,7 +37,7 @@ struct TestCtxt<'a> {
 pub fn inject(sess: &Session, resolver: &mut dyn ResolverExpand, krate: &mut ast::Crate) {
     let span_diagnostic = sess.diagnostic();
     let panic_strategy = sess.panic_strategy();
-    let platform_panic_strategy = sess.target.options.panic_strategy;
+    let platform_panic_strategy = sess.target.panic_strategy;
 
     // Check for #![reexport_test_harness_main = "some_name"] which gives the
     // main test function the name `some_name` without hygiene. This needs to be

--- a/compiler/rustc_codegen_cranelift/src/archive.rs
+++ b/compiler/rustc_codegen_cranelift/src/archive.rs
@@ -63,9 +63,9 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
             sess,
             dst: output.to_path_buf(),
             lib_search_paths: archive_search_paths(sess),
-            use_gnu_style_archive: sess.target.options.archive_format == "gnu",
+            use_gnu_style_archive: sess.target.archive_format == "gnu",
             // FIXME fix builtin ranlib on macOS
-            no_builtin_ranlib: sess.target.options.is_like_osx,
+            no_builtin_ranlib: sess.target.is_like_osx,
 
             src_archives,
             entries,

--- a/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/mod.rs
@@ -50,7 +50,7 @@ impl<'tcx> DebugContext<'tcx> {
             // TODO: this should be configurable
             // macOS doesn't seem to support DWARF > 3
             // 5 version is required for md5 file hash
-            version: if tcx.sess.target.options.is_like_osx {
+            version: if tcx.sess.target.is_like_osx {
                 3
             } else {
                 // FIXME change to version 5 once the gdb and lldb shipping with the latest debian

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -320,8 +320,8 @@ fn codegen_global_asm(tcx: TyCtxt<'_>, cgu_name: &str, global_asm: &str) {
     }
 
     if cfg!(not(feature = "inline_asm"))
-        || tcx.sess.target.options.is_like_osx
-        || tcx.sess.target.options.is_like_windows
+        || tcx.sess.target.is_like_osx
+        || tcx.sess.target.is_like_windows
     {
         if global_asm.contains("__rust_probestack") {
             return;

--- a/compiler/rustc_codegen_cranelift/src/metadata.rs
+++ b/compiler/rustc_codegen_cranelift/src/metadata.rs
@@ -101,7 +101,7 @@ pub(crate) fn write_metadata<P: WriteMetadata>(
     product.add_rustc_section(
         rustc_middle::middle::exported_symbols::metadata_symbol_name(tcx),
         compressed,
-        tcx.sess.target.options.is_like_osx,
+        tcx.sess.target.is_like_osx,
     );
 
     metadata

--- a/compiler/rustc_codegen_cranelift/src/toolchain.rs
+++ b/compiler/rustc_codegen_cranelift/src/toolchain.rs
@@ -91,7 +91,7 @@ fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                 } else if stem == "link" || stem == "lld-link" {
                     LinkerFlavor::Msvc
                 } else if stem == "lld" || stem == "rust-lld" {
-                    LinkerFlavor::Lld(sess.target.options.lld_flavor)
+                    LinkerFlavor::Lld(sess.target.lld_flavor)
                 } else {
                     // fall back to the value in the target spec
                     sess.target.linker_flavor
@@ -115,7 +115,7 @@ fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
 
     if let Some(ret) = infer_from(
         sess,
-        sess.target.options.linker.clone().map(PathBuf::from),
+        sess.target.linker.clone().map(PathBuf::from),
         Some(sess.target.linker_flavor),
     ) {
         return ret;

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -57,7 +57,7 @@ pub(crate) unsafe fn codegen(
         let name = format!("__rust_{}", method.name);
         let llfn = llvm::LLVMRustGetOrInsertFunction(llmod, name.as_ptr().cast(), name.len(), ty);
 
-        if tcx.sess.target.options.default_hidden_visibility {
+        if tcx.sess.target.default_hidden_visibility {
             llvm::LLVMRustSetVisibility(llfn, llvm::Visibility::Hidden);
         }
         if tcx.sess.must_emit_unwind_tables() {
@@ -98,7 +98,7 @@ pub(crate) unsafe fn codegen(
     // -> ! DIFlagNoReturn
     llvm::Attribute::NoReturn.apply_llfn(llvm::AttributePlace::Function, llfn);
 
-    if tcx.sess.target.options.default_hidden_visibility {
+    if tcx.sess.target.default_hidden_visibility {
         llvm::LLVMRustSetVisibility(llfn, llvm::Visibility::Hidden);
     }
     if tcx.sess.must_emit_unwind_tables() {

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -90,7 +90,7 @@ fn set_instrument_function(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
 
         // The function name varies on platforms.
         // See test/CodeGen/mcount.c in clang.
-        let mcount_name = CString::new(cx.sess().target.target_mcount.as_str().as_bytes()).unwrap();
+        let mcount_name = CString::new(cx.sess().target.mcount.as_str().as_bytes()).unwrap();
 
         llvm::AddFunctionAttrStringValue(
             llfn,

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -90,8 +90,7 @@ fn set_instrument_function(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
 
         // The function name varies on platforms.
         // See test/CodeGen/mcount.c in clang.
-        let mcount_name =
-            CString::new(cx.sess().target.options.target_mcount.as_str().as_bytes()).unwrap();
+        let mcount_name = CString::new(cx.sess().target.target_mcount.as_str().as_bytes()).unwrap();
 
         llvm::AddFunctionAttrStringValue(
             llfn,
@@ -105,7 +104,7 @@ fn set_instrument_function(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
 fn set_probestack(cx: &CodegenCx<'ll, '_>, llfn: &'ll Value) {
     // Only use stack probes if the target specification indicates that we
     // should be using stack probes
-    if !cx.sess().target.options.stack_probes {
+    if !cx.sess().target.stack_probes {
         return;
     }
 
@@ -174,7 +173,6 @@ pub fn llvm_target_features(sess: &Session) -> impl Iterator<Item = &str> {
         .split(',')
         .filter(|f| !RUSTC_SPECIFIC_FEATURES.iter().any(|s| f.contains(s)));
     sess.target
-        .options
         .features
         .split(',')
         .chain(cmdline)

--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -206,7 +206,7 @@ impl<'a> LlvmArchiveBuilder<'a> {
     }
 
     fn llvm_archive_kind(&self) -> Result<ArchiveKind, &str> {
-        let kind = &*self.config.sess.target.options.archive_format;
+        let kind = &*self.config.sess.target.archive_format;
         kind.parse().map_err(|_| kind)
     }
 

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -129,13 +129,13 @@ pub fn target_machine_factory(
     let use_softfp = sess.opts.cg.soft_float;
 
     let ffunction_sections =
-        sess.opts.debugging_opts.function_sections.unwrap_or(sess.target.options.function_sections);
+        sess.opts.debugging_opts.function_sections.unwrap_or(sess.target.function_sections);
     let fdata_sections = ffunction_sections;
 
     let code_model = to_llvm_code_model(sess.code_model());
 
     let features = attributes::llvm_target_features(sess).collect::<Vec<_>>();
-    let mut singlethread = sess.target.options.singlethread;
+    let mut singlethread = sess.target.singlethread;
 
     // On the wasm target once the `atomics` feature is enabled that means that
     // we're no longer single-threaded, or otherwise we don't want LLVM to
@@ -151,22 +151,16 @@ pub fn target_machine_factory(
     let cpu = SmallCStr::new(llvm_util::target_cpu(sess));
     let features = features.join(",");
     let features = CString::new(features).unwrap();
-    let abi = SmallCStr::new(&sess.target.options.llvm_abiname);
-    let trap_unreachable = sess.target.options.trap_unreachable;
+    let abi = SmallCStr::new(&sess.target.llvm_abiname);
+    let trap_unreachable = sess.target.trap_unreachable;
     let emit_stack_size_section = sess.opts.debugging_opts.emit_stack_sizes;
 
     let asm_comments = sess.asm_comments();
-    let relax_elf_relocations = sess
-        .opts
-        .debugging_opts
-        .relax_elf_relocations
-        .unwrap_or(sess.target.options.relax_elf_relocations);
+    let relax_elf_relocations =
+        sess.opts.debugging_opts.relax_elf_relocations.unwrap_or(sess.target.relax_elf_relocations);
 
-    let use_init_array = !sess
-        .opts
-        .debugging_opts
-        .use_ctors_section
-        .unwrap_or(sess.target.options.use_ctors_section);
+    let use_init_array =
+        !sess.opts.debugging_opts.use_ctors_section.unwrap_or(sess.target.use_ctors_section);
 
     Arc::new(move || {
         let tm = unsafe {

--- a/compiler/rustc_codegen_llvm/src/callee.rs
+++ b/compiler/rustc_codegen_llvm/src/callee.rs
@@ -176,7 +176,7 @@ pub fn get_fn(cx: &CodegenCx<'ll, 'tcx>, instance: Instance<'tcx>) -> &'ll Value
         // should use dllimport for functions.
         if cx.use_dll_storage_attrs
             && tcx.is_dllimport_foreign_item(instance_def_id)
-            && tcx.sess.target.target_env != "gnu"
+            && tcx.sess.target.env != "gnu"
         {
             unsafe {
                 llvm::LLVMSetDLLStorageClass(llfn, llvm::DLLStorageClass::DllImport);

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -91,7 +91,7 @@ fn set_global_alignment(cx: &CodegenCx<'ll, '_>, gv: &'ll Value, mut align: Alig
     // The target may require greater alignment for globals than the type does.
     // Note: GCC and Clang also allow `__attribute__((aligned))` on variables,
     // which can force it to be smaller.  Rust doesn't support this yet.
-    if let Some(min) = cx.sess().target.options.min_global_align {
+    if let Some(min) = cx.sess().target.min_global_align {
         match Align::from_bits(min) {
             Ok(min) => align = align.max(min),
             Err(err) => {
@@ -283,7 +283,7 @@ impl CodegenCx<'ll, 'tcx> {
             // argument validation.
             debug_assert!(
                 !(self.tcx.sess.opts.cg.linker_plugin_lto.enabled()
-                    && self.tcx.sess.target.options.is_like_windows
+                    && self.tcx.sess.target.is_like_windows
                     && self.tcx.sess.opts.cg.prefer_dynamic)
             );
 
@@ -435,7 +435,7 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
                 // will use load-unaligned instructions instead, and thus avoiding the crash.
                 //
                 // We could remove this hack whenever we decide to drop macOS 10.10 support.
-                if self.tcx.sess.target.options.is_like_osx {
+                if self.tcx.sess.target.is_like_osx {
                     // The `inspect` method is okay here because we checked relocations, and
                     // because we are doing this access to inspect the final interpreter state
                     // (not as part of the interpreter execution).

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -129,7 +129,7 @@ pub unsafe fn create_module(
     }
 
     // Ensure the data-layout values hardcoded remain the defaults.
-    if sess.target.options.is_builtin {
+    if sess.target.is_builtin {
         let tm = crate::back::write::create_informational_target_machine(tcx.sess);
         llvm::LLVMRustSetDataLayoutFromTargetMachine(llmod, tm);
         llvm::LLVMRustDisposeTargetMachine(tm);
@@ -190,7 +190,7 @@ pub unsafe fn create_module(
     }
 
     // Control Flow Guard is currently only supported by the MSVC linker on Windows.
-    if sess.target.options.is_like_msvc {
+    if sess.target.is_like_msvc {
         match sess.opts.cg.control_flow_guard {
             CFGuard::Disabled => {}
             CFGuard::NoChecks => {
@@ -265,7 +265,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
         // linker will take care of everything. Fixing this problem will likely
         // require adding a few attributes to Rust itself (feature gated at the
         // start) and then strongly recommending static linkage on Windows!
-        let use_dll_storage_attrs = tcx.sess.target.options.is_like_windows;
+        let use_dll_storage_attrs = tcx.sess.target.is_like_windows;
 
         let check_overflow = tcx.sess.overflow_checks();
 
@@ -839,7 +839,7 @@ impl CodegenCx<'b, 'tcx> {
             return eh_catch_typeinfo;
         }
         let tcx = self.tcx;
-        assert!(self.sess().target.options.is_like_emscripten);
+        assert!(self.sess().target.is_like_emscripten);
         let eh_catch_typeinfo = match tcx.lang_items().eh_catch_typeinfo() {
             Some(def_id) => self.get_static(def_id),
             _ => {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
@@ -67,5 +67,5 @@ pub fn needs_gdb_debug_scripts_section(cx: &CodegenCx<'_, '_>) -> bool {
 
     !omit_gdb_pretty_printer_section
         && cx.sess().opts.debuginfo != DebugInfo::None
-        && cx.sess().target.options.emit_debug_gdb_scripts
+        && cx.sess().target.emit_debug_gdb_scripts
 }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -870,7 +870,7 @@ fn basic_type_metadata(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll DIType {
 
     // When targeting MSVC, emit MSVC style type names for compatibility with
     // .natvis visualizers (and perhaps other existing native debuggers?)
-    let msvc_like_names = cx.tcx.sess.target.options.is_like_msvc;
+    let msvc_like_names = cx.tcx.sess.target.is_like_msvc;
 
     let (name, encoding) = match t.kind() {
         ty::Never => ("!", DW_ATE_unsigned),
@@ -981,7 +981,7 @@ pub fn compile_unit_metadata(
     // if multiple object files with the same `DW_AT_name` are linked together.
     // As a workaround we generate unique names for each object file. Those do
     // not correspond to an actual source file but that should be harmless.
-    if tcx.sess.target.options.is_like_osx {
+    if tcx.sess.target.is_like_osx {
         name_in_debuginfo.push("@");
         name_in_debuginfo.push(codegen_unit_name);
     }
@@ -1397,7 +1397,7 @@ fn prepare_union_metadata(
 /// on MSVC we have to use the fallback mode, because LLVM doesn't
 /// lower variant parts to PDB.
 fn use_enum_fallback(cx: &CodegenCx<'_, '_>) -> bool {
-    cx.sess().target.options.is_like_msvc
+    cx.sess().target.is_like_msvc
 }
 
 // FIXME(eddyb) maybe precompute this? Right now it's computed once

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -122,12 +122,12 @@ pub fn finalize(cx: &CodegenCx<'_, '_>) {
         // for macOS to understand. For more info see #11352
         // This can be overridden using --llvm-opts -dwarf-version,N.
         // Android has the same issue (#22398)
-        if let Some(version) = cx.sess().target.options.dwarf_version {
+        if let Some(version) = cx.sess().target.dwarf_version {
             llvm::LLVMRustAddModuleFlag(cx.llmod, "Dwarf Version\0".as_ptr().cast(), version)
         }
 
         // Indicate that we want CodeView debug information on MSVC
-        if cx.sess().target.options.is_like_msvc {
+        if cx.sess().target.is_like_msvc {
             llvm::LLVMRustAddModuleFlag(cx.llmod, "CodeView\0".as_ptr().cast(), 1)
         }
 
@@ -251,7 +251,7 @@ impl CodegenCx<'ll, '_> {
         // For MSVC, omit the column number.
         // Otherwise, emit it. This mimics clang behaviour.
         // See discussion in https://github.com/rust-lang/rust/issues/42921
-        if self.sess().target.options.is_like_msvc {
+        if self.sess().target.is_like_msvc {
             DebugLoc { file, line, col: None }
         } else {
             DebugLoc { file, line, col }
@@ -387,7 +387,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             });
 
             // Arguments types
-            if cx.sess().target.options.is_like_msvc {
+            if cx.sess().target.is_like_msvc {
                 // FIXME(#42800):
                 // There is a bug in MSDIA that leads to a crash when it encounters
                 // a fixed-size array of `u8` or something zero-sized in a

--- a/compiler/rustc_codegen_llvm/src/declare.rs
+++ b/compiler/rustc_codegen_llvm/src/declare.rs
@@ -42,7 +42,7 @@ fn declare_raw_fn(
     // be merged.
     llvm::SetUnnamedAddress(llfn, llvm::UnnamedAddr::Global);
 
-    if cx.tcx.sess.opts.cg.no_redzone.unwrap_or(cx.tcx.sess.target.options.disable_redzone) {
+    if cx.tcx.sess.opts.cg.no_redzone.unwrap_or(cx.tcx.sess.target.disable_redzone) {
         llvm::Attribute::NoRedZone.apply_llfn(Function, llfn);
     }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -367,7 +367,7 @@ fn try_intrinsic(
         bx.store(bx.const_i32(0), dest, ret_align);
     } else if wants_msvc_seh(bx.sess()) {
         codegen_msvc_try(bx, try_func, data, catch_func, dest);
-    } else if bx.sess().target.options.is_like_emscripten {
+    } else if bx.sess().target.is_like_emscripten {
         codegen_emcc_try(bx, try_func, data, catch_func, dest);
     } else {
         codegen_gnu_try(bx, try_func, data, catch_func, dest);

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -46,7 +46,7 @@ fn require_inited() {
 }
 
 unsafe fn configure_llvm(sess: &Session) {
-    let n_args = sess.opts.cg.llvm_args.len() + sess.target.options.llvm_args.len();
+    let n_args = sess.opts.cg.llvm_args.len() + sess.target.llvm_args.len();
     let mut llvm_c_strs = Vec::with_capacity(n_args + 1);
     let mut llvm_args = Vec::with_capacity(n_args + 1);
 
@@ -57,7 +57,7 @@ unsafe fn configure_llvm(sess: &Session) {
     }
 
     let cg_opts = sess.opts.cg.llvm_args.iter();
-    let tg_opts = sess.target.options.llvm_args.iter();
+    let tg_opts = sess.target.llvm_args.iter();
     let sess_args = cg_opts.chain(tg_opts);
 
     let user_specified_args: FxHashSet<_> =
@@ -84,12 +84,7 @@ unsafe fn configure_llvm(sess: &Session) {
         if !sess.opts.debugging_opts.no_generate_arange_section {
             add("-generate-arange-section", false);
         }
-        match sess
-            .opts
-            .debugging_opts
-            .merge_functions
-            .unwrap_or(sess.target.options.merge_functions)
-        {
+        match sess.opts.debugging_opts.merge_functions.unwrap_or(sess.target.merge_functions) {
             MergeFunctions::Disabled | MergeFunctions::Trampolines => {}
             MergeFunctions::Aliases => {
                 add("-mergefunc-use-aliases", false);
@@ -215,7 +210,7 @@ fn handle_native(name: &str) -> &str {
 pub fn target_cpu(sess: &Session) -> &str {
     let name = match sess.opts.cg.target_cpu {
         Some(ref s) => &**s,
-        None => &*sess.target.options.cpu,
+        None => &*sess.target.cpu,
     };
 
     handle_native(name)

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -91,7 +91,7 @@ unsafe fn configure_llvm(sess: &Session) {
             }
         }
 
-        if sess.target.target_os == "emscripten" && sess.panic_strategy() == PanicStrategy::Unwind {
+        if sess.target.os == "emscripten" && sess.panic_strategy() == PanicStrategy::Unwind {
             add("-enable-emscripten-cxx-exceptions", false);
         }
 

--- a/compiler/rustc_codegen_llvm/src/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/metadata.rs
@@ -104,7 +104,7 @@ pub fn metadata_section_name(target: &Target) -> &'static str {
     // As a result, we choose a slightly shorter name! As to why
     // `.note.rustc` works on MinGW, that's another good question...
 
-    if target.options.is_like_osx { "__DATA,.rustc" } else { ".rustc" }
+    if target.is_like_osx { "__DATA,.rustc" } else { ".rustc" }
 }
 
 fn read_metadata_section_name(_target: &Target) -> &'static str {

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -52,7 +52,7 @@ fn emit_direct_ptr_va_arg(
     let next = bx.inbounds_gep(addr, &[full_direct_size]);
     bx.store(next, va_list_addr, bx.tcx().data_layout.pointer_align.abi);
 
-    if size.bytes() < slot_size.bytes() && &*bx.tcx().sess.target.target_endian == "big" {
+    if size.bytes() < slot_size.bytes() && &*bx.tcx().sess.target.endian == "big" {
         let adjusted_size = bx.cx().const_i32((slot_size.bytes() - size.bytes()) as i32);
         let adjusted = bx.inbounds_gep(addr, &[adjusted_size]);
         (bx.bitcast(adjusted, bx.cx().type_ptr_to(llty)), addr_align)
@@ -105,7 +105,7 @@ fn emit_aapcs_va_arg(
     let mut end = bx.build_sibling_block("va_arg.end");
     let zero = bx.const_i32(0);
     let offset_align = Align::from_bytes(4).unwrap();
-    assert!(&*bx.tcx().sess.target.target_endian == "little");
+    assert!(&*bx.tcx().sess.target.endian == "little");
 
     let gr_type = target_ty.is_any_ptr() || target_ty.is_integral();
     let (reg_off, reg_top_index, slot_size) = if gr_type {

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -175,22 +175,22 @@ pub(super) fn emit_va_arg(
     let arch = &bx.cx.tcx.sess.target.arch;
     match &**arch {
         // Windows x86
-        "x86" if target.options.is_like_windows => {
+        "x86" if target.is_like_windows => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(4).unwrap(), false)
         }
         // Generic x86
         "x86" => emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(4).unwrap(), true),
         // Windows AArch64
-        "aarch64" if target.options.is_like_windows => {
+        "aarch64" if target.is_like_windows => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(8).unwrap(), false)
         }
         // macOS / iOS AArch64
-        "aarch64" if target.options.is_like_osx => {
+        "aarch64" if target.is_like_osx => {
             emit_ptr_va_arg(bx, addr, target_ty, false, Align::from_bytes(8).unwrap(), true)
         }
         "aarch64" => emit_aapcs_va_arg(bx, addr, target_ty),
         // Windows x86_64
-        "x86_64" if target.options.is_like_windows => {
+        "x86_64" if target.is_like_windows => {
             let target_ty_size = bx.cx.size_of(target_ty).bytes();
             let indirect: bool = target_ty_size > 8 || !target_ty_size.is_power_of_two();
             emit_ptr_va_arg(bx, addr, target_ty, indirect, Align::from_bytes(8).unwrap(), false)

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -7,10 +7,8 @@ use std::path::{Path, PathBuf};
 pub fn find_library(name: Symbol, search_paths: &[PathBuf], sess: &Session) -> PathBuf {
     // On Windows, static libraries sometimes show up as libfoo.a and other
     // times show up as foo.lib
-    let oslibname = format!(
-        "{}{}{}",
-        sess.target.options.staticlib_prefix, name, sess.target.options.staticlib_suffix
-    );
+    let oslibname =
+        format!("{}{}{}", sess.target.staticlib_prefix, name, sess.target.staticlib_suffix);
     let unixlibname = format!("lib{}.a", name);
 
     for path in search_paths {

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -163,7 +163,7 @@ fn get_linker(
     // MSVC needs to link with the Store versions of the runtime libraries (vcruntime, msvcrt, etc).
     let t = &sess.target;
     if (flavor == LinkerFlavor::Msvc || flavor == LinkerFlavor::Lld(LldFlavor::Link))
-        && t.target_vendor == "uwp"
+        && t.vendor == "uwp"
     {
         if let Some(ref tool) = msvc_tool {
             let original_path = tool.path();
@@ -1236,7 +1236,7 @@ fn crt_objects_fallback(sess: &Session, crate_type: CrateType) -> bool {
         Some(CrtObjectsFallback::Musl) => sess.crt_static(Some(crate_type)),
         Some(CrtObjectsFallback::Mingw) => {
             sess.host == sess.target
-                && sess.target.target_vendor != "uwp"
+                && sess.target.vendor != "uwp"
                 && detect_self_contained_mingw(&sess)
         }
         // FIXME: Figure out cases in which WASM needs to link with a native toolchain.
@@ -1510,7 +1510,7 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     let base_cmd = get_linker(sess, path, flavor, crt_objects_fallback);
     // FIXME: Move `/LIBPATH` addition for uwp targets from the linker construction
     // to the linker args construction.
-    assert!(base_cmd.get_args().is_empty() || sess.target.target_vendor == "uwp");
+    assert!(base_cmd.get_args().is_empty() || sess.target.vendor == "uwp");
     let cmd = &mut *codegen_results.linker_info.to_linker(base_cmd, &sess, flavor, target_cpu);
     let link_output_kind = link_output_kind(sess, crate_type);
 
@@ -2078,9 +2078,9 @@ fn are_upstream_rust_objects_already_included(sess: &Session) -> bool {
 
 fn add_apple_sdk(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor) {
     let arch = &sess.target.arch;
-    let os = &sess.target.target_os;
+    let os = &sess.target.os;
     let llvm_target = &sess.target.llvm_target;
-    if sess.target.target_vendor != "apple"
+    if sess.target.vendor != "apple"
         || !matches!(os.as_str(), "ios" | "tvos")
         || flavor != LinkerFlavor::Gcc
     {

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -151,9 +151,7 @@ fn get_linker(
         Some(linker) if cfg!(windows) && linker.ends_with(".bat") => Command::bat_script(linker),
         _ => match flavor {
             LinkerFlavor::Lld(f) => Command::lld(linker, f),
-            LinkerFlavor::Msvc
-                if sess.opts.cg.linker.is_none() && sess.target.options.linker.is_none() =>
-            {
+            LinkerFlavor::Msvc if sess.opts.cg.linker.is_none() && sess.target.linker.is_none() => {
                 Command::new(msvc_tool.as_ref().map(|t| t.path()).unwrap_or(linker))
             }
             _ => Command::new(linker),
@@ -197,7 +195,7 @@ fn get_linker(
     // PATH for the child.
     let mut new_path = sess.host_filesearch(PathKind::All).get_tools_search_paths(self_contained);
     let mut msvc_changed_path = false;
-    if sess.target.options.is_like_msvc {
+    if sess.target.is_like_msvc {
         if let Some(ref tool) = msvc_tool {
             cmd.args(tool.args());
             for &(ref k, ref v) in tool.env() {
@@ -365,7 +363,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
             // After adding all files to the archive, we need to update the
             // symbol table of the archive. This currently dies on macOS (see
             // #11162), and isn't necessary there anyway
-            if !sess.target.options.is_like_osx {
+            if !sess.target.is_like_osx {
                 ab.update_symbols();
             }
         }
@@ -476,10 +474,10 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
 
     linker::disable_localization(&mut cmd);
 
-    for &(ref k, ref v) in &sess.target.options.link_env {
+    for &(ref k, ref v) in &sess.target.link_env {
         cmd.env(k, v);
     }
-    for k in &sess.target.options.link_env_remove {
+    for k in &sess.target.link_env_remove {
         cmd.env_remove(k);
     }
 
@@ -515,7 +513,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
         // if the linker doesn't support -no-pie then it should not default to
         // linking executables as pie. Different versions of gcc seem to use
         // different quotes in the error message so don't check for them.
-        if sess.target.options.linker_is_gnu
+        if sess.target.linker_is_gnu
             && flavor != LinkerFlavor::Ld
             && (out.contains("unrecognized command line option")
                 || out.contains("unknown argument"))
@@ -535,7 +533,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
 
         // Detect '-static-pie' used with an older version of gcc or clang not supporting it.
         // Fallback from '-static-pie' to '-static' in that case.
-        if sess.target.options.linker_is_gnu
+        if sess.target.linker_is_gnu
             && flavor != LinkerFlavor::Ld
             && (out.contains("unrecognized command line option")
                 || out.contains("unknown argument"))
@@ -548,7 +546,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
             );
             // Mirror `add_(pre,post)_link_objects` to replace CRT objects.
             let self_contained = crt_objects_fallback(sess, crate_type);
-            let opts = &sess.target.options;
+            let opts = &sess.target;
             let pre_objects = if self_contained {
                 &opts.pre_link_objects_fallback
             } else {
@@ -670,7 +668,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
                 // is not a Microsoft LNK error then suggest a way to fix or
                 // install the Visual Studio build tools.
                 if let Some(code) = prog.status.code() {
-                    if sess.target.options.is_like_msvc
+                    if sess.target.is_like_msvc
                         && flavor == LinkerFlavor::Msvc
                         // Respect the command line override
                         && sess.opts.cg.linker.is_none()
@@ -741,7 +739,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
 
             linker_error.emit();
 
-            if sess.target.options.is_like_msvc && linker_not_found {
+            if sess.target.is_like_msvc && linker_not_found {
                 sess.note_without_error(
                     "the msvc targets depend on the msvc linker \
                      but `link.exe` was not found",
@@ -758,7 +756,7 @@ fn link_natively<'a, B: ArchiveBuilder<'a>>(
     // On macOS, debuggers need this utility to get run to do some munging of
     // the symbols. Note, though, that if the object files are being preserved
     // for their debug information there's no need for us to run dsymutil.
-    if sess.target.options.is_like_osx
+    if sess.target.is_like_osx
         && sess.opts.debuginfo != DebugInfo::None
         && !preserve_objects_for_their_debuginfo(sess)
     {
@@ -775,9 +773,7 @@ fn link_sanitizers(sess: &Session, crate_type: CrateType, linker: &mut dyn Linke
     // executables only.
     let needs_runtime = match crate_type {
         CrateType::Executable => true,
-        CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro => {
-            sess.target.options.is_like_osx
-        }
+        CrateType::Dylib | CrateType::Cdylib | CrateType::ProcMacro => sess.target.is_like_osx,
         CrateType::Rlib | CrateType::Staticlib => false,
     };
 
@@ -846,7 +842,7 @@ pub fn ignored_for_lto(sess: &Session, info: &CrateInfo, cnum: CrateNum) -> bool
     // If our target enables builtin function lowering in LLVM then the
     // crates providing these functions don't participate in LTO (e.g.
     // no_builtins or compiler builtins crates).
-    !sess.target.options.no_builtins
+    !sess.target.no_builtins
         && (info.compiler_builtins == Some(cnum) || info.is_no_builtins.contains(&cnum))
 }
 
@@ -906,7 +902,7 @@ fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
                 } else if stem == "link" || stem == "lld-link" {
                     LinkerFlavor::Msvc
                 } else if stem == "lld" || stem == "rust-lld" {
-                    LinkerFlavor::Lld(sess.target.options.lld_flavor)
+                    LinkerFlavor::Lld(sess.target.lld_flavor)
                 } else {
                     // fall back to the value in the target spec
                     sess.target.linker_flavor
@@ -926,7 +922,7 @@ fn linker_and_flavor(sess: &Session) -> (PathBuf, LinkerFlavor) {
 
     if let Some(ret) = infer_from(
         sess,
-        sess.target.options.linker.clone().map(PathBuf::from),
+        sess.target.linker.clone().map(PathBuf::from),
         Some(sess.target.linker_flavor),
     ) {
         return ret;
@@ -962,7 +958,7 @@ fn preserve_objects_for_their_debuginfo(sess: &Session) -> bool {
     // Basically as a result this just means that if we're on OSX and we're
     // *not* running dsymutil then the object files are the only source of truth
     // for debug information, so we must preserve them.
-    if sess.target.options.is_like_osx {
+    if sess.target.is_like_osx {
         return !sess.opts.debugging_opts.run_dsymutil;
     }
 
@@ -988,7 +984,7 @@ fn print_native_static_libs(sess: &Session, all_native_libs: &[NativeLib]) {
                 NativeLibKind::StaticNoBundle
                 | NativeLibKind::Dylib
                 | NativeLibKind::Unspecified => {
-                    if sess.target.options.is_like_msvc {
+                    if sess.target.is_like_msvc {
                         Some(format!("{}.lib", name))
                     } else {
                         Some(format!("-l{}", name))
@@ -1070,13 +1066,13 @@ fn exec_linker(
     let mut args = String::new();
     for arg in cmd2.take_args() {
         args.push_str(
-            &Escape { arg: arg.to_str().unwrap(), is_like_msvc: sess.target.options.is_like_msvc }
+            &Escape { arg: arg.to_str().unwrap(), is_like_msvc: sess.target.is_like_msvc }
                 .to_string(),
         );
         args.push('\n');
     }
     let file = tmpdir.join("linker-arguments");
-    let bytes = if sess.target.options.is_like_msvc {
+    let bytes = if sess.target.is_like_msvc {
         let mut out = Vec::with_capacity((1 + args.len()) * 2);
         // start the stream with a UTF-16 BOM
         for c in std::iter::once(0xFEFF).chain(args.encode_utf16()) {
@@ -1192,7 +1188,7 @@ fn link_output_kind(sess: &Session, crate_type: CrateType) -> LinkOutputKind {
     };
 
     // Adjust the output kind to target capabilities.
-    let opts = &sess.target.options;
+    let opts = &sess.target;
     let pic_exe_supported = opts.position_independent_executables;
     let static_pic_exe_supported = opts.static_position_independent_executables;
     let static_dylib_supported = opts.crt_static_allows_dylibs;
@@ -1233,7 +1229,7 @@ fn crt_objects_fallback(sess: &Session, crate_type: CrateType) -> bool {
         return self_contained;
     }
 
-    match sess.target.options.crt_objects_fallback {
+    match sess.target.crt_objects_fallback {
         // FIXME: Find a better heuristic for "native musl toolchain is available",
         // based on host and linker path, for example.
         // (https://github.com/rust-lang/rust/pull/71769#issuecomment-626330237).
@@ -1256,7 +1252,7 @@ fn add_pre_link_objects(
     link_output_kind: LinkOutputKind,
     self_contained: bool,
 ) {
-    let opts = &sess.target.options;
+    let opts = &sess.target;
     let objects =
         if self_contained { &opts.pre_link_objects_fallback } else { &opts.pre_link_objects };
     for obj in objects.get(&link_output_kind).iter().copied().flatten() {
@@ -1271,7 +1267,7 @@ fn add_post_link_objects(
     link_output_kind: LinkOutputKind,
     self_contained: bool,
 ) {
-    let opts = &sess.target.options;
+    let opts = &sess.target;
     let objects =
         if self_contained { &opts.post_link_objects_fallback } else { &opts.post_link_objects };
     for obj in objects.get(&link_output_kind).iter().copied().flatten() {
@@ -1282,7 +1278,7 @@ fn add_post_link_objects(
 /// Add arbitrary "pre-link" args defined by the target spec or from command line.
 /// FIXME: Determine where exactly these args need to be inserted.
 fn add_pre_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor) {
-    if let Some(args) = sess.target.options.pre_link_args.get(&flavor) {
+    if let Some(args) = sess.target.pre_link_args.get(&flavor) {
         cmd.args(args);
     }
     cmd.args(&sess.opts.debugging_opts.pre_link_args);
@@ -1290,9 +1286,9 @@ fn add_pre_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor)
 
 /// Add a link script embedded in the target, if applicable.
 fn add_link_script(cmd: &mut dyn Linker, sess: &Session, tmpdir: &Path, crate_type: CrateType) {
-    match (crate_type, &sess.target.options.link_script) {
+    match (crate_type, &sess.target.link_script) {
         (CrateType::Cdylib | CrateType::Executable, Some(script)) => {
-            if !sess.target.options.linker_is_gnu {
+            if !sess.target.linker_is_gnu {
                 sess.fatal("can only use link script when linking with GNU-like linker");
             }
 
@@ -1335,15 +1331,15 @@ fn add_late_link_args(
             *ty == crate_type && list.iter().any(|&linkage| linkage == Linkage::Dynamic)
         });
     if any_dynamic_crate {
-        if let Some(args) = sess.target.options.late_link_args_dynamic.get(&flavor) {
+        if let Some(args) = sess.target.late_link_args_dynamic.get(&flavor) {
             cmd.args(args);
         }
     } else {
-        if let Some(args) = sess.target.options.late_link_args_static.get(&flavor) {
+        if let Some(args) = sess.target.late_link_args_static.get(&flavor) {
             cmd.args(args);
         }
     }
-    if let Some(args) = sess.target.options.late_link_args.get(&flavor) {
+    if let Some(args) = sess.target.late_link_args.get(&flavor) {
         cmd.args(args);
     }
 }
@@ -1351,7 +1347,7 @@ fn add_late_link_args(
 /// Add arbitrary "post-link" args defined by the target spec.
 /// FIXME: Determine where exactly these args need to be inserted.
 fn add_post_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor) {
-    if let Some(args) = sess.target.options.post_link_args.get(&flavor) {
+    if let Some(args) = sess.target.post_link_args.get(&flavor) {
         cmd.args(args);
     }
 }
@@ -1453,7 +1449,7 @@ fn add_library_search_dirs(cmd: &mut dyn Linker, sess: &Session, self_contained:
 /// Add options making relocation sections in the produced ELF files read-only
 /// and suppressing lazy binding.
 fn add_relro_args(cmd: &mut dyn Linker, sess: &Session) {
-    match sess.opts.debugging_opts.relro_level.unwrap_or(sess.target.options.relro_level) {
+    match sess.opts.debugging_opts.relro_level.unwrap_or(sess.target.relro_level) {
         RelroLevel::Full => cmd.full_relro(),
         RelroLevel::Partial => cmd.partial_relro(),
         RelroLevel::Off => cmd.no_relro(),
@@ -1484,9 +1480,9 @@ fn add_rpath_args(
         let mut rpath_config = RPathConfig {
             used_crates: &codegen_results.crate_info.used_crates_dynamic,
             out_filename: out_filename.to_path_buf(),
-            has_rpath: sess.target.options.has_rpath,
-            is_like_osx: sess.target.options.is_like_osx,
-            linker_is_gnu: sess.target.options.linker_is_gnu,
+            has_rpath: sess.target.has_rpath,
+            is_like_osx: sess.target.is_like_osx,
+            linker_is_gnu: sess.target.linker_is_gnu,
             get_install_prefix_lib_path: &mut get_install_prefix_lib_path,
         };
         cmd.args(&rpath::get_rpath_flags(&mut rpath_config));
@@ -1528,7 +1524,7 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     add_link_script(cmd, sess, tmpdir, crate_type);
 
     // NO-OPT-OUT, OBJECT-FILES-NO, AUDIT-ORDER
-    if sess.target.options.is_like_fuchsia && crate_type == CrateType::Executable {
+    if sess.target.is_like_fuchsia && crate_type == CrateType::Executable {
         let prefix = if sess.opts.debugging_opts.sanitizer.contains(SanitizerSet::ADDRESS) {
             "asan/"
         } else {
@@ -1538,7 +1534,7 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     }
 
     // NO-OPT-OUT, OBJECT-FILES-NO, AUDIT-ORDER
-    if sess.target.options.eh_frame_header {
+    if sess.target.eh_frame_header {
         cmd.add_eh_frame_header();
     }
 
@@ -1551,7 +1547,7 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     add_pre_link_objects(cmd, sess, link_output_kind, crt_objects_fallback);
 
     // NO-OPT-OUT, OBJECT-FILES-NO, AUDIT-ORDER
-    if sess.target.options.is_like_emscripten {
+    if sess.target.is_like_emscripten {
         cmd.arg("-s");
         cmd.arg(if sess.panic_strategy() == PanicStrategy::Abort {
             "DISABLE_EXCEPTION_CATCHING=1"
@@ -1579,7 +1575,7 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     cmd.output_filename(out_filename);
 
     // OBJECT-FILES-NO, AUDIT-ORDER
-    if crate_type == CrateType::Executable && sess.target.options.is_like_windows {
+    if crate_type == CrateType::Executable && sess.target.is_like_windows {
         if let Some(ref s) = codegen_results.windows_subsystem {
             cmd.subsystem(s);
         }
@@ -1623,7 +1619,7 @@ fn linker_with_args<'a, B: ArchiveBuilder<'a>>(
     // OBJECT-FILES-NO, AUDIT-ORDER
     // We want to prevent the compiler from accidentally leaking in any system libraries,
     // so by default we tell linkers not to link to any default libraries.
-    if !sess.opts.cg.default_linker_libraries && sess.target.options.no_default_libraries {
+    if !sess.opts.cg.default_linker_libraries && sess.target.no_default_libraries {
         cmd.no_default_libraries();
     }
 
@@ -1843,7 +1839,7 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
 
     // Converts a library file-stem into a cc -l argument
     fn unlib<'a>(target: &Target, stem: &'a str) -> &'a str {
-        if stem.starts_with("lib") && !target.options.is_like_windows { &stem[3..] } else { stem }
+        if stem.starts_with("lib") && !target.is_like_windows { &stem[3..] } else { stem }
     }
 
     // Adds the static "rlib" versions of all crates to the command line.
@@ -1938,7 +1934,7 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
                 // though, so we let that object file slide.
                 let skip_because_lto = are_upstream_rust_objects_already_included(sess)
                     && is_rust_object
-                    && (sess.target.options.no_builtins
+                    && (sess.target.no_builtins
                         || !codegen_results.crate_info.is_no_builtins.contains(&cnum));
 
                 if skip_because_cfg_say_so || skip_because_lto {

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -184,7 +184,7 @@ impl<'a> GccLinker<'a> {
         // * On OSX they have their own linker, not binutils'
         // * For WebAssembly the only functional linker is LLD, which doesn't
         //   support hint flags
-        !self.sess.target.options.is_like_osx && self.sess.target.arch != "wasm32"
+        !self.sess.target.is_like_osx && self.sess.target.arch != "wasm32"
     }
 
     // Some platforms take hints about whether a library is static or dynamic.
@@ -232,7 +232,7 @@ impl<'a> GccLinker<'a> {
 
     fn build_dylib(&mut self, out_filename: &Path) {
         // On mac we need to tell the linker to let this library be rpathed
-        if self.sess.target.options.is_like_osx {
+        if self.sess.target.is_like_osx {
             self.cmd.arg("-dynamiclib");
             self.linker_arg("-dylib");
 
@@ -248,7 +248,7 @@ impl<'a> GccLinker<'a> {
             }
         } else {
             self.cmd.arg("-shared");
-            if self.sess.target.options.is_like_windows {
+            if self.sess.target.is_like_windows {
                 // The output filename already contains `dll_suffix` so
                 // the resulting import library will have a name in the
                 // form of libfoo.dll.a
@@ -256,9 +256,9 @@ impl<'a> GccLinker<'a> {
                     out_filename.file_name().and_then(|file| file.to_str()).map(|file| {
                         format!(
                             "{}{}{}",
-                            self.sess.target.options.staticlib_prefix,
+                            self.sess.target.staticlib_prefix,
                             file,
-                            self.sess.target.options.staticlib_suffix
+                            self.sess.target.staticlib_suffix
                         )
                     });
                 if let Some(implib_name) = implib_name {
@@ -280,7 +280,7 @@ impl<'a> Linker for GccLinker<'a> {
     fn set_output_kind(&mut self, output_kind: LinkOutputKind, out_filename: &Path) {
         match output_kind {
             LinkOutputKind::DynamicNoPicExe => {
-                if !self.is_ld && self.sess.target.options.linker_is_gnu {
+                if !self.is_ld && self.sess.target.linker_is_gnu {
                     self.cmd.arg("-no-pie");
                 }
             }
@@ -291,7 +291,7 @@ impl<'a> Linker for GccLinker<'a> {
             LinkOutputKind::StaticNoPicExe => {
                 // `-static` works for both gcc wrapper and ld.
                 self.cmd.arg("-static");
-                if !self.is_ld && self.sess.target.options.linker_is_gnu {
+                if !self.is_ld && self.sess.target.linker_is_gnu {
                     self.cmd.arg("-no-pie");
                 }
             }
@@ -386,7 +386,7 @@ impl<'a> Linker for GccLinker<'a> {
     fn link_whole_staticlib(&mut self, lib: Symbol, search_path: &[PathBuf]) {
         self.hint_static();
         let target = &self.sess.target;
-        if !target.options.is_like_osx {
+        if !target.is_like_osx {
             self.linker_arg("--whole-archive").cmd.arg(format!("-l{}", lib));
             self.linker_arg("--no-whole-archive");
         } else {
@@ -400,7 +400,7 @@ impl<'a> Linker for GccLinker<'a> {
 
     fn link_whole_rlib(&mut self, lib: &Path) {
         self.hint_static();
-        if self.sess.target.options.is_like_osx {
+        if self.sess.target.is_like_osx {
             self.linker_arg("-force_load");
             self.linker_arg(&lib);
         } else {
@@ -424,9 +424,9 @@ impl<'a> Linker for GccLinker<'a> {
         // -dead_strip can't be part of the pre_link_args because it's also used
         // for partial linking when using multiple codegen units (-r).  So we
         // insert it here.
-        if self.sess.target.options.is_like_osx {
+        if self.sess.target.is_like_osx {
             self.linker_arg("-dead_strip");
-        } else if self.sess.target.options.is_like_solaris {
+        } else if self.sess.target.is_like_solaris {
             self.linker_arg("-zignore");
 
         // If we're building a dylib, we don't use --gc-sections because LLVM
@@ -440,7 +440,7 @@ impl<'a> Linker for GccLinker<'a> {
     }
 
     fn optimize(&mut self) {
-        if !self.sess.target.options.linker_is_gnu {
+        if !self.sess.target.linker_is_gnu {
             return;
         }
 
@@ -454,7 +454,7 @@ impl<'a> Linker for GccLinker<'a> {
     }
 
     fn pgo_gen(&mut self) {
-        if !self.sess.target.options.linker_is_gnu {
+        if !self.sess.target.linker_is_gnu {
             return;
         }
 
@@ -503,8 +503,7 @@ impl<'a> Linker for GccLinker<'a> {
 
     fn export_symbols(&mut self, tmpdir: &Path, crate_type: CrateType) {
         // Symbol visibility in object files typically takes care of this.
-        if crate_type == CrateType::Executable
-            && self.sess.target.options.override_export_symbols.is_none()
+        if crate_type == CrateType::Executable && self.sess.target.override_export_symbols.is_none()
         {
             return;
         }
@@ -513,7 +512,7 @@ impl<'a> Linker for GccLinker<'a> {
         // The object files have far more public symbols than we actually want to export,
         // so we hide them all here.
 
-        if !self.sess.target.options.limit_rdylib_exports {
+        if !self.sess.target.limit_rdylib_exports {
             return;
         }
 
@@ -521,13 +520,13 @@ impl<'a> Linker for GccLinker<'a> {
             return;
         }
 
-        let is_windows = self.sess.target.options.is_like_windows;
+        let is_windows = self.sess.target.is_like_windows;
         let mut arg = OsString::new();
         let path = tmpdir.join(if is_windows { "list.def" } else { "list" });
 
         debug!("EXPORTED SYMBOLS:");
 
-        if self.sess.target.options.is_like_osx {
+        if self.sess.target.is_like_osx {
             // Write a plain, newline-separated list of symbols
             let res: io::Result<()> = try {
                 let mut f = BufWriter::new(File::create(&path)?);
@@ -573,12 +572,12 @@ impl<'a> Linker for GccLinker<'a> {
             }
         }
 
-        if self.sess.target.options.is_like_osx {
+        if self.sess.target.is_like_osx {
             if !self.is_ld {
                 arg.push("-Wl,")
             }
             arg.push("-exported_symbols_list,");
-        } else if self.sess.target.options.is_like_solaris {
+        } else if self.sess.target.is_like_solaris {
             if !self.is_ld {
                 arg.push("-Wl,")
             }
@@ -1203,7 +1202,7 @@ impl<'a> Linker for WasmLd<'a> {
 }
 
 fn exported_symbols(tcx: TyCtxt<'_>, crate_type: CrateType) -> Vec<String> {
-    if let Some(ref exports) = tcx.sess.target.options.override_export_symbols {
+    if let Some(ref exports) = tcx.sess.target.override_export_symbols {
         return exports.clone();
     }
 
@@ -1293,7 +1292,7 @@ impl<'a> Linker for PtxLinker<'a> {
         // Provide the linker with fallback to internal `target-cpu`.
         self.cmd.arg("--fallback-arch").arg(match self.sess.opts.cg.target_cpu {
             Some(ref s) => s,
-            None => &self.sess.target.options.cpu,
+            None => &self.sess.target.cpu,
         });
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -320,7 +320,7 @@ impl<'a> Linker for GccLinker<'a> {
         // any `#[link]` attributes in the `libc` crate, see #72782 for details.
         // FIXME: Switch to using `#[link]` attributes in the `libc` crate
         // similarly to other targets.
-        if self.sess.target.target_os == "vxworks"
+        if self.sess.target.os == "vxworks"
             && matches!(
                 output_kind,
                 LinkOutputKind::StaticNoPicExe

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -229,8 +229,7 @@ fn exported_symbols_provider_local(
         // needs to be exported.
         // However, on platforms that don't allow for Rust dylibs, having
         // external linkage is enough for monomorphization to be linked to.
-        let need_visibility =
-            tcx.sess.target.options.dynamic_linking && !tcx.sess.target.options.only_cdylib;
+        let need_visibility = tcx.sess.target.dynamic_linking && !tcx.sess.target.only_cdylib;
 
         let (_, cgus) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
 

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -139,7 +139,7 @@ impl ModuleConfig {
 
         let emit_obj = if !should_emit_obj {
             EmitObj::None
-        } else if sess.target.options.obj_is_bitcode
+        } else if sess.target.obj_is_bitcode
             || (sess.opts.cg.linker_plugin_lto.enabled() && !no_builtins)
         {
             // This case is selected if the target uses objects as bitcode, or
@@ -221,11 +221,11 @@ impl ModuleConfig {
                 false
             ),
             emit_obj,
-            bc_cmdline: sess.target.options.bitcode_llvm_cmdline.clone(),
+            bc_cmdline: sess.target.bitcode_llvm_cmdline.clone(),
 
             verify_llvm_ir: sess.verify_llvm_ir(),
             no_prepopulate_passes: sess.opts.cg.no_prepopulate_passes,
-            no_builtins: no_builtins || sess.target.options.no_builtins,
+            no_builtins: no_builtins || sess.target.no_builtins,
 
             // Exclude metadata and allocator modules from time_passes output,
             // since they throw off the "LLVM passes" measurement.
@@ -252,7 +252,7 @@ impl ModuleConfig {
                 .opts
                 .debugging_opts
                 .merge_functions
-                .unwrap_or(sess.target.options.merge_functions)
+                .unwrap_or(sess.target.merge_functions)
             {
                 MergeFunctions::Disabled => false,
                 MergeFunctions::Trampolines | MergeFunctions::Aliases => {
@@ -388,7 +388,7 @@ fn need_bitcode_in_object(sess: &Session) -> bool {
     let requested_for_rlib = sess.opts.cg.embed_bitcode
         && sess.crate_types().contains(&CrateType::Rlib)
         && sess.opts.output_types.contains_key(&OutputType::Exe);
-    let forced_by_target = sess.target.options.forces_embed_bitcode;
+    let forced_by_target = sess.target.forces_embed_bitcode;
     requested_for_rlib || forced_by_target
 }
 
@@ -1865,11 +1865,11 @@ fn msvc_imps_needed(tcx: TyCtxt<'_>) -> bool {
     // something is wrong with commandline arg validation.
     assert!(
         !(tcx.sess.opts.cg.linker_plugin_lto.enabled()
-            && tcx.sess.target.options.is_like_windows
+            && tcx.sess.target.is_like_windows
             && tcx.sess.opts.cg.prefer_dynamic)
     );
 
-    tcx.sess.target.options.is_like_windows &&
+    tcx.sess.target.is_like_windows &&
         tcx.sess.crate_types().iter().any(|ct| *ct == CrateType::Rlib) &&
     // ThinLTO can't handle this workaround in all cases, so we don't
     // emit the `__imp_` symbols. Instead we make them unnecessary by disallowing

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -326,7 +326,7 @@ fn cast_shift_rhs<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 /// currently uses SEH-ish unwinding with DWARF info tables to the side (same as
 /// 64-bit MinGW) instead of "full SEH".
 pub fn wants_msvc_seh(sess: &Session) -> bool {
-    sess.target.options.is_like_msvc
+    sess.target.is_like_msvc
 }
 
 pub fn memcpy_ty<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
@@ -387,7 +387,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     ) -> Bx::Function {
         // The entry function is either `int main(void)` or `int main(int argc, char **argv)`,
         // depending on whether the target needs `argc` and `argv` to be passed in.
-        let llfty = if cx.sess().target.options.main_needs_argc_argv {
+        let llfty = if cx.sess().target.main_needs_argc_argv {
             cx.type_func(&[cx.type_int(), cx.type_ptr_to(cx.type_i8p())], cx.type_int())
         } else {
             cx.type_func(&[], cx.type_int())
@@ -459,7 +459,7 @@ fn get_argc_argv<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     cx: &'a Bx::CodegenCx,
     bx: &mut Bx,
 ) -> (Bx::Value, Bx::Value) {
-    if cx.sess().target.options.main_needs_argc_argv {
+    if cx.sess().target.main_needs_argc_argv {
         // Params from native `main()` used as args for rust start function
         let param_argc = bx.get_param(0);
         let param_argv = bx.get_param(1);

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -33,7 +33,7 @@ pub fn push_debuginfo_type_name<'tcx>(
 ) {
     // When targeting MSVC, emit C++ style type names for compatibility with
     // .natvis visualizers (and perhaps other existing native debuggers?)
-    let cpp_like_names = tcx.sess.target.options.is_like_msvc;
+    let cpp_like_names = tcx.sess.target.is_like_msvc;
 
     match *t.kind() {
         ty::Bool => output.push_str("bool"),

--- a/compiler/rustc_codegen_ssa/src/traits/type_.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/type_.rs
@@ -51,11 +51,11 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
     }
 
     fn type_int(&self) -> Self::Type {
-        match &self.sess().target.target_c_int_width[..] {
+        match &self.sess().target.c_int_width[..] {
             "16" => self.type_i16(),
             "32" => self.type_i32(),
             "64" => self.type_i64(),
-            width => bug!("Unsupported target_c_int_width: {}", width),
+            width => bug!("Unsupported c_int_width: {}", width),
         }
     }
 

--- a/compiler/rustc_metadata/src/dependency_format.rs
+++ b/compiler/rustc_metadata/src/dependency_format.rs
@@ -127,7 +127,7 @@ fn calculate_type(tcx: TyCtxt<'_>, ty: CrateType) -> DependencyList {
         if ty == CrateType::Staticlib
             || (ty == CrateType::Executable
                 && sess.crt_static(Some(ty))
-                && !sess.target.options.crt_static_allows_dylibs)
+                && !sess.target.crt_static_allows_dylibs)
         {
             for &cnum in tcx.crates().iter() {
                 if tcx.dep_kind(cnum).macros_only() {

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -373,11 +373,10 @@ impl<'a> CrateLocator<'a> {
         seen_paths: &mut FxHashSet<PathBuf>,
     ) -> Result<Option<Library>, CrateError> {
         // want: crate_name.dir_part() + prefix + crate_name.file_part + "-"
-        let dylib_prefix =
-            format!("{}{}{}", self.target.options.dll_prefix, self.crate_name, extra_prefix);
+        let dylib_prefix = format!("{}{}{}", self.target.dll_prefix, self.crate_name, extra_prefix);
         let rlib_prefix = format!("lib{}{}", self.crate_name, extra_prefix);
         let staticlib_prefix =
-            format!("{}{}{}", self.target.options.staticlib_prefix, self.crate_name, extra_prefix);
+            format!("{}{}{}", self.target.staticlib_prefix, self.crate_name, extra_prefix);
 
         let mut candidates: FxHashMap<_, (FxHashMap<_, _>, FxHashMap<_, _>, FxHashMap<_, _>)> =
             Default::default();
@@ -405,17 +404,14 @@ impl<'a> CrateLocator<'a> {
                 (&file[(rlib_prefix.len())..(file.len() - ".rlib".len())], CrateFlavor::Rlib)
             } else if file.starts_with(&rlib_prefix) && file.ends_with(".rmeta") {
                 (&file[(rlib_prefix.len())..(file.len() - ".rmeta".len())], CrateFlavor::Rmeta)
-            } else if file.starts_with(&dylib_prefix)
-                && file.ends_with(&self.target.options.dll_suffix)
-            {
+            } else if file.starts_with(&dylib_prefix) && file.ends_with(&self.target.dll_suffix) {
                 (
-                    &file
-                        [(dylib_prefix.len())..(file.len() - self.target.options.dll_suffix.len())],
+                    &file[(dylib_prefix.len())..(file.len() - self.target.dll_suffix.len())],
                     CrateFlavor::Dylib,
                 )
             } else {
                 if file.starts_with(&staticlib_prefix)
-                    && file.ends_with(&self.target.options.staticlib_suffix)
+                    && file.ends_with(&self.target.staticlib_suffix)
                 {
                     staticlibs
                         .push(CrateMismatch { path: spf.path.clone(), got: "static".to_string() });
@@ -679,8 +675,8 @@ impl<'a> CrateLocator<'a> {
             };
 
             if file.starts_with("lib") && (file.ends_with(".rlib") || file.ends_with(".rmeta"))
-                || file.starts_with(&self.target.options.dll_prefix)
-                    && file.ends_with(&self.target.options.dll_suffix)
+                || file.starts_with(&self.target.dll_prefix)
+                    && file.ends_with(&self.target.dll_suffix)
             {
                 // Make sure there's at most one rlib and at most one dylib.
                 // Note to take care and match against the non-canonicalized name:
@@ -712,8 +708,8 @@ impl<'a> CrateLocator<'a> {
             crate_name: self.crate_name,
             root: self.root.cloned(),
             triple: self.triple,
-            dll_prefix: self.target.options.dll_prefix.clone(),
-            dll_suffix: self.target.options.dll_suffix.clone(),
+            dll_prefix: self.target.dll_prefix.clone(),
+            dll_suffix: self.target.dll_suffix.clone(),
             rejected_via_hash: self.rejected_via_hash,
             rejected_via_triple: self.rejected_via_triple,
             rejected_via_kind: self.rejected_via_kind,

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -149,7 +149,7 @@ impl Collector<'tcx> {
             }
             return;
         }
-        let is_osx = self.tcx.sess.target.options.is_like_osx;
+        let is_osx = self.tcx.sess.target.is_like_osx;
         if lib.kind == NativeLibKind::Framework && !is_osx {
             let msg = "native frameworks are only available on macOS targets";
             match span {

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -168,7 +168,7 @@ impl ScalarInt {
     #[inline(always)]
     fn check_data(self) {
         // Using a block `{self.data}` here to force a copy instead of using `self.data`
-        // directly, because `assert_eq` takes references to its arguments and formatting
+        // directly, because `debug_assert_eq` takes references to its arguments and formatting
         // arguments and would thus borrow `self.data`. Since `Self`
         // is a packed struct, that would create a possibly unaligned reference, which
         // is UB.

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2601,15 +2601,14 @@ where
         };
 
         let target = &cx.tcx().sess.target;
-        let target_env_gnu_like = matches!(&target.target_env[..], "gnu" | "musl");
-        let win_x64_gnu =
-            target.target_os == "windows" && target.arch == "x86_64" && target.target_env == "gnu";
+        let target_env_gnu_like = matches!(&target.env[..], "gnu" | "musl");
+        let win_x64_gnu = target.os == "windows" && target.arch == "x86_64" && target.env == "gnu";
         let linux_s390x_gnu_like =
-            target.target_os == "linux" && target.arch == "s390x" && target_env_gnu_like;
+            target.os == "linux" && target.arch == "s390x" && target_env_gnu_like;
         let linux_sparc64_gnu_like =
-            target.target_os == "linux" && target.arch == "sparc64" && target_env_gnu_like;
+            target.os == "linux" && target.arch == "sparc64" && target_env_gnu_like;
         let linux_powerpc_gnu_like =
-            target.target_os == "linux" && target.arch == "powerpc" && target_env_gnu_like;
+            target.os == "linux" && target.arch == "powerpc" && target_env_gnu_like;
         let rust_abi = matches!(sig.abi, RustIntrinsic | PlatformIntrinsic | Rust | RustCall);
 
         // Handle safe Rust thin and fat pointers.

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2775,7 +2775,7 @@ where
                     // anyway, we control all calls to it in libstd.
                     Abi::Vector { .. }
                         if abi != SpecAbi::PlatformIntrinsic
-                            && cx.tcx().sess.target.options.simd_types_indirect =>
+                            && cx.tcx().sess.target.simd_types_indirect =>
                     {
                         arg.make_indirect();
                         return;

--- a/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
@@ -532,7 +532,7 @@ fn mono_item_visibility(
 }
 
 fn default_visibility(tcx: TyCtxt<'_>, id: DefId, is_generic: bool) -> Visibility {
-    if !tcx.sess.target.options.default_hidden_visibility {
+    if !tcx.sess.target.default_hidden_visibility {
         return Visibility::Default;
     }
 

--- a/compiler/rustc_mir/src/transform/inline.rs
+++ b/compiler/rustc_mir/src/transform/inline.rs
@@ -742,6 +742,12 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
     }
 
     fn visit_place(&mut self, place: &mut Place<'tcx>, context: PlaceContext, location: Location) {
+        for elem in place.projection {
+            // FIXME: Make sure that return place is not used in an indexing projection, since it
+            // won't be rebased as it is supposed to be.
+            assert_ne!(ProjectionElem::Index(RETURN_PLACE), elem);
+        }
+
         // If this is the `RETURN_PLACE`, we need to rebase any projections onto it.
         let dest_proj_len = self.destination.projection.len();
         if place.local == RETURN_PLACE && dest_proj_len > 0 {

--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -26,7 +26,7 @@ pub fn check_crate<'tcx>(tcx: TyCtxt<'tcx>, items: &mut lang_items::LanguageItem
     if items.eh_personality().is_none() {
         items.missing.push(LangItem::EhPersonality);
     }
-    if tcx.sess.target.options.is_like_emscripten && items.eh_catch_typeinfo().is_none() {
+    if tcx.sess.target.is_like_emscripten && items.eh_catch_typeinfo().is_none() {
         items.missing.push(LangItem::EhCatchTypeinfo);
     }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -743,7 +743,7 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     let vendor = &sess.target.target_vendor;
     let min_atomic_width = sess.target.min_atomic_width();
     let max_atomic_width = sess.target.max_atomic_width();
-    let atomic_cas = sess.target.options.atomic_cas;
+    let atomic_cas = sess.target.atomic_cas;
     let layout = TargetDataLayout::parse(&sess.target).unwrap_or_else(|err| {
         sess.fatal(&err);
     });
@@ -752,7 +752,7 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     ret.reserve(6); // the minimum number of insertions
     // Target bindings.
     ret.insert((sym::target_os, Some(Symbol::intern(os))));
-    if let Some(ref fam) = sess.target.options.target_family {
+    if let Some(ref fam) = sess.target.target_family {
         ret.insert((sym::target_family, Some(Symbol::intern(fam))));
         if fam == "windows" {
             ret.insert((sym::windows, None));
@@ -765,7 +765,7 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     ret.insert((sym::target_pointer_width, Some(Symbol::intern(&wordsz))));
     ret.insert((sym::target_env, Some(Symbol::intern(env))));
     ret.insert((sym::target_vendor, Some(Symbol::intern(vendor))));
-    if sess.target.options.has_elf_tls {
+    if sess.target.has_elf_tls {
         ret.insert((sym::target_thread_local, None));
     }
     for &(i, align) in &[

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -735,12 +735,12 @@ pub const fn default_lib_output() -> CrateType {
 }
 
 pub fn default_configuration(sess: &Session) -> CrateConfig {
-    let end = &sess.target.target_endian;
+    let end = &sess.target.endian;
     let arch = &sess.target.arch;
     let wordsz = sess.target.pointer_width.to_string();
-    let os = &sess.target.target_os;
-    let env = &sess.target.target_env;
-    let vendor = &sess.target.target_vendor;
+    let os = &sess.target.os;
+    let env = &sess.target.env;
+    let vendor = &sess.target.vendor;
     let min_atomic_width = sess.target.min_atomic_width();
     let max_atomic_width = sess.target.max_atomic_width();
     let atomic_cas = sess.target.atomic_cas;
@@ -752,7 +752,7 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     ret.reserve(6); // the minimum number of insertions
     // Target bindings.
     ret.insert((sym::target_os, Some(Symbol::intern(os))));
-    if let Some(ref fam) = sess.target.target_family {
+    if let Some(ref fam) = sess.target.os_family {
         ret.insert((sym::target_family, Some(Symbol::intern(fam))));
         if fam == "windows" {
             ret.insert((sym::windows, None));

--- a/compiler/rustc_session/src/output.rs
+++ b/compiler/rustc_session/src/output.rs
@@ -150,17 +150,15 @@ pub fn filename_for_input(
     match crate_type {
         CrateType::Rlib => outputs.out_directory.join(&format!("lib{}.rlib", libname)),
         CrateType::Cdylib | CrateType::ProcMacro | CrateType::Dylib => {
-            let (prefix, suffix) =
-                (&sess.target.options.dll_prefix, &sess.target.options.dll_suffix);
+            let (prefix, suffix) = (&sess.target.dll_prefix, &sess.target.dll_suffix);
             outputs.out_directory.join(&format!("{}{}{}", prefix, libname, suffix))
         }
         CrateType::Staticlib => {
-            let (prefix, suffix) =
-                (&sess.target.options.staticlib_prefix, &sess.target.options.staticlib_suffix);
+            let (prefix, suffix) = (&sess.target.staticlib_prefix, &sess.target.staticlib_suffix);
             outputs.out_directory.join(&format!("{}{}{}", prefix, libname, suffix))
         }
         CrateType::Executable => {
-            let suffix = &sess.target.options.exe_suffix;
+            let suffix = &sess.target.exe_suffix;
             let out_filename = outputs.path(OutputType::Exe);
             if suffix.is_empty() { out_filename } else { out_filename.with_extension(&suffix[1..]) }
         }
@@ -177,29 +175,29 @@ pub fn filename_for_input(
 /// interaction with Rust code through static library is the only
 /// option for now
 pub fn default_output_for_target(sess: &Session) -> CrateType {
-    if !sess.target.options.executables { CrateType::Staticlib } else { CrateType::Executable }
+    if !sess.target.executables { CrateType::Staticlib } else { CrateType::Executable }
 }
 
 /// Checks if target supports crate_type as output
 pub fn invalid_output_for_target(sess: &Session, crate_type: CrateType) -> bool {
     match crate_type {
         CrateType::Cdylib | CrateType::Dylib | CrateType::ProcMacro => {
-            if !sess.target.options.dynamic_linking {
+            if !sess.target.dynamic_linking {
                 return true;
             }
-            if sess.crt_static(Some(crate_type)) && !sess.target.options.crt_static_allows_dylibs {
+            if sess.crt_static(Some(crate_type)) && !sess.target.crt_static_allows_dylibs {
                 return true;
             }
         }
         _ => {}
     }
-    if sess.target.options.only_cdylib {
+    if sess.target.only_cdylib {
         match crate_type {
             CrateType::ProcMacro | CrateType::Dylib => return true,
             _ => {}
         }
     }
-    if !sess.target.options.executables && crate_type == CrateType::Executable {
+    if !sess.target.executables && crate_type == CrateType::Executable {
         return true;
     }
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -663,7 +663,7 @@ impl Session {
     /// Calculates the flavor of LTO to use for this compilation.
     pub fn lto(&self) -> config::Lto {
         // If our target has codegen requirements ignore the command line
-        if self.target.options.requires_lto {
+        if self.target.requires_lto {
             return config::Lto::Fat;
         }
 
@@ -731,7 +731,7 @@ impl Session {
     /// Returns the panic strategy for this compile session. If the user explicitly selected one
     /// using '-C panic', use that, otherwise use the panic strategy defined by the target.
     pub fn panic_strategy(&self) -> PanicStrategy {
-        self.opts.cg.panic.unwrap_or(self.target.options.panic_strategy)
+        self.opts.cg.panic.unwrap_or(self.target.panic_strategy)
     }
     pub fn fewer_names(&self) -> bool {
         let more_names = self.opts.output_types.contains_key(&OutputType::LlvmAssembly)
@@ -755,9 +755,9 @@ impl Session {
 
     /// Check whether this compile session and crate type use static crt.
     pub fn crt_static(&self, crate_type: Option<CrateType>) -> bool {
-        if !self.target.options.crt_static_respected {
+        if !self.target.crt_static_respected {
             // If the target does not opt in to crt-static support, use its default.
-            return self.target.options.crt_static_default;
+            return self.target.crt_static_default;
         }
 
         let requested_features = self.opts.cg.target_feature.split(',');
@@ -774,20 +774,20 @@ impl Session {
             // We can't check `#![crate_type = "proc-macro"]` here.
             false
         } else {
-            self.target.options.crt_static_default
+            self.target.crt_static_default
         }
     }
 
     pub fn relocation_model(&self) -> RelocModel {
-        self.opts.cg.relocation_model.unwrap_or(self.target.options.relocation_model)
+        self.opts.cg.relocation_model.unwrap_or(self.target.relocation_model)
     }
 
     pub fn code_model(&self) -> Option<CodeModel> {
-        self.opts.cg.code_model.or(self.target.options.code_model)
+        self.opts.cg.code_model.or(self.target.code_model)
     }
 
     pub fn tls_model(&self) -> TlsModel {
-        self.opts.debugging_opts.tls_model.unwrap_or(self.target.options.tls_model)
+        self.opts.debugging_opts.tls_model.unwrap_or(self.target.tls_model)
     }
 
     pub fn must_not_eliminate_frame_pointers(&self) -> bool {
@@ -798,7 +798,7 @@ impl Session {
         } else if let Some(x) = self.opts.cg.force_frame_pointers {
             x
         } else {
-            !self.target.options.eliminate_frame_pointer
+            !self.target.eliminate_frame_pointer
         }
     }
 
@@ -822,7 +822,7 @@ impl Session {
         // value, if it is provided, or disable them, if not.
         if self.panic_strategy() == PanicStrategy::Unwind {
             true
-        } else if self.target.options.requires_uwtable {
+        } else if self.target.requires_uwtable {
             true
         } else {
             self.opts.cg.force_unwind_tables.unwrap_or(false)
@@ -993,7 +993,7 @@ impl Session {
         if let Some(n) = self.opts.cli_forced_codegen_units {
             return n;
         }
-        if let Some(n) = self.target.options.default_codegen_units {
+        if let Some(n) = self.target.default_codegen_units {
             return n as usize;
         }
 
@@ -1078,11 +1078,11 @@ impl Session {
     pub fn needs_plt(&self) -> bool {
         // Check if the current target usually needs PLT to be enabled.
         // The user can use the command line flag to override it.
-        let needs_plt = self.target.options.needs_plt;
+        let needs_plt = self.target.needs_plt;
 
         let dbg_opts = &self.opts.debugging_opts;
 
-        let relro_level = dbg_opts.relro_level.unwrap_or(self.target.options.relro_level);
+        let relro_level = dbg_opts.relro_level.unwrap_or(self.target.relro_level);
 
         // Only enable this optimization by default if full relro is also enabled.
         // In this case, lazy binding was already unavailable, so nothing is lost.
@@ -1106,7 +1106,7 @@ impl Session {
         match self.opts.cg.link_dead_code {
             Some(explicitly_set) => explicitly_set,
             None => {
-                self.opts.debugging_opts.instrument_coverage && !self.target.options.is_like_msvc
+                self.opts.debugging_opts.instrument_coverage && !self.target.is_like_msvc
                 // Issue #76038: (rustc `-Clink-dead-code` causes MSVC linker to produce invalid
                 // binaries when LLVM InstrProf counters are enabled). As described by this issue,
                 // the "link dead code" option produces incorrect binaries when compiled and linked
@@ -1307,7 +1307,7 @@ pub fn build_session(
 
     let loader = file_loader.unwrap_or(Box::new(RealFileLoader));
     let hash_kind = sopts.debugging_opts.src_hash_algorithm.unwrap_or_else(|| {
-        if target_cfg.options.is_like_msvc {
+        if target_cfg.is_like_msvc {
             SourceFileHashAlgorithm::Sha1
         } else {
             SourceFileHashAlgorithm::Md5
@@ -1417,11 +1417,8 @@ pub fn build_session(
         if candidate.join("library/std/src/lib.rs").is_file() { Some(candidate) } else { None }
     };
 
-    let asm_arch = if target_cfg.options.allow_asm {
-        InlineAsmArch::from_str(&target_cfg.arch).ok()
-    } else {
-        None
-    };
+    let asm_arch =
+        if target_cfg.allow_asm { InlineAsmArch::from_str(&target_cfg.arch).ok() } else { None };
 
     let sess = Session {
         target: target_cfg,
@@ -1487,7 +1484,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     // the `dllimport` attributes and `__imp_` symbols in that case.
     if sess.opts.cg.linker_plugin_lto.enabled()
         && sess.opts.cg.prefer_dynamic
-        && sess.target.options.is_like_windows
+        && sess.target.is_like_windows
     {
         sess.err(
             "Linker plugin based LTO is not supported together with \
@@ -1515,7 +1512,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
             );
         }
 
-        if sess.target.options.requires_uwtable && !include_uwtables {
+        if sess.target.requires_uwtable && !include_uwtables {
             sess.err(
                 "target requires unwind tables, they cannot be disabled with \
                      `-C force-unwind-tables=no`.",
@@ -1530,7 +1527,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     // We should only display this error if we're actually going to run PGO.
     // If we're just supposed to print out some data, don't show the error (#61002).
     if sess.opts.cg.profile_generate.enabled()
-        && sess.target.options.is_like_msvc
+        && sess.target.is_like_msvc
         && sess.panic_strategy() == PanicStrategy::Unwind
         && sess.opts.prints.iter().all(|&p| p == PrintRequest::NativeStaticLibs)
     {

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -562,7 +562,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             "x86_64" => {
                 if abi == spec::abi::Abi::SysV64 {
                     x86_64::compute_abi_info(cx, self);
-                } else if abi == spec::abi::Abi::Win64 || cx.target_spec().options.is_like_windows {
+                } else if abi == spec::abi::Abi::Win64 || cx.target_spec().is_like_windows {
                     x86_win64::compute_abi_info(self);
                 } else {
                     x86_64::compute_abi_info(cx, self);

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -584,7 +584,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             "nvptx64" => nvptx64::compute_abi_info(self),
             "hexagon" => hexagon::compute_abi_info(self),
             "riscv32" | "riscv64" => riscv::compute_abi_info(cx, self),
-            "wasm32" if cx.target_spec().target_os != "emscripten" => {
+            "wasm32" if cx.target_spec().os != "emscripten" => {
                 wasm32_bindgen_compat::compute_abi_info(self)
             }
             "wasm32" | "asmjs" => wasm32::compute_abi_info(cx, self),

--- a/compiler/rustc_target/src/abi/call/powerpc64.rs
+++ b/compiler/rustc_target/src/abi/call/powerpc64.rs
@@ -119,7 +119,7 @@ where
     Ty: TyAndLayoutMethods<'a, C> + Copy,
     C: LayoutOf<Ty = Ty, TyAndLayout = TyAndLayout<'a, Ty>> + HasDataLayout + HasTargetSpec,
 {
-    let abi = if cx.target_spec().target_env == "musl" {
+    let abi = if cx.target_spec().env == "musl" {
         ELFv2
     } else {
         match cx.data_layout().endian {

--- a/compiler/rustc_target/src/abi/call/riscv.rs
+++ b/compiler/rustc_target/src/abi/call/riscv.rs
@@ -323,7 +323,7 @@ where
     Ty: TyAndLayoutMethods<'a, C> + Copy,
     C: LayoutOf<Ty = Ty, TyAndLayout = TyAndLayout<'a, Ty>> + HasDataLayout + HasTargetSpec,
 {
-    let flen = match &cx.target_spec().options.llvm_abiname[..] {
+    let flen = match &cx.target_spec().llvm_abiname[..] {
         "ilp32f" | "lp64f" => 32,
         "ilp32d" | "lp64d" => 64,
         _ => 0,

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -41,10 +41,10 @@ where
             // http://www.angelcode.com/dev/callconv/callconv.html
             // Clang's ABI handling is in lib/CodeGen/TargetInfo.cpp
             let t = cx.target_spec();
-            if t.options.abi_return_struct_as_int {
+            if t.abi_return_struct_as_int {
                 // According to Clang, everyone but MSVC returns single-element
                 // float aggregates directly in a floating-point register.
-                if !t.options.is_like_msvc && is_single_fp_element(cx, fn_abi.ret.layout) {
+                if !t.is_like_msvc && is_single_fp_element(cx, fn_abi.ret.layout) {
                     match fn_abi.ret.layout.size.bytes() {
                         4 => fn_abi.ret.cast_to(Reg::f32()),
                         8 => fn_abi.ret.cast_to(Reg::f64()),

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -156,11 +156,11 @@ impl TargetDataLayout {
             Endian::Little => "little",
             Endian::Big => "big",
         };
-        if endian_str != target.target_endian {
+        if endian_str != target.endian {
             return Err(format!(
                 "inconsistent target specification: \"data-layout\" claims \
                                 architecture is {}-endian, while \"target-endian\" is `{}`",
-                endian_str, target.target_endian
+                endian_str, target.endian
             ));
         }
 

--- a/compiler/rustc_target/src/asm/arm.rs
+++ b/compiler/rustc_target/src/asm/arm.rs
@@ -61,7 +61,7 @@ impl ArmInlineAsmRegClass {
 
 // This uses the same logic as useR7AsFramePointer in LLVM
 fn frame_pointer_is_r7(mut has_feature: impl FnMut(&str) -> bool, target: &Target) -> bool {
-    target.options.is_like_osx || (!target.options.is_like_windows && has_feature("thumb-mode"))
+    target.is_like_osx || (!target.is_like_windows && has_feature("thumb-mode"))
 }
 
 fn frame_pointer_r11(

--- a/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/aarch64_apple_darwin.rs
@@ -19,6 +19,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:o-i64:64-i128:128-n32:64-S128".to_string(),
         arch: arch.to_string(),
-        options: TargetOptions { target_mcount: "\u{1}mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "\u{1}mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/aarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_linux_gnu.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
         arch: "aarch64".to_string(),
         options: TargetOptions {
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}_mcount".to_string(),
+            mcount: "\u{1}_mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/aarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_linux_musl.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
         arch: "aarch64".to_string(),
         options: TargetOptions {
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}_mcount".to_string(),
+            mcount: "\u{1}_mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/aarch64_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_netbsd.rs
@@ -10,6 +10,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128".to_string(),
         arch: "aarch64".to_string(),
-        options: TargetOptions { target_mcount: "__mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "__mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/aarch64_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_none.rs
@@ -10,7 +10,7 @@ use super::{LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOp
 
 pub fn target() -> Target {
     let opts = TargetOptions {
-        target_vendor: String::new(),
+        vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         linker: Some("rust-lld".to_owned()),
         features: "+strict-align,+neon,+fp-armv8".to_string(),

--- a/compiler/rustc_target/src/spec/aarch64_unknown_none_softfloat.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_none_softfloat.rs
@@ -10,7 +10,7 @@ use super::{LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOp
 
 pub fn target() -> Target {
     let opts = TargetOptions {
-        target_vendor: String::new(),
+        vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         linker: Some("rust-lld".to_owned()),
         features: "+strict-align,-neon,-fp-armv8".to_string(),

--- a/compiler/rustc_target/src/spec/android_base.rs
+++ b/compiler/rustc_target/src/spec/android_base.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();
-    base.target_os = "android".to_string();
+    base.os = "android".to_string();
     // Many of the symbols defined in compiler-rt are also defined in libgcc.
     // Android's linker doesn't like that by default.
     base.pre_link_args

--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -17,13 +17,13 @@ pub fn opts(os: &str) -> TargetOptions {
     let version = macos_deployment_target();
 
     TargetOptions {
-        target_os: os.to_string(),
-        target_vendor: "apple".to_string(),
+        os: os.to_string(),
+        vendor: "apple".to_string(),
         // macOS has -dead_strip, which doesn't rely on function_sections
         function_sections: false,
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         is_like_osx: true,
         dwarf_version: Some(2),
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/arm_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/arm_unknown_linux_gnueabi.rs
@@ -12,7 +12,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+strict-align,+v6".to_string(),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/arm_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/arm_unknown_linux_gnueabihf.rs
@@ -12,7 +12,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+strict-align,+v6,+vfp2,-d32".to_string(),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/arm_unknown_linux_musleabi.rs
+++ b/compiler/rustc_target/src/spec/arm_unknown_linux_musleabi.rs
@@ -17,7 +17,7 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
         options: TargetOptions {
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}mcount".to_string(),
+            mcount: "\u{1}mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/arm_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/arm_unknown_linux_musleabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
         options: TargetOptions {
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}mcount".to_string(),
+            mcount: "\u{1}mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabi.rs
@@ -11,8 +11,8 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_vendor: String::new(),
+            endian: "big".to_string(),
+            vendor: String::new(),
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             executables: true,
             linker: Some("rust-lld".to_owned()),

--- a/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armebv7r_none_eabihf.rs
@@ -11,8 +11,8 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_vendor: String::new(),
+            endian: "big".to_string(),
+            vendor: String::new(),
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             executables: true,
             linker: Some("rust-lld".to_owned()),

--- a/compiler/rustc_target/src/spec/armv4t_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/armv4t_unknown_linux_gnueabi.rs
@@ -13,7 +13,7 @@ pub fn target() -> Target {
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             has_thumb_interworking: true,
             ..base
         },

--- a/compiler/rustc_target/src/spec/armv5te_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/armv5te_unknown_linux_gnueabi.rs
@@ -13,7 +13,7 @@ pub fn target() -> Target {
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             has_thumb_interworking: true,
             ..base
         },

--- a/compiler/rustc_target/src/spec/armv5te_unknown_linux_musleabi.rs
+++ b/compiler/rustc_target/src/spec/armv5te_unknown_linux_musleabi.rs
@@ -16,7 +16,7 @@ pub fn target() -> Target {
             // Atomic operations provided by compiler-builtins
             max_atomic_width: Some(32),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}mcount".to_string(),
+            mcount: "\u{1}mcount".to_string(),
             has_thumb_interworking: true,
             ..base
         },

--- a/compiler/rustc_target/src/spec/armv6_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/armv6_unknown_freebsd.rs
@@ -9,11 +9,11 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_env: "gnueabihf".to_string(),
+            env: "gnueabihf".to_string(),
             features: "+v6,+vfp2,-d32".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv6_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv6_unknown_netbsd_eabihf.rs
@@ -10,10 +10,10 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_env: "eabihf".to_string(),
+            env: "eabihf".to_string(),
             features: "+v6,+vfp2,-d32".to_string(),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "__mcount".to_string(),
+            mcount: "__mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv7_unknown_cloudabi_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_cloudabi_eabihf.rs
@@ -13,6 +13,6 @@ pub fn target() -> Target {
         pointer_width: 32,
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".to_string(),
         arch: "arm".to_string(),
-        options: TargetOptions { target_mcount: "\u{1}mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "\u{1}mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/armv7_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_freebsd.rs
@@ -9,11 +9,11 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_env: "gnueabihf".to_string(),
+            env: "gnueabihf".to_string(),
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv7_unknown_linux_gnueabi.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_linux_gnueabi.rs
@@ -16,7 +16,7 @@ pub fn target() -> Target {
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv7_unknown_linux_gnueabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_linux_gnueabihf.rs
@@ -17,7 +17,7 @@ pub fn target() -> Target {
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
+            mcount: "\u{1}__gnu_mcount_nc".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv7_unknown_linux_musleabi.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_linux_musleabi.rs
@@ -21,7 +21,7 @@ pub fn target() -> Target {
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}mcount".to_string(),
+            mcount: "\u{1}mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv7_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_linux_musleabihf.rs
@@ -20,7 +20,7 @@ pub fn target() -> Target {
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}mcount".to_string(),
+            mcount: "\u{1}mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv7_unknown_netbsd_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7_unknown_netbsd_eabihf.rs
@@ -9,12 +9,12 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_env: "eabihf".to_string(),
+            env: "eabihf".to_string(),
             features: "+v7,+vfp3,-d32,+thumb2,-neon".to_string(),
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "__mcount".to_string(),
+            mcount: "__mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/armv7a_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv7a_none_eabi.rs
@@ -10,7 +10,7 @@
 // bare-metal binaries (the `gcc` linker has the advantage that it knows where C
 // libraries and crt*.o are but it's not much of an advantage here); LLD is also
 // faster
-// - `target_os` set to `none`. rationale: matches `thumb` targets
+// - `os` set to `none`. rationale: matches `thumb` targets
 // - `target_{env,vendor}` set to an empty string. rationale: matches `thumb`
 // targets
 // - `panic_strategy` set to `abort`. rationale: matches `thumb` targets
@@ -21,7 +21,7 @@ use super::{LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOp
 
 pub fn target() -> Target {
     let opts = TargetOptions {
-        target_vendor: String::new(),
+        vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         linker: Some("rust-lld".to_owned()),
         features: "+v7,+thumb2,+soft-float,-neon,+strict-align".to_string(),

--- a/compiler/rustc_target/src/spec/armv7a_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv7a_none_eabi.rs
@@ -11,7 +11,7 @@
 // libraries and crt*.o are but it's not much of an advantage here); LLD is also
 // faster
 // - `os` set to `none`. rationale: matches `thumb` targets
-// - `target_{env,vendor}` set to an empty string. rationale: matches `thumb`
+// - `env` and `vendor` are set to an empty string. rationale: matches `thumb`
 // targets
 // - `panic_strategy` set to `abort`. rationale: matches `thumb` targets
 // - `relocation-model` set to `static`; also no PIE, no relro and no dynamic

--- a/compiler/rustc_target/src/spec/armv7a_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7a_none_eabihf.rs
@@ -9,7 +9,7 @@ use super::{LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, Target, TargetOp
 
 pub fn target() -> Target {
     let opts = TargetOptions {
-        target_vendor: String::new(),
+        vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         linker: Some("rust-lld".to_owned()),
         features: "+v7,+vfp3,-d32,+thumb2,-neon,+strict-align".to_string(),

--- a/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabi.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_vendor: String::new(),
+            vendor: String::new(),
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             executables: true,
             linker: Some("rust-lld".to_owned()),

--- a/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
+++ b/compiler/rustc_target/src/spec/armv7r_none_eabihf.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
         arch: "arm".to_string(),
 
         options: TargetOptions {
-            target_vendor: String::new(),
+            vendor: String::new(),
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             executables: true,
             linker: Some("rust-lld".to_owned()),

--- a/compiler/rustc_target/src/spec/asmjs_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/asmjs_unknown_emscripten.rs
@@ -3,7 +3,6 @@ use super::{wasm32_unknown_emscripten, LinkerFlavor, Target};
 pub fn target() -> Target {
     let mut target = wasm32_unknown_emscripten::target();
     target
-        .options
         .post_link_args
         .entry(LinkerFlavor::Em)
         .or_default()

--- a/compiler/rustc_target/src/spec/avr_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/avr_gnu_base.rs
@@ -10,8 +10,8 @@ pub fn target(target_cpu: String) -> Target {
         llvm_target: "avr-unknown-unknown".to_string(),
         pointer_width: 16,
         options: TargetOptions {
-            target_c_int_width: "16".to_string(),
-            target_os: "unknown".to_string(),
+            c_int_width: "16".to_string(),
+            os: "unknown".to_string(),
             cpu: target_cpu.clone(),
             exe_suffix: ".elf".to_string(),
 

--- a/compiler/rustc_target/src/spec/cloudabi_base.rs
+++ b/compiler/rustc_target/src/spec/cloudabi_base.rs
@@ -12,9 +12,9 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "cloudabi".to_string(),
+        os: "cloudabi".to_string(),
         executables: true,
-        target_family: None,
+        os_family: None,
         linker_is_gnu: true,
         pre_link_args: args,
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/dragonfly_base.rs
+++ b/compiler/rustc_target/src/spec/dragonfly_base.rs
@@ -16,10 +16,10 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "dragonfly".to_string(),
+        os: "dragonfly".to_string(),
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         linker_is_gnu: true,
         has_rpath: true,
         pre_link_args: args,

--- a/compiler/rustc_target/src/spec/freebsd_base.rs
+++ b/compiler/rustc_target/src/spec/freebsd_base.rs
@@ -16,10 +16,10 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "freebsd".to_string(),
+        os: "freebsd".to_string(),
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         linker_is_gnu: true,
         has_rpath: true,
         pre_link_args: args,

--- a/compiler/rustc_target/src/spec/fuchsia_base.rs
+++ b/compiler/rustc_target/src/spec/fuchsia_base.rs
@@ -20,14 +20,14 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "fuchsia".to_string(),
-        target_vendor: String::new(),
+        os: "fuchsia".to_string(),
+        vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         linker: Some("rust-lld".to_owned()),
         lld_flavor: LldFlavor::Ld,
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         is_like_fuchsia: true,
         linker_is_gnu: true,
         has_rpath: false,

--- a/compiler/rustc_target/src/spec/haiku_base.rs
+++ b/compiler/rustc_target/src/spec/haiku_base.rs
@@ -2,11 +2,11 @@ use crate::spec::{RelroLevel, TargetOptions};
 
 pub fn opts() -> TargetOptions {
     TargetOptions {
-        target_os: "haiku".to_string(),
+        os: "haiku".to_string(),
         dynamic_linking: true,
         executables: true,
         has_rpath: false,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         relro_level: RelroLevel::Full,
         linker_is_gnu: true,
         ..Default::default()

--- a/compiler/rustc_target/src/spec/hermit_base.rs
+++ b/compiler/rustc_target/src/spec/hermit_base.rs
@@ -9,7 +9,7 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "hermit".to_string(),
+        os: "hermit".to_string(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         linker: Some("rust-lld".to_owned()),
         executables: true,
@@ -20,7 +20,7 @@ pub fn opts() -> TargetOptions {
         position_independent_executables: true,
         static_position_independent_executables: true,
         relocation_model: RelocModel::Pic,
-        target_family: None,
+        os_family: None,
         tls_model: TlsModel::InitialExec,
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/hermit_kernel_base.rs
+++ b/compiler/rustc_target/src/spec/hermit_kernel_base.rs
@@ -9,7 +9,7 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "hermit".to_string(),
+        os: "hermit".to_string(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         disable_redzone: true,
         linker: Some("rust-lld".to_owned()),
@@ -21,7 +21,7 @@ pub fn opts() -> TargetOptions {
         position_independent_executables: true,
         static_position_independent_executables: true,
         relocation_model: RelocModel::Pic,
-        target_family: None,
+        os_family: None,
         tls_model: TlsModel::InitialExec,
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/i586_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/i586_pc_windows_msvc.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::i686_pc_windows_msvc::target();
-    base.options.cpu = "pentium".to_string();
+    base.cpu = "pentium".to_string();
     base.llvm_target = "i586-pc-windows-msvc".to_string();
     base
 }

--- a/compiler/rustc_target/src/spec/i586_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_linux_gnu.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::i686_unknown_linux_gnu::target();
-    base.options.cpu = "pentium".to_string();
+    base.cpu = "pentium".to_string();
     base.llvm_target = "i586-unknown-linux-gnu".to_string();
     base
 }

--- a/compiler/rustc_target/src/spec/i586_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/i586_unknown_linux_musl.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::i686_unknown_linux_musl::target();
-    base.options.cpu = "pentium".to_string();
+    base.cpu = "pentium".to_string();
     base.llvm_target = "i586-unknown-linux-musl".to_string();
     base
 }

--- a/compiler/rustc_target/src/spec/i686_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/i686_apple_darwin.rs
@@ -22,6 +22,6 @@ pub fn target() -> Target {
             f64:32:64-f80:128-n8:16:32-S128"
             .to_string(),
         arch: "x86".to_string(),
-        options: TargetOptions { target_mcount: "\u{1}mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "\u{1}mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/i686_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/i686_unknown_netbsd.rs
@@ -14,6 +14,6 @@ pub fn target() -> Target {
             f64:32:64-f80:32-n8:16:32-S128"
             .to_string(),
         arch: "x86".to_string(),
-        options: TargetOptions { target_mcount: "__mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "__mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/illumos_base.rs
+++ b/compiler/rustc_target/src/spec/illumos_base.rs
@@ -16,11 +16,11 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "illumos".to_string(),
+        os: "illumos".to_string(),
         dynamic_linking: true,
         executables: true,
         has_rpath: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         is_like_solaris: true,
         limit_rdylib_exports: false, // Linker doesn't support this
         eliminate_frame_pointer: false,

--- a/compiler/rustc_target/src/spec/l4re_base.rs
+++ b/compiler/rustc_target/src/spec/l4re_base.rs
@@ -17,15 +17,15 @@ pub fn opts() -> TargetOptions {
     args.insert(LinkerFlavor::Gcc, vec![]);
 
     TargetOptions {
-        target_os: "l4re".to_string(),
-        target_env: "uclibc".to_string(),
+        os: "l4re".to_string(),
+        env: "uclibc".to_string(),
         linker_flavor: LinkerFlavor::Ld,
         executables: true,
         has_elf_tls: false,
         panic_strategy: PanicStrategy::Abort,
         linker: Some("ld".to_string()),
         pre_link_args: args,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/linux_base.rs
+++ b/compiler/rustc_target/src/spec/linux_base.rs
@@ -19,11 +19,11 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "linux".to_string(),
-        target_env: "gnu".to_string(),
+        os: "linux".to_string(),
+        env: "gnu".to_string(),
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         linker_is_gnu: true,
         has_rpath: true,
         pre_link_args: args,

--- a/compiler/rustc_target/src/spec/linux_kernel_base.rs
+++ b/compiler/rustc_target/src/spec/linux_kernel_base.rs
@@ -8,7 +8,7 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_env: "gnu".to_string(),
+        env: "gnu".to_string(),
         disable_redzone: true,
         panic_strategy: PanicStrategy::Abort,
         stack_probes: true,

--- a/compiler/rustc_target/src/spec/linux_musl_base.rs
+++ b/compiler/rustc_target/src/spec/linux_musl_base.rs
@@ -4,7 +4,7 @@ use crate::spec::TargetOptions;
 pub fn opts() -> TargetOptions {
     let mut base = super::linux_base::opts();
 
-    base.target_env = "musl".to_string();
+    base.env = "musl".to_string();
     base.pre_link_objects_fallback = crt_objects::pre_musl_fallback();
     base.post_link_objects_fallback = crt_objects::post_musl_fallback();
     base.crt_objects_fallback = Some(CrtObjectsFallback::Musl);

--- a/compiler/rustc_target/src/spec/linux_uclibc_base.rs
+++ b/compiler/rustc_target/src/spec/linux_uclibc_base.rs
@@ -1,5 +1,5 @@
 use crate::spec::TargetOptions;
 
 pub fn opts() -> TargetOptions {
-    TargetOptions { target_env: "uclibc".to_string(), ..super::linux_base::opts() }
+    TargetOptions { env: "uclibc".to_string(), ..super::linux_base::opts() }
 }

--- a/compiler/rustc_target/src/spec/mips64_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/mips64_unknown_linux_gnuabi64.rs
@@ -7,12 +7,12 @@ pub fn target() -> Target {
         data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
         arch: "mips64".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
+            endian: "big".to_string(),
             // NOTE(mips64r2) matches C toolchain
             cpu: "mips64r2".to_string(),
             features: "+mips64r2".to_string(),
             max_atomic_width: Some(64),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mips64_unknown_linux_muslabi64.rs
+++ b/compiler/rustc_target/src/spec/mips64_unknown_linux_muslabi64.rs
@@ -11,10 +11,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
         arch: "mips64".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/mips64el_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/mips64el_unknown_linux_gnuabi64.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
             cpu: "mips64r2".to_string(),
             features: "+mips64r2".to_string(),
             max_atomic_width: Some(64),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mips64el_unknown_linux_muslabi64.rs
+++ b/compiler/rustc_target/src/spec/mips64el_unknown_linux_muslabi64.rs
@@ -11,6 +11,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
         arch: "mips64".to_string(),
-        options: TargetOptions { target_mcount: "_mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/mips_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/mips_unknown_linux_gnu.rs
@@ -7,11 +7,11 @@ pub fn target() -> Target {
         data_layout: "E-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
         arch: "mips".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
+            endian: "big".to_string(),
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+fpxx,+nooddspreg".to_string(),
             max_atomic_width: Some(32),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mips_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/mips_unknown_linux_musl.rs
@@ -11,10 +11,6 @@ pub fn target() -> Target {
         pointer_width: 32,
         data_layout: "E-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
         arch: "mips".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/mips_unknown_linux_uclibc.rs
+++ b/compiler/rustc_target/src/spec/mips_unknown_linux_uclibc.rs
@@ -7,11 +7,11 @@ pub fn target() -> Target {
         data_layout: "E-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
         arch: "mips".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
+            endian: "big".to_string(),
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+soft-float".to_string(),
             max_atomic_width: Some(32),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_uclibc_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
@@ -15,8 +15,8 @@ pub fn target() -> Target {
         arch: "mips".to_string(),
 
         options: TargetOptions {
-            target_os: "psp".to_string(),
-            target_vendor: "sony".to_string(),
+            os: "psp".to_string(),
+            vendor: "sony".to_string(),
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             cpu: "mips2".to_string(),
             executables: true,

--- a/compiler/rustc_target/src/spec/mipsel_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_linux_gnu.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+fpxx,+nooddspreg".to_string(),
             max_atomic_width: Some(32),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mipsel_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_linux_musl.rs
@@ -11,6 +11,6 @@ pub fn target() -> Target {
         pointer_width: 32,
         data_layout: "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
         arch: "mips".to_string(),
-        options: TargetOptions { target_mcount: "_mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/mipsel_unknown_linux_uclibc.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_linux_uclibc.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+soft-float".to_string(),
             max_atomic_width: Some(32),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_uclibc_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
+++ b/compiler/rustc_target/src/spec/mipsel_unknown_none.rs
@@ -14,7 +14,7 @@ pub fn target() -> Target {
         arch: "mips".to_string(),
 
         options: TargetOptions {
-            target_vendor: String::new(),
+            vendor: String::new(),
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             cpu: "mips32r2".to_string(),
             features: "+mips32r2,+soft-float,+noabicalls".to_string(),

--- a/compiler/rustc_target/src/spec/mipsisa32r6_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/mipsisa32r6_unknown_linux_gnu.rs
@@ -7,11 +7,11 @@ pub fn target() -> Target {
         data_layout: "E-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64".to_string(),
         arch: "mips".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
+            endian: "big".to_string(),
             cpu: "mips32r6".to_string(),
             features: "+mips32r6".to_string(),
             max_atomic_width: Some(32),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mipsisa32r6el_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/mipsisa32r6el_unknown_linux_gnu.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
             cpu: "mips32r6".to_string(),
             features: "+mips32r6".to_string(),
             max_atomic_width: Some(32),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mipsisa64r6_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/mipsisa64r6_unknown_linux_gnuabi64.rs
@@ -7,12 +7,12 @@ pub fn target() -> Target {
         data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
         arch: "mips64".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
+            endian: "big".to_string(),
             // NOTE(mips64r6) matches C toolchain
             cpu: "mips64r6".to_string(),
             features: "+mips64r6".to_string(),
             max_atomic_width: Some(64),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mipsisa64r6el_unknown_linux_gnuabi64.rs
+++ b/compiler/rustc_target/src/spec/mipsisa64r6el_unknown_linux_gnuabi64.rs
@@ -11,7 +11,7 @@ pub fn target() -> Target {
             cpu: "mips64r6".to_string(),
             features: "+mips64r6".to_string(),
             max_atomic_width: Some(64),
-            target_mcount: "_mcount".to_string(),
+            mcount: "_mcount".to_string(),
 
             ..super::linux_base::opts()
         },

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -38,7 +38,7 @@ use crate::spec::abi::{lookup as lookup_abi, Abi};
 use crate::spec::crt_objects::{CrtObjects, CrtObjectsFallback};
 use rustc_serialize::json::{Json, ToJson};
 use std::collections::BTreeMap;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fmt, io};
@@ -446,7 +446,7 @@ macro_rules! supported_targets {
                 $( $($triple)|+ => $module::target(), )+
                 _ => return None,
             };
-            t.options.is_builtin = true;
+            t.is_builtin = true;
             debug!("got builtin target: {:?}", t);
             Some(t)
         }
@@ -691,6 +691,10 @@ impl HasTargetSpec for Target {
 ///
 /// This has an implementation of `Default`, see each field for what the default is. In general,
 /// these try to take "minimal defaults" that don't assume anything about the runtime they run in.
+///
+/// `TargetOptions` as a separate structure is mostly an implementation detail of `Target`
+/// construction, all its fields logically belong to `Target` and available from `Target`
+/// through `Deref` impls.
 #[derive(PartialEq, Clone, Debug)]
 pub struct TargetOptions {
     /// Whether the target is built-in or loaded from a custom target specification.
@@ -1094,13 +1098,18 @@ impl Deref for Target {
         &self.options
     }
 }
+impl DerefMut for Target {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.options
+    }
+}
 
 impl Target {
     /// Given a function ABI, turn it into the correct ABI for this target.
     pub fn adjust_abi(&self, abi: Abi) -> Abi {
         match abi {
             Abi::System => {
-                if self.options.is_like_windows && self.arch == "x86" {
+                if self.is_like_windows && self.arch == "x86" {
                     Abi::Stdcall
                 } else {
                     Abi::C
@@ -1110,7 +1119,7 @@ impl Target {
             // See https://docs.microsoft.com/en-us/cpp/cpp/argument-passing-and-naming-conventions
             // and the individual pages for __stdcall et al.
             Abi::Stdcall | Abi::Fastcall | Abi::Vectorcall | Abi::Thiscall => {
-                if self.options.is_like_windows && self.arch != "x86" { Abi::C } else { abi }
+                if self.is_like_windows && self.arch != "x86" { Abi::C } else { abi }
             }
             Abi::EfiApi => {
                 if self.arch == "x86_64" {
@@ -1126,17 +1135,17 @@ impl Target {
     /// Minimum integer size in bits that this target can perform atomic
     /// operations on.
     pub fn min_atomic_width(&self) -> u64 {
-        self.options.min_atomic_width.unwrap_or(8)
+        self.min_atomic_width.unwrap_or(8)
     }
 
     /// Maximum integer size in bits that this target can perform atomic
     /// operations on.
     pub fn max_atomic_width(&self) -> u64 {
-        self.options.max_atomic_width.unwrap_or_else(|| self.pointer_width.into())
+        self.max_atomic_width.unwrap_or_else(|| self.pointer_width.into())
     }
 
     pub fn is_abi_supported(&self, abi: Abi) -> bool {
-        abi.generic() || !self.options.unsupported_abis.contains(&abi)
+        abi.generic() || !self.unsupported_abis.contains(&abi)
     }
 
     /// Loads a target descriptor from a JSON object.
@@ -1169,19 +1178,19 @@ impl Target {
             ($key_name:ident) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 if let Some(s) = obj.find(&name).and_then(Json::as_string) {
-                    base.options.$key_name = s.to_string();
+                    base.$key_name = s.to_string();
                 }
             } );
             ($key_name:ident = $json_name:expr) => ( {
                 let name = $json_name;
                 if let Some(s) = obj.find(&name).and_then(Json::as_string) {
-                    base.options.$key_name = s.to_string();
+                    base.$key_name = s.to_string();
                 }
             } );
             ($key_name:ident, bool) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 if let Some(s) = obj.find(&name).and_then(Json::as_boolean) {
-                    base.options.$key_name = s;
+                    base.$key_name = s;
                 }
             } );
             ($key_name:ident, Option<u32>) => ( {
@@ -1190,20 +1199,20 @@ impl Target {
                     if s < 1 || s > 5 {
                         return Err("Not a valid DWARF version number".to_string());
                     }
-                    base.options.$key_name = Some(s as u32);
+                    base.$key_name = Some(s as u32);
                 }
             } );
             ($key_name:ident, Option<u64>) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 if let Some(s) = obj.find(&name).and_then(Json::as_u64) {
-                    base.options.$key_name = Some(s);
+                    base.$key_name = Some(s);
                 }
             } );
             ($key_name:ident, MergeFunctions) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match s.parse::<MergeFunctions>() {
-                        Ok(mergefunc) => base.options.$key_name = mergefunc,
+                        Ok(mergefunc) => base.$key_name = mergefunc,
                         _ => return Some(Err(format!("'{}' is not a valid value for \
                                                       merge-functions. Use 'disabled', \
                                                       'trampolines', or 'aliases'.",
@@ -1216,7 +1225,7 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match s.parse::<RelocModel>() {
-                        Ok(relocation_model) => base.options.$key_name = relocation_model,
+                        Ok(relocation_model) => base.$key_name = relocation_model,
                         _ => return Some(Err(format!("'{}' is not a valid relocation model. \
                                                       Run `rustc --print relocation-models` to \
                                                       see the list of supported values.", s))),
@@ -1228,7 +1237,7 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match s.parse::<CodeModel>() {
-                        Ok(code_model) => base.options.$key_name = Some(code_model),
+                        Ok(code_model) => base.$key_name = Some(code_model),
                         _ => return Some(Err(format!("'{}' is not a valid code model. \
                                                       Run `rustc --print code-models` to \
                                                       see the list of supported values.", s))),
@@ -1240,7 +1249,7 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match s.parse::<TlsModel>() {
-                        Ok(tls_model) => base.options.$key_name = tls_model,
+                        Ok(tls_model) => base.$key_name = tls_model,
                         _ => return Some(Err(format!("'{}' is not a valid TLS model. \
                                                       Run `rustc --print tls-models` to \
                                                       see the list of supported values.", s))),
@@ -1252,8 +1261,8 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match s {
-                        "unwind" => base.options.$key_name = PanicStrategy::Unwind,
-                        "abort" => base.options.$key_name = PanicStrategy::Abort,
+                        "unwind" => base.$key_name = PanicStrategy::Unwind,
+                        "abort" => base.$key_name = PanicStrategy::Abort,
                         _ => return Some(Err(format!("'{}' is not a valid value for \
                                                       panic-strategy. Use 'unwind' or 'abort'.",
                                                      s))),
@@ -1265,7 +1274,7 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match s.parse::<RelroLevel>() {
-                        Ok(level) => base.options.$key_name = level,
+                        Ok(level) => base.$key_name = level,
                         _ => return Some(Err(format!("'{}' is not a valid value for \
                                                       relro-level. Use 'full', 'partial, or 'off'.",
                                                       s))),
@@ -1276,7 +1285,7 @@ impl Target {
             ($key_name:ident, list) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 if let Some(v) = obj.find(&name).and_then(Json::as_array) {
-                    base.options.$key_name = v.iter()
+                    base.$key_name = v.iter()
                         .map(|a| a.as_string().unwrap().to_string())
                         .collect();
                 }
@@ -1284,7 +1293,7 @@ impl Target {
             ($key_name:ident, opt_list) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 if let Some(v) = obj.find(&name).and_then(Json::as_array) {
-                    base.options.$key_name = Some(v.iter()
+                    base.$key_name = Some(v.iter()
                         .map(|a| a.as_string().unwrap().to_string())
                         .collect());
                 }
@@ -1292,7 +1301,7 @@ impl Target {
             ($key_name:ident, optional) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 if let Some(o) = obj.find(&name[..]) {
-                    base.options.$key_name = o
+                    base.$key_name = o
                         .as_string()
                         .map(|s| s.to_string() );
                 }
@@ -1301,7 +1310,7 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     if let Some(flavor) = LldFlavor::from_str(&s) {
-                        base.options.$key_name = flavor;
+                        base.$key_name = flavor;
                     } else {
                         return Some(Err(format!(
                             "'{}' is not a valid value for lld-flavor. \
@@ -1315,7 +1324,7 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match LinkerFlavor::from_str(s) {
-                        Some(linker_flavor) => base.options.$key_name = linker_flavor,
+                        Some(linker_flavor) => base.$key_name = linker_flavor,
                         _ => return Some(Err(format!("'{}' is not a valid value for linker-flavor. \
                                                       Use {}", s, LinkerFlavor::one_of()))),
                     }
@@ -1326,7 +1335,7 @@ impl Target {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
                     match s.parse::<CrtObjectsFallback>() {
-                        Ok(fallback) => base.options.$key_name = Some(fallback),
+                        Ok(fallback) => base.$key_name = Some(fallback),
                         _ => return Some(Err(format!("'{}' is not a valid CRT objects fallback. \
                                                       Use 'musl', 'mingw' or 'wasm'", s))),
                     }
@@ -1358,7 +1367,7 @@ impl Target {
 
                         args.insert(kind, v);
                     }
-                    base.options.$key_name = args;
+                    base.$key_name = args;
                 }
             } );
             ($key_name:ident, link_args) => ( {
@@ -1385,7 +1394,7 @@ impl Target {
 
                         args.insert(flavor, v);
                     }
-                    base.options.$key_name = args;
+                    base.$key_name = args;
                 }
             } );
             ($key_name:ident, env) => ( {
@@ -1397,7 +1406,7 @@ impl Target {
                             if p.len() == 2 {
                                 let k = p[0].to_string();
                                 let v = p[1].to_string();
-                                base.options.$key_name.push((k, v));
+                                base.$key_name.push((k, v));
                             }
                         }
                     }
@@ -1513,7 +1522,7 @@ impl Target {
                                 ));
                             }
 
-                            base.options.unsupported_abis.push(abi)
+                            base.unsupported_abis.push(abi)
                         }
                         None => {
                             return Err(format!(
@@ -1602,21 +1611,20 @@ impl ToJson for Target {
         macro_rules! target_option_val {
             ($attr:ident) => {{
                 let name = (stringify!($attr)).replace("_", "-");
-                if default.$attr != self.options.$attr {
-                    d.insert(name, self.options.$attr.to_json());
+                if default.$attr != self.$attr {
+                    d.insert(name, self.$attr.to_json());
                 }
             }};
             ($attr:ident, $key_name:expr) => {{
                 let name = $key_name;
-                if default.$attr != self.options.$attr {
-                    d.insert(name.to_string(), self.options.$attr.to_json());
+                if default.$attr != self.$attr {
+                    d.insert(name.to_string(), self.$attr.to_json());
                 }
             }};
             (link_args - $attr:ident) => {{
                 let name = (stringify!($attr)).replace("_", "-");
-                if default.$attr != self.options.$attr {
+                if default.$attr != self.$attr {
                     let obj = self
-                        .options
                         .$attr
                         .iter()
                         .map(|(k, v)| (k.desc().to_owned(), v.clone()))
@@ -1626,9 +1634,8 @@ impl ToJson for Target {
             }};
             (env - $attr:ident) => {{
                 let name = (stringify!($attr)).replace("_", "-");
-                if default.$attr != self.options.$attr {
+                if default.$attr != self.$attr {
                     let obj = self
-                        .options
                         .$attr
                         .iter()
                         .map(|&(ref k, ref v)| k.clone() + "=" + &v)
@@ -1736,11 +1743,10 @@ impl ToJson for Target {
         target_option_val!(eh_frame_header);
         target_option_val!(has_thumb_interworking);
 
-        if default.unsupported_abis != self.options.unsupported_abis {
+        if default.unsupported_abis != self.unsupported_abis {
             d.insert(
                 "unsupported-abis".to_string(),
-                self.options
-                    .unsupported_abis
+                self.unsupported_abis
                     .iter()
                     .map(|&name| Abi::name(name).to_json())
                     .collect::<Vec<_>>()

--- a/compiler/rustc_target/src/spec/msp430_none_elf.rs
+++ b/compiler/rustc_target/src/spec/msp430_none_elf.rs
@@ -8,8 +8,8 @@ pub fn target() -> Target {
         arch: "msp430".to_string(),
 
         options: TargetOptions {
-            target_c_int_width: "16".to_string(),
-            target_vendor: String::new(),
+            c_int_width: "16".to_string(),
+            vendor: String::new(),
             executables: true,
 
             // The LLVM backend currently can't generate object files. To

--- a/compiler/rustc_target/src/spec/netbsd_base.rs
+++ b/compiler/rustc_target/src/spec/netbsd_base.rs
@@ -14,10 +14,10 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "netbsd".to_string(),
+        os: "netbsd".to_string(),
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         linker_is_gnu: true,
         no_default_libraries: false,
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/nvptx64_nvidia_cuda.rs
+++ b/compiler/rustc_target/src/spec/nvptx64_nvidia_cuda.rs
@@ -9,8 +9,8 @@ pub fn target() -> Target {
         pointer_width: 64,
 
         options: TargetOptions {
-            target_os: "cuda".to_string(),
-            target_vendor: "nvidia".to_string(),
+            os: "cuda".to_string(),
+            vendor: "nvidia".to_string(),
             linker_flavor: LinkerFlavor::PtxLinker,
             // The linker can be installed from `crates.io`.
             linker: Some("rust-ptx-linker".to_string()),

--- a/compiler/rustc_target/src/spec/openbsd_base.rs
+++ b/compiler/rustc_target/src/spec/openbsd_base.rs
@@ -16,10 +16,10 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "openbsd".to_string(),
+        os: "openbsd".to_string(),
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         linker_is_gnu: true,
         has_rpath: true,
         abi_return_struct_as_int: true,

--- a/compiler/rustc_target/src/spec/powerpc64_unknown_freebsd.rs
+++ b/compiler/rustc_target/src/spec/powerpc64_unknown_freebsd.rs
@@ -11,10 +11,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "E-m:e-i64:64-n32:64".to_string(),
         arch: "powerpc64".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/powerpc64_unknown_linux_gnu.rs
@@ -15,10 +15,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "E-m:e-i64:64-n32:64".to_string(),
         arch: "powerpc64".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/powerpc64_unknown_linux_musl.rs
@@ -11,10 +11,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "E-m:e-i64:64-n32:64".to_string(),
         arch: "powerpc64".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc64_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/powerpc64_wrs_vxworks.rs
@@ -11,6 +11,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "E-m:e-i64:64-n32:64".to_string(),
         arch: "powerpc64".to_string(),
-        options: TargetOptions { target_endian: "big".to_string(), ..base },
+        options: TargetOptions { endian: "big".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc64le_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/powerpc64le_unknown_linux_gnu.rs
@@ -11,6 +11,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-i64:64-n32:64".to_string(),
         arch: "powerpc64".to_string(),
-        options: TargetOptions { target_mcount: "_mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc64le_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/powerpc64le_unknown_linux_musl.rs
@@ -11,6 +11,6 @@ pub fn target() -> Target {
         pointer_width: 64,
         data_layout: "e-m:e-i64:64-n32:64".to_string(),
         arch: "powerpc64".to_string(),
-        options: TargetOptions { target_mcount: "_mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/powerpc_unknown_linux_gnu.rs
@@ -10,10 +10,6 @@ pub fn target() -> Target {
         pointer_width: 32,
         data_layout: "E-m:e-p:32:32-i64:64-n32".to_string(),
         arch: "powerpc".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc_unknown_linux_gnuspe.rs
+++ b/compiler/rustc_target/src/spec/powerpc_unknown_linux_gnuspe.rs
@@ -10,10 +10,6 @@ pub fn target() -> Target {
         pointer_width: 32,
         data_layout: "E-m:e-p:32:32-i64:64-n32".to_string(),
         arch: "powerpc".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/powerpc_unknown_linux_musl.rs
@@ -10,10 +10,6 @@ pub fn target() -> Target {
         pointer_width: 32,
         data_layout: "E-m:e-p:32:32-i64:64-n32".to_string(),
         arch: "powerpc".to_string(),
-        options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "_mcount".to_string(),
-            ..base
-        },
+        options: TargetOptions { endian: "big".to_string(), mcount: "_mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/powerpc_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/powerpc_unknown_netbsd.rs
@@ -11,8 +11,8 @@ pub fn target() -> Target {
         data_layout: "E-m:e-p:32:32-i64:64-n32".to_string(),
         arch: "powerpc".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "__mcount".to_string(),
+            endian: "big".to_string(),
+            mcount: "__mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/powerpc_wrs_vxworks.rs
+++ b/compiler/rustc_target/src/spec/powerpc_wrs_vxworks.rs
@@ -12,7 +12,7 @@ pub fn target() -> Target {
         data_layout: "E-m:e-p:32:32-i64:64-n32".to_string(),
         arch: "powerpc".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
+            endian: "big".to_string(),
             features: "+secure-plt".to_string(),
             ..base
         },

--- a/compiler/rustc_target/src/spec/powerpc_wrs_vxworks_spe.rs
+++ b/compiler/rustc_target/src/spec/powerpc_wrs_vxworks_spe.rs
@@ -12,7 +12,7 @@ pub fn target() -> Target {
         data_layout: "E-m:e-p:32:32-i64:64-n32".to_string(),
         arch: "powerpc".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
+            endian: "big".to_string(),
             // feature msync would disable instruction 'fsync' which is not supported by fsl_p1p2
             features: "+secure-plt,+msync".to_string(),
             ..base

--- a/compiler/rustc_target/src/spec/redox_base.rs
+++ b/compiler/rustc_target/src/spec/redox_base.rs
@@ -19,11 +19,11 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "redox".to_string(),
-        target_env: "relibc".to_string(),
+        os: "redox".to_string(),
+        env: "relibc".to_string(),
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         linker_is_gnu: true,
         has_rpath: true,
         pre_link_args: args,

--- a/compiler/rustc_target/src/spec/s390x_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/s390x_unknown_linux_gnu.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
-    base.target_endian = "big".to_string();
+    base.endian = "big".to_string();
     // z10 is the oldest CPU supported by LLVM
     base.cpu = "z10".to_string();
     // FIXME: The data_layout string below and the ABI implementation in

--- a/compiler/rustc_target/src/spec/solaris_base.rs
+++ b/compiler/rustc_target/src/spec/solaris_base.rs
@@ -2,12 +2,12 @@ use crate::spec::TargetOptions;
 
 pub fn opts() -> TargetOptions {
     TargetOptions {
-        target_os: "solaris".to_string(),
-        target_vendor: "sun".to_string(),
+        os: "solaris".to_string(),
+        vendor: "sun".to_string(),
         dynamic_linking: true,
         executables: true,
         has_rpath: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         is_like_solaris: true,
         limit_rdylib_exports: false, // Linker doesn't support this
         eh_frame_header: false,

--- a/compiler/rustc_target/src/spec/sparc64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/sparc64_unknown_linux_gnu.rs
@@ -2,7 +2,7 @@ use crate::spec::Target;
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
-    base.target_endian = "big".to_string();
+    base.endian = "big".to_string();
     base.cpu = "v9".to_string();
     base.max_atomic_width = Some(64);
 

--- a/compiler/rustc_target/src/spec/sparc64_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/sparc64_unknown_netbsd.rs
@@ -12,8 +12,8 @@ pub fn target() -> Target {
         data_layout: "E-m:e-i64:64-n32:64-S128".to_string(),
         arch: "sparc64".to_string(),
         options: TargetOptions {
-            target_endian: "big".to_string(),
-            target_mcount: "__mcount".to_string(),
+            endian: "big".to_string(),
+            mcount: "__mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/sparc64_unknown_openbsd.rs
+++ b/compiler/rustc_target/src/spec/sparc64_unknown_openbsd.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, Target};
 
 pub fn target() -> Target {
     let mut base = super::openbsd_base::opts();
-    base.target_endian = "big".to_string();
+    base.endian = "big".to_string();
     base.cpu = "v9".to_string();
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
     base.max_atomic_width = Some(64);

--- a/compiler/rustc_target/src/spec/sparc_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/sparc_unknown_linux_gnu.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, Target};
 
 pub fn target() -> Target {
     let mut base = super::linux_base::opts();
-    base.target_endian = "big".to_string();
+    base.endian = "big".to_string();
     base.cpu = "v9".to_string();
     base.max_atomic_width = Some(64);
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-mv8plus".to_string());

--- a/compiler/rustc_target/src/spec/sparcv9_sun_solaris.rs
+++ b/compiler/rustc_target/src/spec/sparcv9_sun_solaris.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, Target};
 
 pub fn target() -> Target {
     let mut base = super::solaris_base::opts();
-    base.target_endian = "big".to_string();
+    base.endian = "big".to_string();
     base.pre_link_args.insert(LinkerFlavor::Gcc, vec!["-m64".to_string()]);
     // llvm calls this "v9"
     base.cpu = "v9".to_string();

--- a/compiler/rustc_target/src/spec/tests/tests_impl.rs
+++ b/compiler/rustc_target/src/spec/tests/tests_impl.rs
@@ -14,27 +14,27 @@ impl Target {
         assert_eq!(
             self.linker_flavor == LinkerFlavor::Msvc
                 || self.linker_flavor == LinkerFlavor::Lld(LldFlavor::Link),
-            self.options.lld_flavor == LldFlavor::Link,
+            self.lld_flavor == LldFlavor::Link,
         );
         for args in &[
-            &self.options.pre_link_args,
-            &self.options.late_link_args,
-            &self.options.late_link_args_dynamic,
-            &self.options.late_link_args_static,
-            &self.options.post_link_args,
+            &self.pre_link_args,
+            &self.late_link_args,
+            &self.late_link_args_dynamic,
+            &self.late_link_args_static,
+            &self.post_link_args,
         ] {
             assert_eq!(
                 args.get(&LinkerFlavor::Msvc),
                 args.get(&LinkerFlavor::Lld(LldFlavor::Link)),
             );
             if args.contains_key(&LinkerFlavor::Msvc) {
-                assert_eq!(self.options.lld_flavor, LldFlavor::Link);
+                assert_eq!(self.lld_flavor, LldFlavor::Link);
             }
         }
         assert!(
-            (self.options.pre_link_objects_fallback.is_empty()
-                && self.options.post_link_objects_fallback.is_empty())
-                || self.options.crt_objects_fallback.is_some()
+            (self.pre_link_objects_fallback.is_empty()
+                && self.post_link_objects_fallback.is_empty())
+                || self.crt_objects_fallback.is_some()
         );
     }
 }

--- a/compiler/rustc_target/src/spec/thumb_base.rs
+++ b/compiler/rustc_target/src/spec/thumb_base.rs
@@ -32,7 +32,7 @@ use crate::spec::{LinkerFlavor, LldFlavor, PanicStrategy, RelocModel, TargetOpti
 pub fn opts() -> TargetOptions {
     // See rust-lang/rfcs#1645 for a discussion about these defaults
     TargetOptions {
-        target_vendor: String::new(),
+        vendor: String::new(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         executables: true,
         // In most cases, LLD is good enough

--- a/compiler/rustc_target/src/spec/thumbv7neon_unknown_linux_musleabihf.rs
+++ b/compiler/rustc_target/src/spec/thumbv7neon_unknown_linux_musleabihf.rs
@@ -24,7 +24,7 @@ pub fn target() -> Target {
             cpu: "generic".to_string(),
             max_atomic_width: Some(64),
             unsupported_abis: super::arm_base::unsupported_abis(),
-            target_mcount: "\u{1}mcount".to_string(),
+            mcount: "\u{1}mcount".to_string(),
             ..base
         },
     }

--- a/compiler/rustc_target/src/spec/uefi_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/uefi_msvc_base.rs
@@ -37,7 +37,7 @@ pub fn opts() -> TargetOptions {
         .extend(pre_link_args_msvc);
 
     TargetOptions {
-        target_os: "uefi".to_string(),
+        os: "uefi".to_string(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Link),
         disable_redzone: true,
         exe_suffix: ".efi".to_string(),

--- a/compiler/rustc_target/src/spec/vxworks_base.rs
+++ b/compiler/rustc_target/src/spec/vxworks_base.rs
@@ -17,14 +17,14 @@ pub fn opts() -> TargetOptions {
     );
 
     TargetOptions {
-        target_os: "vxworks".to_string(),
-        target_env: "gnu".to_string(),
-        target_vendor: "wrs".to_string(),
+        os: "vxworks".to_string(),
+        env: "gnu".to_string(),
+        vendor: "wrs".to_string(),
         linker: Some("wr-c++".to_string()),
         exe_suffix: ".vxe".to_string(),
         dynamic_linking: true,
         executables: true,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         linker_is_gnu: true,
         has_rpath: true,
         pre_link_args: args,
@@ -34,7 +34,7 @@ pub fn opts() -> TargetOptions {
         crt_static_respected: true,
         crt_static_allows_dylibs: true,
         // VxWorks needs to implement this to support profiling
-        target_mcount: "_mcount".to_string(),
+        mcount: "_mcount".to_string(),
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -17,7 +17,7 @@ pub fn target() -> Target {
     );
 
     let opts = TargetOptions {
-        target_os: "emscripten".to_string(),
+        os: "emscripten".to_string(),
         linker_flavor: LinkerFlavor::Em,
         // emcc emits two files - a .js file to instantiate the wasm and supply platform
         // functionality, and a .wasm file.
@@ -27,7 +27,7 @@ pub fn target() -> Target {
         is_like_emscripten: true,
         panic_strategy: PanicStrategy::Unwind,
         post_link_args,
-        target_family: Some("unix".to_string()),
+        os_family: Some("unix".to_string()),
         ..wasm32_base::options()
     };
     Target {

--- a/compiler/rustc_target/src/spec/wasm32_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_unknown.rs
@@ -15,7 +15,7 @@ use super::{LinkerFlavor, LldFlavor, Target};
 
 pub fn target() -> Target {
     let mut options = wasm32_base::options();
-    options.target_os = "unknown".to_string();
+    options.os = "unknown".to_string();
     options.linker_flavor = LinkerFlavor::Lld(LldFlavor::Wasm);
     let clang_args = options.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap();
 

--- a/compiler/rustc_target/src/spec/wasm32_wasi.rs
+++ b/compiler/rustc_target/src/spec/wasm32_wasi.rs
@@ -78,8 +78,8 @@ use super::{crt_objects, LinkerFlavor, LldFlavor, Target};
 pub fn target() -> Target {
     let mut options = wasm32_base::options();
 
-    options.target_os = "wasi".to_string();
-    options.target_vendor = String::new();
+    options.os = "wasi".to_string();
+    options.vendor = String::new();
     options.linker_flavor = LinkerFlavor::Lld(LldFlavor::Wasm);
     options
         .pre_link_args

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -62,9 +62,9 @@ pub fn opts() -> TargetOptions {
     late_link_args_static.insert(LinkerFlavor::Lld(LldFlavor::Ld), static_unwind_libs);
 
     TargetOptions {
-        target_os: "windows".to_string(),
-        target_env: "gnu".to_string(),
-        target_vendor: "pc".to_string(),
+        os: "windows".to_string(),
+        env: "gnu".to_string(),
+        vendor: "pc".to_string(),
         // FIXME(#13846) this should be enabled for windows
         function_sections: false,
         linker: Some("gcc".to_string()),
@@ -75,7 +75,7 @@ pub fn opts() -> TargetOptions {
         exe_suffix: ".exe".to_string(),
         staticlib_prefix: "lib".to_string(),
         staticlib_suffix: ".a".to_string(),
-        target_family: Some("windows".to_string()),
+        os_family: Some("windows".to_string()),
         is_like_windows: true,
         allows_weak_linkage: false,
         pre_link_args,

--- a/compiler/rustc_target/src/spec/windows_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/windows_msvc_base.rs
@@ -4,16 +4,16 @@ pub fn opts() -> TargetOptions {
     let base = super::msvc_base::opts();
 
     TargetOptions {
-        target_os: "windows".to_string(),
-        target_env: "msvc".to_string(),
-        target_vendor: "pc".to_string(),
+        os: "windows".to_string(),
+        env: "msvc".to_string(),
+        vendor: "pc".to_string(),
         dynamic_linking: true,
         dll_prefix: String::new(),
         dll_suffix: ".dll".to_string(),
         exe_suffix: ".exe".to_string(),
         staticlib_prefix: String::new(),
         staticlib_suffix: ".lib".to_string(),
-        target_family: Some("windows".to_string()),
+        os_family: Some("windows".to_string()),
         crt_static_allows_dylibs: true,
         crt_static_respected: true,
         requires_uwtable: true,

--- a/compiler/rustc_target/src/spec/windows_uwp_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_uwp_gnu_base.rs
@@ -25,7 +25,7 @@ pub fn opts() -> TargetOptions {
     late_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), mingw_libs);
 
     TargetOptions {
-        target_vendor: "uwp".to_string(),
+        vendor: "uwp".to_string(),
         executables: false,
         limit_rdylib_exports: false,
         late_link_args,

--- a/compiler/rustc_target/src/spec/windows_uwp_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/windows_uwp_msvc_base.rs
@@ -3,7 +3,7 @@ use crate::spec::{LinkerFlavor, LldFlavor, TargetOptions};
 pub fn opts() -> TargetOptions {
     let mut opts = super::windows_msvc_base::opts();
 
-    opts.target_vendor = "uwp".to_string();
+    opts.vendor = "uwp".to_string();
     let pre_link_args_msvc = vec!["/APPCONTAINER".to_string(), "mincore.lib".to_string()];
     opts.pre_link_args.get_mut(&LinkerFlavor::Msvc).unwrap().extend(pre_link_args_msvc.clone());
     opts.pre_link_args

--- a/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_darwin.rs
@@ -24,6 +24,6 @@ pub fn target() -> Target {
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
             .to_string(),
         arch: arch.to_string(),
-        options: TargetOptions { target_mcount: "\u{1}mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "\u{1}mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
+++ b/compiler/rustc_target/src/spec/x86_64_fortanix_unknown_sgx.rs
@@ -55,9 +55,9 @@ pub fn target() -> Target {
         "TEXT_SIZE",
     ];
     let opts = TargetOptions {
-        target_os: "unknown".into(),
-        target_env: "sgx".into(),
-        target_vendor: "fortanix".into(),
+        os: "unknown".into(),
+        env: "sgx".into(),
+        vendor: "fortanix".into(),
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         dynamic_linking: false,
         executables: true,

--- a/compiler/rustc_target/src/spec/x86_64_rumprun_netbsd.rs
+++ b/compiler/rustc_target/src/spec/x86_64_rumprun_netbsd.rs
@@ -2,7 +2,7 @@ use crate::spec::{LinkerFlavor, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut base = super::netbsd_base::opts();
-    base.target_vendor = "rumprun".to_string();
+    base.vendor = "rumprun".to_string();
     base.cpu = "x86-64".to_string();
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
     base.linker = Some("x86_64-rumprun-netbsd-gcc".to_string());
@@ -20,6 +20,6 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
             .to_string(),
         arch: "x86_64".to_string(),
-        options: TargetOptions { target_mcount: "__mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "__mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_target/src/spec/x86_64_unknown_netbsd.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_netbsd.rs
@@ -13,6 +13,6 @@ pub fn target() -> Target {
         data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
             .to_string(),
         arch: "x86_64".to_string(),
-        options: TargetOptions { target_mcount: "__mcount".to_string(), ..base },
+        options: TargetOptions { mcount: "__mcount".to_string(), ..base },
     }
 }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2653,7 +2653,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                             set.path.segments.iter().map(|x| x.ident.name).collect::<Vec<_>>();
                         match segments.as_slice() {
                             [sym::arm, sym::a32] | [sym::arm, sym::t32] => {
-                                if !tcx.sess.target.options.has_thumb_interworking {
+                                if !tcx.sess.target.has_thumb_interworking {
                                     struct_span_err!(
                                         tcx.sess.diagnostic(),
                                         attr.span,

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2136,10 +2136,8 @@ impl<T> InPlaceDrop<T> {
 impl<T> Drop for InPlaceDrop<T> {
     #[inline]
     fn drop(&mut self) {
-        if mem::needs_drop::<T>() {
-            unsafe {
-                ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
-            }
+        unsafe {
+            ptr::drop_in_place(slice::from_raw_parts_mut(self.inner, self.len()));
         }
     }
 }
@@ -2871,10 +2869,8 @@ impl<T> IntoIter<T> {
     }
 
     fn drop_remaining(&mut self) {
-        if mem::needs_drop::<T>() {
-            unsafe {
-                ptr::drop_in_place(self.as_mut_slice());
-            }
+        unsafe {
+            ptr::drop_in_place(self.as_mut_slice());
         }
         self.ptr = self.end;
     }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -788,7 +788,7 @@ extern "rust-intrinsic" {
 
     /// The size of the referenced value in bytes.
     ///
-    /// The stabilized version of this intrinsic is [`size_of_val`].
+    /// The stabilized version of this intrinsic is [`mem::size_of_val`].
     #[rustc_const_unstable(feature = "const_size_of_val", issue = "46571")]
     pub fn size_of_val<T: ?Sized>(_: *const T) -> usize;
     /// The required alignment of the referenced value.
@@ -1704,7 +1704,7 @@ extern "rust-intrinsic" {
     /// Returns the number of variants of the type `T` cast to a `usize`;
     /// if `T` has no variants, returns 0. Uninhabited variants will be counted.
     ///
-    /// The to-be-stabilized version of this intrinsic is [`variant_count`].
+    /// The to-be-stabilized version of this intrinsic is [`mem::variant_count`].
     #[rustc_const_unstable(feature = "variant_count", issue = "73662")]
     pub fn variant_count<T>() -> usize;
 

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -318,7 +318,7 @@ macro_rules! r#try {
 
 /// Writes formatted data into a buffer.
 ///
-/// This macro accepts a format string, a list of arguments, and a 'writer'. Arguments will be
+/// This macro accepts a 'writer', a format string, a list of arguments. Arguments will be
 /// formatted according to the specified format string and the result will be passed to the writer.
 /// The writer may be any value with a `write_fmt` method; generally this comes from an
 /// implementation of either the [`fmt::Write`] or the [`io::Write`] trait. The macro

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -318,7 +318,7 @@ macro_rules! r#try {
 
 /// Writes formatted data into a buffer.
 ///
-/// This macro accepts a 'writer', a format string, a list of arguments. Arguments will be
+/// This macro accepts a 'writer', a format string, and a list of arguments. Arguments will be
 /// formatted according to the specified format string and the result will be passed to the writer.
 /// The writer may be any value with a `write_fmt` method; generally this comes from an
 /// implementation of either the [`fmt::Write`] or the [`io::Write`] trait. The macro

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -316,7 +316,7 @@ pub fn take_alloc_error_hook() -> fn(Layout) {
 }
 
 fn default_alloc_error_hook(layout: Layout) {
-    dumb_print(format_args!("memory allocation of {} bytes failed", layout.size()));
+    dumb_print(format_args!("memory allocation of {} bytes failed\n", layout.size()));
 }
 
 #[cfg(not(test))]

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1967,10 +1967,15 @@ impl Clean<Span> for rustc_span::Span {
             return Span::empty();
         }
 
+        // Get the macro invocation instead of the definition,
+        // in case the span is result of a macro expansion.
+        // (See rust-lang/rust#39726)
+        let span = self.source_callsite();
+
         let sm = cx.sess().source_map();
-        let filename = sm.span_to_filename(*self);
-        let lo = sm.lookup_char_pos(self.lo());
-        let hi = sm.lookup_char_pos(self.hi());
+        let filename = sm.span_to_filename(span);
+        let lo = sm.lookup_char_pos(span.lo());
+        let hi = sm.lookup_char_pos(span.hi());
         Span {
             filename,
             cnum: lo.file.cnum,
@@ -1978,7 +1983,7 @@ impl Clean<Span> for rustc_span::Span {
             locol: lo.col.to_usize(),
             hiline: hi.line,
             hicol: hi.col.to_usize(),
-            original: *self,
+            original: span,
         }
     }
 }

--- a/src/test/rustdoc/external-macro-src.rs
+++ b/src/test/rustdoc/external-macro-src.rs
@@ -1,15 +1,12 @@
 // aux-build:external-macro-src.rs
-// ignore-tidy-linelength
 
 #![crate_name = "foo"]
 
 #[macro_use]
 extern crate external_macro_src;
 
-// @has foo/index.html '//a[@href="../src/foo/external-macro-src.rs.html#4-15"]' '[src]'
+// @has foo/index.html '//a[@href="../src/foo/external-macro-src.rs.html#3-12"]' '[src]'
 
 // @has foo/struct.Foo.html
-// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#8"]' '[src]'
-// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#9-13"]' '[src]'
-// @has - '//a[@href="https://example.com/src/external_macro_src/external-macro-src.rs.html#10-12"]' '[src]'
+// @has - '//a[@href="../src/foo/external-macro-src.rs.html#12"]' '[src]'
 make_foo!();

--- a/src/test/rustdoc/issue-26606.rs
+++ b/src/test/rustdoc/issue-26606.rs
@@ -7,5 +7,5 @@
 extern crate issue_26606_macro;
 
 // @has issue_26606/constant.FOO.html
-// @has - '//a/@href' '../src/issue_26606_macro/issue-26606-macro.rs.html#3'
+// @has - '//a[@href="../src/issue_26606/issue-26606.rs.html#11"]' '[src]'
 make_item!(FOO);

--- a/src/test/rustdoc/thread-local-src.rs
+++ b/src/test/rustdoc/thread-local-src.rs
@@ -2,5 +2,5 @@
 
 // @has foo/index.html '//a[@href="../src/foo/thread-local-src.rs.html#1-6"]' '[src]'
 
-// @has foo/constant.FOO.html '//a/@href' 'https://doc.rust-lang.org/nightly/src/std/'
+// @has foo/constant.FOO.html '//a[@href="../src/foo/thread-local-src.rs.html#6"]' '[src]'
 thread_local!(pub static FOO: bool = false);

--- a/src/test/ui/async-await/issues/issue-63388-1.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-1.stderr
@@ -2,12 +2,14 @@ error[E0623]: lifetime mismatch
   --> $DIR/issue-63388-1.rs:14:9
    |
 LL |         &'a self, foo: &dyn Foo
-   |         -------- this parameter and the return type are declared with different lifetimes...
+   |         -------- this parameter and the returned future are declared with different lifetimes...
 LL |     ) -> &dyn Foo
    |          --------
+   |          |
+   |          this `async fn` implicitly returns an `impl Future<Output = &dyn Foo>`
 LL |     {
 LL |         foo
-   |         ^^^ ...but data from `foo` is returned here
+   |         ^^^ ...but data from `foo` is held across an await point here
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
+++ b/src/test/ui/async-await/multiple-lifetimes/ret-impl-trait-one.stderr
@@ -4,8 +4,9 @@ error[E0623]: lifetime mismatch
 LL | async fn async_ret_impl_trait1<'a, 'b>(a: &'a u8, b: &'b u8) -> impl Trait<'a> {
    |                                           ------                ^^^^^^^^^^^^^^
    |                                           |                     |
-   |                                           |                     ...but data from `b` is returned here
-   |                                           this parameter and the return type are declared with different lifetimes...
+   |                                           |                     ...but data from `b` is held across an await point here
+   |                                           |                     this `async fn` implicitly returns an `impl Future<Output = impl Trait<'a>>`
+   |                                           this parameter and the returned future are declared with different lifetimes...
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/min_const_generics/macro-fail.rs
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.rs
@@ -1,0 +1,48 @@
+#![feature(min_const_generics)]
+
+struct Example<const N: usize>;
+
+macro_rules! external_macro {
+  () => {{
+    //~^ ERROR expected type
+    const X: usize = 1337;
+    X
+  }}
+}
+
+trait Marker<const N: usize> {}
+impl<const N: usize> Marker<N> for Example<N> {}
+
+fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+  Example::<gimme_a_const!(marker)>
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+}
+
+fn from_marker(_: impl Marker<{
+    #[macro_export]
+    macro_rules! inline { () => {{ 3 }} }; inline!()
+}>) {}
+
+fn main() {
+  let _ok = Example::<{
+    #[macro_export]
+    macro_rules! gimme_a_const {
+      ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+      //~^ ERROR expected type
+      //~| ERROR expected type
+    };
+    gimme_a_const!(run)
+  }>;
+
+  let _fail = Example::<external_macro!()>;
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+
+  let _fail = Example::<gimme_a_const!()>;
+  //~^ ERROR wrong number of const
+  //~| ERROR wrong number of type
+  //~| ERROR unexpected end of macro invocation
+}

--- a/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -1,0 +1,107 @@
+error: expected type, found `{`
+  --> $DIR/macro-fail.rs:33:27
+   |
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                                 ----------------------
+   |                                 |
+   |                                 this macro call doesn't expand to a type
+   |                                 in this macro invocation
+...
+LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected type, found `{`
+  --> $DIR/macro-fail.rs:33:27
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ----------------------
+   |             |
+   |             this macro call doesn't expand to a type
+   |             in this macro invocation
+...
+LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected type, found `{`
+  --> $DIR/macro-fail.rs:6:10
+   |
+LL |     () => {{
+   |  __________^
+LL | |
+LL | |     const X: usize = 1337;
+LL | |     X
+LL | |   }}
+   | |___^ expected type
+...
+LL |     let _fail = Example::<external_macro!()>;
+   |                           -----------------
+   |                           |
+   |                           this macro call doesn't expand to a type
+   |                           in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: unexpected end of macro invocation
+  --> $DIR/macro-fail.rs:44:25
+   |
+LL |     macro_rules! gimme_a_const {
+   |     -------------------------- when calling this macro
+...
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:16:26
+   |
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:16:33
+   |
+LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ unexpected type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:19:3
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:19:13
+   |
+LL |   Example::<gimme_a_const!(marker)>
+   |             ^^^^^^^^^^^^^^^^^^^^^^ unexpected type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:40:15
+   |
+LL |   let _fail = Example::<external_macro!()>;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:40:25
+   |
+LL |   let _fail = Example::<external_macro!()>;
+   |                         ^^^^^^^^^^^^^^^^^ unexpected type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/macro-fail.rs:44:15
+   |
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/macro-fail.rs:44:25
+   |
+LL |   let _fail = Example::<gimme_a_const!()>;
+   |                         ^^^^^^^^^^^^^^^^ unexpected type argument
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/min_const_generics/macro.rs
+++ b/src/test/ui/const-generics/min_const_generics/macro.rs
@@ -1,0 +1,57 @@
+// run-pass
+#![feature(min_const_generics)]
+
+struct Example<const N: usize>;
+
+macro_rules! external_macro {
+  () => {{
+    const X: usize = 1337;
+    X
+  }}
+}
+
+trait Marker<const N: usize> {}
+impl<const N: usize> Marker<N> for Example<N> {}
+
+fn make_marker() -> impl Marker<{
+    #[macro_export]
+    macro_rules! const_macro { () => {{ 3 }} }; inline!()
+}> {
+  Example::<{ const_macro!() }>
+}
+
+fn from_marker(_: impl Marker<{
+    #[macro_export]
+    macro_rules! inline { () => {{ 3 }} }; inline!()
+}>) {}
+
+fn main() {
+  let _ok = Example::<{
+    #[macro_export]
+    macro_rules! gimme_a_const {
+      ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
+    };
+    gimme_a_const!(run)
+  }>;
+
+  let _ok = Example::<{ external_macro!() }>;
+
+  let _ok: [_; gimme_a_const!(blah)] = [0,0,0];
+  let _ok: [[u8; gimme_a_const!(blah)]; gimme_a_const!(blah)];
+  let _ok: [u8; gimme_a_const!(blah)];
+
+  let _ok: [u8; {
+    #[macro_export]
+    macro_rules! const_two { () => {{ 2 }} };
+    const_two!()
+  }];
+
+  let _ok = [0; {
+    #[macro_export]
+    macro_rules! const_three { () => {{ 3 }} };
+    const_three!()
+  }];
+  let _ok = [0; const_three!()];
+
+  from_marker(make_marker());
+}

--- a/src/test/ui/consts/const-block-non-item-statement.rs
+++ b/src/test/ui/consts/const-block-non-item-statement.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 enum Foo {
     Bar = { let x = 1; 3 }

--- a/src/test/ui/consts/const-fn-destructuring-arg.rs
+++ b/src/test/ui/consts/const-fn-destructuring-arg.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 const fn i((a, b): (u32, u32)) -> u32 {
     a + b

--- a/src/test/ui/consts/const_let_assign.rs
+++ b/src/test/ui/consts/const_let_assign.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 struct S(i32);
 

--- a/src/test/ui/consts/const_let_assign2.rs
+++ b/src/test/ui/consts/const_let_assign2.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 pub struct AA {
     pub data: [u8; 10],

--- a/src/test/ui/default-alloc-error-hook.rs
+++ b/src/test/ui/default-alloc-error-hook.rs
@@ -16,5 +16,5 @@ fn main() {
     let me = env::current_exe().unwrap();
     let output = Command::new(&me).arg("next").output().unwrap();
     assert!(!output.status.success(), "{:?} is a success", output.status);
-    assert_eq!(str::from_utf8(&output.stderr).unwrap(), "memory allocation of 42 bytes failed");
+    assert_eq!(str::from_utf8(&output.stderr).unwrap(), "memory allocation of 42 bytes failed\n");
 }

--- a/src/test/ui/issues/issue-76547.nll.stderr
+++ b/src/test/ui/issues/issue-76547.nll.stderr
@@ -1,0 +1,20 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-76547.rs:19:14
+   |
+LL | async fn fut(bufs: &mut [&mut [u8]]) {
+   |              ^^^^  -     - let's call the lifetime of this reference `'2`
+   |              |     |
+   |              |     let's call the lifetime of this reference `'1`
+   |              assignment requires that `'1` must outlive `'2`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-76547.rs:33:15
+   |
+LL | async fn fut2(bufs: &mut [&mut [u8]]) -> i32 {
+   |               ^^^^  -     - let's call the lifetime of this reference `'2`
+   |               |     |
+   |               |     let's call the lifetime of this reference `'1`
+   |               assignment requires that `'1` must outlive `'2`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/issues/issue-76547.rs
+++ b/src/test/ui/issues/issue-76547.rs
@@ -1,0 +1,38 @@
+// Test for for diagnostic improvement issue #76547
+// edition:2018
+
+use std::{
+    future::Future,
+    task::{Context, Poll}
+};
+use std::pin::Pin;
+
+pub struct ListFut<'a>(&'a mut [&'a mut [u8]]);
+impl<'a> Future for ListFut<'a> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+        unimplemented!()
+    }
+}
+
+async fn fut(bufs: &mut [&mut [u8]]) {
+    ListFut(bufs).await
+    //~^ ERROR lifetime mismatch
+}
+
+pub struct ListFut2<'a>(&'a mut [&'a mut [u8]]);
+impl<'a> Future for ListFut2<'a> {
+    type Output = i32;
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+        unimplemented!()
+    }
+}
+
+async fn fut2(bufs: &mut [&mut [u8]]) -> i32 {
+    ListFut2(bufs).await
+    //~^ ERROR lifetime mismatch
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-76547.rs
+++ b/src/test/ui/issues/issue-76547.rs
@@ -1,4 +1,4 @@
-// Test for for diagnostic improvement issue #76547
+// Test for diagnostic improvement issue #76547
 // edition:2018
 
 use std::{

--- a/src/test/ui/issues/issue-76547.stderr
+++ b/src/test/ui/issues/issue-76547.stderr
@@ -1,0 +1,25 @@
+error[E0623]: lifetime mismatch
+  --> $DIR/issue-76547.rs:20:13
+   |
+LL | async fn fut(bufs: &mut [&mut [u8]]) {
+   |                          ---------   -
+   |                          |           |
+   |                          |           this `async fn` implicitly returns an `impl Future<Output = ()>`
+   |                          this parameter and the returned future are declared with different lifetimes...
+LL |     ListFut(bufs).await
+   |             ^^^^ ...but data from `bufs` is held across an await point here
+
+error[E0623]: lifetime mismatch
+  --> $DIR/issue-76547.rs:34:14
+   |
+LL | async fn fut2(bufs: &mut [&mut [u8]]) -> i32 {
+   |                           ---------      ---
+   |                           |              |
+   |                           |              this `async fn` implicitly returns an `impl Future<Output = i32>`
+   |                           this parameter and the returned future are declared with different lifetimes...
+LL |     ListFut2(bufs).await
+   |              ^^^^ ...but data from `bufs` is held across an await point here
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/macros/issue-78892-substitution-in-statement-attr.rs
+++ b/src/test/ui/macros/issue-78892-substitution-in-statement-attr.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+// regression test for #78892
+
+macro_rules! mac {
+    ($lint_name:ident) => {{
+        #[allow($lint_name)]
+        let _ = ();
+    }};
+}
+
+fn main() {
+    mac!(dead_code)
+}

--- a/src/test/ui/regions/region-bound-extra-bound-in-inherent-impl.rs
+++ b/src/test/ui/regions/region-bound-extra-bound-in-inherent-impl.rs
@@ -1,7 +1,7 @@
 // Test related to #22779. In this case, the impl is an inherent impl,
 // so it doesn't have to match any trait, so no error results.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 struct MySlice<'a, T:'a>(&'a mut [T]);

--- a/src/test/ui/regions/region-bound-same-bounds-in-trait-and-impl.rs
+++ b/src/test/ui/regions/region-bound-same-bounds-in-trait-and-impl.rs
@@ -1,7 +1,7 @@
 // Test related to #22779, but where the `'a:'b` relation
 // appears in the trait too. No error here.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 trait Tr<'a, T> {
     fn renew<'b: 'a>(self) -> &'b mut [T] where 'a: 'b;

--- a/src/test/ui/regions/region-object-lifetime-1.rs
+++ b/src/test/ui/regions/region-object-lifetime-1.rs
@@ -1,7 +1,7 @@
 // Various tests related to testing how region inference works
 // with respect to the object receivers.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(warnings)]
 
 trait Foo {

--- a/src/test/ui/regions/region-object-lifetime-3.rs
+++ b/src/test/ui/regions/region-object-lifetime-3.rs
@@ -1,7 +1,7 @@
 // Various tests related to testing how region inference works
 // with respect to the object receivers.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(warnings)]
 
 trait Foo {

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-2.rs
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-2.rs
@@ -2,7 +2,7 @@
 // "projection gap": in this test, we know that `T: 'x`, and that is
 // enough to conclude that `T::Foo: 'x`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-3.rs
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-3.rs
@@ -2,7 +2,7 @@
 // "projection gap": in this test, we know that `T::Foo: 'x`, and that
 // is (naturally) enough to conclude that `T::Foo: 'x`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/regions/regions-implied-bounds-projection-gap-4.rs
+++ b/src/test/ui/regions/regions-implied-bounds-projection-gap-4.rs
@@ -2,7 +2,7 @@
 // "projection gap": in this test, we know that `T: 'x`, and that
 // is (naturally) enough to conclude that `T: 'x`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 #![allow(unused_variables)]
 

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-region-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-region-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-region.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-region.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-type-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-type-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-enum-type.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-enum-type.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-region-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-region-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-region.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-region.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-type-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-type-rev.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-type.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-type.rs
@@ -3,7 +3,7 @@
 //
 // Rule OutlivesNominalType from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(rustc_attrs)]
 #![allow(dead_code)]

--- a/src/test/ui/regions/regions-outlives-projection-hrtype.rs
+++ b/src/test/ui/regions/regions-outlives-projection-hrtype.rs
@@ -5,7 +5,7 @@
 // `'r` is bound, that leads to badness. This test checks that
 // everything works.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 trait TheTrait {

--- a/src/test/ui/regions/regions-outlives-projection-trait-def.rs
+++ b/src/test/ui/regions/regions-outlives-projection-trait-def.rs
@@ -1,7 +1,7 @@
 // Test that `<F as Foo<'a>>::Type: 'b`, where `trait Foo<'a> { Type:
 // 'a; }`, does not require that `F: 'b`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 trait SomeTrait<'a> {

--- a/src/test/ui/regions/regions-outlives-scalar.rs
+++ b/src/test/ui/regions/regions-outlives-scalar.rs
@@ -1,7 +1,7 @@
 // Test that scalar values outlive all regions.
 // Rule OutlivesScalar from RFC 1214.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 #![allow(dead_code)]
 
 struct Foo<'a> {

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -2,25 +2,28 @@ error[E0623]: lifetime mismatch
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                          ----               ----   ^ ...but data from `f` is returned here
-   |                          |
-   |                          this parameter and the return type are declared with different lifetimes...
+   |                          ----               ----   ^ ...but data from `f` is held across an await point here
+   |                          |                  |
+   |                          |                  this `async fn` implicitly returns an `impl Future<Output = &Foo>`
+   |                          this parameter and the returned future are declared with different lifetimes...
 
 error[E0623]: lifetime mismatch
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:82
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                          -----                        -----------------          ^ ...but data from `f` is returned here
-   |                          |
-   |                          this parameter and the return type are declared with different lifetimes...
+   |                          -----                        -----------------          ^ ...but data from `f` is held across an await point here
+   |                          |                            |
+   |                          |                            this `async fn` implicitly returns an `impl Future<Output = (Pin<&Foo>, &Foo)>`
+   |                          this parameter and the returned future are declared with different lifetimes...
 
 error[E0623]: lifetime mismatch
   --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |                                  -----                   ---   ^^^ ...but data from `arg` is returned here
-   |                                  |
-   |                                  this parameter and the return type are declared with different lifetimes...
+   |                                  -----                   ---   ^^^ ...but data from `arg` is held across an await point here
+   |                                  |                       |
+   |                                  |                       this `async fn` implicitly returns an `impl Future<Output = &()>`
+   |                                  this parameter and the returned future are declared with different lifetimes...
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/self/elision/lt-ref-self-async.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.stderr
@@ -3,60 +3,66 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -----              ----
-   |                       |
-   |                       this parameter and the return type are declared with different lifetimes...
+   |                       |                  |
+   |                       |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -----              ----
-   |                             |
-   |                             this parameter and the return type are declared with different lifetimes...
+   |                             |                  |
+   |                             |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                    |
+   |                                             |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/lt-ref-self-async.rs:35:9
    |
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                         -----                ----
-   |                                         |
-   |                                         this parameter and the return type are declared with different lifetimes...
+   |                                         |                    |
+   |                                         |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                         this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-self-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.stderr
@@ -3,60 +3,66 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
    |                       ---------              ----
-   |                       |
-   |                       this parameter and the return type are declared with different lifetimes...
+   |                       |                      |
+   |                       |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                             ---------              ----
-   |                             |
-   |                             this parameter and the return type are declared with different lifetimes...
+   |                             |                      |
+   |                             |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                                     ---------               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                       |
+   |                                     |                       this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                                     ---------               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                       |
+   |                                     |                       this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                             ---------                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                        |
+   |                                             |                        this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-self-async.rs:35:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                             ---------                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                        |
+   |                                             |                        this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.stderr
@@ -3,50 +3,55 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                               -----------              ----
-   |                               |
-   |                               this parameter and the return type are declared with different lifetimes...
+   |                               |                        |
+   |                               |                        this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                       -----------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                         |
+   |                                       |                         this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                       -----------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                         |
+   |                                       |                         this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -----------                ----
-   |                                               |
-   |                                               this parameter and the return type are declared with different lifetimes...
+   |                                               |                          |
+   |                                               |                          this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-mut-struct-async.rs:29:9
    |
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -----------                ----
-   |                                               |
-   |                                               this parameter and the return type are declared with different lifetimes...
+   |                                               |                          |
+   |                                               |                          this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/self/elision/ref-self-async.stderr
+++ b/src/test/ui/self/elision/ref-self-async.stderr
@@ -3,70 +3,77 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -----              ----
-   |                       |
-   |                       this parameter and the return type are declared with different lifetimes...
+   |                       |                  |
+   |                       |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:29:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -----              ----
-   |                             |
-   |                             this parameter and the return type are declared with different lifetimes...
+   |                             |                  |
+   |                             |                  this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:33:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:37:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
-   |                                     |
-   |                                     this parameter and the return type are declared with different lifetimes...
+   |                                     |                   |
+   |                                     |                   this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                     this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:41:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                    |
+   |                                             |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:45:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
-   |                                             |
-   |                                             this parameter and the return type are declared with different lifetimes...
+   |                                             |                    |
+   |                                             |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                             this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-self-async.rs:49:9
    |
 LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                            -----                    ---
-   |                                            |
-   |                                            this parameter and the return type are declared with different lifetimes...
+   |                                            |                        |
+   |                                            |                        this `async fn` implicitly returns an `impl Future<Output = &u8>`
+   |                                            this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/self/elision/ref-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.stderr
@@ -3,50 +3,55 @@ error[E0623]: lifetime mismatch
    |
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                               -------              ----
-   |                               |
-   |                               this parameter and the return type are declared with different lifetimes...
+   |                               |                    |
+   |                               |                    this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                       -------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                     |
+   |                                       |                     this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                       -------               ----
-   |                                       |
-   |                                       this parameter and the return type are declared with different lifetimes...
+   |                                       |                     |
+   |                                       |                     this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                       this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                               -------                ----
-   |                                               |
-   |                                               this parameter and the return type are declared with different lifetimes...
+   |                                               |                      |
+   |                                               |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                               this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error[E0623]: lifetime mismatch
   --> $DIR/ref-struct-async.rs:29:9
    |
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                           -------                ----
-   |                                           |
-   |                                           this parameter and the return type are declared with different lifetimes...
+   |                                           |                      |
+   |                                           |                      this `async fn` implicitly returns an `impl Future<Output = &u32>`
+   |                                           this parameter and the returned future are declared with different lifetimes...
 LL |         f
-   |         ^ ...but data from `f` is returned here
+   |         ^ ...but data from `f` is held across an await point here
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #76765 (Make it more clear what an about async fn's returns when referring to what it returns)
 - #78574 (Use check-pass instead of build-pass in regions ui test suite)
 - #78669 (Use check-pass instead of build-pass in some consts ui test suits)
 - #78847 (Assert that a return place is not used for indexing during integration)
 - #78854 (Workaround for "could not fully normalize" ICE )
 - #78875 (rustc_target: Further cleanup use of target options)
 - #78887 (Add comments to explain memory usage optimization)
 - #78890 (comment attribution fix)
 - #78896 (Clarified description of write! macro)
 - #78897 (Add missing newline to error message of the default OOM hook)
 - #78898 (add regression test for #78892)
 - #78908 ((rustdoc) [src] link for types defined by macros shows invocation, not defintion)
 - #78910 (Fix links to stabilized versions of some intrinsics)
 - #78912 (Add macro test for min-const-generics)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=76765,78574,78669,78847,78854,78875,78887,78890,78896,78897,78898,78908,78910,78912)
<!-- homu-ignore:end -->