### PR TITLE
Make the libstd build script smaller

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -3,66 +3,23 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
-    if target.contains("linux") {
-        if target.contains("android") {
-            println!("cargo:rustc-link-lib=dl");
-            println!("cargo:rustc-link-lib=log");
-            println!("cargo:rustc-link-lib=gcc");
-        }
-    } else if target.contains("freebsd") {
-        println!("cargo:rustc-link-lib=execinfo");
-        println!("cargo:rustc-link-lib=pthread");
+    if target.contains("freebsd") {
         if env::var("RUST_STD_FREEBSD_12_ABI").is_ok() {
             println!("cargo:rustc-cfg=freebsd12");
         }
-    } else if target.contains("netbsd") {
-        println!("cargo:rustc-link-lib=pthread");
-        println!("cargo:rustc-link-lib=rt");
-    } else if target.contains("dragonfly") || target.contains("openbsd") {
-        println!("cargo:rustc-link-lib=pthread");
-    } else if target.contains("solaris") {
-        println!("cargo:rustc-link-lib=socket");
-        println!("cargo:rustc-link-lib=posix4");
-        println!("cargo:rustc-link-lib=pthread");
-        println!("cargo:rustc-link-lib=resolv");
-    } else if target.contains("illumos") {
-        println!("cargo:rustc-link-lib=socket");
-        println!("cargo:rustc-link-lib=posix4");
-        println!("cargo:rustc-link-lib=pthread");
-        println!("cargo:rustc-link-lib=resolv");
-        println!("cargo:rustc-link-lib=nsl");
-        // Use libumem for the (malloc-compatible) allocator
-        println!("cargo:rustc-link-lib=umem");
-    } else if target.contains("apple-darwin") {
-        println!("cargo:rustc-link-lib=System");
-
-        // res_init and friends require -lresolv on macOS/iOS.
-        // See #41582 and http://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html
-        println!("cargo:rustc-link-lib=resolv");
-    } else if target.contains("apple-ios") {
-        println!("cargo:rustc-link-lib=System");
-        println!("cargo:rustc-link-lib=objc");
-        println!("cargo:rustc-link-lib=framework=Security");
-        println!("cargo:rustc-link-lib=framework=Foundation");
-        println!("cargo:rustc-link-lib=resolv");
-    } else if target.contains("uwp") {
-        println!("cargo:rustc-link-lib=ws2_32");
-        // For BCryptGenRandom
-        println!("cargo:rustc-link-lib=bcrypt");
-    } else if target.contains("windows") {
-        println!("cargo:rustc-link-lib=advapi32");
-        println!("cargo:rustc-link-lib=ws2_32");
-        println!("cargo:rustc-link-lib=userenv");
-    } else if target.contains("fuchsia") {
-        println!("cargo:rustc-link-lib=zircon");
-        println!("cargo:rustc-link-lib=fdio");
-    } else if target.contains("cloudabi") {
-        if cfg!(feature = "backtrace") {
-            println!("cargo:rustc-link-lib=unwind");
-        }
-        println!("cargo:rustc-link-lib=c");
-        println!("cargo:rustc-link-lib=compiler_rt");
-    } else if (target.contains("sgx") && target.contains("fortanix"))
+    } else if target.contains("linux")
+        || target.contains("netbsd")
+        || target.contains("dragonfly")
+        || target.contains("openbsd")
+        || target.contains("solaris")
+        || target.contains("illumos")
+        || target.contains("apple-darwin")
+        || target.contains("apple-ios")
+        || target.contains("uwp")
+        || target.contains("windows")
+        || target.contains("fuchsia")
+        || target.contains("cloudabi")
+        || (target.contains("sgx") && target.contains("fortanix"))
         || target.contains("hermit")
         || target.contains("l4re")
         || target.contains("redox")

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -563,5 +563,5 @@ include!("keyword_docs.rs");
 // This is required to avoid an unstable error when `restricted-std` is not
 // enabled. The use of #![feature(restricted_std)] in rustc-std-workspace-std
 // is unconditional, so the unstable feature needs to be defined somewhere.
-#[cfg_attr(not(feature = "restricted-std"), unstable(feature = "restricted_std", issue = "none"))]
+#[unstable(feature = "restricted_std", issue = "none")]
 mod __restricted_std_workaround {}

--- a/library/std/src/sys/cloudabi/mod.rs
+++ b/library/std/src/sys/cloudabi/mod.rs
@@ -66,3 +66,8 @@ pub fn hashmap_random_keys() -> (u64, u64) {
         v.assume_init()
     }
 }
+
+#[cfg_attr(feature = "backtrace", link(name = "unwind"))]
+#[link(name = "c")]
+#[link(name = "compiler_rt")]
+extern "C" {}

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -234,3 +234,55 @@ pub fn cvt_nz(error: libc::c_int) -> crate::io::Result<()> {
 pub fn abort_internal() -> ! {
     unsafe { libc::abort() }
 }
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "android")] {
+        #[link(name = "dl")]
+        #[link(name = "log")]
+        #[link(name = "gcc")]
+        extern "C" {}
+    } else if #[cfg(target_os = "freebsd")] {
+        #[link(name = "execinfo")]
+        #[link(name = "pthread")]
+        extern "C" {}
+    } else if #[cfg(target_os = "netbsd")] {
+        #[link(name = "pthread")]
+        #[link(name = "rt")]
+        extern "C" {}
+    } else if #[cfg(any(target_os = "dragonfly", target_os = "openbsd"))] {
+        #[link(name = "pthread")]
+        extern "C" {}
+    } else if #[cfg(target_os = "solaris")] {
+        #[link(name = "socket")]
+        #[link(name = "posix4")]
+        #[link(name = "pthread")]
+        #[link(name = "resolv")]
+        extern "C" {}
+    } else if #[cfg(target_os = "illumos")] {
+        #[link(name = "socket")]
+        #[link(name = "posix4")]
+        #[link(name = "pthread")]
+        #[link(name = "resolv")]
+        #[link(name = "nsl")]
+        // Use libumem for the (malloc-compatible) allocator
+        #[link(name = "umem")]
+        extern "C" {}
+    } else if #[cfg(target_os = "macos")] {
+        #[link(name = "System")]
+        // res_init and friends require -lresolv on macOS/iOS.
+        // See #41582 and http://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html
+        #[link(name = "resolv")]
+        extern "C" {}
+    } else if #[cfg(target_os = "ios")] {
+        #[link(name = "System")]
+        #[link(name = "objc")]
+        #[link(name = "Security", kind = "framework")]
+        #[link(name = "Foundation", kind = "framework")]
+        #[link(name = "resolv")]
+        extern "C" {}
+    } else if #[cfg(target_os = "fuchsia")] {
+        #[link(name = "zircon")]
+        #[link(name = "fdio")]
+        extern "C" {}
+    }
+}

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -270,3 +270,17 @@ pub fn abort_internal() -> ! {
     }
     crate::intrinsics::abort();
 }
+
+cfg_if::cfg_if! {
+    if #[cfg(target_vendor = "uwp")] {
+        #[link(name = "ws2_32")]
+        // For BCryptGenRandom
+        #[link(name = "bcrypt")]
+        extern "C" {}
+    } else {
+        #[link(name = "advapi32")]
+        #[link(name = "ws2_32")]
+        #[link(name = "userenv")]
+        extern "C" {}
+    }
+}


### PR DESCRIPTION
Of all sysroot crates currently only compiler_builtins, miniz_oxide and std require a build script. compiler_builtins uses to conditionally enable certain features and possibly compile a C version ([source](https://github.com/rust-lang/compiler-builtins/blob/63ccaf11f08fb5d0b39cc33884c5a1a63f547ace/build.rs)), miniz_oxide only uses it to detect if liballoc is supported as the MSRV is 1.34.0 instead of the 1.36.0 which stabilized liballoc ([source](https://github.com/Frommi/miniz_oxide/blob/28514ec09f0b1ce74bfb2d561de52a6652ce377a/miniz_oxide/build.rs)). std now only uses it to enable `freebsd12` when the `RUST_STD_FREEBSD_12_ABI` env var is set, to determine if `restricted-std` should be set, to set the `STD_ENV_ARCH` env var identical to `CARGO_CFG_TARGET_ARCH`, and to unconditionally enable `backtrace_in_libstd`.

If all build scripts were to be removed, it would be possible for rustc to completely compile it's own sysroot. It currently requires a rustc version that already has an available libstd to compile the build scripts. If rustc can completely compile it's own sysroot, rustbuild could be simplified to not forcefully use the bootstrap compiler for build scripts.

@rustbot modify labels: +T-compiler +libs-impl