### PR TITLE
Don't print thread ids and names in `tracing` logs

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1292,6 +1292,8 @@ pub fn init_env_logger(env: &str) {
         .with_verbose_exit(true)
         .with_verbose_entry(true)
         .with_indent_amount(2);
+    #[cfg(parallel_compiler)]
+    let layer = layer.with_thread_ids(true).with_thread_names(true);
 
     use tracing_subscriber::layer::SubscriberExt;
     let subscriber = tracing_subscriber::Registry::default().with(filter).with(layer);

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1288,8 +1288,6 @@ pub fn init_env_logger(env: &str) {
         .with_indent_lines(true)
         .with_ansi(true)
         .with_targets(true)
-        .with_thread_ids(true)
-        .with_thread_names(true)
         .with_wraparound(10)
         .with_verbose_exit(true)
         .with_verbose_entry(true)


### PR DESCRIPTION
Before:

```
2:rustc INFO rustc_interface::passes Pre-codegen
2:rustcTy interner             total           ty lt ct all
2:rustc    Adt               :   1078 81.3%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Array             :      1  0.1%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Slice             :      1  0.1%,  0.0%   0.0%  0.0%  0.0%
2:rustc    RawPtr            :      2  0.2%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Ref               :      4  0.3%,  0.1%   0.1%  0.0%  0.0%
2:rustc    FnDef             :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    FnPtr             :     76  5.7%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Placeholder       :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Generator         :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    GeneratorWitness  :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Dynamic           :      3  0.2%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Closure           :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Tuple             :     13  1.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Bound             :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Param             :    146 11.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Infer             :      2  0.2%,  0.1%   0.0%  0.0%  0.0%
2:rustc    Projection        :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Opaque            :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc    Foreign           :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
2:rustc                  total   1326         0.2%   0.1%  0.0%  0.0%
2:rustcInternalSubsts interner: #437
2:rustcRegion interner: #355
2:rustcStability interner: #1
2:rustcConst Stability interner: #0
2:rustcAllocation interner: #0
2:rustcLayout interner: #0
```

After:

```
 INFO rustc_interface::passes Post-codegen
Ty interner             total           ty lt ct all
    Adt               :   1078 81.3%,  0.0%   0.0%  0.0%  0.0%
    Array             :      1  0.1%,  0.0%   0.0%  0.0%  0.0%
    Slice             :      1  0.1%,  0.0%   0.0%  0.0%  0.0%
    RawPtr            :      2  0.2%,  0.0%   0.0%  0.0%  0.0%
    Ref               :      4  0.3%,  0.1%   0.1%  0.0%  0.0%
    FnDef             :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    FnPtr             :     76  5.7%,  0.0%   0.0%  0.0%  0.0%
    Placeholder       :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    Generator         :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    GeneratorWitness  :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    Dynamic           :      3  0.2%,  0.0%   0.0%  0.0%  0.0%
    Closure           :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    Tuple             :     13  1.0%,  0.0%   0.0%  0.0%  0.0%
    Bound             :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    Param             :    146 11.0%,  0.0%   0.0%  0.0%  0.0%
    Infer             :      2  0.2%,  0.1%   0.0%  0.0%  0.0%
    Projection        :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    Opaque            :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
    Foreign           :      0  0.0%,  0.0%   0.0%  0.0%  0.0%
                  total   1326         0.2%   0.1%  0.0%  0.0%
InternalSubsts interner: #437
Region interner: #355
Stability interner: #1
Const Stability interner: #0
Allocation interner: #0
Layout interner: #0
```

Closes https://github.com/rust-lang/rust/issues/78931
r? @oli-obk 