### PR TITLE
or-patterns: enable :pat to match top_pat

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -718,7 +718,7 @@ pub enum NonterminalKind {
 }
 
 /// Used when parsing a non-terminal (see `parse_nonterminal`) to determine if `:pat` should match
-/// `top_pat` or `pat<no_top_alt>`. See issue https://github.com/rust-lang/rust/pull/78935.
+/// `top_pat` or `pat<no_top_alt>`. See issue <https://github.com/rust-lang/rust/pull/78935>.
 pub enum OrPatNonterminalMode {
     TopPat,
     NoTopAlt,

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -717,6 +717,13 @@ pub enum NonterminalKind {
     TT,
 }
 
+/// Used when parsing a non-terminal (see `parse_nonterminal`) to determine if `:pat` should match
+/// `top_pat` or `pat<no_top_alt>`. See issue https://github.com/rust-lang/rust/pull/78935.
+pub enum OrPatNonterminalMode {
+    TopPat,
+    NoTopAlt,
+}
+
 impl NonterminalKind {
     pub fn from_symbol(symbol: Symbol) -> Option<NonterminalKind> {
         Some(match symbol {

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -422,7 +422,7 @@ fn token_name_eq(t1: &Token, t2: &Token) -> bool {
 /// previously be a separator that follows `:pat`. Thus, we make a special case to parse `:pat` the
 /// old way if it happens to be followed by `|` in the matcher.
 ///
-/// See https://github.com/rust-lang/rust/issues/54883 for more info.
+/// See <https://github.com/rust-lang/rust/issues/54883> for more info.
 fn or_pat_mode(item: &MatcherPosHandle<'_, '_>) -> OrPatNonterminalMode {
     if item.idx < item.top_elts.len() - 1 {
         // Look at the token after the current one to see if it is `|`.

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -61,6 +61,7 @@ impl<'a> Parser<'a> {
                 token::OpenDelim(token::Bracket) |  // slice pattern
                 token::BinOp(token::And) |          // reference
                 token::BinOp(token::Minus) |        // negative literal
+                token::BinOp(token::Or) |           // leading vert `|` or-pattern
                 token::AndAnd |                     // double reference
                 token::Literal(..) |                // literal
                 token::DotDot |                     // range pattern (future compat)
@@ -128,7 +129,8 @@ impl<'a> Parser<'a> {
                 }
             }
             NonterminalKind::Pat => {
-                let (mut pat, tokens) = self.collect_tokens(|this| this.parse_pat(None))?;
+                let (mut pat, tokens) =
+                    self.collect_tokens(|this| this.parse_top_pat_no_commas())?;
                 // We have have eaten an NtPat, which could already have tokens
                 if pat.tokens.is_none() {
                     pat.tokens = tokens;

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -62,6 +62,16 @@ impl<'a> Parser<'a> {
         Ok(pat)
     }
 
+    pub(super) fn parse_top_pat_no_commas(&mut self) -> PResult<'a, P<Pat>> {
+        // Allow a '|' before the pats (RFCs 1925, 2530, and 2535).
+        self.eat_or_separator(None);
+
+        // Parse the possibly-or-pattern, but don't recorver commas.
+        let pat = self.parse_pat_with_or(None, GateOr::No, RecoverComma::No)?;
+
+        Ok(pat)
+    }
+
     /// Parse the pattern for a function or function pointer parameter.
     /// Special recovery is provided for or-patterns and leading `|`.
     pub(super) fn parse_fn_param_pat(&mut self) -> PResult<'a, P<Pat>> {

--- a/src/test/ui/macros/macro-pat-follow.rs
+++ b/src/test/ui/macros/macro-pat-follow.rs
@@ -15,17 +15,7 @@ macro_rules! pat_if {
     }}
 }
 
-macro_rules! pat_bar {
-    ($p:pat | $p2:pat) => {{
-        match Some(1u8) {
-            $p | $p2 => {},
-            _ => {}
-        }
-    }}
-}
-
 fn main() {
     pat_in!(Some(_) in 0..10);
     pat_if!(Some(x) if x > 0);
-    pat_bar!(Some(1u8) | None);
 }

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail.rs
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail.rs
@@ -5,16 +5,6 @@
 
 fn main() {}
 
-// Test the `pat` macro fragment parser:
-macro_rules! accept_pat {
-    ($p:pat) => {}
-}
-
-accept_pat!(p | q); //~ ERROR no rules expected the token `|`
-accept_pat!(| p | q); //~ ERROR no rules expected the token `|`
-
-// Non-macro tests:
-
 enum E { A, B }
 use E::*;
 

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -1,53 +1,53 @@
 error: an or-pattern parameter must be wrapped in parenthesis
-  --> $DIR/or-patterns-syntactic-fail.rs:27:13
+  --> $DIR/or-patterns-syntactic-fail.rs:17:13
    |
 LL |     fn fun1(A | B: E) {}
    |             ^^^^^ help: wrap the pattern in parenthesis: `(A | B)`
 
 error: a leading `|` is not allowed in a parameter pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:29:13
+  --> $DIR/or-patterns-syntactic-fail.rs:19:13
    |
 LL |     fn fun2(| A | B: E) {}
    |             ^ help: remove the `|`
 
 error: an or-pattern parameter must be wrapped in parenthesis
-  --> $DIR/or-patterns-syntactic-fail.rs:29:15
+  --> $DIR/or-patterns-syntactic-fail.rs:19:15
    |
 LL |     fn fun2(| A | B: E) {}
    |               ^^^^^ help: wrap the pattern in parenthesis: `(A | B)`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:40:11
+  --> $DIR/or-patterns-syntactic-fail.rs:30:11
    |
 LL |     let ( | A | B) = E::A;
    |           ^ help: remove the `|`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:41:11
+  --> $DIR/or-patterns-syntactic-fail.rs:31:11
    |
 LL |     let ( | A | B,) = (E::B,);
    |           ^ help: remove the `|`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:42:11
+  --> $DIR/or-patterns-syntactic-fail.rs:32:11
    |
 LL |     let [ | A | B ] = [E::A];
    |           ^ help: remove the `|`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:43:13
+  --> $DIR/or-patterns-syntactic-fail.rs:33:13
    |
 LL |     let TS( | A | B );
    |             ^ help: remove the `|`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:44:17
+  --> $DIR/or-patterns-syntactic-fail.rs:34:17
    |
 LL |     let NS { f: | A | B };
    |                 ^ help: remove the `|`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:46:11
+  --> $DIR/or-patterns-syntactic-fail.rs:36:11
    |
 LL |     let ( || A | B) = E::A;
    |           ^^ help: remove the `||`
@@ -55,7 +55,7 @@ LL |     let ( || A | B) = E::A;
    = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:47:11
+  --> $DIR/or-patterns-syntactic-fail.rs:37:11
    |
 LL |     let [ || A | B ] = [E::A];
    |           ^^ help: remove the `||`
@@ -63,7 +63,7 @@ LL |     let [ || A | B ] = [E::A];
    = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:48:13
+  --> $DIR/or-patterns-syntactic-fail.rs:38:13
    |
 LL |     let TS( || A | B );
    |             ^^ help: remove the `||`
@@ -71,33 +71,15 @@ LL |     let TS( || A | B );
    = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
-  --> $DIR/or-patterns-syntactic-fail.rs:49:17
+  --> $DIR/or-patterns-syntactic-fail.rs:39:17
    |
 LL |     let NS { f: || A | B };
    |                 ^^ help: remove the `||`
    |
    = note: alternatives in or-patterns are separated with `|`, not `||`
 
-error: no rules expected the token `|`
-  --> $DIR/or-patterns-syntactic-fail.rs:13:15
-   |
-LL | macro_rules! accept_pat {
-   | ----------------------- when calling this macro
-...
-LL | accept_pat!(p | q);
-   |               ^ no rules expected this token in macro call
-
-error: no rules expected the token `|`
-  --> $DIR/or-patterns-syntactic-fail.rs:14:13
-   |
-LL | macro_rules! accept_pat {
-   | ----------------------- when calling this macro
-...
-LL | accept_pat!(| p | q);
-   |             ^ no rules expected this token in macro call
-
 error[E0369]: no implementation for `E | ()`
-  --> $DIR/or-patterns-syntactic-fail.rs:23:22
+  --> $DIR/or-patterns-syntactic-fail.rs:13:22
    |
 LL |     let _ = |A | B: E| ();
    |                  ----^ -- ()
@@ -107,7 +89,7 @@ LL |     let _ = |A | B: E| ();
    = note: an implementation of `std::ops::BitOr` might be missing for `E`
 
 error[E0308]: mismatched types
-  --> $DIR/or-patterns-syntactic-fail.rs:51:36
+  --> $DIR/or-patterns-syntactic-fail.rs:41:36
    |
 LL |     let recovery_witness: String = 0;
    |                           ------   ^
@@ -116,7 +98,7 @@ LL |     let recovery_witness: String = 0;
    |                           |        help: try using a conversion method: `0.to_string()`
    |                           expected due to this
 
-error: aborting due to 16 previous errors
+error: aborting due to 14 previous errors
 
 Some errors have detailed explanations: E0308, E0369.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/pattern/or-pattern-macro-pat-fallback.rs
+++ b/src/test/ui/pattern/or-pattern-macro-pat-fallback.rs
@@ -1,0 +1,40 @@
+// run-pass
+
+//#![feature(or_patterns)]
+
+macro_rules! foo {
+    ($orpat:pat, $val:expr) => {
+        match $val {
+            x @ ($orpat) => x,
+            _ => 0xDEADBEEF,
+        }
+    };
+    ($nonor:pat | $val:expr, 3) => {
+        match $val {
+            x @ ($orpat) => x,
+            _ => 0xDEADBEEF,
+        }
+    };
+}
+
+macro_rules! bar {
+    ($nonor:pat |) => {};
+}
+
+macro_rules! baz {
+    ($nonor:pat) => {};
+}
+
+fn main() {
+    // Test ambiguity.
+    foo!(1 | 2, 3); //~ERROR: multiple matchers
+
+    // Leading vert not allowed in pat<no_top_alt>
+    bar!(1 | 2 | 3 |); // ok
+    bar!(|1| 2 | 3 |); //~ERROR: no rules expected
+    bar!(1 | 2 | 3); //~ERROR: unexpected end
+
+    baz!(1 | 2 | 3); // ok
+    baz!(|1| 2 | 3); // ok
+    baz!(|1| 2 | 3 |); //~ERROR: no rules expected
+}

--- a/src/test/ui/pattern/or-pattern-macro-pat-fallback.rs
+++ b/src/test/ui/pattern/or-pattern-macro-pat-fallback.rs
@@ -1,21 +1,4 @@
-// run-pass
-
 //#![feature(or_patterns)]
-
-macro_rules! foo {
-    ($orpat:pat, $val:expr) => {
-        match $val {
-            x @ ($orpat) => x,
-            _ => 0xDEADBEEF,
-        }
-    };
-    ($nonor:pat | $val:expr, 3) => {
-        match $val {
-            x @ ($orpat) => x,
-            _ => 0xDEADBEEF,
-        }
-    };
-}
 
 macro_rules! bar {
     ($nonor:pat |) => {};
@@ -26,15 +9,16 @@ macro_rules! baz {
 }
 
 fn main() {
-    // Test ambiguity.
-    foo!(1 | 2, 3); //~ERROR: multiple matchers
-
     // Leading vert not allowed in pat<no_top_alt>
-    bar!(1 | 2 | 3 |); // ok
     bar!(|1| 2 | 3 |); //~ERROR: no rules expected
-    bar!(1 | 2 | 3); //~ERROR: unexpected end
+
+    // Top-level or-patterns not allowed in pat<no_top_alt>
+    bar!(1 | 2 | 3 |); //~ERROR: no rules expected
+    bar!(1 | 2 | 3); //~ERROR: no rules expected
+    bar!((1 | 2 | 3)); //~ERROR: unexpected end
+    bar!((1 | 2 | 3) |); // ok
 
     baz!(1 | 2 | 3); // ok
     baz!(|1| 2 | 3); // ok
-    baz!(|1| 2 | 3 |); //~ERROR: no rules expected
+    baz!(|1| 2 | 3 |); //~ERROR: expected pattern
 }

--- a/src/test/ui/pattern/or-pattern-macro-pat-fallback.stderr
+++ b/src/test/ui/pattern/or-pattern-macro-pat-fallback.stderr
@@ -1,0 +1,49 @@
+error: no rules expected the token `|`
+  --> $DIR/or-pattern-macro-pat-fallback.rs:13:10
+   |
+LL | macro_rules! bar {
+   | ---------------- when calling this macro
+...
+LL |     bar!(|1| 2 | 3 |);
+   |          ^ no rules expected this token in macro call
+
+error: no rules expected the token `2`
+  --> $DIR/or-pattern-macro-pat-fallback.rs:16:14
+   |
+LL | macro_rules! bar {
+   | ---------------- when calling this macro
+...
+LL |     bar!(1 | 2 | 3 |);
+   |              ^ no rules expected this token in macro call
+
+error: no rules expected the token `2`
+  --> $DIR/or-pattern-macro-pat-fallback.rs:17:14
+   |
+LL | macro_rules! bar {
+   | ---------------- when calling this macro
+...
+LL |     bar!(1 | 2 | 3);
+   |              ^ no rules expected this token in macro call
+
+error: unexpected end of macro invocation
+  --> $DIR/or-pattern-macro-pat-fallback.rs:18:21
+   |
+LL | macro_rules! bar {
+   | ---------------- when calling this macro
+...
+LL |     bar!((1 | 2 | 3));
+   |                     ^ missing tokens in macro arguments
+
+error: expected pattern, found `<eof>`
+  --> $DIR/or-pattern-macro-pat-fallback.rs:23:20
+   |
+LL |     ($nonor:pat) => {};
+   |      ---------- while parsing argument for this `pat` macro fragment
+...
+LL |     baz!(|1| 2 | 3 |);
+   |           -        ^ expected pattern
+   |           |
+   |           while parsing this or-pattern starting here
+
+error: aborting due to 5 previous errors
+

--- a/src/test/ui/pattern/or-pattern-macro-pat.rs
+++ b/src/test/ui/pattern/or-pattern-macro-pat.rs
@@ -1,0 +1,40 @@
+// run-pass
+
+//#![feature(or_patterns)]
+
+use Foo::*;
+
+#[derive(Eq, PartialEq, Debug)]
+enum Foo {
+    A(u64),
+    B(u64),
+    C, D
+}
+
+macro_rules! foo {
+    ($orpat:pat, $val:expr) => {
+        match $val {
+            x @ ($orpat) => x,
+            _ => B(0xDEADBEEF),
+        }
+    };
+}
+
+macro_rules! bar {
+    ($orpat:pat, $val:expr) => {
+        match $val {
+            $orpat => 42,
+            _ => 0xDEADBEEF,
+        }
+    };
+}
+
+fn main() {
+    // Test or-pattern.
+    let y = foo!(A(_)|B(_), A(32));
+    assert_eq!(y, A(32));
+
+    // Leading vert in or-pattern.
+    let y = bar!(| C | D, C);
+    assert_eq!(y, 42u64);
+}


### PR DESCRIPTION
Allow :pat in macros to match a top-level or-pattern, as discussed in https://github.com/rust-lang/rust/issues/54883#issuecomment-724898641

~I don't have a good way to run the test locally, so I've included a new UI test to make sure the PR does what I expect... if CI passes, please enqueue a (check-only?) crater run.~

r? @petrochenkov 

cc #54883 

EDIT: notably, this makes :pat match `top_pat` rather than `pat<no_top_alt>`, which was an open question in the RFC. This is a **breaking change**, so we will need to do a crater run and see how to proceed. If the breakage is too much, we may go with a compromise, as outlined in https://github.com/rust-lang/rust/pull/78935#issuecomment-729876500

EDIT 2: this patch now implements petrochenkov's proposal in https://github.com/rust-lang/rust/pull/78935#issuecomment-735232780