### PR TITLE
Linux dist: don't include unique symbols in libLLVM

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -29,7 +29,8 @@ mkdir ../gcc-build
 cd ../gcc-build
 hide_output ../gcc-$GCC/configure \
     --prefix=/rustroot \
-    --enable-languages=c,c++
+    --enable-languages=c,c++ \
+    --disable-gnu-unique-object
 hide_output make -j10
 hide_output make install
 ln -s gcc /rustroot/bin/cc


### PR DESCRIPTION
Fixes #76980