### PR TITLE
test: add `()=()=()=...` to weird-exprs.rs

### DIFF
--- a/src/test/ui/weird-exprs.rs
+++ b/src/test/ui/weird-exprs.rs
@@ -160,7 +160,7 @@ fn match_nested_if() {
     assert!(val);
 }
 
-fn empty_tuple_assignment() {
+fn monkey_barrel() {
     let val = ()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=();
     assert_eq!(val, ());
 }
@@ -183,5 +183,5 @@ pub fn main() {
     r#match();
     i_yield();
     match_nested_if();
-    empty_tuple_assignment();
+    monkey_barrel();
 }

--- a/src/test/ui/weird-exprs.rs
+++ b/src/test/ui/weird-exprs.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(generators)]
+#![feature(destructuring_assignment)]
 
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
@@ -159,6 +160,11 @@ fn match_nested_if() {
     assert!(val);
 }
 
+fn empty_tuple_assignment() {
+    let val = ()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=()=();
+    assert_eq!(val, ());
+}
+
 pub fn main() {
     strange();
     funny();
@@ -177,4 +183,5 @@ pub fn main() {
     r#match();
     i_yield();
     match_nested_if();
+    empty_tuple_assignment();
 }


### PR DESCRIPTION
Idea from https://github.com/rust-lang/rust/pull/71156#discussion_r410953972 😄

Builds on nightly since https://github.com/rust-lang/rust/pull/78748 has been merged.

