### PR TITLE
WIP Generic associated types in trait paths

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1095,7 +1095,11 @@ impl Expr {
     pub fn is_potential_trivial_const_param(&self) -> bool {
         let this = if let ExprKind::Block(ref block, None) = self.kind {
             if block.stmts.len() == 1 {
-                if let StmtKind::Expr(ref expr) = block.stmts[0].kind { expr } else { self }
+                if let StmtKind::Expr(ref expr) = block.stmts[0].kind {
+                    expr
+                } else {
+                    self
+                }
             } else {
                 self
             }
@@ -1833,6 +1837,7 @@ impl UintTy {
 pub struct AssocTyConstraint {
     pub id: NodeId,
     pub ident: Ident,
+    pub gen_args: Vec<GenericArg>,
     pub kind: AssocTyConstraintKind,
     pub span: Span,
 }
@@ -1938,7 +1943,11 @@ impl TyKind {
     }
 
     pub fn is_unit(&self) -> bool {
-        if let TyKind::Tup(ref tys) = *self { tys.is_empty() } else { false }
+        if let TyKind::Tup(ref tys) = *self {
+            tys.is_empty()
+        } else {
+            false
+        }
     }
 }
 

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -444,11 +444,14 @@ pub fn noop_flat_map_arm<T: MutVisitor>(mut arm: Arm, vis: &mut T) -> SmallVec<[
 }
 
 pub fn noop_visit_ty_constraint<T: MutVisitor>(
-    AssocTyConstraint { id, ident, kind, span }: &mut AssocTyConstraint,
+    AssocTyConstraint { id, ident, gen_args, kind, span }: &mut AssocTyConstraint,
     vis: &mut T,
 ) {
     vis.visit_id(id);
     vis.visit_ident(ident);
+    for arg in gen_args {
+        vis.visit_generic_arg(arg);
+    }
     match kind {
         AssocTyConstraintKind::Equality { ref mut ty } => {
             vis.visit_ty(ty);

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -490,6 +490,9 @@ pub fn walk_assoc_ty_constraint<'a, V: Visitor<'a>>(
     constraint: &'a AssocTyConstraint,
 ) {
     visitor.visit_ident(constraint.ident);
+    for arg in &constraint.gen_args {
+        visitor.visit_generic_arg(arg);
+    }
     match constraint.kind {
         AssocTyConstraintKind::Equality { ref ty } => {
             visitor.visit_ty(ty);

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -426,6 +426,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     ) -> hir::TypeBinding<'hir> {
         let ident = Ident::with_dummy_span(hir::FN_OUTPUT_NAME);
         let kind = hir::TypeBindingKind::Equality { ty };
-        hir::TypeBinding { hir_id: self.next_id(), span, ident, kind }
+        let args = arena_vec![self;];
+        let bindings = arena_vec![self;];
+        let gen_args = self.arena.alloc(hir::GenericArgs { args, bindings, parenthesized: false });
+        hir::TypeBinding { hir_id: self.next_id(), gen_args, span, ident, kind }
     }
 }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -937,6 +937,13 @@ impl<'a> State<'a> {
 
     pub fn print_assoc_constraint(&mut self, constraint: &ast::AssocTyConstraint) {
         self.print_ident(constraint.ident);
+        if constraint.gen_args.len() > 0 {
+            self.s.word("<");
+            for arg in &constraint.gen_args {
+                self.print_generic_arg(arg);
+            }
+            self.s.word(">");
+        }
         self.s.space();
         match &constraint.kind {
             ast::AssocTyConstraintKind::Equality { ty } => {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -497,7 +497,11 @@ pub struct WhereClause<'hir> {
 
 impl WhereClause<'_> {
     pub fn span(&self) -> Option<Span> {
-        if self.predicates.is_empty() { None } else { Some(self.span) }
+        if self.predicates.is_empty() {
+            None
+        } else {
+            Some(self.span)
+        }
     }
 
     /// The `WhereClause` under normal circumstances points at either the predicates or the empty
@@ -1940,6 +1944,7 @@ pub struct TypeBinding<'hir> {
     pub hir_id: HirId,
     #[stable_hasher(project(name))]
     pub ident: Ident,
+    pub gen_args: &'hir GenericArgs<'hir>,
     pub kind: TypeBindingKind<'hir>,
     pub span: Span,
 }

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -758,6 +758,8 @@ pub fn walk_assoc_type_binding<'v, V: Visitor<'v>>(
 ) {
     visitor.visit_id(type_binding.hir_id);
     visitor.visit_ident(type_binding.ident);
+    // FIXME: Pass the correct span for the generic arguments here
+    visitor.visit_generic_args(type_binding.span, type_binding.gen_args);
     match type_binding.kind {
         TypeBindingKind::Equality { ref ty } => {
             visitor.visit_ty(ty);

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1801,6 +1801,7 @@ impl<'a> State<'a> {
             for binding in generic_args.bindings.iter() {
                 start_or_comma(self);
                 self.print_ident(binding.ident);
+                self.print_generic_args(binding.gen_args, false, false);
                 self.s.space();
                 match generic_args.bindings[0].kind {
                     hir::TypeBindingKind::Equality { ref ty } => {

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -257,13 +257,11 @@ fn predicates_reference_self(
 }
 
 fn bounds_reference_self(tcx: TyCtxt<'_>, trait_def_id: DefId) -> SmallVec<[Span; 1]> {
-    let trait_ref = ty::Binder::dummy(ty::TraitRef::identity(tcx, trait_def_id));
     tcx.associated_items(trait_def_id)
         .in_definition_order()
         .filter(|item| item.kind == ty::AssocKind::Type)
         .flat_map(|item| tcx.explicit_item_bounds(item.def_id))
-        .map(|&(predicate, sp)| (predicate.subst_supertrait(tcx, &trait_ref), sp))
-        .filter_map(|predicate| predicate_references_self(tcx, predicate))
+        .filter_map(|pred_span_tuple| predicate_references_self(tcx, *pred_span_tuple))
         .collect()
 }
 
@@ -276,7 +274,11 @@ fn predicate_references_self(
     match predicate.skip_binders() {
         ty::PredicateAtom::Trait(ref data, _) => {
             // In the case of a trait predicate, we can skip the "self" type.
-            if data.trait_ref.substs[1..].iter().any(has_self_ty) { Some(sp) } else { None }
+            if data.trait_ref.substs[1..].iter().any(has_self_ty) {
+                Some(sp)
+            } else {
+                None
+            }
         }
         ty::PredicateAtom::Projection(ref data) => {
             // And similarly for projections. This should be redundant with
@@ -528,7 +530,11 @@ fn receiver_for_self_ty<'tcx>(
 ) -> Ty<'tcx> {
     debug!("receiver_for_self_ty({:?}, {:?}, {:?})", receiver_ty, self_ty, method_def_id);
     let substs = InternalSubsts::for_item(tcx, method_def_id, |param, _| {
-        if param.index == 0 { self_ty.into() } else { tcx.mk_param_from_def(param) }
+        if param.index == 0 {
+            self_ty.into()
+        } else {
+            tcx.mk_param_from_def(param)
+        }
     });
 
     let result = receiver_ty.subst(tcx, substs);

--- a/src/test/ui/generic-associated-types/gat_in_trait_path.rs
+++ b/src/test/ui/generic-associated-types/gat_in_trait_path.rs
@@ -1,0 +1,27 @@
+#![feature(generic_associated_types)]
+#![feature(associated_type_defaults)]
+
+trait Foo {
+    type A<'a> where Self: 'a;
+}
+
+struct Fooy;
+
+impl Foo for Fooy {
+    type A<'a> = (&'a ());
+}
+
+#[derive(Clone)]
+struct Fooer<T>(T);
+
+impl<T> Foo for Fooer<T> {
+    type A<'x> where T: 'x = (&'x ());
+}
+
+fn f(arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
+
+
+fn main() {
+  let foo = Fooer(5);
+  f(Box::new(foo));
+}

--- a/src/test/ui/generic-associated-types/issue-67510-pass.rs
+++ b/src/test/ui/generic-associated-types/issue-67510-pass.rs
@@ -1,0 +1,11 @@
+#![feature(generic_associated_types)]
+
+trait X {
+    type Y<'a>;
+}
+
+fn func1<'a>(x: Box<dyn X<Y<'a>=&'a ()>>) {}
+
+fn func2(x: Box<dyn for<'a> X<Y<'a>=&'a ()>>) {}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-67510-pass.stderr
+++ b/src/test/ui/generic-associated-types/issue-67510-pass.stderr
@@ -1,0 +1,39 @@
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510-pass.rs:1:12
+  |
+1 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+
+warning: unused variable: `x`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510-pass.rs:7:14
+  |
+7 | fn func1<'a>(x: Box<dyn X<Y<'a>=&'a ()>>) {}
+  |              ^ help: if this is intentional, prefix it with an underscore: `_x`
+  |
+  = note: `#[warn(unused_variables)]` on by default
+
+warning: unused variable: `x`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510-pass.rs:9:10
+  |
+9 | fn func2(x: Box<dyn for<'a> X<Y<'a>=&'a ()>>) {}
+  |          ^ help: if this is intentional, prefix it with an underscore: `_x`
+
+warning: function is never used: `func1`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510-pass.rs:7:4
+  |
+7 | fn func1<'a>(x: Box<dyn X<Y<'a>=&'a ()>>) {}
+  |    ^^^^^
+  |
+  = note: `#[warn(dead_code)]` on by default
+
+warning: function is never used: `func2`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510-pass.rs:9:4
+  |
+9 | fn func2(x: Box<dyn for<'a> X<Y<'a>=&'a ()>>) {}
+  |    ^^^^^
+
+warning: 5 warnings emitted

--- a/src/test/ui/generic-associated-types/issue-67510.rs
+++ b/src/test/ui/generic-associated-types/issue-67510.rs
@@ -1,0 +1,9 @@
+#![feature(generic_associated_types)]
+
+trait X {
+    type Y<'a>;
+}
+
+fn f(x: Box<dyn X<Y<'a>=&'a ()>>) {}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-67510.stderr
+++ b/src/test/ui/generic-associated-types/issue-67510.stderr
@@ -1,0 +1,33 @@
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510.rs:1:12
+  |
+1 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+
+error[E0261]: use of undeclared lifetime name `'a`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510.rs:7:21
+  |
+7 | fn f(x: Box<dyn X<Y<'a>=&'a ()>>) {}
+  |     -               ^^ undeclared lifetime
+  |     |
+  |     help: consider introducing lifetime `'a` here: `<'a>`
+  |
+  = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+
+error[E0261]: use of undeclared lifetime name `'a`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-67510.rs:7:26
+  |
+7 | fn f(x: Box<dyn X<Y<'a>=&'a ()>>) {}
+  |     -                    ^^ undeclared lifetime
+  |     |
+  |     help: consider introducing lifetime `'a` here: `<'a>`
+  |
+  = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0261`.

--- a/src/test/ui/generic-associated-types/issue-68648-fail-1.rs
+++ b/src/test/ui/generic-associated-types/issue-68648-fail-1.rs
@@ -1,0 +1,22 @@
+#![feature(generic_associated_types)]
+
+trait Fun {
+    type F<'a>;
+    
+    fn identity<'a>(t: Self::F<'a>) -> Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = Self;
+}
+
+fn bug<'a, T: Fun<F = T>>(t: T) -> T::F<'a> {
+    T::identity(t)
+}
+
+
+fn main() {
+    let x = 10;
+    
+    bug(x);
+}

--- a/src/test/ui/generic-associated-types/issue-68648-fail-1.stderr
+++ b/src/test/ui/generic-associated-types/issue-68648-fail-1.stderr
@@ -1,0 +1,18 @@
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-68648-fail-1.rs:1:12
+  |
+1 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 0
+  --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-68648-fail-1.rs:13:19
+   |
+13 | fn bug<'a, T: Fun<F = T>>(t: T) -> T::F<'a> {
+   |                   ^^^^^ expected 1 lifetime argument
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-68648-pass-2.rs
+++ b/src/test/ui/generic-associated-types/issue-68648-pass-2.rs
@@ -1,0 +1,22 @@
+#![feature(generic_associated_types)]
+
+trait Fun {
+    type F<'a>;
+    
+    fn identity<'a>(t: Self::F<'a>) -> Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = Self;
+}
+
+fn bug<'a, T: for<'b> Fun<F<'b> = T>>(t: T) -> T::F<'a> {
+    T::identity(t)
+}
+
+
+fn main() {
+    let x = 10;
+    
+    bug(x);
+}

--- a/src/test/ui/generic-associated-types/issue-68648-pass.rs
+++ b/src/test/ui/generic-associated-types/issue-68648-pass.rs
@@ -1,0 +1,24 @@
+// build-pass
+
+#![feature(generic_associated_types)]
+
+trait Fun {
+    type F<'a>;
+    
+    fn identity<'a>(t: Self::F<'a>) -> Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = Self;
+}
+
+fn bug<'a, T: Fun<F<'a> = T>>(t: T) -> T::F<'a> {
+    T::identity(t)
+}
+
+
+fn main() {
+    let x = 10;
+    
+    bug(x);
+}

--- a/src/test/ui/generic-associated-types/issue-68649-pass.rs
+++ b/src/test/ui/generic-associated-types/issue-68649-pass.rs
@@ -1,0 +1,22 @@
+#![feature(generic_associated_types)]
+
+trait Fun {
+    type F<'a>;
+    
+    fn identity<'a>(t: Self::F<'a>) -> Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = Self;
+}
+
+fn bug<'a, T: Fun<F = ()>>(t: T) -> T::F<'a> {
+    T::identity(())
+}
+
+
+fn main() {
+    let x = 10;
+    
+    bug(x);
+}

--- a/src/test/ui/generic-associated-types/issue-68649.rs
+++ b/src/test/ui/generic-associated-types/issue-68649.rs
@@ -1,0 +1,23 @@
+#![feature(generic_associated_types)]
+
+trait Fun {
+    type F<'a>;
+    
+    fn identity<'a>(t: Self::F<'a>) -> Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = Self;
+}
+
+fn bug<'a, T: for<'b> Fun<F<'b> = ()>>(t: T) -> T::F<'a> {
+    T::identity(())
+    //~^ ERROR: type mismatch resolving `for<'b> <{integer} as Fun>::F<'b> == ()`
+}
+
+
+fn main() {
+    let x = 10;
+    
+    bug(x);
+}

--- a/src/test/ui/generic-associated-types/issue-68649.stderr
+++ b/src/test/ui/generic-associated-types/issue-68649.stderr
@@ -1,0 +1,21 @@
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-68649.rs:1:12
+  |
+1 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error[E0271]: type mismatch resolving `for<'b> <{integer} as Fun>::F<'b> == ()`
+  --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-68649.rs:22:5
+   |
+13 | fn bug<'a, T: for<'b> Fun<F<'b> = ()>>(t: T) -> T::F<'a> {
+   |                           ---------- required by this bound in `bug`
+...
+22 |     bug(x);
+   |     ^^^ expected `()`, found integer
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/generic-associated-types/issue-74684-fail-1.rs
+++ b/src/test/ui/generic-associated-types/issue-74684-fail-1.rs
@@ -1,0 +1,24 @@
+#![feature(generic_associated_types)]
+trait Fun {
+    type F<'a>: ?Sized;
+    
+    fn identity<'a>(t: &'a Self::F<'a>) -> &'a Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = i32;
+}
+
+fn bug<'a, T: ?Sized + Fun<F = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+    //~^ ERROR: wrong number of lifetime arguments: expected 1, found 0
+    let a = [0; 1];
+    let x = T::identity(&a);
+    todo!()
+}
+
+
+fn main() {
+    let x = 10;
+    
+    bug(Box::new(x));
+}

--- a/src/test/ui/generic-associated-types/issue-74684-fail-1.stderr
+++ b/src/test/ui/generic-associated-types/issue-74684-fail-1.stderr
@@ -1,0 +1,18 @@
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-74684-fail-1.rs:1:12
+  |
+1 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 0
+  --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-74684-fail-1.rs:12:28
+   |
+12 | fn bug<'a, T: ?Sized + Fun<F = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+   |                            ^^^^^^^^ expected 1 lifetime argument
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-74684-fail-2.rs
+++ b/src/test/ui/generic-associated-types/issue-74684-fail-2.rs
@@ -1,0 +1,23 @@
+#![feature(generic_associated_types)]
+trait Fun {
+    type F<'a>: ?Sized;
+    
+    fn identity<'a>(t: &'a Self::F<'a>) -> &'a Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = i32;
+}
+
+fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+    let a = [0; 1];
+    let x = T::identity(&a);
+    todo!()
+}
+
+
+fn main() {
+    let x = 10;
+    
+    bug(Box::new(x));
+}

--- a/src/test/ui/generic-associated-types/issue-74684-fail-2.stderr
+++ b/src/test/ui/generic-associated-types/issue-74684-fail-2.stderr
@@ -1,0 +1,21 @@
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-74684-fail-2.rs:1:12
+  |
+1 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error[E0271]: type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
+  --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/issue-74684-fail-2.rs:22:5
+   |
+12 | fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+   |                            ------------ required by this bound in `bug`
+...
+22 |     bug(Box::new(x));
+   |     ^^^ expected slice `[u8]`, found `i32`
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/generic-associated-types/issue-74684-pass.rs
+++ b/src/test/ui/generic-associated-types/issue-74684-pass.rs
@@ -1,0 +1,26 @@
+// build-pass
+
+#![feature(generic_associated_types)]
+
+trait Fun {
+    type F<'a>: ?Sized;
+
+    fn identity<'a>(t: &'a Self::F<'a>) -> &'a Self::F<'a> { t }
+}
+
+impl <T> Fun for T {
+    type F<'a> = [u8];
+}
+
+fn bug<'a, T: ?Sized + Fun<F<'a> = [u8]>>(t: Box<T>) -> &'static T::F<'a> {
+    let a = [0; 1];
+    let x = T::identity(&a);
+    todo!()
+}
+
+
+fn main() {
+    let x = 10;
+
+    bug(Box::new(x));
+}

--- a/src/test/ui/generic-associated-types/parse/issue-67510-1.rs
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-1.rs
@@ -1,0 +1,16 @@
+// Several parsing errors for associated type constraints that are supposed
+// to trigger all errors in ´get_assoc_type_with_generics´ and
+// ´get_generic_args_from_path_segment´ 
+
+#![feature(generic_associated_types)]
+
+trait X {
+    type Y<'a>;
+}
+
+trait Z {}
+
+impl<T : X<X::Y<'a> = &'a u32>> Z for T {} 
+    //~^ ERROR: associated types cannot contain multiple path segments 
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/parse/issue-67510-1.stderr
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-1.stderr
@@ -1,0 +1,10 @@
+error: found a Path with multiple segments, expected a Path with a single segment
+  --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-1.rs:13:12
+   |
+13 | impl<T : X<X::Y<'a> = &'a u32>> Z for T {} 
+   |            ^^^^^^^^
+   |            |
+   |            expected the name of an associated type
+   |            help: try to use only the last segment:: `Y`
+
+error: aborting due to previous error

--- a/src/test/ui/generic-associated-types/parse/issue-67510-2.rs
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-2.rs
@@ -1,0 +1,12 @@
+// Only accept generic arguments of typeTyKind::Path as associated types in
+// trait paths
+#![feature(generic_associated_types)]
+
+trait X { 
+    type Y<'a>;
+}
+
+fn f1<'a>(arg : Box<dyn X<(Y<'a>) = &'a ()>>) {} 
+    //~^ ERROR: Expected the name of an associated type
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/parse/issue-67510-2.stderr
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-2.stderr
@@ -1,0 +1,18 @@
+error: Incorrect type of generic argument, expected a Path with a single path segment
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-2.rs:9:27
+  |
+9 | fn f1<'a>(arg : Box<dyn X<(Y<'a>) = &'a ()>>) {} 
+  |                           ^^^^^^^^-
+  |                                   |
+  |                                   Expected the name of an associated type
+
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-2.rs:3:12
+  |
+3 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error: aborting due to previous error; 1 warning emitted

--- a/src/test/ui/generic-associated-types/parse/issue-67510-3.rs
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-3.rs
@@ -1,0 +1,12 @@
+// Test to ensure that only GenericArg::Type is accepted in associated type
+// constraints
+#![feature(generic_associated_types)]
+
+trait X { 
+    type Y<'a>;
+}
+
+fn f1<'a>(arg : Box<dyn X<'a = &'a ()>>) {}  
+    //~^ ERROR: Expected the name of an associated type
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/parse/issue-67510-3.stderr
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-3.stderr
@@ -1,0 +1,16 @@
+error: Incorrect type of generic argument, expected a path with a single segment
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-3.rs:9:27
+  |
+9 | fn f1<'a>(arg : Box<dyn X<'a = &'a ()>>) {}  
+  |                           ^^^^ expected the name of an associated type
+
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-3.rs:3:12
+  |
+3 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error: aborting due to previous error; 1 warning emitted

--- a/src/test/ui/generic-associated-types/parse/issue-67510-4.rs
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-4.rs
@@ -1,0 +1,14 @@
+// Only accept lifetimes or types as generic arguments for associated types 
+// in trait paths
+
+#![feature(generic_associated_types)]
+
+trait X { 
+    type Y<'a>;
+}
+
+fn f1<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}  
+    //~^  ERROR: generic arguments of associated types must be lifetimes or types
+    //~^^ ERROR: wrong number of lifetime arguments: expected 1, found 0 
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/parse/issue-67510-4.stderr
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-4.stderr
@@ -1,0 +1,24 @@
+error: generic arguments of associated types must be lifetimes or types
+  --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-4.rs:10:27
+   |
+10 | fn f1<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}  
+   |                           ^
+
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-4.rs:4:12
+  |
+4 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 0
+  --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-4.rs:10:27
+   |
+10 | fn f1<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}  
+   |                           ^^^^^^^^^^^^^ expected 1 lifetime argument
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/parse/issue-67510-5.rs
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-5.rs
@@ -1,0 +1,12 @@
+// Test to ensure that the Constraint branch of the pattern match on AngleBracketedArg
+// in `get_assoc_type_with_generic_args` is unreachable
+#![feature(generic_associated_types)]
+
+trait X { 
+    type Y<'a>;
+}
+
+fn f1<'a>(arg : Box<dyn X<Y = B = &'a ()>>) {}  
+    //~^ ERROR: Expected the name of an associated type
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/parse/issue-67510-5.stderr
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-5.stderr
@@ -1,0 +1,16 @@
+error: expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `=`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-5.rs:9:33
+  |
+9 | fn f1<'a>(arg : Box<dyn X<Y = B = &'a ()>>) {}  
+  |                                 ^ expected one of 7 possible tokens
+
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-5.rs:3:12
+  |
+3 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error: aborting due to previous error; 1 warning emitted

--- a/src/test/ui/generic-associated-types/parse/issue-67510-6.rs
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-6.rs
@@ -1,0 +1,16 @@
+// Parser shouldn't accept parenthesized generic arguments for associated types in
+// trait paths
+#![feature(generic_associated_types)]
+
+trait X { 
+    type Y<'a>;
+}
+
+fn f1<'a>(arg : Box<dyn X<Y('a) = &'a ()>>) {}  
+    //~^  ERROR: lifetime in trait object type must be followed by `+`
+    //~^^ ERROR: invalid use of parenthesized generic arguments, expected angle 
+    //           bracketed (`<...>`) generic arguments
+    //~^^^^ ERROR: wrong number of lifetime arguments: expected 1, found 0
+    
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/parse/issue-67510-6.stderr
+++ b/src/test/ui/generic-associated-types/parse/issue-67510-6.stderr
@@ -1,0 +1,30 @@
+error: lifetime in trait object type must be followed by `+`
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-6.rs:9:29
+  |
+9 | fn f1<'a>(arg : Box<dyn X<Y('a) = &'a ()>>) {}  
+  |                             ^^
+
+error: invalid use of parenthesized generic arguments, expected angle bracketed (`<...>`) generic arguments
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-6.rs:9:27
+  |
+9 | fn f1<'a>(arg : Box<dyn X<Y('a) = &'a ()>>) {}  
+  |                           ^^^^^
+
+warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-6.rs:3:12
+  |
+3 | #![feature(generic_associated_types)]
+  |            ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(incomplete_features)]` on by default
+  = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
+
+error[E0107]: wrong number of lifetime arguments: expected 1, found 0
+ --> /Users/bn/Documents/rust_fork/rust/src/test/ui/generic-associated-types/parse/issue-67510-6.rs:9:27
+  |
+9 | fn f1<'a>(arg : Box<dyn X<Y('a) = &'a ()>>) {}  
+  |                           ^^^^^^^^^^^^^^ expected 1 lifetime argument
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Is supposed to fix #67510, #68648, #68649, #68650, #68652, #74684

@petrochenkov Asked me to open a WIP PR, so he can look at the part that was changed in the parser.

A couple of potential problems and things to work on are:

* Error messages must probably be improved in the parser
* There are a couple of spans that are not completely correct
* There are a couple of conflicts with error messages that were created for const-generics. E.g. in `S::<5 + 2 >> 7>;`, which suggests that const expressions must be enclosed in braces, whereas with the current changes we get: `expected one of `,` or `>`, found `+` `
* Currently in `parse_assoc_equality_term` we return `Ok(mk_ty(..., TyKind::Error))` unless the generic argument that is parsed in the beginning of the function is of type `GenericArg::Type`, but a TyKind::Error result is currently not handled after the call.
* In `bounds_reference_self` in object safety checking the map call that used `subst_supertrait`was removed, I've talked to both @matthewjasper and @nikomatsakis about this and both didn't know why the call was there. All relevant ui tests still pass after the removal.