### PR TITLE
Fix rustc_ast_pretty print_qpath resulting in invalid macro input

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2328,11 +2328,12 @@ impl<'a> State<'a> {
             self.print_path(path, false, depth);
         }
         self.s.word(">");
-        self.s.word("::");
-        let item_segment = path.segments.last().unwrap();
-        self.print_ident(item_segment.ident);
-        if let Some(ref args) = item_segment.args {
-            self.print_generic_args(args, colons_before_params)
+        for item_segment in &path.segments[qself.position..] {
+            self.s.word("::");
+            self.print_ident(item_segment.ident);
+            if let Some(ref args) = item_segment.args {
+                self.print_generic_args(args, colons_before_params)
+            }
         }
     }
 

--- a/src/test/pretty/qpath-associated-type-bound.rs
+++ b/src/test/pretty/qpath-associated-type-bound.rs
@@ -1,0 +1,16 @@
+// pp-exact
+
+
+mod m {
+    pub trait Tr {
+        type Ts: super::Tu;
+    }
+}
+
+trait Tu {
+    fn dummy() { }
+}
+
+fn foo<T: m::Tr>() { <T as m::Tr>::Ts::dummy(); }
+
+fn main() { }


### PR DESCRIPTION
related https://github.com/rust-lang/rust/issues/76874 (third case)

### Issue:

The input for a procedural macro is incorrect, for the rust code:
```rust

mod m {
    pub trait Tr {
        type Ts: super::Tu;
    }
}

trait Tu {
    fn dummy() { }
}

#[may_proc_macro]
fn foo() {
    <T as m::Tr>::Ts::dummy();
}
```
the macro will get the input:
```rust
fn foo() {
    <T as m::Tr>::dummy();
}
```
Thus `Ts` has disappeared.

### Fix:

This is due to invalid pretty print of qpath. This PR fix it.