### PR TITLE
Rustdoc check option

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -145,6 +145,9 @@ pub struct Options {
     pub render_options: RenderOptions,
     /// Output format rendering (used only for "show-coverage" option for the moment)
     pub output_format: Option<OutputFormat>,
+    /// If this option is set to `true`, rustdoc will only run checks and not generate
+    /// documentation.
+    pub run_check: bool,
 }
 
 impl fmt::Debug for Options {
@@ -185,6 +188,7 @@ impl fmt::Debug for Options {
             .field("runtool", &self.runtool)
             .field("runtool_args", &self.runtool_args)
             .field("enable-per-target-ignores", &self.enable_per_target_ignores)
+            .field("run_check", &self.run_check)
             .finish()
     }
 }
@@ -581,6 +585,7 @@ impl Options {
         let enable_per_target_ignores = matches.opt_present("enable-per-target-ignores");
         let document_private = matches.opt_present("document-private-items");
         let document_hidden = matches.opt_present("document-hidden-items");
+        let run_check = matches.opt_present("check");
 
         let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(matches, error_format);
 
@@ -616,6 +621,7 @@ impl Options {
             runtool_args,
             enable_per_target_ignores,
             test_builder,
+            run_check,
             render_options: RenderOptions {
                 output,
                 external_html,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -423,6 +423,7 @@ fn opts() -> Vec<RustcOptGroup> {
                 "specified the rustc-like binary to use as the test builder",
             )
         }),
+        unstable("check", |o| o.optflag("", "check", "Run rustdoc checks")),
     ]
 }
 
@@ -514,6 +515,7 @@ fn main_options(options: config::Options) -> MainResult {
     // but we can't crates the Handler ahead of time because it's not Send
     let diag_opts = (options.error_format, options.edition, options.debugging_opts.clone());
     let show_coverage = options.show_coverage;
+    let run_check = options.run_check;
 
     // First, parse the crate and extract all relevant information.
     info!("starting to run rustc");
@@ -538,6 +540,9 @@ fn main_options(options: config::Options) -> MainResult {
     if show_coverage {
         // if we ran coverage, bail early, we don't need to also generate docs at this point
         // (also we didn't load in any of the useful passes)
+        return Ok(());
+    } else if run_check {
+        // Since we're in "check" mode, no need to generate anything beyond this point.
         return Ok(());
     }
 

--- a/src/test/rustdoc-ui/check-fail.rs
+++ b/src/test/rustdoc-ui/check-fail.rs
@@ -1,0 +1,10 @@
+// compile-flags: -Z unstable-options --check
+
+#![deny(missing_docs)]
+//~^ ERROR
+//~^^ ERROR
+#![deny(rustdoc)]
+
+pub fn foo() {}
+//~^ ERROR
+//~^^ ERROR

--- a/src/test/rustdoc-ui/check-fail.rs
+++ b/src/test/rustdoc-ui/check-fail.rs
@@ -1,10 +1,21 @@
 // compile-flags: -Z unstable-options --check
 
 #![deny(missing_docs)]
-//~^ ERROR
-//~^^ ERROR
 #![deny(rustdoc)]
+
+//! ```rust,testharness
+//~^ ERROR
+//! let x = 12;
+//! ```
 
 pub fn foo() {}
 //~^ ERROR
 //~^^ ERROR
+
+/// hello
+//~^ ERROR
+///
+/// ```rust,testharness
+/// let x = 12;
+/// ```
+pub fn bar() {}

--- a/src/test/rustdoc-ui/check-fail.stderr
+++ b/src/test/rustdoc-ui/check-fail.stderr
@@ -1,13 +1,8 @@
-error: missing documentation for the crate
-  --> $DIR/check-fail.rs:3:1
+error: missing documentation for a function
+  --> $DIR/check-fail.rs:11:1
    |
-LL | / #![deny(missing_docs)]
-LL | |
-LL | |
-LL | | #![deny(rustdoc)]
-LL | |
-LL | | pub fn foo() {}
-   | |_______________^
+LL | pub fn foo() {}
+   | ^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/check-fail.rs:3:9
@@ -15,35 +10,48 @@ note: the lint level is defined here
 LL | #![deny(missing_docs)]
    |         ^^^^^^^^^^^^
 
-error: missing documentation for a function
-  --> $DIR/check-fail.rs:8:1
+error: missing code example in this documentation
+  --> $DIR/check-fail.rs:11:1
    |
 LL | pub fn foo() {}
-   | ^^^^^^^^^^^^
-
-error: missing code example in this documentation
-  --> $DIR/check-fail.rs:3:1
-   |
-LL | / #![deny(missing_docs)]
-LL | |
-LL | |
-LL | | #![deny(rustdoc)]
-LL | |
-LL | | pub fn foo() {}
-   | |_______________^
+   | ^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/check-fail.rs:6:9
+  --> $DIR/check-fail.rs:4:9
    |
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
    = note: `#[deny(missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
 
-error: missing code example in this documentation
-  --> $DIR/check-fail.rs:8:1
+error: unknown attribute `testharness`. Did you mean `test_harness`?
+  --> $DIR/check-fail.rs:6:1
    |
-LL | pub fn foo() {}
-   | ^^^^^^^^^^^^^^^
+LL | / //! ```rust,testharness
+LL | |
+LL | | //! let x = 12;
+LL | | //! ```
+   | |_______^
+   |
+note: the lint level is defined here
+  --> $DIR/check-fail.rs:4:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+   = note: `#[deny(invalid_codeblock_attributes)]` implied by `#[deny(rustdoc)]`
+   = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
+
+error: unknown attribute `testharness`. Did you mean `test_harness`?
+  --> $DIR/check-fail.rs:15:1
+   |
+LL | / /// hello
+LL | |
+LL | | ///
+LL | | /// ```rust,testharness
+LL | | /// let x = 12;
+LL | | /// ```
+   | |_______^
+   |
+   = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
 error: aborting due to 4 previous errors
 

--- a/src/test/rustdoc-ui/check-fail.stderr
+++ b/src/test/rustdoc-ui/check-fail.stderr
@@ -1,0 +1,49 @@
+error: missing documentation for the crate
+  --> $DIR/check-fail.rs:3:1
+   |
+LL | / #![deny(missing_docs)]
+LL | |
+LL | |
+LL | | #![deny(rustdoc)]
+LL | |
+LL | | pub fn foo() {}
+   | |_______________^
+   |
+note: the lint level is defined here
+  --> $DIR/check-fail.rs:3:9
+   |
+LL | #![deny(missing_docs)]
+   |         ^^^^^^^^^^^^
+
+error: missing documentation for a function
+  --> $DIR/check-fail.rs:8:1
+   |
+LL | pub fn foo() {}
+   | ^^^^^^^^^^^^
+
+error: missing code example in this documentation
+  --> $DIR/check-fail.rs:3:1
+   |
+LL | / #![deny(missing_docs)]
+LL | |
+LL | |
+LL | | #![deny(rustdoc)]
+LL | |
+LL | | pub fn foo() {}
+   | |_______________^
+   |
+note: the lint level is defined here
+  --> $DIR/check-fail.rs:6:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+   = note: `#[deny(missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
+
+error: missing code example in this documentation
+  --> $DIR/check-fail.rs:8:1
+   |
+LL | pub fn foo() {}
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/rustdoc-ui/check.rs
+++ b/src/test/rustdoc-ui/check.rs
@@ -1,0 +1,11 @@
+// check-pass
+// compile-flags: -Z unstable-options --check
+
+#![warn(missing_docs)]
+//~^ WARN
+//~^^ WARN
+#![warn(rustdoc)]
+
+pub fn foo() {}
+//~^ WARN
+//~^^ WARN

--- a/src/test/rustdoc-ui/check.stderr
+++ b/src/test/rustdoc-ui/check.stderr
@@ -1,0 +1,49 @@
+warning: missing documentation for the crate
+  --> $DIR/check.rs:4:1
+   |
+LL | / #![warn(missing_docs)]
+LL | |
+LL | |
+LL | | #![warn(rustdoc)]
+LL | |
+LL | | pub fn foo() {}
+   | |_______________^
+   |
+note: the lint level is defined here
+  --> $DIR/check.rs:4:9
+   |
+LL | #![warn(missing_docs)]
+   |         ^^^^^^^^^^^^
+
+warning: missing documentation for a function
+  --> $DIR/check.rs:9:1
+   |
+LL | pub fn foo() {}
+   | ^^^^^^^^^^^^
+
+warning: missing code example in this documentation
+  --> $DIR/check.rs:4:1
+   |
+LL | / #![warn(missing_docs)]
+LL | |
+LL | |
+LL | | #![warn(rustdoc)]
+LL | |
+LL | | pub fn foo() {}
+   | |_______________^
+   |
+note: the lint level is defined here
+  --> $DIR/check.rs:7:9
+   |
+LL | #![warn(rustdoc)]
+   |         ^^^^^^^
+   = note: `#[warn(missing_doc_code_examples)]` implied by `#[warn(rustdoc)]`
+
+warning: missing code example in this documentation
+  --> $DIR/check.rs:9:1
+   |
+LL | pub fn foo() {}
+   | ^^^^^^^^^^^^^^^
+
+warning: 4 warnings emitted
+

--- a/src/test/rustdoc/check.rs
+++ b/src/test/rustdoc/check.rs
@@ -1,0 +1,5 @@
+// compile-flags: -Z unstable-options --check
+
+// @!has check/fn.foo.html
+// @!has check/index.html
+pub fn foo() {}


### PR DESCRIPTION
The ultimate goal behind this option would be to have `rustdoc --check` being run when you use `cargo check` as a second step.

r? @jyn514 