### PR TITLE
extend min_const_generics param ty tests

### DIFF
--- a/src/test/ui/const-generics/core-types.rs
+++ b/src/test/ui/const-generics/core-types.rs
@@ -1,0 +1,51 @@
+// Check that all types allowed with `min_const_generics` work.
+// run-pass
+// revisions: full min
+
+#![cfg_attr(full, feature(const_generics))]
+#![cfg_attr(full, allow(incomplete_features))]
+#![cfg_attr(min, feature(min_const_generics))]
+
+struct A<const N: u8>;
+struct B<const N: u16>;
+struct C<const N: u32>;
+struct D<const N: u64>;
+struct E<const N: u128>;
+struct F<const N: usize>;
+struct G<const N: i8>;
+struct H<const N: i16>;
+struct I<const N: i32>;
+struct J<const N: i64>;
+struct K<const N: i128>;
+struct L<const N: isize>;
+struct M<const N: char>;
+struct N<const N: bool>;
+
+fn main() {
+    let _ = A::<{u8::MIN}>;
+    let _ = A::<{u8::MAX}>;
+    let _ = B::<{u16::MIN}>;
+    let _ = B::<{u16::MAX}>;
+    let _ = C::<{u32::MIN}>;
+    let _ = C::<{u32::MAX}>;
+    let _ = D::<{u64::MIN}>;
+    let _ = D::<{u64::MAX}>;
+    let _ = E::<{u128::MIN}>;
+    let _ = E::<{u128::MAX}>;
+    let _ = F::<{usize::MIN}>;
+    let _ = F::<{usize::MAX}>;
+    let _ = G::<{i8::MIN}>;
+    let _ = G::<{i8::MAX}>;
+    let _ = H::<{i16::MIN}>;
+    let _ = H::<{i16::MAX}>;
+    let _ = I::<{i32::MIN}>;
+    let _ = I::<{i32::MAX}>;
+    let _ = J::<{i64::MIN}>;
+    let _ = J::<{i64::MAX}>;
+    let _ = K::<{i128::MIN}>;
+    let _ = K::<{i128::MAX}>;
+    let _ = L::<{isize::MIN}>;
+    let _ = L::<{isize::MAX}>;
+    let _ = M::<'A'>;
+    let _ = N::<true>;
+}

--- a/src/test/ui/const-generics/min_const_generics/complex-types.rs
+++ b/src/test/ui/const-generics/min_const_generics/complex-types.rs
@@ -1,4 +1,5 @@
 #![feature(min_const_generics)]
+#![feature(never_type)]
 
 struct Foo<const N: [u8; 0]>;
 //~^ ERROR `[u8; 0]` is forbidden
@@ -13,5 +14,15 @@ struct Fez<const N: No>;
 
 struct Faz<const N: &'static u8>;
 //~^ ERROR `&'static u8` is forbidden
+
+struct Fiz<const N: !>;
+//~^ ERROR `!` is forbidden
+
+enum Goo<const N: ()> { A, B }
+//~^ ERROR `()` is forbidden
+
+union Boo<const N: ()> { a: () }
+//~^ ERROR `()` is forbidden
+
 
 fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/complex-types.stderr
+++ b/src/test/ui/const-generics/min_const_generics/complex-types.stderr
@@ -1,5 +1,5 @@
 error: `[u8; 0]` is forbidden as the type of a const generic parameter
-  --> $DIR/complex-types.rs:3:21
+  --> $DIR/complex-types.rs:4:21
    |
 LL | struct Foo<const N: [u8; 0]>;
    |                     ^^^^^^^
@@ -8,7 +8,7 @@ LL | struct Foo<const N: [u8; 0]>;
    = note: more complex types are supported with `#[feature(const_generics)]`
 
 error: `()` is forbidden as the type of a const generic parameter
-  --> $DIR/complex-types.rs:6:21
+  --> $DIR/complex-types.rs:7:21
    |
 LL | struct Bar<const N: ()>;
    |                     ^^
@@ -17,7 +17,7 @@ LL | struct Bar<const N: ()>;
    = note: more complex types are supported with `#[feature(const_generics)]`
 
 error: `No` is forbidden as the type of a const generic parameter
-  --> $DIR/complex-types.rs:11:21
+  --> $DIR/complex-types.rs:12:21
    |
 LL | struct Fez<const N: No>;
    |                     ^^
@@ -26,7 +26,7 @@ LL | struct Fez<const N: No>;
    = note: more complex types are supported with `#[feature(const_generics)]`
 
 error: `&'static u8` is forbidden as the type of a const generic parameter
-  --> $DIR/complex-types.rs:14:21
+  --> $DIR/complex-types.rs:15:21
    |
 LL | struct Faz<const N: &'static u8>;
    |                     ^^^^^^^^^^^
@@ -34,5 +34,32 @@ LL | struct Faz<const N: &'static u8>;
    = note: the only supported types are integers, `bool` and `char`
    = note: more complex types are supported with `#[feature(const_generics)]`
 
-error: aborting due to 4 previous errors
+error: `!` is forbidden as the type of a const generic parameter
+  --> $DIR/complex-types.rs:18:21
+   |
+LL | struct Fiz<const N: !>;
+   |                     ^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = note: more complex types are supported with `#[feature(const_generics)]`
+
+error: `()` is forbidden as the type of a const generic parameter
+  --> $DIR/complex-types.rs:21:19
+   |
+LL | enum Goo<const N: ()> { A, B }
+   |                   ^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = note: more complex types are supported with `#[feature(const_generics)]`
+
+error: `()` is forbidden as the type of a const generic parameter
+  --> $DIR/complex-types.rs:24:20
+   |
+LL | union Boo<const N: ()> { a: () }
+   |                    ^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = note: more complex types are supported with `#[feature(const_generics)]`
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Apparently we never tested for `u128` and `i128` before this, so I added a test for all types which are allowed.

r? @varkor 