### PR TITLE
rustc_target: Fix dash vs underscore mismatches in option names

### DIFF
--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1428,8 +1428,8 @@ impl Target {
         }
 
         key!(is_builtin, bool);
-        key!(endian = "target_endian");
-        key!(c_int_width = "target_c_int_width");
+        key!(endian = "target-endian");
+        key!(c_int_width = "target-c-int-width");
         key!(os);
         key!(env);
         key!(vendor);
@@ -1466,7 +1466,7 @@ impl Target {
         key!(exe_suffix);
         key!(staticlib_prefix);
         key!(staticlib_suffix);
-        key!(os_family = "target_family", optional);
+        key!(os_family = "target-family", optional);
         key!(abi_return_struct_as_int, bool);
         key!(is_like_osx, bool);
         key!(is_like_solaris, bool);
@@ -1511,7 +1511,7 @@ impl Target {
         key!(limit_rdylib_exports, bool);
         key!(override_export_symbols, opt_list);
         key!(merge_functions, MergeFunctions)?;
-        key!(mcount = "target_mcount");
+        key!(mcount = "target-mcount");
         key!(llvm_abiname);
         key!(relax_elf_relocations, bool);
         key!(llvm_args, list);
@@ -1663,8 +1663,8 @@ impl ToJson for Target {
         target_val!(data_layout);
 
         target_option_val!(is_builtin);
-        target_option_val!(endian, "target_endian");
-        target_option_val!(c_int_width, "target_c_int_width");
+        target_option_val!(endian, "target-endian");
+        target_option_val!(c_int_width, "target-c-int-width");
         target_option_val!(os);
         target_option_val!(env);
         target_option_val!(vendor);
@@ -1701,7 +1701,7 @@ impl ToJson for Target {
         target_option_val!(exe_suffix);
         target_option_val!(staticlib_prefix);
         target_option_val!(staticlib_suffix);
-        target_option_val!(os_family, "target_family");
+        target_option_val!(os_family, "target-family");
         target_option_val!(abi_return_struct_as_int);
         target_option_val!(is_like_osx);
         target_option_val!(is_like_solaris);
@@ -1746,7 +1746,7 @@ impl ToJson for Target {
         target_option_val!(limit_rdylib_exports);
         target_option_val!(override_export_symbols);
         target_option_val!(merge_functions);
-        target_option_val!(mcount, "target_mcount");
+        target_option_val!(mcount, "target-mcount");
         target_option_val!(llvm_abiname);
         target_option_val!(relax_elf_relocations);
         target_option_val!(llvm_args);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/78981 (regression from https://github.com/rust-lang/rust/pull/78875, the old option names used dashes)