### PR TITLE
Handle empty matches cleanly in exhaustiveness checking

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/_match.rs
@@ -1588,7 +1588,7 @@ fn all_constructors<'p, 'tcx>(pcx: PatCtxt<'_, 'p, 'tcx>) -> Vec<Constructor<'tc
             let is_declared_nonexhaustive = cx.is_foreign_non_exhaustive_enum(pcx.ty);
 
             // If `exhaustive_patterns` is disabled and our scrutinee is an empty enum, we treat it
-            // as though it had an "unknown" constructor to avoid exposing its emptyness. The
+            // as though it had an "unknown" constructor to avoid exposing its emptiness. The
             // exception is if the pattern is at the top level, because we want empty matches to be
             // considered exhaustive.
             let is_secretly_empty = def.variants.is_empty()
@@ -1640,7 +1640,7 @@ fn all_constructors<'p, 'tcx>(pcx: PatCtxt<'_, 'p, 'tcx>) -> Vec<Constructor<'tc
             vec![make_range(0, max)]
         }
         // If `exhaustive_patterns` is disabled and our scrutinee is the never type, we cannot
-        // expose its emptyness. The exception is if the pattern is at the top level, because we
+        // expose its emptiness. The exception is if the pattern is at the top level, because we
         // want empty matches to be considered exhaustive.
         ty::Never if !cx.tcx.features().exhaustive_patterns && !pcx.is_top_level => {
             vec![NonExhaustive]

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -1,6 +1,7 @@
 use super::_match::Usefulness::*;
-use super::_match::WitnessPreference::*;
-use super::_match::{expand_pattern, is_useful, MatchCheckCtxt, Matrix, PatStack};
+use super::_match::{
+    compute_match_usefulness, expand_pattern, MatchArm, MatchCheckCtxt, UsefulnessReport,
+};
 use super::{PatCtxt, PatKind, PatternError};
 
 use rustc_arena::TypedArena;
@@ -169,39 +170,50 @@ impl<'tcx> MatchVisitor<'_, 'tcx> {
 
         let mut have_errors = false;
 
-        let inlined_arms: Vec<_> = arms
+        let arms: Vec<_> = arms
             .iter()
-            .map(|hir::Arm { pat, guard, .. }| {
-                (self.lower_pattern(&mut cx, pat, &mut have_errors).0, pat.hir_id, guard.is_some())
+            .map(|hir::Arm { pat, guard, .. }| MatchArm {
+                pat: self.lower_pattern(&mut cx, pat, &mut have_errors).0,
+                hir_id: pat.hir_id,
+                has_guard: guard.is_some(),
             })
             .collect();
 
-        // Bail out early if inlining failed.
+        // Bail out early if lowering failed.
         if have_errors {
             return;
         }
 
-        // Fourth, check for unreachable arms.
-        let matrix = check_arms(&mut cx, &inlined_arms, source);
+        let scrut_ty = self.typeck_results.expr_ty_adjusted(scrut);
+        let report = compute_match_usefulness(&cx, &arms, scrut.hir_id, scrut_ty);
 
-        // Fifth, check if the match is exhaustive.
+        // Report unreachable arms.
+        report_arm_reachability(&cx, &report, source);
+
+        // Check if the match is exhaustive.
         // Note: An empty match isn't the same as an empty matrix for diagnostics purposes,
         // since an empty matrix can occur when there are arms, if those arms all have guards.
-        let scrut_ty = self.typeck_results.expr_ty_adjusted(scrut);
-        let is_empty_match = inlined_arms.is_empty();
-        check_exhaustive(&mut cx, scrut_ty, scrut.span, &matrix, scrut.hir_id, is_empty_match);
+        let is_empty_match = arms.is_empty();
+        let witnesses = report.non_exhaustiveness_witnesses;
+        if !witnesses.is_empty() {
+            non_exhaustive_match(&cx, scrut_ty, scrut.span, witnesses, is_empty_match);
+        }
     }
 
     fn check_irrefutable(&self, pat: &'tcx Pat<'tcx>, origin: &str, sp: Option<Span>) {
         let mut cx = self.new_cx(pat.hir_id);
 
         let (pattern, pattern_ty) = self.lower_pattern(&mut cx, pat, &mut false);
-        let pats: Matrix<'_, '_> = vec![PatStack::from_pattern(pattern)].into_iter().collect();
+        let arms = vec![MatchArm { pat: pattern, hir_id: pat.hir_id, has_guard: false }];
+        let report = compute_match_usefulness(&cx, &arms, pat.hir_id, pattern_ty);
 
-        let witnesses = match check_not_useful(&mut cx, pattern_ty, &pats, pat.hir_id) {
-            Ok(_) => return,
-            Err(err) => err,
-        };
+        // Note: we ignore whether the pattern is unreachable (i.e. whether the type is empty). We
+        // only care about exhaustiveness here.
+        let witnesses = report.non_exhaustiveness_witnesses;
+        if witnesses.is_empty() {
+            // The pattern is irrefutable.
+            return;
+        }
 
         let joined_patterns = joined_uncovered_patterns(&witnesses);
         let mut err = struct_span_err!(
@@ -354,17 +366,15 @@ fn irrefutable_let_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, source: hir::
     });
 }
 
-/// Check for unreachable patterns.
-fn check_arms<'p, 'tcx>(
-    cx: &mut MatchCheckCtxt<'p, 'tcx>,
-    arms: &[(&'p super::Pat<'tcx>, HirId, bool)],
+/// Report unreachable arms, if any.
+fn report_arm_reachability<'p, 'tcx>(
+    cx: &MatchCheckCtxt<'p, 'tcx>,
+    report: &UsefulnessReport<'p, 'tcx>,
     source: hir::MatchSource,
-) -> Matrix<'p, 'tcx> {
-    let mut seen = Matrix::empty();
+) {
     let mut catchall = None;
-    for (arm_index, (pat, id, has_guard)) in arms.iter().copied().enumerate() {
-        let v = PatStack::from_pattern(pat);
-        match is_useful(cx, &seen, &v, LeaveOutWitness, id, has_guard, true) {
+    for (arm_index, (arm, is_useful)) in report.arm_usefulness.iter().enumerate() {
+        match is_useful {
             NotUseful => {
                 match source {
                     hir::MatchSource::IfDesugar { .. } | hir::MatchSource::WhileDesugar => bug!(),
@@ -373,15 +383,15 @@ fn check_arms<'p, 'tcx>(
                         // Check which arm we're on.
                         match arm_index {
                             // The arm with the user-specified pattern.
-                            0 => unreachable_pattern(cx.tcx, pat.span, id, None),
+                            0 => unreachable_pattern(cx.tcx, arm.pat.span, arm.hir_id, None),
                             // The arm with the wildcard pattern.
-                            1 => irrefutable_let_pattern(cx.tcx, pat.span, id, source),
+                            1 => irrefutable_let_pattern(cx.tcx, arm.pat.span, arm.hir_id, source),
                             _ => bug!(),
                         }
                     }
 
                     hir::MatchSource::ForLoopDesugar | hir::MatchSource::Normal => {
-                        unreachable_pattern(cx.tcx, pat.span, id, catchall);
+                        unreachable_pattern(cx.tcx, arm.pat.span, arm.hir_id, catchall);
                     }
 
                     // Unreachable patterns in try and await expressions occur when one of
@@ -392,60 +402,29 @@ fn check_arms<'p, 'tcx>(
             Useful(unreachables) if unreachables.is_empty() => {}
             // The arm is reachable, but contains unreachable subpatterns (from or-patterns).
             Useful(unreachables) => {
-                let mut unreachables: Vec<_> = unreachables.into_iter().flatten().collect();
+                let mut unreachables: Vec<_> = unreachables.iter().flatten().copied().collect();
                 // Emit lints in the order in which they occur in the file.
                 unreachables.sort_unstable();
                 for span in unreachables {
-                    unreachable_pattern(cx.tcx, span, id, None);
+                    unreachable_pattern(cx.tcx, span, arm.hir_id, None);
                 }
             }
             UsefulWithWitness(_) => bug!(),
         }
-        if !has_guard {
-            seen.push(v);
-            if catchall.is_none() && pat_is_catchall(pat) {
-                catchall = Some(pat.span);
-            }
+        if !arm.has_guard && catchall.is_none() && pat_is_catchall(arm.pat) {
+            catchall = Some(arm.pat.span);
         }
     }
-    seen
 }
 
-fn check_not_useful<'p, 'tcx>(
-    cx: &mut MatchCheckCtxt<'p, 'tcx>,
-    ty: Ty<'tcx>,
-    matrix: &Matrix<'p, 'tcx>,
-    hir_id: HirId,
-) -> Result<(), Vec<super::Pat<'tcx>>> {
-    let wild_pattern = cx.pattern_arena.alloc(super::Pat::wildcard_from_ty(ty));
-    let v = PatStack::from_pattern(wild_pattern);
-
-    // false is given for `is_under_guard` argument due to the wildcard
-    // pattern not having a guard
-    match is_useful(cx, matrix, &v, ConstructWitness, hir_id, false, true) {
-        NotUseful => Ok(()), // This is good, wildcard pattern isn't reachable.
-        UsefulWithWitness(pats) => Err(if pats.is_empty() {
-            bug!("Exhaustiveness check returned no witnesses")
-        } else {
-            pats.into_iter().map(|w| w.single_pattern()).collect()
-        }),
-        Useful(_) => bug!(),
-    }
-}
-
-fn check_exhaustive<'p, 'tcx>(
-    cx: &mut MatchCheckCtxt<'p, 'tcx>,
+/// Report that a match is not exhaustive.
+fn non_exhaustive_match<'p, 'tcx>(
+    cx: &MatchCheckCtxt<'p, 'tcx>,
     scrut_ty: Ty<'tcx>,
     sp: Span,
-    matrix: &Matrix<'p, 'tcx>,
-    hir_id: HirId,
+    witnesses: Vec<super::Pat<'tcx>>,
     is_empty_match: bool,
 ) {
-    let witnesses = match check_not_useful(cx, scrut_ty, matrix, hir_id) {
-        Ok(_) => return,
-        Err(err) => err,
-    };
-
     let non_empty_enum = match scrut_ty.kind() {
         ty::Adt(def, _) => def.is_enum() && !def.variants.is_empty(),
         _ => false,

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -439,24 +439,6 @@ fn check_exhaustive<'p, 'tcx>(
     hir_id: HirId,
     is_empty_match: bool,
 ) {
-    // In the absence of the `exhaustive_patterns` feature, empty matches are not detected by
-    // `is_useful` to exhaustively match uninhabited types, so we manually check here.
-    if is_empty_match && !cx.tcx.features().exhaustive_patterns {
-        let scrutinee_is_visibly_uninhabited = match scrut_ty.kind() {
-            ty::Never => true,
-            ty::Adt(def, _) => {
-                def.is_enum()
-                    && def.variants.is_empty()
-                    && !cx.is_foreign_non_exhaustive_enum(scrut_ty)
-            }
-            _ => false,
-        };
-        if scrutinee_is_visibly_uninhabited {
-            // If the type *is* uninhabited, an empty match is vacuously exhaustive.
-            return;
-        }
-    }
-
     let witnesses = match check_not_useful(cx, scrut_ty, matrix, hir_id) {
         Ok(_) => return,
         Err(err) => err,

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -389,6 +389,8 @@ fn check_arms<'p, 'tcx>(
                     hir::MatchSource::AwaitDesugar | hir::MatchSource::TryDesugar => {}
                 }
             }
+            Useful(unreachables) if unreachables.is_empty() => {}
+            // The arm is reachable, but contains unreachable subpatterns (from or-patterns).
             Useful(unreachables) => {
                 let mut unreachables: Vec<_> = unreachables.into_iter().flatten().collect();
                 // Emit lints in the order in which they occur in the file.

--- a/src/test/ui/pattern/usefulness/auxiliary/empty.rs
+++ b/src/test/ui/pattern/usefulness/auxiliary/empty.rs
@@ -1,0 +1,2 @@
+#![crate_type = "rlib"]
+pub enum EmptyForeignEnum {}

--- a/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.rs
+++ b/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.rs
@@ -1,4 +1,5 @@
 #![feature(never_type)]
+#![feature(never_type_fallback)]
 #![feature(exhaustive_patterns)]
 #![deny(unreachable_patterns)]
 enum Foo {}
@@ -42,7 +43,17 @@ macro_rules! match_false {
 }
 
 fn foo(x: Foo) {
-    match_empty!(x); // ok
+    match x {} // ok
+    match x {
+        _ => {}, //~ ERROR unreachable pattern
+    }
+    match x {
+        _ if false => {}, //~ ERROR unreachable pattern
+    }
+}
+
+fn never(x: !) {
+    match x {} // ok
     match x {
         _ => {}, //~ ERROR unreachable pattern
     }

--- a/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.rs
+++ b/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.rs
@@ -1,8 +1,12 @@
+// aux-build:empty.rs
 #![feature(never_type)]
 #![feature(never_type_fallback)]
 #![feature(exhaustive_patterns)]
 #![deny(unreachable_patterns)]
-enum Foo {}
+
+extern crate empty;
+
+enum EmptyEnum {}
 
 struct NonEmptyStruct(bool); //~ `NonEmptyStruct` defined here
 union NonEmptyUnion1 { //~ `NonEmptyUnion1` defined here
@@ -42,7 +46,17 @@ macro_rules! match_false {
     };
 }
 
-fn foo(x: Foo) {
+fn empty_enum(x: EmptyEnum) {
+    match x {} // ok
+    match x {
+        _ => {}, //~ ERROR unreachable pattern
+    }
+    match x {
+        _ if false => {}, //~ ERROR unreachable pattern
+    }
+}
+
+fn empty_foreign_enum(x: empty::EmptyForeignEnum) {
     match x {} // ok
     match x {
         _ => {}, //~ ERROR unreachable pattern
@@ -67,7 +81,7 @@ fn main() {
         None => {}
         Some(_) => {} //~ ERROR unreachable pattern
     }
-    match None::<Foo> {
+    match None::<EmptyEnum> {
         None => {}
         Some(_) => {} //~ ERROR unreachable pattern
     }

--- a/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
@@ -1,35 +1,47 @@
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:47:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:48:9
    |
 LL |         _ => {},
    |         ^
    |
 note: the lint level is defined here
-  --> $DIR/match-empty-exhaustive_patterns.rs:3:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:50:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:51:9
    |
 LL |         _ if false => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:57:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:58:9
+   |
+LL |         _ => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty-exhaustive_patterns.rs:61:9
+   |
+LL |         _ if false => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty-exhaustive_patterns.rs:68:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:61:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:72:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
 
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:64:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:75:18
    |
 LL |     match_empty!(0u8);
    |                  ^^^
@@ -38,7 +50,7 @@ LL |     match_empty!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:66:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:77:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -50,7 +62,7 @@ LL |     match_empty!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:68:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:79:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -64,7 +76,7 @@ LL |       match_empty!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:70:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:81:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -79,7 +91,7 @@ LL |       match_empty!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:72:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:83:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -96,7 +108,7 @@ LL |       match_empty!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:74:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:85:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -117,7 +129,7 @@ LL |       match_empty!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:76:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:87:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -131,7 +143,7 @@ LL |       match_empty!(NonEmptyEnum5::V1);
    = note: the matched value is of type `NonEmptyEnum5`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:79:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:90:18
    |
 LL |     match_false!(0u8);
    |                  ^^^ pattern `_` not covered
@@ -140,7 +152,7 @@ LL |     match_false!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct(_)` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:81:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:92:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -152,7 +164,7 @@ LL |     match_false!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:83:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:94:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -166,7 +178,7 @@ LL |       match_false!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:85:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:96:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -181,7 +193,7 @@ LL |       match_false!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:87:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:98:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -198,7 +210,7 @@ LL |       match_false!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:89:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:100:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -219,7 +231,7 @@ LL |       match_false!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:91:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:102:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -232,6 +244,6 @@ LL |       match_false!(NonEmptyEnum5::V1);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `NonEmptyEnum5`
 
-error: aborting due to 18 previous errors
+error: aborting due to 20 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty-exhaustive_patterns.stderr
@@ -1,47 +1,59 @@
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:48:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:52:9
    |
 LL |         _ => {},
    |         ^
    |
 note: the lint level is defined here
-  --> $DIR/match-empty-exhaustive_patterns.rs:4:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:5:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:51:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:55:9
    |
 LL |         _ if false => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:58:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:62:9
    |
 LL |         _ => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:61:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:65:9
    |
 LL |         _ if false => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:68:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:72:9
+   |
+LL |         _ => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty-exhaustive_patterns.rs:75:9
+   |
+LL |         _ if false => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty-exhaustive_patterns.rs:82:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/match-empty-exhaustive_patterns.rs:72:9
+  --> $DIR/match-empty-exhaustive_patterns.rs:86:9
    |
 LL |         Some(_) => {}
    |         ^^^^^^^
 
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:75:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:89:18
    |
 LL |     match_empty!(0u8);
    |                  ^^^
@@ -50,7 +62,7 @@ LL |     match_empty!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:77:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:91:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -62,7 +74,7 @@ LL |     match_empty!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:79:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:93:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -76,7 +88,7 @@ LL |       match_empty!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/match-empty-exhaustive_patterns.rs:81:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:95:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -91,7 +103,7 @@ LL |       match_empty!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:83:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:97:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -108,7 +120,7 @@ LL |       match_empty!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:85:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:99:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -129,7 +141,7 @@ LL |       match_empty!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:87:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:101:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -143,7 +155,7 @@ LL |       match_empty!(NonEmptyEnum5::V1);
    = note: the matched value is of type `NonEmptyEnum5`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:90:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:104:18
    |
 LL |     match_false!(0u8);
    |                  ^^^ pattern `_` not covered
@@ -152,7 +164,7 @@ LL |     match_false!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct(_)` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:92:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:106:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -164,7 +176,7 @@ LL |     match_false!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:94:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:108:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -178,7 +190,7 @@ LL |       match_false!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:96:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:110:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -193,7 +205,7 @@ LL |       match_false!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:98:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:112:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -210,7 +222,7 @@ LL |       match_false!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:100:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:114:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -231,7 +243,7 @@ LL |       match_false!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty-exhaustive_patterns.rs:102:18
+  --> $DIR/match-empty-exhaustive_patterns.rs:116:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -244,6 +256,6 @@ LL |       match_false!(NonEmptyEnum5::V1);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `NonEmptyEnum5`
 
-error: aborting due to 20 previous errors
+error: aborting due to 22 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/match-empty.rs
+++ b/src/test/ui/pattern/usefulness/match-empty.rs
@@ -44,22 +44,20 @@ macro_rules! match_false {
 fn foo(x: Foo) {
     match x {} // ok
     match x {
-        _ => {}, // Not detected as unreachable, see #55123.
+        _ => {}, //~ ERROR unreachable pattern
     }
     match x {
-    //~^ ERROR non-exhaustive patterns: `_` not covered
-        _ if false => {}, // Not detected as unreachable nor exhaustive.
+        _ if false => {}, //~ ERROR unreachable pattern
     }
 }
 
 fn never(x: !) {
     match x {} // ok
     match x {
-        _ => {}, // Not detected as unreachable.
+        _ => {}, //~ ERROR unreachable pattern
     }
     match x {
-    //~^ ERROR non-exhaustive patterns: `_` not covered
-        _ if false => {}, // Not detected as unreachable nor exhaustive.
+        _ if false => {}, //~ ERROR unreachable pattern
     }
 }
 

--- a/src/test/ui/pattern/usefulness/match-empty.rs
+++ b/src/test/ui/pattern/usefulness/match-empty.rs
@@ -1,7 +1,11 @@
+// aux-build:empty.rs
 #![feature(never_type)]
 #![feature(never_type_fallback)]
 #![deny(unreachable_patterns)]
-enum Foo {}
+
+extern crate empty;
+
+enum EmptyEnum {}
 
 struct NonEmptyStruct(bool); //~ `NonEmptyStruct` defined here
 union NonEmptyUnion1 { //~ `NonEmptyUnion1` defined here
@@ -41,7 +45,17 @@ macro_rules! match_false {
     };
 }
 
-fn foo(x: Foo) {
+fn empty_enum(x: EmptyEnum) {
+    match x {} // ok
+    match x {
+        _ => {}, //~ ERROR unreachable pattern
+    }
+    match x {
+        _ if false => {}, //~ ERROR unreachable pattern
+    }
+}
+
+fn empty_foreign_enum(x: empty::EmptyForeignEnum) {
     match x {} // ok
     match x {
         _ => {}, //~ ERROR unreachable pattern
@@ -67,7 +81,7 @@ fn main() {
         None => {}
         Some(_) => {}
     }
-    match None::<Foo> {
+    match None::<EmptyEnum> {
         None => {}
         Some(_) => {}
     }

--- a/src/test/ui/pattern/usefulness/match-empty.rs
+++ b/src/test/ui/pattern/usefulness/match-empty.rs
@@ -1,4 +1,5 @@
 #![feature(never_type)]
+#![feature(never_type_fallback)]
 #![deny(unreachable_patterns)]
 enum Foo {}
 
@@ -41,11 +42,24 @@ macro_rules! match_false {
 }
 
 fn foo(x: Foo) {
-    match_empty!(x); // ok
-    match_false!(x); // Not detected as unreachable nor exhaustive.
-    //~^ ERROR non-exhaustive patterns: `_` not covered
+    match x {} // ok
     match x {
         _ => {}, // Not detected as unreachable, see #55123.
+    }
+    match x {
+    //~^ ERROR non-exhaustive patterns: `_` not covered
+        _ if false => {}, // Not detected as unreachable nor exhaustive.
+    }
+}
+
+fn never(x: !) {
+    match x {} // ok
+    match x {
+        _ => {}, // Not detected as unreachable.
+    }
+    match x {
+    //~^ ERROR non-exhaustive patterns: `_` not covered
+        _ if false => {}, // Not detected as unreachable nor exhaustive.
     }
 }
 

--- a/src/test/ui/pattern/usefulness/match-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty.stderr
@@ -1,17 +1,26 @@
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty.rs:45:18
+  --> $DIR/match-empty.rs:49:11
    |
 LL | enum Foo {}
    | ----------- `Foo` defined here
 ...
-LL |     match_false!(x); // Not detected as unreachable nor exhaustive.
-   |                  ^ pattern `_` not covered
+LL |     match x {
+   |           ^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `Foo`
 
+error[E0004]: non-exhaustive patterns: `_` not covered
+  --> $DIR/match-empty.rs:60:11
+   |
+LL |     match x {
+   |           ^ pattern `_` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `!`
+
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/match-empty.rs:63:18
+  --> $DIR/match-empty.rs:77:18
    |
 LL |     match_empty!(0u8);
    |                  ^^^
@@ -20,7 +29,7 @@ LL |     match_empty!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct` is non-empty
-  --> $DIR/match-empty.rs:65:18
+  --> $DIR/match-empty.rs:79:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -32,7 +41,7 @@ LL |     match_empty!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/match-empty.rs:67:18
+  --> $DIR/match-empty.rs:81:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -46,7 +55,7 @@ LL |       match_empty!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/match-empty.rs:69:18
+  --> $DIR/match-empty.rs:83:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -61,7 +70,7 @@ LL |       match_empty!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty.rs:71:18
+  --> $DIR/match-empty.rs:85:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -78,7 +87,7 @@ LL |       match_empty!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty.rs:73:18
+  --> $DIR/match-empty.rs:87:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -99,7 +108,7 @@ LL |       match_empty!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty.rs:75:18
+  --> $DIR/match-empty.rs:89:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -113,7 +122,7 @@ LL |       match_empty!(NonEmptyEnum5::V1);
    = note: the matched value is of type `NonEmptyEnum5`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty.rs:78:18
+  --> $DIR/match-empty.rs:92:18
    |
 LL |     match_false!(0u8);
    |                  ^^^ pattern `_` not covered
@@ -122,7 +131,7 @@ LL |     match_false!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct(_)` not covered
-  --> $DIR/match-empty.rs:80:18
+  --> $DIR/match-empty.rs:94:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -134,7 +143,7 @@ LL |     match_false!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/match-empty.rs:82:18
+  --> $DIR/match-empty.rs:96:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -148,7 +157,7 @@ LL |       match_false!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/match-empty.rs:84:18
+  --> $DIR/match-empty.rs:98:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -163,7 +172,7 @@ LL |       match_false!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty.rs:86:18
+  --> $DIR/match-empty.rs:100:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -180,7 +189,7 @@ LL |       match_false!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty.rs:88:18
+  --> $DIR/match-empty.rs:102:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -201,7 +210,7 @@ LL |       match_false!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty.rs:90:18
+  --> $DIR/match-empty.rs:104:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -214,6 +223,6 @@ LL |       match_false!(NonEmptyEnum5::V1);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `NonEmptyEnum5`
 
-error: aborting due to 15 previous errors
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/match-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty.stderr
@@ -1,26 +1,35 @@
-error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty.rs:49:11
+error: unreachable pattern
+  --> $DIR/match-empty.rs:47:9
    |
-LL | enum Foo {}
-   | ----------- `Foo` defined here
-...
-LL |     match x {
-   |           ^ pattern `_` not covered
+LL |         _ => {},
+   |         ^
    |
-   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `Foo`
+note: the lint level is defined here
+  --> $DIR/match-empty.rs:3:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
 
-error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty.rs:60:11
+error: unreachable pattern
+  --> $DIR/match-empty.rs:50:9
    |
-LL |     match x {
-   |           ^ pattern `_` not covered
+LL |         _ if false => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty.rs:57:9
    |
-   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `!`
+LL |         _ => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty.rs:60:9
+   |
+LL |         _ if false => {},
+   |         ^
 
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/match-empty.rs:77:18
+  --> $DIR/match-empty.rs:75:18
    |
 LL |     match_empty!(0u8);
    |                  ^^^
@@ -29,7 +38,7 @@ LL |     match_empty!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct` is non-empty
-  --> $DIR/match-empty.rs:79:18
+  --> $DIR/match-empty.rs:77:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -41,7 +50,7 @@ LL |     match_empty!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/match-empty.rs:81:18
+  --> $DIR/match-empty.rs:79:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -55,7 +64,7 @@ LL |       match_empty!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/match-empty.rs:83:18
+  --> $DIR/match-empty.rs:81:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -70,7 +79,7 @@ LL |       match_empty!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty.rs:85:18
+  --> $DIR/match-empty.rs:83:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -87,7 +96,7 @@ LL |       match_empty!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty.rs:87:18
+  --> $DIR/match-empty.rs:85:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -108,7 +117,7 @@ LL |       match_empty!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty.rs:89:18
+  --> $DIR/match-empty.rs:87:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -122,7 +131,7 @@ LL |       match_empty!(NonEmptyEnum5::V1);
    = note: the matched value is of type `NonEmptyEnum5`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty.rs:92:18
+  --> $DIR/match-empty.rs:90:18
    |
 LL |     match_false!(0u8);
    |                  ^^^ pattern `_` not covered
@@ -131,7 +140,7 @@ LL |     match_false!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct(_)` not covered
-  --> $DIR/match-empty.rs:94:18
+  --> $DIR/match-empty.rs:92:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -143,7 +152,7 @@ LL |     match_false!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/match-empty.rs:96:18
+  --> $DIR/match-empty.rs:94:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -157,7 +166,7 @@ LL |       match_false!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/match-empty.rs:98:18
+  --> $DIR/match-empty.rs:96:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -172,7 +181,7 @@ LL |       match_false!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty.rs:100:18
+  --> $DIR/match-empty.rs:98:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -189,7 +198,7 @@ LL |       match_false!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty.rs:102:18
+  --> $DIR/match-empty.rs:100:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -210,7 +219,7 @@ LL |       match_false!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty.rs:104:18
+  --> $DIR/match-empty.rs:102:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -223,6 +232,6 @@ LL |       match_false!(NonEmptyEnum5::V1);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `NonEmptyEnum5`
 
-error: aborting due to 16 previous errors
+error: aborting due to 18 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/match-empty.stderr
+++ b/src/test/ui/pattern/usefulness/match-empty.stderr
@@ -1,35 +1,47 @@
 error: unreachable pattern
-  --> $DIR/match-empty.rs:47:9
+  --> $DIR/match-empty.rs:51:9
    |
 LL |         _ => {},
    |         ^
    |
 note: the lint level is defined here
-  --> $DIR/match-empty.rs:3:9
+  --> $DIR/match-empty.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/match-empty.rs:50:9
+  --> $DIR/match-empty.rs:54:9
    |
 LL |         _ if false => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/match-empty.rs:57:9
+  --> $DIR/match-empty.rs:61:9
    |
 LL |         _ => {},
    |         ^
 
 error: unreachable pattern
-  --> $DIR/match-empty.rs:60:9
+  --> $DIR/match-empty.rs:64:9
+   |
+LL |         _ if false => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty.rs:71:9
+   |
+LL |         _ => {},
+   |         ^
+
+error: unreachable pattern
+  --> $DIR/match-empty.rs:74:9
    |
 LL |         _ if false => {},
    |         ^
 
 error[E0004]: non-exhaustive patterns: type `u8` is non-empty
-  --> $DIR/match-empty.rs:75:18
+  --> $DIR/match-empty.rs:89:18
    |
 LL |     match_empty!(0u8);
    |                  ^^^
@@ -38,7 +50,7 @@ LL |     match_empty!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyStruct` is non-empty
-  --> $DIR/match-empty.rs:77:18
+  --> $DIR/match-empty.rs:91:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -50,7 +62,7 @@ LL |     match_empty!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion1` is non-empty
-  --> $DIR/match-empty.rs:79:18
+  --> $DIR/match-empty.rs:93:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -64,7 +76,7 @@ LL |       match_empty!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: type `NonEmptyUnion2` is non-empty
-  --> $DIR/match-empty.rs:81:18
+  --> $DIR/match-empty.rs:95:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -79,7 +91,7 @@ LL |       match_empty!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty.rs:83:18
+  --> $DIR/match-empty.rs:97:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -96,7 +108,7 @@ LL |       match_empty!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty.rs:85:18
+  --> $DIR/match-empty.rs:99:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -117,7 +129,7 @@ LL |       match_empty!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty.rs:87:18
+  --> $DIR/match-empty.rs:101:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -131,7 +143,7 @@ LL |       match_empty!(NonEmptyEnum5::V1);
    = note: the matched value is of type `NonEmptyEnum5`
 
 error[E0004]: non-exhaustive patterns: `_` not covered
-  --> $DIR/match-empty.rs:90:18
+  --> $DIR/match-empty.rs:104:18
    |
 LL |     match_false!(0u8);
    |                  ^^^ pattern `_` not covered
@@ -140,7 +152,7 @@ LL |     match_false!(0u8);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyStruct(_)` not covered
-  --> $DIR/match-empty.rs:92:18
+  --> $DIR/match-empty.rs:106:18
    |
 LL | struct NonEmptyStruct(bool);
    | ---------------------------- `NonEmptyStruct` defined here
@@ -152,7 +164,7 @@ LL |     match_false!(NonEmptyStruct(true));
    = note: the matched value is of type `NonEmptyStruct`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion1 { .. }` not covered
-  --> $DIR/match-empty.rs:94:18
+  --> $DIR/match-empty.rs:108:18
    |
 LL | / union NonEmptyUnion1 {
 LL | |     foo: (),
@@ -166,7 +178,7 @@ LL |       match_false!((NonEmptyUnion1 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion1`
 
 error[E0004]: non-exhaustive patterns: `NonEmptyUnion2 { .. }` not covered
-  --> $DIR/match-empty.rs:96:18
+  --> $DIR/match-empty.rs:110:18
    |
 LL | / union NonEmptyUnion2 {
 LL | |     foo: (),
@@ -181,7 +193,7 @@ LL |       match_false!((NonEmptyUnion2 { foo: () }));
    = note: the matched value is of type `NonEmptyUnion2`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` not covered
-  --> $DIR/match-empty.rs:98:18
+  --> $DIR/match-empty.rs:112:18
    |
 LL | / enum NonEmptyEnum1 {
 LL | |     Foo(bool),
@@ -198,7 +210,7 @@ LL |       match_false!(NonEmptyEnum1::Foo(true));
    = note: the matched value is of type `NonEmptyEnum1`
 
 error[E0004]: non-exhaustive patterns: `Foo(_)` and `Bar` not covered
-  --> $DIR/match-empty.rs:100:18
+  --> $DIR/match-empty.rs:114:18
    |
 LL | / enum NonEmptyEnum2 {
 LL | |     Foo(bool),
@@ -219,7 +231,7 @@ LL |       match_false!(NonEmptyEnum2::Foo(true));
    = note: the matched value is of type `NonEmptyEnum2`
 
 error[E0004]: non-exhaustive patterns: `V1`, `V2`, `V3` and 2 more not covered
-  --> $DIR/match-empty.rs:102:18
+  --> $DIR/match-empty.rs:116:18
    |
 LL | / enum NonEmptyEnum5 {
 LL | |     V1, V2, V3, V4, V5,
@@ -232,6 +244,6 @@ LL |       match_false!(NonEmptyEnum5::V1);
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `NonEmptyEnum5`
 
-error: aborting due to 18 previous errors
+error: aborting due to 20 previous errors
 
 For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
@@ -25,7 +25,7 @@ pub enum EmptyNonExhaustiveEnum {}
 fn empty_non_exhaustive(x: EmptyNonExhaustiveEnum) {
     match x {}
     match x {
-        _ => {} // not detected as unreachable
+        _ => {}, //~ ERROR unreachable pattern
     }
 }
 

--- a/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.rs
@@ -25,7 +25,7 @@ pub enum EmptyNonExhaustiveEnum {}
 fn empty_non_exhaustive(x: EmptyNonExhaustiveEnum) {
     match x {}
     match x {
-        _ => {}, //~ ERROR unreachable pattern
+        _ => {} //~ ERROR unreachable pattern
     }
 }
 

--- a/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -1,7 +1,7 @@
 error: unreachable pattern
   --> $DIR/enum_same_crate_empty_match.rs:28:9
    |
-LL |         _ => {},
+LL |         _ => {}
    |         ^
    |
 note: the lint level is defined here

--- a/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -1,3 +1,15 @@
+error: unreachable pattern
+  --> $DIR/enum_same_crate_empty_match.rs:28:9
+   |
+LL |         _ => {},
+   |         ^
+   |
+note: the lint level is defined here
+  --> $DIR/enum_same_crate_empty_match.rs:1:9
+   |
+LL | #![deny(unreachable_patterns)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
 error[E0004]: non-exhaustive patterns: `Unit`, `Tuple(_)` and `Struct { .. }` not covered
   --> $DIR/enum_same_crate_empty_match.rs:33:11
    |
@@ -42,6 +54,6 @@ LL |       match NormalEnum::Unit {}
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `NormalEnum`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
This removes the special-casing of empty matches that was done in `check_match`. This fixes most of https://github.com/rust-lang/rust/issues/55123.
Somewhat unrelatedly, I also made `_match.rs` more self-contained, because I think it's cleaner.

r? @varkor 
@rustbot modify labels: +A-exhaustiveness-checking