### PR TITLE
stability: More precise location for deprecation lint on macros

### DIFF
--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -4,7 +4,7 @@
 pub use self::StabilityLevel::*;
 
 use crate::ty::{self, TyCtxt};
-use rustc_ast::CRATE_NODE_ID;
+use rustc_ast::NodeId;
 use rustc_attr::{self as attr, ConstStability, Deprecation, Stability};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{Applicability, DiagnosticBuilder};
@@ -211,13 +211,14 @@ pub fn early_report_deprecation(
     suggestion: Option<Symbol>,
     lint: &'static Lint,
     span: Span,
+    node_id: NodeId,
 ) {
     if span.in_derive_expansion() {
         return;
     }
 
     let diag = BuiltinLintDiagnostics::DeprecatedMacro(suggestion, span);
-    lint_buffer.buffer_lint_with_diagnostic(lint, CRATE_NODE_ID, span, message, diag);
+    lint_buffer.buffer_lint_with_diagnostic(lint, node_id, span, message, diag);
 }
 
 fn late_report_deprecation(

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1028,6 +1028,7 @@ impl<'a> Resolver<'a> {
                 depr.suggestion,
                 lint,
                 span,
+                node_id,
             );
         }
     }

--- a/src/test/ui/lint/expansion-time.rs
+++ b/src/test/ui/lint/expansion-time.rs
@@ -12,6 +12,16 @@ mod benches {
     fn foo() {}
 }
 
+#[deprecated = "reason"]
+macro_rules! deprecated {
+    () => {}
+}
+
+#[allow(deprecated)]
+mod deprecated {
+    deprecated!(); // No warning
+}
+
 #[warn(incomplete_include)]
 fn main() {
     // WARN see in the stderr file, the warning points to the included file.

--- a/src/test/ui/lint/expansion-time.stderr
+++ b/src/test/ui/lint/expansion-time.stderr
@@ -33,7 +33,7 @@ LL | 2
    | ^
    |
 note: the lint level is defined here
-  --> $DIR/expansion-time.rs:15:8
+  --> $DIR/expansion-time.rs:25:8
    |
 LL | #[warn(incomplete_include)]
    |        ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
One missing piece of https://github.com/rust-lang/rust/pull/73178.