### PR TITLE
Pretty print assertion failures in tests

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -31,21 +31,22 @@ macro_rules! panic {
 /// ```
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow_internal_unstable(core_panic)]
+#[allow_internal_unstable(core_panic, panic_internals)]
 macro_rules! assert_eq {
     ($left:expr, $right:expr $(,)?) => ({
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
-                    let kind = $crate::panicking::AssertKind::Eq;
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
                     $crate::panicking::assert_failed(
-                        kind,
-                        $crate::stringify!($left),
+                        &$crate::panic::assert_info::BinaryAssertionStaticData {
+                            kind: $crate::panic::assert_info::BinaryAssertKind::Eq,
+                            left_expr: $crate::stringify!($left),
+                            right_expr: $crate::stringify!($right),
+                        },
                         &*left_val,
-                        $crate::stringify!($right),
                         &*right_val,
                         $crate::option::Option::None,
                     );
@@ -57,15 +58,16 @@ macro_rules! assert_eq {
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
-                    let kind = $crate::panicking::AssertKind::Eq;
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
                     $crate::panicking::assert_failed(
-                        kind,
-                        $crate::stringify!($left),
+                        &$crate::panic::assert_info::BinaryAssertionStaticData {
+                            kind: $crate::panic::assert_info::BinaryAssertKind::Eq,
+                            left_expr: $crate::stringify!($left),
+                            right_expr: $crate::stringify!($right),
+                        },
                         &*left_val,
-                        $crate::stringify!($right),
                         &*right_val,
                         $crate::option::Option::Some($crate::format_args!($($arg)+)),
                     );
@@ -94,21 +96,22 @@ macro_rules! assert_eq {
 /// ```
 #[macro_export]
 #[stable(feature = "assert_ne", since = "1.13.0")]
-#[allow_internal_unstable(core_panic)]
+#[allow_internal_unstable(core_panic, panic_internals)]
 macro_rules! assert_ne {
     ($left:expr, $right:expr $(,)?) => ({
         match (&$left, &$right) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
-                    let kind = $crate::panicking::AssertKind::Ne;
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
                     $crate::panicking::assert_failed(
-                        kind,
-                        $crate::stringify!($left),
+                        &$crate::panic::assert_info::BinaryAssertionStaticData {
+                            kind: $crate::panic::assert_info::BinaryAssertKind::Ne,
+                            left_expr: $crate::stringify!($left),
+                            right_expr: $crate::stringify!($right),
+                        },
                         &*left_val,
-                        $crate::stringify!($right),
                         &*right_val,
                         $crate::option::Option::None,
                     );
@@ -120,15 +123,16 @@ macro_rules! assert_ne {
         match (&($left), &($right)) {
             (left_val, right_val) => {
                 if *left_val == *right_val {
-                    let kind = $crate::panicking::AssertKind::Ne;
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
                     $crate::panicking::assert_failed(
-                        kind,
-                        $crate::stringify!($left),
+                        &$crate::panic::assert_info::BinaryAssertionStaticData {
+                            kind: $crate::panic::assert_info::BinaryAssertKind::Ne,
+                            left_expr: $crate::stringify!($left),
+                            right_expr: $crate::stringify!($right),
+                        },
                         &*left_val,
-                        $crate::stringify!($right),
                         &*right_val,
                         $crate::option::Option::Some($crate::format_args!($($arg)+)),
                     );
@@ -165,7 +169,7 @@ macro_rules! assert_ne {
 /// assert_matches!(c, Ok(x) | Err(x) if x.len() < 100);
 /// ```
 #[unstable(feature = "assert_matches", issue = "82775")]
-#[allow_internal_unstable(core_panic)]
+#[allow_internal_unstable(core_panic, panic_internals)]
 #[rustc_macro_transparency = "semitransparent"]
 pub macro assert_matches {
     ($left:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? $(,)?) => ({
@@ -173,9 +177,12 @@ pub macro assert_matches {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
-                    $crate::stringify!($left),
+                    &$crate::panic::assert_info::BinaryAssertionStaticData {
+                        kind: $crate::panic::assert_info::BinaryAssertKind::Match,
+                        left_expr: $crate::stringify!($left),
+                        right_expr: $crate::stringify!($($pattern)|+ $(if $guard)?),
+                    },
                     left_val,
-                    $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::None
                 );
             }
@@ -186,9 +193,12 @@ pub macro assert_matches {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
-                    $crate::stringify!($left),
+                    &$crate::panic::assert_info::BinaryAssertionStaticData {
+                        kind: $crate::panic::assert_info::BinaryAssertKind::Match,
+                        left_expr: $crate::stringify!($left),
+                        right_expr: $crate::stringify!($($pattern)|+ $(if $guard)?),
+                    },
                     left_val,
-                    $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::Some($crate::format_args!($($arg)+))
                 );
             }

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -41,7 +41,14 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(
+                        kind,
+                        $crate::stringify!($left),
+                        &*left_val,
+                        $crate::stringify!($right),
+                        &*right_val,
+                        $crate::option::Option::None,
+                    );
                 }
             }
         }
@@ -54,7 +61,14 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(
+                        kind,
+                        $crate::stringify!($left),
+                        &*left_val,
+                        $crate::stringify!($right),
+                        &*right_val,
+                        $crate::option::Option::Some($crate::format_args!($($arg)+)),
+                    );
                 }
             }
         }
@@ -90,7 +104,14 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(
+                        kind,
+                        $crate::stringify!($left),
+                        &*left_val,
+                        $crate::stringify!($right),
+                        &*right_val,
+                        $crate::option::Option::None,
+                    );
                 }
             }
         }
@@ -103,7 +124,14 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(
+                        kind,
+                        $crate::stringify!($left),
+                        &*left_val,
+                        $crate::stringify!($right),
+                        &*right_val,
+                        $crate::option::Option::Some($crate::format_args!($($arg)+)),
+                    );
                 }
             }
         }
@@ -145,6 +173,7 @@ pub macro assert_matches {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
+                    $crate::stringify!($left),
                     left_val,
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::None
@@ -157,6 +186,7 @@ pub macro assert_matches {
             $( $pattern )|+ $( if $guard )? => {}
             ref left_val => {
                 $crate::panicking::assert_matches_failed(
+                    $crate::stringify!($left),
                     left_val,
                     $crate::stringify!($($pattern)|+ $(if $guard)?),
                     $crate::option::Option::Some($crate::format_args!($($arg)+))

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -5,6 +5,20 @@
 mod location;
 mod panic_info;
 mod unwind_safe;
+#[unstable(
+    feature = "panic_internals",
+    reason = "internal details of the implementation of the `panic!` and related macros",
+    issue = "none"
+)]
+#[doc(hidden)]
+pub mod assert_info;
+#[unstable(
+    feature = "panic_internals",
+    reason = "internal details of the implementation of the `panic!` and related macros",
+    issue = "none"
+)]
+#[doc(hidden)]
+pub mod extra_info;
 
 use crate::any::Any;
 
@@ -36,7 +50,10 @@ pub macro panic_2015 {
         $crate::panicking::panic_display(&$arg)
     ),
     ($fmt:expr, $($arg:tt)+) => (
-        $crate::panicking::panic_fmt($crate::const_format_args!($fmt, $($arg)+))
+        $crate::panicking::panic_fmt(
+            $crate::const_format_args!($fmt, $($arg)+),
+            $crate::option::Option::None,
+        )
     ),
 }
 
@@ -54,7 +71,10 @@ pub macro panic_2021 {
         $crate::panicking::panic_display(&$arg)
     ),
     ($($t:tt)+) => (
-        $crate::panicking::panic_fmt($crate::const_format_args!($($t)+))
+        $crate::panicking::panic_fmt(
+            $crate::const_format_args!($($t)+),
+            $crate::option::Option::None,
+        )
     ),
 }
 

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -2,9 +2,6 @@
 
 #![stable(feature = "core_panic_info", since = "1.41.0")]
 
-mod location;
-mod panic_info;
-mod unwind_safe;
 #[unstable(
     feature = "panic_internals",
     reason = "internal details of the implementation of the `panic!` and related macros",
@@ -12,13 +9,16 @@ mod unwind_safe;
 )]
 #[doc(hidden)]
 pub mod assert_info;
+mod location;
 #[unstable(
     feature = "panic_internals",
     reason = "internal details of the implementation of the `panic!` and related macros",
     issue = "none"
 )]
 #[doc(hidden)]
-pub mod extra_info;
+pub mod panic_description;
+mod panic_info;
+mod unwind_safe;
 
 use crate::any::Any;
 
@@ -50,10 +50,7 @@ pub macro panic_2015 {
         $crate::panicking::panic_display(&$arg)
     ),
     ($fmt:expr, $($arg:tt)+) => (
-        $crate::panicking::panic_fmt(
-            $crate::const_format_args!($fmt, $($arg)+),
-            $crate::option::Option::None,
-        )
+        $crate::panicking::panic_fmt($crate::const_format_args!($fmt, $($arg)+))
     ),
 }
 
@@ -71,10 +68,7 @@ pub macro panic_2021 {
         $crate::panicking::panic_display(&$arg)
     ),
     ($($t:tt)+) => (
-        $crate::panicking::panic_fmt(
-            $crate::const_format_args!($($t)+),
-            $crate::option::Option::None,
-        )
+        $crate::panicking::panic_fmt($crate::const_format_args!($($t)+))
     ),
 }
 

--- a/library/core/src/panic/assert_info.rs
+++ b/library/core/src/panic/assert_info.rs
@@ -1,0 +1,52 @@
+use crate::fmt::Debug;
+
+/// Information about a failed assertion.
+#[derive(Debug)]
+pub struct AssertInfo<'a> {
+    /// The assertion that failed.
+    pub assertion: Assertion<'a>,
+    /// Optional additional message to include in the failure report.
+    pub message: Option<crate::fmt::Arguments<'a>>,
+}
+
+#[derive(Debug)]
+pub enum Assertion<'a> {
+    /// The assertion is a boolean assertion.
+    Bool(BoolAssertion),
+    /// The assertion is a binary comparison assertion.
+    Binary(BinaryAssertion<'a>),
+}
+
+/// Information about a failed boolean assertion.
+#[derive(Debug)]
+pub struct BoolAssertion {
+    /// The expression that was evaluated.
+    pub expr: &'static str,
+}
+
+/// Information about a failed binary comparison assertion.
+#[derive(Debug)]
+pub struct BinaryAssertion<'a> {
+    /// The operator used to compare left and right.
+    pub op: &'static str,
+    /// The left expression as string.
+    pub left_expr: &'static str,
+    /// The right expression as string.
+    pub right_expr: &'static str,
+    /// The value of the left expression.
+    pub left_val: &'a dyn Debug,
+    /// The value of the right expression.
+    pub right_val: &'a dyn Debug,
+}
+
+impl<'a> From<BoolAssertion> for Assertion<'a> {
+    fn from(other: BoolAssertion) -> Self {
+        Self::Bool(other)
+    }
+}
+
+impl<'a> From<BinaryAssertion<'a>> for Assertion<'a> {
+    fn from(other: BinaryAssertion<'a>) -> Self {
+        Self::Binary(other)
+    }
+}

--- a/library/core/src/panic/assert_info.rs
+++ b/library/core/src/panic/assert_info.rs
@@ -5,6 +5,8 @@ use crate::fmt::Debug;
 pub struct AssertInfo<'a> {
     /// The assertion that failed.
     pub assertion: Assertion<'a>,
+    /// The name of the macro that triggered the panic.
+    pub macro_name: &'static str,
     /// Optional additional message to include in the failure report.
     pub message: Option<crate::fmt::Arguments<'a>>,
 }

--- a/library/core/src/panic/assert_info.rs
+++ b/library/core/src/panic/assert_info.rs
@@ -9,22 +9,41 @@ pub struct AssertInfo<'a> {
     pub message: Option<crate::fmt::Arguments<'a>>,
 }
 
+/// Details about the expression that failed an assertion.
 #[derive(Debug)]
 pub enum Assertion<'a> {
-    /// The assertion is a boolean assertion.
+    /// The failed assertion is a boolean expression.
+    ///
+    /// This variant is only used for expressions that can't be described more specifically
+    /// by another variant.
     Bool(BoolAssertion),
-    /// The assertion is a binary comparison assertion.
+
+    /// The failed assertion is a binary comparison expression.
+    ///
+    /// This is used by `assert_eq!()`, `assert_ne!()` and expressions like
+    /// `assert!(x > 10)`.
     Binary(BinaryAssertion<'a>),
 }
 
 /// Information about a failed boolean assertion.
+///
+/// The expression was asserted to be true, but it evaluated to false.
+///
+/// This struct is only used for assertion failures that can't be described more specifically
+/// by another assertion type.
 #[derive(Debug)]
 pub struct BoolAssertion {
-    /// The expression that was evaluated.
+    /// The expression that was evaluated to false.
     pub expr: &'static str,
 }
 
 /// Information about a failed binary comparison assertion.
+///
+/// The left expression was compared with the right expression using `op`,
+/// and the comparison evaluted to false.
+///
+/// This struct is used for `assert_eq!()`, `assert_ne!()` and expressions like
+/// `assert!(x > 10)`.
 #[derive(Debug)]
 pub struct BinaryAssertion<'a> {
     /// The operator used to compare left and right.

--- a/library/core/src/panic/assert_info.rs
+++ b/library/core/src/panic/assert_info.rs
@@ -1,73 +1,97 @@
-use crate::fmt::Debug;
+use crate::fmt::{self, Debug};
 
 /// Information about a failed assertion.
 #[derive(Debug)]
 pub struct AssertInfo<'a> {
     /// The assertion that failed.
     pub assertion: Assertion<'a>,
-    /// The name of the macro that triggered the panic.
-    pub macro_name: &'static str,
     /// Optional additional message to include in the failure report.
     pub message: Option<crate::fmt::Arguments<'a>>,
+}
+
+impl fmt::Display for AssertInfo<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.assertion {
+            Assertion::Binary(ref assertion) => match self.message {
+                Some(message) => write!(
+                    formatter,
+                    r#"assertion failed: `(left {} right)`
+  left: `{:?}`,
+ right: `{:?}`: {}"#,
+                    assertion.static_data.kind.op(),
+                    assertion.left_val,
+                    assertion.right_val,
+                    message
+                ),
+                None => write!(
+                    formatter,
+                    r#"assertion failed: `(left {} right)`
+  left: `{:?}`,
+ right: `{:?}`"#,
+                    assertion.static_data.kind.op(),
+                    assertion.left_val,
+                    assertion.right_val
+                ),
+            },
+        }
+    }
 }
 
 /// Details about the expression that failed an assertion.
 #[derive(Debug)]
 pub enum Assertion<'a> {
-    /// The failed assertion is a boolean expression.
-    ///
-    /// This variant is only used for expressions that can't be described more specifically
-    /// by another variant.
-    Bool(BoolAssertion),
-
-    /// The failed assertion is a binary comparison expression.
-    ///
-    /// This is used by `assert_eq!()`, `assert_ne!()` and expressions like
-    /// `assert!(x > 10)`.
+    /// The failed assertion is a binary expression.
     Binary(BinaryAssertion<'a>),
 }
 
-/// Information about a failed boolean assertion.
-///
-/// The expression was asserted to be true, but it evaluated to false.
-///
-/// This struct is only used for assertion failures that can't be described more specifically
-/// by another assertion type.
-#[derive(Debug)]
-pub struct BoolAssertion {
-    /// The expression that was evaluated to false.
-    pub expr: &'static str,
-}
-
-/// Information about a failed binary comparison assertion.
-///
-/// The left expression was compared with the right expression using `op`,
-/// and the comparison evaluted to false.
-///
-/// This struct is used for `assert_eq!()`, `assert_ne!()` and expressions like
-/// `assert!(x > 10)`.
+/// Information about a failed binary assertion.
 #[derive(Debug)]
 pub struct BinaryAssertion<'a> {
-    /// The operator used to compare left and right.
-    pub op: &'static str,
-    /// The left expression as string.
-    pub left_expr: &'static str,
-    /// The right expression as string.
-    pub right_expr: &'static str,
-    /// The value of the left expression.
+    /// Static information about the failed assertion.
+    pub static_data: &'static BinaryAssertionStaticData,
+    /// The left value of the binary assertion.
     pub left_val: &'a dyn Debug,
-    /// The value of the right expression.
+    /// The right value of the binary assertion.
     pub right_val: &'a dyn Debug,
 }
 
-impl<'a> From<BoolAssertion> for Assertion<'a> {
-    fn from(other: BoolAssertion) -> Self {
-        Self::Bool(other)
-    }
+/// Information about a binary assertion that can be constructed at compile time.
+///
+/// This struct helps to reduce the size `AssertInfo`.
+#[derive(Debug)]
+pub struct BinaryAssertionStaticData {
+    /// The kind of the binary assertion
+    pub kind: BinaryAssertKind,
+    /// The left expression of the binary assertion.
+    pub left_expr: &'static str,
+    /// The right expression of the binary assertion.
+    pub right_expr: &'static str,
 }
 
-impl<'a> From<BinaryAssertion<'a>> for Assertion<'a> {
-    fn from(other: BinaryAssertion<'a>) -> Self {
-        Self::Binary(other)
+/// The kind of a binary assertion
+#[derive(Debug)]
+pub enum BinaryAssertKind {
+    Eq,
+    Ne,
+    Match,
+}
+
+impl BinaryAssertKind {
+    /// The name of the macro that triggered the panic.
+    pub fn macro_name(&self) -> &'static str {
+        match self {
+            Self::Eq { .. } => "assert_eq",
+            Self::Ne { .. } => "assert_ne",
+            Self::Match { .. } => "assert_matches",
+        }
+    }
+
+    /// Symbolic representation of the binary assertion.
+    pub fn op(&self) -> &'static str {
+        match self {
+            Self::Eq { .. } => "==",
+            Self::Ne { .. } => "!=",
+            Self::Match { .. } => "matches",
+        }
     }
 }

--- a/library/core/src/panic/extra_info.rs
+++ b/library/core/src/panic/extra_info.rs
@@ -1,7 +1,0 @@
-use crate::panic::assert_info::AssertInfo;
-
-#[derive(Debug, Copy, Clone)]
-#[non_exhaustive]
-pub enum ExtraInfo<'a> {
-    AssertInfo(&'a AssertInfo<'a>),
-}

--- a/library/core/src/panic/extra_info.rs
+++ b/library/core/src/panic/extra_info.rs
@@ -1,0 +1,6 @@
+use crate::panic::assert_info::AssertInfo;
+
+#[derive(Debug, Copy, Clone)]
+pub enum ExtraInfo<'a> {
+    AssertInfo(&'a AssertInfo<'a>),
+}

--- a/library/core/src/panic/extra_info.rs
+++ b/library/core/src/panic/extra_info.rs
@@ -1,6 +1,7 @@
 use crate::panic::assert_info::AssertInfo;
 
 #[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
 pub enum ExtraInfo<'a> {
     AssertInfo(&'a AssertInfo<'a>),
 }

--- a/library/core/src/panic/panic_description.rs
+++ b/library/core/src/panic/panic_description.rs
@@ -1,0 +1,27 @@
+use crate::fmt;
+use crate::panic::assert_info::AssertInfo;
+
+/// Describes the cause of the panic.
+#[doc(hidden)]
+#[derive(Debug, Copy, Clone)]
+#[non_exhaustive]
+pub enum PanicDescription<'a> {
+    /// Formatted arguments that were passed to the panic.
+    Message(&'a fmt::Arguments<'a>),
+    /// Information about the assertion that caused the panic.
+    AssertInfo(&'a AssertInfo<'a>),
+}
+
+#[unstable(
+    feature = "panic_internals",
+    reason = "internal details of the implementation of the `panic!` and related macros",
+    issue = "none"
+)]
+impl fmt::Display for PanicDescription<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Message(message) => write!(formatter, "{}", message),
+            Self::AssertInfo(info) => write!(formatter, "{}", info),
+        }
+    }
+}

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -187,10 +187,10 @@ fn assert_failed_inner(
     right_val: &dyn fmt::Debug,
     args: Option<fmt::Arguments<'_>>,
 ) -> ! {
-    let op = match kind {
-        AssertKind::Eq => "==",
-        AssertKind::Ne => "!=",
-        AssertKind::Match => "matches",
+    let (op, macro_name) = match kind {
+        AssertKind::Eq => ("==", "assert_eq"),
+        AssertKind::Ne => ("!=", "assert_ne"),
+        AssertKind::Match => ("matches", "assert_matches"),
     };
 
     match args {
@@ -209,6 +209,7 @@ fn assert_failed_inner(
                     left_val,
                     right_val,
                 }),
+                macro_name,
                 message: Some(args),
             })),
         ),
@@ -227,6 +228,7 @@ fn assert_failed_inner(
                     left_val,
                     right_val,
                 }),
+                macro_name,
                 message: None,
             })),
         ),

--- a/library/test/src/cli.rs
+++ b/library/test/src/cli.rs
@@ -23,6 +23,7 @@ pub struct TestOpts {
     pub format: OutputFormat,
     pub shuffle: bool,
     pub shuffle_seed: Option<u64>,
+    pub pretty_print_assertions: bool,
     pub test_threads: Option<usize>,
     pub skip: Vec<String>,
     pub time_options: Option<TestTimeOptions>,
@@ -147,6 +148,11 @@ fn optgroups() -> getopts::Options {
             "shuffle-seed",
             "Run tests in random order; seed the random number generator with SEED",
             "SEED",
+        )
+        .optflag(
+            "",
+            "pretty-print-assertions",
+            "Pretty-print assertion failures using experimental formatting.",
         );
     opts
 }
@@ -276,6 +282,8 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
     let test_threads = get_test_threads(&matches)?;
     let color = get_color_config(&matches)?;
     let format = get_format(&matches, quiet, allow_unstable)?;
+    let pretty_print_assertions =
+        unstable_optflag!(matches, allow_unstable, "pretty-print-assertions");
 
     let options = Options::new().display_output(matches.opt_present("show-output"));
 
@@ -294,6 +302,7 @@ fn parse_opts_impl(matches: getopts::Matches) -> OptRes {
         format,
         shuffle,
         shuffle_seed,
+        pretty_print_assertions,
         test_threads,
         skip,
         time_options,

--- a/library/test/src/helpers/isatty.rs
+++ b/library/test/src/helpers/isatty.rs
@@ -10,7 +10,7 @@ cfg_if::cfg_if! {
         pub fn stdout_isatty() -> bool {
             type DWORD = u32;
             type BOOL = i32;
-            type HANDLE = *mut u8;
+            type HANDLE = *mut core::ffi::c_void;
             type LPDWORD = *mut u32;
             const STD_OUTPUT_HANDLE: DWORD = -11i32 as DWORD;
             extern "system" {

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -23,10 +23,12 @@
 #![feature(libc)]
 #![feature(rustc_private)]
 #![feature(nll)]
+#![feature(core_panic)]
 #![feature(available_parallelism)]
 #![feature(bench_black_box)]
 #![feature(internal_output_capture)]
 #![feature(panic_unwind)]
+#![feature(panic_internals)]
 #![feature(staged_api)]
 #![feature(termination_trait_lib)]
 #![feature(test)]
@@ -79,6 +81,7 @@ mod event;
 mod formatters;
 mod helpers;
 mod options;
+mod pretty_print_assertion;
 pub mod stats;
 mod term;
 mod test_result;

--- a/library/test/src/pretty_print_assertion.rs
+++ b/library/test/src/pretty_print_assertion.rs
@@ -1,9 +1,8 @@
-use core::panic::assert_info::{AssertInfo, Assertion, BinaryAssertion, BoolAssertion};
+use core::panic::assert_info::{AssertInfo, Assertion, BinaryAssertion};
 use core::panic::Location;
 
 const RED: &str = "\x1b[31m";
 const YELLOW: &str = "\x1b[33m";
-const BLUE: &str = "\x1b[34m";
 const MAGENTA: &str = "\x1b[35m";
 const CYAN: &str = "\x1b[36m";
 const BOLD: &str = "\x1b[1m";
@@ -14,22 +13,19 @@ const RESET: &str = "\x1b[0m";
 /// If `ansi_colors` is true, this function unconditionally prints ANSI color codes.
 /// It should only be set to true only if it is known that the terminal supports it.
 pub fn pretty_print_assertion(assert: &AssertInfo<'_>, loc: Location<'_>, ansi_colors: bool) {
-    let macro_name = assert.macro_name;
     if ansi_colors {
         print_pretty_header(loc);
-        match &assert.assertion {
-            Assertion::Bool(assert) => print_pretty_bool_assertion(macro_name, assert),
-            Assertion::Binary(assert) => print_pretty_binary_assertion(macro_name, assert),
-        }
+        match assert.assertion {
+            Assertion::Binary(ref assertion) => print_pretty_binary_assertion(assertion),
+        };
         if let Some(msg) = &assert.message {
             print_pretty_message(msg);
         }
     } else {
         print_plain_header(loc);
-        match &assert.assertion {
-            Assertion::Bool(assert) => print_plain_bool_assertion(macro_name, assert),
-            Assertion::Binary(assert) => print_plain_binary_assertion(macro_name, assert),
-        }
+        match assert.assertion {
+            Assertion::Binary(ref assertion) => print_plain_binary_assertion(assertion),
+        };
         if let Some(msg) = &assert.message {
             print_plain_message(msg);
         }
@@ -52,111 +48,41 @@ fn print_pretty_header(loc: Location<'_>) {
     );
 }
 
-fn print_plain_bool_assertion(macro_name: &'static str, assert: &BoolAssertion) {
+fn print_plain_binary_assertion(assertion: &BinaryAssertion<'_>) {
     eprint!(
         concat!(
             "Assertion:\n",
-            "  {macro_name}!( {expr} )\n",
+            "  {macro_name}!( {left_expr}, {right_expr} )\n",
             "Expansion:\n",
-            "  {macro_name}!( false )\n",
+            "  {macro_name}!( {left_val:?}, {right_val:?} )\n",
         ),
-        macro_name = macro_name,
-        expr = assert.expr,
-    )
-}
-
-fn print_pretty_bool_assertion(macro_name: &'static str, assert: &BoolAssertion) {
-    eprint!(
-        concat!(
-            "{bold}Assertion:{reset}\n",
-            "  {magenta}{macro_name}!( {cyan}{expr} {magenta}){reset}\n",
-            "{bold}Expansion:{reset}\n",
-            "  {magenta}{macro_name}!( {cyan}false {magenta}){reset}\n",
-        ),
-        magenta = MAGENTA,
-        cyan = CYAN,
-        reset = RESET,
-        bold = BOLD,
-        macro_name = macro_name,
-        expr = assert.expr,
+        macro_name = assertion.static_data.kind.macro_name(),
+        left_expr = assertion.static_data.left_expr,
+        right_expr = assertion.static_data.right_expr,
+        left_val = assertion.left_val,
+        right_val = assertion.right_val,
     );
 }
 
-fn print_plain_binary_assertion(macro_name: &'static str, assert: &BinaryAssertion<'_>) {
-    if is_specalized_macro(macro_name) {
-        eprint!(
-            concat!(
-                "Assertion:\n",
-                "  {macro_name}!( {left_expr}, {right_expr} )\n",
-                "Expansion:\n",
-                "  {macro_name}!( {left_val:?}, {right_val:?} )\n",
-            ),
-            macro_name = macro_name,
-            left_expr = assert.left_expr,
-            right_expr = assert.right_expr,
-            left_val = assert.left_val,
-            right_val = assert.right_val,
-        );
-    } else {
-        eprint!(
-            concat!(
-                "Assertion:\n",
-                "  {macro_name}!( {left_expr} {op} {right_expr} )\n",
-                "Expansion:\n",
-                "  {macro_name}!( {left_val:?} {op} {right_val:?} )\n",
-            ),
-            macro_name = macro_name,
-            op = assert.op,
-            left_expr = assert.left_expr,
-            right_expr = assert.right_expr,
-            left_val = assert.left_val,
-            right_val = assert.right_val,
-        );
-    };
-}
-
-fn print_pretty_binary_assertion(macro_name: &'static str, assert: &BinaryAssertion<'_>) {
-    if is_specalized_macro(macro_name) {
-        eprint!(
-            concat!(
-                "{bold}Assertion:{reset}\n",
-                "  {magenta}{macro_name}!( {cyan}{left_expr}{magenta}, {yellow}{right_expr} {magenta}){reset}\n",
-                "{bold}Expansion:{reset}\n",
-                "  {magenta}{macro_name}!( {cyan}{left_val:?}{magenta}, {yellow}{right_val:?} {magenta}){reset}\n",
-            ),
-            cyan = CYAN,
-            magenta = MAGENTA,
-            yellow = YELLOW,
-            bold = BOLD,
-            reset = RESET,
-            macro_name = macro_name,
-            left_expr = assert.left_expr,
-            right_expr = assert.right_expr,
-            left_val = assert.left_val,
-            right_val = assert.right_val,
-        );
-    } else {
-        eprint!(
-            concat!(
-                "{bold}Assertion:{reset}\n",
-                "  {magenta}{macro_name}!( {cyan}{left_expr} {bold}{blue}{op}{reset} {yellow}{right_expr} {magenta}){reset}\n",
-                "{bold}Expansion:{reset}\n",
-                "  {magenta}{macro_name}!( {cyan}{left_val:?} {bold}{blue}{op}{reset} {yellow}{right_val:?} {magenta}){reset}\n",
-            ),
-            blue = BLUE,
-            cyan = CYAN,
-            magenta = MAGENTA,
-            yellow = YELLOW,
-            bold = BOLD,
-            reset = RESET,
-            macro_name = macro_name,
-            op = assert.op,
-            left_expr = assert.left_expr,
-            right_expr = assert.right_expr,
-            left_val = assert.left_val,
-            right_val = assert.right_val,
-        );
-    };
+fn print_pretty_binary_assertion(assertion: &BinaryAssertion<'_>) {
+    eprint!(
+        concat!(
+            "{bold}Assertion:{reset}\n",
+            "  {magenta}{macro_name}!( {cyan}{left_expr}{magenta}, {yellow}{right_expr} {magenta}){reset}\n",
+            "{bold}Expansion:{reset}\n",
+            "  {magenta}{macro_name}!( {cyan}{left_val:?}{magenta}, {yellow}{right_val:?} {magenta}){reset}\n",
+        ),
+        cyan = CYAN,
+        magenta = MAGENTA,
+        yellow = YELLOW,
+        bold = BOLD,
+        reset = RESET,
+        macro_name = assertion.static_data.kind.macro_name(),
+        left_expr = assertion.static_data.left_expr,
+        right_expr = assertion.static_data.right_expr,
+        left_val = assertion.left_val,
+        right_val = assertion.right_val,
+    );
 }
 
 fn print_plain_message(message: &std::fmt::Arguments<'_>) {
@@ -165,10 +91,4 @@ fn print_plain_message(message: &std::fmt::Arguments<'_>) {
 
 fn print_pretty_message(message: &std::fmt::Arguments<'_>) {
     eprintln!("{bold}Message:{reset}\n  {msg}", bold = BOLD, reset = RESET, msg = message,);
-}
-
-fn is_specalized_macro(macro_name: &str) -> bool {
-    // Specialized macros already imply the operator in their name,
-    // so we print them without repeating the operator.
-    macro_name == "assert_eq" || macro_name == "assert_neq" || macro_name == "assert_matches"
 }

--- a/library/test/src/pretty_print_assertion.rs
+++ b/library/test/src/pretty_print_assertion.rs
@@ -1,0 +1,110 @@
+use core::panic::assert_info::{AssertInfo, Assertion, BinaryAssertion, BoolAssertion};
+use core::panic::Location;
+
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const BLUE: &str = "\x1b[34m";
+const CYAN: &str = "\x1b[36m";
+const BOLD: &str = "\x1b[1m";
+const RESET: &str = "\x1b[0m";
+
+/// Print an assertion to standard error.
+///
+/// If `ansi_colors` is true, this function unconditionally prints ANSI color codes.
+/// It should only be set to true only if it is known that the terminal supports it.
+pub fn pretty_print_assertion(assert: &AssertInfo<'_>, loc: Location<'_>, ansi_colors: bool) {
+    if ansi_colors {
+        print_pretty_header(loc);
+        match &assert.assertion {
+            Assertion::Bool(assert) => print_pretty_bool_assertion(assert),
+            Assertion::Binary(assert) => print_pretty_binary_assertion(assert),
+        }
+        if let Some(msg) = &assert.message {
+            print_pretty_message(msg);
+        }
+    } else {
+        print_plain_header(loc);
+        match &assert.assertion {
+            Assertion::Bool(assert) => print_plain_bool_assertion(assert),
+            Assertion::Binary(assert) => print_plain_binary_assertion(assert),
+        }
+        if let Some(msg) = &assert.message {
+            print_plain_message(msg);
+        }
+    }
+}
+
+fn print_plain_header(loc: Location<'_>) {
+    eprintln!("Assertion failed at {}:{}:{}:", loc.file(), loc.line(), loc.column())
+}
+
+fn print_pretty_header(loc: Location<'_>) {
+    eprintln!(
+        "{bold}{red}Assertion failed{reset} at {bold}{file}{reset}:{line}:{col}:",
+        red = RED,
+        bold = BOLD,
+        reset = RESET,
+        file = loc.file(),
+        line = loc.line(),
+        col = loc.column(),
+    );
+}
+
+fn print_plain_bool_assertion(assert: &BoolAssertion) {
+    eprintln!("Assertion:\n  {}", assert.expr);
+    eprintln!("Expansion:\n  false");
+}
+
+fn print_pretty_bool_assertion(assert: &BoolAssertion) {
+    eprintln!(
+        "{bold}Assertion:{reset}\n  {cyan}{expr}{reset}",
+        cyan = CYAN,
+        reset = RESET,
+        bold = BOLD,
+        expr = assert.expr,
+    );
+    eprintln!(
+        "{bold}Expansion:{reset}\n  {cyan}false{reset}",
+        cyan = CYAN,
+        bold = BOLD,
+        reset = RESET,
+    );
+}
+
+fn print_plain_binary_assertion(assert: &BinaryAssertion<'_>) {
+    eprintln!("Assertion:\n  {} {} {}", assert.left_expr, assert.op, assert.right_expr);
+    eprintln!("Expansion:\n  {:?} {} {:?}", assert.left_val, assert.op, assert.right_val);
+}
+
+fn print_pretty_binary_assertion(assert: &BinaryAssertion<'_>) {
+    eprintln!(
+        "{bold}Assertion:{reset}\n  {cyan}{left} {bold}{blue}{op}{reset} {yellow}{right}{reset}",
+        cyan = CYAN,
+        blue = BLUE,
+        yellow = YELLOW,
+        bold = BOLD,
+        reset = RESET,
+        left = assert.left_expr,
+        op = assert.op,
+        right = assert.right_expr,
+    );
+    eprintln!(
+        "{bold}Expansion:{reset}\n  {cyan}{left:?} {bold}{blue}{op}{reset} {yellow}{right:?}{reset}",
+        cyan = CYAN,
+        blue = BLUE,
+        yellow = YELLOW,
+        bold = BOLD,
+        reset = RESET,
+        left = assert.left_val,
+        op = assert.op,
+        right = assert.right_val,
+    );
+}
+
+fn print_plain_message(message: &std::fmt::Arguments<'_>) {
+    eprintln!("Message:\n  {}", message);
+}
+
+fn print_pretty_message(message: &std::fmt::Arguments<'_>) {
+    eprintln!("{bold}Message:{reset}\n  {msg}", bold = BOLD, reset = RESET, msg = message,);
+}

--- a/library/test/src/pretty_print_assertion.rs
+++ b/library/test/src/pretty_print_assertion.rs
@@ -83,7 +83,7 @@ fn print_pretty_bool_assertion(macro_name: &'static str, assert: &BoolAssertion)
 }
 
 fn print_plain_binary_assertion(macro_name: &'static str, assert: &BinaryAssertion<'_>) {
-    if macro_name == "assert_eq" || macro_name == "assert_ne" {
+    if is_specalized_macro(macro_name) {
         eprint!(
             concat!(
                 "Assertion:\n",
@@ -116,7 +116,7 @@ fn print_plain_binary_assertion(macro_name: &'static str, assert: &BinaryAsserti
 }
 
 fn print_pretty_binary_assertion(macro_name: &'static str, assert: &BinaryAssertion<'_>) {
-    if macro_name == "assert_eq" || macro_name == "assert_ne" {
+    if is_specalized_macro(macro_name) {
         eprint!(
             concat!(
                 "{bold}Assertion:{reset}\n",
@@ -165,4 +165,10 @@ fn print_plain_message(message: &std::fmt::Arguments<'_>) {
 
 fn print_pretty_message(message: &std::fmt::Arguments<'_>) {
     eprintln!("{bold}Message:{reset}\n  {msg}", bold = BOLD, reset = RESET, msg = message,);
+}
+
+fn is_specalized_macro(macro_name: &str) -> bool {
+    // Specialized macros already imply the operator in their name,
+    // so we print them without repeating the operator.
+    macro_name == "assert_eq" || macro_name == "assert_neq" || macro_name == "assert_matches"
 }

--- a/library/test/src/term.rs
+++ b/library/test/src/term.rs
@@ -71,6 +71,12 @@ pub trait Terminal: Write {
     /// if there was an I/O error.
     fn fg(&mut self, color: color::Color) -> io::Result<bool>;
 
+    /// Returns `true` if the terminal supports ANSI color codes.
+    ///
+    /// ANSI color codes can be buffered along with the output,
+    /// but not all Windows terminals support them.
+    fn supports_ansi_colors(&self) -> bool;
+
     /// Resets all terminal attributes and colors to their defaults.
     ///
     /// Returns `Ok(true)` if the terminal was reset, `Ok(false)` otherwise, and `Err(e)` if there

--- a/library/test/src/term/terminfo/mod.rs
+++ b/library/test/src/term/terminfo/mod.rs
@@ -125,6 +125,10 @@ impl<T: Write + Send> Terminal for TerminfoTerminal<T> {
         Ok(false)
     }
 
+    fn supports_ansi_colors(&self) -> bool {
+        self.num_colors > 0
+    }
+
     fn reset(&mut self) -> io::Result<bool> {
         // are there any terminals that have color/attrs and not sgr0?
         // Try falling back to sgr, then op

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -47,6 +47,7 @@ impl TestOpts {
             format: OutputFormat::Pretty,
             shuffle: false,
             shuffle_seed: None,
+            pretty_print_assertions: false,
             test_threads: None,
             skip: vec![],
             time_options: None,

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -13,11 +13,13 @@
       let mut _11: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _13: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _15: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _16: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _17: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _15: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _16: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _17: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _18: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _19: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -25,14 +27,11 @@
               debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
               let _9: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _10: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _20: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _22: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
                   debug left_val => _9;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _10;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _14: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  scope 5 {
-                      debug kind => _14;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  }
+                  let mut _21: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               }
           }
       }
@@ -60,14 +59,14 @@
           StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _7 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _20 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
-                                           // + val: Unevaluated(main, [], Some(promoted[0]))
+                                           // + val: Unevaluated(main, [], Some(promoted[1]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-          _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[1]) }) }
+          _8 = _22;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.0: &i32) = move _7;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.1: &i32) = move _8;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -89,27 +88,30 @@
   
       bb1: {
           StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _16 = _9;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _15 = _16;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_17);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _18 = _10;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _17 = _18;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_19);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_19) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
+          StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
-                                           // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
+                                           // + ty: &core::panic::assert_info::BinaryAssertionStaticData
+                                           // + val: Unevaluated(main, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+                                           // + literal: Const { ty: &core::panic::assert_info::BinaryAssertionStaticData, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
+          _15 = _21;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = _15;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _17 = _9;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _16 = _17;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = _10;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _18 = _19;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::assert_failed::<i32, i32>(move _14, move _16, move _18, move _20); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'static core::panic::assert_info::BinaryAssertionStaticData, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb2: {

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -13,11 +13,13 @@
       let mut _11: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _12: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _13: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _15: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _16: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _17: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _18: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _19: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _15: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _16: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _17: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _18: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _19: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _4: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -25,14 +27,11 @@
               debug _prev => _4;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
               let _9: &i32;                // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _10: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _20: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _22: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
                   debug left_val => _9;    // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _10;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _14: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  scope 5 {
-                      debug kind => _14;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  }
+                  let mut _21: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               }
           }
       }
@@ -60,14 +59,14 @@
           StorageLive(_7);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _7 = &_1;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _20 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
-                                           // + val: Unevaluated(main, [], Some(promoted[0]))
+                                           // + val: Unevaluated(main, [], Some(promoted[1]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-          _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[1]) }) }
+          _8 = _22;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.0: &i32) = move _7;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.1: &i32) = move _8;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -89,27 +88,30 @@
   
       bb1: {
           StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _16 = _9;                        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _15 = _16;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_17);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _18 = _10;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _17 = _18;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_19);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_19) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
+          StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
-                                           // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
+                                           // + ty: &core::panic::assert_info::BinaryAssertionStaticData
+                                           // + val: Unevaluated(main, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+                                           // + literal: Const { ty: &core::panic::assert_info::BinaryAssertionStaticData, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
+          _15 = _21;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = _15;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_16);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_17);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _17 = _9;                        // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _16 = _17;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_18);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = _10;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _18 = _19;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::assert_failed::<i32, i32>(move _14, move _16, move _18, move _20); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'static core::panic::assert_info::BinaryAssertionStaticData, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb2: {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -19,13 +19,16 @@
       let mut _17: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _18: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _19: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _21: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _22: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _23: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _24: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _20: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _22: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _23: core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _24: core::panic::assert_info::BinaryAssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _25: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _27: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _27: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _28: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _29: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -33,14 +36,11 @@
               debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
               let _13: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _14: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _28: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _31: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
                   debug left_val => _13;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _14;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _20: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  scope 5 {
-                      debug kind => _20;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  }
+                  let mut _30: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               }
           }
       }
@@ -81,14 +81,14 @@
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _10 = &_1;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _28 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _31 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
-                                           // + val: Unevaluated(main, [], Some(promoted[0]))
+                                           // + val: Unevaluated(main, [], Some(promoted[1]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-          _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[1]) }) }
+          _11 = _31;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -113,36 +113,31 @@
   
       bb3: {
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_22);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _22 = const core::panicking::AssertKind::Eq; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
-                                           // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
+                                           // + ty: &core::panic::assert_info::BinaryAssertionStaticData
+                                           // + val: Unevaluated(main, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
-          StorageLive(_23);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_24);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _24 = _13;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _23 = _24;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_25);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_26);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _26 = _14;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _25 = _26;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_27);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_27) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _23, move _25, move _27); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &core::panic::assert_info::BinaryAssertionStaticData, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
+          _22 = _30;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = _22;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _26 = _13;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = _26;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_27);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_28);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _28 = _14;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _27 = _28;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_29);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_29) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::assert_failed::<i32, i32>(move _21, move _25, move _27, move _29); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
-                                           // ty::Const
-                                           // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'static core::panic::assert_info::BinaryAssertionStaticData, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb4: {

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -19,13 +19,16 @@
       let mut _17: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _18: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _19: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _21: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _22: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _23: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _24: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _20: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _22: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _23: core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _24: core::panic::assert_info::BinaryAssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _25: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let _26: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _27: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _27: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _28: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _29: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       scope 1 {
           debug split => _1;               // in scope 1 at $DIR/issue-73223.rs:2:9: 2:14
           let _6: std::option::Option<i32>; // in scope 1 at $DIR/issue-73223.rs:7:9: 7:14
@@ -33,14 +36,11 @@
               debug _prev => _6;           // in scope 3 at $DIR/issue-73223.rs:7:9: 7:14
               let _13: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               let _14: &i32;               // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _28: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _31: &i32;           // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
                   debug left_val => _13;   // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   debug right_val => _14;  // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _20: core::panicking::AssertKind; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  scope 5 {
-                      debug kind => _20;   // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  }
+                  let mut _30: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               }
           }
       }
@@ -81,14 +81,14 @@
           StorageLive(_10);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _10 = &_1;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _28 = const main::promoted[0];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _31 = const main::promoted[1];   // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
                                            // + ty: &i32
-                                           // + val: Unevaluated(main, [], Some(promoted[0]))
+                                           // + val: Unevaluated(main, [], Some(promoted[1]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-          _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &i32, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[1]) }) }
+          _11 = _31;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -113,36 +113,31 @@
   
       bb3: {
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_22);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _22 = const core::panicking::AssertKind::Eq; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = const main::promoted[0];   // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // ty::Const
-                                           // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
+                                           // + ty: &core::panic::assert_info::BinaryAssertionStaticData
+                                           // + val: Unevaluated(main, [], Some(promoted[0]))
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
-          StorageLive(_23);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_24);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _24 = _13;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _23 = _24;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_25);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_26);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _26 = _14;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _25 = _26;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_27);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_27) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _23, move _25, move _27); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &core::panic::assert_info::BinaryAssertionStaticData, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:3 ~ issue_73223[2d0f]::main), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
+          _22 = _30;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = _22;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_26);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _26 = _13;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = _26;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_27);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_28);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _28 = _14;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _27 = _28;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_29);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_29) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          core::panicking::assert_failed::<i32, i32>(move _21, move _25, move _27, move _29); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
-                                           // ty::Const
-                                           // + ty: core::panicking::AssertKind
-                                           // + val: Value(Scalar(0x00))
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'static core::panic::assert_info::BinaryAssertionStaticData, &'r i32, &'s i32, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
       }
   
       bb4: {

--- a/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -23,13 +23,16 @@ fn array_casts() -> () {
     let mut _24: usize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _25: usize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _26: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _28: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _29: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _30: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let _31: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _27: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _28: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _29: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _30: core::panic::assert_info::BinaryAssertionStaticData; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _31: core::panic::assert_info::BinaryAssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let mut _32: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     let _33: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-    let mut _34: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _34: &usize;                 // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let _35: &usize;                     // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    let mut _36: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 {
         debug x => _1;                   // in scope 1 at $DIR/retag.rs:58:9: 58:14
         let _2: *mut usize;              // in scope 1 at $DIR/retag.rs:59:9: 59:10
@@ -45,16 +48,13 @@ fn array_casts() -> () {
                     debug p => _9;       // in scope 5 at $DIR/retag.rs:63:9: 63:10
                     let _20: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     let _21: &usize;     // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                    let mut _35: &usize; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                    let mut _38: &usize; // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     scope 6 {
                     }
                     scope 7 {
                         debug left_val => _20; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                         debug right_val => _21; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                        let _27: core::panicking::AssertKind; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                        scope 8 {
-                            debug kind => _27; // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                        }
+                        let mut _37: &core::panic::assert_info::BinaryAssertionStaticData; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                     }
                 }
             }
@@ -121,15 +121,15 @@ fn array_casts() -> () {
         _14 = &_15;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_14);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _35 = const array_casts::promoted[0]; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _38 = const array_casts::promoted[1]; // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // ty::Const
                                          // + ty: &usize
-                                         // + val: Unevaluated(array_casts, [], Some(promoted[0]))
+                                         // + val: Unevaluated(array_casts, [], Some(promoted[1]))
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: &usize, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:15 ~ retag[13e7]::array_casts), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-        Retag(_35);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _18 = &(*_35);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: &usize, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:15 ~ retag[13e7]::array_casts), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[1]) }) }
+        Retag(_38);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _18 = &(*_38);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_18);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _13 = (move _14, move _18);      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -156,28 +156,38 @@ fn array_casts() -> () {
 
     bb3: {
         StorageLive(_27);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _27 = core::panicking::AssertKind::Eq; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_28);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_29);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _29 = move _27;                  // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_30);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_31);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _31 = &(*_20);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        Retag(_31);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _30 = &(*_31);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        Retag(_30);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_32);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_33);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _33 = &(*_21);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        Retag(_33);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _32 = &(*_33);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        Retag(_32);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        StorageLive(_34);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _34 = Option::<Arguments>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        core::panicking::assert_failed::<usize, usize>(move _29, move _30, move _32, move _34); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_28);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_29);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _37 = const array_casts::promoted[0]; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // ty::Const
+                                         // + ty: &core::panic::assert_info::BinaryAssertionStaticData
+                                         // + val: Unevaluated(array_casts, [], Some(promoted[0]))
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                         // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r usize, &'s usize, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(Scalar(<ZST>)) }
+                                         // + literal: Const { ty: &core::panic::assert_info::BinaryAssertionStaticData, val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:15 ~ retag[13e7]::array_casts), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
+        Retag(_37);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _29 = &(*_37);                   // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_29);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _28 = &(*_29);                   // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_28);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_32);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_33);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _33 = &(*_20);                   // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_33);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _32 = &(*_33);                   // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_32);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_34);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_35);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _35 = &(*_21);                   // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_35);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _34 = &(*_35);                   // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag(_34);                      // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageLive(_36);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _36 = Option::<Arguments>::None; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        core::panicking::assert_failed::<usize, usize>(move _28, move _32, move _34, move _36); // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // mir::Constant
+                                         // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                         // + literal: Const { ty: for<'r, 's, 't0> fn(&'static core::panic::assert_info::BinaryAssertionStaticData, &'r usize, &'s usize, std::option::Option<std::fmt::Arguments<'t0>>) -> ! {core::panicking::assert_failed::<usize, usize>}, val: Value(Scalar(<ZST>)) }
     }
 
     bb4: {

--- a/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -32,7 +32,7 @@ note: ...which requires const-evaluating + checking `Tr::B`...
 LL |     const B: u8 = Self::A;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires normalizing `<() as Tr>::A`, completing the cycle
-note: cycle used when const-evaluating + checking `main::promoted[1]`
+note: cycle used when const-evaluating + checking `main::promoted[2]`
   --> $DIR/defaults-cyclic-fail.rs:14:1
    |
 LL | fn main() {

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -508,6 +508,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         color: config.color,
         shuffle: false,
         shuffle_seed: None,
+        pretty_print_assertions: false,
         test_threads: None,
         skip: vec![],
         list: false,


### PR DESCRIPTION
This PR aims to allow the test framework to pretty-print assertion failures with colors and a more readable format than the current panic messages. It is meant to work towards https://github.com/rust-lang/rust/issues/44838 (without actually modifying `assert!()` itself at this point).

The PR adds a new `extra_info` field to `PanicInfo`. Currently, `extra_info` is an enum that can only contain `&AssertInfo`, but it is meant to be extendable with different variants in the future. It could potentially be used to record details for other sources of panics too. The panic handler in `std` ensures that the `extra_info` is also passed to the panic hook unmodified.

I also looked into passing the `AssertInfo` as panic payload rather than a new field on `PanicInfo`. However, casting an `&AssertInfo` to `&dyn Any` would require `AssertInfo: 'static`,  but it borrows the evaluated expressions.

The PR adds an new unstable `--pretty-print-assertions` flag to test binaries to enable the pretty printing. When used, the test runner installs a panic hook that does the pretty-printing. The printing is done with `print!()/println!()` to ensure the output is still captured by the test framework. That means that the color codes need to be included in the `print!()` calls, which is only possible with terminals that support ANSI color codes. Support for ANSI color codes is checked before enabling them.

For now, the PR only modifies `assert_eq!()` and `assert_ne!()`, since they're much easier. Next up would be `assert!()` parsing the input expression and generating the proper `AssertInfo` for the panic.

And now some pictures!

Without pretty-printing:

![not-pretty](https://user-images.githubusercontent.com/786213/98994769-9c8bd600-2530-11eb-8120-6e9f9debe7aa.png)

![pretty](https://user-images.githubusercontent.com/786213/98994778-a1e92080-2530-11eb-9c99-5cd1e2ce7fb4.png)

The pretty printing is hidden behind an unstable command line flag to allow more time to tweak the format, and of course to actually implement expression parsing in `assert!()`.

I imagine there is a lot of bike-shedding potential on the exact output format. Initially I wanted to go with the format used by [`assert2`](https://docs.rs/assert2/), but I figured that might be too opinionated.

r? @m-ou-se 