### PR TITLE
rustc_expand: Mark inner `#![test]` attributes as soft-unstable

### DIFF
--- a/library/std/src/num/tests.rs
+++ b/library/std/src/num/tests.rs
@@ -75,8 +75,8 @@ fn test_checked_mul() {
 
 macro_rules! test_is_power_of_two {
     ($test_name:ident, $T:ident) => {
+        #[test]
         fn $test_name() {
-            #![test]
             assert_eq!((0 as $T).is_power_of_two(), false);
             assert_eq!((1 as $T).is_power_of_two(), true);
             assert_eq!((2 as $T).is_power_of_two(), true);
@@ -96,8 +96,8 @@ test_is_power_of_two! { test_is_power_of_two_uint, usize }
 
 macro_rules! test_next_power_of_two {
     ($test_name:ident, $T:ident) => {
+        #[test]
         fn $test_name() {
-            #![test]
             assert_eq!((0 as $T).next_power_of_two(), 1);
             let mut next_power = 1;
             for i in 1 as $T..40 {
@@ -118,8 +118,8 @@ test_next_power_of_two! { test_next_power_of_two_uint, usize }
 
 macro_rules! test_checked_next_power_of_two {
     ($test_name:ident, $T:ident) => {
+        #[test]
         fn $test_name() {
-            #![test]
             assert_eq!((0 as $T).checked_next_power_of_two(), Some(1));
             let smax = $T::MAX >> 1;
             assert_eq!(smax.checked_next_power_of_two(), Some(smax + 1));

--- a/src/test/ui/feature-gate/issue-43106-gating-of-test.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-test.rs
@@ -1,5 +1,6 @@
 // The non-crate level cases are in issue-43106-gating-of-builtin-attrs.rs.
 
+#![allow(soft_unstable)]
 #![test                    = "4200"]
 //~^ ERROR cannot determine resolution for the attribute macro `test`
 

--- a/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-test.stderr
@@ -1,5 +1,5 @@
 error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-43106-gating-of-test.rs:3:4
+  --> $DIR/issue-43106-gating-of-test.rs:4:4
    |
 LL | #![test                    = "4200"]
    |    ^^^^

--- a/src/test/ui/issues/issue-28134.rs
+++ b/src/test/ui/issues/issue-28134.rs
@@ -1,3 +1,4 @@
 // compile-flags: --test
 
+#![allow(soft_unstable)]
 #![test] //~ ERROR cannot determine resolution for the attribute macro `test`

--- a/src/test/ui/issues/issue-28134.stderr
+++ b/src/test/ui/issues/issue-28134.stderr
@@ -1,5 +1,5 @@
 error: cannot determine resolution for the attribute macro `test`
-  --> $DIR/issue-28134.rs:3:4
+  --> $DIR/issue-28134.rs:4:4
    |
 LL | #![test]
    |    ^^^^

--- a/src/test/ui/proc-macro/proc-macro-gates.rs
+++ b/src/test/ui/proc-macro/proc-macro-gates.rs
@@ -45,4 +45,9 @@ fn attrs() {
     //~^ ERROR: custom attributes cannot be applied to expressions
 }
 
+fn test_case() {
+    #![test] //~ ERROR inner macro attributes are unstable
+             //~| WARN this was previously accepted
+}
+
 fn main() {}

--- a/src/test/ui/proc-macro/proc-macro-gates.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates.stderr
@@ -76,6 +76,16 @@ LL |     let _x = #[identity_attr] println!();
    = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
-error: aborting due to 9 previous errors
+error: inner macro attributes are unstable
+  --> $DIR/proc-macro-gates.rs:49:8
+   |
+LL |     #![test]
+   |        ^^^^
+   |
+   = note: `#[deny(soft_unstable)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Custom inner attributes are feature gated (https://github.com/rust-lang/rust/issues/54726) except for attributes having name `test` literally, which are not gated for historical reasons.

`#![test]` is an inner proc macro attribute, so it has all the issues described in https://github.com/rust-lang/rust/issues/54726 too.
This PR gates it with the `soft_unstable` lint.