### PR TITLE
Add #[must_use] to Option and Result overlap methods

### DIFF
--- a/compiler/rustc_data_structures/src/jobserver.rs
+++ b/compiler/rustc_data_structures/src/jobserver.rs
@@ -22,7 +22,7 @@ static GLOBAL_CLIENT: SyncLazy<Client> = SyncLazy::new(|| unsafe {
     Client::from_env().unwrap_or_else(|| {
         let client = Client::new(32).expect("failed to create jobserver");
         // Acquire a token for the main thread which we can release later
-        client.acquire_raw().ok();
+        client.acquire_raw().expect("failed to acquire token");
         client
     })
 });
@@ -32,9 +32,9 @@ pub fn client() -> Client {
 }
 
 pub fn acquire_thread() {
-    GLOBAL_CLIENT.acquire_raw().ok();
+    GLOBAL_CLIENT.acquire_raw().expect("failed to acquire");
 }
 
 pub fn release_thread() {
-    GLOBAL_CLIENT.release_raw().ok();
+    GLOBAL_CLIENT.release_raw().expect("failed to release");
 }

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -148,7 +148,7 @@ impl<'tcx> Queries<'tcx> {
             // load before dep_graph() is called, but it also can't happen
             // until after rustc_incremental::prepare_session_directory() is
             // called, which happens within passes::register_plugins().
-            self.dep_graph_future().ok();
+            self.dep_graph_future()?;
 
             result
         })
@@ -273,7 +273,7 @@ impl<'tcx> Queries<'tcx> {
         self.ongoing_codegen.compute(|| {
             let outputs = self.prepare_outputs()?;
             self.global_ctxt()?.peek_mut().enter(|tcx| {
-                tcx.analysis(LOCAL_CRATE).ok();
+                tcx.analysis(LOCAL_CRATE)?;
 
                 // Don't do code generation if there were any errors
                 self.session().compile_status()?;

--- a/compiler/rustc_parse/src/validate_attr.rs
+++ b/compiler/rustc_parse/src/validate_attr.rs
@@ -27,11 +27,9 @@ pub fn check_meta(sess: &ParseSess, attr: &Attribute) {
         _ => {
             if let MacArgs::Eq(..) = attr.get_normal_item().args {
                 // All key-value attributes are restricted to meta-item syntax.
-                parse_meta(sess, attr)
-                    .map_err(|mut err| {
-                        err.emit();
-                    })
-                    .ok();
+                let _ = parse_meta(sess, attr).map_err(|mut err| {
+                    err.emit();
+                });
             }
         }
     }

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -355,13 +355,12 @@ fn test_drain_filter_drop_panic_leak() {
     set.insert(D(4));
     set.insert(D(8));
 
-    catch_unwind(move || {
+    let _ = catch_unwind(move || {
         drop(set.drain_filter(|d| {
             PREDS.fetch_add(1u32 << d.0, Ordering::SeqCst);
             true
         }))
-    })
-    .ok();
+    });
 
     assert_eq!(PREDS.load(Ordering::SeqCst), 0x011);
     assert_eq!(DROPS.load(Ordering::SeqCst), 3);
@@ -385,7 +384,7 @@ fn test_drain_filter_pred_panic_leak() {
     set.insert(D(4));
     set.insert(D(8));
 
-    catch_unwind(AssertUnwindSafe(|| {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
         drop(set.drain_filter(|d| {
             PREDS.fetch_add(1u32 << d.0, Ordering::SeqCst);
             match d.0 {
@@ -393,8 +392,7 @@ fn test_drain_filter_pred_panic_leak() {
                 _ => panic!(),
             }
         }))
-    }))
-    .ok();
+    }));
 
     assert_eq!(PREDS.load(Ordering::SeqCst), 0x011);
     assert_eq!(DROPS.load(Ordering::SeqCst), 1);

--- a/library/alloc/tests/binary_heap.rs
+++ b/library/alloc/tests/binary_heap.rs
@@ -315,7 +315,7 @@ fn test_drain_sorted_leak() {
         D(5, false),
     ]);
 
-    catch_unwind(AssertUnwindSafe(|| drop(q.drain_sorted()))).ok();
+    let _ = catch_unwind(AssertUnwindSafe(|| drop(q.drain_sorted())));
 
     assert_eq!(DROPS.load(Ordering::SeqCst), 6);
 }

--- a/library/alloc/tests/linked_list.rs
+++ b/library/alloc/tests/linked_list.rs
@@ -559,7 +559,7 @@ fn drain_filter_drop_panic_leak() {
     q.push_front(D(true));
     q.push_front(D(false));
 
-    catch_unwind(AssertUnwindSafe(|| drop(q.drain_filter(|_| true)))).ok();
+    let _ = catch_unwind(AssertUnwindSafe(|| drop(q.drain_filter(|_| true))));
 
     assert_eq!(unsafe { DROPS }, 8);
     assert!(q.is_empty());
@@ -590,10 +590,9 @@ fn drain_filter_pred_panic_leak() {
     q.push_front(D(1));
     q.push_front(D(0));
 
-    catch_unwind(AssertUnwindSafe(|| {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
         drop(q.drain_filter(|item| if item.0 >= 2 { panic!() } else { true }))
-    }))
-    .ok();
+    }));
 
     assert_eq!(unsafe { DROPS }, 2); // 0 and 1
     assert_eq!(q.len(), 6);
@@ -699,7 +698,7 @@ fn test_drop_panic() {
     q.push_front(D(false));
     q.push_front(D(true));
 
-    catch_unwind(move || drop(q)).ok();
+    let _ = catch_unwind(move || drop(q));
 
     assert_eq!(unsafe { DROPS }, 8);
 }

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -707,10 +707,9 @@ fn test_drain_leak() {
         D(6, false),
     ];
 
-    catch_unwind(AssertUnwindSafe(|| {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
         v.drain(2..=5);
-    }))
-    .ok();
+    }));
 
     assert_eq!(unsafe { DROPS }, 4);
     assert_eq!(v, vec![D(0, false), D(1, false), D(6, false),]);
@@ -891,7 +890,7 @@ fn test_into_iter_leak() {
 
     let v = vec![D(false), D(true), D(false)];
 
-    catch_unwind(move || drop(v.into_iter())).ok();
+    let _ = catch_unwind(move || drop(v.into_iter()));
 
     assert_eq!(unsafe { DROPS }, 3);
 }

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -752,7 +752,7 @@ fn test_drop_panic() {
     q.push_front(D(false));
     q.push_front(D(true));
 
-    catch_unwind(move || drop(q)).ok();
+    let _ = catch_unwind(move || drop(q));
 
     assert_eq!(unsafe { DROPS }, 8);
 }
@@ -1616,7 +1616,7 @@ fn truncate_leak() {
     q.push_front(D(false));
     q.push_front(D(false));
 
-    catch_unwind(AssertUnwindSafe(|| q.truncate(1))).ok();
+    let _ = catch_unwind(AssertUnwindSafe(|| q.truncate(1)));
 
     assert_eq!(unsafe { DROPS }, 7);
 }
@@ -1649,10 +1649,9 @@ fn test_drain_leak() {
     v.push_front(D(1, false));
     v.push_front(D(0, false));
 
-    catch_unwind(AssertUnwindSafe(|| {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
         v.drain(1..=4);
-    }))
-    .ok();
+    }));
 
     assert_eq!(unsafe { DROPS }, 4);
     assert_eq!(v.len(), 3);

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -527,6 +527,7 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.ok_or(0), Err(0));
     /// ```
+    #[must_use]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok_or<E>(self, err: E) -> Result<T, E> {
@@ -553,6 +554,7 @@ impl<T> Option<T> {
     /// let x: Option<&str> = None;
     /// assert_eq!(x.ok_or_else(|| 0), Err(0));
     /// ```
+    #[must_use]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok_or_else<E, F: FnOnce() -> E>(self, err: F) -> Result<T, E> {
@@ -1241,6 +1243,7 @@ impl<T, E> Option<Result<T, E>> {
     /// let y: Option<Result<i32, SomeErr>> = Some(Ok(5));
     /// assert_eq!(x, y.transpose());
     /// ```
+    #[must_use]
     #[inline]
     #[stable(feature = "transpose_result", since = "1.33.0")]
     pub fn transpose(self) -> Result<Option<T>, E> {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -381,6 +381,7 @@ impl<T, E> Result<T, E> {
     /// let x: Result<u32, &str> = Err("Nothing here");
     /// assert_eq!(x.ok(), None);
     /// ```
+    #[must_use]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn ok(self) -> Option<T> {
@@ -408,6 +409,7 @@ impl<T, E> Result<T, E> {
     /// let x: Result<u32, &str> = Err("Nothing here");
     /// assert_eq!(x.err(), Some("Nothing here"));
     /// ```
+    #[must_use]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn err(self) -> Option<E> {

--- a/library/std/src/collections/hash/set/tests.rs
+++ b/library/std/src/collections/hash/set/tests.rs
@@ -445,13 +445,12 @@ fn test_drain_filter_drop_panic_leak() {
 
     let mut set = (0..3).map(|i| D(i)).collect::<HashSet<_>>();
 
-    catch_unwind(move || {
+    let _ = catch_unwind(move || {
         drop(set.drain_filter(|_| {
             PREDS.fetch_add(1, Ordering::SeqCst);
             true
         }))
-    })
-    .ok();
+    });
 
     assert_eq!(PREDS.load(Ordering::SeqCst), 3);
     assert_eq!(DROPS.load(Ordering::SeqCst), 3);
@@ -472,13 +471,12 @@ fn test_drain_filter_pred_panic_leak() {
 
     let mut set: HashSet<_> = (0..3).map(|_| D).collect();
 
-    catch_unwind(AssertUnwindSafe(|| {
+    let _ = catch_unwind(AssertUnwindSafe(|| {
         drop(set.drain_filter(|_| match PREDS.fetch_add(1, Ordering::SeqCst) {
             0 => true,
             _ => panic!(),
         }))
-    }))
-    .ok();
+    }));
 
     assert_eq!(PREDS.load(Ordering::SeqCst), 1);
     assert_eq!(DROPS.load(Ordering::SeqCst), 3);


### PR DESCRIPTION
This helps users avoid the dropping of errors/`None` without checking, for example Miserlou/Loop/pull/66.