### PR TITLE
[beta] limit chunk size for copy_file_range to 1GB per iteration

### DIFF
--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1147,7 +1147,7 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     let mut written = 0u64;
     while written < max_len {
         let copy_result = if has_copy_file_range {
-            let bytes_to_copy = cmp::min(max_len - written, usize::MAX as u64) as usize;
+            let bytes_to_copy = cmp::min(max_len - written, 0x4000_0000 as u64) as usize;
             let copy_result = unsafe {
                 // We actually don't have to adjust the offsets,
                 // because copy_file_range adjusts the file offset automatically


### PR DESCRIPTION
This will hopefully avoid EOVERFLOW errors on mipsel-unknown-linux-gnu
But the error will remain unhandled if it still occurs. Proper handling is left to a future change.

I'm not entirely sure if it'll fix the issue, for a certain alternative see #79008

Resolves #78979