### PR TITLE
[beta] always disable copy_file_range to avoid EOVERFLOW errors

### DIFF
--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1126,7 +1126,7 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
 
     // Kernel prior to 4.5 don't have copy_file_range
     // We store the availability in a global to avoid unnecessary syscalls
-    static HAS_COPY_FILE_RANGE: AtomicBool = AtomicBool::new(true);
+    static HAS_COPY_FILE_RANGE: AtomicBool = AtomicBool::new(false);
 
     unsafe fn copy_file_range(
         fd_in: libc::c_int,


### PR DESCRIPTION
A bigger hammer as alternative to #79007

Pro: will certainly fix the issue
Cons: will disable copy_file_range for everyone

Resolves #78979

