### PR TITLE
Clean up outdated `use_once_payload` pretty printer comment

### DIFF
--- a/compiler/rustc_driver/src/pretty.rs
+++ b/compiler/rustc_driver/src/pretty.rs
@@ -32,9 +32,6 @@ use crate::abort_on_err;
 // Note that since the `&PrinterSupport` is freshly constructed on each
 // call, it would not make sense to try to attach the lifetime of `self`
 // to the lifetime of the `&PrinterObject`.
-//
-// (The `use_once_payload` is working around the current lack of once
-// functions in the compiler.)
 
 /// Constructs a `PrinterSupport` object and passes it to `f`.
 fn call_with_pp_support<'tcx, A, F>(


### PR DESCRIPTION
While reading some parts of the pretty printer code, I noticed this old comment
which seemed out of place. The `use_once_payload` this outdated comment mentions
was removed in 2017 in 40f03a1e0d6702add1922f82d716d5b2c23a59f0, so this
completes the work by removing the comment.