### PR TITLE
Give a better error for `cargo check` on libstd itself

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+use x.py instead: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -193,7 +193,10 @@ def default_build_triple(verbose):
     # install, use their preference. This fixes most issues with Windows builds
     # being detected as GNU instead of MSVC.
     try:
-        version = subprocess.check_output(["rustc", "--version", "--verbose"])
+        # https://stackoverflow.com/questions/48333999
+        fs_root = os.path.abspath('.').split(os.path.sep)[0]+os.path.sep
+        version = subprocess.check_output(["rustc", "--version", "--verbose"],
+                cwd=fs_root)
         host = next(x for x in version.split('\n') if x.startswith("host: "))
         triple = host.split("host: ")[1]
         if verbose:


### PR DESCRIPTION
Or, Abusing `rust-toolchain` For Fun and Profit.

Before: hundreds of errors about `Sized` not being implemented for types in `core`
After:

```
$ cargo check
error: invalid channel name 'use x.py instead: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html' in '/home/joshua/rustc/rust-toolchain'
error: caused by: invalid toolchain name: 'use x.py instead: https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html'
```

r? @Mark-Simulacrum 
Closes https://github.com/rust-lang/rust/pull/76446, fixes https://github.com/rust-lang/rust/issues/76444.

Unlike https://github.com/rust-lang/rust/pull/76446, this requires no changes to people trying to build the standard library out-of-tree, and also works for `cargo fmt`.