### PR TITLE
improve type const mismatch errors

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -282,6 +282,14 @@ impl GenericArg<'_> {
             GenericArg::Const(_) => "constant",
         }
     }
+
+    pub fn short_descr(&self) -> &'static str {
+        match self {
+            GenericArg::Lifetime(_) => "lifetime",
+            GenericArg::Type(_) => "type",
+            GenericArg::Const(_) => "const",
+        }
+    }
 }
 
 #[derive(Debug, HashStable_Generic)]

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -22,6 +22,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         sess: &Session,
         arg: &GenericArg<'_>,
         kind: &'static str,
+        possible_ordering_error: bool,
         help: Option<&str>,
     ) {
         let mut err = struct_span_err!(
@@ -48,8 +49,23 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             GenericArg::Const(_) => ParamKindOrd::Const { unordered },
         };
 
+        if matches!(arg, GenericArg::Type(hir::Ty { kind: hir::TyKind::Path { .. }, .. }))
+            && matches!(kind_ord, ParamKindOrd::Const { .. })
+        {
+            let suggestions = vec![
+                (arg.span().shrink_to_lo(), String::from("{ ")),
+                (arg.span().shrink_to_hi(), String::from(" }")),
+            ];
+            err.multipart_suggestion(
+                "if this generic argument was intended as a const parameter, \
+                try surrounding it with braces:",
+                suggestions,
+                Applicability::MaybeIncorrect,
+            );
+        }
+
         // This note is only true when generic parameters are strictly ordered by their kind.
-        if kind_ord.cmp(&arg_ord) != core::cmp::Ordering::Equal {
+        if possible_ordering_error && kind_ord.cmp(&arg_ord) != core::cmp::Ordering::Equal {
             let (first, last) =
                 if kind_ord < arg_ord { (kind, arg.descr()) } else { (arg.descr(), kind) };
             err.note(&format!("{} arguments must be provided before {} arguments", first, last));
@@ -153,8 +169,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             // Check whether this segment takes generic arguments and the user has provided any.
             let (generic_args, infer_args) = args_for_def_id(def_id);
 
-            let mut args =
-                generic_args.iter().flat_map(|generic_args| generic_args.args.iter()).peekable();
+            let args_iter = generic_args.iter().flat_map(|generic_args| generic_args.args.iter());
+            let mut args = args_iter.clone().peekable();
 
             // If we encounter a type or const when we expect a lifetime, we infer the lifetimes.
             // If we later encounter a lifetime, we know that the arguments were provided in the
@@ -221,8 +237,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                                     GenericParamDefKind::Const => {
                                                         ParamKindOrd::Const {
                                                             unordered: tcx
-                                                                .sess
-                                                                .features_untracked()
+                                                                .features()
                                                                 .const_generics,
                                                         }
                                                     }
@@ -242,6 +257,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                         tcx.sess,
                                         arg,
                                         kind.descr(),
+                                        !args_iter.clone().is_sorted_by_key(|arg| match arg {
+                                            GenericArg::Lifetime(_) => ParamKindOrd::Lifetime,
+                                            GenericArg::Type(_) => ParamKindOrd::Type,
+                                            GenericArg::Const(_) => ParamKindOrd::Const {
+                                                unordered: tcx.features().const_generics,
+                                            },
+                                        }),
                                         Some(&format!(
                                             "reorder the arguments: {}: `<{}>`",
                                             param_types_present
@@ -293,7 +315,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             assert_eq!(kind, "lifetime");
                             let provided =
                                 force_infer_lt.expect("lifetimes ought to have been inferred");
-                            Self::generic_arg_mismatch_err(tcx.sess, provided, kind, None);
+                            Self::generic_arg_mismatch_err(tcx.sess, provided, kind, false, None);
                         }
 
                         break;
@@ -351,6 +373,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         // that lifetimes will proceed types. So it suffices to check the number of each generic
         // arguments in order to validate them with respect to the generic parameters.
         let param_counts = def.own_counts();
+        let named_type_param_count = param_counts.types - has_self as usize;
         let arg_counts = args.own_counts();
         let infer_lifetimes = position != GenericArgPosition::Type && arg_counts.lifetimes == 0;
 
@@ -389,11 +412,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             // For kinds without defaults (e.g.., lifetimes), `required == permitted`.
             // For other kinds (i.e., types), `permitted` may be greater than `required`.
             if required <= provided && provided <= permitted {
-                return Ok(());
+                return true;
             }
 
             if silent {
-                return Err((0i32, None));
+                return false;
             }
 
             // Unfortunately lifetime and type parameter mismatches are typically styled
@@ -409,25 +432,26 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 (required, "")
             };
 
-            let (spans, label) = if provided > permitted {
+            let (spans, labels) = if provided > permitted {
                 // In the case when the user has provided too many arguments,
                 // we want to point to the unexpected arguments.
-                let spans: Vec<Span> = args.args[offset + permitted..offset + provided]
+                let (spans, labels): (Vec<Span>, Vec<String>) = args.args
+                    [offset + permitted..offset + provided]
                     .iter()
-                    .map(|arg| arg.span())
-                    .collect();
+                    .map(|arg| (arg.span(), format!("unexpected {} argument", arg.short_descr())))
+                    .unzip();
                 unexpected_spans.extend(spans.clone());
-                (spans, format!("unexpected {} argument", kind))
+                (spans, labels)
             } else {
                 (
                     vec![span],
-                    format!(
+                    vec![format!(
                         "expected {}{} {} argument{}",
                         quantifier,
                         bound,
                         kind,
                         pluralize!(bound),
-                    ),
+                    )],
                 )
             };
 
@@ -439,12 +463,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 ),
                 DiagnosticId::Error("E0107".into()),
             );
-            for span in spans {
+            for (span, label) in spans.into_iter().zip(labels) {
                 err.span_label(span, label.as_str());
             }
-
-            assert_ne!(bound, provided);
-            Err((bound as i32 - provided as i32, Some(err)))
+            err.emit();
+            false
         };
 
         let mut unexpected_spans = vec![];
@@ -459,75 +482,38 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             explicit_late_bound == ExplicitLateBound::Yes,
         );
 
-        // FIXME(const_generics:defaults)
-        let mut const_count_correct = check_kind_count(
-            "const",
-            if infer_args { 0 } else { param_counts.consts },
-            param_counts.consts,
-            arg_counts.consts,
-            arg_counts.lifetimes + arg_counts.types,
-            &mut unexpected_spans,
-            false,
-        );
+        let kind_str = if param_counts.consts + arg_counts.consts == 0 {
+            "type"
+        } else if named_type_param_count + arg_counts.types == 0 {
+            "const"
+        } else {
+            "generic"
+        };
 
-        // Note that type errors are currently be emitted *after* const errors.
-        let mut type_count_correct = check_kind_count(
-            "type",
-            if infer_args { 0 } else { param_counts.types - defaults.types - has_self as usize },
-            param_counts.types - has_self as usize,
-            arg_counts.types,
+        let arg_count_correct = check_kind_count(
+            kind_str,
+            if infer_args {
+                0
+            } else {
+                param_counts.consts + named_type_param_count - defaults.types
+            },
+            param_counts.consts + named_type_param_count,
+            arg_counts.consts + arg_counts.types,
             arg_counts.lifetimes,
             &mut unexpected_spans,
             false,
         );
 
-        // Emit a help message if it's possible that a type could be surrounded in braces
-        if let Err((c_mismatch, Some(ref mut _const_err))) = const_count_correct {
-            if let Err((_, Some(ref mut type_err))) = type_count_correct {
-                let possible_matches = args.args[arg_counts.lifetimes..]
-                    .iter()
-                    .filter(|arg| {
-                        matches!(
-                            arg,
-                            GenericArg::Type(hir::Ty { kind: hir::TyKind::Path { .. }, .. })
-                        )
-                    })
-                    .take(c_mismatch.max(0) as usize);
-                for arg in possible_matches {
-                    let suggestions = vec![
-                        (arg.span().shrink_to_lo(), String::from("{ ")),
-                        (arg.span().shrink_to_hi(), String::from(" }")),
-                    ];
-                    type_err.multipart_suggestion(
-                        "If this generic argument was intended as a const parameter, \
-                        try surrounding it with braces:",
-                        suggestions,
-                        Applicability::MaybeIncorrect,
-                    );
-                }
-            }
-        }
-
-        let emit_correct =
-            |correct: Result<(), (_, Option<rustc_errors::DiagnosticBuilder<'_>>)>| match correct {
-                Ok(()) => Ok(()),
-                Err((_, None)) => Err(()),
-                Err((_, Some(mut err))) => {
-                    err.emit();
-                    Err(())
-                }
-            };
-
-        let arg_count_correct = emit_correct(lifetime_count_correct)
-            .and(emit_correct(const_count_correct))
-            .and(emit_correct(type_count_correct));
-
         GenericArgCountResult {
             explicit_late_bound,
-            correct: arg_count_correct.map_err(|()| GenericArgCountMismatch {
-                reported: Some(ErrorReported),
-                invalid_args: unexpected_spans,
-            }),
+            correct: if lifetime_count_correct && arg_count_correct {
+                Ok(())
+            } else {
+                Err(GenericArgCountMismatch {
+                    reported: Some(ErrorReported),
+                    invalid_args: unexpected_spans,
+                })
+            },
         }
     }
 

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -409,7 +409,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 (required, "")
             };
 
-            let (spans, label) = if required == permitted && provided > permitted {
+            let (spans, label) = if provided > permitted {
                 // In the case when the user has provided too many arguments,
                 // we want to point to the unexpected arguments.
                 let spans: Vec<Span> = args.args[offset + permitted..offset + provided]

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -61,6 +61,7 @@ This API is completely unstable and subject to change.
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
 #![feature(in_band_lifetimes)]
+#![feature(is_sorted)]
 #![feature(nll)]
 #![feature(or_patterns)]
 #![feature(try_blocks)]

--- a/src/test/ui/const-generics/const-param-shadowing.rs
+++ b/src/test/ui/const-generics/const-param-shadowing.rs
@@ -1,0 +1,9 @@
+#![feature(min_const_generics)]
+
+type N = u32;
+struct Foo<const M: usize>;
+fn test<const N: usize>() -> Foo<N> { //~ ERROR type provided when
+    Foo
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/const-param-shadowing.stderr
+++ b/src/test/ui/const-generics/const-param-shadowing.stderr
@@ -1,0 +1,14 @@
+error[E0747]: type provided when a constant was expected
+  --> $DIR/const-param-shadowing.rs:5:34
+   |
+LL | fn test<const N: usize>() -> Foo<N> {
+   |                                  ^
+   |
+help: if this generic argument was intended as a const parameter, try surrounding it with braces:
+   |
+LL | fn test<const N: usize>() -> Foo<{ N }> {
+   |                                  ^   ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/const-generics/invalid-constant-in-args.rs
+++ b/src/test/ui/const-generics/invalid-constant-in-args.rs
@@ -1,3 +1,4 @@
 fn main() {
-    let _: Vec<&str, "a"> = Vec::new(); //~ ERROR wrong number of const arguments
+    let _: Vec<&str, "a"> = Vec::new();
+    //~^ ERROR wrong number of generic arguments
 }

--- a/src/test/ui/const-generics/invalid-constant-in-args.stderr
+++ b/src/test/ui/const-generics/invalid-constant-in-args.stderr
@@ -1,4 +1,4 @@
-error[E0107]: wrong number of const arguments: expected 0, found 1
+error[E0107]: wrong number of generic arguments: expected 1, found 2
   --> $DIR/invalid-constant-in-args.rs:2:22
    |
 LL |     let _: Vec<&str, "a"> = Vec::new();

--- a/src/test/ui/const-generics/invalid-enum.rs
+++ b/src/test/ui/const-generics/invalid-enum.rs
@@ -20,20 +20,16 @@ impl<const CF: CompileFlag, T> Example<CF, T> {
 pub fn main() {
   test_1::<CompileFlag::A>();
   //~^ ERROR: expected type, found variant
-  //~| ERROR: wrong number of const arguments
-  //~| ERROR: wrong number of type arguments
+  //~| ERROR: type provided when a constant was expected
 
   test_2::<_, CompileFlag::A>(0);
   //~^ ERROR: expected type, found variant
-  //~| ERROR: wrong number of const arguments
-  //~| ERROR: wrong number of type arguments
+  //~| ERROR: type provided when a constant was expected
 
   let _: Example<CompileFlag::A, _> = Example { x: 0 };
   //~^ ERROR: expected type, found variant
-  //~| ERROR: wrong number of const arguments
-  //~| ERROR: wrong number of type arguments
+  //~| ERROR: type provided when a constant was expected
 
   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
-  //~^ ERROR: wrong number of const arguments
-  //~| ERROR: wrong number of type arguments
+  //~^ ERROR: type provided when a constant was expected
 }

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -32,10 +32,10 @@ LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
 
 error[E0107]: wrong number of type arguments: expected at most 1, found 2
-  --> $DIR/invalid-enum.rs:31:10
+  --> $DIR/invalid-enum.rs:31:34
    |
 LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 1 type argument
+   |                                  ^ unexpected type argument
    |
 help: If this generic argument was intended as a const parameter, try surrounding it with braces:
    |
@@ -49,10 +49,10 @@ LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
 
 error[E0107]: wrong number of type arguments: expected at most 1, found 2
-  --> $DIR/invalid-enum.rs:36:10
+  --> $DIR/invalid-enum.rs:36:39
    |
 LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 1 type argument
+   |                                       ^ unexpected type argument
    |
 help: If this generic argument was intended as a const parameter, try surrounding it with braces:
    |

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -8,7 +8,7 @@ LL |   test_1::<CompileFlag::A>();
    |            help: try using the variant's enum: `CompileFlag`
 
 error[E0573]: expected type, found variant `CompileFlag::A`
-  --> $DIR/invalid-enum.rs:26:15
+  --> $DIR/invalid-enum.rs:25:15
    |
 LL |   test_2::<_, CompileFlag::A>(0);
    |               ^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |   test_2::<_, CompileFlag::A>(0);
    |               help: try using the variant's enum: `CompileFlag`
 
 error[E0573]: expected type, found variant `CompileFlag::A`
-  --> $DIR/invalid-enum.rs:31:18
+  --> $DIR/invalid-enum.rs:29:18
    |
 LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
    |                  ^^^^^^^^^^^^^^
@@ -25,75 +25,51 @@ LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
    |                  not a type
    |                  help: try using the variant's enum: `CompileFlag`
 
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/invalid-enum.rs:31:10
+error[E0747]: type provided when a constant was expected
+  --> $DIR/invalid-enum.rs:29:18
    |
 LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
-
-error[E0107]: wrong number of type arguments: expected at most 1, found 2
-  --> $DIR/invalid-enum.rs:31:34
+   |                  ^^^^^^^^^^^^^^
    |
-LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
-   |                                  ^ unexpected type argument
-   |
-help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+help: if this generic argument was intended as a const parameter, try surrounding it with braces:
    |
 LL |   let _: Example<{ CompileFlag::A }, _> = Example { x: 0 };
    |                  ^                ^
 
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/invalid-enum.rs:36:10
+error[E0747]: type provided when a constant was expected
+  --> $DIR/invalid-enum.rs:33:18
    |
 LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
-
-error[E0107]: wrong number of type arguments: expected at most 1, found 2
-  --> $DIR/invalid-enum.rs:36:39
+   |                  ^^^^^^^^^^^^^^^^^^^
    |
-LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
-   |                                       ^ unexpected type argument
-   |
-help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+help: if this generic argument was intended as a const parameter, try surrounding it with braces:
    |
 LL |   let _: Example<{ Example::ASSOC_FLAG }, _> = Example { x: 0 };
    |                  ^                     ^
 
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/invalid-enum.rs:21:3
-   |
-LL |   test_1::<CompileFlag::A>();
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
-
-error[E0107]: wrong number of type arguments: expected 0, found 1
+error[E0747]: type provided when a constant was expected
   --> $DIR/invalid-enum.rs:21:12
    |
 LL |   test_1::<CompileFlag::A>();
-   |            ^^^^^^^^^^^^^^ unexpected type argument
+   |            ^^^^^^^^^^^^^^
    |
-help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+help: if this generic argument was intended as a const parameter, try surrounding it with braces:
    |
 LL |   test_1::<{ CompileFlag::A }>();
    |            ^                ^
 
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/invalid-enum.rs:26:3
+error[E0747]: type provided when a constant was expected
+  --> $DIR/invalid-enum.rs:25:15
    |
 LL |   test_2::<_, CompileFlag::A>(0);
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
-
-error[E0107]: wrong number of type arguments: expected 1, found 2
-  --> $DIR/invalid-enum.rs:26:15
+   |               ^^^^^^^^^^^^^^
    |
-LL |   test_2::<_, CompileFlag::A>(0);
-   |               ^^^^^^^^^^^^^^ unexpected type argument
-   |
-help: If this generic argument was intended as a const parameter, try surrounding it with braces:
+help: if this generic argument was intended as a const parameter, try surrounding it with braces:
    |
 LL |   test_2::<_, { CompileFlag::A }>(0);
    |               ^                ^
 
-error: aborting due to 11 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0107, E0573.
-For more information about an error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0573, E0747.
+For more information about an error, try `rustc --explain E0573`.

--- a/src/test/ui/const-generics/issues/issue-62878.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-62878.full.stderr
@@ -4,17 +4,11 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
 
-error[E0107]: wrong number of const arguments: expected 2, found 1
-  --> $DIR/issue-62878.rs:11:5
-   |
-LL |     foo::<_, {[1]}>();
-   |     ^^^^^^^^^^^^^^^ expected 2 const arguments
-
-error[E0107]: wrong number of type arguments: expected 0, found 1
+error[E0747]: type provided when a constant was expected
   --> $DIR/issue-62878.rs:11:11
    |
 LL |     foo::<_, {[1]}>();
-   |           ^ unexpected type argument
+   |           ^
 
 error[E0308]: mismatched types
   --> $DIR/issue-62878.rs:11:15
@@ -22,7 +16,7 @@ error[E0308]: mismatched types
 LL |     foo::<_, {[1]}>();
    |               ^^^ expected `usize`, found array `[{integer}; 1]`
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0107, E0308, E0770.
-For more information about an error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0308, E0747, E0770.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/issues/issue-62878.rs
+++ b/src/test/ui/const-generics/issues/issue-62878.rs
@@ -9,7 +9,6 @@ fn foo<const N: usize, const A: [u8; N]>() {}
 
 fn main() {
     foo::<_, {[1]}>();
-    //[full]~^ ERROR wrong number of const arguments
-    //[full]~| ERROR wrong number of type arguments
+    //[full]~^ ERROR type provided when a constant was expected
     //[full]~| ERROR mismatched types
 }

--- a/src/test/ui/const-generics/issues/issue-76595.rs
+++ b/src/test/ui/const-generics/issues/issue-76595.rs
@@ -13,5 +13,5 @@ fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
 
 fn main() {
     test::<2>();
-    //~^ ERROR wrong number of type
+    //~^ ERROR wrong number of generic arguments
 }

--- a/src/test/ui/const-generics/issues/issue-76595.stderr
+++ b/src/test/ui/const-generics/issues/issue-76595.stderr
@@ -1,8 +1,8 @@
-error[E0107]: wrong number of type arguments: expected 1, found 0
+error[E0107]: wrong number of generic arguments: expected 2, found 1
   --> $DIR/issue-76595.rs:15:5
    |
 LL |     test::<2>();
-   |     ^^^^^^^^^ expected 1 type argument
+   |     ^^^^^^^^^ expected 2 generic arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.rs
@@ -13,8 +13,7 @@ fn b() {
     foo::<BAR + BAR>();
     //~^ ERROR expected trait, found constant `BAR`
     //~| ERROR expected trait, found constant `BAR`
-    //~| ERROR wrong number of const arguments: expected 1, found 0
-    //~| ERROR wrong number of type arguments: expected 0, found 1
+    //~| ERROR type provided when a constant was expected
     //~| WARN trait objects without an explicit `dyn` are deprecated
 }
 fn c() {

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
@@ -10,7 +10,7 @@ LL |     foo::<{ BAR + 3 }>();
    |           ^         ^
 
 error: expressions must be enclosed in braces to be used as const generic arguments
-  --> $DIR/const-expression-suggest-missing-braces.rs:21:11
+  --> $DIR/const-expression-suggest-missing-braces.rs:20:11
    |
 LL |     foo::<3 + 3>();
    |           ^^^^^
@@ -21,7 +21,7 @@ LL |     foo::<{ 3 + 3 }>();
    |           ^       ^
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:24:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:23:15
    |
 LL |     foo::<BAR - 3>();
    |               ^ expected one of `,` or `>`
@@ -32,7 +32,7 @@ LL |     foo::<{ BAR - 3 }>();
    |           ^         ^
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:27:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:26:15
    |
 LL |     foo::<BAR - BAR>();
    |               ^ expected one of `,` or `>`
@@ -43,7 +43,7 @@ LL |     foo::<{ BAR - BAR }>();
    |           ^           ^
 
 error: expressions must be enclosed in braces to be used as const generic arguments
-  --> $DIR/const-expression-suggest-missing-braces.rs:30:11
+  --> $DIR/const-expression-suggest-missing-braces.rs:29:11
    |
 LL |     foo::<100 - BAR>();
    |           ^^^^^^^^^
@@ -54,7 +54,7 @@ LL |     foo::<{ 100 - BAR }>();
    |           ^           ^
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:33:19
+  --> $DIR/const-expression-suggest-missing-braces.rs:32:19
    |
 LL |     foo::<bar<i32>()>();
    |                   ^ expected one of `,` or `>`
@@ -65,7 +65,7 @@ LL |     foo::<{ bar<i32>() }>();
    |           ^            ^
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:36:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:35:21
    |
 LL |     foo::<bar::<i32>()>();
    |                     ^ expected one of `,` or `>`
@@ -76,7 +76,7 @@ LL |     foo::<{ bar::<i32>() }>();
    |           ^              ^
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:39:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:38:21
    |
 LL |     foo::<bar::<i32>() + BAR>();
    |                     ^ expected one of `,` or `>`
@@ -87,7 +87,7 @@ LL |     foo::<{ bar::<i32>() + BAR }>();
    |           ^                    ^
 
 error: expected one of `,` or `>`, found `(`
-  --> $DIR/const-expression-suggest-missing-braces.rs:42:21
+  --> $DIR/const-expression-suggest-missing-braces.rs:41:21
    |
 LL |     foo::<bar::<i32>() - BAR>();
    |                     ^ expected one of `,` or `>`
@@ -98,7 +98,7 @@ LL |     foo::<{ bar::<i32>() - BAR }>();
    |           ^                    ^
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:45:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:44:15
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
@@ -109,7 +109,7 @@ LL |     foo::<{ BAR - bar::<i32>() }>();
    |           ^                    ^
 
 error: expected one of `,` or `>`, found `-`
-  --> $DIR/const-expression-suggest-missing-braces.rs:48:15
+  --> $DIR/const-expression-suggest-missing-braces.rs:47:15
    |
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
@@ -139,19 +139,13 @@ LL |     foo::<BAR + BAR>();
    |
    = note: `#[warn(bare_trait_objects)]` on by default
 
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/const-expression-suggest-missing-braces.rs:13:5
-   |
-LL |     foo::<BAR + BAR>();
-   |     ^^^^^^^^^^^^^^^^ expected 1 const argument
-
-error[E0107]: wrong number of type arguments: expected 0, found 1
+error[E0747]: type provided when a constant was expected
   --> $DIR/const-expression-suggest-missing-braces.rs:13:11
    |
 LL |     foo::<BAR + BAR>();
-   |           ^^^^^^^^^ unexpected type argument
+   |           ^^^^^^^^^
 
-error: aborting due to 15 previous errors; 1 warning emitted
+error: aborting due to 14 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0107, E0404.
-For more information about an error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0404, E0747.
+For more information about an error, try `rustc --explain E0404`.

--- a/src/test/ui/const-generics/min_const_generics/macro-fail.rs
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.rs
@@ -14,11 +14,9 @@ trait Marker<const N: usize> {}
 impl<const N: usize> Marker<N> for Example<N> {}
 
 fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
-  //~^ ERROR wrong number of const
-  //~| ERROR wrong number of type
+  //~^ ERROR: type provided when a constant was expected
   Example::<gimme_a_const!(marker)>
-  //~^ ERROR wrong number of const
-  //~| ERROR wrong number of type
+  //~^ ERROR: type provided when a constant was expected
 }
 
 fn from_marker(_: impl Marker<{
@@ -38,11 +36,9 @@ fn main() {
   }>;
 
   let _fail = Example::<external_macro!()>;
-  //~^ ERROR wrong number of const
-  //~| ERROR wrong number of type
+  //~^ ERROR: type provided when a constant was expected
 
   let _fail = Example::<gimme_a_const!()>;
-  //~^ ERROR wrong number of const
-  //~| ERROR wrong number of type
+  //~^ ERROR: type provided when a constant was expected
   //~| ERROR unexpected end of macro invocation
 }

--- a/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -1,5 +1,5 @@
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:33:27
+  --> $DIR/macro-fail.rs:31:27
    |
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
    |                                 ----------------------
@@ -13,7 +13,7 @@ LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
-  --> $DIR/macro-fail.rs:33:27
+  --> $DIR/macro-fail.rs:31:27
    |
 LL |   Example::<gimme_a_const!(marker)>
    |             ----------------------
@@ -46,7 +46,7 @@ LL |     let _fail = Example::<external_macro!()>;
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
-  --> $DIR/macro-fail.rs:44:25
+  --> $DIR/macro-fail.rs:41:25
    |
 LL |     macro_rules! gimme_a_const {
    |     -------------------------- when calling this macro
@@ -54,54 +54,30 @@ LL |     macro_rules! gimme_a_const {
 LL |   let _fail = Example::<gimme_a_const!()>;
    |                         ^^^^^^^^^^^^^^^^ missing tokens in macro arguments
 
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/macro-fail.rs:16:26
-   |
-LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
-
-error[E0107]: wrong number of type arguments: expected 0, found 1
+error[E0747]: type provided when a constant was expected
   --> $DIR/macro-fail.rs:16:33
    |
 LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
-   |                                 ^^^^^^^^^^^^^^^^^^^^^^ unexpected type argument
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/macro-fail.rs:19:3
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:18:13
    |
 LL |   Example::<gimme_a_const!(marker)>
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+   |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/macro-fail.rs:19:13
-   |
-LL |   Example::<gimme_a_const!(marker)>
-   |             ^^^^^^^^^^^^^^^^^^^^^^ unexpected type argument
-
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/macro-fail.rs:40:15
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:38:25
    |
 LL |   let _fail = Example::<external_macro!()>;
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+   |                         ^^^^^^^^^^^^^^^^^
 
-error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/macro-fail.rs:40:25
-   |
-LL |   let _fail = Example::<external_macro!()>;
-   |                         ^^^^^^^^^^^^^^^^^ unexpected type argument
-
-error[E0107]: wrong number of const arguments: expected 1, found 0
-  --> $DIR/macro-fail.rs:44:15
+error[E0747]: type provided when a constant was expected
+  --> $DIR/macro-fail.rs:41:25
    |
 LL |   let _fail = Example::<gimme_a_const!()>;
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+   |                         ^^^^^^^^^^^^^^^^
 
-error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/macro-fail.rs:44:25
-   |
-LL |   let _fail = Example::<gimme_a_const!()>;
-   |                         ^^^^^^^^^^^^^^^^ unexpected type argument
+error: aborting due to 8 previous errors
 
-error: aborting due to 12 previous errors
-
-For more information about this error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0747`.

--- a/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -1,8 +1,8 @@
 error[E0107]: wrong number of type arguments: expected at most 2, found 3
-  --> $DIR/generic-impl-more-params-with-defaults.rs:13:5
+  --> $DIR/generic-impl-more-params-with-defaults.rs:13:24
    |
 LL |     Vec::<isize, Heap, bool>::new();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 2 type arguments
+   |                        ^^^^ unexpected type argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -1,8 +1,8 @@
 error[E0107]: wrong number of type arguments: expected at most 2, found 3
-  --> $DIR/generic-type-more-params-with-defaults.rs:9:12
+  --> $DIR/generic-type-more-params-with-defaults.rs:9:29
    |
 LL |     let _: Vec<isize, Heap, bool>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^ expected at most 2 type arguments
+   |                             ^^^^ unexpected type argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-14303-fncall.stderr
+++ b/src/test/ui/parser/issue-14303-fncall.stderr
@@ -3,8 +3,6 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL |         .collect::<Vec<S<_, 'a>>>();
    |                          ^
-   |
-   = note: lifetime arguments must be provided before type arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-14303-path.stderr
+++ b/src/test/ui/parser/issue-14303-path.stderr
@@ -3,8 +3,6 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL | fn bar<'a, 'b, 'c, T>(x: foo::X<'a, T, 'b, 'c>) {}
    |                                     ^
-   |
-   = note: lifetime arguments must be provided before type arguments
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/privacy-ns1.rs
+++ b/src/test/ui/privacy/privacy-ns1.rs
@@ -32,8 +32,8 @@ pub mod foo2 {
 fn test_glob2() {
     use foo2::*;
 
-    let _x: Box<Bar>;  //~ ERROR wrong number of const arguments: expected 0, found 1
-    //~^ ERROR wrong number of type arguments: expected at least 1, found 0
+    let _x: Box<Bar>;
+    //~^ ERROR constant provided when a type was expected
 }
 
 // neither public

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -52,19 +52,13 @@ help: consider importing this trait
 LL | use foo1::Bar;
    |
 
-error[E0107]: wrong number of const arguments: expected 0, found 1
+error[E0747]: constant provided when a type was expected
   --> $DIR/privacy-ns1.rs:35:17
    |
 LL |     let _x: Box<Bar>;
-   |                 ^^^ unexpected const argument
+   |                 ^^^
 
-error[E0107]: wrong number of type arguments: expected at least 1, found 0
-  --> $DIR/privacy-ns1.rs:35:13
-   |
-LL |     let _x: Box<Bar>;
-   |             ^^^^^^^^ expected at least 1 type argument
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0107, E0412, E0423, E0425.
-For more information about an error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0412, E0423, E0425, E0747.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/privacy/privacy-ns2.rs
+++ b/src/test/ui/privacy/privacy-ns2.rs
@@ -38,16 +38,14 @@ pub mod foo2 {
 fn test_single2() {
     use foo2::Bar;
 
-    let _x : Box<Bar>; //~ ERROR wrong number of const arguments: expected 0, found 1
-    //~^ ERROR wrong number of type arguments: expected at least 1, found 0
+    let _x : Box<Bar>; //~ ERROR constant provided when a type was expected
     let _x : Bar(); //~ ERROR expected type, found function `Bar`
 }
 
 fn test_list2() {
     use foo2::{Bar,Baz};
 
-    let _x: Box<Bar>; //~ ERROR wrong number of const arguments: expected 0, found 1
-    //~^ ERROR wrong number of type arguments: expected at least 1, found 0
+    let _x: Box<Bar>; //~ ERROR constant provided when a type was expected
 }
 
 // neither public

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -28,7 +28,7 @@ LL | use foo2::Bar;
    |
 
 error[E0573]: expected type, found function `Bar`
-  --> $DIR/privacy-ns2.rs:43:14
+  --> $DIR/privacy-ns2.rs:42:14
    |
 LL |     let _x : Bar();
    |              ^^^^^ not a type
@@ -43,66 +43,54 @@ LL | use foo1::Bar;
    |
 
 error[E0603]: trait `Bar` is private
-  --> $DIR/privacy-ns2.rs:63:15
+  --> $DIR/privacy-ns2.rs:61:15
    |
 LL |     use foo3::Bar;
    |               ^^^ private trait
    |
 note: the trait `Bar` is defined here
-  --> $DIR/privacy-ns2.rs:55:5
+  --> $DIR/privacy-ns2.rs:53:5
    |
 LL |     trait Bar {
    |     ^^^^^^^^^
 
 error[E0603]: trait `Bar` is private
-  --> $DIR/privacy-ns2.rs:67:15
+  --> $DIR/privacy-ns2.rs:65:15
    |
 LL |     use foo3::Bar;
    |               ^^^ private trait
    |
 note: the trait `Bar` is defined here
-  --> $DIR/privacy-ns2.rs:55:5
+  --> $DIR/privacy-ns2.rs:53:5
    |
 LL |     trait Bar {
    |     ^^^^^^^^^
 
 error[E0603]: trait `Bar` is private
-  --> $DIR/privacy-ns2.rs:74:16
+  --> $DIR/privacy-ns2.rs:72:16
    |
 LL |     use foo3::{Bar,Baz};
    |                ^^^ private trait
    |
 note: the trait `Bar` is defined here
-  --> $DIR/privacy-ns2.rs:55:5
+  --> $DIR/privacy-ns2.rs:53:5
    |
 LL |     trait Bar {
    |     ^^^^^^^^^
 
-error[E0107]: wrong number of const arguments: expected 0, found 1
+error[E0747]: constant provided when a type was expected
   --> $DIR/privacy-ns2.rs:41:18
    |
 LL |     let _x : Box<Bar>;
-   |                  ^^^ unexpected const argument
+   |                  ^^^
 
-error[E0107]: wrong number of type arguments: expected at least 1, found 0
-  --> $DIR/privacy-ns2.rs:41:14
-   |
-LL |     let _x : Box<Bar>;
-   |              ^^^^^^^^ expected at least 1 type argument
-
-error[E0107]: wrong number of const arguments: expected 0, found 1
-  --> $DIR/privacy-ns2.rs:49:17
+error[E0747]: constant provided when a type was expected
+  --> $DIR/privacy-ns2.rs:48:17
    |
 LL |     let _x: Box<Bar>;
-   |                 ^^^ unexpected const argument
+   |                 ^^^
 
-error[E0107]: wrong number of type arguments: expected at least 1, found 0
-  --> $DIR/privacy-ns2.rs:49:13
-   |
-LL |     let _x: Box<Bar>;
-   |             ^^^^^^^^ expected at least 1 type argument
+error: aborting due to 8 previous errors
 
-error: aborting due to 10 previous errors
-
-Some errors have detailed explanations: E0107, E0423, E0573, E0603.
-For more information about an error, try `rustc --explain E0107`.
+Some errors have detailed explanations: E0423, E0573, E0603, E0747.
+For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/suggestions/suggest-move-types.stderr
+++ b/src/test/ui/suggestions/suggest-move-types.stderr
@@ -107,16 +107,12 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL | struct Al<'a, T, M: OneWithLifetime<A=(), T, 'a>> {
    |                                           ^
-   |
-   = note: lifetime arguments must be provided before type arguments
 
 error[E0747]: type provided when a lifetime was expected
   --> $DIR/suggest-move-types.rs:48:71
    |
 LL | struct Bl<'a, 'b, 'c, T, U, V, M: ThreeWithLifetime<A=(), B=(), C=(), T, U, V, 'a, 'b, 'c>> {
    |                                                                       ^
-   |
-   = note: lifetime arguments must be provided before type arguments
 
 error[E0747]: lifetime provided when a type was expected
   --> $DIR/suggest-move-types.rs:65:56

--- a/src/test/ui/traits/trait-object-vs-lifetime.stderr
+++ b/src/test/ui/traits/trait-object-vs-lifetime.stderr
@@ -27,8 +27,6 @@ error[E0747]: type provided when a lifetime was expected
    |
 LL |     let _: S<dyn 'static +, 'static>;
    |              ^^^^^^^^^^^^^
-   |
-   = note: lifetime arguments must be provided before type arguments
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Doesn't completely remove `check_generic_arg_count` as that would have required some more complex changes but
instead checks type and const params in only one step. Also moved the help added by @JulianKnodt in #75611 to `generic_arg_mismatch_err`. 

r? @varkor cc @petrochenkov 