### PR TITLE
Access Session and OnDiskCache in rustc_query_system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4084,6 +4084,7 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_serialize",
+ "rustc_session",
  "rustc_span",
  "smallvec 1.4.2",
  "tracing",

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -235,7 +235,5 @@ fn encode_work_product_index(
 }
 
 fn encode_query_cache(tcx: TyCtxt<'_>, encoder: &mut Encoder) {
-    tcx.sess.time("incr_comp_serialize_result_cache", || {
-        tcx.serialize_query_result_cache(encoder).unwrap();
-    })
+    tcx.sess.time("incr_comp_serialize_result_cache", || tcx.serialize_query_result_cache(encoder))
 }

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -50,22 +50,6 @@ impl<'tcx, E: TyEncoder<'tcx>> EncodableWithShorthand<'tcx, E> for ty::Predicate
     }
 }
 
-pub trait OpaqueEncoder: Encoder {
-    fn opaque(&mut self) -> &mut rustc_serialize::opaque::Encoder;
-    fn encoder_position(&self) -> usize;
-}
-
-impl OpaqueEncoder for rustc_serialize::opaque::Encoder {
-    #[inline]
-    fn opaque(&mut self) -> &mut rustc_serialize::opaque::Encoder {
-        self
-    }
-    #[inline]
-    fn encoder_position(&self) -> usize {
-        self.position()
-    }
-}
-
 pub trait TyEncoder<'tcx>: Encoder {
     const CLEAR_CROSS_CRATE: bool;
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -47,6 +47,7 @@ use rustc_hir::{
 };
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_macros::HashStable;
+use rustc_serialize::opaque;
 use rustc_session::config::{BorrowckMode, CrateType, OutputFilenames};
 use rustc_session::lint::{Level, Lint};
 use rustc_session::Session;
@@ -1335,10 +1336,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    pub fn serialize_query_result_cache<E>(self, encoder: &mut E) -> Result<(), E::Error>
-    where
-        E: ty::codec::OpaqueEncoder,
-    {
+    pub fn serialize_query_result_cache(self, encoder: &mut opaque::Encoder) -> Result<(), !> {
         self.queries.on_disk_cache.as_ref().map(|c| c.serialize(self, encoder)).unwrap_or(Ok(()))
     }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -47,6 +47,7 @@ use rustc_hir::{
 };
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_macros::HashStable;
+use rustc_query_system::dep_graph::OnDiskCache as _;
 use rustc_serialize::opaque;
 use rustc_session::config::{BorrowckMode, CrateType, OutputFilenames};
 use rustc_session::lint::{Level, Lint};
@@ -1336,8 +1337,8 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    pub fn serialize_query_result_cache(self, encoder: &mut opaque::Encoder) -> Result<(), !> {
-        self.queries.on_disk_cache.as_ref().map(|c| c.serialize(self, encoder)).unwrap_or(Ok(()))
+    pub fn serialize_query_result_cache(self, encoder: &mut opaque::Encoder) {
+        self.queries.on_disk_cache.as_ref().map(|c| c.serialize(self, encoder)).unwrap_or(())
     }
 
     /// If `true`, we should use the MIR-based borrowck, but also

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -240,7 +240,7 @@ impl<'sess> OnDiskCache<'sess> {
         }
     }
 
-    pub fn serialize<'tcx>(
+    crate fn serialize<'tcx>(
         &self,
         tcx: TyCtxt<'tcx>,
         encoder: &mut opaque::Encoder,
@@ -422,7 +422,7 @@ impl<'sess> OnDiskCache<'sess> {
     }
 
     /// Loads a diagnostic emitted during the previous compilation session.
-    pub fn load_diagnostics(
+    crate fn load_diagnostics(
         &self,
         tcx: TyCtxt<'_>,
         dep_node_index: SerializedDepNodeIndex,
@@ -438,7 +438,7 @@ impl<'sess> OnDiskCache<'sess> {
     /// the next compilation session.
     #[inline(never)]
     #[cold]
-    pub fn store_diagnostics(
+    crate fn store_diagnostics(
         &self,
         dep_node_index: DepNodeIndex,
         diagnostics: ThinVec<Diagnostic>,
@@ -506,7 +506,7 @@ impl<'sess> OnDiskCache<'sess> {
     /// 1:1 relationship between query-key and `DepNode`.
     #[inline(never)]
     #[cold]
-    pub fn store_diagnostics_for_anon_node(
+    crate fn store_diagnostics_for_anon_node(
         &self,
         dep_node_index: DepNodeIndex,
         diagnostics: ThinVec<Diagnostic>,
@@ -1153,7 +1153,7 @@ where
 struct IntEncodedWithFixedSize(u64);
 
 impl IntEncodedWithFixedSize {
-    pub const ENCODED_SIZE: usize = 8;
+    const ENCODED_SIZE: usize = 8;
 }
 
 impl Encodable<opaque::Encoder> for IntEncodedWithFixedSize {

--- a/compiler/rustc_middle/src/ty/query/plumbing.rs
+++ b/compiler/rustc_middle/src/ty/query/plumbing.rs
@@ -19,13 +19,6 @@ use rustc_span::Span;
 impl QueryContext for TyCtxt<'tcx> {
     type Query = Query<'tcx>;
 
-    fn incremental_verify_ich(&self) -> bool {
-        self.sess.opts.debugging_opts.incremental_verify_ich
-    }
-    fn verbose(&self) -> bool {
-        self.sess.verbose()
-    }
-
     fn def_path_str(&self, def_id: DefId) -> String {
         TyCtxt::def_path_str(*self, def_id)
     }

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -16,6 +16,7 @@ rustc_errors = { path = "../rustc_errors" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_index = { path = "../rustc_index" }
 rustc_serialize = { path = "../rustc_serialize" }
+rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 parking_lot = "0.11"
 smallvec = { version = "1.0", features = ["union", "may_dangle"] }

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -88,7 +88,10 @@ impl<K: DepKind> DepNode<K> {
 
         #[cfg(debug_assertions)]
         {
-            if !kind.can_reconstruct_query_key() && tcx.debug_dep_node() {
+            if !kind.can_reconstruct_query_key()
+                && (tcx.sess().opts.debugging_opts.incremental_info
+                    || tcx.sess().opts.debugging_opts.query_dep_graph)
+            {
                 tcx.dep_graph().register_dep_node_debug_str(dep_node, || arg.to_debug_str(tcx));
             }
         }

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -258,7 +258,7 @@ impl<K: DepKind> DepGraph<K> {
                 task_deps.map(|lock| lock.into_inner()),
             );
 
-            let print_status = cfg!(debug_assertions) && cx.debug_dep_tasks();
+            let print_status = cfg!(debug_assertions) && cx.sess().opts.debugging_opts.dep_tasks;
 
             // Determine the color of the new DepNode.
             if let Some(prev_index) = data.previous.node_to_index_opt(&key) {
@@ -645,7 +645,7 @@ impl<K: DepKind> DepGraph<K> {
                                 return None;
                             }
                             None => {
-                                if !tcx.has_errors_or_delayed_span_bugs() {
+                                if !tcx.sess().has_errors_or_delayed_span_bugs() {
                                     panic!(
                                         "try_mark_previous_green() - Forcing the DepNode \
                                           should have set its color"
@@ -753,7 +753,7 @@ impl<K: DepKind> DepGraph<K> {
             // Promote the previous diagnostics to the current session.
             tcx.store_diagnostics(dep_node_index, diagnostics.clone().into());
 
-            let handle = tcx.diagnostic();
+            let handle = tcx.sess().diagnostic();
 
             for diagnostic in diagnostics {
                 handle.emit_diagnostic(&diagnostic);

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -15,6 +15,7 @@ use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sync::Lock;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::Diagnostic;
+use rustc_session::Session;
 use rustc_span::def_id::DefPathHash;
 
 use std::fmt;
@@ -27,19 +28,10 @@ pub trait DepContext: Copy {
     /// Create a hashing context for hashing new results.
     fn create_stable_hashing_context(&self) -> Self::StableHashingContext;
 
-    fn debug_dep_tasks(&self) -> bool;
-    fn debug_dep_node(&self) -> bool;
-
     /// Try to force a dep node to execute and see if it's green.
     fn try_force_from_dep_node(&self, dep_node: &DepNode<Self::DepKind>) -> bool;
 
     fn register_reused_dep_path_hash(&self, hash: DefPathHash);
-
-    /// Return whether the current session is tainted by errors.
-    fn has_errors_or_delayed_span_bugs(&self) -> bool;
-
-    /// Return the diagnostic handler.
-    fn diagnostic(&self) -> &rustc_errors::Handler;
 
     /// Load data from the on-disk cache.
     fn try_load_from_on_disk_cache(&self, dep_node: &DepNode<Self::DepKind>);
@@ -59,6 +51,9 @@ pub trait DepContext: Copy {
 
     /// Access the profiler.
     fn profiler(&self) -> &SelfProfilerRef;
+
+    /// Access the compiler session.
+    fn sess(&self) -> &Session;
 }
 
 /// Describe the different families of dependency nodes.

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -26,9 +26,6 @@ use rustc_span::def_id::DefId;
 pub trait QueryContext: DepContext {
     type Query: Clone + HashStable<Self::StableHashingContext>;
 
-    fn incremental_verify_ich(&self) -> bool;
-    fn verbose(&self) -> bool;
-
     /// Get string representation from DefPath.
     fn def_path_str(&self, def_id: DefId) -> String;
 

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -530,7 +530,7 @@ where
 
     // If `-Zincremental-verify-ich` is specified, re-hash results from
     // the cache and make sure that they have the expected fingerprint.
-    if unlikely!(tcx.incremental_verify_ich()) {
+    if unlikely!(tcx.sess().opts.debugging_opts.incremental_verify_ich) {
         incremental_verify_ich(tcx, &result, dep_node, dep_node_index, query);
     }
 


### PR DESCRIPTION
Reduces the boilerplace of implementing the `DepContext` trait.
The OnDiskCache is accessed directly through a dedicated trait.