### PR TITLE
Build the compiler with -Ctarget-cpu=x86-64-v2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,8 +36,8 @@
 	url = https://github.com/rust-lang/edition-guide.git
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/11.0-2020-10-12
+	url = https://github.com/est31/llvm-project.git
+	branch = rustc/11.0-2020-11-14
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -149,7 +149,7 @@ impl Step for Rustc {
             target,
             cargo_subcommand(builder.kind),
         );
-        rustc_cargo(builder, &mut cargo, target);
+        rustc_cargo(builder, &mut cargo, target, compiler);
         if let Subcommand::Check { all_targets: true, .. } = builder.config.cmd {
             cargo.arg("--all-targets");
         }
@@ -215,7 +215,7 @@ impl Step for CodegenBackend {
         cargo
             .arg("--manifest-path")
             .arg(builder.src.join(format!("compiler/rustc_codegen_{}/Cargo.toml", backend)));
-        rustc_cargo_env(builder, &mut cargo, target);
+        rustc_cargo_env(builder, &mut cargo, target, compiler);
 
         run_cargo(
             builder,

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -499,7 +499,7 @@ impl Step for Rustc {
         });
 
         let mut cargo = builder.cargo(compiler, Mode::Rustc, SourceType::InTree, target, "build");
-        rustc_cargo(builder, &mut cargo, target);
+        rustc_cargo(builder, &mut cargo, target, compiler);
 
         builder.info(&format!(
             "Building stage{} compiler artifacts ({} -> {})",
@@ -522,16 +522,16 @@ impl Step for Rustc {
     }
 }
 
-pub fn rustc_cargo(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelection) {
+pub fn rustc_cargo(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelection, compiler: Compiler) {
     cargo
         .arg("--features")
         .arg(builder.rustc_features())
         .arg("--manifest-path")
         .arg(builder.src.join("compiler/rustc/Cargo.toml"));
-    rustc_cargo_env(builder, cargo, target);
+    rustc_cargo_env(builder, cargo, target, compiler);
 }
 
-pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelection) {
+pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetSelection, compiler: Compiler) {
     // Set some configuration variables picked up by build scripts and
     // the compiler alike
     cargo
@@ -561,7 +561,11 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
     if builder.config.rust_verify_llvm_ir {
         cargo.env("RUSTC_VERIFY_LLVM_IR", "1");
     }
-
+    if target == "x86_64-unknown-linux-gnu" && compiler.stage > 0 {
+        if builder.is_rust_llvm(target) {
+            cargo.rustflag("-Ctarget-cpu=x86-64-v2");
+        }
+    }
     // Pass down configuration from the LLVM build into the build of
     // rustc_llvm and rustc_codegen_llvm.
     //
@@ -701,7 +705,7 @@ impl Step for CodegenBackend {
         cargo
             .arg("--manifest-path")
             .arg(builder.src.join(format!("compiler/rustc_codegen_{}/Cargo.toml", backend)));
-        rustc_cargo_env(builder, &mut cargo, target);
+        rustc_cargo_env(builder, &mut cargo, target, compiler);
 
         let tmp_stamp = out_dir.join(".tmp.stamp");
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -563,7 +563,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
     }
     if target == "x86_64-unknown-linux-gnu" && compiler.stage > 0 {
         if builder.is_rust_llvm(target) {
-            cargo.rustflag("-Ctarget-cpu=x86-64-v2");
+            cargo.rustflag("-Ctarget-cpu=x86-64-v3");
         }
     }
     // Pass down configuration from the LLVM build into the build of

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -527,7 +527,7 @@ impl Step for Rustc {
         cargo.rustdocflag("--document-private-items");
         cargo.rustdocflag("--enable-index-page");
         cargo.rustdocflag("-Zunstable-options");
-        compile::rustc_cargo(builder, &mut cargo, target);
+        compile::rustc_cargo(builder, &mut cargo, target, compiler);
 
         // Only include compiler crates, no dependencies of those, such as `libc`.
         cargo.arg("--no-deps");

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1732,7 +1732,7 @@ impl Step for Crate {
             }
             Mode::Rustc => {
                 builder.ensure(compile::Rustc { compiler, target });
-                compile::rustc_cargo(builder, &mut cargo, target);
+                compile::rustc_cargo(builder, &mut cargo, target, compiler);
             }
             _ => panic!("can only test libraries"),
         };


### PR DESCRIPTION
This PR instructs rustbuild to compile the compiler with the `-Ctarget-cpu=x86-64-v2` option enabled in hope of getting some optimization gains from autovectorization.

The PR also adds support for `x86-64-{2,3,4}` target CPUs by [backporting an LLVM 12.0 commit](https://github.com/llvm/llvm-project/commit/012dd42e027e).

I'm opening this to get a perf run to gauge the potential speedups on the rustc side. The LLVM side isn't built with the option enabled, as that would require clang 12.0 or manual enabling of the target features corresponding to the target CPU.

If the perf run shows up nice improvements one can talk about how to get this to users. One can't just enable this unconditionally for all users as it'd break for users of older CPUs. It's a similar question to #59667.