### PR TITLE
Print 'checking cranelift artifacts' to easily separate it from other artifacts

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -232,6 +232,11 @@ impl Step for CodegenBackend {
             .arg(builder.src.join(format!("compiler/rustc_codegen_{}/Cargo.toml", backend)));
         rustc_cargo_env(builder, &mut cargo, target);
 
+        builder.info(&format!(
+            "Checking {} artifacts ({} -> {})",
+            backend, &compiler.host.triple, target.triple
+        ));
+
         run_cargo(
             builder,
             cargo,


### PR DESCRIPTION
Before:

```
Checking rustdoc artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    Checking rustdoc v0.0.0 (/home/joshua/rustc/src/librustdoc)
    Checking rustdoc-tool v0.0.0 (/home/joshua/rustc/src/tools/rustdoc)
    Finished release [optimized] target(s) in 2.08s
    Checking regalloc v0.0.31
    Checking gimli v0.22.0
    Checking object v0.21.1
    Checking cranelift-codegen v0.67.0 (https://github.com/bytecodealliance/wasmtime/?branch=main#44cbdece)
    Checking cranelift-module v0.67.0 (https://github.com/bytecodealliance/wasmtime/?branch=main#44cbdece)
    Checking cranelift-native v0.67.0 (https://github.com/bytecodealliance/wasmtime/?branch=main#44cbdece)
    Checking cranelift-frontend v0.67.0 (https://github.com/bytecodealliance/wasmtime/?branch=main#44cbdece)
    Checking cranelift-object v0.67.0 (https://github.com/bytecodealliance/wasmtime/?branch=main#44cbdece)
    Checking cranelift-simplejit v0.67.0 (https://github.com/bytecodealliance/wasmtime/?branch=main#44cbdece)
    Checking rustc_codegen_cranelift v0.1.0 (/home/joshua/rustc/compiler/rustc_codegen_cranelift)
    Finished release [optimized] target(s) in 10.55s

```

After:

```
Checking rustdoc artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    Checking rustdoc v0.0.0 (/home/joshua/rustc/src/librustdoc)
    Checking rustdoc-tool v0.0.0 (/home/joshua/rustc/src/tools/rustdoc)
    Finished release [optimized] target(s) in 2.08s
Checking cranelift artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
    Checking cranelift-codegen v0.67.0 (https://github.com/bytecodealliance/wasmtime/?branch=main#44cbdece)
```

r? @bjorn3 
@bors delegate=bjorn3