### PR TITLE
Fix displaying errors when rustbook tests fail.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,6 +3016,7 @@ name = "rustbook"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "env_logger 0.7.1",
  "mdbook",
 ]
 

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.25.0"
+env_logger = "0.7.1"
 
 [dependencies.mdbook]
 version = "0.4.3"

--- a/src/tools/rustbook/src/main.rs
+++ b/src/tools/rustbook/src/main.rs
@@ -9,6 +9,7 @@ use mdbook::errors::Result as Result3;
 use mdbook::MDBook;
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
     let d_message = "-d, --dest-dir=[dest-dir]
 'The output directory for your book{n}(Defaults to ./book when omitted)'";
     let dir_message = "[dir]


### PR DESCRIPTION
This ensures that output from mdbook is displayed when running the rustbook wrapper. I believe this was a regression as a result of #69115 where it was changed from running `rustdoc` directly to using rustbook.
