### PR TITLE
Improve the diagnostic for when an `fn` contains qualifiers inside an `extern` block.

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -522,7 +522,7 @@ impl<'a> AstValidator<'a> {
             self.err_handler()
                 .struct_span_err(ident.span, "functions in `extern` blocks cannot have qualifiers")
                 .span_label(self.current_extern_span(), "in this `extern` block")
-                .span_suggestion(
+                .span_suggestion_verbose(
                     span.until(ident.span.shrink_to_lo()),
                     "remove the qualifiers",
                     "fn ".to_string(),

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -108,9 +108,12 @@ error: functions in `extern` blocks cannot have qualifiers
 LL |     extern {
    |     ------ in this `extern` block
 LL |         async fn fe1();
-   |         ---------^^^
-   |         |
-   |         help: remove the qualifiers: `fn`
+   |                  ^^^
+   |
+help: remove the qualifiers
+   |
+LL |         fn fe1();
+   |         ^^
 
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:52:19
@@ -119,9 +122,12 @@ LL |     extern {
    |     ------ in this `extern` block
 LL |         async fn fe1();
 LL |         unsafe fn fe2();
-   |         ----------^^^
-   |         |
-   |         help: remove the qualifiers: `fn`
+   |                   ^^^
+   |
+help: remove the qualifiers
+   |
+LL |         fn fe2();
+   |         ^^
 
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:53:18
@@ -130,9 +136,12 @@ LL |     extern {
    |     ------ in this `extern` block
 ...
 LL |         const fn fe3();
-   |         ---------^^^
-   |         |
-   |         help: remove the qualifiers: `fn`
+   |                  ^^^
+   |
+help: remove the qualifiers
+   |
+LL |         fn fe3();
+   |         ^^
 
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:54:23
@@ -141,9 +150,12 @@ LL |     extern {
    |     ------ in this `extern` block
 ...
 LL |         extern "C" fn fe4();
-   |         --------------^^^
-   |         |
-   |         help: remove the qualifiers: `fn`
+   |                       ^^^
+   |
+help: remove the qualifiers
+   |
+LL |         fn fe4();
+   |         ^^
 
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/fn-header-semantic-fail.rs:55:42
@@ -152,9 +164,12 @@ LL |     extern {
    |     ------ in this `extern` block
 ...
 LL |         const async unsafe extern "C" fn fe5();
-   |         ---------------------------------^^^
-   |         |
-   |         help: remove the qualifiers: `fn`
+   |                                          ^^^
+   |
+help: remove the qualifiers
+   |
+LL |         fn fe5();
+   |         ^^
 
 error: functions cannot be both `const` and `async`
   --> $DIR/fn-header-semantic-fail.rs:55:9

--- a/src/test/ui/parser/no-const-fn-in-extern-block.stderr
+++ b/src/test/ui/parser/no-const-fn-in-extern-block.stderr
@@ -4,9 +4,12 @@ error: functions in `extern` blocks cannot have qualifiers
 LL | extern {
    | ------ in this `extern` block
 LL |     const fn foo();
-   |     ---------^^^
-   |     |
-   |     help: remove the qualifiers: `fn`
+   |              ^^^
+   |
+help: remove the qualifiers
+   |
+LL |     fn foo();
+   |     ^^
 
 error: functions in `extern` blocks cannot have qualifiers
   --> $DIR/no-const-fn-in-extern-block.rs:4:21
@@ -15,9 +18,12 @@ LL | extern {
    | ------ in this `extern` block
 ...
 LL |     const unsafe fn bar();
-   |     ----------------^^^
-   |     |
-   |     help: remove the qualifiers: `fn`
+   |                     ^^^
+   |
+help: remove the qualifiers
+   |
+LL |     fn bar();
+   |     ^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This mitigates #78941. As suggested by @estebank, `span_suggestion` was replaced with `span_suggestion_verbose` for this specific diagnostic.