### PR TITLE
Add Backtrace::set_enabled to override environment variables

### DIFF
--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -231,6 +231,8 @@ impl fmt::Debug for BytesOrWide {
     }
 }
 
+static ENABLED: AtomicUsize = AtomicUsize::new(0);
+
 impl Backtrace {
     /// Returns whether backtrace captures are enabled through environment
     /// variables.
@@ -238,7 +240,6 @@ impl Backtrace {
         // Cache the result of reading the environment variables to make
         // backtrace captures speedy, because otherwise reading environment
         // variables every time can be somewhat slow.
-        static ENABLED: AtomicUsize = AtomicUsize::new(0);
         match ENABLED.load(SeqCst) {
             0 => {}
             1 => return false,
@@ -251,8 +252,15 @@ impl Backtrace {
                 Err(_) => false,
             },
         };
-        ENABLED.store(enabled as usize + 1, SeqCst);
+        Self::set_enabled(enabled);
         enabled
+    }
+
+    /// Explicitly enable or disable backtrace capturing, overriding the default
+    /// derived from the `RUST_BACKTRACE` or `RUST_LIB_BACKTRACE` environment
+    /// variables.
+    pub fn set_enabled(enabled: bool) {
+        ENABLED.store(enabled as usize + 1, SeqCst);
     }
 
     /// Capture a stack backtrace of the current thread.


### PR DESCRIPTION
Implements the API discussed in https://internals.rust-lang.org/t/backtrace-libstd-runtime-enable-disable/13268.

A couple of quotes for reasons why this should be configurable outside just the default environment variables:

> *When it could be needed?* Production use on the server, when sys-admin detected incorrect behavior or developer want to detect why Error was returned. So it would be really useful to change backtrace behaviour of error at run-time.
>
> * notice error in logs
> * call private API (or debug button if UI app) and receive backtraces till disabled.
> 
> So the application user won't have the overhead of backtrace until it's required.

> Another benefit is that you would be able to put this option into your app's configuration file (or any other unified source of configuration) instead of requiring an environment variable.

The reason this needs to be globally configurable is to support deeply enabling backtraces created by libraries, e.g. ones exposed through `Error::backtrace`. An application could use `Backtrace::{force_capture, disabled}` along with checking against its own `enabled` flag, but that would only control points at which it might capture backtraces itself, not backtraces that may be passed back from external libraries.

It might make sense to also expose `Backtrace::enabled()` publicly with this, that would avoid the cost of having to call `Backtrace::capture().status() != BacktraceStatus::Disabled` to detect the current state (though would not give any indication of whether it will be supported or not).

(Given that https://github.com/rust-lang/rust/pull/72981 is close to merging, it's probably best to delay this till that is done and I can create a separate feature flag for it, just wanted to get discussion rolling already).