### PR TITLE
overhaul "missing main" diagnostic

### DIFF
--- a/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
@@ -1,9 +1,13 @@
 error[E0601]: `main` function not found in crate `cfg_attr_cfg_2`
   --> $DIR/cfg-attr-cfg-2.rs:8:1
    |
-LL | / #[cfg_attr(foo, cfg(bar))]
-LL | | fn main() { }
-   | |_____________^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`
+LL | #[cfg_attr(foo, cfg(bar))]
+   | ^
+   |
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
+++ b/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
@@ -2,7 +2,12 @@ error[E0601]: `main` function not found in crate `cfg_in_crate_1`
   --> $DIR/cfg-in-crate-1.rs:3:1
    |
 LL | #![cfg(bar)]
-   | ^^^^^^^^^^^^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
+   | ^
+   |
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/continue-after-missing-main.stderr
+++ b/src/test/ui/continue-after-missing-main.stderr
@@ -1,14 +1,9 @@
 error[E0601]: `main` function not found in crate `continue_after_missing_main`
-  --> $DIR/continue-after-missing-main.rs:1:1
    |
-LL | / #![allow(dead_code)]
-LL | |
-LL | | struct Tableau<'a, MP> {
-LL | |     provider: &'a MP,
-...  |
-LL | |
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error[E0623]: lifetime mismatch
   --> $DIR/continue-after-missing-main.rs:28:56

--- a/src/test/ui/elided-test.stderr
+++ b/src/test/ui/elided-test.stderr
@@ -1,10 +1,13 @@
 error[E0601]: `main` function not found in crate `elided_test`
   --> $DIR/elided-test.rs:5:1
    |
-LL | / #[test]
-LL | | fn main() {
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/elided-test.rs`
+LL | #[test]
+   | ^
+   |
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0601.stderr
+++ b/src/test/ui/error-codes/E0601.stderr
@@ -2,7 +2,12 @@ error[E0601]: `main` function not found in crate `E0601`
   --> $DIR/E0601.rs:1:37
    |
 LL |
-   |                                     ^ consider adding a `main` function to `$DIR/E0601.rs`
+   |                                     ^
+   |
+help: define a function named `main` at the crate root
+   |
+LL |
+   |                                     ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-49040.stderr
+++ b/src/test/ui/issues/issue-49040.stderr
@@ -5,12 +5,11 @@ LL | #![allow(unused_variables)];
    |                            ^ help: remove this semicolon
 
 error[E0601]: `main` function not found in crate `issue_49040`
-  --> $DIR/issue-49040.rs:1:1
    |
-LL | / #![allow(unused_variables)];
-LL | |
-LL | | fn foo() {}
-   | |__^ consider adding a `main` function to `$DIR/issue-49040.rs`
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/json-short.stderr
+++ b/src/test/ui/json-short.stderr
@@ -13,7 +13,8 @@ If you don't know the basics of Rust, you can look at the
 [Rust Book][rust-book] to get started.
 
 [rust-book]: https://doc.rust-lang.org/book/
-"},"level":"error","spans":[{"file_name":"$DIR/json-short.rs","byte_start":62,"byte_end":62,"line_start":1,"line_end":1,"column_start":63,"column_end":63,"is_primary":true,"text":[{"text":"// compile-flags: --json=diagnostic-short --error-format=json","highlight_start":63,"highlight_end":63}],"label":"consider adding a `main` function to `$DIR/json-short.rs`","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[],"rendered":"$DIR/json-short.rs:1:63: error[E0601]: `main` function not found in crate `json_short`
+"},"level":"error","spans":[{"file_name":"$DIR/json-short.rs","byte_start":62,"byte_end":62,"line_start":1,"line_end":1,"column_start":63,"column_end":63,"is_primary":true,"text":[{"text":"// compile-flags: --json=diagnostic-short --error-format=json","highlight_start":63,"highlight_end":63}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"define a function named `main` at the crate root","code":null,"level":"help","spans":[{"file_name":"$DIR/json-short.rs","byte_start":62,"byte_end":62,"line_start":1,"line_end":1,"column_start":63,"column_end":63,"is_primary":true,"text":[{"text":"// compile-flags: --json=diagnostic-short --error-format=json","highlight_start":63,"highlight_end":63}],"label":null,"suggested_replacement":"fn main() {}
+","suggestion_applicability":"MaybeIncorrect","expansion":null}],"children":[],"rendered":null}],"rendered":"$DIR/json-short.rs:1:63: error[E0601]: `main` function not found in crate `json_short`
 "}
 {"message":"aborting due to previous error","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to previous error
 "}

--- a/src/test/ui/main-wrong-location.stderr
+++ b/src/test/ui/main-wrong-location.stderr
@@ -1,21 +1,14 @@
 error[E0601]: `main` function not found in crate `main_wrong_location`
-  --> $DIR/main-wrong-location.rs:1:1
    |
-LL | / mod m {
-LL | |
-LL | |     // An inferred main entry point (that doesn't use #[main])
-LL | |     // must appear at the top of the crate
-LL | |     fn main() { }
-LL | | }
-   | |_^ the main function must be defined at the crate level (in `$DIR/main-wrong-location.rs`)
-   |
-note: here is a function named `main`
+help: consider moving one of these function definitions to the crate root
   --> $DIR/main-wrong-location.rs:5:5
    |
 LL |     fn main() { }
    |     ^^^^^^^^^^^^^
-   = note: you have one or more functions named `main` not defined at the crate level
-   = help: either move the `main` function definitions or attach the `#[main]` attribute to one of them
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing/missing-main.stderr
+++ b/src/test/ui/missing/missing-main.stderr
@@ -2,7 +2,12 @@ error[E0601]: `main` function not found in crate `missing_main`
   --> $DIR/missing-main.rs:2:1
    |
 LL | fn mian() { }
-   | ^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/missing-main.rs`
+   | ^
+   |
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/issue-59191-replace-root-with-fn.stderr
+++ b/src/test/ui/proc-macro/issue-59191-replace-root-with-fn.stderr
@@ -9,10 +9,13 @@ LL | #![issue_59191::no_main]
 error[E0601]: `main` function not found in crate `issue_59191_replace_root_with_fn`
   --> $DIR/issue-59191-replace-root-with-fn.rs:5:1
    |
-LL | / #![feature(custom_inner_attributes)]
-LL | |
-LL | | #![issue_59191::no_main]
-   | |________________________^ consider adding a `main` function to `$DIR/issue-59191-replace-root-with-fn.rs`
+LL | #![feature(custom_inner_attributes)]
+   | ^
+   |
+help: define a function named `main` at the crate root
+   |
+LL | fn main() {}
+   |
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This PR updates the diagnostic emitted when there is no main function at the crate root.

- Chiefly, shrinks the span to avoid highlighting the entire root module
- Uses the modern diagnostic machinery instead of referring to file names in the message
- Removes a reference to the unstable `#[main]` attribute

Fixes #77968.

r? @estebank 