### PR TITLE
Update E0744 about control flow in `const` contexts to accurately describe when the error is triggered and why

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0744.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0744.md
@@ -1,4 +1,4 @@
-A control-flow expression was used inside a const context.
+An unsupported expression was used inside a const context.
 
 Erroneous code example:
 
@@ -12,12 +12,15 @@ const _: i32 = {
 };
 ```
 
-At the moment, `if` and `match`, as well as the looping constructs `for`,
-`while`, and `loop`, are forbidden inside a `const`, `static`, or `const fn`.
+At the moment, `for` loops, `.await`, and the `Try` operator (`?`) are forbidden
+inside a `const`, `static`, or `const fn`.
 
-This will be allowed at some point in the future, but the implementation is not
-yet complete. See the tracking issue for [conditionals] or [loops] in a const
-context for the current status.
+This may be allowed at some point in the future, but the implementation is not
+yet complete. See the tracking issues for [`async`] and [`?`] in `const fn`, and
+(to support `for` loops in `const fn`) the tracking issues for [`impl const
+Trait for Ty`] and [`&mut T`] in `const fn`.
 
-[conditionals]: https://github.com/rust-lang/rust/issues/49146
-[loops]: https://github.com/rust-lang/rust/issues/52000
+[`async`]: https://github.com/rust-lang/rust/issues/69431
+[`?`]: https://github.com/rust-lang/rust/issues/74935
+[`impl const Trait for Ty`]: https://github.com/rust-lang/rust/issues/67792
+[`&mut T`]: https://github.com/rust-lang/rust/issues/57349


### PR DESCRIPTION
This PR fixes #79083. `const fn` currently supports `if`, `match`, `loop`, and `while` in terms of control flow. The error relating to control flow in `const` contexts currently states that those control flow constructs are not allowed in `const` contexts. That is no longer true, as RFC 2342 and 2344 were [stabilized](https://github.com/rust-lang/rust/pull/72437). `for` loops, however, as well as `?` and `.await` are still not allowed, so I changed the error message to be more descriptive of the error as it is not just control flow that could trigger this error. I also added links to tracking issues that mark things that are blocking the usage of these expressions.