### PR TITLE
Rust 1.48.0 stable release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -297,6 +297,7 @@ Compiler
 - [Added the `tiny` value to the `code-model` codegen flag.][72397]
 - [Added tier 3 support\* for the `mipsel-sony-psp` target.][72062]
 - [Added tier 3 support for the `thumbv7a-uwp-windows-msvc` target.][72133]
+- [Upgraded to LLVM 10.][67759]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
 information on Rust's tiered platform support.
@@ -396,6 +397,7 @@ Internals Only
 [72062]: https://github.com/rust-lang/rust/pull/72062/
 [72094]: https://github.com/rust-lang/rust/pull/72094/
 [72133]: https://github.com/rust-lang/rust/pull/72133/
+[67759]: https://github.com/rust-lang/rust/pull/67759/
 [71900]: https://github.com/rust-lang/rust/pull/71900/
 [71928]: https://github.com/rust-lang/rust/pull/71928/
 [71662]: https://github.com/rust-lang/rust/pull/71662/
@@ -1270,6 +1272,7 @@ Compiler
   `armv7-unknown-linux-musleabi` targets.][63107]
 - [Added tier 3 support for the `hexagon-unknown-linux-musl` target.][62814]
 - [Added tier 3 support for the `riscv32i-unknown-none-elf` target.][62784]
+- [Upgraded to LLVM 9.][62592]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
 information on Rust's tiered platform support.
@@ -1336,6 +1339,7 @@ Compatibility Notes
 [62735]: https://github.com/rust-lang/rust/pull/62735/
 [62766]: https://github.com/rust-lang/rust/pull/62766/
 [62784]: https://github.com/rust-lang/rust/pull/62784/
+[62592]: https://github.com/rust-lang/rust/pull/62592/
 [62785]: https://github.com/rust-lang/rust/issues/62785/
 [62814]: https://github.com/rust-lang/rust/pull/62814/
 [62896]: https://github.com/rust-lang/rust/issues/62896/
@@ -2431,6 +2435,7 @@ Compiler
 --------
 - [Added the `riscv32imc-unknown-none-elf` target.][53822]
 - [Added the `aarch64-unknown-netbsd` target][53165]
+- [Upgraded to LLVM 8.][53611]
 
 Libraries
 ---------
@@ -2479,6 +2484,7 @@ Misc
 [53033]: https://github.com/rust-lang/rust/pull/53033/
 [53044]: https://github.com/rust-lang/rust/pull/53044/
 [53165]: https://github.com/rust-lang/rust/pull/53165/
+[53611]: https://github.com/rust-lang/rust/pull/53611/
 [53213]: https://github.com/rust-lang/rust/pull/53213/
 [53236]: https://github.com/rust-lang/rust/pull/53236/
 [53272]: https://github.com/rust-lang/rust/pull/53272/
@@ -2537,6 +2543,7 @@ Compiler
 - [Bumped minimum LLVM version to 5.0.][51899]
 - [Added `powerpc64le-unknown-linux-musl` target.][51619]
 - [Added `aarch64-unknown-hermit` and `x86_64-unknown-hermit` targets.][52861]
+- [Upgraded to LLVM 7.][51966]
 
 Libraries
 ---------
@@ -2588,6 +2595,7 @@ Compatibility Notes
 
 [53893]: https://github.com/rust-lang/rust/pull/53893/
 [52861]: https://github.com/rust-lang/rust/pull/52861/
+[51966]: https://github.com/rust-lang/rust/pull/51966/
 [52656]: https://github.com/rust-lang/rust/pull/52656/
 [52239]: https://github.com/rust-lang/rust/pull/52239/
 [52330]: https://github.com/rust-lang/rust/pull/52330/

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -90,7 +90,7 @@ Compatibility Notes
 
 Internal Only
 --------
-- [Improved default settings for bootstrapping in `x.py`.][73964] You can read details about this change in the ["Changes To `x.py` Defaults"](https://blog.rust-lang.org/inside-rust/2020/08/30/changes-to-x-py-defaults.html) post on the Inside Rust blog.
+- [Improved default settings for bootstrapping in `x.py`.][73964] You can read details about this change in the ["Changes to `x.py` defaults"](https://blog.rust-lang.org/inside-rust/2020/08/30/changes-to-x-py-defaults.html) post on the Inside Rust blog.
 
 [1.47.0-cfg]: https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
 [75048]: https://github.com/rust-lang/rust/pull/75048/

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,7 @@ Compiler
   `rustc` whether to link its own C runtime and libraries or to rely on a external 
   linker to find them. (Supported only on `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
+  Note: If you're using cargo you must explicitly pass the `--target` flag.
 - [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
@@ -79,8 +80,10 @@ Compatibility Notes
   disallow zero-initialization.][71274]
 - [`#[target_feature]` will now error if used in a place where it has no effect.][78143]
 - [Foreign exceptions are now caught by `catch_unwind` and will cause an abort.][70212]
+  Note: This behaviour is not guaranteed and is still considered undefined behaviour,
+  see the [`catch_unwind`] documentation for further information.
+  
 
-[78143]: https://github.com/rust-lang/rust/issues/78143
 
 Internal Only
 -------------
@@ -94,6 +97,7 @@ related tools.
 - [cg_llvm: `fewer_names` in `uncached_llvm_type`][76030]
 - [Made `ensure_sufficient_stack()` non-generic][76680]
 
+[78143]: https://github.com/rust-lang/rust/issues/78143
 [76680]: https://github.com/rust-lang/rust/pull/76680/
 [76030]: https://github.com/rust-lang/rust/pull/76030/
 [70212]: https://github.com/rust-lang/rust/pull/70212/
@@ -118,6 +122,7 @@ related tools.
 [73461]: https://github.com/rust-lang/rust/pull/73461/
 [73166]: https://github.com/rust-lang/rust/pull/73166/
 [intradoc-links]: https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html
+[`catch_unwind`]: https://doc.rust-lang.org/std/panic/fn.catch_unwind.html
 [`Option::is_some`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some
 [`Option::is_none`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none
 [`Option::as_ref`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.as_ref

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,125 @@
+Version 1.48.0 (2020-11-19)
+==========================
+
+Language
+--------
+
+- [The `unsafe` keyword is now syntactically permitted on modules.][75857] This
+  is still rejected *semantically*, but can now be parsed by procedural macros.
+
+Compiler
+--------
+- [Stabilised the `-C link=<yes|no>`][76158] Which tells `rustc` whether to link
+  its own libraries or to rely on a external linker. (supported only on
+  `windows-gnu`, `linux-musl`, and `wasi` platforms.)
+- [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
+- [Added tier 2\* support for  `aarch64-unknown-linux-musl`.][76420]
+
+Libraries
+---------
+- [`io::Write` is now implemented for `&ChildStdin` `&Sink`, `&Stdout`,
+  and `&Stderr`.][76275]
+- [All arrays now implement `TryFrom<Vec<T>>`.][76310]
+- [The `matches!` macro now supports having a trailing comma.][74880]
+- [`Vec<A>` now implements `PartialEq<[B]>` where `A: PartialEq<B>`.][74194]
+- [Nearly all of `Cell`'s panicking functions now use the `#[track_caller]`
+  attribute.][77055]
+
+Stabilized APIs
+---------------
+- [`slice::as_ptr_range`]
+- [`slice::as_mut_ptr_range`]
+- [`VecDeque::make_contiguous`]
+- [`future::pending`]
+- [`future::ready`]
+
+The following previously stable methods are now `const fn`'s:
+
+- [`Option::is_some`]
+- [`Option::is_none`]
+- [`Option::as_ref`]
+- [`Result::is_ok`]
+- [`Result::is_err`]
+- [`Result::as_ref`]
+- [`Ordering::reverse`]
+- [`Ordering::then`]
+
+Cargo
+-----
+
+Misc
+----
+- [You can now link to different items in `rustdoc` using the intra-doc link
+  syntax.][74430] E.g. ``/// Uses [`std::future`] `` will automatically generate
+  a link to `std::future`'s documentation. See ["Linking to items by
+  name"][intradoc-links] for more information.
+- [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
+  when searching through `rustdoc`'s UI.][75740]
+- [You can now use `rustup install <major>.<minor>` to specify installing the
+  latest availeble patch of that minor version of the toolchain.][76107] E.g.
+  `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
+
+Compatibility Notes
+-------------------
+- [`const fn`s are now implicitly promoted to `const`.][75502] Meaning that it
+  will only warn if your code fails `const` evaluation, and not produce an error.
+- [Associated type bindings on trait objects are now verified to meet the bounds
+  declared on the trait when checking that they implement the trait.][27675]
+- [When traits bounds on associated types or opaque types are ambiguous the
+  compiler no longer makes an arbitrary choice on which bound to use.][54121]
+- [Fixed recursive nonterminals not being expended in macros during
+  pretty-print/reparse check.][77153] This may cause errors if your macro wasn't
+  correctly handling recursive nonterminal tokens.
+- [`&mut` references to non zero-sized types are not longer promoted.][75585]
+- [`rustc` will now warn if you use attributes like `#[link_name]` or `#[cold]`
+  in places where they have no effect.][73461]
+- [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in
+  `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
+
+
+
+Internal Only
+-------------
+- [Building `rustc` from source now uses `ninja` by default over `make`.][74922]
+  You can continue building with `make` by setting `ninja=false` in
+  your `config.toml`.
+
+[27675]: https://github.com/rust-lang/rust/issues/27675/
+[54121]: https://github.com/rust-lang/rust/issues/54121/
+[77386]: https://github.com/rust-lang/rust/pull/77386/
+[77153]: https://github.com/rust-lang/rust/pull/77153/
+[77055]: https://github.com/rust-lang/rust/pull/77055/
+[76275]: https://github.com/rust-lang/rust/pull/76275/
+[76310]: https://github.com/rust-lang/rust/pull/76310/
+[76420]: https://github.com/rust-lang/rust/pull/76420/
+[76107]: https://github.com/rust-lang/rust/pull/76107/
+[76158]: https://github.com/rust-lang/rust/pull/76158/
+[75857]: https://github.com/rust-lang/rust/pull/75857/
+[75585]: https://github.com/rust-lang/rust/pull/75585/
+[75740]: https://github.com/rust-lang/rust/pull/75740/
+[75502]: https://github.com/rust-lang/rust/pull/75502/
+[74880]: https://github.com/rust-lang/rust/pull/74880/
+[74922]: https://github.com/rust-lang/rust/pull/74922/
+[74430]: https://github.com/rust-lang/rust/pull/74430/
+[74194]: https://github.com/rust-lang/rust/pull/74194/
+[73461]: https://github.com/rust-lang/rust/pull/73461/
+[73166]: https://github.com/rust-lang/rust/pull/73166/
+[intradoc-links]: https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html
+[`Option::is_some`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some
+[`Option::is_none`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none
+[`Option::as_ref`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.as_ref
+[`Result::is_ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok
+[`Result::is_err`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err
+[`Result::as_ref`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.as_ref
+[`Ordering::reverse`]: https://doc.rust-lang.org/std/cmp/enum.Ordering.html#method.reverse
+[`Ordering::then`]: https://doc.rust-lang.org/std/cmp/enum.Ordering.html#method.then
+[`slice::as_ptr_range`]: https://doc.rust-lang.org/std/primitive.slice.html#method.as_ptr_range
+[`slice::as_mut_ptr_range`]: https://doc.rust-lang.org/std/primitive.slice.html#method.as_mut_ptr_range
+[`VecDeque::make_contiguous`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.make_contiguous
+[`future::pending`]: https://doc.rust-lang.org/std/future/fn.pending.html
+[`future::ready`]: https://doc.rust-lang.org/std/future/fn.ready.html
+
+
 Version 1.47.0 (2020-10-08)
 ==========================
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,7 +22,7 @@ Libraries
 ---------
 - [`io::Write` is now implemented for `&ChildStdin` `&Sink`, `&Stdout`,
   and `&Stderr`.][76275]
-- [All arrays now implement `TryFrom<Vec<T>>`.][76310]
+- [All arrays of any length now implement `TryFrom<Vec<T>>`.][76310]
 - [The `matches!` macro now supports having a trailing comma.][74880]
 - [`Vec<A>` now implements `PartialEq<[B]>` where `A: PartialEq<B>`.][74194]
 - [Nearly all of `Cell`'s panicking functions now use the `#[track_caller]`

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -82,7 +82,7 @@ Compatibility Notes
 - [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in
   `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
 - [`mem::uninitialized` will now panic if any inner types inside a struct or enum
-  disallow zero-initialization].[71274]
+  disallow zero-initialization.][71274]
 
 Internal Only
 -------------

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -78,15 +78,25 @@ Compatibility Notes
 - [`mem::uninitialized` will now panic if any inner types inside a struct or enum
   disallow zero-initialization.][71274]
 - [`#[target_feature]` will now error if used in a place where it has no effect.][78143]
+- [Foreign exceptions are now caught by `catch_unwind` and will cause an abort.][70212]
 
 [78143]: https://github.com/rust-lang/rust/issues/78143
 
 Internal Only
 -------------
+These changes provide no direct user facing benefits, but represent significant
+improvements to the internals and overall performance of rustc and
+related tools.
+
 - [Building `rustc` from source now uses `ninja` by default over `make`.][74922]
   You can continue building with `make` by setting `ninja=false` in
   your `config.toml`.
+- [cg_llvm: `fewer_names` in `uncached_llvm_type`][76030]
+- [Made `ensure_sufficient_stack()` non-generic][76680]
 
+[76680]: https://github.com/rust-lang/rust/pull/76680/
+[76030]: https://github.com/rust-lang/rust/pull/76030/
+[70212]: https://github.com/rust-lang/rust/pull/70212/
 [27675]: https://github.com/rust-lang/rust/issues/27675/
 [54121]: https://github.com/rust-lang/rust/issues/54121/  
 [71274]: https://github.com/rust-lang/rust/pull/71274/
@@ -215,6 +225,7 @@ Compatibility Notes
 
 Internal Only
 --------
+
 - [Improved default settings for bootstrapping in `x.py`.][73964] You can read details about this change in the ["Changes to `x.py` defaults"](https://blog.rust-lang.org/inside-rust/2020/08/30/changes-to-x-py-defaults.html) post on the Inside Rust blog.
 
 [1.47.0-cfg]: https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,6 +15,9 @@ Compiler
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
 - [Added tier 2\* support for  `aarch64-unknown-linux-musl`.][76420]
 
+\* Refer to Rust's [platform support page][forge-platform-support] for more
+information on Rust's tiered platform support.
+
 Libraries
 ---------
 - [`io::Write` is now implemented for `&ChildStdin` `&Sink`, `&Stdout`,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,8 +25,7 @@ Libraries
 - [All arrays of any length now implement `TryFrom<Vec<T>>`.][76310]
 - [The `matches!` macro now supports having a trailing comma.][74880]
 - [`Vec<A>` now implements `PartialEq<[B]>` where `A: PartialEq<B>`.][74194]
-- [Nearly all of `Cell`'s panicking functions now use the `#[track_caller]`
-  attribute.][77055]
+- [The `RefCell::{replace, replace_with, clone}` methods now all use `#[track_caller]`.][77055]
 
 Stabilized APIs
 ---------------
@@ -61,8 +60,9 @@ Rustdoc
 
 Compatibility Notes
 -------------------
-- [`const fn`s are now implicitly promoted to `const`.][75502] Meaning that it
-  will only warn if your code fails `const` evaluation, and not produce an error.
+- [Promotion of references to `'static` lifetime inside `const fn` now follows the
+  same rules as inside a `fn` body.][75502] In particular, `&foo()` will not be
+  promoted to `'static` lifetime any more inside `const fn`s.
 - [Associated type bindings on trait objects are now verified to meet the bounds
   declared on the trait when checking that they implement the trait.][27675]
 - [When trait bounds on associated types or opaque types are ambiguous, the

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,8 +9,8 @@ Language
 
 Compiler
 --------
-- [Stabilised the `-C link-self-contained=<yes|no>`][76158] Which tells `rustc` whether to link
-  its own C runtime and libraries or to rely on a external linker to find them. (supported only on
+- [Stabilised the `-C link-self-contained=<yes|no>`.][76158] This tells `rustc` whether to link
+  its own C runtime and libraries or to rely on a external linker to find them. (Supported only on
   `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
 - [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
@@ -52,14 +52,14 @@ Cargo
 
 Misc
 ----
-- [You can now link to different items in `rustdoc` using the intra-doc link
+- [You can now link to items in `rustdoc` using the intra-doc link
   syntax.][74430] E.g. ``/// Uses [`std::future`]`` will automatically generate
   a link to `std::future`'s documentation. See ["Linking to items by
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
 - [You can now use `rustup install <major>.<minor>` to specify installing the
-  latest available patch of that minor version of the toolchain.][76107] E.g.
+  latest available patch of the specified minor version of the toolchain.][76107] E.g.
   `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
 
 Compatibility Notes
@@ -70,7 +70,7 @@ Compatibility Notes
   declared on the trait when checking that they implement the trait.][27675]
 - [When trait bounds on associated types or opaque types are ambiguous, the
   compiler no longer makes an arbitrary choice on which bound to use.][54121]
-- [Fixed recursive nonterminals not being expended in macros during
+- [Fixed recursive nonterminals not being expanded in macros during
   pretty-print/reparse check.][77153] This may cause errors if your macro wasn't
   correctly handling recursive nonterminal tokens.
 - [`&mut` references to non zero-sized types are no longer promoted.][75585]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -58,12 +58,6 @@ Rustdoc
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
-  
-Rustup
-------
-- [You can now use `rustup install <major>.<minor>` to specify installing the
-  latest available patch of the specified minor version of the toolchain.][76107] E.g.
-  `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
 
 Compatibility Notes
 -------------------
@@ -83,6 +77,9 @@ Compatibility Notes
   `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
 - [`mem::uninitialized` will now panic if any inner types inside a struct or enum
   disallow zero-initialization.][71274]
+- [`#[target_feature]` will now error if used in a place where it has no effect.][78143]
+
+[78143]: https://github.com/rust-lang/rust/issues/78143
 
 Internal Only
 -------------
@@ -99,7 +96,6 @@ Internal Only
 [76275]: https://github.com/rust-lang/rust/pull/76275/
 [76310]: https://github.com/rust-lang/rust/pull/76310/
 [76420]: https://github.com/rust-lang/rust/pull/76420/
-[76107]: https://github.com/rust-lang/rust/pull/76107/
 [76158]: https://github.com/rust-lang/rust/pull/76158/
 [75857]: https://github.com/rust-lang/rust/pull/75857/
 [75585]: https://github.com/rust-lang/rust/pull/75585/

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,10 +10,10 @@ Language
 Compiler
 --------
 - [Stabilised the `-C link-self-contained=<yes|no>`][76158] Which tells `rustc` whether to link
-  its own libraries or to rely on a external linker. (supported only on
+  its own C runtime and libraries or to rely on a external linker to find them. (supported only on
   `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
-- [Added tier 2\* support for  `aarch64-unknown-linux-musl`.][76420]
+- [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
 information on Rust's tiered platform support.
@@ -53,13 +53,13 @@ Cargo
 Misc
 ----
 - [You can now link to different items in `rustdoc` using the intra-doc link
-  syntax.][74430] E.g. ``/// Uses [`std::future`] `` will automatically generate
+  syntax.][74430] E.g. ``/// Uses [`std::future`]`` will automatically generate
   a link to `std::future`'s documentation. See ["Linking to items by
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
 - [You can now use `rustup install <major>.<minor>` to specify installing the
-  latest availeble patch of that minor version of the toolchain.][76107] E.g.
+  latest available patch of that minor version of the toolchain.][76107] E.g.
   `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
 
 Compatibility Notes
@@ -68,12 +68,12 @@ Compatibility Notes
   will only warn if your code fails `const` evaluation, and not produce an error.
 - [Associated type bindings on trait objects are now verified to meet the bounds
   declared on the trait when checking that they implement the trait.][27675]
-- [When traits bounds on associated types or opaque types are ambiguous the
+- [When trait bounds on associated types or opaque types are ambiguous, the
   compiler no longer makes an arbitrary choice on which bound to use.][54121]
 - [Fixed recursive nonterminals not being expended in macros during
   pretty-print/reparse check.][77153] This may cause errors if your macro wasn't
   correctly handling recursive nonterminal tokens.
-- [`&mut` references to non zero-sized types are not longer promoted.][75585]
+- [`&mut` references to non zero-sized types are no longer promoted.][75585]
 - [`rustc` will now warn if you use attributes like `#[link_name]` or `#[cold]`
   in places where they have no effect.][73461]
 - [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,14 +50,17 @@ The following previously stable methods are now `const fn`'s:
 Cargo
 -----
 
-Misc
-----
+Rustdoc
+-------
 - [You can now link to items in `rustdoc` using the intra-doc link
   syntax.][74430] E.g. ``/// Uses [`std::future`]`` will automatically generate
   a link to `std::future`'s documentation. See ["Linking to items by
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
+  
+Rustup
+------
 - [You can now use `rustup install <major>.<minor>` to specify installing the
   latest available patch of the specified minor version of the toolchain.][76107] E.g.
   `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
@@ -78,8 +81,8 @@ Compatibility Notes
   in places where they have no effect.][73461]
 - [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in
   `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
-
-
+- [`mem::uninitialized` will now panic if any inner types inside a struct or enum
+  disallow zero-initialization].[71274]
 
 Internal Only
 -------------
@@ -88,7 +91,8 @@ Internal Only
   your `config.toml`.
 
 [27675]: https://github.com/rust-lang/rust/issues/27675/
-[54121]: https://github.com/rust-lang/rust/issues/54121/
+[54121]: https://github.com/rust-lang/rust/issues/54121/  
+[71274]: https://github.com/rust-lang/rust/pull/71274/
 [77386]: https://github.com/rust-lang/rust/pull/77386/
 [77153]: https://github.com/rust-lang/rust/pull/77153/
 [77055]: https://github.com/rust-lang/rust/pull/77055/

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,9 +9,9 @@ Language
 
 Compiler
 --------
-- [Stabilised the `-C link-self-contained=<yes|no>`.][76158] This tells `rustc` whether to link
-  its own C runtime and libraries or to rely on a external linker to find them. (Supported only on
-  `windows-gnu`, `linux-musl`, and `wasi` platforms.)
+- [Stabilised the `-C link-self-contained=<yes|no>` compiler flag.][76158] This tells
+  `rustc` whether to link its own C runtime and libraries or to rely on a external 
+  linker to find them. (Supported only on `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
 - [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@ Language
 
 Compiler
 --------
-- [Stabilised the `-C link=<yes|no>`][76158] Which tells `rustc` whether to link
+- [Stabilised the `-C link-self-contained=<yes|no>`][76158] Which tells `rustc` whether to link
   its own libraries or to rely on a external linker. (supported only on
   `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -63,7 +63,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 
 # Always set the release channel for bootstrap; this is normally not important (i.e., only dist
 # builds would seem to matter) but in practice bootstrap wants to know whether we're targeting

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -21,6 +21,8 @@ pub fn render_with_highlighting(
     playground_button: Option<&str>,
     tooltip: Option<(&str, &str)>,
 ) -> String {
+    // This replace allows to fix how the code source with DOS backline characters is displayed.
+    let src = src.replace("\r\n", "\n");
     debug!("highlighting: ================\n{}\n==============", src);
     let mut out = String::with_capacity(src.len());
     if let Some((tooltip, class)) = tooltip {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -21,8 +21,6 @@ pub fn render_with_highlighting(
     playground_button: Option<&str>,
     tooltip: Option<(&str, &str)>,
 ) -> String {
-    // This replace allows to fix how the code source with DOS backline characters is displayed.
-    let src = src.replace("\r\n", "\n");
     debug!("highlighting: ================\n{}\n==============", src);
     let mut out = String::with_capacity(src.len());
     if let Some((tooltip, class)) = tooltip {
@@ -48,7 +46,9 @@ fn write_header(out: &mut String, class: Option<&str>) {
 }
 
 fn write_code(out: &mut String, src: &str) {
-    Classifier::new(src).highlight(&mut |highlight| {
+    // This replace allows to fix how the code source with DOS backline characters is displayed.
+    let src = src.replace("\r\n", "\n");
+    Classifier::new(&src).highlight(&mut |highlight| {
         match highlight {
             Highlight::Token { text, class } => string(out, Escape(text), class),
             Highlight::EnterSpan { class } => enter_span(out, class),

--- a/src/librustdoc/html/highlight/fixtures/dos_line.html
+++ b/src/librustdoc/html/highlight/fixtures/dos_line.html
@@ -1,0 +1,3 @@
+<span class="kw">pub</span> <span class="kw">fn</span> <span class="ident">foo</span>() {
+<span class="macro">println</span><span class="macro">!</span>(<span class="string">&quot;foo&quot;</span>);
+}

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -1,17 +1,6 @@
 use super::write_code;
 use expect_test::expect_file;
 
-#[test]
-fn test_html_highlighting() {
-    let src = include_str!("fixtures/sample.rs");
-    let html = {
-        let mut out = String::new();
-        write_code(&mut out, src);
-        format!("{}<pre><code>{}</code></pre>\n", STYLE, out)
-    };
-    expect_file!["fixtures/sample.html"].assert_eq(&html);
-}
-
 const STYLE: &str = r#"
 <style>
 .kw { color: #8959A8; }
@@ -23,3 +12,24 @@ const STYLE: &str = r#"
 .question-mark { color: #ff9011; }
 </style>
 "#;
+
+#[test]
+fn test_html_highlighting() {
+    let src = include_str!("fixtures/sample.rs");
+    let html = {
+        let mut out = String::new();
+        write_code(&mut out, src);
+        format!("{}<pre><code>{}</code></pre>\n", STYLE, out)
+    };
+    expect_file!["fixtures/sample.html"].assert_eq(&html);
+}
+
+#[test]
+fn test_dos_backline() {
+    let src = "pub fn foo() {\r\n\
+    println!(\"foo\");\r\n\
+}\r\n";
+    let mut html = String::new();
+    write_code(&mut html, src);
+    expect_file!["fixtures/dos_line.html"].assert_eq(&html);
+}


### PR DESCRIPTION
This PR bumps the 1.48 beta branch to the 1.48 stable branch, and applies these last minute backports:

* #77939 - Ensure that the source code display is working with DOS backline
* #77508 - Fix capitalization in blog post name
* #78559 - Add LLVM upgrades from 7 to 10 to RELEASES.md
* #78364 - Update RELEASES.md for 1.48.0

r? @ghost
cc @rust-lang/release 