### PR TITLE
Add //ignore-macos to pretty-std-collections.rs

### DIFF
--- a/src/test/debuginfo/pretty-std-collections.rs
+++ b/src/test/debuginfo/pretty-std-collections.rs
@@ -2,6 +2,7 @@
 // ignore-windows failing on win32 bot
 // ignore-freebsd: gdb package too new
 // ignore-android: FIXME(#10381)
+// ignore-macos: FIXME(#78665)
 // compile-flags:-g
 
 // The pretty printers being tested here require the patch from


### PR DESCRIPTION
On macOS the test is flaky and sometimes fails,
sometimes succeeds on CI.

This is no fix for the underlying issue,
but I feel the workaround is worth it as
the issue makes it harder
to get things merged into master.

cc #78665