### PR TITLE
std: Fix test `symlink_hard_link` on Windows

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1341,6 +1341,9 @@ fn metadata_access_times() {
 #[test]
 fn symlink_hard_link() {
     let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
 
     // Create "file", a file.
     check!(fs::File::create(tmpdir.join("file")));


### PR DESCRIPTION
The test was introduced in https://github.com/rust-lang/rust/pull/78026 and fails depending on Windows version and admin rights.
Other similar tests check for symlink creation permissions before doing anything, this PR performs the same check for `symlink_hard_link` as well.