### PR TITLE
Fix setting inline hint based on `InstanceDef::requires_inline`

### DIFF
--- a/src/test/codegen/inline-hint.rs
+++ b/src/test/codegen/inline-hint.rs
@@ -1,0 +1,31 @@
+// Checks that closures, constructors, and shims except
+// for a drop glue receive inline hint by default.
+//
+// compile-flags: -Cno-prepopulate-passes -Zsymbol-mangling-version=v0
+#![crate_type = "lib"]
+
+pub fn f() {
+    let a = A;
+    let b = (0i32, 1i32, 2i32, 3i32);
+    let c = || {};
+
+    a(String::new(), String::new());
+    b.clone();
+    c();
+}
+
+struct A(String, String);
+
+// CHECK:      ; core::ptr::drop_in_place::<inline_hint::A>
+// CHECK-NEXT: ; Function Attrs:
+// CHECK-NOT:  inlinehint
+// CHECK-SAME: {{$}}
+
+// CHECK:      ; <(i32, i32, i32, i32) as core::clone::Clone>::clone
+// CHECK-NEXT: ; Function Attrs: inlinehint
+
+// CHECK:      ; inline_hint::f::{closure#0}
+// CHECK-NEXT: ; Function Attrs: inlinehint
+
+// CHECK:      ; inline_hint::A
+// CHECK-NEXT: ; Function Attrs: inlinehint


### PR DESCRIPTION
For instances where `InstanceDef::requires_inline` is true, an attempt
is made to set an inline hint though a call to the `inline` function.
The attempt is ineffective, since all attributes will be usually removed
by the second call.

Fix the issue by applying the attributes only once, with user provided
attributes having a priority when provided.

Closes #79108.