### PR TITLE
x.py: allow a custom string appended to the version

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -446,6 +446,11 @@ changelog-seen = 2
 # nightly features
 #channel = "dev"
 
+# A descriptive string to be appended to `rustc --version` output, which is
+# also used in places like debuginfo `DW_AT_producer`. This may be useful for
+# supplementary build information, like distro-specific package versions.
+#description = ""
+
 # The root location of the musl installation directory.
 #musl-root = "..."
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -152,6 +152,7 @@ pub struct Config {
     // misc
     pub low_priority: bool,
     pub channel: String,
+    pub description: Option<String>,
     pub verbose_tests: bool,
     pub save_toolstates: Option<PathBuf>,
     pub print_step_timings: bool,
@@ -470,6 +471,7 @@ struct Rust {
     parallel_compiler: Option<bool>,
     default_linker: Option<String>,
     channel: Option<String>,
+    description: Option<String>,
     musl_root: Option<String>,
     rpath: Option<bool>,
     verbose_tests: Option<bool>,
@@ -841,6 +843,7 @@ impl Config {
                 .map(|v| v.parse().expect("failed to parse rust.llvm-libunwind"));
             set(&mut config.backtrace, rust.backtrace);
             set(&mut config.channel, rust.channel);
+            config.description = rust.description;
             set(&mut config.rust_dist_src, rust.dist_src);
             set(&mut config.verbose_tests, rust.verbose_tests);
             // in the case "false" is set explicitly, do not overwrite the command line args

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -146,6 +146,7 @@ v("qemu-riscv64-rootfs", "target.riscv64gc-unknown-linux-gnu.qemu-rootfs",
 v("experimental-targets", "llvm.experimental-targets",
   "experimental LLVM targets to build")
 v("release-channel", "rust.channel", "the name of the release channel to build")
+v("release-description", "rust.description", "optional descriptive string for version output")
 
 # Used on systems where "cc" is unavailable
 v("default-linker", "rust.default-linker", "the default linker")

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1082,7 +1082,13 @@ impl Build {
     /// Note that this is a descriptive string which includes the commit date,
     /// sha, version, etc.
     fn rust_version(&self) -> String {
-        self.rust_info.version(self, &self.version)
+        let mut version = self.rust_info.version(self, &self.version);
+        if let Some(ref s) = self.config.description {
+            version.push_str(" (");
+            version.push_str(s);
+            version.push_str(")");
+        }
+        version
     }
 
     /// Returns the full commit hash.


### PR DESCRIPTION
This adds `rust.description` to the config as a descriptive string to be
appended to `rustc --version` output, which is also used in places like
debuginfo `DW_AT_producer`. This may be useful for supplementary build
information, like distro-specific package versions.

For example, in Fedora 33, `gcc --version` outputs:

    gcc (GCC) 10.2.1 20201016 (Red Hat 10.2.1-6)

With this change, we can add similar vendor info to `rustc --version`.