### PR TITLE
compiletest: Fix a warning in debuginfo tests on windows-gnu

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -977,7 +977,8 @@ impl<'test> TestCx<'test> {
             script_str.push_str("set print pretty off\n");
 
             // Add the pretty printer directory to GDB's source-file search path
-            script_str.push_str(&format!("directory {}\n", rust_pp_module_abs_path));
+            script_str
+                .push_str(&format!("directory {}\n", rust_pp_module_abs_path.replace(r"\", r"\\")));
 
             // Load the target executable
             script_str


### PR DESCRIPTION
The warning looked like this for me:
```
Warning: C:msys64homewerust./src/etc: No such file or directory.
```
It didn't affect actual testing because we don't currently emit gdb pretty-printer information into executables on windows-gnu.