### PR TITLE
Get rid of `clean::{Method, TyMethod}`

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -883,14 +883,12 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics, ty::GenericPredicates<'tcx
     }
 }
 
-impl<'a> Clean<Method>
-    for (&'a hir::FnSig<'a>, &'a hir::Generics<'a>, hir::BodyId, Option<hir::Defaultness>)
-{
-    fn clean(&self, cx: &DocContext<'_>) -> Method {
+impl<'a> Clean<Function> for (&'a hir::FnSig<'a>, &'a hir::Generics<'a>, hir::BodyId) {
+    fn clean(&self, cx: &DocContext<'_>) -> Function {
         let (generics, decl) =
             enter_impl_trait(cx, || (self.1.clean(cx), (&*self.0.decl, self.2).clean(cx)));
         let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
-        Method { decl, generics, header: self.0.header, defaultness: self.3, all_types, ret_types }
+        Function { decl, generics, header: self.0.header, all_types, ret_types }
     }
 }
 
@@ -1107,13 +1105,13 @@ impl Clean<Item> for hir::TraitItem<'_> {
                 AssocConstItem(ty.clean(cx), default.map(|e| print_const_expr(cx, e)))
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
-                let mut m = (sig, &self.generics, body, None).clean(cx);
+                let mut m = (sig, &self.generics, body).clean(cx);
                 if m.header.constness == hir::Constness::Const
                     && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
                     m.header.constness = hir::Constness::NotConst;
                 }
-                MethodItem(m)
+                MethodItem(m, None)
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Required(ref names)) => {
                 let (generics, decl) = enter_impl_trait(cx, || {
@@ -1153,13 +1151,13 @@ impl Clean<Item> for hir::ImplItem<'_> {
                 AssocConstItem(ty.clean(cx), Some(print_const_expr(cx, expr)))
             }
             hir::ImplItemKind::Fn(ref sig, body) => {
-                let mut m = (sig, &self.generics, body, Some(self.defaultness)).clean(cx);
+                let mut m = (sig, &self.generics, body).clean(cx);
                 if m.header.constness == hir::Constness::Const
                     && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
                     m.header.constness = hir::Constness::NotConst;
                 }
-                MethodItem(m)
+                MethodItem(m, Some(self.defaultness))
             }
             hir::ImplItemKind::TyAlias(ref ty) => {
                 let type_ = ty.clean(cx);
@@ -1235,19 +1233,21 @@ impl Clean<Item> for ty::AssocItem {
                         ty::ImplContainer(_) => Some(self.defaultness),
                         ty::TraitContainer(_) => None,
                     };
-                    MethodItem(Method {
-                        generics,
-                        decl,
-                        header: hir::FnHeader {
-                            unsafety: sig.unsafety(),
-                            abi: sig.abi(),
-                            constness,
-                            asyncness,
+                    MethodItem(
+                        Function {
+                            generics,
+                            decl,
+                            header: hir::FnHeader {
+                                unsafety: sig.unsafety(),
+                                abi: sig.abi(),
+                                constness,
+                                asyncness,
+                            },
+                            all_types,
+                            ret_types,
                         },
                         defaultness,
-                        all_types,
-                        ret_types,
-                    })
+                    )
                 } else {
                     TyMethodItem(Function {
                         generics,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1120,7 +1120,7 @@ impl Clean<Item> for hir::TraitItem<'_> {
                     (self.generics.clean(cx), (&*sig.decl, &names[..]).clean(cx))
                 });
                 let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
-                let mut t = TyMethod { header: sig.header, decl, generics, all_types, ret_types };
+                let mut t = Function { header: sig.header, decl, generics, all_types, ret_types };
                 if t.header.constness == hir::Constness::Const
                     && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
@@ -1249,7 +1249,7 @@ impl Clean<Item> for ty::AssocItem {
                         ret_types,
                     })
                 } else {
-                    TyMethodItem(TyMethod {
+                    TyMethodItem(Function {
                         generics,
                         decl,
                         header: hir::FnHeader {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -227,12 +227,8 @@ impl Item {
 
     crate fn is_default(&self) -> bool {
         match self.kind {
-            ItemKind::MethodItem(ref meth) => {
-                if let Some(defaultness) = meth.defaultness {
-                    defaultness.has_value() && !defaultness.is_final()
-                } else {
-                    false
-                }
+            ItemKind::MethodItem(_, Some(defaultness)) => {
+                defaultness.has_value() && !defaultness.is_final()
             }
             _ => false,
         }
@@ -266,7 +262,7 @@ crate enum ItemKind {
     /// non-default-methods).
     TyMethodItem(Function),
     /// A method with a body.
-    MethodItem(Method),
+    MethodItem(Function, Option<hir::Defaultness>),
     StructFieldItem(Type),
     VariantItem(Variant),
     /// `fn`s from an extern block
@@ -908,16 +904,6 @@ impl GenericParamDef {
 crate struct Generics {
     crate params: Vec<GenericParamDef>,
     crate where_predicates: Vec<WherePredicate>,
-}
-
-#[derive(Clone, Debug)]
-crate struct Method {
-    crate generics: Generics,
-    crate decl: FnDecl,
-    crate header: hir::FnHeader,
-    crate defaultness: Option<hir::Defaultness>,
-    crate all_types: Vec<(Type, TypeKind)>,
-    crate ret_types: Vec<(Type, TypeKind)>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -264,7 +264,7 @@ crate enum ItemKind {
     ImplItem(Impl),
     /// A method signature only. Used for required methods in traits (ie,
     /// non-default-methods).
-    TyMethodItem(TyMethod),
+    TyMethodItem(Function),
     /// A method with a body.
     MethodItem(Method),
     StructFieldItem(Type),
@@ -916,15 +916,6 @@ crate struct Method {
     crate decl: FnDecl,
     crate header: hir::FnHeader,
     crate defaultness: Option<hir::Defaultness>,
-    crate all_types: Vec<(Type, TypeKind)>,
-    crate ret_types: Vec<(Type, TypeKind)>,
-}
-
-#[derive(Clone, Debug)]
-crate struct TyMethod {
-    crate header: hir::FnHeader,
-    crate decl: FnDecl,
-    crate generics: Generics,
     crate all_types: Vec<(Type, TypeKind)>,
     crate ret_types: Vec<(Type, TypeKind)>,
 }

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -167,7 +167,7 @@ crate fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
 crate fn get_index_search_type(item: &clean::Item) -> Option<IndexItemFunctionType> {
     let (all_types, ret_types) = match item.kind {
         clean::FunctionItem(ref f) => (&f.all_types, &f.ret_types),
-        clean::MethodItem(ref m) => (&m.all_types, &m.ret_types),
+        clean::MethodItem(ref m, _) => (&m.all_types, &m.ret_types),
         clean::TyMethodItem(ref m) => (&m.all_types, &m.ret_types),
         _ => return None,
     };

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3752,8 +3752,7 @@ fn render_impl(
                 (true, " hidden")
             };
         match item.kind {
-            clean::MethodItem(clean::Method { .. })
-            | clean::TyMethodItem(clean::TyMethod { .. }) => {
+            clean::MethodItem(_) | clean::TyMethodItem(_) => {
                 // Only render when the method is not static or we allow static methods
                 if render_method_item {
                     let id = cx.derive_id(format!("{}.{}", item_type, name));

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2589,7 +2589,9 @@ fn item_trait(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Trait, 
             for (pos, m) in provided.iter().enumerate() {
                 render_assoc_item(w, m, AssocItemLink::Anchor(None), ItemType::Trait);
                 match m.kind {
-                    clean::MethodItem(ref inner) if !inner.generics.where_predicates.is_empty() => {
+                    clean::MethodItem(ref inner, _)
+                        if !inner.generics.where_predicates.is_empty() =>
+                    {
                         write!(w, ",\n    {{ ... }}\n");
                     }
                     _ => {
@@ -2968,7 +2970,9 @@ fn render_assoc_item(
     match item.kind {
         clean::StrippedItem(..) => {}
         clean::TyMethodItem(ref m) => method(w, item, m.header, &m.generics, &m.decl, link, parent),
-        clean::MethodItem(ref m) => method(w, item, m.header, &m.generics, &m.decl, link, parent),
+        clean::MethodItem(ref m, _) => {
+            method(w, item, m.header, &m.generics, &m.decl, link, parent)
+        }
         clean::AssocConstItem(ref ty, ref default) => assoc_const(
             w,
             item,
@@ -3545,7 +3549,7 @@ fn render_deref_methods(
 
 fn should_render_item(item: &clean::Item, deref_mut_: bool) -> bool {
     let self_type_opt = match item.kind {
-        clean::MethodItem(ref method) => method.decl.self_type(),
+        clean::MethodItem(ref method, _) => method.decl.self_type(),
         clean::TyMethodItem(ref method) => method.decl.self_type(),
         _ => None,
     };
@@ -3752,7 +3756,7 @@ fn render_impl(
                 (true, " hidden")
             };
         match item.kind {
-            clean::MethodItem(_) | clean::TyMethodItem(_) => {
+            clean::MethodItem(..) | clean::TyMethodItem(_) => {
                 // Only render when the method is not static or we allow static methods
                 if render_method_item {
                     let id = cx.derive_id(format!("{}.{}", item_type, name));


### PR DESCRIPTION
They're redundant and almost the same as `clean::Function`.

I needed this for https://github.com/rust-lang/rust/pull/78082, although I forget why.

r? @GuillaumeGomez 