### PR TITLE
Remove duplicate `Trait::auto` field

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -193,7 +193,6 @@ crate fn build_external_trait(cx: &DocContext<'_>, did: DefId) -> clean::Trait {
     let trait_items =
         cx.tcx.associated_items(did).in_definition_order().map(|item| item.clean(cx)).collect();
 
-    let auto_trait = cx.tcx.trait_def(did).has_auto_impl;
     let predicates = cx.tcx.predicates_of(did);
     let generics = (cx.tcx.generics_of(did), predicates).clean(cx);
     let generics = filter_non_trait_generics(did, generics);
@@ -201,7 +200,6 @@ crate fn build_external_trait(cx: &DocContext<'_>, did: DefId) -> clean::Trait {
     let is_spotlight = load_attrs(cx, did).clean(cx).has_doc_flag(sym::spotlight);
     let is_auto = cx.tcx.trait_is_auto(did);
     clean::Trait {
-        auto: auto_trait,
         unsafety: cx.tcx.trait_def(did).unsafety,
         generics,
         items: trait_items,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1024,7 +1024,6 @@ impl Clean<Item> for doctree::Trait<'_> {
             stability: cx.stability(self.id),
             deprecation: cx.deprecation(self.id).clean(cx),
             kind: TraitItem(Trait {
-                auto: self.is_auto.clean(cx),
                 unsafety: self.unsafety,
                 items: self.items.iter().map(|ti| ti.clean(cx)).collect(),
                 generics: self.generics.clean(cx),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1026,7 +1026,6 @@ impl GetDefId for FnRetTy {
 
 #[derive(Clone, Debug)]
 crate struct Trait {
-    crate auto: bool,
     crate unsafety: hir::Unsafety,
     crate items: Vec<Item>,
     crate generics: Generics,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2759,7 +2759,7 @@ fn item_trait(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Trait, 
         }
         write_loading_content(w, "</div>");
 
-        if t.auto {
+        if t.is_auto {
             write_small_section_header(
                 w,
                 "synthetic-implementors",
@@ -2790,7 +2790,7 @@ fn item_trait(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Trait, 
         );
         write_loading_content(w, "</div>");
 
-        if t.auto {
+        if t.is_auto {
             write_small_section_header(
                 w,
                 "synthetic-implementors",
@@ -4454,7 +4454,7 @@ fn sidebar_trait(buf: &mut Buffer, it: &clean::Item, t: &clean::Trait) {
     sidebar.push_str(&sidebar_assoc_items(it));
 
     sidebar.push_str("<a class=\"sidebar-title\" href=\"#implementors\">Implementors</a>");
-    if t.auto {
+    if t.is_auto {
         sidebar.push_str(
             "<a class=\"sidebar-title\" \
                 href=\"#synthetic-implementors\">Auto Implementors</a>",


### PR DESCRIPTION
It was exactly the same as `is_auto`.

I found this while working on #78082, but it's not required for that PR.

r? @GuillaumeGomez 