### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "dlmalloc"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35055b1021724f4eb5262eb49130eebff23fc59fc5a14160e05faad8eeb36673"
+checksum = "332570860c2edf2d57914987bf9e24835425f75825086b6ba7d1e6a3e4f1f254"
 dependencies = [
  "compiler_builtins",
  "libc",

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -184,16 +184,18 @@ impl<'a> DiagnosticBuilder<'a> {
         self.cancel();
     }
 
-    /// Adds a span/label to be included in the resulting snippet.
+    /// Appends a labeled span to the diagnostic.
     ///
-    /// This is pushed onto the [`MultiSpan`] that was created when the diagnostic
-    /// was first built. That means it will be shown together with the original
-    /// span/label, *not* a span added by one of the `span_{note,warn,help,suggestions}` methods.
+    /// Labels are used to convey additional context for the diagnostic's primary span. They will
+    /// be shown together with the original diagnostic's span, *not* with spans added by
+    /// `span_note`, `span_help`, etc. Therefore, if the primary span is not displayable (because
+    /// the span is `DUMMY_SP` or the source code isn't found), labels will not be displayed
+    /// either.
     ///
-    /// This span is *not* considered a ["primary span"][`MultiSpan`]; only
-    /// the `Span` supplied when creating the diagnostic is primary.
-    ///
-    /// [`MultiSpan`]: ../rustc_span/struct.MultiSpan.html
+    /// Implementation-wise, the label span is pushed onto the [`MultiSpan`] that was created when
+    /// the diagnostic was constructed. However, the label span is *not* considered a
+    /// ["primary span"][`MultiSpan`]; only the `Span` supplied when creating the diagnostic is
+    /// primary.
     pub fn span_label(&mut self, span: Span, label: impl Into<String>) -> &mut Self {
         self.0.diagnostic.span_label(span, label);
         self

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -420,7 +420,9 @@ impl<'tcx> Body<'tcx> {
     /// Returns an iterator over all user-defined variables and compiler-generated temporaries (all
     /// locals that are neither arguments nor the return place).
     #[inline]
-    pub fn vars_and_temps_iter(&self) -> impl Iterator<Item = Local> + ExactSizeIterator {
+    pub fn vars_and_temps_iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = Local> + ExactSizeIterator {
         let arg_count = self.arg_count;
         let local_count = self.local_decls.len();
         (arg_count + 1..local_count).map(Local::new)

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -23,6 +23,8 @@ extern "Rust" {
     // (the code expanding that attribute macro generates those functions), or to call
     // the default implementations in libstd (`__rdl_alloc` etc. in `library/std/src/alloc.rs`)
     // otherwise.
+    // The rustc fork of LLVM also special-cases these function names to be able to optimize them
+    // like `malloc`, `realloc`, and `free`, respectively.
     #[rustc_allocator]
     #[rustc_allocator_nounwind]
     fn __rust_alloc(size: usize, align: usize) -> *mut u8;

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -36,7 +36,7 @@ features = ['read_core', 'elf', 'macho', 'pe']
 rand = "0.7"
 
 [target.'cfg(any(all(target_arch = "wasm32", not(target_os = "emscripten")), all(target_vendor = "fortanix", target_env = "sgx")))'.dependencies]
-dlmalloc = { version = "0.1", features = ['rustc-dep-of-std'] }
+dlmalloc = { version = "0.2.1", features = ['rustc-dep-of-std'] }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
 fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1341,6 +1341,9 @@ fn metadata_access_times() {
 #[test]
 fn symlink_hard_link() {
     let tmpdir = tmpdir();
+    if !got_symlink_permission(&tmpdir) {
+        return;
+    };
 
     // Create "file", a file.
     check!(fs::File::create(tmpdir.join("file")));

--- a/library/std/src/sys/sgx/abi/mem.rs
+++ b/library/std/src/sys/sgx/abi/mem.rs
@@ -12,6 +12,18 @@ pub(crate) unsafe fn rel_ptr_mut<T>(offset: u64) -> *mut T {
 
 extern "C" {
     static ENCLAVE_SIZE: usize;
+    static HEAP_BASE: u64;
+    static HEAP_SIZE: usize;
+}
+
+/// Returns the base memory address of the heap
+pub(crate) fn heap_base() -> *const u8 {
+    unsafe { rel_ptr_mut(HEAP_BASE) }
+}
+
+/// Returns the size of the heap
+pub(crate) fn heap_size() -> usize {
+    unsafe { HEAP_SIZE }
 }
 
 // Do not remove inline: will result in relocation failure

--- a/library/std/src/sys/wasm/alloc.rs
+++ b/library/std/src/sys/wasm/alloc.rs
@@ -18,7 +18,7 @@
 
 use crate::alloc::{GlobalAlloc, Layout, System};
 
-static mut DLMALLOC: dlmalloc::Dlmalloc = dlmalloc::DLMALLOC_INIT;
+static mut DLMALLOC: dlmalloc::Dlmalloc = dlmalloc::Dlmalloc::new();
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -21,6 +21,8 @@ pub fn render_with_highlighting(
     playground_button: Option<&str>,
     tooltip: Option<(&str, &str)>,
 ) -> String {
+    // This replace allows to fix how the code source with DOS backline characters is displayed.
+    let src = src.replace("\r\n", "\n");
     debug!("highlighting: ================\n{}\n==============", src);
     let mut out = String::with_capacity(src.len());
     if let Some((tooltip, class)) = tooltip {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -21,8 +21,6 @@ pub fn render_with_highlighting(
     playground_button: Option<&str>,
     tooltip: Option<(&str, &str)>,
 ) -> String {
-    // This replace allows to fix how the code source with DOS backline characters is displayed.
-    let src = src.replace("\r\n", "\n");
     debug!("highlighting: ================\n{}\n==============", src);
     let mut out = String::with_capacity(src.len());
     if let Some((tooltip, class)) = tooltip {
@@ -48,7 +46,9 @@ fn write_header(out: &mut String, class: Option<&str>) {
 }
 
 fn write_code(out: &mut String, src: &str) {
-    Classifier::new(src).highlight(&mut |highlight| {
+    // This replace allows to fix how the code source with DOS backline characters is displayed.
+    let src = src.replace("\r\n", "\n");
+    Classifier::new(&src).highlight(&mut |highlight| {
         match highlight {
             Highlight::Token { text, class } => string(out, Escape(text), class),
             Highlight::EnterSpan { class } => enter_span(out, class),

--- a/src/librustdoc/html/highlight/fixtures/dos_line.html
+++ b/src/librustdoc/html/highlight/fixtures/dos_line.html
@@ -1,0 +1,3 @@
+<span class="kw">pub</span> <span class="kw">fn</span> <span class="ident">foo</span>() {
+<span class="macro">println</span><span class="macro">!</span>(<span class="string">&quot;foo&quot;</span>);
+}

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -1,17 +1,6 @@
 use super::write_code;
 use expect_test::expect_file;
 
-#[test]
-fn test_html_highlighting() {
-    let src = include_str!("fixtures/sample.rs");
-    let html = {
-        let mut out = String::new();
-        write_code(&mut out, src);
-        format!("{}<pre><code>{}</code></pre>\n", STYLE, out)
-    };
-    expect_file!["fixtures/sample.html"].assert_eq(&html);
-}
-
 const STYLE: &str = r#"
 <style>
 .kw { color: #8959A8; }
@@ -23,3 +12,24 @@ const STYLE: &str = r#"
 .question-mark { color: #ff9011; }
 </style>
 "#;
+
+#[test]
+fn test_html_highlighting() {
+    let src = include_str!("fixtures/sample.rs");
+    let html = {
+        let mut out = String::new();
+        write_code(&mut out, src);
+        format!("{}<pre><code>{}</code></pre>\n", STYLE, out)
+    };
+    expect_file!["fixtures/sample.html"].assert_eq(&html);
+}
+
+#[test]
+fn test_dos_backline() {
+    let src = "pub fn foo() {\r\n\
+    println!(\"foo\");\r\n\
+}\r\n";
+    let mut html = String::new();
+    write_code(&mut html, src);
+    expect_file!["fixtures/dos_line.html"].assert_eq(&html);
+}

--- a/src/test/codegen/internalize-closures.rs
+++ b/src/test/codegen/internalize-closures.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C no-prepopulate-passes
+// compile-flags: -C no-prepopulate-passes -Zmir-opt-level=0
 
 pub fn main() {
 

--- a/src/test/codegen/issue-37945.rs
+++ b/src/test/codegen/issue-37945.rs
@@ -1,26 +1,34 @@
-// compile-flags: -O
+// compile-flags: -O -Zmerge-functions=disabled
 // ignore-x86
 // ignore-arm
 // ignore-emscripten
 // ignore-gnux32
 // ignore 32-bit platforms (LLVM has a bug with them)
 
-// See issue #37945.
+// Check that LLVM understands that `Iter` pointer is not null. Issue #37945.
 
 #![crate_type = "lib"]
 
 use std::slice::Iter;
 
-// CHECK-LABEL: @is_empty_1
 #[no_mangle]
 pub fn is_empty_1(xs: Iter<f32>) -> bool {
-// CHECK-NOT: icmp eq float* {{.*}}, null
+// CHECK-LABEL: @is_empty_1(
+// CHECK-NEXT:  start:
+// CHECK-NEXT:    [[A:%.*]] = icmp ne i32* %xs.1, null
+// CHECK-NEXT:    tail call void @llvm.assume(i1 [[A]])
+// CHECK-NEXT:    [[B:%.*]] = icmp eq i32* %xs.0, %xs.1
+// CHECK-NEXT:    ret i1 [[B:%.*]]
     {xs}.next().is_none()
 }
 
-// CHECK-LABEL: @is_empty_2
 #[no_mangle]
 pub fn is_empty_2(xs: Iter<f32>) -> bool {
-// CHECK-NOT: icmp eq float* {{.*}}, null
+// CHECK-LABEL: @is_empty_2
+// CHECK-NEXT:  start:
+// CHECK-NEXT:    [[C:%.*]] = icmp ne i32* %xs.1, null
+// CHECK-NEXT:    tail call void @llvm.assume(i1 [[C]])
+// CHECK-NEXT:    [[D:%.*]] = icmp eq i32* %xs.0, %xs.1
+// CHECK-NEXT:    ret i1 [[D:%.*]]
     xs.map(|&x| x).next().is_none()
 }

--- a/src/test/codegen/vec-shrink-panic.rs
+++ b/src/test/codegen/vec-shrink-panic.rs
@@ -15,9 +15,9 @@ pub fn shrink_to_fit(vec: &mut Vec<u32>) {
 
 // CHECK-LABEL: @issue71861
 #[no_mangle]
-pub fn issue71861(n: usize) -> Box<[u32]> {
+pub fn issue71861(vec: Vec<u32>) -> Box<[u32]> {
     // CHECK-NOT: panic
-    vec![0; n].into_boxed_slice()
+    vec.into_boxed_slice()
 }
 
 // CHECK-LABEL: @issue75636

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -40,6 +40,7 @@
 -                                          // mir::Constant
                                            // + span: $DIR/inline-diverging.rs:22:16: 22:21
                                            // + literal: Const { ty: fn() -> ! {sleep}, val: Value(Scalar(<ZST>)) }
++         StorageLive(_6);                 // scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
 +         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
 +         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
 +         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -65,12 +65,16 @@
 -                                          // + literal: Const { ty: for<'r> fn(std::pin::Pin<&'r mut impl std::ops::Generator<bool>>, bool) -> std::ops::GeneratorState<<impl std::ops::Generator<bool> as std::ops::Generator<bool>>::Yield, <impl std::ops::Generator<bool> as std::ops::Generator<bool>>::Return> {<impl std::ops::Generator<bool> as std::ops::Generator<bool>>::resume}, val: Value(Scalar(<ZST>)) }
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 +         _7 = const false;                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
++         StorageLive(_8);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
++         StorageLive(_9);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 +         _9 = discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41 {bool, i32}]))); // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
 +         switchInt(move _9) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
       }
   
 -     bb3: {
 +     bb1: {
++         StorageDead(_9);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
++         StorageDead(_8);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageDead(_7);                 // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
           StorageDead(_2);                 // scope 0 at $DIR/inline-generator.rs:9:45: 9:46
           StorageDead(_4);                 // scope 0 at $DIR/inline-generator.rs:9:46: 9:47

--- a/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
@@ -36,11 +36,15 @@
 -                                          // mir::Constant
 -                                          // + span: $DIR/inline-shims.rs:12:14: 12:37
 -                                          // + literal: Const { ty: unsafe fn(*mut std::option::Option<B>) {std::intrinsics::drop_in_place::<std::option::Option<B>>}, val: Value(Scalar(<ZST>)) }
++         StorageLive(_6);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
++         StorageLive(_7);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
 +         _6 = discriminant((*_5));        // scope 3 at $DIR/inline-shims.rs:12:14: 12:40
 +         switchInt(move _6) -> [0_isize: bb2, otherwise: bb3]; // scope 3 at $DIR/inline-shims.rs:12:14: 12:40
       }
   
       bb2: {
++         StorageDead(_7);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
++         StorageDead(_6);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
           StorageDead(_5);                 // scope 2 at $DIR/inline-shims.rs:12:39: 12:40
           return;                          // scope 0 at $DIR/inline-shims.rs:13:2: 13:2
 +     }

--- a/src/test/rustdoc-ui/invalid-html-tags.rs
+++ b/src/test/rustdoc-ui/invalid-html-tags.rs
@@ -87,3 +87,24 @@ pub fn h() {}
 /// <!--
 //~^ ERROR Unclosed HTML comment
 pub fn i() {}
+
+/// hello
+///
+/// ```
+/// uiapp.run(&env::args().collect::<Vec<_>>());
+/// ```
+pub fn j() {}
+
+// Check that nested codeblocks are working as well
+/// hello
+///
+/// ``````markdown
+/// normal markdown
+///
+/// ```
+/// uiapp.run(&env::args().collect::<Vec<_>>());
+/// ```
+///
+/// <Vec<_> shouldn't warn!
+/// ``````
+pub fn k() {}

--- a/src/test/ui/mir/auxiliary/issue_76375_aux.rs
+++ b/src/test/ui/mir/auxiliary/issue_76375_aux.rs
@@ -1,8 +1,8 @@
 // edition:2018
-// compile-flags: -Z mir-opt-level=2 -Z unsound-mir-opts
+// compile-flags: -Z mir-opt-level=2
 
 #[inline(always)]
-pub fn f(s: bool) -> String {
+pub fn copy_prop(s: bool) -> String {
     let a = "Hello world!".to_string();
     let b = a;
     let c = b;
@@ -11,4 +11,10 @@ pub fn f(s: bool) -> String {
     } else {
         String::new()
     }
+}
+
+#[inline(always)]
+pub fn dest_prop(x: &[u8]) -> &[u8] {
+    let y = &x[..x.len()];
+    y
 }

--- a/src/test/ui/mir/issue-76375.rs
+++ b/src/test/ui/mir/issue-76375.rs
@@ -1,6 +1,8 @@
+// Regression test for issue #76375.
+//
 // edition:2018
 // build-pass
-// compile-flags: -Z mir-opt-level=2 -L.
+// compile-flags: -Z mir-opt-level=2
 // aux-build:issue_76375_aux.rs
 
 #![crate_type = "lib"]
@@ -8,8 +10,18 @@
 extern crate issue_76375_aux;
 
 pub async fn g() {
-    issue_76375_aux::f(true);
+    issue_76375_aux::copy_prop(true);
     h().await;
+}
+
+pub async fn u() {
+    let b = [0u8; 32];
+    let mut i = 0;
+    while i != 10 {
+        issue_76375_aux::dest_prop(&b);
+        h().await;
+        i += 1;
+    }
 }
 
 pub async fn h() {}

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use tar::Archive;
 
 const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
-const RUSTC_VERSION: &str = include_str!("../../../version");
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub(crate) enum PkgType {
@@ -177,10 +176,10 @@ impl Versions {
     ) -> Result<String, Error> {
         let component_name = package.tarball_component_name();
         let version = match self.channel.as_str() {
-            "stable" => RUSTC_VERSION.into(),
+            "stable" => self.rustc_version().into(),
             "beta" => "beta".into(),
             "nightly" => "nightly".into(),
-            _ => format!("{}-dev", RUSTC_VERSION),
+            _ => format!("{}-dev", self.rustc_version()),
         };
 
         if package.target_independent() {
@@ -199,6 +198,7 @@ impl Versions {
     }
 
     pub(crate) fn rustc_version(&self) -> &str {
-        RUSTC_VERSION
+        const RUSTC_VERSION: &str = include_str!("../../../version");
+        RUSTC_VERSION.trim()
     }
 }


### PR DESCRIPTION
Successful merges:

 - #77939 (Ensure that the source code display is working with DOS backline)
 - #78138 (Upgrade dlmalloc to version 0.2)
 - #78967 (Make codegen tests compatible with extra inlining)
 - #79027 (Limit storage duration of inlined always live locals)
 - #79077 (document that __rust_alloc is also magic to our LLVM fork)
 - #79088 (clarify `span_label` documentation)
 - #79097 (Code block invalid html tag lint)
 - #79105 (std: Fix test `symlink_hard_link` on Windows)
 - #79107 (build-manifest: strip newline from rustc version)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=77939,78138,78967,79027,79077,79088,79097,79105,79107)
<!-- homu-ignore:end -->