### PR TITLE
bootstrap: use the same version number for rustc and cargo

### DIFF
--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -1,6 +1,5 @@
 # This file describes the stage0 compiler that's used to then bootstrap the Rust
-# compiler itself. For the rustbuild build system, this also describes the
-# relevant Cargo revision that we're using.
+# compiler itself.
 #
 # Currently Rust always bootstraps from the previous stable release, and in our
 # train model this means that the master branch bootstraps from beta, beta
@@ -8,13 +7,13 @@
 # release.
 #
 # If you're looking at this file on the master branch, you'll likely see that
-# rustc and cargo are configured to `beta`, whereas if you're looking at a
-# source tarball for a stable release you'll likely see `1.x.0` for rustc and
-# `0.(x+1).0` for Cargo where they were released on `date`.
+# rustc is configured to `beta`, whereas if you're looking at a source tarball
+# for a stable release you'll likely see `1.x.0` for rustc, with the previous
+# stable release's version number. `date` is the date where the release we're
+# bootstrapping off was released.
 
 date: 2020-10-16
 rustc: beta
-cargo: beta
 
 # We use a nightly rustfmt to format the source because it solves some
 # bootstrapping issues with use of new syntax in this repo. If you're looking at


### PR DESCRIPTION
Historically the stable tarballs were named after the version number ofthe specific tool, instead of the version number of Rust. For example, both of the following tarballs were part of the same release:

    rustc-1.48.0-x86_64-unknown-linux-gnu.tar.xz
    cargo-0.49.0-x86_64-unknown-linux-gnu.tar.xz

PR #77336 changed the dist code to instead use Rust's version number for all the tarballs, regardless of the tool they contain:

    rustc-1.48.0-x86_64-unknown-linux-gnu.tar.xz
    cargo-1.48.0-x86_64-unknown-linux-gnu.tar.xz

Because of that there is no need anymore to have a separate `cargo` field in `src/stage0.txt`, as the Cargo version will always be the same as the rustc version. This PR removes the field, simplifying the code and the maintenance work required while producing releases.

r? @Mark-Simulacrum 