### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.26"
+version = "1.4.27"
 dependencies = [
  "annotate-snippets 0.6.1",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4301,7 +4301,6 @@ dependencies = [
  "serde_json",
  "smallvec 1.4.2",
  "tempfile",
- "termcolor",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4301,6 +4301,7 @@ dependencies = [
  "serde_json",
  "smallvec 1.4.2",
  "tempfile",
+ "termcolor",
 ]
 
 [[package]]

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -200,6 +200,11 @@ pub trait Emitter {
         true
     }
 
+    /// Checks if we can use colors in the current output stream.
+    fn supports_color(&self) -> bool {
+        false
+    }
+
     fn source_map(&self) -> Option<&Lrc<SourceMap>>;
 
     /// Formats the substitutions of the primary_span
@@ -503,6 +508,10 @@ impl Emitter for EmitterWriter {
 
     fn should_show_explain(&self) -> bool {
         !self.short_message
+    }
+
+    fn supports_color(&self) -> bool {
+        self.dst.supports_color()
     }
 }
 
@@ -2055,6 +2064,14 @@ impl Destination {
             }
             Destination::Raw(ref mut t, false) => WritableDst::Raw(t),
             Destination::Raw(ref mut t, true) => WritableDst::ColoredRaw(Ansi::new(t)),
+        }
+    }
+
+    fn supports_color(&self) -> bool {
+        match *self {
+            Self::Terminal(ref stream) => stream.supports_color(),
+            Self::Buffered(ref buffer) => buffer.buffer().supports_color(),
+            Self::Raw(_, supports_color) => supports_color,
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -418,6 +418,12 @@ pub struct TypeckResults<'tcx> {
     /// Stores the type, expression, span and optional scope span of all types
     /// that are live across the yield of this generator (if a generator).
     pub generator_interior_types: Vec<GeneratorInteriorTypeCause<'tcx>>,
+
+    /// We sometimes treat byte string literals (which are of type `&[u8; N]`)
+    /// as `&[u8]`, depending on the pattern  in which they are used.
+    /// This hashset records all instances where we behave
+    /// like this to allow `const_to_pat` to reliably handle this situation.
+    pub treat_byte_string_as_slice: ItemLocalSet,
 }
 
 impl<'tcx> TypeckResults<'tcx> {
@@ -443,6 +449,7 @@ impl<'tcx> TypeckResults<'tcx> {
             concrete_opaque_types: Default::default(),
             closure_captures: Default::default(),
             generator_interior_types: Default::default(),
+            treat_byte_string_as_slice: Default::default(),
         }
     }
 
@@ -677,6 +684,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             ref concrete_opaque_types,
             ref closure_captures,
             ref generator_interior_types,
+            ref treat_byte_string_as_slice,
         } = *self;
 
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
@@ -710,6 +718,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             concrete_opaque_types.hash_stable(hcx, hasher);
             closure_captures.hash_stable(hcx, hasher);
             generator_interior_types.hash_stable(hcx, hasher);
+            treat_byte_string_as_slice.hash_stable(hcx, hasher);
         })
     }
 }

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -70,6 +70,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         debug!("used_trait_imports({:?}) = {:?}", item_def_id, used_trait_imports);
         wbcx.typeck_results.used_trait_imports = used_trait_imports;
 
+        wbcx.typeck_results.treat_byte_string_as_slice =
+            mem::take(&mut self.typeck_results.borrow_mut().treat_byte_string_as_slice);
+
         wbcx.typeck_results.closure_captures =
             mem::take(&mut self.typeck_results.borrow_mut().closure_captures);
 

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -20,6 +20,3 @@ regex = "1"
 
 [dev-dependencies]
 expect-test = "1.0"
-
-[target.'cfg(windows)'.dependencies]
-termcolor = "1.0"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -20,3 +20,6 @@ regex = "1"
 
 [dev-dependencies]
 expect-test = "1.0"
+
+[target.'cfg(windows)'.dependencies]
+termcolor = "1.0"

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -193,7 +193,6 @@ crate fn build_external_trait(cx: &DocContext<'_>, did: DefId) -> clean::Trait {
     let trait_items =
         cx.tcx.associated_items(did).in_definition_order().map(|item| item.clean(cx)).collect();
 
-    let auto_trait = cx.tcx.trait_def(did).has_auto_impl;
     let predicates = cx.tcx.predicates_of(did);
     let generics = (cx.tcx.generics_of(did), predicates).clean(cx);
     let generics = filter_non_trait_generics(did, generics);
@@ -201,7 +200,6 @@ crate fn build_external_trait(cx: &DocContext<'_>, did: DefId) -> clean::Trait {
     let is_spotlight = load_attrs(cx, did).clean(cx).has_doc_flag(sym::spotlight);
     let is_auto = cx.tcx.trait_is_auto(did);
     clean::Trait {
-        auto: auto_trait,
         unsafety: cx.tcx.trait_def(did).unsafety,
         generics,
         items: trait_items,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1024,7 +1024,6 @@ impl Clean<Item> for doctree::Trait<'_> {
             stability: cx.stability(self.id),
             deprecation: cx.deprecation(self.id).clean(cx),
             kind: TraitItem(Trait {
-                auto: self.is_auto.clean(cx),
                 unsafety: self.unsafety,
                 items: self.items.iter().map(|ti| ti.clean(cx)).collect(),
                 generics: self.generics.clean(cx),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -883,14 +883,12 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics, ty::GenericPredicates<'tcx
     }
 }
 
-impl<'a> Clean<Method>
-    for (&'a hir::FnSig<'a>, &'a hir::Generics<'a>, hir::BodyId, Option<hir::Defaultness>)
-{
-    fn clean(&self, cx: &DocContext<'_>) -> Method {
+impl<'a> Clean<Function> for (&'a hir::FnSig<'a>, &'a hir::Generics<'a>, hir::BodyId) {
+    fn clean(&self, cx: &DocContext<'_>) -> Function {
         let (generics, decl) =
             enter_impl_trait(cx, || (self.1.clean(cx), (&*self.0.decl, self.2).clean(cx)));
         let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
-        Method { decl, generics, header: self.0.header, defaultness: self.3, all_types, ret_types }
+        Function { decl, generics, header: self.0.header, all_types, ret_types }
     }
 }
 
@@ -1107,13 +1105,13 @@ impl Clean<Item> for hir::TraitItem<'_> {
                 AssocConstItem(ty.clean(cx), default.map(|e| print_const_expr(cx, e)))
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
-                let mut m = (sig, &self.generics, body, None).clean(cx);
+                let mut m = (sig, &self.generics, body).clean(cx);
                 if m.header.constness == hir::Constness::Const
                     && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
                     m.header.constness = hir::Constness::NotConst;
                 }
-                MethodItem(m)
+                MethodItem(m, None)
             }
             hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Required(ref names)) => {
                 let (generics, decl) = enter_impl_trait(cx, || {
@@ -1153,13 +1151,13 @@ impl Clean<Item> for hir::ImplItem<'_> {
                 AssocConstItem(ty.clean(cx), Some(print_const_expr(cx, expr)))
             }
             hir::ImplItemKind::Fn(ref sig, body) => {
-                let mut m = (sig, &self.generics, body, Some(self.defaultness)).clean(cx);
+                let mut m = (sig, &self.generics, body).clean(cx);
                 if m.header.constness == hir::Constness::Const
                     && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
                     m.header.constness = hir::Constness::NotConst;
                 }
-                MethodItem(m)
+                MethodItem(m, Some(self.defaultness))
             }
             hir::ImplItemKind::TyAlias(ref ty) => {
                 let type_ = ty.clean(cx);
@@ -1235,19 +1233,21 @@ impl Clean<Item> for ty::AssocItem {
                         ty::ImplContainer(_) => Some(self.defaultness),
                         ty::TraitContainer(_) => None,
                     };
-                    MethodItem(Method {
-                        generics,
-                        decl,
-                        header: hir::FnHeader {
-                            unsafety: sig.unsafety(),
-                            abi: sig.abi(),
-                            constness,
-                            asyncness,
+                    MethodItem(
+                        Function {
+                            generics,
+                            decl,
+                            header: hir::FnHeader {
+                                unsafety: sig.unsafety(),
+                                abi: sig.abi(),
+                                constness,
+                                asyncness,
+                            },
+                            all_types,
+                            ret_types,
                         },
                         defaultness,
-                        all_types,
-                        ret_types,
-                    })
+                    )
                 } else {
                     TyMethodItem(Function {
                         generics,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1120,7 +1120,7 @@ impl Clean<Item> for hir::TraitItem<'_> {
                     (self.generics.clean(cx), (&*sig.decl, &names[..]).clean(cx))
                 });
                 let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
-                let mut t = TyMethod { header: sig.header, decl, generics, all_types, ret_types };
+                let mut t = Function { header: sig.header, decl, generics, all_types, ret_types };
                 if t.header.constness == hir::Constness::Const
                     && is_unstable_const_fn(cx.tcx, local_did.to_def_id()).is_some()
                 {
@@ -1249,7 +1249,7 @@ impl Clean<Item> for ty::AssocItem {
                         ret_types,
                     })
                 } else {
-                    TyMethodItem(TyMethod {
+                    TyMethodItem(Function {
                         generics,
                         decl,
                         header: hir::FnHeader {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -227,12 +227,8 @@ impl Item {
 
     crate fn is_default(&self) -> bool {
         match self.kind {
-            ItemKind::MethodItem(ref meth) => {
-                if let Some(defaultness) = meth.defaultness {
-                    defaultness.has_value() && !defaultness.is_final()
-                } else {
-                    false
-                }
+            ItemKind::MethodItem(_, Some(defaultness)) => {
+                defaultness.has_value() && !defaultness.is_final()
             }
             _ => false,
         }
@@ -266,7 +262,7 @@ crate enum ItemKind {
     /// non-default-methods).
     TyMethodItem(Function),
     /// A method with a body.
-    MethodItem(Method),
+    MethodItem(Function, Option<hir::Defaultness>),
     StructFieldItem(Type),
     VariantItem(Variant),
     /// `fn`s from an extern block
@@ -908,16 +904,6 @@ impl GenericParamDef {
 crate struct Generics {
     crate params: Vec<GenericParamDef>,
     crate where_predicates: Vec<WherePredicate>,
-}
-
-#[derive(Clone, Debug)]
-crate struct Method {
-    crate generics: Generics,
-    crate decl: FnDecl,
-    crate header: hir::FnHeader,
-    crate defaultness: Option<hir::Defaultness>,
-    crate all_types: Vec<(Type, TypeKind)>,
-    crate ret_types: Vec<(Type, TypeKind)>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1026,7 +1026,6 @@ impl GetDefId for FnRetTy {
 
 #[derive(Clone, Debug)]
 crate struct Trait {
-    crate auto: bool,
     crate unsafety: hir::Unsafety,
     crate items: Vec<Item>,
     crate generics: Generics,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -264,7 +264,7 @@ crate enum ItemKind {
     ImplItem(Impl),
     /// A method signature only. Used for required methods in traits (ie,
     /// non-default-methods).
-    TyMethodItem(TyMethod),
+    TyMethodItem(Function),
     /// A method with a body.
     MethodItem(Method),
     StructFieldItem(Type),
@@ -916,15 +916,6 @@ crate struct Method {
     crate decl: FnDecl,
     crate header: hir::FnHeader,
     crate defaultness: Option<hir::Defaultness>,
-    crate all_types: Vec<(Type, TypeKind)>,
-    crate ret_types: Vec<(Type, TypeKind)>,
-}
-
-#[derive(Clone, Debug)]
-crate struct TyMethod {
-    crate header: hir::FnHeader,
-    crate decl: FnDecl,
-    crate generics: Generics,
     crate all_types: Vec<(Type, TypeKind)>,
     crate ret_types: Vec<(Type, TypeKind)>,
 }

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1,13 +1,14 @@
 use rustc_ast as ast;
 use rustc_data_structures::sync::Lrc;
-use rustc_errors::ErrorReported;
+use rustc_errors::{ColorConfig, ErrorReported};
+use rustc_feature::UnstableFeatures;
 use rustc_hir as hir;
 use rustc_hir::intravisit;
 use rustc_hir::{HirId, CRATE_HIR_ID};
 use rustc_interface::interface;
 use rustc_middle::hir::map::Map;
 use rustc_middle::ty::TyCtxt;
-use rustc_session::config::{self, CrateType};
+use rustc_session::config::{self, CrateType, ErrorOutputType};
 use rustc_session::{lint, DiagnosticOutput, Session};
 use rustc_span::edition::Edition;
 use rustc_span::source_map::SourceMap;
@@ -293,6 +294,18 @@ fn run_test(
             path.to_str().expect("target path must be valid unicode").to_string()
         }
     });
+    match options.error_format {
+        ErrorOutputType::HumanReadable(kind) => {
+            let (_, color_config) = kind.unzip();
+            match color_config {
+                ColorConfig::Never => {}
+                _ => {
+                    compiler.arg("--color").arg("always");
+                }
+            }
+        }
+        _ => {}
+    }
 
     compiler.arg("-");
     compiler.stdin(Stdio::piped());

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -336,6 +336,9 @@ fn run_test(
         (true, false) => {}
         (false, true) => {
             if !error_codes.is_empty() {
+                // We used to check if the output contained "error[{}]: " but since we added the
+                // colored output, we can't anymore because of the color escape characters before
+                // the ":".
                 error_codes.retain(|err| !out.contains(&format!("error[{}]", err)));
 
                 if !error_codes.is_empty() {

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1,7 +1,6 @@
 use rustc_ast as ast;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{ColorConfig, ErrorReported};
-use rustc_feature::UnstableFeatures;
 use rustc_hir as hir;
 use rustc_hir::intravisit;
 use rustc_hir::{HirId, CRATE_HIR_ID};

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -333,7 +333,7 @@ fn run_test(
         (true, false) => {}
         (false, true) => {
             if !error_codes.is_empty() {
-                error_codes.retain(|err| !out.contains(&format!("error[{}]: ", err)));
+                error_codes.retain(|err| !out.contains(&format!("error[{}]", err)));
 
                 if !error_codes.is_empty() {
                     return Err(TestFailure::MissingErrorCodes(error_codes));

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -428,10 +428,12 @@ crate fn make_test(
             // Any errors in parsing should also appear when the doctest is compiled for real, so just
             // send all the errors that librustc_ast emits directly into a `Sink` instead of stderr.
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
+            supports_color =
+                EmitterWriter::stderr(ColorConfig::Auto, None, false, false, Some(80), false)
+                    .supports_color();
+
             let emitter =
                 EmitterWriter::new(box io::sink(), None, false, false, false, None, false);
-
-            supports_color = emitter.supports_color();
 
             // FIXME(misdreavus): pass `-Z treat-err-as-bug` to the doctest parser
             let handler = Handler::with_emitter(false, None, box emitter);

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -11,8 +11,8 @@ fn main() {
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, None, false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -26,8 +26,8 @@ fn main() {
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -44,8 +44,8 @@ use asdf::qwop;
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 3));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 3));
 }
 
 #[test]
@@ -61,8 +61,8 @@ use asdf::qwop;
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -79,8 +79,8 @@ use std::*;
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("std"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, Some("std"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -98,8 +98,8 @@ use asdf::qwop;
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -115,8 +115,8 @@ use asdf::qwop;
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -134,8 +134,8 @@ use asdf::qwop;
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 3));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 3));
 
     // Adding more will also bump the returned line offset.
     opts.attrs.push("feature(hella_dope)".to_string());
@@ -147,8 +147,8 @@ use asdf::qwop;
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 4));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 4));
 }
 
 #[test]
@@ -164,8 +164,8 @@ fn main() {
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, None, false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -180,8 +180,8 @@ fn main() {
     assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, None, false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 1));
+    let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 1));
 }
 
 #[test]
@@ -196,8 +196,8 @@ fn main() {
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, None, false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 }
 
 #[test]
@@ -210,8 +210,8 @@ assert_eq!(2+2, 4);";
 //Ceci n'est pas une `fn main`
 assert_eq!(2+2, 4);"
         .to_string();
-    let output = make_test(input, None, true, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 1));
+    let (output, len, _) = make_test(input, None, true, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 1));
 }
 
 #[test]
@@ -224,8 +224,8 @@ fn make_test_display_warnings() {
 assert_eq!(2+2, 4);
 }"
     .to_string();
-    let output = make_test(input, None, false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 1));
+    let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 1));
 }
 
 #[test]
@@ -242,8 +242,8 @@ assert_eq!(2+2, 4);
 }"
     .to_string();
 
-    let output = make_test(input, None, false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 2));
+    let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 2));
 
     let input = "extern crate hella_qwop;
 assert_eq!(asdf::foo, 4);";
@@ -256,8 +256,8 @@ assert_eq!(asdf::foo, 4);
 }"
     .to_string();
 
-    let output = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 3));
+    let (output, len, _) = make_test(input, Some("asdf"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 3));
 }
 
 #[test]
@@ -274,6 +274,6 @@ test_wrapper! {
 }"
     .to_string();
 
-    let output = make_test(input, Some("my_crate"), false, &opts, DEFAULT_EDITION);
-    assert_eq!(output, (expected, 1));
+    let (output, len, _) = make_test(input, Some("my_crate"), false, &opts, DEFAULT_EDITION);
+    assert_eq!((output, len), (expected, 1));
 }

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -62,7 +62,6 @@ fn write_footer(out: &mut String, playground_button: Option<&str>) {
 /// How a span of text is classified. Mostly corresponds to token kinds.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Class {
-    None,
     Comment,
     DocComment,
     Attribute,
@@ -87,7 +86,6 @@ impl Class {
     /// Returns the css class expected by rustdoc for each `Class`.
     fn as_html(self) -> &'static str {
         match self {
-            Class::None => "",
             Class::Comment => "comment",
             Class::DocComment => "doccomment",
             Class::Attribute => "attribute",
@@ -110,7 +108,7 @@ impl Class {
 }
 
 enum Highlight<'a> {
-    Token { text: &'a str, class: Class },
+    Token { text: &'a str, class: Option<Class> },
     EnterSpan { class: Class },
     ExitSpan,
 }
@@ -164,8 +162,9 @@ impl<'a> Classifier<'a> {
     /// a couple of following ones as well.
     fn advance(&mut self, token: TokenKind, text: &'a str, sink: &mut dyn FnMut(Highlight<'a>)) {
         let lookahead = self.peek();
+        let no_highlight = |sink: &mut dyn FnMut(_)| sink(Highlight::Token { text, class: None });
         let class = match token {
-            TokenKind::Whitespace => Class::None,
+            TokenKind::Whitespace => return no_highlight(sink),
             TokenKind::LineComment { doc_style } | TokenKind::BlockComment { doc_style, .. } => {
                 if doc_style.is_some() {
                     Class::DocComment
@@ -190,12 +189,12 @@ impl<'a> Classifier<'a> {
             TokenKind::And => match lookahead {
                 Some(TokenKind::And) => {
                     let _and = self.tokens.next();
-                    sink(Highlight::Token { text: "&&", class: Class::Op });
+                    sink(Highlight::Token { text: "&&", class: Some(Class::Op) });
                     return;
                 }
                 Some(TokenKind::Eq) => {
                     let _eq = self.tokens.next();
-                    sink(Highlight::Token { text: "&=", class: Class::Op });
+                    sink(Highlight::Token { text: "&=", class: Some(Class::Op) });
                     return;
                 }
                 Some(TokenKind::Whitespace) => Class::Op,
@@ -226,7 +225,7 @@ impl<'a> Classifier<'a> {
             | TokenKind::At
             | TokenKind::Tilde
             | TokenKind::Colon
-            | TokenKind::Unknown => Class::None,
+            | TokenKind::Unknown => return no_highlight(sink),
 
             TokenKind::Question => Class::QuestionMark,
 
@@ -235,7 +234,7 @@ impl<'a> Classifier<'a> {
                     self.in_macro_nonterminal = true;
                     Class::MacroNonTerminal
                 }
-                _ => Class::None,
+                _ => return no_highlight(sink),
             },
 
             // This might be the start of an attribute. We're going to want to
@@ -251,8 +250,8 @@ impl<'a> Classifier<'a> {
                             self.in_attribute = true;
                             sink(Highlight::EnterSpan { class: Class::Attribute });
                         }
-                        sink(Highlight::Token { text: "#", class: Class::None });
-                        sink(Highlight::Token { text: "!", class: Class::None });
+                        sink(Highlight::Token { text: "#", class: None });
+                        sink(Highlight::Token { text: "!", class: None });
                         return;
                     }
                     // Case 2: #[outer_attribute]
@@ -262,16 +261,16 @@ impl<'a> Classifier<'a> {
                     }
                     _ => (),
                 }
-                Class::None
+                return no_highlight(sink);
             }
             TokenKind::CloseBracket => {
                 if self.in_attribute {
                     self.in_attribute = false;
-                    sink(Highlight::Token { text: "]", class: Class::None });
+                    sink(Highlight::Token { text: "]", class: None });
                     sink(Highlight::ExitSpan);
                     return;
                 }
-                Class::None
+                return no_highlight(sink);
             }
             TokenKind::Literal { kind, .. } => match kind {
                 // Text literals.
@@ -307,7 +306,7 @@ impl<'a> Classifier<'a> {
         };
         // Anything that didn't return above is the simple case where we the
         // class just spans a single token, so we can use the `string` method.
-        sink(Highlight::Token { text, class });
+        sink(Highlight::Token { text, class: Some(class) });
     }
 
     fn peek(&mut self) -> Option<TokenKind> {
@@ -337,10 +336,10 @@ fn exit_span(out: &mut String) {
 /// ```
 /// The latter can be thought of as a shorthand for the former, which is more
 /// flexible.
-fn string<T: Display>(out: &mut String, text: T, klass: Class) {
+fn string<T: Display>(out: &mut String, text: T, klass: Option<Class>) {
     match klass {
-        Class::None => write!(out, "{}", text).unwrap(),
-        klass => write!(out, "<span class=\"{}\">{}</span>", klass.as_html(), text).unwrap(),
+        None => write!(out, "{}", text).unwrap(),
+        Some(klass) => write!(out, "<span class=\"{}\">{}</span>", klass.as_html(), text).unwrap(),
     }
 }
 

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -243,7 +243,8 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
                 .collect::<Vec<Cow<'_, str>>>()
                 .join("\n");
             let krate = krate.as_ref().map(|s| &**s);
-            let (test, _) = doctest::make_test(&test, krate, false, &Default::default(), edition);
+            let (test, _, _) =
+                doctest::make_test(&test, krate, false, &Default::default(), edition);
             let channel = if test.contains("#![feature(") { "&amp;version=nightly" } else { "" };
 
             let edition_string = format!("&amp;edition={}", edition);

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -167,7 +167,7 @@ crate fn build_index(krate: &clean::Crate, cache: &mut Cache) -> String {
 crate fn get_index_search_type(item: &clean::Item) -> Option<IndexItemFunctionType> {
     let (all_types, ret_types) = match item.kind {
         clean::FunctionItem(ref f) => (&f.all_types, &f.ret_types),
-        clean::MethodItem(ref m) => (&m.all_types, &m.ret_types),
+        clean::MethodItem(ref m, _) => (&m.all_types, &m.ret_types),
         clean::TyMethodItem(ref m) => (&m.all_types, &m.ret_types),
         _ => return None,
     };

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3752,8 +3752,7 @@ fn render_impl(
                 (true, " hidden")
             };
         match item.kind {
-            clean::MethodItem(clean::Method { .. })
-            | clean::TyMethodItem(clean::TyMethod { .. }) => {
+            clean::MethodItem(_) | clean::TyMethodItem(_) => {
                 // Only render when the method is not static or we allow static methods
                 if render_method_item {
                     let id = cx.derive_id(format!("{}.{}", item_type, name));

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2589,7 +2589,9 @@ fn item_trait(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Trait, 
             for (pos, m) in provided.iter().enumerate() {
                 render_assoc_item(w, m, AssocItemLink::Anchor(None), ItemType::Trait);
                 match m.kind {
-                    clean::MethodItem(ref inner) if !inner.generics.where_predicates.is_empty() => {
+                    clean::MethodItem(ref inner, _)
+                        if !inner.generics.where_predicates.is_empty() =>
+                    {
                         write!(w, ",\n    {{ ... }}\n");
                     }
                     _ => {
@@ -2968,7 +2970,9 @@ fn render_assoc_item(
     match item.kind {
         clean::StrippedItem(..) => {}
         clean::TyMethodItem(ref m) => method(w, item, m.header, &m.generics, &m.decl, link, parent),
-        clean::MethodItem(ref m) => method(w, item, m.header, &m.generics, &m.decl, link, parent),
+        clean::MethodItem(ref m, _) => {
+            method(w, item, m.header, &m.generics, &m.decl, link, parent)
+        }
         clean::AssocConstItem(ref ty, ref default) => assoc_const(
             w,
             item,
@@ -3545,7 +3549,7 @@ fn render_deref_methods(
 
 fn should_render_item(item: &clean::Item, deref_mut_: bool) -> bool {
     let self_type_opt = match item.kind {
-        clean::MethodItem(ref method) => method.decl.self_type(),
+        clean::MethodItem(ref method, _) => method.decl.self_type(),
         clean::TyMethodItem(ref method) => method.decl.self_type(),
         _ => None,
     };
@@ -3752,7 +3756,7 @@ fn render_impl(
                 (true, " hidden")
             };
         match item.kind {
-            clean::MethodItem(_) | clean::TyMethodItem(_) => {
+            clean::MethodItem(..) | clean::TyMethodItem(_) => {
                 // Only render when the method is not static or we allow static methods
                 if render_method_item {
                     let id = cx.derive_id(format!("{}.{}", item_type, name));

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2759,7 +2759,7 @@ fn item_trait(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Trait, 
         }
         write_loading_content(w, "</div>");
 
-        if t.auto {
+        if t.is_auto {
             write_small_section_header(
                 w,
                 "synthetic-implementors",
@@ -2790,7 +2790,7 @@ fn item_trait(w: &mut Buffer, cx: &Context, it: &clean::Item, t: &clean::Trait, 
         );
         write_loading_content(w, "</div>");
 
-        if t.auto {
+        if t.is_auto {
             write_small_section_header(
                 w,
                 "synthetic-implementors",
@@ -4454,7 +4454,7 @@ fn sidebar_trait(buf: &mut Buffer, it: &clean::Item, t: &clean::Trait) {
     sidebar.push_str(&sidebar_assoc_items(it));
 
     sidebar.push_str("<a class=\"sidebar-title\" href=\"#implementors\">Implementors</a>");
-    if t.auto {
+    if t.is_auto {
         sidebar.push_str(
             "<a class=\"sidebar-title\" \
                 href=\"#synthetic-implementors\">Auto Implementors</a>",

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -54,6 +54,10 @@ extern crate rustc_target;
 extern crate rustc_trait_selection;
 extern crate rustc_typeck;
 extern crate test as testing;
+#[macro_use]
+extern crate tracing;
+#[cfg(windows)]
+extern crate termcolor;
 
 use std::default::Default;
 use std::env;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -54,10 +54,6 @@ extern crate rustc_target;
 extern crate rustc_trait_selection;
 extern crate rustc_typeck;
 extern crate test as testing;
-#[macro_use]
-extern crate tracing;
-#[cfg(windows)]
-extern crate termcolor;
 
 use std::default::Default;
 use std::env;

--- a/src/test/ui/const-generics/macro_rules-braces.full.stderr
+++ b/src/test/ui/const-generics/macro_rules-braces.full.stderr
@@ -9,6 +9,17 @@ help: enclose the `const` expression in braces
 LL |     let _: baz!({ N });
    |                 ^   ^
 
+error: expressions must be enclosed in braces to be used as const generic arguments
+  --> $DIR/macro_rules-braces.rs:54:17
+   |
+LL |     let _: baz!(10 + 7);
+   |                 ^^^^^^
+   |
+help: enclose the `const` expression in braces
+   |
+LL |     let _: baz!({ 10 + 7 });
+   |                 ^        ^
+
 error: constant expression depends on a generic parameter
   --> $DIR/macro_rules-braces.rs:10:13
    |
@@ -57,5 +68,5 @@ LL |     let _: biz!({ N });
    = note: this may fail depending on what value the parameter takes
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/const-generics/macro_rules-braces.min.stderr
+++ b/src/test/ui/const-generics/macro_rules-braces.min.stderr
@@ -9,6 +9,17 @@ help: enclose the `const` expression in braces
 LL |     let _: baz!({ N });
    |                 ^   ^
 
+error: expressions must be enclosed in braces to be used as const generic arguments
+  --> $DIR/macro_rules-braces.rs:54:17
+   |
+LL |     let _: baz!(10 + 7);
+   |                 ^^^^^^
+   |
+help: enclose the `const` expression in braces
+   |
+LL |     let _: baz!({ 10 + 7 });
+   |                 ^        ^
+
 error: generic parameters may not be used in const operations
   --> $DIR/macro_rules-braces.rs:31:20
    |
@@ -41,5 +52,5 @@ LL |     let _: biz!({ N });
    |
    = help: const parameters may only be used as standalone arguments, i.e. `N`
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/const-generics/macro_rules-braces.rs
+++ b/src/test/ui/const-generics/macro_rules-braces.rs
@@ -36,6 +36,26 @@ fn test<const N: usize>() {
     let _: baz!({{ N }}); //[min]~ ERROR generic parameters may not
     let _: biz!(N);
     let _: biz!({ N }); //[min]~ ERROR generic parameters may not
+    let _: foo!(3);
+    let _: foo!({ 3 });
+    let _: foo!({{ 3 }});
+    let _: bar!(3);
+    let _: bar!({ 3 });
+    let _: baz!(3);
+    let _: baz!({ 3 });
+    let _: baz!({{ 3 }});
+    let _: biz!(3);
+    let _: biz!({ 3 });
+    let _: foo!(10 + 7);
+    let _: foo!({ 10 + 7 });
+    let _: foo!({{ 10 + 7 }});
+    let _: bar!(10 + 7);
+    let _: bar!({ 10 + 7 });
+    let _: baz!(10 + 7); //~ ERROR expressions must be enclosed in braces
+    let _: baz!({ 10 + 7 });
+    let _: baz!({{ 10 + 7 }});
+    let _: biz!(10 + 7);
+    let _: biz!({ 10 + 7 });
 }
 
 fn main() {

--- a/src/test/ui/match/type_polymorphic_byte_str_literals.rs
+++ b/src/test/ui/match/type_polymorphic_byte_str_literals.rs
@@ -1,0 +1,36 @@
+#[deny(unreachable_patterns)]
+
+fn parse_data1(data: &[u8]) -> u32 {
+    match data {
+        b"" => 1,
+        _ => 2,
+    }
+}
+
+fn parse_data2(data: &[u8]) -> u32 {
+    match data { //~ ERROR non-exhaustive patterns: `&[_, ..]` not covered
+        b"" => 1,
+    }
+}
+
+fn parse_data3(data: &[u8; 0]) -> u8 {
+    match data {
+        b"" => 1,
+    }
+}
+
+fn parse_data4(data: &[u8]) -> u8 {
+    match data { //~ ERROR non-exhaustive patterns
+        b"aaa" => 0,
+        [_, _, _] => 1,
+    }
+}
+
+fn parse_data5(data: &[u8; 3]) -> u8 {
+    match data {
+        b"aaa" => 0,
+        [_, _, _] => 1,
+    }
+}
+
+fn main() {}

--- a/src/test/ui/match/type_polymorphic_byte_str_literals.stderr
+++ b/src/test/ui/match/type_polymorphic_byte_str_literals.stderr
@@ -1,0 +1,21 @@
+error[E0004]: non-exhaustive patterns: `&[_, ..]` not covered
+  --> $DIR/type_polymorphic_byte_str_literals.rs:11:11
+   |
+LL |     match data {
+   |           ^^^^ pattern `&[_, ..]` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[u8]`
+
+error[E0004]: non-exhaustive patterns: `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
+  --> $DIR/type_polymorphic_byte_str_literals.rs:23:11
+   |
+LL |     match data {
+   |           ^^^^ patterns `&[]`, `&[_]`, `&[_, _]` and 1 more not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&[u8]`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
+++ b/src/test/ui/pattern/usefulness/match-byte-array-patterns-2.stderr
@@ -7,11 +7,11 @@ LL |     match buf {
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&[u8; 4]`
 
-error[E0004]: non-exhaustive patterns: `&[0_u8..=64_u8, _, _, _]` and `&[66_u8..=u8::MAX, _, _, _]` not covered
+error[E0004]: non-exhaustive patterns: `&[]`, `&[_]`, `&[_, _]` and 2 more not covered
   --> $DIR/match-byte-array-patterns-2.rs:10:11
    |
 LL |     match buf {
-   |           ^^^ patterns `&[0_u8..=64_u8, _, _, _]` and `&[66_u8..=u8::MAX, _, _, _]` not covered
+   |           ^^^ patterns `&[]`, `&[_]`, `&[_, _]` and 2 more not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&[u8]`


### PR DESCRIPTION
Successful merges:

 - #74293 (Rustdoc test compiler output color)
 - #78702 ([self-profiling] Include the estimated size of each cgu in the profile)
 - #79069 (Get rid of `highlight::Class::None`)
 - #79072 (Fix exhaustiveness in case a byte string literal is used at slice type)
 - #79120 (update rustfmt to v1.4.27)
 - #79125 (Get rid of clean::{Method, TyMethod})
 - #79126 (Remove duplicate `Trait::auto` field)
 - #79130 (extend macro braces test)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=74293,78702,79069,79072,79120,79125,79126,79130)
<!-- homu-ignore:end -->