### PR TITLE
fix handling the default config for profiler and sanitizers

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -280,8 +280,8 @@ pub struct Target {
     pub ranlib: Option<PathBuf>,
     pub linker: Option<PathBuf>,
     pub ndk: Option<PathBuf>,
-    pub sanitizers: bool,
-    pub profiler: bool,
+    pub sanitizers: Option<bool>,
+    pub profiler: Option<bool>,
     pub crt_static: Option<bool>,
     pub musl_root: Option<PathBuf>,
     pub musl_libdir: Option<PathBuf>,
@@ -896,8 +896,8 @@ impl Config {
                 target.musl_libdir = cfg.musl_libdir.map(PathBuf::from);
                 target.wasi_root = cfg.wasi_root.map(PathBuf::from);
                 target.qemu_rootfs = cfg.qemu_rootfs.map(PathBuf::from);
-                target.sanitizers = cfg.sanitizers.unwrap_or(build.sanitizers.unwrap_or_default());
-                target.profiler = cfg.profiler.unwrap_or(build.profiler.unwrap_or_default());
+                target.sanitizers = cfg.sanitizers;
+                target.profiler = cfg.profiler;
 
                 config.target_config.insert(TargetSelection::from_user(&triple), target);
             }
@@ -1008,19 +1008,19 @@ impl Config {
     }
 
     pub fn sanitizers_enabled(&self, target: TargetSelection) -> bool {
-        self.target_config.get(&target).map(|t| t.sanitizers).unwrap_or(self.sanitizers)
+        self.target_config.get(&target).map(|t| t.sanitizers).flatten().unwrap_or(self.sanitizers)
     }
 
     pub fn any_sanitizers_enabled(&self) -> bool {
-        self.target_config.values().any(|t| t.sanitizers) || self.sanitizers
+        self.target_config.values().any(|t| t.sanitizers == Some(true)) || self.sanitizers
     }
 
     pub fn profiler_enabled(&self, target: TargetSelection) -> bool {
-        self.target_config.get(&target).map(|t| t.profiler).unwrap_or(self.profiler)
+        self.target_config.get(&target).map(|t| t.profiler).flatten().unwrap_or(self.profiler)
     }
 
     pub fn any_profiler_enabled(&self) -> bool {
-        self.target_config.values().any(|t| t.profiler) || self.profiler
+        self.target_config.values().any(|t| t.profiler == Some(true)) || self.profiler
     }
 
     pub fn llvm_enabled(&self) -> bool {


### PR DESCRIPTION
#78354 don't handle the case that user don't add any target-specific config in `[target.*]` of `config.toml`:
```toml
changelog-seen = 2
[llvm]
link-shared = true
[build]
sanitizers = true
profiler = true
[install]
[rust]
[dist]
```

The previes code handle the default config in `Config::prase()`:

```rust
target.sanitizers = cfg.sanitizers.unwrap_or(build.sanitizers.unwrap_or_default());
target.profiler = cfg.profiler.unwrap_or(build.profiler.unwrap_or_default());
config.target_config.insert(TargetSelection::from_user(&triple), target);
```

In this case, `toml.target` don't contain any target, so the above code won't execute. Instead, a default `Target` is insert in https://github.com/rust-lang/rust/blob/c919f490bbcd2b29b74016101f7ec71aaa24bdbb/src/bootstrap/sanity.rs#L162-L166

The default value for `bool` is false, hence the issue in #79124

This fix change the type of `sanitizers` and `profiler` to `Option<bool>`, so the default value is `None`, and fallback config is handled in  `Config::sanitizers_enabled` and `Config::profiler_enabled`

fix #79124

cc @Mark-Simulacrum @richkadel