### PR TITLE
Allow using `download-ci-llvm` from directories other than the root

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -447,12 +447,15 @@ class RustBuild(object):
             #
             # This works even in a repository that has not yet initialized
             # submodules.
+            top_level = subprocess.check_output([
+                "git", "rev-parse", "--show-toplevel",
+            ]).decode(sys.getdefaultencoding()).strip()
             llvm_sha = subprocess.check_output([
                 "git", "log", "--author=bors", "--format=%H", "-n1",
                 "-m", "--first-parent",
                 "--",
-                "src/llvm-project",
-                "src/bootstrap/download-ci-llvm-stamp",
+                "{}/src/llvm-project".format(top_level),
+                "{}/src/bootstrap/download-ci-llvm-stamp".format(top_level),
             ]).decode(sys.getdefaultencoding()).strip()
             llvm_assertions = self.get_toml('assertions', 'llvm') == 'true'
             if self.program_out_of_date(self.llvm_stamp(), llvm_sha + str(llvm_assertions)):


### PR DESCRIPTION
Previously, bootstrap.py would attempt to find the LLVM commit from
`src/llvm-project`. However, it assumed it was always being run from the
top-level directory, which isn't always the case.

Before:

```
downloading https://ci-artifacts.rust-lang.org/rustc-builds//rust-dev-nightly-x86_64-unknown-linux-gnu.tar.gz

curl: (22) The requested URL returned error: 404
failed to run: curl -# -y 30 -Y 10 --connect-timeout 30 --retry 3 -Sf -o /tmp/tmppyh4w8 https://ci-artifacts.rust-lang.org/rustc-builds//rust-dev-nightly-x86_64-unknown-linux-gnu.tar.gz
Build completed unsuccessfully in 0:00:02
```

After:

```
downloading https://ci-artifacts.rust-lang.org/rustc-builds/430feb24a46993e5073c1bb1b39da190d83fa2bf/rust-dev-nightly-x86_64-unknown-linux-gnu.tar.gz
 ###################################################################################################################################################################### 100.0%
extracting /home/joshua/rustc/src/bootstrap/build/cache/llvm-430feb24a46993e5073c1bb1b39da190d83fa2bf-False/rust-dev-nightly-x86_64-unknown-linux-gnu.tar.gz
```

r? @Mark-Simulacrum 
cc @pnkfelix 