### PR TITLE
type is too big -> values of the type are too big

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -176,7 +176,7 @@ impl<'tcx> fmt::Display for LayoutError<'tcx> {
         match *self {
             LayoutError::Unknown(ty) => write!(f, "the type `{}` has an unknown layout", ty),
             LayoutError::SizeOverflow(ty) => {
-                write!(f, "the type `{}` is too big for the current architecture", ty)
+                write!(f, "values of the type `{}` are too big for the current architecture", ty)
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -97,6 +97,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
         self.infcx.tcx
     }
 
+    #[instrument(skip(self))]
     fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
         if !ty.has_projections() {
             return ty;

--- a/src/test/compile-fail/consts/issue-55878.rs
+++ b/src/test/compile-fail/consts/issue-55878.rs
@@ -1,7 +1,7 @@
 // normalize-stderr-64bit "18446744073709551615" -> "SIZE"
 // normalize-stderr-32bit "4294967295" -> "SIZE"
 
-// error-pattern: is too big for the current architecture
+// error-pattern: are too big for the current architecture
 fn main() {
     println!("Size: {}", std::mem::size_of::<[u8; std::u64::MAX as usize]>());
 }

--- a/src/test/ui/huge-array-simple-32.stderr
+++ b/src/test/ui/huge-array-simple-32.stderr
@@ -1,4 +1,4 @@
-error: the type `[u8; 2147516416]` is too big for the current architecture
+error: values of the type `[u8; 2147516416]` are too big for the current architecture
   --> $DIR/huge-array-simple-32.rs:10:9
    |
 LL |     let _fat: [u8; (1<<31)+(1<<15)] =

--- a/src/test/ui/huge-array-simple-64.stderr
+++ b/src/test/ui/huge-array-simple-64.stderr
@@ -1,4 +1,4 @@
-error: the type `[u8; 2305843011361177600]` is too big for the current architecture
+error: values of the type `[u8; 2305843011361177600]` are too big for the current architecture
   --> $DIR/huge-array-simple-64.rs:10:9
    |
 LL |     let _fat: [u8; (1<<61)+(1<<31)] =

--- a/src/test/ui/huge-array.rs
+++ b/src/test/ui/huge-array.rs
@@ -6,7 +6,7 @@
 
 fn generic<T: Copy>(t: T) {
     let s: [T; 1518600000] = [t; 1518600000];
-    //~^ ERROR the type `[[u8; 1518599999]; 1518600000]` is too big for the current architecture
+    //~^ ERROR values of the type `[[u8; 1518599999]; 1518600000]` are too big
 }
 
 fn main() {

--- a/src/test/ui/huge-array.stderr
+++ b/src/test/ui/huge-array.stderr
@@ -1,4 +1,4 @@
-error: the type `[[u8; 1518599999]; 1518600000]` is too big for the current architecture
+error: values of the type `[[u8; 1518599999]; 1518600000]` are too big for the current architecture
   --> $DIR/huge-array.rs:8:9
    |
 LL |     let s: [T; 1518600000] = [t; 1518600000];

--- a/src/test/ui/huge-enum.rs
+++ b/src/test/ui/huge-enum.rs
@@ -14,5 +14,5 @@ type BIG = Option<[u32; (1<<45)-1]>;
 
 fn main() {
     let big: BIG = None;
-    //~^ ERROR is too big for the current architecture
+    //~^ ERROR are too big for the current architecture
 }

--- a/src/test/ui/huge-enum.stderr
+++ b/src/test/ui/huge-enum.stderr
@@ -1,4 +1,4 @@
-error: the type `Option<TYPE>` is too big for the current architecture
+error: values of the type `Option<TYPE>` are too big for the current architecture
   --> $DIR/huge-enum.rs:16:9
    |
 LL |     let big: BIG = None;

--- a/src/test/ui/huge-struct.rs
+++ b/src/test/ui/huge-struct.rs
@@ -48,6 +48,6 @@ struct S1M<T> { val: S1k<S1k<T>> }
 
 fn main() {
     let fat: Option<S1M<S1M<S1M<u32>>>> = None;
-    //~^ ERROR is too big for the current architecture
+    //~^ ERROR are too big for the current architecture
 
 }

--- a/src/test/ui/huge-struct.stderr
+++ b/src/test/ui/huge-struct.stderr
@@ -1,4 +1,4 @@
-error: the type `SXX<SXX<SXX<u32>>>` is too big for the current architecture
+error: values of the type `SXX<SXX<SXX<u32>>>` are too big for the current architecture
   --> $DIR/huge-struct.rs:50:9
    |
 LL |     let fat: Option<SXX<SXX<SXX<u32>>>> = None;

--- a/src/test/ui/issues/issue-15919-32.stderr
+++ b/src/test/ui/issues/issue-15919-32.stderr
@@ -1,4 +1,4 @@
-error: the type `[usize; 4294967295]` is too big for the current architecture
+error: values of the type `[usize; 4294967295]` are too big for the current architecture
   --> $DIR/issue-15919-32.rs:9:9
    |
 LL |     let x = [0usize; 0xffff_ffff];

--- a/src/test/ui/issues/issue-15919-64.stderr
+++ b/src/test/ui/issues/issue-15919-64.stderr
@@ -1,4 +1,4 @@
-error: the type `[usize; 18446744073709551615]` is too big for the current architecture
+error: values of the type `[usize; 18446744073709551615]` are too big for the current architecture
   --> $DIR/issue-15919-64.rs:9:9
    |
 LL |     let x = [0usize; 0xffff_ffff_ffff_ffff];

--- a/src/test/ui/issues/issue-17913.stderr
+++ b/src/test/ui/issues/issue-17913.stderr
@@ -1,4 +1,4 @@
-error: the type `[&usize; N]` is too big for the current architecture
+error: values of the type `[&usize; N]` are too big for the current architecture
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-56762.rs
+++ b/src/test/ui/issues/issue-56762.rs
@@ -17,8 +17,8 @@ impl TooBigArray {
 }
 
 static MY_TOO_BIG_ARRAY_1: TooBigArray = TooBigArray::new();
-//~^ ERROR the type `[u8; 2305843009213693951]` is too big for the current architecture
+//~^ ERROR values of the type `[u8; 2305843009213693951]` are too big
 static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];
-//~^ ERROR the type `[u8; 2305843009213693951]` is too big for the current architecture
+//~^ ERROR values of the type `[u8; 2305843009213693951]` are too big
 
 fn main() { }

--- a/src/test/ui/issues/issue-56762.stderr
+++ b/src/test/ui/issues/issue-56762.stderr
@@ -1,10 +1,10 @@
-error[E0080]: the type `[u8; 2305843009213693951]` is too big for the current architecture
+error[E0080]: values of the type `[u8; 2305843009213693951]` are too big for the current architecture
   --> $DIR/issue-56762.rs:19:1
    |
 LL | static MY_TOO_BIG_ARRAY_1: TooBigArray = TooBigArray::new();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0080]: the type `[u8; 2305843009213693951]` is too big for the current architecture
+error[E0080]: values of the type `[u8; 2305843009213693951]` are too big for the current architecture
   --> $DIR/issue-56762.rs:21:1
    |
 LL | static MY_TOO_BIG_ARRAY_2: [u8; HUGE_SIZE] = [0x00; HUGE_SIZE];

--- a/src/test/ui/layout/big-type-no-err.rs
+++ b/src/test/ui/layout/big-type-no-err.rs
@@ -1,0 +1,13 @@
+// Enormous types are allowed if they are never actually instantiated.
+// run-pass
+trait Foo {
+    type Assoc;
+}
+
+impl Foo for [u16; usize::MAX] {
+    type Assoc = u32;
+}
+
+fn main() {
+    let _a: Option<<[u16; usize::MAX] as Foo>::Assoc> = None;
+}

--- a/src/test/ui/lint/issue-69485-var-size-diffs-too-large.rs
+++ b/src/test/ui/lint/issue-69485-var-size-diffs-too-large.rs
@@ -3,7 +3,7 @@
 // compile-flags: -Zmir-opt-level=0
 
 fn main() {
-    Bug::V([0; !0]); //~ ERROR is too big for the current
+    Bug::V([0; !0]); //~ ERROR are too big for the current
 }
 
 enum Bug {

--- a/src/test/ui/lint/issue-69485-var-size-diffs-too-large.stderr
+++ b/src/test/ui/lint/issue-69485-var-size-diffs-too-large.stderr
@@ -1,4 +1,4 @@
-error: the type `[u8; 18446744073709551615]` is too big for the current architecture
+error: values of the type `[u8; 18446744073709551615]` are too big for the current architecture
   --> $DIR/issue-69485-var-size-diffs-too-large.rs:6:12
    |
 LL |     Bug::V([0; !0]);


### PR DESCRIPTION
strictly speaking, `[u8; usize::MAX]` or even `[[[u128; usize::MAX]; usize::MAX]; usize::MAX]` are absolutely fine types as long as you don't try to deal with any values of it.

This error message seems to cause some confusion imo, for example in https://github.com/rust-lang/rust/pull/79135#issuecomment-729361380 so I would prefer us to be more precise here.

See the added test case which uses one of these types without causing an error.

r? @oli-obk