### PR TITLE
Actually prepare beta 1.49.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,7 @@ Compiler
   `rustc` whether to link its own C runtime and libraries or to rely on a external 
   linker to find them. (Supported only on `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
+  Note: If you're using cargo you must explicitly pass the `--target` flag.
 - [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
@@ -79,8 +80,10 @@ Compatibility Notes
   disallow zero-initialization.][71274]
 - [`#[target_feature]` will now error if used in a place where it has no effect.][78143]
 - [Foreign exceptions are now caught by `catch_unwind` and will cause an abort.][70212]
+  Note: This behaviour is not guaranteed and is still considered undefined behaviour,
+  see the [`catch_unwind`] documentation for further information.
+  
 
-[78143]: https://github.com/rust-lang/rust/issues/78143
 
 Internal Only
 -------------
@@ -94,6 +97,7 @@ related tools.
 - [cg_llvm: `fewer_names` in `uncached_llvm_type`][76030]
 - [Made `ensure_sufficient_stack()` non-generic][76680]
 
+[78143]: https://github.com/rust-lang/rust/issues/78143
 [76680]: https://github.com/rust-lang/rust/pull/76680/
 [76030]: https://github.com/rust-lang/rust/pull/76030/
 [70212]: https://github.com/rust-lang/rust/pull/70212/
@@ -118,6 +122,7 @@ related tools.
 [73461]: https://github.com/rust-lang/rust/pull/73461/
 [73166]: https://github.com/rust-lang/rust/pull/73166/
 [intradoc-links]: https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html
+[`catch_unwind`]: https://doc.rust-lang.org/std/panic/fn.catch_unwind.html
 [`Option::is_some`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some
 [`Option::is_none`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none
 [`Option::as_ref`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.as_ref

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,125 @@
+Version 1.48.0 (2020-11-19)
+==========================
+
+Language
+--------
+
+- [The `unsafe` keyword is now syntactically permitted on modules.][75857] This
+  is still rejected *semantically*, but can now be parsed by procedural macros.
+
+Compiler
+--------
+- [Stabilised the `-C link=<yes|no>`][76158] Which tells `rustc` whether to link
+  its own libraries or to rely on a external linker. (supported only on
+  `windows-gnu`, `linux-musl`, and `wasi` platforms.)
+- [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
+- [Added tier 2\* support for  `aarch64-unknown-linux-musl`.][76420]
+
+Libraries
+---------
+- [`io::Write` is now implemented for `&ChildStdin` `&Sink`, `&Stdout`,
+  and `&Stderr`.][76275]
+- [All arrays now implement `TryFrom<Vec<T>>`.][76310]
+- [The `matches!` macro now supports having a trailing comma.][74880]
+- [`Vec<A>` now implements `PartialEq<[B]>` where `A: PartialEq<B>`.][74194]
+- [Nearly all of `Cell`'s panicking functions now use the `#[track_caller]`
+  attribute.][77055]
+
+Stabilized APIs
+---------------
+- [`slice::as_ptr_range`]
+- [`slice::as_mut_ptr_range`]
+- [`VecDeque::make_contiguous`]
+- [`future::pending`]
+- [`future::ready`]
+
+The following previously stable methods are now `const fn`'s:
+
+- [`Option::is_some`]
+- [`Option::is_none`]
+- [`Option::as_ref`]
+- [`Result::is_ok`]
+- [`Result::is_err`]
+- [`Result::as_ref`]
+- [`Ordering::reverse`]
+- [`Ordering::then`]
+
+Cargo
+-----
+
+Misc
+----
+- [You can now link to different items in `rustdoc` using the intra-doc link
+  syntax.][74430] E.g. ``/// Uses [`std::future`] `` will automatically generate
+  a link to `std::future`'s documentation. See ["Linking to items by
+  name"][intradoc-links] for more information.
+- [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
+  when searching through `rustdoc`'s UI.][75740]
+- [You can now use `rustup install <major>.<minor>` to specify installing the
+  latest availeble patch of that minor version of the toolchain.][76107] E.g.
+  `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
+
+Compatibility Notes
+-------------------
+- [`const fn`s are now implicitly promoted to `const`.][75502] Meaning that it
+  will only warn if your code fails `const` evaluation, and not produce an error.
+- [Associated type bindings on trait objects are now verified to meet the bounds
+  declared on the trait when checking that they implement the trait.][27675]
+- [When traits bounds on associated types or opaque types are ambiguous the
+  compiler no longer makes an arbitrary choice on which bound to use.][54121]
+- [Fixed recursive nonterminals not being expended in macros during
+  pretty-print/reparse check.][77153] This may cause errors if your macro wasn't
+  correctly handling recursive nonterminal tokens.
+- [`&mut` references to non zero-sized types are not longer promoted.][75585]
+- [`rustc` will now warn if you use attributes like `#[link_name]` or `#[cold]`
+  in places where they have no effect.][73461]
+- [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in
+  `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
+
+
+
+Internal Only
+-------------
+- [Building `rustc` from source now uses `ninja` by default over `make`.][74922]
+  You can continue building with `make` by setting `ninja=false` in
+  your `config.toml`.
+
+[27675]: https://github.com/rust-lang/rust/issues/27675/
+[54121]: https://github.com/rust-lang/rust/issues/54121/
+[77386]: https://github.com/rust-lang/rust/pull/77386/
+[77153]: https://github.com/rust-lang/rust/pull/77153/
+[77055]: https://github.com/rust-lang/rust/pull/77055/
+[76275]: https://github.com/rust-lang/rust/pull/76275/
+[76310]: https://github.com/rust-lang/rust/pull/76310/
+[76420]: https://github.com/rust-lang/rust/pull/76420/
+[76107]: https://github.com/rust-lang/rust/pull/76107/
+[76158]: https://github.com/rust-lang/rust/pull/76158/
+[75857]: https://github.com/rust-lang/rust/pull/75857/
+[75585]: https://github.com/rust-lang/rust/pull/75585/
+[75740]: https://github.com/rust-lang/rust/pull/75740/
+[75502]: https://github.com/rust-lang/rust/pull/75502/
+[74880]: https://github.com/rust-lang/rust/pull/74880/
+[74922]: https://github.com/rust-lang/rust/pull/74922/
+[74430]: https://github.com/rust-lang/rust/pull/74430/
+[74194]: https://github.com/rust-lang/rust/pull/74194/
+[73461]: https://github.com/rust-lang/rust/pull/73461/
+[73166]: https://github.com/rust-lang/rust/pull/73166/
+[intradoc-links]: https://doc.rust-lang.org/rustdoc/linking-to-items-by-name.html
+[`Option::is_some`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some
+[`Option::is_none`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.is_none
+[`Option::as_ref`]: https://doc.rust-lang.org/std/option/enum.Option.html#method.as_ref
+[`Result::is_ok`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.is_ok
+[`Result::is_err`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.is_err
+[`Result::as_ref`]: https://doc.rust-lang.org/std/result/enum.Result.html#method.as_ref
+[`Ordering::reverse`]: https://doc.rust-lang.org/std/cmp/enum.Ordering.html#method.reverse
+[`Ordering::then`]: https://doc.rust-lang.org/std/cmp/enum.Ordering.html#method.then
+[`slice::as_ptr_range`]: https://doc.rust-lang.org/std/primitive.slice.html#method.as_ptr_range
+[`slice::as_mut_ptr_range`]: https://doc.rust-lang.org/std/primitive.slice.html#method.as_mut_ptr_range
+[`VecDeque::make_contiguous`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.make_contiguous
+[`future::pending`]: https://doc.rust-lang.org/std/future/fn.pending.html
+[`future::ready`]: https://doc.rust-lang.org/std/future/fn.ready.html
+
+
 Version 1.47.0 (2020-10-08)
 ==========================
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,7 +22,7 @@ Libraries
 ---------
 - [`io::Write` is now implemented for `&ChildStdin` `&Sink`, `&Stdout`,
   and `&Stderr`.][76275]
-- [All arrays now implement `TryFrom<Vec<T>>`.][76310]
+- [All arrays of any length now implement `TryFrom<Vec<T>>`.][76310]
 - [The `matches!` macro now supports having a trailing comma.][74880]
 - [`Vec<A>` now implements `PartialEq<[B]>` where `A: PartialEq<B>`.][74194]
 - [Nearly all of `Cell`'s panicking functions now use the `#[track_caller]`

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -82,7 +82,7 @@ Compatibility Notes
 - [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in
   `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
 - [`mem::uninitialized` will now panic if any inner types inside a struct or enum
-  disallow zero-initialization].[71274]
+  disallow zero-initialization.][71274]
 
 Internal Only
 -------------

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -78,15 +78,25 @@ Compatibility Notes
 - [`mem::uninitialized` will now panic if any inner types inside a struct or enum
   disallow zero-initialization.][71274]
 - [`#[target_feature]` will now error if used in a place where it has no effect.][78143]
+- [Foreign exceptions are now caught by `catch_unwind` and will cause an abort.][70212]
 
 [78143]: https://github.com/rust-lang/rust/issues/78143
 
 Internal Only
 -------------
+These changes provide no direct user facing benefits, but represent significant
+improvements to the internals and overall performance of rustc and
+related tools.
+
 - [Building `rustc` from source now uses `ninja` by default over `make`.][74922]
   You can continue building with `make` by setting `ninja=false` in
   your `config.toml`.
+- [cg_llvm: `fewer_names` in `uncached_llvm_type`][76030]
+- [Made `ensure_sufficient_stack()` non-generic][76680]
 
+[76680]: https://github.com/rust-lang/rust/pull/76680/
+[76030]: https://github.com/rust-lang/rust/pull/76030/
+[70212]: https://github.com/rust-lang/rust/pull/70212/
 [27675]: https://github.com/rust-lang/rust/issues/27675/
 [54121]: https://github.com/rust-lang/rust/issues/54121/  
 [71274]: https://github.com/rust-lang/rust/pull/71274/
@@ -215,6 +225,7 @@ Compatibility Notes
 
 Internal Only
 --------
+
 - [Improved default settings for bootstrapping in `x.py`.][73964] You can read details about this change in the ["Changes to `x.py` defaults"](https://blog.rust-lang.org/inside-rust/2020/08/30/changes-to-x-py-defaults.html) post on the Inside Rust blog.
 
 [1.47.0-cfg]: https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,6 +15,9 @@ Compiler
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
 - [Added tier 2\* support for  `aarch64-unknown-linux-musl`.][76420]
 
+\* Refer to Rust's [platform support page][forge-platform-support] for more
+information on Rust's tiered platform support.
+
 Libraries
 ---------
 - [`io::Write` is now implemented for `&ChildStdin` `&Sink`, `&Stdout`,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,8 +25,7 @@ Libraries
 - [All arrays of any length now implement `TryFrom<Vec<T>>`.][76310]
 - [The `matches!` macro now supports having a trailing comma.][74880]
 - [`Vec<A>` now implements `PartialEq<[B]>` where `A: PartialEq<B>`.][74194]
-- [Nearly all of `Cell`'s panicking functions now use the `#[track_caller]`
-  attribute.][77055]
+- [The `RefCell::{replace, replace_with, clone}` methods now all use `#[track_caller]`.][77055]
 
 Stabilized APIs
 ---------------
@@ -61,8 +60,9 @@ Rustdoc
 
 Compatibility Notes
 -------------------
-- [`const fn`s are now implicitly promoted to `const`.][75502] Meaning that it
-  will only warn if your code fails `const` evaluation, and not produce an error.
+- [Promotion of references to `'static` lifetime inside `const fn` now follows the
+  same rules as inside a `fn` body.][75502] In particular, `&foo()` will not be
+  promoted to `'static` lifetime any more inside `const fn`s.
 - [Associated type bindings on trait objects are now verified to meet the bounds
   declared on the trait when checking that they implement the trait.][27675]
 - [When trait bounds on associated types or opaque types are ambiguous, the

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,8 +9,8 @@ Language
 
 Compiler
 --------
-- [Stabilised the `-C link-self-contained=<yes|no>`][76158] Which tells `rustc` whether to link
-  its own C runtime and libraries or to rely on a external linker to find them. (supported only on
+- [Stabilised the `-C link-self-contained=<yes|no>`.][76158] This tells `rustc` whether to link
+  its own C runtime and libraries or to rely on a external linker to find them. (Supported only on
   `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
 - [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
@@ -52,14 +52,14 @@ Cargo
 
 Misc
 ----
-- [You can now link to different items in `rustdoc` using the intra-doc link
+- [You can now link to items in `rustdoc` using the intra-doc link
   syntax.][74430] E.g. ``/// Uses [`std::future`]`` will automatically generate
   a link to `std::future`'s documentation. See ["Linking to items by
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
 - [You can now use `rustup install <major>.<minor>` to specify installing the
-  latest available patch of that minor version of the toolchain.][76107] E.g.
+  latest available patch of the specified minor version of the toolchain.][76107] E.g.
   `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
 
 Compatibility Notes
@@ -70,7 +70,7 @@ Compatibility Notes
   declared on the trait when checking that they implement the trait.][27675]
 - [When trait bounds on associated types or opaque types are ambiguous, the
   compiler no longer makes an arbitrary choice on which bound to use.][54121]
-- [Fixed recursive nonterminals not being expended in macros during
+- [Fixed recursive nonterminals not being expanded in macros during
   pretty-print/reparse check.][77153] This may cause errors if your macro wasn't
   correctly handling recursive nonterminal tokens.
 - [`&mut` references to non zero-sized types are no longer promoted.][75585]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -58,12 +58,6 @@ Rustdoc
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
-  
-Rustup
-------
-- [You can now use `rustup install <major>.<minor>` to specify installing the
-  latest available patch of the specified minor version of the toolchain.][76107] E.g.
-  `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
 
 Compatibility Notes
 -------------------
@@ -83,6 +77,9 @@ Compatibility Notes
   `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
 - [`mem::uninitialized` will now panic if any inner types inside a struct or enum
   disallow zero-initialization.][71274]
+- [`#[target_feature]` will now error if used in a place where it has no effect.][78143]
+
+[78143]: https://github.com/rust-lang/rust/issues/78143
 
 Internal Only
 -------------
@@ -99,7 +96,6 @@ Internal Only
 [76275]: https://github.com/rust-lang/rust/pull/76275/
 [76310]: https://github.com/rust-lang/rust/pull/76310/
 [76420]: https://github.com/rust-lang/rust/pull/76420/
-[76107]: https://github.com/rust-lang/rust/pull/76107/
 [76158]: https://github.com/rust-lang/rust/pull/76158/
 [75857]: https://github.com/rust-lang/rust/pull/75857/
 [75585]: https://github.com/rust-lang/rust/pull/75585/

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,10 +10,10 @@ Language
 Compiler
 --------
 - [Stabilised the `-C link-self-contained=<yes|no>`][76158] Which tells `rustc` whether to link
-  its own libraries or to rely on a external linker. (supported only on
+  its own C runtime and libraries or to rely on a external linker to find them. (supported only on
   `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
-- [Added tier 2\* support for  `aarch64-unknown-linux-musl`.][76420]
+- [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
 information on Rust's tiered platform support.
@@ -53,13 +53,13 @@ Cargo
 Misc
 ----
 - [You can now link to different items in `rustdoc` using the intra-doc link
-  syntax.][74430] E.g. ``/// Uses [`std::future`] `` will automatically generate
+  syntax.][74430] E.g. ``/// Uses [`std::future`]`` will automatically generate
   a link to `std::future`'s documentation. See ["Linking to items by
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
 - [You can now use `rustup install <major>.<minor>` to specify installing the
-  latest availeble patch of that minor version of the toolchain.][76107] E.g.
+  latest available patch of that minor version of the toolchain.][76107] E.g.
   `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
 
 Compatibility Notes
@@ -68,12 +68,12 @@ Compatibility Notes
   will only warn if your code fails `const` evaluation, and not produce an error.
 - [Associated type bindings on trait objects are now verified to meet the bounds
   declared on the trait when checking that they implement the trait.][27675]
-- [When traits bounds on associated types or opaque types are ambiguous the
+- [When trait bounds on associated types or opaque types are ambiguous, the
   compiler no longer makes an arbitrary choice on which bound to use.][54121]
 - [Fixed recursive nonterminals not being expended in macros during
   pretty-print/reparse check.][77153] This may cause errors if your macro wasn't
   correctly handling recursive nonterminal tokens.
-- [`&mut` references to non zero-sized types are not longer promoted.][75585]
+- [`&mut` references to non zero-sized types are no longer promoted.][75585]
 - [`rustc` will now warn if you use attributes like `#[link_name]` or `#[cold]`
   in places where they have no effect.][73461]
 - [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,14 +50,17 @@ The following previously stable methods are now `const fn`'s:
 Cargo
 -----
 
-Misc
-----
+Rustdoc
+-------
 - [You can now link to items in `rustdoc` using the intra-doc link
   syntax.][74430] E.g. ``/// Uses [`std::future`]`` will automatically generate
   a link to `std::future`'s documentation. See ["Linking to items by
   name"][intradoc-links] for more information.
 - [You can now specify `#[doc(alias = "<alias>")]` on items to add search aliases
   when searching through `rustdoc`'s UI.][75740]
+  
+Rustup
+------
 - [You can now use `rustup install <major>.<minor>` to specify installing the
   latest available patch of the specified minor version of the toolchain.][76107] E.g.
   `rustup install 1.45` would install `1.45.2`, and `1.46` would install `1.46.0`.
@@ -78,8 +81,8 @@ Compatibility Notes
   in places where they have no effect.][73461]
 - [Updated `_mm256_extract_epi8` and `_mm256_extract_epi16` signatures in
   `arch::{x86, x86_64}` to return `i32` to match the vendor signatures.][73166]
-
-
+- [`mem::uninitialized` will now panic if any inner types inside a struct or enum
+  disallow zero-initialization].[71274]
 
 Internal Only
 -------------
@@ -88,7 +91,8 @@ Internal Only
   your `config.toml`.
 
 [27675]: https://github.com/rust-lang/rust/issues/27675/
-[54121]: https://github.com/rust-lang/rust/issues/54121/
+[54121]: https://github.com/rust-lang/rust/issues/54121/  
+[71274]: https://github.com/rust-lang/rust/pull/71274/
 [77386]: https://github.com/rust-lang/rust/pull/77386/
 [77153]: https://github.com/rust-lang/rust/pull/77153/
 [77055]: https://github.com/rust-lang/rust/pull/77055/

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,9 +9,9 @@ Language
 
 Compiler
 --------
-- [Stabilised the `-C link-self-contained=<yes|no>`.][76158] This tells `rustc` whether to link
-  its own C runtime and libraries or to rely on a external linker to find them. (Supported only on
-  `windows-gnu`, `linux-musl`, and `wasi` platforms.)
+- [Stabilised the `-C link-self-contained=<yes|no>` compiler flag.][76158] This tells
+  `rustc` whether to link its own C runtime and libraries or to rely on a external 
+  linker to find them. (Supported only on `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]
 - [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@ Language
 
 Compiler
 --------
-- [Stabilised the `-C link=<yes|no>`][76158] Which tells `rustc` whether to link
+- [Stabilised the `-C link-self-contained=<yes|no>`][76158] Which tells `rustc` whether to link
   its own libraries or to rely on a external linker. (supported only on
   `windows-gnu`, `linux-musl`, and `wasi` platforms.)
 - [You can now use `-C target-feature=+crt-static` on `linux-gnu` targets.][77386]

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2358,7 +2358,7 @@ fn maybe_install_llvm(builder: &Builder<'_>, target: TargetSelection, dst_libdir
     }
 
     if let Some(config) = builder.config.target_config.get(&target) {
-        if config.llvm_config.is_some() {
+        if config.llvm_config.is_some() && !builder.config.llvm_from_ci {
             // If the LLVM was externally provided, then we don't currently copy
             // artifacts into the sysroot. This is not necessarily the right
             // choice (in particular, it will require the LLVM dylib to be in
@@ -2369,6 +2369,9 @@ fn maybe_install_llvm(builder: &Builder<'_>, target: TargetSelection, dst_libdir
             // with the wrong files and isn't what distributions want.
             //
             // This behavior may be revisited in the future though.
+            //
+            // If the LLVM is coming from ourselves (just from CI) though, we
+            // still want to install it, as it otherwise won't be available.
             return;
         }
     }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2357,6 +2357,22 @@ fn maybe_install_llvm(builder: &Builder<'_>, target: TargetSelection, dst_libdir
         return;
     }
 
+    if let Some(config) = builder.config.target_config.get(&target) {
+        if config.llvm_config.is_some() {
+            // If the LLVM was externally provided, then we don't currently copy
+            // artifacts into the sysroot. This is not necessarily the right
+            // choice (in particular, it will require the LLVM dylib to be in
+            // the linker's load path at runtime), but the common use case for
+            // external LLVMs is distribution provided LLVMs, and in that case
+            // they're usually in the standard search path (e.g., /usr/lib) and
+            // copying them here is going to cause problems as we may end up
+            // with the wrong files and isn't what distributions want.
+            //
+            // This behavior may be revisited in the future though.
+            return;
+        }
+    }
+
     // On macOS, rustc (and LLVM tools) link to an unversioned libLLVM.dylib
     // instead of libLLVM-11-rust-....dylib, as on linux. It's not entirely
     // clear why this is the case, though. llvm-config will emit the versioned

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1336,7 +1336,13 @@ impl Step for Rls {
         let rls = builder
             .ensure(tool::Rls { compiler, target, extra_features: Vec::new() })
             .or_else(|| {
-                missing_tool("RLS", builder.build.config.missing_tools);
+                // We ignore failure on aarch64 Windows because RLS currently
+                // fails to build, due to winapi 0.2 not supporting aarch64.
+                missing_tool(
+                    "RLS",
+                    builder.build.config.missing_tools
+                        || (target.triple.contains("aarch64") && target.triple.contains("windows")),
+                );
                 None
             })?;
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -63,7 +63,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=nightly
+export RUST_RELEASE_CHANNEL=beta
 
 # Always set the release channel for bootstrap; this is normally not important (i.e., only dist
 # builds would seem to matter) but in practice bootstrap wants to know whether we're targeting

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -21,6 +21,8 @@ pub fn render_with_highlighting(
     playground_button: Option<&str>,
     tooltip: Option<(&str, &str)>,
 ) -> String {
+    // This replace allows to fix how the code source with DOS backline characters is displayed.
+    let src = src.replace("\r\n", "\n");
     debug!("highlighting: ================\n{}\n==============", src);
     let mut out = String::with_capacity(src.len());
     if let Some((tooltip, class)) = tooltip {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -21,8 +21,6 @@ pub fn render_with_highlighting(
     playground_button: Option<&str>,
     tooltip: Option<(&str, &str)>,
 ) -> String {
-    // This replace allows to fix how the code source with DOS backline characters is displayed.
-    let src = src.replace("\r\n", "\n");
     debug!("highlighting: ================\n{}\n==============", src);
     let mut out = String::with_capacity(src.len());
     if let Some((tooltip, class)) = tooltip {
@@ -48,7 +46,9 @@ fn write_header(out: &mut String, class: Option<&str>) {
 }
 
 fn write_code(out: &mut String, src: &str) {
-    Classifier::new(src).highlight(&mut |highlight| {
+    // This replace allows to fix how the code source with DOS backline characters is displayed.
+    let src = src.replace("\r\n", "\n");
+    Classifier::new(&src).highlight(&mut |highlight| {
         match highlight {
             Highlight::Token { text, class } => string(out, Escape(text), class),
             Highlight::EnterSpan { class } => enter_span(out, class),

--- a/src/librustdoc/html/highlight/fixtures/dos_line.html
+++ b/src/librustdoc/html/highlight/fixtures/dos_line.html
@@ -1,0 +1,3 @@
+<span class="kw">pub</span> <span class="kw">fn</span> <span class="ident">foo</span>() {
+<span class="macro">println</span><span class="macro">!</span>(<span class="string">&quot;foo&quot;</span>);
+}

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -1,17 +1,6 @@
 use super::write_code;
 use expect_test::expect_file;
 
-#[test]
-fn test_html_highlighting() {
-    let src = include_str!("fixtures/sample.rs");
-    let html = {
-        let mut out = String::new();
-        write_code(&mut out, src);
-        format!("{}<pre><code>{}</code></pre>\n", STYLE, out)
-    };
-    expect_file!["fixtures/sample.html"].assert_eq(&html);
-}
-
 const STYLE: &str = r#"
 <style>
 .kw { color: #8959A8; }
@@ -23,3 +12,24 @@ const STYLE: &str = r#"
 .question-mark { color: #ff9011; }
 </style>
 "#;
+
+#[test]
+fn test_html_highlighting() {
+    let src = include_str!("fixtures/sample.rs");
+    let html = {
+        let mut out = String::new();
+        write_code(&mut out, src);
+        format!("{}<pre><code>{}</code></pre>\n", STYLE, out)
+    };
+    expect_file!["fixtures/sample.html"].assert_eq(&html);
+}
+
+#[test]
+fn test_dos_backline() {
+    let src = "pub fn foo() {\r\n\
+    println!(\"foo\");\r\n\
+}\r\n";
+    let mut html = String::new();
+    write_code(&mut html, src);
+    expect_file!["fixtures/dos_line.html"].assert_eq(&html);
+}

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,15 +12,15 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.(x+1).0` for Cargo where they were released on `date`.
 
-date: 2020-10-16
-rustc: beta
-cargo: beta
+date: 2020-11-16
+rustc: 1.48.0
+cargo: 1.48.0
 
 # We use a nightly rustfmt to format the source because it solves some
 # bootstrapping issues with use of new syntax in this repo. If you're looking at
 # the beta/stable branch, this key should be omitted, as we don't want to depend
 # on rustfmt from nightly there.
-rustfmt: nightly-2020-10-12
+#rustfmt: nightly-2020-10-12
 
 # When making a stable release the process currently looks like:
 #
@@ -40,4 +40,4 @@ rustfmt: nightly-2020-10-12
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-#dev: 1
+dev: 1

--- a/src/test/ui-fulldeps/session-derive-errors.stderr
+++ b/src/test/ui-fulldeps/session-derive-errors.stderr
@@ -1,25 +1,20 @@
 error: `#[derive(SessionDiagnostic)]` can only be used on structs
   --> $DIR/session-derive-errors.rs:28:1
    |
-LL | / #[error = "E0123"]
-LL | |
-LL | | enum SessionDiagnosticOnEnum {
-LL | |     Foo,
-LL | |     Bar,
-LL | | }
-   | |_^
+LL | #[error = "E0123"]
+   | ^
 
 error: `#[label = ...]` is not a valid SessionDiagnostic struct attribute
   --> $DIR/session-derive-errors.rs:37:1
    |
 LL | #[label = "This is in the wrong place"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^
 
 error: `#[suggestion = ...]` is not a valid SessionDiagnostic field attribute
   --> $DIR/session-derive-errors.rs:44:5
    |
 LL |     #[suggestion = "this is the wrong kind of attribute"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^
 
 error: `error` specified multiple times
   --> $DIR/session-derive-errors.rs:52:11
@@ -37,7 +32,7 @@ error: `code` not specified
   --> $DIR/session-derive-errors.rs:67:1
    |
 LL | struct ErrorCodeNotProvided {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^
    |
    = help: use the [code = "..."] attribute to set this diagnostic's error code 
 
@@ -45,13 +40,13 @@ error: the `#[message = "..."]` attribute can only be applied to fields of type 
   --> $DIR/session-derive-errors.rs:95:5
    |
 LL |     #[message = "this message is applied to a String field"]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^
 
 error: `name` doesn't refer to a field on this type
   --> $DIR/session-derive-errors.rs:102:1
    |
 LL | #[message = "This error has a field, and references {name}"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^
 
 error: invalid format string: expected `'}'` but string was terminated
   --> $DIR/session-derive-errors.rs:110:1
@@ -77,59 +72,53 @@ error: The `#[label = ...]` attribute can only be applied to fields of type Span
   --> $DIR/session-derive-errors.rs:138:5
    |
 LL |     #[label = "See here"]
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^
 
 error: `nonsense` is not a valid key for `#[suggestion(...)]`
   --> $DIR/session-derive-errors.rs:163:18
    |
 LL |     #[suggestion(nonsense = "This is nonsense")]
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^
 
 error: `msg` is not a valid key for `#[suggestion(...)]`
   --> $DIR/session-derive-errors.rs:171:18
    |
 LL |     #[suggestion(msg = "This is a suggestion")]
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^
 
 error: missing suggestion message
   --> $DIR/session-derive-errors.rs:179:7
    |
 LL |     #[suggestion(code = "This is suggested code")]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
    |
    = help: provide a suggestion message using #[suggestion(message = "...")]
 
 error: wrong field type for suggestion
   --> $DIR/session-derive-errors.rs:194:5
    |
-LL | /     #[suggestion(message = "This is a message", code = "This is suggested code")]
-LL | |
-LL | |     suggestion: Applicability,
-   | |_____________________________^
+LL |     #[suggestion(message = "This is a message", code = "This is suggested code")]
+   |     ^
    |
    = help: #[suggestion(...)] should be applied to fields of type Span or (Span, Applicability)
 
 error: type of field annotated with `#[suggestion(...)]` contains more than one Span
   --> $DIR/session-derive-errors.rs:209:5
    |
-LL | /     #[suggestion(message = "This is a message", code = "This is suggested code")]
-LL | |
-LL | |     suggestion: (Span, Span, Applicability),
-   | |___________________________________________^
+LL |     #[suggestion(message = "This is a message", code = "This is suggested code")]
+   |     ^
 
 error: type of field annotated with `#[suggestion(...)]` contains more than one Applicability
   --> $DIR/session-derive-errors.rs:217:5
    |
-LL | /     #[suggestion(message = "This is a message", code = "This is suggested code")]
-LL | |
-LL | |     suggestion: (Applicability, Applicability, Span),
-   | |____________________________________________________^
+LL |     #[suggestion(message = "This is a message", code = "This is suggested code")]
+   |     ^
 
 error: invalid annotation list `#[label(...)]`
   --> $DIR/session-derive-errors.rs:225:7
    |
 LL |     #[label("wrong kind of annotation for label")]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^
 
 error: aborting due to 18 previous errors
 

--- a/src/tools/build-manifest/src/versions.rs
+++ b/src/tools/build-manifest/src/versions.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use tar::Archive;
 
 const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
-const RUSTC_VERSION: &str = include_str!("../../../version");
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub(crate) enum PkgType {
@@ -177,10 +176,10 @@ impl Versions {
     ) -> Result<String, Error> {
         let component_name = package.tarball_component_name();
         let version = match self.channel.as_str() {
-            "stable" => RUSTC_VERSION.into(),
+            "stable" => self.rustc_version().into(),
             "beta" => "beta".into(),
             "nightly" => "nightly".into(),
-            _ => format!("{}-dev", RUSTC_VERSION),
+            _ => format!("{}-dev", self.rustc_version()),
         };
 
         if package.target_independent() {
@@ -199,6 +198,7 @@ impl Versions {
     }
 
     pub(crate) fn rustc_version(&self) -> &str {
-        RUSTC_VERSION
+        const RUSTC_VERSION: &str = include_str!("../../../version");
+        RUSTC_VERSION.trim()
     }
 }


### PR DESCRIPTION
This PR sets everything up for beta 1.49.0, and backports the following PRs to it:

* #79107 - build-manifest: strip newline from rustc version
* #78986 - Avoid installing external LLVM dylibs
* #79074 - Install CI llvm into the library directory
* #78364 - Update RELEASES.md for 1.48.0
* #77939 - Ensure that the source code display is working with DOS backline

This is the same as #79132, but actually targeting the right branch.

r? @ghost
cc @rust-lang/release