### PR TITLE
rustc_target: don't limit SPIR-V inline asm! types to a fixed subset.

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1396,17 +1396,22 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // features. We check that at least one type is available for
                 // the current target.
                 let reg_class = reg.reg_class();
-                for &(_, feature) in reg_class.supported_types(asm_arch) {
-                    if let Some(feature) = feature {
-                        if self.sess.target_features.contains(&Symbol::intern(feature)) {
-                            required_features.clear();
-                            break;
-                        } else {
-                            required_features.push(feature);
+                match reg_class.supported_types(asm_arch) {
+                    asm::InlineAsmSupportedTypes::Any => {}
+                    asm::InlineAsmSupportedTypes::OneOf(types) => {
+                        for &(_, feature) in types {
+                            if let Some(feature) = feature {
+                                if self.sess.target_features.contains(&Symbol::intern(feature)) {
+                                    required_features.clear();
+                                    break;
+                                } else {
+                                    required_features.push(feature);
+                                }
+                            } else {
+                                required_features.clear();
+                                break;
+                            }
                         }
-                    } else {
-                        required_features.clear();
-                        break;
                     }
                 }
                 // We are sorting primitive strs here and can use unstable sort here

--- a/compiler/rustc_codegen_cranelift/src/inline_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/inline_asm.rs
@@ -28,12 +28,12 @@ pub(crate) fn codegen_inline_asm<'tcx>(
     let mut outputs = Vec::new();
 
     let mut new_slot = |reg_class: InlineAsmRegClass| {
-        let reg_size = reg_class
-            .supported_types(InlineAsmArch::X86_64)
-            .iter()
-            .map(|(ty, _)| ty.size())
-            .max()
-            .unwrap();
+        let reg_size = match reg_class.supported_types(InlineAsmArch::X86_64) {
+            InlineAsmSupportedTypes::OneOf(supported_tys) => {
+                supported_tys.iter().map(|(ty, _)| ty.size()).max().unwrap()
+            }
+            _ => unreachable!(),
+        };
         let align = rustc_target::abi::Align::from_bytes(reg_size.bytes()).unwrap();
         slot_size = slot_size.align_to(align);
         let offset = slot_size;

--- a/compiler/rustc_target/src/asm/aarch64.rs
+++ b/compiler/rustc_target/src/asm/aarch64.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use rustc_macros::HashStable_Generic;
 use std::fmt;
 
@@ -50,10 +50,7 @@ impl AArch64InlineAsmRegClass {
         }
     }
 
-    pub fn supported_types(
-        self,
-        _arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+    pub fn supported_types(self, _arch: InlineAsmArch) -> InlineAsmSupportedTypes {
         match self {
             Self::reg => types! { _: I8, I16, I32, I64, F32, F64; },
             Self::vreg | Self::vreg_low16 => types! {

--- a/compiler/rustc_target/src/asm/arm.rs
+++ b/compiler/rustc_target/src/asm/arm.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use crate::spec::Target;
 use rustc_macros::HashStable_Generic;
 use std::fmt;
@@ -42,10 +42,7 @@ impl ArmInlineAsmRegClass {
         None
     }
 
-    pub fn supported_types(
-        self,
-        _arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+    pub fn supported_types(self, _arch: InlineAsmArch) -> InlineAsmSupportedTypes {
         match self {
             Self::reg | Self::reg_thumb => types! { _: I8, I16, I32, F32; },
             Self::sreg | Self::sreg_low16 => types! { "vfp2": I32, F32; },

--- a/compiler/rustc_target/src/asm/hexagon.rs
+++ b/compiler/rustc_target/src/asm/hexagon.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use rustc_macros::HashStable_Generic;
 use std::fmt;
 
@@ -29,10 +29,7 @@ impl HexagonInlineAsmRegClass {
         None
     }
 
-    pub fn supported_types(
-        self,
-        _arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+    pub fn supported_types(self, _arch: InlineAsmArch) -> InlineAsmSupportedTypes {
         match self {
             Self::reg => types! { _: I8, I16, I32, F32; },
         }

--- a/compiler/rustc_target/src/asm/mips.rs
+++ b/compiler/rustc_target/src/asm/mips.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use rustc_macros::HashStable_Generic;
 use std::fmt;
 
@@ -30,10 +30,7 @@ impl MipsInlineAsmRegClass {
         None
     }
 
-    pub fn supported_types(
-        self,
-        arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+    pub fn supported_types(self, arch: InlineAsmArch) -> InlineAsmSupportedTypes {
         match (self, arch) {
             (Self::reg, InlineAsmArch::Mips64) => types! { _: I8, I16, I32, I64, F32, F64; },
             (Self::reg, _) => types! { _: I8, I16, I32, F32; },

--- a/compiler/rustc_target/src/asm/nvptx.rs
+++ b/compiler/rustc_target/src/asm/nvptx.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use rustc_macros::HashStable_Generic;
 
 def_reg_class! {
@@ -30,10 +30,7 @@ impl NvptxInlineAsmRegClass {
         None
     }
 
-    pub fn supported_types(
-        self,
-        _arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+    pub fn supported_types(self, _arch: InlineAsmArch) -> InlineAsmSupportedTypes {
         match self {
             Self::reg16 => types! { _: I8, I16; },
             Self::reg32 => types! { _: I8, I16, I32, F32; },

--- a/compiler/rustc_target/src/asm/riscv.rs
+++ b/compiler/rustc_target/src/asm/riscv.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use crate::spec::Target;
 use rustc_macros::HashStable_Generic;
 use std::fmt;
@@ -31,10 +31,7 @@ impl RiscVInlineAsmRegClass {
         None
     }
 
-    pub fn supported_types(
-        self,
-        arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+    pub fn supported_types(self, arch: InlineAsmArch) -> InlineAsmSupportedTypes {
         match self {
             Self::reg => {
                 if arch == InlineAsmArch::RiscV64 {

--- a/compiler/rustc_target/src/asm/spirv.rs
+++ b/compiler/rustc_target/src/asm/spirv.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use rustc_macros::HashStable_Generic;
 
 def_reg_class! {
@@ -28,15 +28,8 @@ impl SpirVInlineAsmRegClass {
         None
     }
 
-    pub fn supported_types(
-        self,
-        _arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
-        match self {
-            Self::reg => {
-                types! { _: I8, I16, I32, I64, F32, F64; }
-            }
-        }
+    pub fn supported_types(self, _arch: InlineAsmArch) -> InlineAsmSupportedTypes {
+        InlineAsmSupportedTypes::Any
     }
 }
 

--- a/compiler/rustc_target/src/asm/x86.rs
+++ b/compiler/rustc_target/src/asm/x86.rs
@@ -1,4 +1,4 @@
-use super::{InlineAsmArch, InlineAsmType};
+use super::{InlineAsmArch, InlineAsmSupportedTypes, InlineAsmType};
 use crate::spec::Target;
 use rustc_macros::HashStable_Generic;
 use std::fmt;
@@ -93,10 +93,7 @@ impl X86InlineAsmRegClass {
         }
     }
 
-    pub fn supported_types(
-        self,
-        arch: InlineAsmArch,
-    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+    pub fn supported_types(self, arch: InlineAsmArch) -> InlineAsmSupportedTypes {
         match self {
             Self::reg | Self::reg_abcd => {
                 if arch == InlineAsmArch::X86_64 {


### PR DESCRIPTION
Follow-up to #78950, which hardcoded `I8, I16, I32, I64, F32, F64` as the supported types for SPIR-V `asm!`.

This PR lifts that limitation and allows any `InlineAsmType`, as the [`rust-gpu`](https://github.com/EmbarkStudios/rust-gpu) backend can support any SPIR-V SSA value type.

However, the general type restriction to scalars (integers, floats, pointers) and vectors thereof, remains, as lifting that felt like a more drastic change, but it seems like it might be necessary soon, so if there are no objections, I can also that in this PR.

**EDIT**: see https://github.com/EmbarkStudios/rust-gpu/pull/256#discussion_r526321178 for example usecase.

cc @khyperia r? @Amanieu 