### PR TITLE
refactor: removing custom nth Zip fn

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -28,14 +28,9 @@ where
         ZipNew::new(a, b)
     }
 
-    fn super_nth(&mut self, mut n: usize) -> Option<(A::Item, B::Item)> {
-        while let Some(x) = Iterator::next(self) {
-            if n == 0 {
-                return Some(x);
-            }
-            n -= 1;
-        }
-        None
+    fn super_nth(&mut self, n: usize) -> Option<(A::Item, B::Item)> {
+        self.advance_by(n).ok()?;
+        self.next()
     }
 }
 

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -18,7 +18,12 @@ pub struct Zip<A, B> {
     len: usize,
     a_len: usize,
 }
-impl<A: Iterator, B: Iterator> Zip<A, B> {
+
+impl<A, B> Zip<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
     pub(in crate::iter) fn new(a: A, b: B) -> Zip<A, B> {
         ZipNew::new(a, b)
     }
@@ -101,40 +106,6 @@ where
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A, B> Iterator for Zip<A, B>
-where
-    A: Iterator,
-    B: Iterator,
-{
-    type Item = (A::Item, B::Item);
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        ZipImpl::next(self)
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        ZipImpl::size_hint(self)
-    }
-
-    #[inline]
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        ZipImpl::nth(self, n)
-    }
-
-    #[inline]
-    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
-    where
-        Self: TrustedRandomAccess,
-    {
-        // SAFETY: `ZipImpl::__iterator_get_unchecked` has same safety
-        // requirements as `Iterator::__iterator_get_unchecked`.
-        unsafe { ZipImpl::get_unchecked(self, idx) }
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
 impl<A, B> DoubleEndedIterator for Zip<A, B>
 where
     A: DoubleEndedIterator + ExactSizeIterator,
@@ -213,22 +184,8 @@ where
     }
 }
 
-// Zip specialization trait
-#[doc(hidden)]
-trait ZipImpl<A, B> {
-    type Item;
-    fn next(&mut self) -> Option<Self::Item>;
-    fn size_hint(&self) -> (usize, Option<usize>);
-    fn nth(&mut self, n: usize) -> Option<Self::Item>;
-    // This has the same safety requirements as `Iterator::__iterator_get_unchecked`
-    unsafe fn get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item
-    where
-        Self: Iterator + TrustedRandomAccess;
-}
-
-// General Zip impl
-#[doc(hidden)]
-impl<A, B> ZipImpl<A, B> for Zip<A, B>
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<A, B> Iterator for Zip<A, B>
 where
     A: Iterator,
     B: Iterator,
@@ -264,7 +221,7 @@ where
         (lower, upper)
     }
 
-    default unsafe fn get_unchecked(&mut self, _idx: usize) -> <Self as Iterator>::Item
+    default unsafe fn __iterator_get_unchecked(&mut self, _idx: usize) -> <Self as Iterator>::Item
     where
         Self: TrustedRandomAccess,
     {
@@ -272,8 +229,8 @@ where
     }
 }
 
-#[doc(hidden)]
-impl<A, B> ZipImpl<A, B> for Zip<A, B>
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<A, B> Iterator for Zip<A, B>
 where
     A: TrustedRandomAccess + Iterator,
     B: TrustedRandomAccess + Iterator,
@@ -335,7 +292,7 @@ where
     }
 
     #[inline]
-    unsafe fn get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item {
+    unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item {
         let idx = self.index + idx;
         // SAFETY: the caller must uphold the contract for
         // `Iterator::__iterator_get_unchecked`.

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -149,14 +149,13 @@ where
             // of `next_back` does this, otherwise we will break the restriction
             // on calls to `self.next_back()` after calling `get_unchecked()`.
             if sz_a != sz_b {
-                let sz_a = self.a.size();
                 if A::MAY_HAVE_SIDE_EFFECT && sz_a > self.len {
                     for _ in 0..sz_a - self.len {
                         self.a.next_back();
                     }
                     self.a_len = self.len;
                 }
-                let sz_b = self.b.size();
+
                 if B::MAY_HAVE_SIDE_EFFECT && sz_b > self.len {
                     for _ in 0..sz_b - self.len {
                         self.b.next_back();


### PR DESCRIPTION
Noticed `super_nth()` that seems very similar to `nth()` in `iterator.rs`. 

If you look at `nth()` in `iterator.rs` before the commit `ecacc7534b6bf50205c37c89402565b82d95a257`  `super_nth()` looks exactly the same as `fn nth()` in `iterator.rs`. 

I may be misunderstanding something, but I think `super_nth()` can just be removed.