### PR TITLE
Stop adding '*' at the end of slice and str typenames for MSVC case

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -94,7 +94,10 @@ pub fn push_debuginfo_type_name<'tcx>(
             push_debuginfo_type_name(tcx, inner_type, true, output, visited);
 
             if cpp_like_names {
-                output.push('*');
+                match inner_type.kind {
+                    ty::Slice(_) | ty::Str => {}
+                    _ => output.push('*');
+                }
             }
         }
         ty::Array(inner_type, len) => {


### PR DESCRIPTION
Rust compiler add '*' at the end of type names for Slice and Str types, causing the Natvis engine for WinDbg fail to display Slice and Str data.