### PR TITLE
Make compiletest testing use the local sysroot

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -484,10 +484,13 @@ impl Step for CompiletestTest {
         let host = self.host;
         let compiler = builder.compiler(0, host);
 
+        // We need `ToolStd` for the locally-built sysroot because
+        // compiletest uses unstable features of the `test` crate.
+        builder.ensure(compile::Std { compiler, target: host });
         let cargo = tool::prepare_tool_cargo(
             builder,
             compiler,
-            Mode::ToolBootstrap,
+            Mode::ToolStd,
             host,
             "test",
             "src/tools/compiletest",


### PR DESCRIPTION
We already set `compiletest` to use the local sysroot in #68019, but
that missed the configuration for testing `compiletest` itself.