### PR TITLE
expand/resolve: Pre-requisites to "Turn `#[derive]` into a regular macro attribute"

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -407,13 +407,7 @@ impl<'a> TraitDef<'a> {
                             _ => false,
                         })
                     }
-                    _ => {
-                        // Non-ADT derive is an error, but it should have been
-                        // set earlier; see
-                        // librustc_expand/expand.rs:MacroExpander::fully_expand_fragment()
-                        // librustc_expand/base.rs:Annotatable::derive_allowed()
-                        return;
-                    }
+                    _ => unreachable!(),
                 };
                 let container_id = cx.current_expansion.id.expn_data().parent;
                 let always_copy = has_no_type_params && cx.resolver.has_derive_copy(container_id);
@@ -475,12 +469,7 @@ impl<'a> TraitDef<'a> {
                 );
                 push(Annotatable::Item(P(ast::Item { attrs, ..(*newitem).clone() })))
             }
-            _ => {
-                // Non-Item derive is an error, but it should have been
-                // set earlier; see
-                // librustc_expand/expand.rs:MacroExpander::fully_expand_fragment()
-                // librustc_expand/base.rs:Annotatable::derive_allowed()
-            }
+            _ => unreachable!(),
         }
     }
 

--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -98,13 +98,7 @@ fn inject_impl_of_structural_trait(
 ) {
     let item = match *item {
         Annotatable::Item(ref item) => item,
-        _ => {
-            // Non-Item derive is an error, but it should have been
-            // set earlier; see
-            // librustc_expand/expand.rs:MacroExpander::fully_expand_fragment()
-            // librustc_expand/base.rs:Annotatable::derive_allowed()
-            return;
-        }
+        _ => unreachable!(),
     };
 
     let generics = match item.kind {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -888,8 +888,10 @@ pub trait ResolverExpand {
     /// Some parent node that is close enough to the given macro call.
     fn lint_node_id(&mut self, expn_id: ExpnId) -> NodeId;
 
+    // Resolver interfaces for specific built-in macros.
+    /// Does `#[derive(...)]` attribute with the given `ExpnId` have built-in `Copy` inside it?
     fn has_derive_copy(&self, expn_id: ExpnId) -> bool;
-    fn add_derive_copy(&mut self, expn_id: ExpnId);
+    /// Path resolution logic for `#[cfg_accessible(path)]`.
     fn cfg_accessible(&mut self, expn_id: ExpnId, path: &ast::Path) -> Result<bool, Indeterminate>;
 }
 

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -251,8 +251,7 @@ pub enum ExpandResult<T, U> {
     /// Expansion produced a result (possibly dummy).
     Ready(T),
     /// Expansion could not produce a result and needs to be retried.
-    /// The string is an explanation that will be printed if we are stuck in an infinite retry loop.
-    Retry(U, String),
+    Retry(U),
 }
 
 // `meta_item` is the attribute, and `item` is the item being modified.
@@ -919,6 +918,9 @@ pub struct ExtCtxt<'a> {
     pub root_path: PathBuf,
     pub resolver: &'a mut dyn ResolverExpand,
     pub current_expansion: ExpansionData,
+    /// Error recovery mode entered when expansion is stuck
+    /// (or during eager expansion, but that's a hack).
+    pub force_mode: bool,
     pub expansions: FxHashMap<Span, Vec<String>>,
     /// Called directly after having parsed an external `mod foo;` in expansion.
     pub(super) extern_mod_loaded: Option<&'a dyn Fn(&ast::Crate)>,
@@ -945,6 +947,7 @@ impl<'a> ExtCtxt<'a> {
                 directory_ownership: DirectoryOwnership::Owned { relative: None },
                 prior_type_ascription: None,
             },
+            force_mode: false,
             expansions: FxHashMap::default(),
         }
     }

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -1,5 +1,7 @@
 //! Conditional compilation stripping.
 
+use crate::base::Annotatable;
+
 use rustc_ast::attr::HasAttrs;
 use rustc_ast::mut_visit::*;
 use rustc_ast::ptr::P;
@@ -495,6 +497,49 @@ impl<'a> StripUnconfigured<'a> {
 
     pub fn configure_fn_decl(&mut self, fn_decl: &mut ast::FnDecl) {
         fn_decl.inputs.flat_map_in_place(|arg| self.configure(arg));
+    }
+
+    pub fn fully_configure(&mut self, item: Annotatable) -> Annotatable {
+        // Since the item itself has already been configured by the InvocationCollector,
+        // we know that fold result vector will contain exactly one element
+        match item {
+            Annotatable::Item(item) => Annotatable::Item(self.flat_map_item(item).pop().unwrap()),
+            Annotatable::TraitItem(item) => {
+                Annotatable::TraitItem(self.flat_map_trait_item(item).pop().unwrap())
+            }
+            Annotatable::ImplItem(item) => {
+                Annotatable::ImplItem(self.flat_map_impl_item(item).pop().unwrap())
+            }
+            Annotatable::ForeignItem(item) => {
+                Annotatable::ForeignItem(self.flat_map_foreign_item(item).pop().unwrap())
+            }
+            Annotatable::Stmt(stmt) => {
+                Annotatable::Stmt(stmt.map(|stmt| self.flat_map_stmt(stmt).pop().unwrap()))
+            }
+            Annotatable::Expr(mut expr) => Annotatable::Expr({
+                self.visit_expr(&mut expr);
+                expr
+            }),
+            Annotatable::Arm(arm) => Annotatable::Arm(self.flat_map_arm(arm).pop().unwrap()),
+            Annotatable::Field(field) => {
+                Annotatable::Field(self.flat_map_field(field).pop().unwrap())
+            }
+            Annotatable::FieldPat(fp) => {
+                Annotatable::FieldPat(self.flat_map_field_pattern(fp).pop().unwrap())
+            }
+            Annotatable::GenericParam(param) => {
+                Annotatable::GenericParam(self.flat_map_generic_param(param).pop().unwrap())
+            }
+            Annotatable::Param(param) => {
+                Annotatable::Param(self.flat_map_param(param).pop().unwrap())
+            }
+            Annotatable::StructField(sf) => {
+                Annotatable::StructField(self.flat_map_struct_field(sf).pop().unwrap())
+            }
+            Annotatable::Variant(v) => {
+                Annotatable::Variant(self.flat_map_variant(v).pop().unwrap())
+            }
+        }
     }
 }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1797,7 +1797,4 @@ impl<'feat> ExpansionConfig<'feat> {
     fn proc_macro_hygiene(&self) -> bool {
         self.features.map_or(false, |features| features.proc_macro_hygiene)
     }
-    fn custom_inner_attributes(&self) -> bool {
-        self.features.map_or(false, |features| features.custom_inner_attributes)
-    }
 }

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -609,48 +609,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         (fragment, invocations)
     }
 
-    fn fully_configure(&mut self, item: Annotatable) -> Annotatable {
-        let mut cfg = StripUnconfigured { sess: &self.cx.sess, features: self.cx.ecfg.features };
-        // Since the item itself has already been configured by the InvocationCollector,
-        // we know that fold result vector will contain exactly one element
-        match item {
-            Annotatable::Item(item) => Annotatable::Item(cfg.flat_map_item(item).pop().unwrap()),
-            Annotatable::TraitItem(item) => {
-                Annotatable::TraitItem(cfg.flat_map_trait_item(item).pop().unwrap())
-            }
-            Annotatable::ImplItem(item) => {
-                Annotatable::ImplItem(cfg.flat_map_impl_item(item).pop().unwrap())
-            }
-            Annotatable::ForeignItem(item) => {
-                Annotatable::ForeignItem(cfg.flat_map_foreign_item(item).pop().unwrap())
-            }
-            Annotatable::Stmt(stmt) => {
-                Annotatable::Stmt(stmt.map(|stmt| cfg.flat_map_stmt(stmt).pop().unwrap()))
-            }
-            Annotatable::Expr(mut expr) => Annotatable::Expr({
-                cfg.visit_expr(&mut expr);
-                expr
-            }),
-            Annotatable::Arm(arm) => Annotatable::Arm(cfg.flat_map_arm(arm).pop().unwrap()),
-            Annotatable::Field(field) => {
-                Annotatable::Field(cfg.flat_map_field(field).pop().unwrap())
-            }
-            Annotatable::FieldPat(fp) => {
-                Annotatable::FieldPat(cfg.flat_map_field_pattern(fp).pop().unwrap())
-            }
-            Annotatable::GenericParam(param) => {
-                Annotatable::GenericParam(cfg.flat_map_generic_param(param).pop().unwrap())
-            }
-            Annotatable::Param(param) => {
-                Annotatable::Param(cfg.flat_map_param(param).pop().unwrap())
-            }
-            Annotatable::StructField(sf) => {
-                Annotatable::StructField(cfg.flat_map_struct_field(sf).pop().unwrap())
-            }
-            Annotatable::Variant(v) => Annotatable::Variant(cfg.flat_map_variant(v).pop().unwrap()),
-        }
-    }
-
     fn error_recursion_limit_reached(&mut self) {
         let expn_data = self.cx.current_expansion.id.expn_data();
         let suggested_limit = self.cx.ecfg.recursion_limit * 2;

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -767,9 +767,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             InvocationKind::Derive { path, item } => match ext {
                 SyntaxExtensionKind::Derive(expander)
                 | SyntaxExtensionKind::LegacyDerive(expander) => {
-                    if !item.derive_allowed() {
-                        return ExpandResult::Ready(fragment_kind.dummy(span));
-                    }
                     if let SyntaxExtensionKind::Derive(..) = ext {
                         self.gate_proc_macro_input(&item);
                     }

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -75,38 +75,9 @@ impl MultiItemModifier for ProcMacroDerive {
         item: Annotatable,
     ) -> ExpandResult<Vec<Annotatable>, Annotatable> {
         let item = match item {
-            Annotatable::Arm(..)
-            | Annotatable::Field(..)
-            | Annotatable::FieldPat(..)
-            | Annotatable::GenericParam(..)
-            | Annotatable::Param(..)
-            | Annotatable::StructField(..)
-            | Annotatable::Variant(..) => panic!("unexpected annotatable"),
-            Annotatable::Item(item) => item,
-            Annotatable::ImplItem(_)
-            | Annotatable::TraitItem(_)
-            | Annotatable::ForeignItem(_)
-            | Annotatable::Stmt(_)
-            | Annotatable::Expr(_) => {
-                ecx.span_err(
-                    span,
-                    "proc-macro derives may only be applied to a struct, enum, or union",
-                );
-                return ExpandResult::Ready(Vec::new());
-            }
+            Annotatable::Item(item) => token::NtItem(item),
+            _ => unreachable!(),
         };
-        match item.kind {
-            ItemKind::Struct(..) | ItemKind::Enum(..) | ItemKind::Union(..) => {}
-            _ => {
-                ecx.span_err(
-                    span,
-                    "proc-macro derives may only be applied to a struct, enum, or union",
-                );
-                return ExpandResult::Ready(Vec::new());
-            }
-        }
-
-        let item = token::NtItem(item);
         let input = if item.pretty_printing_compatibility_hack() {
             TokenTree::token(token::Interpolated(Lrc::new(item)), DUMMY_SP).into()
         } else {

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -39,6 +39,9 @@ pub enum NonMacroAttrKind {
     Tool,
     /// Single-segment custom attribute registered by a derive macro (`#[serde(default)]`).
     DeriveHelper,
+    /// Single-segment custom attribute registered by a derive macro
+    /// but used before that derive macro was expanded (deprecated).
+    DeriveHelperCompat,
     /// Single-segment custom attribute registered with `#[register_attr]`.
     Registered,
 }
@@ -370,7 +373,9 @@ impl NonMacroAttrKind {
         match self {
             NonMacroAttrKind::Builtin => "built-in attribute",
             NonMacroAttrKind::Tool => "tool attribute",
-            NonMacroAttrKind::DeriveHelper => "derive helper attribute",
+            NonMacroAttrKind::DeriveHelper | NonMacroAttrKind::DeriveHelperCompat => {
+                "derive helper attribute"
+            }
             NonMacroAttrKind::Registered => "explicitly registered attribute",
         }
     }
@@ -385,7 +390,9 @@ impl NonMacroAttrKind {
     /// Users of some attributes cannot mark them as used, so they are considered always used.
     pub fn is_used(self) -> bool {
         match self {
-            NonMacroAttrKind::Tool | NonMacroAttrKind::DeriveHelper => true,
+            NonMacroAttrKind::Tool
+            | NonMacroAttrKind::DeriveHelper
+            | NonMacroAttrKind::DeriveHelperCompat => true,
             NonMacroAttrKind::Builtin | NonMacroAttrKind::Registered => false,
         }
     }

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -312,14 +312,13 @@ impl<'a> Parser<'a> {
 }
 
 pub fn maybe_needs_tokens(attrs: &[ast::Attribute]) -> bool {
+    // One of the attributes may either itself be a macro, or apply derive macros (`derive`),
+    // or expand to macro attributes (`cfg_attr`).
     attrs.iter().any(|attr| {
-        if let Some(ident) = attr.ident() {
+        attr.ident().map_or(true, |ident| {
             ident.name == sym::derive
-            // This might apply a custom attribute/derive
-            || ident.name == sym::cfg_attr
-            || !rustc_feature::is_builtin_attr_name(ident.name)
-        } else {
-            true
-        }
+                || ident.name == sym::cfg_attr
+                || !rustc_feature::is_builtin_attr_name(ident.name)
+        })
     })
 }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -609,7 +609,7 @@ impl<'a> Resolver<'a> {
                     }
                 }
                 Scope::DeriveHelpersCompat => {
-                    let res = Res::NonMacroAttr(NonMacroAttrKind::DeriveHelper);
+                    let res = Res::NonMacroAttr(NonMacroAttrKind::DeriveHelperCompat);
                     if filter_fn(res) {
                         for derive in parent_scope.derives {
                             let parent_scope = &ParentScope { derives: &[], ..*parent_scope };

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -12,24 +12,24 @@ use rustc_ast_pretty::pprust;
 use rustc_attr::StabilityLevel;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::ptr_key::PtrKey;
+use rustc_data_structures::sync::Lrc;
 use rustc_errors::struct_span_err;
 use rustc_expand::base::{Indeterminate, InvocationRes, ResolverExpand, SyntaxExtension};
 use rustc_expand::compile_declarative_macro;
-use rustc_expand::expand::{AstFragment, AstFragmentKind, Invocation, InvocationKind};
+use rustc_expand::expand::{AstFragment, Invocation, InvocationKind};
 use rustc_feature::is_builtin_attr_name;
 use rustc_hir::def::{self, DefKind, NonMacroAttrKind};
 use rustc_hir::def_id;
 use rustc_middle::middle::stability;
 use rustc_middle::ty;
 use rustc_session::lint::builtin::UNUSED_MACROS;
+use rustc_session::parse::feature_err;
 use rustc_session::Session;
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{self, ExpnData, ExpnId, ExpnKind};
+use rustc_span::hygiene::{AstPass, MacroKind};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
-
-use rustc_data_structures::sync::Lrc;
-use rustc_span::hygiene::{AstPass, MacroKind};
 use std::cell::Cell;
 use std::{mem, ptr};
 
@@ -241,15 +241,20 @@ impl<'a> ResolverExpand for Resolver<'a> {
             }
         };
 
-        let (path, kind, derives, after_derive) = match invoc.kind {
+        let (path, kind, inner_attr, derives, after_derive) = match invoc.kind {
             InvocationKind::Attr { ref attr, ref derives, after_derive, .. } => (
                 &attr.get_normal_item().path,
                 MacroKind::Attr,
+                attr.style == ast::AttrStyle::Inner,
                 self.arenas.alloc_ast_paths(derives),
                 after_derive,
             ),
-            InvocationKind::Bang { ref mac, .. } => (&mac.path, MacroKind::Bang, &[][..], false),
-            InvocationKind::Derive { ref path, .. } => (path, MacroKind::Derive, &[][..], false),
+            InvocationKind::Bang { ref mac, .. } => {
+                (&mac.path, MacroKind::Bang, false, &[][..], false)
+            }
+            InvocationKind::Derive { ref path, .. } => {
+                (path, MacroKind::Derive, false, &[][..], false)
+            }
             InvocationKind::DeriveContainer { ref derives, .. } => {
                 // Block expansion of the container until we resolve all derives in it.
                 // This is required for two reasons:
@@ -299,8 +304,17 @@ impl<'a> ResolverExpand for Resolver<'a> {
 
         // Derives are not included when `invocations` are collected, so we have to add them here.
         let parent_scope = &ParentScope { derives, ..parent_scope };
+        let require_inert = !invoc.fragment_kind.supports_macro_expansion();
         let node_id = self.lint_node_id(eager_expansion_root);
-        let (ext, res) = self.smart_resolve_macro_path(path, kind, parent_scope, node_id, force)?;
+        let (ext, res) = self.smart_resolve_macro_path(
+            path,
+            kind,
+            require_inert,
+            inner_attr,
+            parent_scope,
+            node_id,
+            force,
+        )?;
 
         let span = invoc.span();
         invoc_id.set_expn_data(ext.expn_data(
@@ -316,29 +330,6 @@ impl<'a> ResolverExpand for Resolver<'a> {
             }
             let normal_module_def_id = self.macro_def_scope(invoc_id).normal_ancestor_id;
             self.definitions.add_parent_module_of_macro_def(invoc_id, normal_module_def_id);
-        }
-
-        match invoc.fragment_kind {
-            AstFragmentKind::Arms
-            | AstFragmentKind::Fields
-            | AstFragmentKind::FieldPats
-            | AstFragmentKind::GenericParams
-            | AstFragmentKind::Params
-            | AstFragmentKind::StructFields
-            | AstFragmentKind::Variants => {
-                if let Res::Def(..) = res {
-                    self.session.span_err(
-                        span,
-                        &format!(
-                            "expected an inert attribute, found {} {}",
-                            res.article(),
-                            res.descr()
-                        ),
-                    );
-                    return Ok(InvocationRes::Single(self.dummy_ext(kind)));
-                }
-            }
-            _ => {}
         }
 
         Ok(InvocationRes::Single(ext))
@@ -403,10 +394,14 @@ impl<'a> ResolverExpand for Resolver<'a> {
 
 impl<'a> Resolver<'a> {
     /// Resolve macro path with error reporting and recovery.
+    /// Uses dummy syntax extensions for unresolved macros or macros with unexpected resolutions
+    /// for better error recovery.
     fn smart_resolve_macro_path(
         &mut self,
         path: &ast::Path,
         kind: MacroKind,
+        require_inert: bool,
+        inner_attr: bool,
         parent_scope: &ParentScope<'a>,
         node_id: NodeId,
         force: bool,
@@ -414,7 +409,6 @@ impl<'a> Resolver<'a> {
         let (ext, res) = match self.resolve_macro_path(path, Some(kind), parent_scope, true, force)
         {
             Ok((Some(ext), res)) => (ext, res),
-            // Use dummy syntax extensions for unresolved macros for better recovery.
             Ok((None, res)) => (self.dummy_ext(kind), res),
             Err(Determinacy::Determined) => (self.dummy_ext(kind), Res::Err),
             Err(Determinacy::Undetermined) => return Err(Indeterminate),
@@ -451,19 +445,43 @@ impl<'a> Resolver<'a> {
 
         self.check_stability_and_deprecation(&ext, path, node_id);
 
-        Ok(if ext.macro_kind() != kind {
-            let expected = kind.descr_expected();
+        let unexpected_res = if ext.macro_kind() != kind {
+            Some((kind.article(), kind.descr_expected()))
+        } else if require_inert && matches!(res, Res::Def(..)) {
+            Some(("a", "non-macro attribute"))
+        } else {
+            None
+        };
+        if let Some((article, expected)) = unexpected_res {
             let path_str = pprust::path_to_string(path);
             let msg = format!("expected {}, found {} `{}`", expected, res.descr(), path_str);
             self.session
                 .struct_span_err(path.span, &msg)
-                .span_label(path.span, format!("not {} {}", kind.article(), expected))
+                .span_label(path.span, format!("not {} {}", article, expected))
                 .emit();
-            // Use dummy syntax extensions for unexpected macro kinds for better recovery.
-            (self.dummy_ext(kind), Res::Err)
-        } else {
-            (ext, res)
-        })
+            return Ok((self.dummy_ext(kind), Res::Err));
+        }
+
+        // We are trying to avoid reporting this error if other related errors were reported.
+        if inner_attr
+            && !self.session.features_untracked().custom_inner_attributes
+            && path != &sym::test
+            && res != Res::Err
+        {
+            feature_err(
+                &self.session.parse_sess,
+                sym::custom_inner_attributes,
+                path.span,
+                match res {
+                    Res::Def(..) => "inner macro attributes are unstable",
+                    Res::NonMacroAttr(..) => "custom inner attributes are unstable",
+                    _ => unreachable!(),
+                },
+            )
+            .emit();
+        }
+
+        Ok((ext, res))
     }
 
     pub fn resolve_macro_path(

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -286,7 +286,7 @@ impl<'a> ResolverExpand for Resolver<'a> {
                                     ext.helper_attrs.iter().map(|name| Ident::new(*name, span)),
                                 );
                                 if ext.is_derive_copy {
-                                    self.add_derive_copy(invoc_id);
+                                    self.containers_deriving_copy.insert(invoc_id);
                                 }
                                 ext
                             }
@@ -349,10 +349,6 @@ impl<'a> ResolverExpand for Resolver<'a> {
 
     fn has_derive_copy(&self, expn_id: ExpnId) -> bool {
         self.containers_deriving_copy.contains(&expn_id)
-    }
-
-    fn add_derive_copy(&mut self, expn_id: ExpnId) {
-        self.containers_deriving_copy.insert(expn_id);
     }
 
     // The function that implements the resolution logic of `#[cfg_accessible(path)]`.

--- a/src/test/ui/attrs-resolution-errors.rs
+++ b/src/test/ui/attrs-resolution-errors.rs
@@ -1,12 +1,12 @@
 enum FooEnum {
     #[test]
-    //~^ ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
     Bar(i32),
 }
 
 struct FooStruct {
     #[test]
-    //~^ ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
     bar: i32,
 }
 
@@ -21,20 +21,20 @@ fn main() {
     match foo_struct {
         FooStruct {
             #[test] bar
-            //~^ ERROR expected an inert attribute, found an attribute macro
+            //~^ ERROR expected non-macro attribute, found attribute macro
         } => {}
     }
 
     match 1 {
         0 => {}
         #[test]
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         _ => {}
     }
 
     let _another_foo_strunct = FooStruct {
         #[test]
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         bar: 1,
     };
 }

--- a/src/test/ui/attrs-resolution-errors.stderr
+++ b/src/test/ui/attrs-resolution-errors.stderr
@@ -1,32 +1,32 @@
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/attrs-resolution-errors.rs:2:5
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/attrs-resolution-errors.rs:2:7
    |
 LL |     #[test]
-   |     ^^^^^^^
+   |       ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/attrs-resolution-errors.rs:8:5
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/attrs-resolution-errors.rs:8:7
    |
 LL |     #[test]
-   |     ^^^^^^^
+   |       ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/attrs-resolution-errors.rs:23:13
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/attrs-resolution-errors.rs:23:15
    |
 LL |             #[test] bar
-   |             ^^^^^^^
+   |               ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/attrs-resolution-errors.rs:30:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/attrs-resolution-errors.rs:30:11
    |
 LL |         #[test]
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/attrs-resolution-errors.rs:36:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/attrs-resolution-errors.rs:36:11
    |
 LL |         #[test]
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/conditional-compilation/cfg_accessible-stuck.rs
+++ b/src/test/ui/conditional-compilation/cfg_accessible-stuck.rs
@@ -1,6 +1,6 @@
 #![feature(cfg_accessible)]
 
-#[cfg_accessible(Z)] //~ ERROR cannot determine whether the path is accessible or not
+#[cfg_accessible(Z)] // OK, recovered after the other `cfg_accessible` produces an error.
 struct S;
 
 #[cfg_accessible(S)] //~ ERROR cannot determine whether the path is accessible or not

--- a/src/test/ui/conditional-compilation/cfg_accessible-stuck.stderr
+++ b/src/test/ui/conditional-compilation/cfg_accessible-stuck.stderr
@@ -4,11 +4,5 @@ error: cannot determine whether the path is accessible or not
 LL | #[cfg_accessible(S)]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: cannot determine whether the path is accessible or not
-  --> $DIR/cfg_accessible-stuck.rs:3:1
-   |
-LL | #[cfg_accessible(Z)]
-   | ^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-36617.rs
+++ b/src/test/ui/issues/issue-36617.rs
@@ -1,5 +1,4 @@
 #![derive(Copy)] //~ ERROR `derive` may only be applied to structs, enums and unions
                  //~| ERROR cannot determine resolution for the derive macro `Copy`
-                 //~| ERROR cannot determine resolution for the derive macro `Copy`
 
 fn main() {}

--- a/src/test/ui/issues/issue-36617.stderr
+++ b/src/test/ui/issues/issue-36617.stderr
@@ -12,14 +12,6 @@ LL | #![derive(Copy)]
    |
    = note: import resolution is stuck, try simplifying macro imports
 
-error: cannot determine resolution for the derive macro `Copy`
-  --> $DIR/issue-36617.rs:1:11
-   |
-LL | #![derive(Copy)]
-   |           ^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0774`.

--- a/src/test/ui/issues/issue-49934-errors.rs
+++ b/src/test/ui/issues/issue-49934-errors.rs
@@ -1,10 +1,8 @@
 fn foo<#[derive(Debug)] T>() {
 //~^ ERROR `derive` may only be applied to structs, enums and unions
-//~| ERROR expected an inert attribute, found a derive macro
     match 0 {
         #[derive(Debug)]
         //~^ ERROR `derive` may only be applied to structs, enums and unions
-        //~| ERROR expected an inert attribute, found a derive macro
         _ => (),
     }
 }

--- a/src/test/ui/issues/issue-49934-errors.stderr
+++ b/src/test/ui/issues/issue-49934-errors.stderr
@@ -4,24 +4,12 @@ error[E0774]: `derive` may only be applied to structs, enums and unions
 LL | fn foo<#[derive(Debug)] T>() {
    |        ^^^^^^^^^^^^^^^^
 
-error: expected an inert attribute, found a derive macro
-  --> $DIR/issue-49934-errors.rs:1:17
-   |
-LL | fn foo<#[derive(Debug)] T>() {
-   |                 ^^^^^
-
 error[E0774]: `derive` may only be applied to structs, enums and unions
-  --> $DIR/issue-49934-errors.rs:5:9
+  --> $DIR/issue-49934-errors.rs:4:9
    |
 LL |         #[derive(Debug)]
    |         ^^^^^^^^^^^^^^^^
 
-error: expected an inert attribute, found a derive macro
-  --> $DIR/issue-49934-errors.rs:5:18
-   |
-LL |         #[derive(Debug)]
-   |                  ^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0774`.

--- a/src/test/ui/malformed/issue-69341-malformed-derive-inert.rs
+++ b/src/test/ui/malformed/issue-69341-malformed-derive-inert.rs
@@ -4,7 +4,6 @@ struct CLI {
     #[derive(parse())]
     //~^ ERROR traits in `#[derive(...)]` don't accept arguments
     //~| ERROR cannot find derive macro `parse` in this scope
-    //~| ERROR cannot find derive macro `parse` in this scope
     path: (),
     //~^ ERROR `derive` may only be applied to structs, enums and unions
 }

--- a/src/test/ui/malformed/issue-69341-malformed-derive-inert.stderr
+++ b/src/test/ui/malformed/issue-69341-malformed-derive-inert.stderr
@@ -5,7 +5,7 @@ LL |     #[derive(parse())]
    |                   ^^ help: remove the arguments
 
 error[E0774]: `derive` may only be applied to structs, enums and unions
-  --> $DIR/issue-69341-malformed-derive-inert.rs:8:5
+  --> $DIR/issue-69341-malformed-derive-inert.rs:7:5
    |
 LL |     path: (),
    |     ^^^^^^^^
@@ -16,12 +16,6 @@ error: cannot find derive macro `parse` in this scope
 LL |     #[derive(parse())]
    |              ^^^^^
 
-error: cannot find derive macro `parse` in this scope
-  --> $DIR/issue-69341-malformed-derive-inert.rs:4:14
-   |
-LL |     #[derive(parse())]
-   |              ^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0774`.

--- a/src/test/ui/proc-macro/proc-macro-gates.rs
+++ b/src/test/ui/proc-macro/proc-macro-gates.rs
@@ -7,11 +7,11 @@
 extern crate test_macros;
 
 fn _test_inner() {
-    #![empty_attr] //~ ERROR: non-builtin inner attributes are unstable
+    #![empty_attr] //~ ERROR: inner macro attributes are unstable
 }
 
 mod _test2_inner {
-    #![empty_attr] //~ ERROR: non-builtin inner attributes are unstable
+    #![empty_attr] //~ ERROR: inner macro attributes are unstable
 }
 
 #[empty_attr = "y"] //~ ERROR: key-value macro attributes are not supported

--- a/src/test/ui/proc-macro/proc-macro-gates.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates.stderr
@@ -1,17 +1,17 @@
-error[E0658]: non-builtin inner attributes are unstable
-  --> $DIR/proc-macro-gates.rs:10:5
+error[E0658]: inner macro attributes are unstable
+  --> $DIR/proc-macro-gates.rs:10:8
    |
 LL |     #![empty_attr]
-   |     ^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
-error[E0658]: non-builtin inner attributes are unstable
-  --> $DIR/proc-macro-gates.rs:14:5
+error[E0658]: inner macro attributes are unstable
+  --> $DIR/proc-macro-gates.rs:14:8
    |
 LL |     #![empty_attr]
-   |     ^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable

--- a/src/test/ui/proc-macro/proc-macro-gates2.rs
+++ b/src/test/ui/proc-macro/proc-macro-gates2.rs
@@ -10,11 +10,11 @@ extern crate test_macros;
 // should either require a feature gate or not be allowed on stable.
 
 fn _test6<#[empty_attr] T>() {}
-//~^ ERROR: expected an inert attribute, found an attribute macro
+//~^ ERROR: expected non-macro attribute, found attribute macro
 
 fn _test7() {
     match 1 {
-        #[empty_attr] //~ ERROR: expected an inert attribute, found an attribute macro
+        #[empty_attr] //~ ERROR: expected non-macro attribute, found attribute macro
         0 => {}
         _ => {}
     }

--- a/src/test/ui/proc-macro/proc-macro-gates2.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates2.stderr
@@ -1,14 +1,14 @@
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-gates2.rs:12:11
+error: expected non-macro attribute, found attribute macro `empty_attr`
+  --> $DIR/proc-macro-gates2.rs:12:13
    |
 LL | fn _test6<#[empty_attr] T>() {}
-   |           ^^^^^^^^^^^^^
+   |             ^^^^^^^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-gates2.rs:17:9
+error: expected non-macro attribute, found attribute macro `empty_attr`
+  --> $DIR/proc-macro-gates2.rs:17:11
    |
 LL |         #[empty_attr]
-   |         ^^^^^^^^^^^^^
+   |           ^^^^^^^^^^ not a non-macro attribute
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-builtin-attrs.rs
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-builtin-attrs.rs
@@ -3,7 +3,7 @@ extern "C" {
         /// Foo
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: i32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Bar
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
@@ -19,7 +19,7 @@ type FnType = fn(
     /// Foo
     //~^ ERROR documentation comments cannot be applied to function
     #[test] a: u32,
-    //~^ ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
     /// Bar
     //~^ ERROR documentation comments cannot be applied to function
     #[must_use]
@@ -34,7 +34,7 @@ pub fn foo(
     /// Foo
     //~^ ERROR documentation comments cannot be applied to function
     #[test] a: u32,
-    //~^ ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
     /// Bar
     //~^ ERROR documentation comments cannot be applied to function
     #[must_use]
@@ -54,7 +54,7 @@ impl SelfStruct {
         /// Bar
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: i32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Baz
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
@@ -69,7 +69,7 @@ impl SelfStruct {
         /// Foo
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: i32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Baz
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
@@ -90,7 +90,7 @@ impl RefStruct {
         /// Bar
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: i32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Baz
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
@@ -109,7 +109,7 @@ trait RefTrait {
         /// Bar
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: i32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Baz
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
@@ -124,7 +124,7 @@ trait RefTrait {
         /// Foo
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: i32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Baz
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
@@ -144,7 +144,7 @@ impl RefTrait for RefStruct {
         /// Bar
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: i32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Baz
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]
@@ -161,7 +161,7 @@ fn main() {
         /// Foo
         //~^ ERROR documentation comments cannot be applied to function
         #[test] a: u32,
-        //~^ ERROR expected an inert attribute, found an attribute macro
+        //~^ ERROR expected non-macro attribute, found attribute macro
         /// Bar
         //~^ ERROR documentation comments cannot be applied to function
         #[must_use]

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
@@ -1,62 +1,62 @@
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:5:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:5:11
    |
 LL |         #[test] a: i32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:21:5
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:21:7
    |
 LL |     #[test] a: u32,
-   |     ^^^^^^^
+   |       ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:36:5
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:36:7
    |
 LL |     #[test] a: u32,
-   |     ^^^^^^^
+   |       ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:56:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:56:11
    |
 LL |         #[test] a: i32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:71:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:71:11
    |
 LL |         #[test] a: i32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:92:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:92:11
    |
 LL |         #[test] a: i32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:111:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:111:11
    |
 LL |         #[test] a: i32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:126:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:126:11
    |
 LL |         #[test] a: i32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:146:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:146:11
    |
 LL |         #[test] a: i32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/param-attrs-builtin-attrs.rs:163:9
+error: expected non-macro attribute, found attribute macro `test`
+  --> $DIR/param-attrs-builtin-attrs.rs:163:11
    |
 LL |         #[test] a: u32,
-   |         ^^^^^^^
+   |           ^^^^ not a non-macro attribute
 
 error: documentation comments cannot be applied to function parameters
   --> $DIR/param-attrs-builtin-attrs.rs:3:9

--- a/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.rs
+++ b/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.rs
@@ -8,58 +8,58 @@ use ident_mac::id;
 struct W(u8);
 
 extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
-//~^ ERROR expected an inert attribute, found an attribute macro
-//~| ERROR expected an inert attribute, found an attribute macro
+//~^ ERROR expected non-macro attribute, found attribute macro
+//~| ERROR expected non-macro attribute, found attribute macro
 
 unsafe extern "C" fn cvar(arg1: i32, #[id] mut args: ...) {}
-//~^ ERROR expected an inert attribute, found an attribute macro
+//~^ ERROR expected non-macro attribute, found attribute macro
 
 type Alias = extern "C" fn(#[id] u8, #[id] ...);
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
 
 fn free(#[id] arg1: u8) {
-    //~^ ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
     let lam = |#[id] W(x), #[id] y: usize| ();
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
 }
 
 impl W {
     fn inherent1(#[id] self, #[id] arg1: u8) {}
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn inherent2(#[id] &self, #[id] arg1: u8) {}
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8) {}
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
 }
 
 trait A {
     fn trait1(#[id] self, #[id] arg1: u8);
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn trait2(#[id] &self, #[id] arg1: u8);
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8);
-    //~^ ERROR expected an inert attribute, found an attribute macro
-    //~| ERROR expected an inert attribute, found an attribute macro
+    //~^ ERROR expected non-macro attribute, found attribute macro
+    //~| ERROR expected non-macro attribute, found attribute macro
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.stderr
@@ -1,176 +1,176 @@
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:10:21
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:10:23
    |
 LL | extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
-   |                     ^^^^^
+   |                       ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:10:38
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:10:40
    |
 LL | extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
-   |                                      ^^^^^
+   |                                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:14:38
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:14:40
    |
 LL | unsafe extern "C" fn cvar(arg1: i32, #[id] mut args: ...) {}
-   |                                      ^^^^^
+   |                                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:17:28
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:17:30
    |
 LL | type Alias = extern "C" fn(#[id] u8, #[id] ...);
-   |                            ^^^^^
+   |                              ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:17:38
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:17:40
    |
 LL | type Alias = extern "C" fn(#[id] u8, #[id] ...);
-   |                                      ^^^^^
+   |                                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:21:9
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:21:11
    |
 LL | fn free(#[id] arg1: u8) {
-   |         ^^^^^
+   |           ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:23:16
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:23:18
    |
 LL |     let lam = |#[id] W(x), #[id] y: usize| ();
-   |                ^^^^^
+   |                  ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:23:28
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:23:30
    |
 LL |     let lam = |#[id] W(x), #[id] y: usize| ();
-   |                            ^^^^^
+   |                              ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:29:18
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:29:20
    |
 LL |     fn inherent1(#[id] self, #[id] arg1: u8) {}
-   |                  ^^^^^
+   |                    ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:29:30
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:29:32
    |
 LL |     fn inherent1(#[id] self, #[id] arg1: u8) {}
-   |                              ^^^^^
+   |                                ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:32:18
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:32:20
    |
 LL |     fn inherent2(#[id] &self, #[id] arg1: u8) {}
-   |                  ^^^^^
+   |                    ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:32:31
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:32:33
    |
 LL |     fn inherent2(#[id] &self, #[id] arg1: u8) {}
-   |                               ^^^^^
+   |                                 ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:35:22
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:35:24
    |
 LL |     fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
-   |                      ^^^^^
+   |                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:35:42
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:35:44
    |
 LL |     fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
-   |                                          ^^^^^
+   |                                            ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:38:22
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:38:24
    |
 LL |     fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
-   |                      ^^^^^
+   |                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:38:45
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:38:47
    |
 LL |     fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
-   |                                             ^^^^^
+   |                                               ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:41:38
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:41:40
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8) {}
-   |                                      ^^^^^
+   |                                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:41:54
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:41:56
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8) {}
-   |                                                      ^^^^^
+   |                                                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:47:15
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:47:17
    |
 LL |     fn trait1(#[id] self, #[id] arg1: u8);
-   |               ^^^^^
+   |                 ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:47:27
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:47:29
    |
 LL |     fn trait1(#[id] self, #[id] arg1: u8);
-   |                           ^^^^^
+   |                             ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:50:15
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:50:17
    |
 LL |     fn trait2(#[id] &self, #[id] arg1: u8);
-   |               ^^^^^
+   |                 ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:50:28
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:50:30
    |
 LL |     fn trait2(#[id] &self, #[id] arg1: u8);
-   |                            ^^^^^
+   |                              ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:53:19
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:53:21
    |
 LL |     fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
-   |                   ^^^^^
+   |                     ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:53:39
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:53:41
    |
 LL |     fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
-   |                                       ^^^^^
+   |                                         ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:56:19
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:56:21
    |
 LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
-   |                   ^^^^^
+   |                     ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:56:42
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:56:44
    |
 LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
-   |                                          ^^^^^
+   |                                            ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:56:58
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:56:60
    |
 LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
-   |                                                          ^^^^^
+   |                                                            ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:60:38
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:60:40
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8);
-   |                                      ^^^^^
+   |                                        ^^ not a non-macro attribute
 
-error: expected an inert attribute, found an attribute macro
-  --> $DIR/proc-macro-cannot-be-used.rs:60:54
+error: expected non-macro attribute, found attribute macro `id`
+  --> $DIR/proc-macro-cannot-be-used.rs:60:56
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8);
-   |                                                      ^^^^^
+   |                                                        ^^ not a non-macro attribute
 
 error: aborting due to 29 previous errors
 

--- a/src/test/ui/span/issue-36530.rs
+++ b/src/test/ui/span/issue-36530.rs
@@ -6,7 +6,7 @@
 
 #[foo]
 mod foo {
-    #![foo] //~ ERROR non-builtin inner attributes are unstable
+    #![foo] //~ ERROR custom inner attributes are unstable
 }
 
 fn main() {}

--- a/src/test/ui/span/issue-36530.stderr
+++ b/src/test/ui/span/issue-36530.stderr
@@ -1,8 +1,8 @@
-error[E0658]: non-builtin inner attributes are unstable
-  --> $DIR/issue-36530.rs:9:5
+error[E0658]: custom inner attributes are unstable
+  --> $DIR/issue-36530.rs:9:8
    |
 LL |     #![foo]
-   |     ^^^^^^^
+   |        ^^^
    |
    = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable

--- a/src/test/ui/span/issue-43927-non-ADT-derive.rs
+++ b/src/test/ui/span/issue-43927-non-ADT-derive.rs
@@ -5,9 +5,6 @@
 //~| ERROR cannot determine resolution for the derive macro `Debug`
 //~| ERROR cannot determine resolution for the derive macro `PartialEq`
 //~| ERROR cannot determine resolution for the derive macro `Eq`
-//~| ERROR cannot determine resolution for the derive macro `Debug`
-//~| ERROR cannot determine resolution for the derive macro `PartialEq`
-//~| ERROR cannot determine resolution for the derive macro `Eq`
 struct DerivedOn;
 
 fn main() {}

--- a/src/test/ui/span/issue-43927-non-ADT-derive.stderr
+++ b/src/test/ui/span/issue-43927-non-ADT-derive.stderr
@@ -28,30 +28,6 @@ LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
    |
    = note: import resolution is stuck, try simplifying macro imports
 
-error: cannot determine resolution for the derive macro `Eq`
-  --> $DIR/issue-43927-non-ADT-derive.rs:3:29
-   |
-LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
-   |                             ^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the derive macro `PartialEq`
-  --> $DIR/issue-43927-non-ADT-derive.rs:3:18
-   |
-LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
-   |                  ^^^^^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: cannot determine resolution for the derive macro `Debug`
-  --> $DIR/issue-43927-non-ADT-derive.rs:3:11
-   |
-LL | #![derive(Debug, PartialEq, Eq)] // should be an outer attribute!
-   |           ^^^^^
-   |
-   = note: import resolution is stuck, try simplifying macro imports
-
-error: aborting due to 7 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0774`.


### PR DESCRIPTION
Miscellaneous refactorings and error reporting changes extracted from https://github.com/rust-lang/rust/pull/79078.

Unlike https://github.com/rust-lang/rust/pull/79078 this PR doesn't make any observable changes to the language or library.
r? @Aaron1011 