### PR TITLE
Made matches! more useful by adding mapping support

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -221,6 +221,10 @@ macro_rules! debug_assert_ne {
 /// Like in a `match` expression, the pattern can be optionally followed by `if`
 /// and a guard expression that has access to names bound by the pattern.
 ///
+/// If the pattern is followed by a `=>` and a further mapping expression, an
+/// [`Option`] will be produced, optionally containing the value produced by
+/// evaluating the mapping expression in the context of the pattern.
+///
 /// # Examples
 ///
 /// ```
@@ -229,6 +233,14 @@ macro_rules! debug_assert_ne {
 ///
 /// let bar = Some(4);
 /// assert!(matches!(bar, Some(x) if x > 2));
+///
+/// enum Baz {
+///     A(bool),
+///     B(i32),
+/// }
+///
+/// let baz = Baz::A(true);
+/// assert_eq!(matches!(baz, Baz::A(x) => !x), Some(false));
 /// ```
 #[macro_export]
 #[stable(feature = "matches_macro", since = "1.42.0")]
@@ -238,7 +250,13 @@ macro_rules! matches {
             $( $pattern )|+ $( if $guard )? => true,
             _ => false
         }
-    }
+    };
+    ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )? $(,)? => $mapping:expr) => {
+        match $expression {
+            $( $pattern )|+ $( if $guard )? => $crate::option::Option::Some($mapping),
+            _ => $crate::option::Option::None
+        }
+    };
 }
 
 /// Unwraps a result or propagates its error.


### PR DESCRIPTION
This PR adds support for a trailing expression after the pattern in the `matches!` macro.

While `matches!` is extremely useful by itself, it does not have the ability to do anything other than perform a binary match.

A common pattern in Rust code looks something like the following:

```rust
enum Foo {
    A(i32),
    B(bool),
    C,
}

let maybe_a = if let Foo::A(n) = my_foo {
    Some(n)
} else {
    None
};
```

This is rather unwieldy, particularly when used inline. This PR instead allows the following:

```rust
let maybe_a = matches!(my_foo, Foo::A(n) => n);
```

Points in favour:

- `matches!` becomes significantly more useful with this change
- It is not a breaking change
- The behaviour is a natural extension of the `match` syntax that this macro emulates

Points not in favour:

- The name of the macro implies a binary operation. While `Option` is still binary in nature, it isn't quite so clear that a non-`bool` value may be produced