### PR TITLE
Never inline naked functions

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -67,7 +67,7 @@ fn handle_errors(sess: &ParseSess, span: Span, error: AttrError) {
     }
 }
 
-#[derive(Clone, PartialEq, Encodable, Decodable)]
+#[derive(Copy, Clone, PartialEq, Encodable, Decodable)]
 pub enum InlineAttr {
     None,
     Hint,

--- a/compiler/rustc_mir/src/transform/inline.rs
+++ b/compiler/rustc_mir/src/transform/inline.rs
@@ -254,6 +254,11 @@ impl Inliner<'tcx> {
             self.tcx.sess.opts.debugging_opts.inline_mir_threshold
         };
 
+        if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::NAKED) {
+            debug!("#[naked] present - not inlining");
+            return false;
+        }
+
         if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::COLD) {
             debug!("#[cold] present - not inlining");
             return false;

--- a/src/test/codegen/naked-noinline.rs
+++ b/src/test/codegen/naked-noinline.rs
@@ -1,0 +1,30 @@
+// Checks that naked functions are never inlined.
+// compile-flags: -O -Zmir-opt-level=2
+// ignore-wasm32
+#![crate_type = "lib"]
+#![feature(asm)]
+#![feature(naked_functions)]
+
+#[inline(always)]
+#[naked]
+#[no_mangle]
+pub unsafe extern "C" fn f() {
+// Check that f has naked and noinline attributes.
+//
+// CHECK:       define void @f() unnamed_addr [[ATTR:#[0-9]+]]
+// CHECK-NEXT:  start:
+// CHECK-NEXT:    call void asm
+    asm!("", options(noreturn));
+}
+
+#[no_mangle]
+pub unsafe fn g() {
+// Check that call to f is not inlined.
+//
+// CHECK-LABEL: define void @g()
+// CHECK-NEXT:  start:
+// CHECK-NEXT:    call void @f()
+    f();
+}
+
+// CHECK: attributes [[ATTR]] = { naked noinline{{.*}} }


### PR DESCRIPTION
The `#[naked]` attribute disabled prologue / epilogue emission for the
function and it is responsibility of a developer to provide them. The
compiler is no position to inline such functions correctly.

Disable inlining of naked functions at LLVM and MIR level.

Closes #60919.