### PR TITLE
Make as{_mut,}_slice on array::IntoIter public

### DIFF
--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -69,7 +69,8 @@ impl<T, const N: usize> IntoIter<T, N> {
 
     /// Returns an immutable slice of all elements that have not been yielded
     /// yet.
-    fn as_slice(&self) -> &[T] {
+    #[unstable(feature = "array_value_iter_slice", issue = "65798")]
+    pub fn as_slice(&self) -> &[T] {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {
             let slice = self.data.get_unchecked(self.alive.clone());
@@ -78,7 +79,8 @@ impl<T, const N: usize> IntoIter<T, N> {
     }
 
     /// Returns a mutable slice of all elements that have not been yielded yet.
-    fn as_mut_slice(&mut self) -> &mut [T] {
+    #[unstable(feature = "array_value_iter_slice", issue = "65798")]
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {
             let slice = self.data.get_unchecked_mut(self.alive.clone());


### PR DESCRIPTION
The functions are useful in cases where you want to move data out of the IntoIter in bulk, by transmute_copy'ing the slice and then forgetting the IntoIter.

In the compiler, this is useful for providing a sped up IntoIter implementation. One can alternatively provide a separate allocate_array function but one can avoid duplicating some logic by passing everything through the generic iterator using interface.

As per suggestion in https://github.com/rust-lang/rust/pull/78569/files#r526506964