### PR TITLE
unix/weak: pass arguments to syscall at the given type

### DIFF
--- a/library/std/src/sys/unix/weak.rs
+++ b/library/std/src/sys/unix/weak.rs
@@ -135,7 +135,7 @@ macro_rules! syscall {
             } else {
                 syscall(
                     concat_idents!(SYS_, $name),
-                    $($arg_name as c_long),*
+                    $($arg_name),*
                 ) as $ret
             }
         }


### PR DESCRIPTION
Given that we know the type the argument should have, it seems a bit strange not to use that information.

r? @m-ou-se @cuviper 