### PR TITLE
Extend meta parameters to all generated code in compat_fn.

### DIFF
--- a/library/std/src/sys/windows/compat.rs
+++ b/library/std/src/sys/windows/compat.rs
@@ -90,6 +90,7 @@ macro_rules! compat_fn {
             }
         }
 
+        $(#[$meta])*
         pub use $symbol::call as $symbol;
     )*)
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/79203. This addresses a regression from 7e2032390cf34f3ffa726b7bd890141e2684ba63 for UWP targets.