### PR TITLE
Add the "memcpy" doc alias to slice::copy_from_slice

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2724,6 +2724,7 @@ impl<T> [T] {
     ///
     /// [`clone_from_slice`]: #method.clone_from_slice
     /// [`split_at_mut`]: #method.split_at_mut
+    #[doc(alias = "memcpy")]
     #[stable(feature = "copy_from_slice", since = "1.9.0")]
     pub fn copy_from_slice(&mut self, src: &[T])
     where


### PR DESCRIPTION
[RFC1419](https://github.com/rust-lang/rfcs/pull/1419) describes `slice::copy_from_slice` as a "safe memcpy". This enables people searching for `memcpy` to find the `slice::copy_from_slice` method. Thanks!

## Screenshots

This is currently the output when searching for "memcpy" -- `copy_from_slice` is safe, and should be part of this list.

![Screenshot_2020-11-19 Results for memcpy - Rust](https://user-images.githubusercontent.com/2467194/99722964-c9e8fe80-2ab1-11eb-82a5-4afe703a0eea.png)
