### PR TITLE
Add "memset" as doc alias to slice::fill()

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2585,6 +2585,7 @@ impl<T> [T] {
     /// buf.fill(1);
     /// assert_eq!(buf, vec![1; 10]);
     /// ```
+    #[doc(alias = "memset")]
     #[unstable(feature = "slice_fill", issue = "70758")]
     pub fn fill(&mut self, value: T)
     where


### PR DESCRIPTION
Similar to 53f969dfd1b5c128145c24653c668193e8c50f85 and should make it easier for people coming from C to find this function.