### PR TITLE
Resolve typedefs in HashMap gdb/lldb pretty-printers

### DIFF
--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -351,7 +351,7 @@ class StdHashMapProvider:
         ctrl = table["ctrl"]["pointer"]
 
         self.size = int(table["items"])
-        self.pair_type = table.type.template_argument(0)
+        self.pair_type = table.type.template_argument(0).strip_typedefs()
 
         self.new_layout = not table.type.has_key("data")
         if self.new_layout:

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -531,7 +531,7 @@ class StdHashMapSyntheticProvider:
         ctrl = table.GetChildMemberWithName("ctrl").GetChildAtIndex(0)
 
         self.size = table.GetChildMemberWithName("items").GetValueAsUnsigned()
-        self.pair_type = table.type.template_args[0]
+        self.pair_type = table.type.template_args[0].GetTypedefedType()
         self.pair_type_size = self.pair_type.GetByteSize()
 
         self.new_layout = not table.GetChildMemberWithName("data").IsValid()


### PR DESCRIPTION
`GetTypedefedType` (LLDB) and `strip_typedefs` (GDB) calls are needed to resolve key and value types completely.
Without these calls, debugger doesn't show the actual type.

**Before** (without `GetTypedefedType`):
```
(lldb) frame variable hm[0]
(T) hm[0] = { ... }
```

**After** (with `GetTypedefedType`):
```
(lldb) frame variable hm[0]
((i32, alloc::string::String)) hm[0] = { ... }
```

Based on https://github.com/intellij-rust/intellij-rust/pull/6258