### PR TITLE
const_generics: assert resolve hack causes an error

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -143,7 +143,7 @@ impl<'a> Resolver<'a> {
                     _ => {
                         bug!(
                             "GenericParamsFromOuterFunction should only be used with Res::SelfTy, \
-                            DefKind::TyParam"
+                            DefKind::TyParam or DefKind::ConstParam"
                         );
                     }
                 }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2539,6 +2539,7 @@ impl<'a> Resolver<'a> {
         span: Span,
         all_ribs: &[Rib<'a>],
     ) -> Res {
+        const CG_BUG_STR: &str = "min_const_generics resolve check didn't stop compilation";
         debug!("validate_res_from_ribs({:?})", res);
         let ribs = &all_ribs[rib_index + 1..];
 
@@ -2639,6 +2640,8 @@ impl<'a> Resolver<'a> {
                                             },
                                         );
                                     }
+
+                                    self.session.delay_span_bug(span, CG_BUG_STR);
                                     return Res::Err;
                                 }
                             }
@@ -2720,6 +2723,8 @@ impl<'a> Resolver<'a> {
                                         },
                                     );
                                 }
+
+                                self.session.delay_span_bug(span, CG_BUG_STR);
                                 return Res::Err;
                             }
 


### PR DESCRIPTION
prevent the min_const_generics `HACK`s in resolve from triggering a fallback path which successfully compiles so that we don't have to worry about future compat issues when removing it

r? @eddyb cc @varkor 