### PR TITLE
Direct RUSTC_LOG (tracing/log) output to stderr instead of stdout.

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1286,6 +1286,7 @@ pub fn init_env_logger(env: &str) {
     }
     let filter = tracing_subscriber::EnvFilter::from_env(env);
     let layer = tracing_tree::HierarchicalLayer::default()
+        .with_writer(io::stderr)
         .with_indent_lines(true)
         .with_ansi(true)
         .with_targets(true)


### PR DESCRIPTION
Looks like this got missed in the initial implementation, AFAIK the old behavior was to output on stderr.
(Hit this while trying to debug `rustc` running inside a build script which was only letting stderr through)

r? @oli-obk cc @davidbarsky @hawkw