### PR TITLE
BTree: remove Ord bound where it is absent elsewhere

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -501,11 +501,8 @@ impl<K, V> BTreeMap<K, V> {
     /// assert!(a.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn clear(&mut self)
-    where
-        K: Ord,
-    {
-        *self = BTreeMap::new();
+    pub fn clear(&mut self) {
+        *self = BTreeMap { root: None, length: 0 };
     }
 
     /// Returns a reference to the value corresponding to the key.
@@ -1226,10 +1223,7 @@ impl<K, V> BTreeMap<K, V> {
     /// ```
     #[inline]
     #[unstable(feature = "map_into_keys_values", issue = "75294")]
-    pub fn into_keys(self) -> IntoKeys<K, V>
-    where
-        K: Ord,
-    {
+    pub fn into_keys(self) -> IntoKeys<K, V> {
         IntoKeys { inner: self.into_iter() }
     }
 
@@ -1252,10 +1246,7 @@ impl<K, V> BTreeMap<K, V> {
     /// ```
     #[inline]
     #[unstable(feature = "map_into_keys_values", issue = "75294")]
-    pub fn into_values(self) -> IntoValues<K, V>
-    where
-        K: Ord,
-    {
+    pub fn into_values(self) -> IntoValues<K, V> {
         IntoValues { inner: self.into_iter() }
     }
 }

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -1711,12 +1711,19 @@ fn test_ord_absence() {
     fn map<K>(mut map: BTreeMap<K, ()>) {
         map.is_empty();
         map.len();
+        map.clear();
         map.iter();
         map.iter_mut();
         map.keys();
         map.values();
         map.values_mut();
-        map.into_iter();
+        if true {
+            map.into_values();
+        } else if true {
+            map.into_iter();
+        } else {
+            map.into_keys();
+        }
     }
 
     fn map_debug<K: Debug>(mut map: BTreeMap<K, ()>) {
@@ -1726,7 +1733,13 @@ fn test_ord_absence() {
         format!("{:?}", map.keys());
         format!("{:?}", map.values());
         format!("{:?}", map.values_mut());
-        format!("{:?}", map.into_iter());
+        if true {
+            format!("{:?}", map.into_iter());
+        } else if true {
+            format!("{:?}", map.into_keys());
+        } else {
+            format!("{:?}", map.into_values());
+        }
     }
 
     fn map_clone<K: Clone>(mut map: BTreeMap<K, ()>) {

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -457,10 +457,7 @@ impl<T> BTreeSet<T> {
     /// assert!(v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn clear(&mut self)
-    where
-        T: Ord,
-    {
+    pub fn clear(&mut self) {
         self.map.clear()
     }
 

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -641,9 +641,10 @@ fn test_send() {
 
 #[allow(dead_code)]
 fn test_ord_absence() {
-    fn set<K>(set: BTreeSet<K>) {
+    fn set<K>(mut set: BTreeSet<K>) {
         set.is_empty();
         set.len();
+        set.clear();
         set.iter();
         set.into_iter();
     }


### PR DESCRIPTION
Some btree methods don't really need an Ord bound and don't have one, while some methods that more obviously don't need it, do have one.

An example of the former is `iter`, even though it explicitly exposes the work of the Ord implementation (["sorted by key"](https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.iter) - but I'm not suggesting it should have the Ord bound). An example of the latter is `new`, which doesn't involve any keys whatsoever.