### PR TITLE
Avoid generating realloc call in []::to_vec.

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -156,7 +156,7 @@ mod hack {
     where
         T: Clone,
     {
-        let mut vec = Vec::with_capacity(s.len());
+        let mut vec = Vec::new();
         vec.extend_from_slice(s);
         vec
     }


### PR DESCRIPTION
r? @ghost