### PR TITLE
BTreeMap: optimize removal from nearly underfull leaf nodes

### DIFF
--- a/library/alloc/src/collections/btree/split.rs
+++ b/library/alloc/src/collections/btree/split.rs
@@ -63,7 +63,7 @@ impl<K, V> Root<K, V> {
                 let mut last_kv = node.last_kv().consider_for_balancing();
 
                 if last_kv.can_merge() {
-                    cur_node = last_kv.merge(None).into_node();
+                    cur_node = last_kv.merge();
                 } else {
                     let right_len = last_kv.right_child_len();
                     // `MIN_LEN + 1` to avoid readjust if merge happens on the next level.
@@ -89,7 +89,7 @@ impl<K, V> Root<K, V> {
                 let mut first_kv = node.first_kv().consider_for_balancing();
 
                 if first_kv.can_merge() {
-                    cur_node = first_kv.merge(None).into_node();
+                    cur_node = first_kv.merge();
                 } else {
                     let left_len = first_kv.left_child_len();
                     // `MIN_LEN + 1` to avoid readjust if merge happens on the next level.


### PR DESCRIPTION
Imagine being a key-value pair in a waiting room. There are 11 seats and 5 of you sit on the leftmost seats. Your leftmost neighbour gets called in, and the supervisor tells the 4 remaining of you to scooch over to the left. Right next they realize there are too few of you waiting, which doesn't rub off well on the institution, and tell you to scooch over to the right again while they fetch someone from an adjacent room.

This waste happens whenever `remove_kv_tracking` fingers an element among the first 4 of a leaf that has only 5 elements, if the leaf has a left sibling (which it most often has, unless it's a lone root). In a map that was built with ascending keys (like in all benchmarks and probably often in real life code), a 5 element leaf is any leaf that experienced only 1 previous removal. All in all, this seems common enough in non-trivial maps.

The remedy is neither trivial nor terrible. To convincingly demonstrate its effect in benchmarks, I needed to bring in some pretty obese patients that take a long time to scooch over (e.g. with keys worth 666 `usize`s). A slightly more reasonable size (both keys and values of "only" 256 `usize`s) barely shows a difference:

```
 name                                         old ns/iter  new ns/iter  diff ns/iter  diff %  speedup
 btree::map::clone_fat_100                     45,985       46,906               921   2.00%   x 0.98
 btree::map::clone_fat_100_and_drain_all      153,007      142,620           -10,387  -6.79%   x 1.07
 btree::map::clone_fat_100_and_drain_half     108,712      100,282            -8,430  -7.75%   x 1.08
 btree::map::clone_fat_100_and_remove_half    125,472      116,740            -8,732  -6.96%   x 1.07
```
The difference is more significant than the percentage says because each iteration includes cloning and dropping, but there's no difference for normally sized keys and values. So I'm not sure it's worth the extra code.

r? @Mark-Simulacrum 