### PR TITLE
BTreeMap: address namespace conflicts

### DIFF
--- a/library/alloc/src/collections/btree/search.rs
+++ b/library/alloc/src/collections/btree/search.rs
@@ -50,7 +50,7 @@ where
 {
     match search_linear(&node, key) {
         (idx, true) => Found(unsafe { Handle::new_kv(node, idx) }),
-        (idx, false) => SearchResult::GoDown(unsafe { Handle::new_edge(node, idx) }),
+        (idx, false) => GoDown(unsafe { Handle::new_edge(node, idx) }),
     }
 }
 


### PR DESCRIPTION
Fix an annoyance popping up whenever synchronizing the test cases with a version capable of miri-track-raw-pointers.

r? @Mark-Simulacrum 