### PR TITLE
Add Iterator::find_or_{first,nth,last}

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2284,7 +2284,7 @@ pub trait Iterator {
     /// `find_or_nth()` takes a closure that returns `true` or `false`. It applies this closure to
     /// each element of the iterator, and if any of them return `true`, then `find_or_nth()`
     /// returns [`Some(element)`]. If they all return `false`, it returns the same as if [`nth(n)`]
-    /// was invoked instead, though the iterator will be empty end.
+    /// was invoked instead, though the iterator will be empty.
     ///
     /// Like most indexing operations, the count starts from zero, so if `predicate` is never
     /// satisfied, `find_or_nth(predicate, 0)` returns the first item, `find_or_nth(1)` the second,

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -1931,6 +1931,62 @@ fn test_find() {
 }
 
 #[test]
+fn find_or_first() {
+    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 1), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 2), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 3), Some(0));
+    assert_eq!([3, 2, 1, 0].iter().find_or_first(|&&n| n > 1), Some(3));
+    assert_eq!([1].iter().find_or_first(|&&n| n > 1), Some(1));
+    assert_eq!([2].iter().find_or_first(|&&n| n > 1), Some(2));
+    assert_eq!([(); 0].iter().find_or_first(|()| unreachable!()), None);
+}
+
+#[test]
+fn find_or_nth() {
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 0), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 1), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 2), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 3), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 4), Some(2));
+
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 0), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 1), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 2), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 3), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 4), Some(3));
+
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 0), Some(0));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 1), Some(1));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 2), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 3), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 4), None);
+
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 0), Some(3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 1), Some(3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 2), Some(3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 3), Some(3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 4), Some(3));
+
+    assert_eq!([1].iter().find_or_nth(|&&n| n > 1, 0), Some(1));
+    assert_eq!([1].iter().find_or_nth(|&&n| n > 1, 1), None);
+    assert_eq!([2].iter().find_or_nth(|&&n| n > 1, 0), Some(2));
+    assert_eq!([2].iter().find_or_nth(|&&n| n > 1, 1), Some(2));
+
+    assert_eq!([(); 0].iter().find_or_nth(|()| unreachable!(), 0), None);
+}
+
+#[test]
+fn find_or_last() {
+    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 1), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 2), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 3), Some(3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_last(|&&n| n > 1), Some(3));
+    assert_eq!([1].iter().find_or_last(|&&n| n > 1), Some(1));
+    assert_eq!([2].iter().find_or_last(|&&n| n > 1), Some(2));
+    assert_eq!([(); 0].iter().find_or_last(|()| unreachable!()), None);
+}
+
+#[test]
 fn test_find_map() {
     let xs: &[isize] = &[];
     assert_eq!(xs.iter().find_map(half_if_even), None);

--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -1932,57 +1932,57 @@ fn test_find() {
 
 #[test]
 fn find_or_first() {
-    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 1), Some(2));
-    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 2), Some(3));
-    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 3), Some(0));
-    assert_eq!([3, 2, 1, 0].iter().find_or_first(|&&n| n > 1), Some(3));
-    assert_eq!([1].iter().find_or_first(|&&n| n > 1), Some(1));
-    assert_eq!([2].iter().find_or_first(|&&n| n > 1), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 1), Some(&2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 2), Some(&3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_first(|&&n| n > 3), Some(&0));
+    assert_eq!([3, 2, 1, 0].iter().find_or_first(|&&n| n > 1), Some(&3));
+    assert_eq!([1].iter().find_or_first(|&&n| n > 1), Some(&1));
+    assert_eq!([2].iter().find_or_first(|&&n| n > 1), Some(&2));
     assert_eq!([(); 0].iter().find_or_first(|()| unreachable!()), None);
 }
 
 #[test]
 fn find_or_nth() {
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 0), Some(2));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 1), Some(2));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 2), Some(2));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 3), Some(2));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 4), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 0), Some(&2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 1), Some(&2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 2), Some(&2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 3), Some(&2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 1, 4), Some(&2));
 
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 0), Some(3));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 1), Some(3));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 2), Some(3));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 3), Some(3));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 4), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 0), Some(&3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 1), Some(&3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 2), Some(&3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 3), Some(&3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 2, 4), Some(&3));
 
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 0), Some(0));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 1), Some(1));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 2), Some(2));
-    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 3), Some(3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 0), Some(&0));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 1), Some(&1));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 2), Some(&2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 3), Some(&3));
     assert_eq!([0, 1, 2, 3].iter().find_or_nth(|&&n| n > 3, 4), None);
 
-    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 0), Some(3));
-    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 1), Some(3));
-    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 2), Some(3));
-    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 3), Some(3));
-    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 4), Some(3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 0), Some(&3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 1), Some(&3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 2), Some(&3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 3), Some(&3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_nth(|&&n| n > 1, 4), Some(&3));
 
-    assert_eq!([1].iter().find_or_nth(|&&n| n > 1, 0), Some(1));
+    assert_eq!([1].iter().find_or_nth(|&&n| n > 1, 0), Some(&1));
     assert_eq!([1].iter().find_or_nth(|&&n| n > 1, 1), None);
-    assert_eq!([2].iter().find_or_nth(|&&n| n > 1, 0), Some(2));
-    assert_eq!([2].iter().find_or_nth(|&&n| n > 1, 1), Some(2));
+    assert_eq!([2].iter().find_or_nth(|&&n| n > 1, 0), Some(&2));
+    assert_eq!([2].iter().find_or_nth(|&&n| n > 1, 1), Some(&2));
 
     assert_eq!([(); 0].iter().find_or_nth(|()| unreachable!(), 0), None);
 }
 
 #[test]
 fn find_or_last() {
-    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 1), Some(2));
-    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 2), Some(3));
-    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 3), Some(3));
-    assert_eq!([3, 2, 1, 0].iter().find_or_last(|&&n| n > 1), Some(3));
-    assert_eq!([1].iter().find_or_last(|&&n| n > 1), Some(1));
-    assert_eq!([2].iter().find_or_last(|&&n| n > 1), Some(2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 1), Some(&2));
+    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 2), Some(&3));
+    assert_eq!([0, 1, 2, 3].iter().find_or_last(|&&n| n > 3), Some(&3));
+    assert_eq!([3, 2, 1, 0].iter().find_or_last(|&&n| n > 1), Some(&3));
+    assert_eq!([1].iter().find_or_last(|&&n| n > 1), Some(&1));
+    assert_eq!([2].iter().find_or_last(|&&n| n > 1), Some(&2));
     assert_eq!([(); 0].iter().find_or_last(|()| unreachable!()), None);
 }
 

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -43,7 +43,7 @@
 #![feature(int_error_matching)]
 #![feature(array_value_iter)]
 #![feature(iter_advance_by)]
-#![feature(iter_next_or_fnl)]
+#![feature(iter_find_or_fnl)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -43,6 +43,7 @@
 #![feature(int_error_matching)]
 #![feature(array_value_iter)]
 #![feature(iter_advance_by)]
+#![feature(iter_next_or_fnl)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]


### PR DESCRIPTION
I'm proposing to add the methods `find_or_{first,nth,last}` to the `Iterator` trait, to facilitate returning an item that is part of the sequence itself in case no item satisfies the predicate.

Example:
```rust
let a = [0, 1, 2, 3];

assert_eq!(a.iter().find_or_first(|&&e| e == 5   ), Some(&0)); // predicate is never satisfied, so `find_or_first` returns the first item (`&0`)
assert_eq!(a.iter().find_or_nth(  |&&e| e == 5, 1), Some(&1)); // predicate is never satisfied, so `find_or_nth` returns the 2nd item (`&1`) (count begins from `0`)
assert_eq!(a.iter().find_or_last( |&&e| e == 5   ), Some(&3)); // predicate is never satisfied, so `find_or_last` returns the last item (`&3`)
```

Some APIs return different formats or profiles/configurations that it supports and the developer shall choose one from them. Usually these have differing properties, where the developer can choose one according to their requirements or preferences. Examples for such an API can be found in Vulkan, like choosing a color-format where a listing obtained is via [`vkGetPhysicalDeviceSurfaceFormatsKHR`](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkGetPhysicalDeviceSurfaceFormatsKHR.html) ([`Surface::get_physical_device_surface_formats`](https://docs.rs/ash/0.31.0/ash/extensions/khr/struct.Surface.html#method.get_physical_device_surface_formats) in ash, a wrapper library for Rust).

With such a list at hand, `Iterator::find` can be used to find a fitting option, and if none is found, any item should be selected instead. By providing additional methods in the `Iterator` trait, this task can be implemented elegantly.

For the mentioned use case the sequences that are processed may either have a specific order of preferences, with the most preferred one either first or last, or no communicated preference in the items.  
In the former case (preference present), one would normally either want the first or last items as default, and in the latter it wouldn't matter. Either way, `find_or_nth` seems to not solve a concrete use case.  
I added it for some semblance of "symmetry" with other item-retrieval methods already available on `Iterator`. Likewise, `find_or_min` and `find_or_max` could be added as well, though conceptually these would be like "find items with this (caller-provided) predicate, or else this other (hard-coded) predicate", which is a little weird, while the methods I intend to add are more like "find items with this predicate, or else return the item on this position", which in my head makes more sense to provide.  
Maybe only `find_or_first` and `find_or_last` are really useful to have though and `find_or_nth` shouldn't be added to libstd.

I started implementing `DoubleEndedIterator::rfind_or_{first,nth_back,last}`, but again just for some semblance of symmetry. I think I'll see to some feedback first before spending time on those. An argument could perhaps be made for adding `find_or_nth_back` and `rfind_or_nth` in that case, too.