### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -36,7 +36,7 @@ impl ArgAttributeExt for ArgAttribute {
     where
         F: FnMut(llvm::Attribute),
     {
-        for_each_kind!(self, f, NoAlias, NoCapture, NonNull, ReadOnly, SExt, StructRet, ZExt, InReg)
+        for_each_kind!(self, f, NoAlias, NoCapture, NonNull, ReadOnly, StructRet, InReg)
     }
 }
 
@@ -65,6 +65,15 @@ impl ArgAttributesExt for ArgAttributes {
                 llvm::LLVMRustAddByValAttr(llfn, idx.as_uint(), ty.unwrap());
             }
             regular.for_each_kind(|attr| attr.apply_llfn(idx, llfn));
+            match self.arg_ext {
+                ArgExtension::None => {}
+                ArgExtension::Zext => {
+                    llvm::Attribute::ZExt.apply_llfn(idx, llfn);
+                }
+                ArgExtension::Sext => {
+                    llvm::Attribute::SExt.apply_llfn(idx, llfn);
+                }
+            }
         }
     }
 
@@ -95,6 +104,15 @@ impl ArgAttributesExt for ArgAttributes {
                 llvm::LLVMRustAddByValCallSiteAttr(callsite, idx.as_uint(), ty.unwrap());
             }
             regular.for_each_kind(|attr| attr.apply_callsite(idx, callsite));
+            match self.arg_ext {
+                ArgExtension::None => {}
+                ArgExtension::Zext => {
+                    llvm::Attribute::ZExt.apply_callsite(idx, callsite);
+                }
+                ArgExtension::Sext => {
+                    llvm::Attribute::SExt.apply_callsite(idx, callsite);
+                }
+            }
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -158,7 +158,7 @@ impl LlvmType for CastTarget {
             .prefix
             .iter()
             .flat_map(|option_kind| {
-                option_kind.map(|kind| Reg { kind, size: self.prefix_chunk }.llvm_type(cx))
+                option_kind.map(|kind| Reg { kind, size: self.prefix_chunk_size }.llvm_type(cx))
             })
             .chain((0..rest_count).map(|_| rest_ll_unit))
             .collect();

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -36,7 +36,7 @@ impl ArgAttributeExt for ArgAttribute {
     where
         F: FnMut(llvm::Attribute),
     {
-        for_each_kind!(self, f, NoAlias, NoCapture, NonNull, ReadOnly, StructRet, InReg)
+        for_each_kind!(self, f, NoAlias, NoCapture, NonNull, ReadOnly, InReg)
     }
 }
 
@@ -429,7 +429,8 @@ impl<'tcx> FnAbiLlvmExt<'tcx> for FnAbi<'tcx, Ty<'tcx>> {
             }
             PassMode::Indirect { ref attrs, extra_attrs: _, on_stack } => {
                 assert!(!on_stack);
-                apply(attrs);
+                let i = apply(attrs);
+                llvm::Attribute::StructRet.apply_llfn(llvm::AttributePlace::Argument(i), llfn);
             }
             _ => {}
         }
@@ -484,7 +485,9 @@ impl<'tcx> FnAbiLlvmExt<'tcx> for FnAbi<'tcx, Ty<'tcx>> {
             }
             PassMode::Indirect { ref attrs, extra_attrs: _, on_stack } => {
                 assert!(!on_stack);
-                apply(attrs);
+                let i = apply(attrs);
+                llvm::Attribute::StructRet
+                    .apply_callsite(llvm::AttributePlace::Argument(i), callsite);
             }
             _ => {}
         }

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -255,7 +255,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             return;
         }
         let llval = match self.fn_abi.ret.mode {
-            PassMode::Ignore | PassMode::Indirect(..) => {
+            PassMode::Ignore | PassMode::Indirect { .. } => {
                 bx.ret_void();
                 return;
             }
@@ -1101,7 +1101,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         // Force by-ref if we have to load through a cast pointer.
         let (mut llval, align, by_ref) = match op.val {
             Immediate(_) | Pair(..) => match arg.mode {
-                PassMode::Indirect(..) | PassMode::Cast(_) => {
+                PassMode::Indirect { .. } | PassMode::Cast(_) => {
                     let scratch = PlaceRef::alloca(bx, arg.layout);
                     op.val.store(bx, scratch);
                     (scratch.llval, scratch.align, true)

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1286,6 +1286,7 @@ pub fn init_env_logger(env: &str) {
     }
     let filter = tracing_subscriber::EnvFilter::from_env(env);
     let layer = tracing_tree::HierarchicalLayer::default()
+        .with_writer(io::stderr)
         .with_indent_lines(true)
         .with_ansi(true)
         .with_targets(true)

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -947,7 +947,12 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
     }
 
     fn get_type(&self, id: DefIndex, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
-        self.root.tables.ty.get(self, id).unwrap().decode((self, tcx))
+        self.root
+            .tables
+            .ty
+            .get(self, id)
+            .unwrap_or_else(|| panic!("Not a type: {:?}", id))
+            .decode((self, tcx))
     }
 
     fn get_stability(&self, id: DefIndex) -> Option<attr::Stability> {

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2801,7 +2801,8 @@ where
             for arg in &mut self.args {
                 fixup(arg, false);
             }
-            if let PassMode::Indirect(ref mut attrs, _) = self.ret.mode {
+            if let PassMode::Indirect { ref mut attrs, extra_attrs: _, on_stack: _ } = self.ret.mode
+            {
                 attrs.set(ArgAttribute::StructRet);
             }
             return;

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -15,7 +15,7 @@ use rustc_session::{DataTypeKind, FieldInfo, SizeKind, VariantInfo};
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::DUMMY_SP;
 use rustc_target::abi::call::{
-    ArgAbi, ArgAttribute, ArgAttributes, Conv, FnAbi, PassMode, Reg, RegKind,
+    ArgAbi, ArgAttribute, ArgAttributes, ArgExtension, Conv, FnAbi, PassMode, Reg, RegKind,
 };
 use rustc_target::abi::*;
 use rustc_target::spec::{abi::Abi as SpecAbi, HasTargetSpec, PanicStrategy};
@@ -2619,7 +2619,7 @@ where
                                       is_return: bool| {
             // Booleans are always an i1 that needs to be zero-extended.
             if scalar.is_bool() {
-                attrs.zext();
+                attrs.ext(ArgExtension::Zext);
                 return;
             }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2619,7 +2619,7 @@ where
                                       is_return: bool| {
             // Booleans are always an i1 that needs to be zero-extended.
             if scalar.is_bool() {
-                attrs.set(ArgAttribute::ZExt);
+                attrs.zext();
                 return;
             }
 

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2801,10 +2801,6 @@ where
             for arg in &mut self.args {
                 fixup(arg, false);
             }
-            if let PassMode::Indirect { ref mut attrs, extra_attrs: _, on_stack: _ } = self.ret.mode
-            {
-                attrs.set(ArgAttribute::StructRet);
-            }
             return;
         }
 

--- a/compiler/rustc_mir/src/interpret/intrinsics.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics.rs
@@ -83,7 +83,26 @@ crate fn eval_nullary_intrinsic<'tcx>(
             | ty::Bound(_, _)
             | ty::Placeholder(_)
             | ty::Infer(_) => throw_inval!(TooGeneric),
-            _ => ConstValue::from_machine_usize(0u64, &tcx),
+            ty::Bool
+            | ty::Char
+            | ty::Int(_)
+            | ty::Uint(_)
+            | ty::Float(_)
+            | ty::Foreign(_)
+            | ty::Str
+            | ty::Array(_, _)
+            | ty::Slice(_)
+            | ty::RawPtr(_)
+            | ty::Ref(_, _, _)
+            | ty::FnDef(_, _)
+            | ty::FnPtr(_)
+            | ty::Dynamic(_, _)
+            | ty::Closure(_, _)
+            | ty::Generator(_, _, _)
+            | ty::GeneratorWitness(_)
+            | ty::Never
+            | ty::Tuple(_)
+            | ty::Error(_) => ConstValue::from_machine_usize(0u64, &tcx),
         },
         other => bug!("`{}` is not a zero arg intrinsic", other),
     })

--- a/compiler/rustc_mir/src/interpret/intrinsics.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics.rs
@@ -75,13 +75,16 @@ crate fn eval_nullary_intrinsic<'tcx>(
             ensure_monomorphic_enough(tcx, tp_ty)?;
             ConstValue::from_u64(tcx.type_id_hash(tp_ty))
         }
-        sym::variant_count => {
-            if let ty::Adt(ref adt, _) = tp_ty.kind() {
-                ConstValue::from_machine_usize(adt.variants.len() as u64, &tcx)
-            } else {
-                ConstValue::from_machine_usize(0u64, &tcx)
-            }
-        }
+        sym::variant_count => match tp_ty.kind() {
+            ty::Adt(ref adt, _) => ConstValue::from_machine_usize(adt.variants.len() as u64, &tcx),
+            ty::Projection(_)
+            | ty::Opaque(_, _)
+            | ty::Param(_)
+            | ty::Bound(_, _)
+            | ty::Placeholder(_)
+            | ty::Infer(_) => throw_inval!(TooGeneric),
+            _ => ConstValue::from_machine_usize(0u64, &tcx),
+        },
         other => bug!("`{}` is not a zero arg intrinsic", other),
     })
 }

--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -33,11 +33,11 @@ pub struct QueryInfo<Q> {
 
 pub(crate) type QueryMap<D, Q> = FxHashMap<QueryJobId<D>, QueryJobInfo<D, Q>>;
 
-/// A value uniquely identifiying an active query job within a shard in the query cache.
+/// A value uniquely identifying an active query job within a shard in the query cache.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct QueryShardJobId(pub NonZeroU32);
 
-/// A value uniquely identifiying an active query job.
+/// A value uniquely identifying an active query job.
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct QueryJobId<D> {
     /// Which job within a shard is this
@@ -536,7 +536,7 @@ fn remove_cycle<CTX: QueryContext>(
         };
 
         // We unwrap `waiter` here since there must always be one
-        // edge which is resumeable / waited using a query latch
+        // edge which is resumable / waited using a query latch
         let (waitee_query, waiter_idx) = waiter.unwrap();
 
         // Extract the waiter we want to resume

--- a/compiler/rustc_target/src/abi/call/mips64.rs
+++ b/compiler/rustc_target/src/abi/call/mips64.rs
@@ -1,4 +1,4 @@
-use crate::abi::call::{ArgAbi, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
+use crate::abi::call::{ArgAbi, ArgExtension, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
 use crate::abi::{self, HasDataLayout, LayoutOf, Size, TyAndLayout, TyAndLayoutMethods};
 
 fn extend_integer_width_mips<Ty>(arg: &mut ArgAbi<'_, Ty>, bits: u64) {
@@ -7,7 +7,7 @@ fn extend_integer_width_mips<Ty>(arg: &mut ArgAbi<'_, Ty>, bits: u64) {
         if let abi::Int(i, signed) = scalar.value {
             if !signed && i.size().bits() == 32 {
                 if let PassMode::Direct(ref mut attrs) = arg.mode {
-                    attrs.sext();
+                    attrs.ext(ArgExtension::Sext);
                     return;
                 }
             }

--- a/compiler/rustc_target/src/abi/call/mips64.rs
+++ b/compiler/rustc_target/src/abi/call/mips64.rs
@@ -1,4 +1,4 @@
-use crate::abi::call::{ArgAbi, ArgAttribute, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
+use crate::abi::call::{ArgAbi, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
 use crate::abi::{self, HasDataLayout, LayoutOf, Size, TyAndLayout, TyAndLayoutMethods};
 
 fn extend_integer_width_mips<Ty>(arg: &mut ArgAbi<'_, Ty>, bits: u64) {
@@ -7,7 +7,7 @@ fn extend_integer_width_mips<Ty>(arg: &mut ArgAbi<'_, Ty>, bits: u64) {
         if let abi::Int(i, signed) = scalar.value {
             if !signed && i.size().bits() == 32 {
                 if let PassMode::Direct(ref mut attrs) = arg.mode {
-                    attrs.set(ArgAttribute::SExt);
+                    attrs.sext();
                     return;
                 }
             }

--- a/compiler/rustc_target/src/abi/call/mips64.rs
+++ b/compiler/rustc_target/src/abi/call/mips64.rs
@@ -137,7 +137,7 @@ where
     let rest_size = size - Size::from_bytes(8) * prefix_index as u64;
     arg.cast_to(CastTarget {
         prefix,
-        prefix_chunk: Size::from_bytes(8),
+        prefix_chunk_size: Size::from_bytes(8),
         rest: Uniform { unit: Reg::i64(), total: rest_size },
     });
 }

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -203,7 +203,7 @@ impl Uniform {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct CastTarget {
     pub prefix: [Option<RegKind>; 8],
-    pub prefix_chunk: Size,
+    pub prefix_chunk_size: Size,
     pub rest: Uniform,
 }
 
@@ -215,7 +215,7 @@ impl From<Reg> for CastTarget {
 
 impl From<Uniform> for CastTarget {
     fn from(uniform: Uniform) -> CastTarget {
-        CastTarget { prefix: [None; 8], prefix_chunk: Size::ZERO, rest: uniform }
+        CastTarget { prefix: [None; 8], prefix_chunk_size: Size::ZERO, rest: uniform }
     }
 }
 
@@ -223,13 +223,13 @@ impl CastTarget {
     pub fn pair(a: Reg, b: Reg) -> CastTarget {
         CastTarget {
             prefix: [Some(a.kind), None, None, None, None, None, None, None],
-            prefix_chunk: a.size,
+            prefix_chunk_size: a.size,
             rest: Uniform::from(b),
         }
     }
 
     pub fn size<C: HasDataLayout>(&self, cx: &C) -> Size {
-        (self.prefix_chunk * self.prefix.iter().filter(|x| x.is_some()).count() as u64)
+        (self.prefix_chunk_size * self.prefix.iter().filter(|x| x.is_some()).count() as u64)
             .align_to(self.rest.align(cx))
             + self.rest.total
     }
@@ -237,7 +237,7 @@ impl CastTarget {
     pub fn align<C: HasDataLayout>(&self, cx: &C) -> Align {
         self.prefix
             .iter()
-            .filter_map(|x| x.map(|kind| Reg { kind, size: self.prefix_chunk }.align(cx)))
+            .filter_map(|x| x.map(|kind| Reg { kind, size: self.prefix_chunk_size }.align(cx)))
             .fold(cx.data_layout().aggregate_align.abi.max(self.rest.align(cx)), |acc, align| {
                 acc.max(align)
             })

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -96,15 +96,9 @@ impl ArgAttributes {
         }
     }
 
-    pub fn zext(&mut self) -> &mut Self {
-        assert_ne!(self.arg_ext, ArgExtension::Sext);
-        self.arg_ext = ArgExtension::Zext;
-        self
-    }
-
-    pub fn sext(&mut self) -> &mut Self {
-        assert_ne!(self.arg_ext, ArgExtension::Zext);
-        self.arg_ext = ArgExtension::Sext;
+    pub fn ext(&mut self, ext: ArgExtension) -> &mut Self {
+        assert!(self.arg_ext == ArgExtension::None || self.arg_ext == ext);
+        self.arg_ext = ext;
         self
     }
 
@@ -481,9 +475,9 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
                 if i.size().bits() < bits {
                     if let PassMode::Direct(ref mut attrs) = self.mode {
                         if signed {
-                            attrs.sext()
+                            attrs.ext(ArgExtension::Sext)
                         } else {
-                            attrs.zext()
+                            attrs.ext(ArgExtension::Zext)
                         };
                     }
                 }

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -59,7 +59,6 @@ mod attr_impl {
             const NoCapture = 1 << 2;
             const NonNull   = 1 << 3;
             const ReadOnly  = 1 << 4;
-            const StructRet = 1 << 6;
             const InReg     = 1 << 8;
         }
     }
@@ -617,10 +616,6 @@ impl<'a, Ty> FnAbi<'a, Ty> {
             }
             "wasm32" | "asmjs" => wasm32::compute_abi_info(cx, self),
             a => return Err(format!("unrecognized arch \"{}\" in target specification", a)),
-        }
-
-        if let PassMode::Indirect { ref mut attrs, extra_attrs: _, on_stack: _ } = self.ret.mode {
-            attrs.set(ArgAttribute::StructRet);
         }
 
         Ok(())

--- a/compiler/rustc_target/src/abi/call/riscv.rs
+++ b/compiler/rustc_target/src/abi/call/riscv.rs
@@ -4,7 +4,7 @@
 // Reference: Clang RISC-V ELF psABI lowering code
 // https://github.com/llvm/llvm-project/blob/8e780252a7284be45cf1ba224cabd884847e8e92/clang/lib/CodeGen/TargetInfo.cpp#L9311-L9773
 
-use crate::abi::call::{ArgAbi, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
+use crate::abi::call::{ArgAbi, ArgExtension, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
 use crate::abi::{
     self, Abi, FieldsShape, HasDataLayout, LayoutOf, Size, TyAndLayout, TyAndLayoutMethods,
 };
@@ -308,7 +308,7 @@ fn extend_integer_width<'a, Ty>(arg: &mut ArgAbi<'a, Ty>, xlen: u64) {
             // 32-bit integers are always sign-extended
             if i.size().bits() == 32 && xlen > 32 {
                 if let PassMode::Direct(ref mut attrs) = arg.mode {
-                    attrs.sext();
+                    attrs.ext(ArgExtension::Sext);
                     return;
                 }
             }

--- a/compiler/rustc_target/src/abi/call/riscv.rs
+++ b/compiler/rustc_target/src/abi/call/riscv.rs
@@ -4,7 +4,7 @@
 // Reference: Clang RISC-V ELF psABI lowering code
 // https://github.com/llvm/llvm-project/blob/8e780252a7284be45cf1ba224cabd884847e8e92/clang/lib/CodeGen/TargetInfo.cpp#L9311-L9773
 
-use crate::abi::call::{ArgAbi, ArgAttribute, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
+use crate::abi::call::{ArgAbi, CastTarget, FnAbi, PassMode, Reg, RegKind, Uniform};
 use crate::abi::{
     self, Abi, FieldsShape, HasDataLayout, LayoutOf, Size, TyAndLayout, TyAndLayoutMethods,
 };
@@ -308,7 +308,7 @@ fn extend_integer_width<'a, Ty>(arg: &mut ArgAbi<'a, Ty>, xlen: u64) {
             // 32-bit integers are always sign-extended
             if i.size().bits() == 32 && xlen > 32 {
                 if let PassMode::Direct(ref mut attrs) = arg.mode {
-                    attrs.set(ArgAttribute::SExt);
+                    attrs.sext();
                     return;
                 }
             }

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -92,9 +92,14 @@ where
 
         for arg in &mut fn_abi.args {
             let attrs = match arg.mode {
-                PassMode::Ignore | PassMode::Indirect(_, None) => continue,
+                PassMode::Ignore
+                | PassMode::Indirect { attrs: _, extra_attrs: None, on_stack: _ } => {
+                    continue;
+                }
                 PassMode::Direct(ref mut attrs) => attrs,
-                PassMode::Pair(..) | PassMode::Indirect(_, Some(_)) | PassMode::Cast(_) => {
+                PassMode::Pair(..)
+                | PassMode::Indirect { attrs: _, extra_attrs: Some(_), on_stack: _ }
+                | PassMode::Cast(_) => {
                     unreachable!("x86 shouldn't be passing arguments by {:?}", arg.mode)
                 }
             };

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -62,10 +62,12 @@
 //! T` obtained from [`Box::<T>::into_raw`] may be deallocated using the
 //! [`Global`] allocator with [`Layout::for_value(&*value)`].
 //!
-//! For zero-sized values, the `Box` pointer still has to be [valid] for reads and writes and
-//! sufficiently aligned. In particular, casting any aligned non-zero integer literal to a raw
-//! pointer produces a valid pointer, but a pointer pointing into previously allocated memory that
-//! since got freed is not valid.
+//! For zero-sized values, the `Box` pointer still has to be [valid] for reads
+//! and writes and sufficiently aligned. In particular, casting any aligned
+//! non-zero integer literal to a raw pointer produces a valid pointer, but a
+//! pointer pointing into previously allocated memory that since got freed is
+//! not valid. The recommended way to build a Box to a ZST if `Box::new` cannot
+//! be used is to use [`ptr::NonNull::dangling`].
 //!
 //! So long as `T: Sized`, a `Box<T>` is guaranteed to be represented
 //! as a single pointer and is also ABI-compatible with C pointers

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -62,6 +62,11 @@
 //! T` obtained from [`Box::<T>::into_raw`] may be deallocated using the
 //! [`Global`] allocator with [`Layout::for_value(&*value)`].
 //!
+//! For zero-sized values, the `Box` pointer still has to be [valid] for reads and writes and
+//! sufficiently aligned. In particular, casting any aligned non-zero integer to a raw pointer
+//! produces a valid pointer, but a pointer pointing into previously allocated memory that since got
+//! freed is not valid.
+//!
 //! So long as `T: Sized`, a `Box<T>` is guaranteed to be represented
 //! as a single pointer and is also ABI-compatible with C pointers
 //! (i.e. the C type `T*`). This means that if you have extern "C"
@@ -125,6 +130,7 @@
 //! [`Global`]: crate::alloc::Global
 //! [`Layout`]: crate::alloc::Layout
 //! [`Layout::for_value(&*value)`]: crate::alloc::Layout::for_value
+//! [valid]: ptr#safety
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -385,7 +391,10 @@ impl<T: ?Sized> Box<T> {
     /// memory problems. For example, a double-free may occur if the
     /// function is called twice on the same raw pointer.
     ///
+    /// The safety conditions are described in the [memory layout] section.
+    ///
     /// # Examples
+    ///
     /// Recreate a `Box` which was previously converted to a raw pointer
     /// using [`Box::into_raw`]:
     /// ```

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -63,9 +63,9 @@
 //! [`Global`] allocator with [`Layout::for_value(&*value)`].
 //!
 //! For zero-sized values, the `Box` pointer still has to be [valid] for reads and writes and
-//! sufficiently aligned. In particular, casting any aligned non-zero integer to a raw pointer
-//! produces a valid pointer, but a pointer pointing into previously allocated memory that since got
-//! freed is not valid.
+//! sufficiently aligned. In particular, casting any aligned non-zero integer literal to a raw
+//! pointer produces a valid pointer, but a pointer pointing into previously allocated memory that
+//! since got freed is not valid.
 //!
 //! So long as `T: Sized`, a `Box<T>` is guaranteed to be represented
 //! as a single pointer and is also ABI-compatible with C pointers

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -20,11 +20,12 @@
 //!   be *dereferenceable*: the memory range of the given size starting at the pointer must all be
 //!   within the bounds of a single allocated object. Note that in Rust,
 //!   every (stack-allocated) variable is considered a separate allocated object.
-//! * Even for operations of [size zero][zst], the pointer must not be "dangling" in the sense of
-//!   pointing to deallocated memory. However, casting any non-zero integer literal to a pointer is
-//!   valid for zero-sized accesses. This corresponds to writing your own allocator; allocating
-//!   zero-sized objects is not very hard. In contrast, when you use the standard allocator, after
-//!   memory got deallocated, even zero-sized accesses to that memory are invalid.
+//! * Even for operations of [size zero][zst], the pointer must not be pointing to deallocated
+//!   memory, i.e., deallocation makes pointers invalid even for zero-sized operations. However,
+//!   casting any non-zero integer *literal* to a pointer is valid for zero-sized accesses, even if
+//!   some memory happens to exist at that address and gets deallocated. This corresponds to writing
+//!   your own allocator: allocating zero-sized objects is not very hard. The canonical way to
+//!   obtain a pointer that is valid for zero-sized accesses is [`NonNull::dangling`].
 //! * All accesses performed by functions in this module are *non-atomic* in the sense
 //!   of [atomic operations] used to synchronize between threads. This means it is
 //!   undefined behavior to perform two concurrent accesses to the same location from different

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -16,12 +16,15 @@
 //! provided at this point are very minimal:
 //!
 //! * A [null] pointer is *never* valid, not even for accesses of [size zero][zst].
-//! * All pointers (except for the null pointer) are valid for all operations of
-//!   [size zero][zst].
 //! * For a pointer to be valid, it is necessary, but not always sufficient, that the pointer
 //!   be *dereferenceable*: the memory range of the given size starting at the pointer must all be
 //!   within the bounds of a single allocated object. Note that in Rust,
 //!   every (stack-allocated) variable is considered a separate allocated object.
+//! * Even for operations of [size zero][zst], the pointer must not be "dangling" in the sense of
+//!   pointing to deallocated memory. However, casting any non-zero integer to a pointer is valid
+//!   for zero-sized accesses. This corresponds to writing your own allocator; allocating zero-sized
+//!   objects is not very hard. In contrast, when you use the standard allocator, after memory got
+//!   deallocated, even zero-sized accesses to that memory are invalid.
 //! * All accesses performed by functions in this module are *non-atomic* in the sense
 //!   of [atomic operations] used to synchronize between threads. This means it is
 //!   undefined behavior to perform two concurrent accesses to the same location from different

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -21,10 +21,10 @@
 //!   within the bounds of a single allocated object. Note that in Rust,
 //!   every (stack-allocated) variable is considered a separate allocated object.
 //! * Even for operations of [size zero][zst], the pointer must not be "dangling" in the sense of
-//!   pointing to deallocated memory. However, casting any non-zero integer to a pointer is valid
-//!   for zero-sized accesses. This corresponds to writing your own allocator; allocating zero-sized
-//!   objects is not very hard. In contrast, when you use the standard allocator, after memory got
-//!   deallocated, even zero-sized accesses to that memory are invalid.
+//!   pointing to deallocated memory. However, casting any non-zero integer literal to a pointer is
+//!   valid for zero-sized accesses. This corresponds to writing your own allocator; allocating
+//!   zero-sized objects is not very hard. In contrast, when you use the standard allocator, after
+//!   memory got deallocated, even zero-sized accesses to that memory are invalid.
 //! * All accesses performed by functions in this module are *non-atomic* in the sense
 //!   of [atomic operations] used to synchronize between threads. This means it is
 //!   undefined behavior to perform two concurrent accesses to the same location from different

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1922,13 +1922,17 @@ impl Clean<BareFunctionDecl> for hir::BareFnTy<'_> {
     }
 }
 
-impl Clean<Item> for hir::Item<'_> {
+impl Clean<Item> for (&hir::Item<'_>, Option<Ident>) {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
         use hir::ItemKind;
 
-        let def_id = cx.tcx.hir().local_def_id(self.hir_id).to_def_id();
-        let name = cx.tcx.hir().name(self.hir_id);
-        let kind = match self.kind {
+        let (item, renamed) = self;
+        let def_id = cx.tcx.hir().local_def_id(item.hir_id).to_def_id();
+        let name = match renamed {
+            Some(ident) => ident.name,
+            None => cx.tcx.hir().name(item.hir_id),
+        };
+        let kind = match item.kind {
             ItemKind::Static(ty, mutability, body_id) => StaticItem(Static {
                 type_: ty.clean(cx),
                 mutability,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -231,21 +231,14 @@ impl Clean<Item> for doctree::Module<'_> {
         let mut items: Vec<Item> = vec![];
         items.extend(self.extern_crates.iter().flat_map(|x| x.clean(cx)));
         items.extend(self.imports.iter().flat_map(|x| x.clean(cx)));
-        items.extend(self.structs.iter().map(|x| x.clean(cx)));
-        items.extend(self.unions.iter().map(|x| x.clean(cx)));
-        items.extend(self.enums.iter().map(|x| x.clean(cx)));
         items.extend(self.fns.iter().map(|x| x.clean(cx)));
         items.extend(self.foreigns.iter().map(|x| x.clean(cx)));
         items.extend(self.mods.iter().map(|x| x.clean(cx)));
-        items.extend(self.typedefs.iter().map(|x| x.clean(cx)));
-        items.extend(self.opaque_tys.iter().map(|x| x.clean(cx)));
-        items.extend(self.statics.iter().map(|x| x.clean(cx)));
-        items.extend(self.constants.iter().map(|x| x.clean(cx)));
+        items.extend(self.items.iter().map(|x| x.clean(cx)));
         items.extend(self.traits.iter().map(|x| x.clean(cx)));
         items.extend(self.impls.iter().flat_map(|x| x.clean(cx)));
         items.extend(self.macros.iter().map(|x| x.clean(cx)));
         items.extend(self.proc_macros.iter().map(|x| x.clean(cx)));
-        items.extend(self.trait_aliases.iter().map(|x| x.clean(cx)));
 
         // determine if we should display the inner contents or
         // the outer `mod` item for the source code.
@@ -1020,20 +1013,6 @@ impl Clean<Item> for doctree::Trait<'_> {
     }
 }
 
-impl Clean<Item> for doctree::TraitAlias<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> Item {
-        Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            TraitAliasItem(TraitAlias {
-                generics: self.generics.clean(cx),
-                bounds: self.bounds.clean(cx),
-            }),
-            cx,
-        )
-    }
-}
-
 impl Clean<bool> for hir::IsAuto {
     fn clean(&self, _: &DocContext<'_>) -> bool {
         match *self {
@@ -1777,38 +1756,6 @@ impl Clean<Visibility> for ty::Visibility {
     }
 }
 
-impl Clean<Item> for doctree::Struct<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> Item {
-        Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            StructItem(Struct {
-                struct_type: self.struct_type,
-                generics: self.generics.clean(cx),
-                fields: self.fields.clean(cx),
-                fields_stripped: false,
-            }),
-            cx,
-        )
-    }
-}
-
-impl Clean<Item> for doctree::Union<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> Item {
-        Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            UnionItem(Union {
-                struct_type: self.struct_type,
-                generics: self.generics.clean(cx),
-                fields: self.fields.clean(cx),
-                fields_stripped: false,
-            }),
-            cx,
-        )
-    }
-}
-
 impl Clean<VariantStruct> for rustc_hir::VariantData<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> VariantStruct {
         VariantStruct {
@@ -1816,21 +1763,6 @@ impl Clean<VariantStruct> for rustc_hir::VariantData<'_> {
             fields: self.fields().iter().map(|x| x.clean(cx)).collect(),
             fields_stripped: false,
         }
-    }
-}
-
-impl Clean<Item> for doctree::Enum<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> Item {
-        Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            EnumItem(Enum {
-                variants: self.variants.iter().map(|v| v.clean(cx)).collect(),
-                generics: self.generics.clean(cx),
-                variants_stripped: false,
-            }),
-            cx,
-        )
     }
 }
 
@@ -1981,33 +1913,6 @@ impl Clean<String> for Symbol {
     }
 }
 
-impl Clean<Item> for doctree::Typedef<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> Item {
-        let type_ = self.ty.clean(cx);
-        let item_type = type_.def_id().and_then(|did| inline::build_ty(cx, did));
-        Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            TypedefItem(Typedef { type_, generics: self.gen.clean(cx), item_type }, false),
-            cx,
-        )
-    }
-}
-
-impl Clean<Item> for doctree::OpaqueTy<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> Item {
-        Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            OpaqueTyItem(OpaqueTy {
-                bounds: self.opaque_ty.bounds.clean(cx),
-                generics: self.opaque_ty.generics.clean(cx),
-            }),
-            cx,
-        )
-    }
-}
-
 impl Clean<BareFunctionDecl> for hir::BareFnTy<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> BareFunctionDecl {
         let (generic_params, decl) = enter_impl_trait(cx, || {
@@ -2017,37 +1922,71 @@ impl Clean<BareFunctionDecl> for hir::BareFnTy<'_> {
     }
 }
 
-impl Clean<Item> for doctree::Static<'_> {
+impl Clean<Item> for hir::Item<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
-        debug!("cleaning static {}: {:?}", self.name.clean(cx), self);
-        Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            StaticItem(Static {
-                type_: self.type_.clean(cx),
-                mutability: self.mutability,
-                expr: print_const_expr(cx, self.expr),
+        use hir::ItemKind;
+
+        let def_id = cx.tcx.hir().local_def_id(self.hir_id).to_def_id();
+        let name = cx.tcx.hir().name(self.hir_id);
+        let kind = match self.kind {
+            ItemKind::Static(ty, mutability, body_id) => StaticItem(Static {
+                type_: ty.clean(cx),
+                mutability,
+                expr: print_const_expr(cx, body_id),
             }),
-            cx,
-        )
+            ItemKind::Const(ty, body_id) => ConstantItem(Constant {
+                type_: ty.clean(cx),
+                expr: print_const_expr(cx, body_id),
+                value: print_evaluated_const(cx, def_id),
+                is_literal: is_literal_expr(cx, body_id.hir_id),
+            }),
+            ItemKind::OpaqueTy(ref ty) => OpaqueTyItem(OpaqueTy {
+                bounds: ty.bounds.clean(cx),
+                generics: ty.generics.clean(cx),
+            }),
+            ItemKind::TyAlias(ty, ref generics) => {
+                let rustdoc_ty = ty.clean(cx);
+                let item_type = rustdoc_ty.def_id().and_then(|did| inline::build_ty(cx, did));
+                TypedefItem(
+                    Typedef { type_: rustdoc_ty, generics: generics.clean(cx), item_type },
+                    false,
+                )
+            }
+            ItemKind::Enum(ref def, ref generics) => EnumItem(Enum {
+                variants: def.variants.iter().map(|v| v.clean(cx)).collect(),
+                generics: generics.clean(cx),
+                variants_stripped: false,
+            }),
+            ItemKind::TraitAlias(ref generics, bounds) => TraitAliasItem(TraitAlias {
+                generics: generics.clean(cx),
+                bounds: bounds.clean(cx),
+            }),
+            ItemKind::Union(ref variant_data, ref generics) => UnionItem(Union {
+                struct_type: doctree::struct_type_from_def(&variant_data),
+                generics: generics.clean(cx),
+                fields: variant_data.fields().clean(cx),
+                fields_stripped: false,
+            }),
+            ItemKind::Struct(ref variant_data, ref generics) => StructItem(Struct {
+                struct_type: doctree::struct_type_from_def(&variant_data),
+                generics: generics.clean(cx),
+                fields: variant_data.fields().clean(cx),
+                fields_stripped: false,
+            }),
+            _ => unreachable!("not yet converted"),
+        };
+
+        Item::from_def_id_and_parts(def_id, Some(name), kind, cx)
     }
 }
 
-impl Clean<Item> for doctree::Constant<'_> {
+impl Clean<Item> for hir::Variant<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
-        let def_id = cx.tcx.hir().local_def_id(self.id).to_def_id();
-
-        Item::from_def_id_and_parts(
-            def_id,
-            Some(self.name),
-            ConstantItem(Constant {
-                type_: self.type_.clean(cx),
-                expr: print_const_expr(cx, self.expr),
-                value: print_evaluated_const(cx, def_id),
-                is_literal: is_literal_expr(cx, self.expr.hir_id),
-            }),
-            cx,
-        )
+        let kind = VariantItem(Variant { kind: self.data.clean(cx) });
+        let what_rustc_thinks =
+            Item::from_hir_id_and_parts(self.id, Some(self.ident.name), kind, cx);
+        // don't show `pub` for variants, which are always public
+        Item { visibility: Inherited, ..what_rustc_thinks }
     }
 }
 

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -4,7 +4,7 @@ crate use self::StructType::*;
 
 use rustc_ast as ast;
 use rustc_span::hygiene::MacroKind;
-use rustc_span::{self, Span, Symbol};
+use rustc_span::{self, symbol::Ident, Span, Symbol};
 
 use rustc_hir as hir;
 use rustc_hir::def_id::CrateNum;
@@ -20,7 +20,8 @@ crate struct Module<'hir> {
     crate fns: Vec<Function<'hir>>,
     crate mods: Vec<Module<'hir>>,
     crate id: hir::HirId,
-    crate items: Vec<&'hir hir::Item<'hir>>,
+    // (item, renamed)
+    crate items: Vec<(&'hir hir::Item<'hir>, Option<Ident>)>,
     crate traits: Vec<Trait<'hir>>,
     crate impls: Vec<Impl<'hir>>,
     crate foreigns: Vec<ForeignItem<'hir>>,

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -17,22 +17,15 @@ crate struct Module<'hir> {
     crate where_inner: Span,
     crate extern_crates: Vec<ExternCrate<'hir>>,
     crate imports: Vec<Import<'hir>>,
-    crate structs: Vec<Struct<'hir>>,
-    crate unions: Vec<Union<'hir>>,
-    crate enums: Vec<Enum<'hir>>,
     crate fns: Vec<Function<'hir>>,
     crate mods: Vec<Module<'hir>>,
     crate id: hir::HirId,
-    crate typedefs: Vec<Typedef<'hir>>,
-    crate opaque_tys: Vec<OpaqueTy<'hir>>,
-    crate statics: Vec<Static<'hir>>,
-    crate constants: Vec<Constant<'hir>>,
+    crate items: Vec<&'hir hir::Item<'hir>>,
     crate traits: Vec<Trait<'hir>>,
     crate impls: Vec<Impl<'hir>>,
     crate foreigns: Vec<ForeignItem<'hir>>,
     crate macros: Vec<Macro>,
     crate proc_macros: Vec<ProcMacro>,
-    crate trait_aliases: Vec<TraitAlias<'hir>>,
     crate is_crate: bool,
 }
 
@@ -46,21 +39,14 @@ impl Module<'hir> {
             attrs,
             extern_crates: Vec::new(),
             imports: Vec::new(),
-            structs: Vec::new(),
-            unions: Vec::new(),
-            enums: Vec::new(),
             fns: Vec::new(),
             mods: Vec::new(),
-            typedefs: Vec::new(),
-            opaque_tys: Vec::new(),
-            statics: Vec::new(),
-            constants: Vec::new(),
+            items: Vec::new(),
             traits: Vec::new(),
             impls: Vec::new(),
             foreigns: Vec::new(),
             macros: Vec::new(),
             proc_macros: Vec::new(),
-            trait_aliases: Vec::new(),
             is_crate: false,
         }
     }
@@ -74,29 +60,6 @@ crate enum StructType {
     Tuple,
     /// A unit struct
     Unit,
-}
-
-crate struct Struct<'hir> {
-    crate id: hir::HirId,
-    crate struct_type: StructType,
-    crate name: Symbol,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate fields: &'hir [hir::StructField<'hir>],
-}
-
-crate struct Union<'hir> {
-    crate id: hir::HirId,
-    crate struct_type: StructType,
-    crate name: Symbol,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate fields: &'hir [hir::StructField<'hir>],
-}
-
-crate struct Enum<'hir> {
-    crate variants: Vec<Variant<'hir>>,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate id: hir::HirId,
-    crate name: Symbol,
 }
 
 crate struct Variant<'hir> {
@@ -114,38 +77,6 @@ crate struct Function<'hir> {
     crate body: hir::BodyId,
 }
 
-crate struct Typedef<'hir> {
-    crate ty: &'hir hir::Ty<'hir>,
-    crate gen: &'hir hir::Generics<'hir>,
-    crate name: Symbol,
-    crate id: hir::HirId,
-}
-
-crate struct OpaqueTy<'hir> {
-    crate opaque_ty: &'hir hir::OpaqueTy<'hir>,
-    crate name: Symbol,
-    crate id: hir::HirId,
-}
-
-#[derive(Debug)]
-crate struct Static<'hir> {
-    crate type_: &'hir hir::Ty<'hir>,
-    crate mutability: hir::Mutability,
-    crate expr: hir::BodyId,
-    crate name: Symbol,
-    crate attrs: &'hir [ast::Attribute],
-    crate vis: &'hir hir::Visibility<'hir>,
-    crate id: hir::HirId,
-    crate span: Span,
-}
-
-crate struct Constant<'hir> {
-    crate type_: &'hir hir::Ty<'hir>,
-    crate expr: hir::BodyId,
-    crate name: Symbol,
-    crate id: hir::HirId,
-}
-
 crate struct Trait<'hir> {
     crate is_auto: hir::IsAuto,
     crate unsafety: hir::Unsafety,
@@ -154,13 +85,6 @@ crate struct Trait<'hir> {
     crate generics: &'hir hir::Generics<'hir>,
     crate bounds: &'hir [hir::GenericBound<'hir>],
     crate attrs: &'hir [ast::Attribute],
-    crate id: hir::HirId,
-}
-
-crate struct TraitAlias<'hir> {
-    crate name: Symbol,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate bounds: &'hir [hir::GenericBound<'hir>],
     crate id: hir::HirId,
 }
 

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -492,7 +492,14 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
             Res::PrimTy(prim) => Some(
                 self.resolve_primitive_associated_item(prim, ns, module_id, item_name, item_str),
             ),
-            Res::Def(DefKind::Struct | DefKind::Union | DefKind::Enum | DefKind::TyAlias, did) => {
+            Res::Def(
+                DefKind::Struct
+                | DefKind::Union
+                | DefKind::Enum
+                | DefKind::TyAlias
+                | DefKind::ForeignTy,
+                did,
+            ) => {
                 debug!("looking for associated item named {} for item {:?}", item_name, did);
                 // Checks if item_name belongs to `impl SomeItem`
                 let assoc_item = cx

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -82,50 +82,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         module
     }
 
-    fn visit_variant_data(
-        &mut self,
-        item: &'tcx hir::Item<'_>,
-        name: Symbol,
-        sd: &'tcx hir::VariantData<'_>,
-        generics: &'tcx hir::Generics<'_>,
-    ) -> Struct<'tcx> {
-        debug!("visiting struct");
-        let struct_type = struct_type_from_def(&*sd);
-        Struct { id: item.hir_id, struct_type, name, generics, fields: sd.fields() }
-    }
-
-    fn visit_union_data(
-        &mut self,
-        item: &'tcx hir::Item<'_>,
-        name: Symbol,
-        sd: &'tcx hir::VariantData<'_>,
-        generics: &'tcx hir::Generics<'_>,
-    ) -> Union<'tcx> {
-        debug!("visiting union");
-        let struct_type = struct_type_from_def(&*sd);
-        Union { id: item.hir_id, struct_type, name, generics, fields: sd.fields() }
-    }
-
-    fn visit_enum_def(
-        &mut self,
-        it: &'tcx hir::Item<'_>,
-        name: Symbol,
-        def: &'tcx hir::EnumDef<'_>,
-        generics: &'tcx hir::Generics<'_>,
-    ) -> Enum<'tcx> {
-        debug!("visiting enum");
-        Enum {
-            name,
-            variants: def
-                .variants
-                .iter()
-                .map(|v| Variant { name: v.ident.name, id: v.id, def: &v.data })
-                .collect(),
-            generics,
-            id: it.hir_id,
-        }
-    }
-
     fn visit_fn(
         &mut self,
         om: &mut Module<'tcx>,
@@ -414,45 +370,21 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     Some(ident.name),
                 ));
             }
-            hir::ItemKind::Enum(ref ed, ref gen) => {
-                om.enums.push(self.visit_enum_def(item, ident.name, ed, gen))
-            }
-            hir::ItemKind::Struct(ref sd, ref gen) => {
-                om.structs.push(self.visit_variant_data(item, ident.name, sd, gen))
-            }
-            hir::ItemKind::Union(ref sd, ref gen) => {
-                om.unions.push(self.visit_union_data(item, ident.name, sd, gen))
-            }
+            hir::ItemKind::Enum(..) => om.items.push(item),
+            hir::ItemKind::Struct(..) => om.items.push(item),
+            hir::ItemKind::Union(..) => om.items.push(item),
             hir::ItemKind::Fn(ref sig, ref gen, body) => {
                 self.visit_fn(om, item, ident.name, &sig.decl, sig.header, gen, body)
             }
-            hir::ItemKind::TyAlias(ty, ref gen) => {
-                let t = Typedef { ty, gen, name: ident.name, id: item.hir_id };
-                om.typedefs.push(t);
-            }
-            hir::ItemKind::OpaqueTy(ref opaque_ty) => {
-                let t = OpaqueTy { opaque_ty, name: ident.name, id: item.hir_id };
-                om.opaque_tys.push(t);
-            }
-            hir::ItemKind::Static(type_, mutability, expr) => {
-                let s = Static {
-                    type_,
-                    mutability,
-                    expr,
-                    id: item.hir_id,
-                    name: ident.name,
-                    attrs: &item.attrs,
-                    span: item.span,
-                    vis: &item.vis,
-                };
-                om.statics.push(s);
-            }
-            hir::ItemKind::Const(type_, expr) => {
+            hir::ItemKind::TyAlias(..)
+            | hir::ItemKind::OpaqueTy(..)
+            | hir::ItemKind::Static(..)
+            | hir::ItemKind::TraitAlias(..) => om.items.push(item),
+            hir::ItemKind::Const(..) => {
                 // Underscore constants do not correspond to a nameable item and
                 // so are never useful in documentation.
                 if ident.name != kw::Underscore {
-                    let s = Constant { type_, expr, id: item.hir_id, name: ident.name };
-                    om.constants.push(s);
+                    om.items.push(item);
                 }
             }
             hir::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, ref item_ids) => {
@@ -469,11 +401,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 };
                 om.traits.push(t);
             }
-            hir::ItemKind::TraitAlias(ref generics, ref bounds) => {
-                let t = TraitAlias { name: ident.name, generics, bounds, id: item.hir_id };
-                om.trait_aliases.push(t);
-            }
-
             hir::ItemKind::Impl {
                 unsafety,
                 polarity,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -370,21 +370,21 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     Some(ident.name),
                 ));
             }
-            hir::ItemKind::Enum(..) => om.items.push(item),
-            hir::ItemKind::Struct(..) => om.items.push(item),
-            hir::ItemKind::Union(..) => om.items.push(item),
             hir::ItemKind::Fn(ref sig, ref gen, body) => {
                 self.visit_fn(om, item, ident.name, &sig.decl, sig.header, gen, body)
             }
-            hir::ItemKind::TyAlias(..)
+            hir::ItemKind::Enum(..)
+            | hir::ItemKind::Struct(..)
+            | hir::ItemKind::Union(..)
+            | hir::ItemKind::TyAlias(..)
             | hir::ItemKind::OpaqueTy(..)
             | hir::ItemKind::Static(..)
-            | hir::ItemKind::TraitAlias(..) => om.items.push(item),
+            | hir::ItemKind::TraitAlias(..) => om.items.push((item, renamed)),
             hir::ItemKind::Const(..) => {
                 // Underscore constants do not correspond to a nameable item and
                 // so are never useful in documentation.
                 if ident.name != kw::Underscore {
-                    om.items.push(item);
+                    om.items.push((item, renamed));
                 }
             }
             hir::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, ref item_ids) => {

--- a/src/test/rustdoc-ui/doc-without-codeblock.stderr
+++ b/src/test/rustdoc-ui/doc-without-codeblock.stderr
@@ -17,12 +17,6 @@ LL | #![deny(missing_doc_code_examples)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing code example in this documentation
-  --> $DIR/doc-without-codeblock.rs:3:1
-   |
-LL | /// Some docs.
-   | ^^^^^^^^^^^^^^
-
-error: missing code example in this documentation
   --> $DIR/doc-without-codeblock.rs:7:1
    |
 LL | /// And then, the princess died.
@@ -33,6 +27,12 @@ error: missing code example in this documentation
    |
 LL |     /// Or maybe not because she saved herself!
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: missing code example in this documentation
+  --> $DIR/doc-without-codeblock.rs:3:1
+   |
+LL | /// Some docs.
+   | ^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -1,14 +1,29 @@
-error: `ambiguous` is both a struct and a function
-  --> $DIR/intra-links-ambiguity.rs:27:6
+error: `true` is both a module and a builtin type
+  --> $DIR/intra-links-ambiguity.rs:38:6
    |
-LL | /// [`ambiguous`] is ambiguous.
-   |      ^^^^^^^^^^^ ambiguous link
+LL | /// [true]
+   |      ^^^^ ambiguous link
    |
 note: the lint level is defined here
   --> $DIR/intra-links-ambiguity.rs:1:9
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+help: to link to the module, prefix with `mod@`
+   |
+LL | /// [mod@true]
+   |      ^^^^^^^^
+help: to link to the builtin type, prefix with `prim@`
+   |
+LL | /// [prim@true]
+   |      ^^^^^^^^^
+
+error: `ambiguous` is both a struct and a function
+  --> $DIR/intra-links-ambiguity.rs:27:6
+   |
+LL | /// [`ambiguous`] is ambiguous.
+   |      ^^^^^^^^^^^ ambiguous link
+   |
 help: to link to the struct, prefix with `struct@`
    |
 LL | /// [`struct@ambiguous`] is ambiguous.
@@ -81,21 +96,6 @@ help: to link to the function, add parentheses
    |
 LL | /// Ambiguous non-implied shortcut link [`foo::bar()`].
    |                                          ^^^^^^^^^^^^
-
-error: `true` is both a module and a builtin type
-  --> $DIR/intra-links-ambiguity.rs:38:6
-   |
-LL | /// [true]
-   |      ^^^^ ambiguous link
-   |
-help: to link to the module, prefix with `mod@`
-   |
-LL | /// [mod@true]
-   |      ^^^^^^^^
-help: to link to the builtin type, prefix with `prim@`
-   |
-LL | /// [prim@true]
-   |      ^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -36,6 +36,60 @@ warning: unresolved link to `Qux::Z`
 LL |       //! , [Uniooon::X] and [Qux::Z].
    |                               ^^^^^^ no item named `Qux` in scope
 
+warning: unresolved link to `BarA`
+  --> $DIR/intra-links-warning.rs:21:10
+   |
+LL | /// bar [BarA] bar
+   |          ^^^^ no item named `BarA` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+warning: unresolved link to `BarB`
+  --> $DIR/intra-links-warning.rs:27:9
+   |
+LL |  * bar [BarB] bar
+   |         ^^^^ no item named `BarB` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+warning: unresolved link to `BarC`
+  --> $DIR/intra-links-warning.rs:34:6
+   |
+LL | bar [BarC] bar
+   |      ^^^^ no item named `BarC` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+warning: unresolved link to `BarD`
+  --> $DIR/intra-links-warning.rs:45:1
+   |
+LL | #[doc = "Foo\nbar [BarD] bar\nbaz"]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the link appears in this line:
+           
+           bar [BarD] bar
+                ^^^^
+   = note: no item named `BarD` in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+warning: unresolved link to `BarF`
+  --> $DIR/intra-links-warning.rs:50:9
+   |
+LL |         #[doc = $f]
+   |         ^^^^^^^^^^^
+...
+LL | f!("Foo\nbar [BarF] bar\nbaz");
+   | ------------------------------- in this macro invocation
+   |
+   = note: the link appears in this line:
+           
+           bar [BarF] bar
+                ^^^^
+   = note: no item named `BarF` in scope
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
 warning: unresolved link to `Qux:Y`
   --> $DIR/intra-links-warning.rs:14:13
    |
@@ -116,60 +170,6 @@ LL | /// docs [error2]
    |           ^^^^^^ no item named `error2` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-warning: unresolved link to `BarA`
-  --> $DIR/intra-links-warning.rs:21:10
-   |
-LL | /// bar [BarA] bar
-   |          ^^^^ no item named `BarA` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-warning: unresolved link to `BarB`
-  --> $DIR/intra-links-warning.rs:27:9
-   |
-LL |  * bar [BarB] bar
-   |         ^^^^ no item named `BarB` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-warning: unresolved link to `BarC`
-  --> $DIR/intra-links-warning.rs:34:6
-   |
-LL | bar [BarC] bar
-   |      ^^^^ no item named `BarC` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-warning: unresolved link to `BarD`
-  --> $DIR/intra-links-warning.rs:45:1
-   |
-LL | #[doc = "Foo\nbar [BarD] bar\nbaz"]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the link appears in this line:
-           
-           bar [BarD] bar
-                ^^^^
-   = note: no item named `BarD` in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-warning: unresolved link to `BarF`
-  --> $DIR/intra-links-warning.rs:50:9
-   |
-LL |         #[doc = $f]
-   |         ^^^^^^^^^^^
-...
-LL | f!("Foo\nbar [BarF] bar\nbaz");
-   | ------------------------------- in this macro invocation
-   |
-   = note: the link appears in this line:
-           
-           bar [BarF] bar
-                ^^^^
-   = note: no item named `BarF` in scope
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 19 warnings emitted
 

--- a/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
+++ b/src/test/rustdoc-ui/lint-missing-doc-code-example.stderr
@@ -1,8 +1,9 @@
 error: missing code example in this documentation
-  --> $DIR/lint-missing-doc-code-example.rs:49:1
+  --> $DIR/lint-missing-doc-code-example.rs:19:1
    |
-LL | /// Doc
-   | ^^^^^^^
+LL | / mod module1 {
+LL | | }
+   | |_^
    |
 note: the lint level is defined here
   --> $DIR/lint-missing-doc-code-example.rs:2:9
@@ -11,7 +12,13 @@ LL | #![deny(missing_doc_code_examples)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: missing code example in this documentation
-  --> $DIR/lint-missing-doc-code-example.rs:63:1
+  --> $DIR/lint-missing-doc-code-example.rs:37:3
+   |
+LL |   /// doc
+   |   ^^^^^^^
+
+error: missing code example in this documentation
+  --> $DIR/lint-missing-doc-code-example.rs:49:1
    |
 LL | /// Doc
    | ^^^^^^^
@@ -23,17 +30,10 @@ LL | /// Doc
    | ^^^^^^^
 
 error: missing code example in this documentation
-  --> $DIR/lint-missing-doc-code-example.rs:19:1
+  --> $DIR/lint-missing-doc-code-example.rs:63:1
    |
-LL | / mod module1 {
-LL | | }
-   | |_^
-
-error: missing code example in this documentation
-  --> $DIR/lint-missing-doc-code-example.rs:37:3
-   |
-LL |   /// doc
-   |   ^^^^^^^
+LL | /// Doc
+   | ^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/rustdoc/intra-link-extern-type.rs
+++ b/src/test/rustdoc/intra-link-extern-type.rs
@@ -1,0 +1,18 @@
+#![feature(extern_types)]
+
+extern {
+    pub type ExternType;
+}
+
+impl ExternType {
+    pub fn f(&self) {
+
+    }
+}
+
+// @has 'intra_link_extern_type/foreigntype.ExternType.html'
+// @has 'intra_link_extern_type/fn.links_to_extern_type.html' \
+// 'href="../intra_link_extern_type/foreigntype.ExternType.html#method.f"'
+/// See also [ExternType::f]
+pub fn links_to_extern_type() {
+}

--- a/src/test/rustdoc/redirect-rename.rs
+++ b/src/test/rustdoc/redirect-rename.rs
@@ -4,6 +4,10 @@ mod hidden {
     // @has foo/hidden/struct.Foo.html
     // @has - '//p/a' '../../foo/struct.FooBar.html'
     pub struct Foo {}
+    pub union U { a: usize }
+    pub enum Empty {}
+    pub const C: usize = 1;
+    pub static S: usize = 1;
 
     // @has foo/hidden/bar/index.html
     // @has - '//p/a' '../../foo/baz/index.html'
@@ -16,6 +20,14 @@ mod hidden {
 
 // @has foo/struct.FooBar.html
 pub use hidden::Foo as FooBar;
+// @has foo/union.FooU.html
+pub use hidden::U as FooU;
+// @has foo/enum.FooEmpty.html
+pub use hidden::Empty as FooEmpty;
+// @has foo/constant.FooC.html
+pub use hidden::C as FooC;
+// @has foo/static.FooS.html
+pub use hidden::S as FooS;
 
 // @has foo/baz/index.html
 // @has foo/baz/struct.Thing.html

--- a/src/test/ui/consts/issue-79137-monomorphic.rs
+++ b/src/test/ui/consts/issue-79137-monomorphic.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+// Verify that variant count intrinsic can still evaluate for types like `Option<T>`.
+
+#![feature(variant_count)]
+
+pub struct GetVariantCount<T>(T);
+
+impl<T> GetVariantCount<T> {
+    pub const VALUE: usize = std::mem::variant_count::<T>();
+}
+
+const fn check_variant_count<T>() -> bool {
+    matches!(GetVariantCount::<Option<T>>::VALUE, GetVariantCount::<Option<()>>::VALUE)
+}
+
+fn main() {
+    assert!(check_variant_count::<()>());
+}

--- a/src/test/ui/consts/issue-79137-toogeneric.rs
+++ b/src/test/ui/consts/issue-79137-toogeneric.rs
@@ -1,0 +1,21 @@
+// The instrinsic call for variant count should exhaustively match on `tp_ty` and forbid
+// `ty::Projection`, `ty::Opaque`, `ty::Param`, `ty::Bound`, `ty::Placeholder` and `ty::Infer`
+// variant. This test checks that it will fail if it's too generic.
+
+#![feature(variant_count)]
+
+pub struct GetVariantCount<T>(T);
+
+impl<T> GetVariantCount<T> {
+    pub const VALUE: usize = std::mem::variant_count::<T>();
+}
+
+const fn check_variant_count<T>() -> bool {
+    matches!(GetVariantCount::<T>::VALUE, GetVariantCount::<T>::VALUE)
+    //~^ ERROR constant pattern depends on a generic parameter
+    //~| ERROR constant pattern depends on a generic parameter
+}
+
+fn main() {
+    assert!(check_variant_count::<Option<()>>());
+}

--- a/src/test/ui/consts/issue-79137-toogeneric.rs
+++ b/src/test/ui/consts/issue-79137-toogeneric.rs
@@ -1,6 +1,4 @@
-// The instrinsic call for variant count should exhaustively match on `tp_ty` and forbid
-// `ty::Projection`, `ty::Opaque`, `ty::Param`, `ty::Bound`, `ty::Placeholder` and `ty::Infer`
-// variant. This test checks that it will fail if it's too generic.
+// Test that `variant_count` only gets evaluated once the type is concrete enough.
 
 #![feature(variant_count)]
 

--- a/src/test/ui/consts/issue-79137-toogeneric.stderr
+++ b/src/test/ui/consts/issue-79137-toogeneric.stderr
@@ -1,11 +1,11 @@
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-79137-toogeneric.rs:14:43
+  --> $DIR/issue-79137-toogeneric.rs:12:43
    |
 LL |     matches!(GetVariantCount::<T>::VALUE, GetVariantCount::<T>::VALUE)
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/issue-79137-toogeneric.rs:14:43
+  --> $DIR/issue-79137-toogeneric.rs:12:43
    |
 LL |     matches!(GetVariantCount::<T>::VALUE, GetVariantCount::<T>::VALUE)
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/issue-79137-toogeneric.stderr
+++ b/src/test/ui/consts/issue-79137-toogeneric.stderr
@@ -1,0 +1,14 @@
+error: constant pattern depends on a generic parameter
+  --> $DIR/issue-79137-toogeneric.rs:14:43
+   |
+LL |     matches!(GetVariantCount::<T>::VALUE, GetVariantCount::<T>::VALUE)
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: constant pattern depends on a generic parameter
+  --> $DIR/issue-79137-toogeneric.rs:14:43
+   |
+LL |     matches!(GetVariantCount::<T>::VALUE, GetVariantCount::<T>::VALUE)
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/mir/mir-inlining/array-clone-with-generic-size.rs
+++ b/src/test/ui/mir/mir-inlining/array-clone-with-generic-size.rs
@@ -1,0 +1,13 @@
+// Checks that we can build a clone shim for array with generic size.
+// Regression test for issue #79269.
+//
+// build-pass
+// compile-flags: -Zmir-opt-level=2 -Zvalidate-mir
+#![feature(min_const_generics)]
+
+#[derive(Clone)]
+struct Array<T, const N: usize>([T; N]);
+
+fn main() {
+    let _ = Array([0u32, 1u32, 2u32]).clone();
+}


### PR DESCRIPTION
Successful merges:

 - #77844 (clarify rules for ZST Boxes)
 - #79067 (Refactor the abi handling code a bit)
 - #79182 (Fix links to extern types in rustdoc (fixes #78777))
 - #79231 (Exhaustively match in variant count instrinsic)
 - #79238 (Direct RUSTC_LOG (tracing/log) output to stderr instead of stdout.)
 - #79256 (Fix typos)
 - #79264 (Get rid of some doctree items)
 - #79272 (Support building clone shims for arrays with generic size)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=77844,79067,79182,79231,79238,79256,79264,79272)
<!-- homu-ignore:end -->