### PR TITLE
rustbuild: don't require network for vendoring libtest

### DIFF
--- a/library/test/Cargo.toml
+++ b/library/test/Cargo.toml
@@ -35,3 +35,10 @@ panic_immediate_abort = ["std/panic_immediate_abort"]
 profiler = ["std/profiler"]
 std_detect_file_io = ["std/std_detect_file_io"]
 std_detect_dlsym_getauxval = ["std/std_detect_dlsym_getauxval"]
+
+# We duplicate these from the toplevel to be able to properly use cargo vendor
+[patch.crates-io]
+rustc-std-workspace-core = { path = '../rustc-std-workspace-core' }
+rustc-std-workspace-alloc = { path = '../rustc-std-workspace-alloc' }
+rustc-std-workspace-std = { path = '../rustc-std-workspace-std' }
+backtrace = { path = "../backtrace" }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1057,7 +1057,7 @@ impl Step for Src {
         builder.really_copy(&root_lock, &temp_lock);
 
         let mut cmd = Command::new(&builder.initial_cargo);
-        cmd.arg("vendor").arg(dst_vendor).current_dir(&dst_libtest);
+        cmd.args(&["vendor", "--offline"]).arg(dst_vendor).current_dir(&dst_libtest);
         builder.info("Dist src");
         let _time = timeit(builder);
         builder.run(&mut cmd);


### PR DESCRIPTION
Sadly, we need to copy the [patch] section from the toplevel Cargo.toml
for the --offline mode to properly work

Fixes #79218

Pros: it seems to work!
Cons: There's now this warning during the build: `warning: patch for the non root package will be ignored, specify patch at the workspace root:`