### PR TITLE
Stabilize Arc::{increment,decrement}_strong_count

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -870,15 +870,13 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_mutate_strong_count)]
-    ///
     /// use std::sync::Arc;
     ///
     /// let five = Arc::new(5);
     ///
     /// unsafe {
     ///     let ptr = Arc::into_raw(five);
-    ///     Arc::incr_strong_count(ptr);
+    ///     Arc::increment_strong_count(ptr);
     ///
     ///     // This assertion is deterministic because we haven't shared
     ///     // the `Arc` between threads.
@@ -887,8 +885,8 @@ impl<T: ?Sized> Arc<T> {
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "arc_mutate_strong_count", issue = "71983")]
-    pub unsafe fn incr_strong_count(ptr: *const T) {
+    #[stable(feature = "arc_mutate_strong_count", since = "1.50.0")]
+    pub unsafe fn increment_strong_count(ptr: *const T) {
         // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
         let arc = unsafe { mem::ManuallyDrop::new(Arc::<T>::from_raw(ptr)) };
         // Now increase refcount, but don't drop new refcount either
@@ -909,27 +907,25 @@ impl<T: ?Sized> Arc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(arc_mutate_strong_count)]
-    ///
     /// use std::sync::Arc;
     ///
     /// let five = Arc::new(5);
     ///
     /// unsafe {
     ///     let ptr = Arc::into_raw(five);
-    ///     Arc::incr_strong_count(ptr);
+    ///     Arc::increment_strong_count(ptr);
     ///
     ///     // Those assertions are deterministic because we haven't shared
     ///     // the `Arc` between threads.
     ///     let five = Arc::from_raw(ptr);
     ///     assert_eq!(2, Arc::strong_count(&five));
-    ///     Arc::decr_strong_count(ptr);
+    ///     Arc::decrement_strong_count(ptr);
     ///     assert_eq!(1, Arc::strong_count(&five));
     /// }
     /// ```
     #[inline]
-    #[unstable(feature = "arc_mutate_strong_count", issue = "71983")]
-    pub unsafe fn decr_strong_count(ptr: *const T) {
+    #[stable(feature = "arc_mutate_strong_count", since = "1.50.0")]
+    pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { mem::drop(Arc::from_raw(ptr)) };
     }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -885,7 +885,7 @@ impl<T: ?Sized> Arc<T> {
     /// }
     /// ```
     #[inline]
-    #[stable(feature = "arc_mutate_strong_count", since = "1.50.0")]
+    #[stable(feature = "arc_mutate_strong_count", since = "1.51.0")]
     pub unsafe fn increment_strong_count(ptr: *const T) {
         // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
         let arc = unsafe { mem::ManuallyDrop::new(Arc::<T>::from_raw(ptr)) };
@@ -924,7 +924,7 @@ impl<T: ?Sized> Arc<T> {
     /// }
     /// ```
     #[inline]
-    #[stable(feature = "arc_mutate_strong_count", since = "1.50.0")]
+    #[stable(feature = "arc_mutate_strong_count", since = "1.51.0")]
     pub unsafe fn decrement_strong_count(ptr: *const T) {
         unsafe { mem::drop(Arc::from_raw(ptr)) };
     }

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -60,7 +60,7 @@ impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for RawWaker {
 fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
     // Increment the reference count of the arc to clone it.
     unsafe fn clone_waker<W: Wake + Send + Sync + 'static>(waker: *const ()) -> RawWaker {
-        unsafe { Arc::incr_strong_count(waker as *const W) };
+        unsafe { Arc::increment_strong_count(waker as *const W) };
         RawWaker::new(
             waker as *const (),
             &RawWakerVTable::new(clone_waker::<W>, wake::<W>, wake_by_ref::<W>, drop_waker::<W>),
@@ -81,7 +81,7 @@ fn raw_waker<W: Wake + Send + Sync + 'static>(waker: Arc<W>) -> RawWaker {
 
     // Decrement the reference count of the Arc on drop
     unsafe fn drop_waker<W: Wake + Send + Sync + 'static>(waker: *const ()) {
-        unsafe { Arc::decr_strong_count(waker as *const W) };
+        unsafe { Arc::decrement_strong_count(waker as *const W) };
     }
 
     RawWaker::new(


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/71983

Stabilizes `Arc::{incr,decr}_strong_count`, enabling unsafely incrementing an decrementing the Arc strong count directly with fewer gotchas. This API was first introduced on nightly six months ago, and has not seen any changes since. The initial PR showed two existing pieces of code that would benefit from this API, and included a change inside the stdlib to use this.

Given the small surface area, predictable use, and no changes since introduction, I'd like to propose we stabilize this.

closes https://github.com/rust-lang/rust/issues/71983
r? @Mark-Simulacrum 

## Links
 * [Initial implementation](https://github.com/rust-lang/rust/pull/70733)
 * [Motivation from #68700](https://github.com/rust-lang/rust/pull/68700#discussion_r396169064)
 * [Real world example in an executor](https://docs.rs/extreme/666.666.666666/src/extreme/lib.rs.html#13)