### PR TITLE
Rename `AllocRef` to `Allocator` and `(de)alloc` to `(de)allocate`

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -38,7 +38,7 @@ extern "Rust" {
 
 /// The global memory allocator.
 ///
-/// This type implements the [`AllocRef`] trait by forwarding calls
+/// This type implements the [`Allocator`] trait by forwarding calls
 /// to the allocator registered with the `#[global_allocator]` attribute
 /// if there is one, or the `std` crate’s default.
 ///
@@ -59,7 +59,7 @@ pub use std::alloc::Global;
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `alloc` method
-/// of the [`Global`] type when it and the [`AllocRef`] trait become stable.
+/// of the [`Global`] type when it and the [`Allocator`] trait become stable.
 ///
 /// # Safety
 ///
@@ -93,7 +93,7 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `dealloc` method
-/// of the [`Global`] type when it and the [`AllocRef`] trait become stable.
+/// of the [`Global`] type when it and the [`Allocator`] trait become stable.
 ///
 /// # Safety
 ///
@@ -111,7 +111,7 @@ pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `realloc` method
-/// of the [`Global`] type when it and the [`AllocRef`] trait become stable.
+/// of the [`Global`] type when it and the [`Allocator`] trait become stable.
 ///
 /// # Safety
 ///
@@ -129,7 +129,7 @@ pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `alloc_zeroed` method
-/// of the [`Global`] type when it and the [`AllocRef`] trait become stable.
+/// of the [`Global`] type when it and the [`Allocator`] trait become stable.
 ///
 /// # Safety
 ///
@@ -170,7 +170,7 @@ impl Global {
         }
     }
 
-    // SAFETY: Same as `AllocRef::grow`
+    // SAFETY: Same as `Allocator::grow`
     #[inline]
     unsafe fn grow_impl(
         &self,
@@ -211,7 +211,7 @@ impl Global {
             old_size => unsafe {
                 let new_ptr = self.alloc_impl(new_layout, zeroed)?;
                 ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), old_size);
-                self.dealloc(ptr, old_layout);
+                self.deallocate(ptr, old_layout);
                 Ok(new_ptr)
             },
         }
@@ -220,19 +220,19 @@ impl Global {
 
 #[unstable(feature = "allocator_api", issue = "32838")]
 #[cfg(not(test))]
-unsafe impl AllocRef for Global {
+unsafe impl Allocator for Global {
     #[inline]
-    fn alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.alloc_impl(layout, false)
     }
 
     #[inline]
-    fn alloc_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.alloc_impl(layout, true)
     }
 
     #[inline]
-    unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) {
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         if layout.size() != 0 {
             // SAFETY: `layout` is non-zero in size,
             // other conditions must be upheld by the caller
@@ -277,7 +277,7 @@ unsafe impl AllocRef for Global {
         match new_layout.size() {
             // SAFETY: conditions must be upheld by the caller
             0 => unsafe {
-                self.dealloc(ptr, old_layout);
+                self.deallocate(ptr, old_layout);
                 Ok(NonNull::slice_from_raw_parts(new_layout.dangling(), 0))
             },
 
@@ -297,9 +297,9 @@ unsafe impl AllocRef for Global {
             // `new_ptr`. Thus, the call to `copy_nonoverlapping` is safe. The safety contract
             // for `dealloc` must be upheld by the caller.
             new_size => unsafe {
-                let new_ptr = self.alloc(new_layout)?;
+                let new_ptr = self.allocate(new_layout)?;
                 ptr::copy_nonoverlapping(ptr.as_ptr(), new_ptr.as_mut_ptr(), new_size);
-                self.dealloc(ptr, old_layout);
+                self.deallocate(ptr, old_layout);
                 Ok(new_ptr)
             },
         }
@@ -313,7 +313,7 @@ unsafe impl AllocRef for Global {
 #[inline]
 unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
     let layout = unsafe { Layout::from_size_align_unchecked(size, align) };
-    match Global.alloc(layout) {
+    match Global.allocate(layout) {
         Ok(ptr) => ptr.as_mut_ptr(),
         Err(_) => handle_alloc_error(layout),
     }
@@ -322,16 +322,16 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
 #[cfg_attr(not(test), lang = "box_free")]
 #[inline]
 // This signature has to be the same as `Box`, otherwise an ICE will happen.
-// When an additional parameter to `Box` is added (like `A: AllocRef`), this has to be added here as
+// When an additional parameter to `Box` is added (like `A: Allocator`), this has to be added here as
 // well.
-// For example if `Box` is changed to  `struct Box<T: ?Sized, A: AllocRef>(Unique<T>, A)`,
-// this function has to be changed to `fn box_free<T: ?Sized, A: AllocRef>(Unique<T>, A)` as well.
-pub(crate) unsafe fn box_free<T: ?Sized, A: AllocRef>(ptr: Unique<T>, alloc: A) {
+// For example if `Box` is changed to  `struct Box<T: ?Sized, A: Allocator>(Unique<T>, A)`,
+// this function has to be changed to `fn box_free<T: ?Sized, A: Allocator>(Unique<T>, A)` as well.
+pub(crate) unsafe fn box_free<T: ?Sized, A: Allocator>(ptr: Unique<T>, alloc: A) {
     unsafe {
         let size = size_of_val(ptr.as_ref());
         let align = min_align_of_val(ptr.as_ref());
         let layout = Layout::from_size_align_unchecked(size, align);
-        alloc.dealloc(ptr.cast().into(), layout)
+        alloc.deallocate(ptr.cast().into(), layout)
     }
 }
 

--- a/library/alloc/src/alloc/tests.rs
+++ b/library/alloc/src/alloc/tests.rs
@@ -9,7 +9,7 @@ fn allocate_zeroed() {
     unsafe {
         let layout = Layout::from_size_align(1024, 1).unwrap();
         let ptr =
-            Global.alloc_zeroed(layout.clone()).unwrap_or_else(|_| handle_alloc_error(layout));
+            Global.allocate_zeroed(layout.clone()).unwrap_or_else(|_| handle_alloc_error(layout));
 
         let mut i = ptr.as_non_null_ptr().as_ptr();
         let end = i.add(layout.size());
@@ -17,7 +17,7 @@ fn allocate_zeroed() {
             assert_eq!(*i, 0);
             i = i.offset(1);
         }
-        Global.dealloc(ptr.as_non_null_ptr(), layout);
+        Global.deallocate(ptr.as_non_null_ptr(), layout);
     }
 }
 

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -36,7 +36,7 @@ use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
 use core::ptr::{self, NonNull};
 
-use crate::alloc::{AllocRef, Global, Layout};
+use crate::alloc::{Allocator, Global, Layout};
 use crate::boxed::Box;
 
 const B: usize = 6;
@@ -195,7 +195,7 @@ impl<K, V> NodeRef<marker::Owned, K, V, marker::LeafOrInternal> {
         self.borrow_mut().clear_parent_link();
 
         unsafe {
-            Global.dealloc(top.cast(), Layout::new::<InternalNode<K, V>>());
+            Global.deallocate(top.cast(), Layout::new::<InternalNode<K, V>>());
         }
     }
 }
@@ -449,7 +449,7 @@ impl<K, V> NodeRef<marker::Owned, K, V, marker::LeafOrInternal> {
         let node = self.node;
         let ret = self.ascend().ok();
         unsafe {
-            Global.dealloc(
+            Global.deallocate(
                 node.cast(),
                 if height > 0 {
                     Layout::new::<InternalNode<K, V>>()
@@ -1407,9 +1407,9 @@ impl<'a, K: 'a, V: 'a> BalancingContext<'a, K, V> {
 
                 left_node.correct_childrens_parent_links(left_len + 1..=left_len + 1 + right_len);
 
-                Global.dealloc(right_node.node.cast(), Layout::new::<InternalNode<K, V>>());
+                Global.deallocate(right_node.node.cast(), Layout::new::<InternalNode<K, V>>());
             } else {
-                Global.dealloc(right_node.node.cast(), Layout::new::<LeafNode<K, V>>());
+                Global.deallocate(right_node.node.cast(), Layout::new::<LeafNode<K, V>>());
             }
 
             let new_idx = match track_edge_idx {

--- a/library/alloc/src/raw_vec/tests.rs
+++ b/library/alloc/src/raw_vec/tests.rs
@@ -20,13 +20,13 @@ fn allocator_param() {
     struct BoundedAlloc {
         fuel: Cell<usize>,
     }
-    unsafe impl AllocRef for BoundedAlloc {
-        fn alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+    unsafe impl Allocator for BoundedAlloc {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
             let size = layout.size();
             if size > self.fuel.get() {
                 return Err(AllocError);
             }
-            match Global.alloc(layout) {
+            match Global.allocate(layout) {
                 ok @ Ok(_) => {
                     self.fuel.set(self.fuel.get() - size);
                     ok
@@ -34,8 +34,8 @@ fn allocator_param() {
                 err @ Err(_) => err,
             }
         }
-        unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) {
-            unsafe { Global.dealloc(ptr, layout) }
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            unsafe { Global.deallocate(ptr, layout) }
         }
     }
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -262,7 +262,7 @@ use core::pin::Pin;
 use core::ptr::{self, NonNull};
 use core::slice::from_raw_parts_mut;
 
-use crate::alloc::{box_free, handle_alloc_error, AllocError, AllocRef, Global, Layout};
+use crate::alloc::{box_free, handle_alloc_error, AllocError, Allocator, Global, Layout};
 use crate::borrow::{Cow, ToOwned};
 use crate::string::String;
 use crate::vec::Vec;
@@ -416,7 +416,7 @@ impl<T> Rc<T> {
         unsafe {
             Rc::from_ptr(Rc::allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.alloc(layout),
+                |layout| Global.allocate(layout),
                 |mem| mem as *mut RcBox<mem::MaybeUninit<T>>,
             ))
         }
@@ -447,7 +447,7 @@ impl<T> Rc<T> {
         unsafe {
             Rc::from_ptr(Rc::allocate_for_layout(
                 Layout::new::<T>(),
-                |layout| Global.alloc_zeroed(layout),
+                |layout| Global.allocate_zeroed(layout),
                 |mem| mem as *mut RcBox<mem::MaybeUninit<T>>,
             ))
         }
@@ -555,7 +555,7 @@ impl<T> Rc<[T]> {
         unsafe {
             Rc::from_ptr(Rc::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| Global.alloc_zeroed(layout),
+                |layout| Global.allocate_zeroed(layout),
                 |mem| {
                     ptr::slice_from_raw_parts_mut(mem as *mut T, len)
                         as *mut RcBox<[mem::MaybeUninit<T>]>
@@ -1040,7 +1040,7 @@ impl<T: ?Sized> Rc<T> {
         unsafe {
             Self::allocate_for_layout(
                 Layout::for_value(&*ptr),
-                |layout| Global.alloc(layout),
+                |layout| Global.allocate(layout),
                 |mem| set_data_ptr(ptr as *mut T, mem) as *mut RcBox<T>,
             )
         }
@@ -1075,7 +1075,7 @@ impl<T> Rc<[T]> {
         unsafe {
             Self::allocate_for_layout(
                 Layout::array::<T>(len).unwrap(),
-                |layout| Global.alloc(layout),
+                |layout| Global.allocate(layout),
                 |mem| ptr::slice_from_raw_parts_mut(mem as *mut T, len) as *mut RcBox<[T]>,
             )
         }
@@ -1125,7 +1125,7 @@ impl<T> Rc<[T]> {
                     let slice = from_raw_parts_mut(self.elems, self.n_elems);
                     ptr::drop_in_place(slice);
 
-                    Global.dealloc(self.mem, self.layout);
+                    Global.deallocate(self.mem, self.layout);
                 }
             }
         }
@@ -1225,7 +1225,7 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {
                 self.inner().dec_weak();
 
                 if self.inner().weak() == 0 {
-                    Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()));
+                    Global.deallocate(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()));
                 }
             }
         }
@@ -2040,7 +2040,7 @@ impl<T: ?Sized> Drop for Weak<T> {
         // the strong pointers have disappeared.
         if inner.weak() == 0 {
             unsafe {
-                Global.dealloc(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()));
+                Global.deallocate(self.ptr.cast(), Layout::for_value(self.ptr.as_ref()));
             }
         }
     }

--- a/library/alloc/tests/heap.rs
+++ b/library/alloc/tests/heap.rs
@@ -1,4 +1,4 @@
-use std::alloc::{AllocRef, Global, Layout, System};
+use std::alloc::{Allocator, Global, Layout, System};
 
 /// Issue #45955 and #62251.
 #[test]
@@ -11,7 +11,7 @@ fn std_heap_overaligned_request() {
     check_overalign_requests(Global)
 }
 
-fn check_overalign_requests<T: AllocRef>(allocator: T) {
+fn check_overalign_requests<T: Allocator>(allocator: T) {
     for &align in &[4, 8, 16, 32] {
         // less than and bigger than `MIN_ALIGN`
         for &size in &[align / 2, align - 1] {
@@ -20,7 +20,7 @@ fn check_overalign_requests<T: AllocRef>(allocator: T) {
             unsafe {
                 let pointers: Vec<_> = (0..iterations)
                     .map(|_| {
-                        allocator.alloc(Layout::from_size_align(size, align).unwrap()).unwrap()
+                        allocator.allocate(Layout::from_size_align(size, align).unwrap()).unwrap()
                     })
                     .collect();
                 for &ptr in &pointers {
@@ -33,7 +33,7 @@ fn check_overalign_requests<T: AllocRef>(allocator: T) {
 
                 // Clean up
                 for &ptr in &pointers {
-                    allocator.dealloc(
+                    allocator.deallocate(
                         ptr.as_non_null_ptr(),
                         Layout::from_size_align(size, align).unwrap(),
                     )

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -19,7 +19,7 @@ const fn size_align<T>() -> (usize, usize) {
 /// even though `GlobalAlloc` requires that all memory requests
 /// be non-zero in size. A caller must either ensure that conditions
 /// like this are met, use specific allocators with looser
-/// requirements, or use the more lenient `AllocRef` interface.)
+/// requirements, or use the more lenient `Allocator` interface.)
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[lang = "alloc_layout"]

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -439,11 +439,11 @@ impl<T> NonNull<[T]> {
     /// ```rust
     /// #![feature(allocator_api, ptr_as_uninit)]
     ///
-    /// use std::alloc::{AllocRef, Layout, Global};
+    /// use std::alloc::{Allocator, Layout, Global};
     /// use std::mem::MaybeUninit;
     /// use std::ptr::NonNull;
     ///
-    /// let memory: NonNull<[u8]> = Global.alloc(Layout::new::<[u8; 32]>())?;
+    /// let memory: NonNull<[u8]> = Global.allocate(Layout::new::<[u8; 32]>())?;
     /// // This is safe as `memory` is valid for reads and writes for `memory.len()` many bytes.
     /// // Note that calling `memory.as_mut()` is not allowed here as the content may be uninitialized.
     /// # #[allow(unused_variables)]

--- a/src/test/ui/allocator/xcrate-use.rs
+++ b/src/test/ui/allocator/xcrate-use.rs
@@ -10,7 +10,7 @@
 extern crate custom;
 extern crate helper;
 
-use std::alloc::{AllocRef, Global, Layout, System};
+use std::alloc::{Allocator, Global, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[global_allocator]
@@ -21,16 +21,16 @@ fn main() {
         let n = GLOBAL.0.load(Ordering::SeqCst);
         let layout = Layout::from_size_align(4, 2).unwrap();
 
-        let memory = Global.alloc(layout.clone()).unwrap();
+        let memory = Global.allocate(layout.clone()).unwrap();
         helper::work_with(&memory);
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 1);
-        Global.dealloc(memory.as_non_null_ptr(), layout);
+        Global.deallocate(memory.as_non_null_ptr(), layout);
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
 
-        let memory = System.alloc(layout.clone()).unwrap();
+        let memory = System.allocate(layout.clone()).unwrap();
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
         helper::work_with(&memory);
-        System.dealloc(memory.as_non_null_ptr(), layout);
+        System.deallocate(memory.as_non_null_ptr(), layout);
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
     }
 }

--- a/src/test/ui/associated-types/defaults-wf.stderr
+++ b/src/test/ui/associated-types/defaults-wf.stderr
@@ -6,7 +6,7 @@ LL |     type Ty = Vec<[u8]>;
    | 
   ::: $SRC_DIR/alloc/src/vec.rs:LL:COL
    |
-LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global> {
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
    |                - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `[u8]`

--- a/src/test/ui/bad/bad-sized.stderr
+++ b/src/test/ui/bad/bad-sized.stderr
@@ -17,7 +17,7 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    | 
   ::: $SRC_DIR/alloc/src/vec.rs:LL:COL
    |
-LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global> {
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
    |                - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `dyn Trait`

--- a/src/test/ui/box/leak-alloc.rs
+++ b/src/test/ui/box/leak-alloc.rs
@@ -1,26 +1,26 @@
 #![feature(allocator_api)]
 
-use std::alloc::{AllocError, AllocRef, Layout, System};
+use std::alloc::{AllocError, Allocator, Layout, System};
 use std::ptr::NonNull;
 
 use std::boxed::Box;
 
-struct Allocator {}
+struct Alloc {}
 
-unsafe impl AllocRef for Allocator {
-    fn alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        System.alloc(layout)
+unsafe impl Allocator for Alloc {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        System.allocate(layout)
     }
 
-    unsafe fn dealloc(&self, ptr: NonNull<u8>, layout: Layout) {
-        System.dealloc(ptr, layout)
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        System.deallocate(ptr, layout)
     }
 }
 
 fn use_value(_: u32) {}
 
 fn main() {
-    let alloc = Allocator {};
+    let alloc = Alloc {};
     let boxed = Box::new_in(10, alloc.by_ref());
     let theref = Box::leak(boxed);
     drop(alloc);

--- a/src/test/ui/error-codes/e0119/conflict-with-std.stderr
+++ b/src/test/ui/error-codes/e0119/conflict-with-std.stderr
@@ -6,7 +6,7 @@ LL | impl AsRef<Q> for Box<Q> {
    |
    = note: conflicting implementation in crate `alloc`:
            - impl<T, A> AsRef<T> for Box<T, A>
-             where A: AllocRef, T: ?Sized;
+             where A: Allocator, T: ?Sized;
 
 error[E0119]: conflicting implementations of trait `std::convert::From<S>` for type `S`:
   --> $DIR/conflict-with-std.rs:12:1

--- a/src/test/ui/issues/issue-20433.stderr
+++ b/src/test/ui/issues/issue-20433.stderr
@@ -6,7 +6,7 @@ LL |     fn iceman(c: Vec<[i32]>) {}
    | 
   ::: $SRC_DIR/alloc/src/vec.rs:LL:COL
    |
-LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global> {
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
    |                - required by this bound in `Vec`
    |
    = help: the trait `Sized` is not implemented for `[i32]`

--- a/src/test/ui/issues/issue-41974.stderr
+++ b/src/test/ui/issues/issue-41974.stderr
@@ -6,7 +6,7 @@ LL | impl<T> Drop for T where T: A {
    |
    = note: conflicting implementation in crate `alloc`:
            - impl<T, A> Drop for Box<T, A>
-             where A: AllocRef, T: ?Sized;
+             where A: Allocator, T: ?Sized;
    = note: downstream crates may implement trait `A` for type `std::boxed::Box<_, _>`
 
 error[E0120]: the `Drop` trait may only be implemented for structs, enums, and unions

--- a/src/test/ui/realloc-16687.rs
+++ b/src/test/ui/realloc-16687.rs
@@ -7,7 +7,7 @@
 #![feature(allocator_api)]
 #![feature(slice_ptr_get)]
 
-use std::alloc::{handle_alloc_error, AllocRef, Global, Layout};
+use std::alloc::{handle_alloc_error, Allocator, Global, Layout};
 use std::ptr::{self, NonNull};
 
 fn main() {
@@ -42,7 +42,7 @@ unsafe fn test_triangle() -> bool {
             println!("allocate({:?})", layout);
         }
 
-        let ptr = Global.alloc(layout).unwrap_or_else(|_| handle_alloc_error(layout));
+        let ptr = Global.allocate(layout).unwrap_or_else(|_| handle_alloc_error(layout));
 
         if PRINT {
             println!("allocate({:?}) = {:?}", layout, ptr);
@@ -56,7 +56,7 @@ unsafe fn test_triangle() -> bool {
             println!("deallocate({:?}, {:?}", ptr, layout);
         }
 
-        Global.dealloc(NonNull::new_unchecked(ptr), layout);
+        Global.deallocate(NonNull::new_unchecked(ptr), layout);
     }
 
     unsafe fn reallocate(ptr: *mut u8, old: Layout, new: Layout) -> *mut u8 {

--- a/src/test/ui/regions/regions-mock-codegen.rs
+++ b/src/test/ui/regions/regions-mock-codegen.rs
@@ -4,7 +4,7 @@
 // pretty-expanded FIXME #23616
 #![feature(allocator_api)]
 
-use std::alloc::{handle_alloc_error, AllocRef, Global, Layout};
+use std::alloc::{handle_alloc_error, Allocator, Global, Layout};
 use std::ptr::NonNull;
 
 struct arena(());
@@ -22,23 +22,23 @@ struct Ccx {
     x: isize,
 }
 
-fn alloc(_bcx: &arena) -> &Bcx<'_> {
+fn allocate(_bcx: &arena) -> &Bcx<'_> {
     unsafe {
         let layout = Layout::new::<Bcx>();
-        let ptr = Global.alloc(layout).unwrap_or_else(|_| handle_alloc_error(layout));
+        let ptr = Global.allocate(layout).unwrap_or_else(|_| handle_alloc_error(layout));
         &*(ptr.as_ptr() as *const _)
     }
 }
 
 fn h<'a>(bcx: &'a Bcx<'a>) -> &'a Bcx<'a> {
-    return alloc(bcx.fcx.arena);
+    return allocate(bcx.fcx.arena);
 }
 
 fn g(fcx: &Fcx) {
     let bcx = Bcx { fcx };
     let bcx2 = h(&bcx);
     unsafe {
-        Global.dealloc(NonNull::new_unchecked(bcx2 as *const _ as *mut _), Layout::new::<Bcx>());
+        Global.deallocate(NonNull::new_unchecked(bcx2 as *const _ as *mut _), Layout::new::<Bcx>());
     }
 }
 

--- a/src/test/ui/unique-object-noncopyable.stderr
+++ b/src/test/ui/unique-object-noncopyable.stderr
@@ -22,7 +22,7 @@ LL |       fn clone(&self) -> Self;
    |
 LL | / pub struct Box<
 LL | |     T: ?Sized,
-LL | |     #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global,
+LL | |     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 LL | | >(Unique<T>, A);
    | |________________- doesn't satisfy `Box<dyn Foo>: Clone`
    |

--- a/src/test/ui/unique-pinned-nocopy.stderr
+++ b/src/test/ui/unique-pinned-nocopy.stderr
@@ -19,7 +19,7 @@ LL |       fn clone(&self) -> Self;
    |
 LL | / pub struct Box<
 LL | |     T: ?Sized,
-LL | |     #[unstable(feature = "allocator_api", issue = "32838")] A: AllocRef = Global,
+LL | |     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
 LL | | >(Unique<T>, A);
    | |________________- doesn't satisfy `Box<R>: Clone`
    |


### PR DESCRIPTION
Calling `Box::alloc_ref` and `Vec::alloc_ref` sounds like allocating a reference. To solve this ambiguity, this renames `AllocRef` to `Allocator` and `alloc` to `allocate`. For a more detailed explaination see https://github.com/rust-lang/wg-allocators/issues/76.

closes https://github.com/rust-lang/wg-allocators/issues/76

r? @KodrAus
@rustbot modify labels: +A-allocators +T-libs
@rustbot ping wg-allocators