### PR TITLE
Add error message for private fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,6 +4132,7 @@ dependencies = [
  "rustc_middle",
  "rustc_session",
  "rustc_span",
+ "rustc_trait_selection",
  "rustc_typeck",
  "tracing",
 ]

--- a/compiler/rustc_privacy/Cargo.toml
+++ b/compiler/rustc_privacy/Cargo.toml
@@ -13,4 +13,5 @@ rustc_typeck = { path = "../rustc_typeck" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_data_structures = { path = "../rustc_data_structures" }
+rustc_trait_selection = { path = "../rustc_trait_selection" }
 tracing = "0.1"

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -6,7 +6,7 @@ pub mod auto_trait;
 mod chalk_fulfill;
 pub mod codegen;
 mod coherence;
-mod const_evaluatable;
+pub mod const_evaluatable;
 mod engine;
 pub mod error_reporting;
 mod fulfill;

--- a/src/test/ui/const-generics/const_evaluatable_checked/eval-privacy.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/eval-privacy.rs
@@ -1,0 +1,31 @@
+#![crate_type = "lib"]
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+pub struct Const<const U: u8>;
+
+pub trait Trait {
+    type AssocTy;
+    fn assoc_fn() -> Self::AssocTy;
+}
+
+impl<const U: u8> Trait for Const<U>
+//~^ WARN private type
+//~| WARN this was previously
+//~| WARN private type
+//~| WARN this was previously
+
+where
+    Const<{ my_const_fn(U) }>: ,
+{
+    type AssocTy = Const<{ my_const_fn(U) }>;
+    //~^ ERROR private type
+    fn assoc_fn() -> Self::AssocTy {
+        Const
+    }
+}
+
+const fn my_const_fn(val: u8) -> u8 {
+    // body of this function doesn't matter
+    val
+}

--- a/src/test/ui/const-generics/const_evaluatable_checked/eval-privacy.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/eval-privacy.stderr
@@ -1,0 +1,43 @@
+warning: private type `fn(u8) -> u8 {my_const_fn}` in public interface (error E0446)
+  --> $DIR/eval-privacy.rs:12:1
+   |
+LL | / impl<const U: u8> Trait for Const<U>
+LL | |
+LL | |
+LL | |
+...  |
+LL | |     }
+LL | | }
+   | |_^
+   |
+   = note: `#[warn(private_in_public)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+warning: private type `fn(u8) -> u8 {my_const_fn}` in public interface (error E0446)
+  --> $DIR/eval-privacy.rs:12:1
+   |
+LL | / impl<const U: u8> Trait for Const<U>
+LL | |
+LL | |
+LL | |
+...  |
+LL | |     }
+LL | | }
+   | |_^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+  --> $DIR/eval-privacy.rs:21:5
+   |
+LL |     type AssocTy = Const<{ my_const_fn(U) }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+...
+LL | const fn my_const_fn(val: u8) -> u8 {
+   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+
+error: aborting due to previous error; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0446`.


### PR DESCRIPTION
Attempts to add a more detailed error when a `const_evaluatable` fn from another scope is used inside of a scope which cannot access it. 

r? @lcnr 