### PR TITLE
Fix typo in doc comment for report_too_many_hashes

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -510,7 +510,7 @@ impl<'a> StringReader<'a> {
         FatalError.raise()
     }
 
-    /// Note: It was decided to not add a test case, because it would be to big.
+    /// Note: It was decided to not add a test case, because it would be too big.
     /// <https://github.com/rust-lang/rust/pull/50296#issuecomment-392135180>
     fn report_too_many_hashes(&self, start: BytePos, found: usize) -> ! {
         self.fatal_span_(


### PR DESCRIPTION
"to big" -> "too big"