### PR TITLE
BTreeMap: swap the names of NodeRef::new and Root::new_leaf

### DIFF
--- a/library/alloc/src/collections/btree/append.rs
+++ b/library/alloc/src/collections/btree/append.rs
@@ -67,7 +67,7 @@ impl<K, V> Root<K, V> {
 
                 // Push key-value pair and new right subtree.
                 let tree_height = open_node.height() - 1;
-                let mut right_tree = Root::new_leaf();
+                let mut right_tree = Root::new();
                 for _ in 0..tree_height {
                     right_tree.push_internal_level();
                 }

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -134,13 +134,13 @@ pub type Root<K, V> = NodeRef<marker::Owned, K, V, marker::LeafOrInternal>;
 
 impl<K, V> Root<K, V> {
     /// Returns a new owned tree, with its own root node that is initially empty.
-    pub fn new_leaf() -> Self {
-        NodeRef::new().forget_type()
+    pub fn new() -> Self {
+        NodeRef::new_leaf().forget_type()
     }
 }
 
 impl<K, V> NodeRef<marker::Owned, K, V, marker::Leaf> {
-    fn new() -> Self {
+    fn new_leaf() -> Self {
         Self::from_new_leaf(Box::new(unsafe { LeafNode::new() }))
     }
 

--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -74,12 +74,12 @@ fn test_splitpoint() {
 
 #[test]
 fn test_partial_cmp_eq() {
-    let mut root1 = NodeRef::new();
+    let mut root1 = NodeRef::new_leaf();
     let mut leaf1 = root1.borrow_mut();
     leaf1.push(1, ());
     let mut root1 = root1.forget_type();
     root1.push_internal_level();
-    let root2 = Root::new_leaf();
+    let root2 = Root::new();
     root1.reborrow().assert_back_pointers();
     root2.reborrow().assert_back_pointers();
 


### PR DESCRIPTION
#78104 preserved the name of Root::new_leaf to minimize changes, but the resulting names are confusing.

r? @Mark-Simulacrum