### PR TITLE
Stabilise `then`

### DIFF
--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(allow_internal_unstable)]
-#![feature(bool_to_option)]
 #![feature(const_fn)]
 #![feature(const_panic)]
 #![feature(extend_one)]

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(bool_to_option)]
 #![feature(core_intrinsics)]
 #![feature(crate_visibility_modifier)]
 #![feature(drain_filter)]

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -1,6 +1,5 @@
 //! The main parser interface.
 
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(bindings_after_at)]
 #![feature(iter_order_by)]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -23,12 +23,10 @@ impl bool {
     /// # Examples
     ///
     /// ```
-    /// #![feature(bool_to_option)]
-    ///
     /// assert_eq!(false.then(|| 0), None);
     /// assert_eq!(true.then(|| 0), Some(0));
     /// ```
-    #[unstable(feature = "bool_to_option", issue = "64260")]
+    #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[inline]
     pub fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
         if self { Some(f()) } else { None }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -227,7 +227,6 @@
 #![feature(asm)]
 #![feature(associated_type_bounds)]
 #![feature(atomic_mut_ptr)]
-#![feature(bool_to_option)]
 #![feature(box_syntax)]
 #![feature(c_variadic)]
 #![feature(cfg_accessible)]

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -23,7 +23,6 @@
 #![cfg_attr(any(unix, target_os = "cloudabi"), feature(libc))]
 #![feature(rustc_private)]
 #![feature(nll)]
-#![feature(bool_to_option)]
 #![feature(available_concurrency)]
 #![feature(internal_output_capture)]
 #![feature(panic_unwind)]


### PR DESCRIPTION
Stabilises the lazy variant of https://github.com/rust-lang/rust/issues/64260 now that the FCP [has ended](https://github.com/rust-lang/rust/issues/64260#issuecomment-731636203).

I've kept the original feature gate `bool_to_option` for the strict variant (`then_some`), and created a new insta-stable feature gate `lazy_bool_to_option` for `then`.