### PR TITLE
Prevent feature information to be hidden if it's on the impl directly

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2332,12 +2332,18 @@ function defocusSearchBar() {
             var dontApplyBlockRule = toggle.parentNode.parentNode.id !== "main";
             if (action === "show") {
                 removeClass(relatedDoc, "fns-now-collapsed");
-                removeClass(docblock, "hidden-by-usual-hider");
+                // Stability information is never hidden.
+                if (hasClass(docblock, "stability") === false) {
+                    removeClass(docblock, "hidden-by-usual-hider");
+                }
                 onEachLazy(toggle.childNodes, adjustToggle(false, dontApplyBlockRule));
                 onEachLazy(relatedDoc.childNodes, implHider(false, dontApplyBlockRule));
             } else if (action === "hide") {
                 addClass(relatedDoc, "fns-now-collapsed");
-                addClass(docblock, "hidden-by-usual-hider");
+                // Stability information should be shown even when detailed info is hidden.
+                if (hasClass(docblock, "stability") === false) {
+                    addClass(docblock, "hidden-by-usual-hider");
+                }
                 onEachLazy(toggle.childNodes, adjustToggle(true, dontApplyBlockRule));
                 onEachLazy(relatedDoc.childNodes, implHider(true, dontApplyBlockRule));
             }


### PR DESCRIPTION
Fixes #79279.

So when a `#[doc(cfg...)]` is used on a trait impl directly, it's not hidden by the toggle.

![Screenshot from 2020-11-22 14-40-11](https://user-images.githubusercontent.com/3050060/99905528-997fab00-2cd1-11eb-83be-ed06b0cb97df.png)

r? @jyn514 