### PR TITLE
resolve: allow super in module in block to refer to block items

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -747,6 +747,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             path_span,
             crate_lint,
             Some(&self.ribs),
+            crate::AllowResolveBlocks::No,
         )
     }
 

--- a/src/test/rustdoc/mod-in-doctest.rs
+++ b/src/test/rustdoc/mod-in-doctest.rs
@@ -1,0 +1,13 @@
+// compile-flags:--test
+// edition:2018
+
+//! ```
+//! fn foo() {}
+//!
+//! mod bar {
+//!     use super::foo;
+//!     fn bar() {
+//!         foo()
+//!     }
+//! }
+//! ```

--- a/src/test/ui/resolve/module-in-block-build-pass.rs
+++ b/src/test/ui/resolve/module-in-block-build-pass.rs
@@ -1,0 +1,98 @@
+// build-pass
+
+const CONST: &str = "OUTER";
+fn bar() -> &'static str { "outer" }
+
+fn module_in_function_use_super() {
+    mod inner {
+        use super::{bar, CONST};
+        fn call_bar() {
+            bar();
+        }
+
+        fn get_const() -> &'static str {
+            CONST
+        }
+    }
+}
+
+fn module_in_function_resolve_super() {
+    mod inner {
+        fn call_bar() {
+            super::bar();
+        }
+
+        fn get_const() -> &'static str {
+            super::CONST
+        }
+    }
+}
+
+
+fn module_in_function_use_super_glob() {
+    mod inner {
+        use super::*;
+        fn call_bar() {
+            bar();
+        }
+
+        fn get_const() -> &'static str {
+            CONST
+        }
+    }
+}
+
+fn module_in_block_use_super() {
+    {
+        mod inner {
+            use super::{bar, CONST};
+            fn call_bar() {
+                bar();
+            }
+
+            fn get_const() -> &'static str {
+                CONST
+            }
+        }
+    }
+}
+
+fn module_in_block_resolve_super() {
+    {
+        mod inner {
+            fn call_bar() {
+                super::bar();
+            }
+
+            fn get_const() -> &'static str {
+                super::CONST
+            }
+        }
+    }
+}
+
+
+fn module_in_block_use_super_glob() {
+    {
+        mod inner {
+            use super::*;
+            fn call_bar() {
+                bar();
+            }
+
+            fn get_const() -> &'static str {
+                CONST
+            }
+        }
+    }
+}
+
+fn main() {
+    module_in_function_use_super();
+    module_in_function_resolve_super();
+    module_in_function_use_super_glob();
+
+    module_in_block_use_super();
+    module_in_block_resolve_super();
+    module_in_block_use_super_glob();
+}

--- a/src/test/ui/resolve/module-in-block-compile-fail.rs
+++ b/src/test/ui/resolve/module-in-block-compile-fail.rs
@@ -1,0 +1,12 @@
+fn module_in_function_cannot_access_variables() {
+    let x: i32 = 5;
+
+    mod inner {
+        use super::x;  //~ ERROR unresolved import `super::x`
+        fn get_x() -> i32 {
+            x
+        }
+    }
+}
+
+fn main() { }

--- a/src/test/ui/resolve/module-in-block-compile-fail.stderr
+++ b/src/test/ui/resolve/module-in-block-compile-fail.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `super::x`
+  --> $DIR/module-in-block-compile-fail.rs:5:13
+   |
+LL |         use super::x;
+   |             ^^^^^^^^ no `x` in `<opaque>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/resolve/module-in-block-run-pass.rs
+++ b/src/test/ui/resolve/module-in-block-run-pass.rs
@@ -1,0 +1,101 @@
+// run-pass
+// compile-flags:--test
+
+// These two items are marked as allow(dead_code) because none of the
+// test code should ever resolve to them.
+#[allow(dead_code)]
+const CONST: &str = "OUTER";
+#[allow(dead_code)]
+fn bar() -> &'static str { "outer" }
+
+#[test]
+fn module_in_function_prefer_inner() {
+
+    const CONST: &str = "INNER";
+    fn bar() -> &'static str { "inner" }
+
+    mod inner {
+        use super::{bar, CONST};
+        pub fn call_bar() -> &'static str {
+            bar()
+        }
+
+        pub fn get_const() -> &'static str {
+            CONST
+        }
+    }
+
+    assert_eq!(inner::call_bar(), "inner");
+    assert_eq!(inner::get_const(), "INNER")
+}
+
+#[test]
+fn module_in_function_prefer_inner_glob() {
+
+    const CONST: &str = "INNER";
+    fn bar() -> &'static str { "inner" }
+
+    mod inner {
+        use super::*;
+        pub fn call_bar() -> &'static str {
+            bar()
+        }
+
+        pub fn get_const() -> &'static str {
+            CONST
+        }
+    }
+
+    assert_eq!(inner::call_bar(), "inner");
+    assert_eq!(inner::get_const(), "INNER");
+}
+
+#[test]
+fn module_in_block_prefer_inner() {
+
+    const CONST: &str = "INNER";
+
+    // anonymous block
+    {
+        fn bar() -> &'static str { "inner_block" }
+
+        mod inner {
+            use super::{CONST, bar};
+            pub fn call_bar() -> &'static str {
+                bar()
+            }
+
+            pub fn get_const() -> &'static str {
+                CONST
+            }
+        }
+
+        assert_eq!(inner::call_bar(), "inner_block");
+        assert_eq!(inner::get_const(), "INNER");
+    }
+}
+
+
+#[test]
+fn module_in_block_prefer_inner_glob() {
+    const CONST: &str = "INNER";
+
+    // anonymous block
+    {
+        fn bar() -> &'static str { "inner_block" }
+
+        mod inner {
+            use super::*;
+            pub fn call_bar() -> &'static str {
+                bar()
+            }
+
+            pub fn get_const() -> &'static str {
+                CONST
+            }
+        }
+
+        assert_eq!(inner::call_bar(), "inner_block");
+        assert_eq!(inner::get_const(), "INNER");
+    }
+}

--- a/src/test/ui/resolve/module-in-block-run-pass.rs
+++ b/src/test/ui/resolve/module-in-block-run-pass.rs
@@ -99,3 +99,36 @@ fn module_in_block_prefer_inner_glob() {
         assert_eq!(inner::get_const(), "INNER");
     }
 }
+
+#[test]
+fn module_in_block_does_not_use_variables() {
+    #[allow(unused_variables)]
+    let bar = || "inner_block";
+
+
+    // anonymous block
+    mod inner {
+        use super::bar;
+        pub fn call_bar() -> &'static str {
+            bar()
+        }
+    }
+
+    assert_eq!(inner::call_bar(), "outer");
+}
+
+#[test]
+fn module_in_block_does_not_use_variables_glob() {
+    #[allow(unused_variables)]
+    let bar = || "inner_block";
+
+    // anonymous block
+    mod inner {
+        use super::*;
+        pub fn call_bar() -> &'static str {
+            bar()
+        }
+    }
+
+    assert_eq!(inner::call_bar(), "outer");
+}


### PR DESCRIPTION
This PR attempts to resolve #79260 by changing the way the resolver interprets `super` in `mod` items that are children of blocks.

Most notably, this means that doctests with modules which use other items from the snippet can now compile:

```
//! ```rust
//! struct Foo;
//!
//! mod foobar {
//!     use super::*;
//!
//!     fn bar() -> Foo { Foo }
//! }
//!
//! ```
```

At the moment this doctest will fail to compile. ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=5be71c537adbcd1a84b9c62d3027c555))

### Background

At the moment, when an inline module is inside a block, the `super` keyword refers to the parent module of the block. The result of this is that the inline module has no way to refer to its sibling items inside the block.

```rust
fn foo() {
    const FOO: u64 = 0;
    mod foo {
        pub use super::FOO; //~ ERROR no `Foo` in the root
    }
}
```

([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=2339d8e979dc45a25735b87ad1f85602))

The current interpretation of the `super` keyword is theoretically pure, however I want to argue it has practical drawbacks. As well as issues with doctests as per the first example, it means that in general code of the following form is interpreted differently depending on whether it is inside a block:

```rust
const FOO: u64 = 0;
mod foo {
    pub use super::FOO;
}
```

In isolation it seems fair to me to assume that most readers would state this code compiles and that `foo::FOO` can resolve. However, if this code is actually inside a block, it doesn't compile.

### Proposed Design

This PR modifies the behaviour of the `super` keyword in examples like the above such that usage inside a module which is a child of (one of more) blocks will attempt to resolve items from those blocks as well as the parent module of those blocks.

Ambiguity is resolved by always preferring items that are closer to the module in the hierarchy. E.g. in the following example:

```rust
const FOO: u64 = 0;
fn main() {
    const FOO: u64 = 1;
    mod foo {
        pub use super::FOO;
    }
}
```

the item `foo::FOO` will resolve to have the value `1`.

### ⚠️ Breakage ⚠️ 

This example just above is unfortunately also an example where current code could break under these changes. Today the compiler would not see the `FOO` constant which is the child of `main` from its sibling `mod foo`, and so the item `foo::FOO` today would instead resolve to have the value `0`. 

(Assuming, of course, that the snippet just above were not itself wholly inside a block, in which case the compiler today would not consider the `FOO` on the first line either 🙃)

I would argue inline modules inside blocks are rare. (I myself only found this case while testing a macro which created a module and discovering it did not compile when inside a block.) So this breakage is not likely to be widespread. Nevertheless we should assess carefully.

If we were to take a conservative approach it should be possible to change this PR to be backwards compatible. I'd propose in that case to push the complete change to the proposed design in this PR via an edition boundary, with a lint to warn of cases that will change.

### Alternatives

I'm quite happy to throw this PR away in favour of an alternative design. I'll try to list them here as I see them:

- @petrochenkov has proposed that a `#[transparent] mod foo` could behave as if it did not create a name boundary, which would allow these modules in blocks to share scope with their parent block. (See https://github.com/rust-lang/rust/issues/79260#issuecomment-731773625)
- @Aaron1011 wrote a pre-RFC on a `fn` modifier in use statements. (See https://internals.rust-lang.org/t/pre-rfc-add-fn-path-qualifier/10900)
- Also in that thread was the proposal of plain `use;`. I'd personally prefer it was a new keyword e.g. `use scope::*;` or `use scope::foo;` - that probably needs a new edition though as a new keyword.

### TODO

- [ ] I think it's quite likely a change like this could be worthy of a wider design review. Please feel free to ask me to first present this as an RFC. (I started with the implementation so I could learn about this design and play with it.)
- [ ] Feature gate? (I 100% assume this change will need one.)
- [ ] Make a decision on the backwards-compatibility story, especially if it might want to become part of the 2021 edition.
- [ ] Refactoring in the implementation of this PR - at the moment I kept to the most direct implementation I could find because I'm not familar with the `rustc_resolve` codebase. Please be unafraid to encourage me to rewrite this PR multiple times to get the cleanest result!

