### PR TITLE
Unify ty::AssocKind with hir::AssocItemKind.

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2607,11 +2607,18 @@ pub struct ImplItemRef<'hir> {
     pub defaultness: Defaultness,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Encodable, Debug, HashStable_Generic)]
+#[derive(Copy, Clone, Hash, Encodable, Debug, HashStable_Generic)]
 pub enum AssocItemKind {
     Const,
     Fn { has_self: bool },
     Type,
+}
+
+impl PartialEq for AssocItemKind {
+    fn eq(&self, other: &AssocItemKind) -> bool {
+        // ignore `has_self` parameter
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
 }
 
 impl AssocItemKind {

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2607,11 +2607,32 @@ pub struct ImplItemRef<'hir> {
     pub defaultness: Defaultness,
 }
 
-#[derive(Copy, Clone, PartialEq, Encodable, Debug, HashStable_Generic)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Encodable, Debug, HashStable_Generic)]
 pub enum AssocItemKind {
     Const,
     Fn { has_self: bool },
     Type,
+}
+
+impl AssocItemKind {
+    pub fn is_fn(&self) -> bool {
+        matches!(self, AssocItemKind::Fn { .. })
+    }
+
+    pub fn namespace(&self) -> Namespace {
+        match *self {
+            AssocItemKind::Type => Namespace::TypeNS,
+            AssocItemKind::Const | AssocItemKind::Fn { .. } => Namespace::ValueNS,
+        }
+    }
+
+    pub fn as_def_kind(&self) -> DefKind {
+        match self {
+            AssocItemKind::Const => DefKind::AssocConst,
+            AssocItemKind::Fn { .. } => DefKind::AssocFn,
+            AssocItemKind::Type => DefKind::AssocTy,
+        }
+    }
 }
 
 #[derive(Debug, HashStable_Generic)]

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -10,7 +10,7 @@ use rustc_hir::def::Res;
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::Visitor;
 use rustc_middle::ty::error::ExpectedFound;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{Ty, TyCtxt};
 use rustc_span::{MultiSpan, Span};
 
 impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
@@ -65,7 +65,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let assoc_item = self.tcx().associated_item(trait_def_id);
         let mut visitor = TypeParamSpanVisitor { tcx: self.tcx(), types: vec![] };
         match assoc_item.kind {
-            ty::AssocKind::Fn => {
+            hir::AssocItemKind::Fn { .. } => {
                 let hir = self.tcx().hir();
                 if let Some(hir_id) =
                     assoc_item.def_id.as_local().map(|id| hir.local_def_id_to_hir_id(id))

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/util.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/util.rs
@@ -169,7 +169,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             && self
                 .tcx()
                 .opt_associated_item(scope_def_id.to_def_id())
-                .map(|i| i.fn_has_self_parameter)
+                .map(|i| i.fn_has_self_parameter())
                 == Some(true)
     }
 }

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1264,13 +1264,13 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         let parent = self.local_def_id(def_key.parent.unwrap());
         let ident = self.item_ident(id, sess);
 
-        let (kind, container, has_self) = match self.kind(id) {
-            EntryKind::AssocConst(container, _, _) => (ty::AssocKind::Const, container, false),
+        let (kind, container) = match self.kind(id) {
+            EntryKind::AssocConst(container, _, _) => (hir::AssocItemKind::Const, container),
             EntryKind::AssocFn(data) => {
                 let data = data.decode(self);
-                (ty::AssocKind::Fn, data.container, data.has_self)
+                (hir::AssocItemKind::Fn { has_self: data.has_self }, data.container)
             }
-            EntryKind::AssocType(container) => (ty::AssocKind::Type, container, false),
+            EntryKind::AssocType(container) => (hir::AssocItemKind::Type, container),
             _ => bug!("cannot get associated-item of `{:?}`", def_key),
         };
 
@@ -1281,7 +1281,6 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
             defaultness: container.defaultness(),
             def_id: self.local_def_id(id),
             container: container.with_def_id(parent),
-            fn_has_self_parameter: has_self,
         }
     }
 

--- a/compiler/rustc_middle/src/traits/specialization_graph.rs
+++ b/compiler/rustc_middle/src/traits/specialization_graph.rs
@@ -5,6 +5,7 @@ use crate::ty::{self, TyCtxt};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_errors::ErrorReported;
+use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, DefIdMap};
 use rustc_span::symbol::Ident;
 
@@ -95,7 +96,7 @@ impl<'tcx> Node {
         &self,
         tcx: TyCtxt<'tcx>,
         trait_item_name: Ident,
-        trait_item_kind: ty::AssocKind,
+        trait_item_kind: hir::AssocItemKind,
         trait_def_id: DefId,
     ) -> Option<ty::AssocItem> {
         tcx.associated_items(self.def_id())
@@ -187,7 +188,7 @@ impl<'tcx> Ancestors<'tcx> {
         mut self,
         tcx: TyCtxt<'tcx>,
         trait_item_name: Ident,
-        trait_item_kind: ty::AssocKind,
+        trait_item_kind: hir::AssocItemKind,
     ) -> Option<LeafDef> {
         let trait_def_id = self.trait_def_id;
         let mut finalizing_node = None;

--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -125,7 +125,7 @@ impl<'tcx> OverloadedDeref<'tcx> {
         let method_def_id = tcx
             .associated_items(trait_def_id)
             .in_definition_order()
-            .find(|m| m.kind == ty::AssocKind::Fn)
+            .find(|m| m.kind.is_fn())
             .unwrap()
             .def_id;
         (method_def_id, tcx.mk_substs_trait(source, &[]))

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -751,9 +751,7 @@ fn foo(&self) -> Self::T { String::new() }
         let methods: Vec<(Span, String)> = items
             .items
             .iter()
-            .filter(|(name, item)| {
-                ty::AssocKind::Fn == item.kind && Some(**name) != current_method_ident
-            })
+            .filter(|(name, item)| item.kind.is_fn() && Some(**name) != current_method_ident)
             .filter_map(|(_, item)| {
                 let method = self.fn_sig(item.def_id);
                 match *method.output().skip_binder().kind() {

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -444,7 +444,7 @@ impl<'tcx> Instance<'tcx> {
         let call_once = tcx
             .associated_items(fn_once)
             .in_definition_order()
-            .find(|it| it.kind == ty::AssocKind::Fn)
+            .find(|it| it.kind.is_fn())
             .unwrap()
             .def_id;
         let def = ty::InstanceDef::ClosureOnceShim { call_once };

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -184,7 +184,7 @@ pub enum ImplPolarity {
     Reservation,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, HashStable, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, HashStable, Hash)]
 pub struct AssocItem {
     pub def_id: DefId,
     #[stable_hasher(project(name))]
@@ -194,6 +194,8 @@ pub struct AssocItem {
     pub defaultness: hir::Defaultness,
     pub container: AssocItemContainer,
 }
+
+impl Eq for AssocItem {}
 
 impl AssocItem {
     /// Whether this is a method with an explicit self

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1138,7 +1138,7 @@ impl<'tcx> ProjectionTy<'tcx> {
     ) -> ProjectionTy<'tcx> {
         let item_def_id = tcx
             .associated_items(trait_ref.def_id)
-            .find_by_name_and_kind(tcx, item_name, ty::AssocKind::Type, trait_ref.def_id)
+            .find_by_name_and_kind(tcx, item_name, hir::AssocItemKind::Type, trait_ref.def_id)
             .unwrap()
             .def_id;
 

--- a/compiler/rustc_mir/src/shim.rs
+++ b/compiler/rustc_mir/src/shim.rs
@@ -58,7 +58,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
             let call_mut = tcx
                 .associated_items(fn_mut)
                 .in_definition_order()
-                .find(|it| it.kind == ty::AssocKind::Fn)
+                .find(|it| it.kind.is_fn())
                 .unwrap()
                 .def_id;
 

--- a/compiler/rustc_mir/src/util/find_self_call.rs
+++ b/compiler/rustc_mir/src/util/find_self_call.rs
@@ -19,9 +19,7 @@ pub fn find_self_call<'tcx>(
         debug!("find_self_call: func={:?}", func);
         if let Operand::Constant(box Constant { literal: ty::Const { ty, .. }, .. }) = func {
             if let ty::FnDef(def_id, substs) = *ty.kind() {
-                if let Some(ty::AssocItem { fn_has_self_parameter: true, .. }) =
-                    tcx.opt_associated_item(def_id)
-                {
+                if tcx.opt_associated_item(def_id).map_or(false, |i| i.fn_has_self_parameter()) {
                     debug!("find_self_call: args={:?}", args);
                     if let [Operand::Move(self_place) | Operand::Copy(self_place), ..] = **args {
                         if self_place.as_local() == Some(local) {

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -170,7 +170,7 @@ impl<'a, 'tcx> Cx<'a, 'tcx> {
             .tcx
             .associated_items(trait_def_id)
             .filter_by_name_unhygienic(method_name)
-            .find(|item| item.kind == ty::AssocKind::Fn)
+            .find(|item| item.kind.is_fn())
             .expect("trait method not found");
 
         let method_ty = self.tcx.type_of(item.def_id);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -993,7 +993,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             Res::Def(DefKind::AssocFn, def_id) => {
                 if cstore
                     .associated_item_cloned_untracked(def_id, self.r.session)
-                    .fn_has_self_parameter
+                    .fn_has_self_parameter()
                 {
                     self.r.has_self.insert(def_id);
                 }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1207,7 +1207,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         trait_ref: DefId,
     ) {
         if let Some(assoc_item) = self.tcx.opt_associated_item(def_id) {
-            if let ty::AssocKind::Const | ty::AssocKind::Type = assoc_item.kind {
+            if let hir::AssocItemKind::Const | hir::AssocItemKind::Type = assoc_item.kind {
                 err.note(&format!(
                     "{}s cannot be accessed directly on a `trait`, they can only be \
                         accessed through a specific `impl`",

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -466,7 +466,7 @@ fn vtable_methods<'tcx>(
         let trait_methods = tcx
             .associated_items(trait_ref.def_id())
             .in_definition_order()
-            .filter(|item| item.kind == ty::AssocKind::Fn);
+            .filter(|item| item.kind.is_fn());
 
         // Now list each method's DefId and InternalSubsts (for within its trait).
         // If the method can never be called from this object, produce None.

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -21,6 +21,7 @@ use crate::infer::{InferCtxt, InferOk, LateBoundRegionConversionTime};
 use crate::traits::error_reporting::InferCtxtExt;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::ErrorReported;
+use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::lang_items::LangItem;
 use rustc_infer::infer::resolve::OpportunisticRegionResolver;
@@ -1479,7 +1480,7 @@ fn assoc_ty_def(
     // cycle error if the specialization graph is currently being built.
     let impl_node = specialization_graph::Node::Impl(impl_def_id);
     for item in impl_node.items(tcx) {
-        if matches!(item.kind, ty::AssocKind::Type)
+        if matches!(item.kind, hir::AssocItemKind::Type)
             && tcx.hygienic_eq(item.ident, assoc_ty_name, trait_def_id)
         {
             return Ok(specialization_graph::LeafDef {
@@ -1491,7 +1492,7 @@ fn assoc_ty_def(
     }
 
     let ancestors = trait_def.ancestors(tcx, impl_def_id)?;
-    if let Some(assoc_item) = ancestors.leaf_def(tcx, assoc_ty_name, ty::AssocKind::Type) {
+    if let Some(assoc_item) = ancestors.leaf_def(tcx, assoc_ty_name, hir::AssocItemKind::Type) {
         Ok(assoc_item)
     } else {
         // This is saying that neither the trait nor

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -7,6 +7,7 @@
 //! [rustc dev guide]:
 //! https://rustc-dev-guide.rust-lang.org/traits/resolution.html#confirmation
 use rustc_data_structures::stack::ensure_sufficient_stack;
+use rustc_hir as hir;
 use rustc_hir::lang_items::LangItem;
 use rustc_index::bit_set::GrowableBitSet;
 use rustc_infer::infer::InferOk;
@@ -454,9 +455,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let assoc_types: Vec<_> = tcx
             .associated_items(trait_predicate.def_id())
             .in_definition_order()
-            .filter_map(
-                |item| if item.kind == ty::AssocKind::Type { Some(item.def_id) } else { None },
-            )
+            .filter_map(|item| {
+                if item.kind == hir::AssocItemKind::Type { Some(item.def_id) } else { None }
+            })
             .collect();
 
         for assoc_type in assoc_types {

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -289,7 +289,7 @@ pub fn count_own_vtable_entries(tcx: TyCtxt<'tcx>, trait_ref: ty::PolyTraitRef<'
     // Count number of methods and add them to the total offset.
     // Skip over associated types and constants.
     for trait_item in tcx.associated_items(trait_ref.def_id()).in_definition_order() {
-        if trait_item.kind == ty::AssocKind::Fn {
+        if trait_item.kind.is_fn() {
             entries += 1;
         }
     }
@@ -311,10 +311,10 @@ pub fn get_vtable_index_of_object_method<N>(
     for trait_item in tcx.associated_items(object.upcast_trait_ref.def_id()).in_definition_order() {
         if trait_item.def_id == method_def_id {
             // The item with the ID we were given really ought to be a method.
-            assert_eq!(trait_item.kind, ty::AssocKind::Fn);
+            assert!(trait_item.kind.is_fn());
             return entries;
         }
-        if trait_item.kind == ty::AssocKind::Fn {
+        if trait_item.kind.is_fn() {
             entries += 1;
         }
     }

--- a/compiler/rustc_traits/src/chalk/db.rs
+++ b/compiler/rustc_traits/src/chalk/db.rs
@@ -8,9 +8,10 @@
 
 use rustc_middle::traits::ChalkRustInterner as RustInterner;
 use rustc_middle::ty::subst::{InternalSubsts, Subst, SubstsRef};
-use rustc_middle::ty::{self, AssocItemContainer, AssocKind, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, AssocItemContainer, TyCtxt, TypeFoldable};
 
 use rustc_hir::def_id::DefId;
+use rustc_hir::AssocItemKind;
 
 use rustc_span::symbol::sym;
 
@@ -77,7 +78,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
             _ => unimplemented!("Not possible??"),
         };
         match assoc_item.kind {
-            AssocKind::Type => {}
+            AssocItemKind::Type => {}
             _ => unimplemented!("Not possible??"),
         }
         let bound_vars = bound_vars_for_item(self.interner.tcx, def_id);
@@ -114,7 +115,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
             .tcx
             .associated_items(def_id)
             .in_definition_order()
-            .filter(|i| i.kind == AssocKind::Type)
+            .filter(|i| i.kind == AssocItemKind::Type)
             .map(|i| chalk_ir::AssocTypeId(i.def_id))
             .collect();
 
@@ -279,7 +280,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
             .tcx
             .associated_items(def_id)
             .in_definition_order()
-            .filter(|i| i.kind == AssocKind::Type)
+            .filter(|i| i.kind == AssocItemKind::Type)
             .map(|i| chalk_solve::rust_ir::AssociatedTyValueId(i.def_id))
             .collect();
 
@@ -415,7 +416,7 @@ impl<'tcx> chalk_solve::RustIrDatabase<RustInterner<'tcx>> for RustIrDatabase<'t
             }
         };
         match assoc_item.kind {
-            AssocKind::Type => {}
+            AssocItemKind::Type => {}
             _ => unimplemented!("Not possible??"),
         }
 

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -1,4 +1,5 @@
 use rustc_errors::ErrorReported;
+use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::ty::subst::SubstsRef;
@@ -187,7 +188,7 @@ fn resolve_associated_item<'tcx>(
             // performs (i.e. that the definition's type in the `impl` matches
             // the declaration in the `trait`), so that we can cheaply check
             // here if it failed, instead of approximating it.
-            if trait_item.kind == ty::AssocKind::Const
+            if trait_item.kind == hir::AssocItemKind::Const
                 && trait_item.def_id != leaf_def.item.def_id
                 && leaf_def.item.def_id.is_local()
             {

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -83,20 +83,14 @@ fn associated_item_from_trait_item_ref(
     trait_item_ref: &hir::TraitItemRef,
 ) -> ty::AssocItem {
     let def_id = tcx.hir().local_def_id(trait_item_ref.id.hir_id);
-    let (kind, has_self) = match trait_item_ref.kind {
-        hir::AssocItemKind::Const => (ty::AssocKind::Const, false),
-        hir::AssocItemKind::Fn { has_self } => (ty::AssocKind::Fn, has_self),
-        hir::AssocItemKind::Type => (ty::AssocKind::Type, false),
-    };
 
     ty::AssocItem {
         ident: trait_item_ref.ident,
-        kind,
+        kind: trait_item_ref.kind,
         vis: tcx.visibility(def_id),
         defaultness: trait_item_ref.defaultness,
         def_id: def_id.to_def_id(),
         container: ty::TraitContainer(parent_def_id.to_def_id()),
-        fn_has_self_parameter: has_self,
     }
 }
 
@@ -106,20 +100,14 @@ fn associated_item_from_impl_item_ref(
     impl_item_ref: &hir::ImplItemRef<'_>,
 ) -> ty::AssocItem {
     let def_id = tcx.hir().local_def_id(impl_item_ref.id.hir_id);
-    let (kind, has_self) = match impl_item_ref.kind {
-        hir::AssocItemKind::Const => (ty::AssocKind::Const, false),
-        hir::AssocItemKind::Fn { has_self } => (ty::AssocKind::Fn, has_self),
-        hir::AssocItemKind::Type => (ty::AssocKind::Type, false),
-    };
 
     ty::AssocItem {
         ident: impl_item_ref.ident,
-        kind,
+        kind: impl_item_ref.kind,
         vis: tcx.visibility(def_id),
         defaultness: impl_item_ref.defaultness,
         def_id: def_id.to_def_id(),
         container: ty::ImplContainer(parent_def_id.to_def_id()),
-        fn_has_self_parameter: has_self,
     }
 }
 

--- a/compiler/rustc_typeck/src/astconv/errors.rs
+++ b/compiler/rustc_typeck/src/astconv/errors.rs
@@ -174,9 +174,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let all_candidate_names: Vec<_> = all_candidates()
             .map(|r| self.tcx().associated_items(r.def_id()).in_definition_order())
             .flatten()
-            .filter_map(
-                |item| if item.kind == ty::AssocKind::Type { Some(item.ident.name) } else { None },
-            )
+            .filter_map(|item| {
+                if item.kind == hir::AssocItemKind::Type { Some(item.ident.name) } else { None }
+            })
             .collect();
 
         if let (Some(suggested_name), true) = (

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -749,7 +749,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     fn trait_defines_associated_type_named(&self, trait_def_id: DefId, assoc_name: Ident) -> bool {
         self.tcx()
             .associated_items(trait_def_id)
-            .find_by_name_and_kind(self.tcx(), assoc_name, ty::AssocKind::Type, trait_def_id)
+            .find_by_name_and_kind(self.tcx(), assoc_name, hir::AssocItemKind::Type, trait_def_id)
             .is_some()
     }
 
@@ -981,7 +981,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             .associated_items(candidate.def_id())
             .filter_by_name_unhygienic(assoc_ident.name)
             .find(|i| {
-                i.kind == ty::AssocKind::Type && i.ident.normalize_to_macros_2_0() == assoc_ident
+                i.kind == hir::AssocItemKind::Type
+                    && i.ident.normalize_to_macros_2_0() == assoc_ident
             })
             .expect("missing associated type");
 
@@ -1164,7 +1165,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         associated_types.entry(span).or_default().extend(
                             tcx.associated_items(pred.def_id())
                                 .in_definition_order()
-                                .filter(|item| item.kind == ty::AssocKind::Type)
+                                .filter(|item| item.kind == hir::AssocItemKind::Type)
                                 .map(|item| item.def_id),
                         );
                     }
@@ -1438,7 +1439,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let bound_span = self
                     .tcx()
                     .associated_items(bound_id)
-                    .find_by_name_and_kind(self.tcx(), assoc_name, ty::AssocKind::Type, bound_id)
+                    .find_by_name_and_kind(
+                        self.tcx(),
+                        assoc_name,
+                        hir::AssocItemKind::Type,
+                        bound_id,
+                    )
                     .and_then(|item| self.tcx().hir().span_if_local(item.def_id));
 
                 if let Some(bound_span) = bound_span {

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -510,7 +510,7 @@ fn compare_self_type<'tcx>(
         })
     };
 
-    match (trait_m.fn_has_self_parameter, impl_m.fn_has_self_parameter) {
+    match (trait_m.fn_has_self_parameter(), impl_m.fn_has_self_parameter()) {
         (false, false) | (true, true) => {}
 
         (false, true) => {
@@ -1292,8 +1292,8 @@ pub fn check_type_bounds<'tcx>(
 
 fn assoc_item_kind_str(impl_item: &ty::AssocItem) -> &'static str {
     match impl_item.kind {
-        ty::AssocKind::Const => "const",
-        ty::AssocKind::Fn => "method",
-        ty::AssocKind::Type => "type",
+        hir::AssocItemKind::Const => "const",
+        hir::AssocItemKind::Fn { .. } => "method",
+        hir::AssocItemKind::Type => "type",
     }
 }

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -255,8 +255,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// This function checks whether the method is not static and does not accept other parameters than `self`.
     fn has_only_self_parameter(&self, method: &AssocItem) -> bool {
         match method.kind {
-            ty::AssocKind::Fn => {
-                method.fn_has_self_parameter
+            hir::AssocItemKind::Fn { .. } => {
+                method.fn_has_self_parameter()
                     && self.tcx.fn_sig(method.def_id).inputs().skip_binder().len() == 1
             }
             _ => false,

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -158,8 +158,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             let path = self.tcx.def_path_str(trait_ref.def_id);
 
                             let ty = match item.kind {
-                                ty::AssocKind::Const | ty::AssocKind::Type => rcvr_ty,
-                                ty::AssocKind::Fn => self
+                                hir::AssocItemKind::Const | hir::AssocItemKind::Type => rcvr_ty,
+                                hir::AssocItemKind::Fn { .. } => self
                                     .tcx
                                     .fn_sig(item.def_id)
                                     .inputs()
@@ -1004,7 +1004,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     && self
                         .associated_item(info.def_id, item_name, Namespace::ValueNS)
                         .filter(|item| {
-                            if let ty::AssocKind::Fn = item.kind {
+                            if item.kind.is_fn() {
                                 let id = item
                                     .def_id
                                     .as_local()
@@ -1429,14 +1429,14 @@ fn print_disambiguation_help(
     err: &mut DiagnosticBuilder<'_>,
     trait_name: String,
     rcvr_ty: Ty<'_>,
-    kind: ty::AssocKind,
+    kind: hir::AssocItemKind,
     def_id: DefId,
     span: Span,
     candidate: Option<usize>,
     source_map: &source_map::SourceMap,
 ) {
     let mut applicability = Applicability::MachineApplicable;
-    let sugg_args = if let (ty::AssocKind::Fn, Some(args)) = (kind, args) {
+    let sugg_args = if let (hir::AssocItemKind::Fn { .. }, Some(args)) = (kind, args) {
         format!(
             "({}{})",
             if rcvr_ty.is_region_ptr() {

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -401,12 +401,12 @@ fn check_associated_item(
         };
 
         match item.kind {
-            ty::AssocKind::Const => {
+            hir::AssocItemKind::Const => {
                 let ty = fcx.tcx.type_of(item.def_id);
                 let ty = fcx.normalize_associated_types_in(span, ty);
                 fcx.register_wf_obligation(ty.into(), span, code.clone());
             }
-            ty::AssocKind::Fn => {
+            hir::AssocItemKind::Fn { .. } => {
                 let sig = fcx.tcx.fn_sig(item.def_id);
                 let sig = fcx.normalize_associated_types_in(span, sig);
                 let hir_sig = sig_if_method.expect("bad signature for method");
@@ -421,7 +421,7 @@ fn check_associated_item(
                 );
                 check_method_receiver(fcx, hir_sig, &item, self_ty);
             }
-            ty::AssocKind::Type => {
+            hir::AssocItemKind::Type => {
                 if let ty::AssocItemContainer::TraitContainer(_) = item.container {
                     check_associated_type_bounds(fcx, item, span)
                 }
@@ -1058,7 +1058,7 @@ fn check_method_receiver<'fcx, 'tcx>(
     // Check that the method has a valid receiver type, given the type `Self`.
     debug!("check_method_receiver({:?}, self_ty={:?})", method, self_ty);
 
-    if !method.fn_has_self_parameter {
+    if !method.fn_has_self_parameter() {
         return;
     }
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2866,7 +2866,7 @@ fn should_inherit_track_caller(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
                     .associated_items(trait_def_id)
                     .filter_by_name_unhygienic(impl_item.ident.name)
                     .find(move |trait_item| {
-                        trait_item.kind == ty::AssocKind::Fn
+                        trait_item.kind.is_fn()
                             && tcx.hygienic_eq(impl_item.ident, trait_item.ident, trait_def_id)
                     })
                 {

--- a/compiler/rustc_typeck/src/impl_wf_check.rs
+++ b/compiler/rustc_typeck/src/impl_wf_check.rs
@@ -133,14 +133,14 @@ fn enforce_impl_params_are_constrained(
         .flat_map(|def_id| {
             let item = tcx.associated_item(def_id);
             match item.kind {
-                ty::AssocKind::Type => {
+                hir::AssocItemKind::Type => {
                     if item.defaultness.has_value() {
                         cgp::parameters_for(&tcx.type_of(def_id), true)
                     } else {
                         Vec::new()
                     }
                 }
-                ty::AssocKind::Fn | ty::AssocKind::Const => Vec::new(),
+                hir::AssocItemKind::Fn { .. } | hir::AssocItemKind::Const => Vec::new(),
             }
         })
         .collect();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1144,7 +1144,7 @@ impl Clean<Item> for hir::ImplItem<'_> {
 impl Clean<Item> for ty::AssocItem {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
         let kind = match self.kind {
-            ty::AssocKind::Const => {
+            hir::AssocItemKind::Const => {
                 let ty = cx.tcx.type_of(self.def_id);
                 let default = if self.defaultness.has_value() {
                     Some(inline::print_inlined_const(cx, self.def_id))
@@ -1153,14 +1153,14 @@ impl Clean<Item> for ty::AssocItem {
                 };
                 AssocConstItem(ty.clean(cx), default)
             }
-            ty::AssocKind::Fn => {
+            hir::AssocItemKind::Fn { has_self } => {
                 let generics =
                     (cx.tcx.generics_of(self.def_id), cx.tcx.explicit_predicates_of(self.def_id))
                         .clean(cx);
                 let sig = cx.tcx.fn_sig(self.def_id);
                 let mut decl = (self.def_id, sig).clean(cx);
 
-                if self.fn_has_self_parameter {
+                if has_self {
                     let self_ty = match self.container {
                         ty::ImplContainer(def_id) => cx.tcx.type_of(def_id),
                         ty::TraitContainer(_) => cx.tcx.types.self_param,
@@ -1226,7 +1226,7 @@ impl Clean<Item> for ty::AssocItem {
                     })
                 }
             }
-            ty::AssocKind::Type => {
+            hir::AssocItemKind::Type => {
                 let my_name = self.ident.name.clean(cx);
 
                 if let ty::TraitContainer(_) = self.container {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -21,7 +21,7 @@ use rustc_hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::Mutability;
 use rustc_index::vec::IndexVec;
-use rustc_middle::ty::{AssocKind, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_span::hygiene::MacroKind;
 use rustc_span::source_map::DUMMY_SP;
 use rustc_span::symbol::{kw, sym, Ident, Symbol, SymbolStr};
@@ -331,11 +331,14 @@ impl ItemKind {
         }
     }
 
-    crate fn as_assoc_kind(&self) -> Option<AssocKind> {
+    crate fn as_assoc_kind(&self) -> Option<hir::AssocItemKind> {
         match *self {
-            ItemKind::AssocConstItem(..) => Some(AssocKind::Const),
-            ItemKind::AssocTypeItem(..) => Some(AssocKind::Type),
-            ItemKind::TyMethodItem(..) | ItemKind::MethodItem(..) => Some(AssocKind::Fn),
+            ItemKind::AssocConstItem(..) => Some(hir::AssocItemKind::Const),
+            ItemKind::AssocTypeItem(..) => Some(hir::AssocItemKind::Type),
+            ItemKind::TyMethodItem(Function { ref decl, .. })
+            | ItemKind::MethodItem(Function { ref decl, .. }, _) => {
+                Some(hir::AssocItemKind::Fn { has_self: decl.self_type().is_some() })
+            }
             _ => None,
         }
     }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -310,9 +310,9 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                         impl_,
                     )
                     .map(|item| match item.kind {
-                        ty::AssocKind::Fn => "method",
-                        ty::AssocKind::Const => "associatedconstant",
-                        ty::AssocKind::Type => "associatedtype",
+                        hir::AssocItemKind::Fn { .. } => "method",
+                        hir::AssocItemKind::Const => "associatedconstant",
+                        hir::AssocItemKind::Type => "associatedtype",
                     })
                     .map(|out| {
                         (
@@ -524,9 +524,9 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
 
                 if let Some((kind, id)) = assoc_item {
                     let out = match kind {
-                        ty::AssocKind::Fn => "method",
-                        ty::AssocKind::Const => "associatedconstant",
-                        ty::AssocKind::Type => "associatedtype",
+                        hir::AssocItemKind::Fn { .. } => "method",
+                        hir::AssocItemKind::Const => "associatedconstant",
+                        hir::AssocItemKind::Type => "associatedtype",
                     };
                     Some(if extra_fragment.is_some() {
                         Err(ErrorKind::AnchorFailure(AnchorFailure::RustdocAnchorConflict(ty_res)))
@@ -588,9 +588,9 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                 .find_by_name_and_namespace(cx.tcx, Ident::with_dummy_span(item_name), ns, did)
                 .map(|item| {
                     let kind = match item.kind {
-                        ty::AssocKind::Const => "associatedconstant",
-                        ty::AssocKind::Type => "associatedtype",
-                        ty::AssocKind::Fn => {
+                        hir::AssocItemKind::Const => "associatedconstant",
+                        hir::AssocItemKind::Type => "associatedtype",
+                        hir::AssocItemKind::Fn { .. } => {
                             if item.defaultness.has_value() {
                                 "method"
                             } else {
@@ -665,7 +665,7 @@ fn resolve_associated_trait_item(
     item_name: Symbol,
     ns: Namespace,
     cx: &DocContext<'_>,
-) -> Option<(ty::AssocKind, DefId)> {
+) -> Option<(hir::AssocItemKind, DefId)> {
     let ty = cx.tcx.type_of(did);
     // First consider blanket impls: `impl From<T> for T`
     let implicit_impls = crate::clean::get_auto_trait_and_blanket_impls(cx, ty, did);

--- a/src/tools/clippy/clippy_lints/src/len_zero.rs
+++ b/src/tools/clippy/clippy_lints/src/len_zero.rs
@@ -186,8 +186,8 @@ fn check_trait_items(cx: &LateContext<'_>, visited_trait: &Item<'_>, trait_items
             .iter()
             .flat_map(|&i| cx.tcx.associated_items(i).in_definition_order())
             .any(|i| {
-                i.kind == ty::AssocKind::Fn
-                    && i.fn_has_self_parameter
+                i.kind.is_fn()
+                    && i.fn_has_self_parameter()
                     && i.ident.name == sym!(is_empty)
                     && cx.tcx.fn_sig(i.def_id).inputs().skip_binder().len() == 1
             });
@@ -337,7 +337,7 @@ fn is_empty_array(expr: &Expr<'_>) -> bool {
 fn has_is_empty(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
     /// Gets an `AssocItem` and return true if it matches `is_empty(self)`.
     fn is_is_empty(cx: &LateContext<'_>, item: &ty::AssocItem) -> bool {
-        if let ty::AssocKind::Fn = item.kind {
+        if item.kind.is_fn() {
             if item.ident.name.as_str() == "is_empty" {
                 let sig = cx.tcx.fn_sig(item.def_id);
                 let ty = sig.skip_binder();

--- a/src/tools/clippy/clippy_lints/src/non_copy_const.rs
+++ b/src/tools/clippy/clippy_lints/src/non_copy_const.rs
@@ -5,11 +5,13 @@
 use std::ptr;
 
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::{Expr, ExprKind, ImplItem, ImplItemKind, Item, ItemKind, Node, TraitItem, TraitItemKind, UnOp};
+use rustc_hir::{
+    AssocItemKind, Expr, ExprKind, ImplItem, ImplItemKind, Item, ItemKind, Node, TraitItem, TraitItemKind, UnOp,
+};
 use rustc_infer::traits::specialization_graph;
 use rustc_lint::{LateContext, LateLintPass, Lint};
 use rustc_middle::ty::adjustment::Adjust;
-use rustc_middle::ty::{AssocKind, Ty};
+use rustc_middle::ty::Ty;
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::{InnerSpan, Span, DUMMY_SP};
 use rustc_typeck::hir_ty_to_ty;
@@ -196,7 +198,7 @@ impl<'tcx> LateLintPass<'tcx> for NonCopyConst {
                         // assuming a assoc const is not meant to be a interior mutable type.
                         if let Some(of_trait_def_id) = of_trait_ref.trait_def_id();
                         if let Some(of_assoc_item) = specialization_graph::Node::Trait(of_trait_def_id)
-                            .item(cx.tcx, impl_item.ident, AssocKind::Const, of_trait_def_id);
+                            .item(cx.tcx, impl_item.ident, AssocItemKind::Const, of_trait_def_id);
                         if cx
                             .tcx
                             .layout_of(cx.tcx.param_env(of_trait_def_id).and(

--- a/src/tools/clippy/clippy_lints/src/unused_self.rs
+++ b/src/tools/clippy/clippy_lints/src/unused_self.rs
@@ -50,7 +50,7 @@ impl<'tcx> LateLintPass<'tcx> for UnusedSelf {
         let assoc_item = cx.tcx.associated_item(def_id);
         if_chain! {
             if let ItemKind::Impl { of_trait: None, .. } = parent_item.kind;
-            if assoc_item.fn_has_self_parameter;
+            if assoc_item.fn_has_self_parameter();
             if let ImplItemKind::Fn(.., body_id) = &impl_item.kind;
             let body = cx.tcx.hir().body(*body_id);
             if !body.params.is_empty();

--- a/src/tools/clippy/clippy_lints/src/use_self.rs
+++ b/src/tools/clippy/clippy_lints/src/use_self.rs
@@ -119,7 +119,8 @@ fn check_trait_method_impl_decl<'tcx>(
     let trait_method = cx
         .tcx
         .associated_items(impl_trait_ref.def_id)
-        .find_by_name_and_kind(cx.tcx, impl_item.ident, ty::AssocKind::Fn, impl_trait_ref.def_id)
+        .filter_by_name(cx.tcx, impl_item.ident, impl_trait_ref.def_id)
+        .find(|i| i.kind.is_fn())
         .expect("impl method matches a trait method");
 
     let trait_method_sig = cx.tcx.fn_sig(trait_method.def_id);


### PR DESCRIPTION
Both types serve the same purpose.