### PR TITLE
Add #[track_caller] to panicking Vec functions

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -126,6 +126,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     /// Like `with_capacity`, but parameterized over the choice of
     /// allocator for the returned `RawVec`.
     #[inline]
+    #[track_caller]
     pub fn with_capacity_in(capacity: usize, alloc: A) -> Self {
         Self::allocate_in(capacity, AllocInit::Uninitialized, alloc)
     }
@@ -133,6 +134,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     /// Like `with_capacity_zeroed`, but parameterized over the choice
     /// of allocator for the returned `RawVec`.
     #[inline]
+    #[track_caller]
     pub fn with_capacity_zeroed_in(capacity: usize, alloc: A) -> Self {
         Self::allocate_in(capacity, AllocInit::Zeroed, alloc)
     }
@@ -171,6 +173,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
         }
     }
 
+    #[track_caller]
     fn allocate_in(capacity: usize, init: AllocInit, alloc: A) -> Self {
         if mem::size_of::<T>() == 0 {
             Self::new_in(alloc)
@@ -302,6 +305,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     /// #   vector.push_all(&[1, 3, 5, 7, 9]);
     /// # }
     /// ```
+    #[track_caller]
     pub fn reserve(&mut self, len: usize, additional: usize) {
         handle_reserve(self.try_reserve(len, additional));
     }
@@ -332,6 +336,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     /// # Aborts
     ///
     /// Aborts on OOM.
+    #[track_caller]
     pub fn reserve_exact(&mut self, len: usize, additional: usize) {
         handle_reserve(self.try_reserve_exact(len, additional));
     }
@@ -355,6 +360,7 @@ impl<T, A: AllocRef> RawVec<T, A> {
     /// # Aborts
     ///
     /// Aborts on OOM.
+    #[track_caller]
     pub fn shrink_to_fit(&mut self, amount: usize) {
         handle_reserve(self.shrink(amount));
     }
@@ -504,6 +510,7 @@ unsafe impl<#[may_dangle] T, A: AllocRef> Drop for RawVec<T, A> {
 
 // Central function for reserve error handling.
 #[inline]
+#[track_caller]
 fn handle_reserve(result: Result<(), TryReserveError>) {
     match result {
         Err(CapacityOverflow) => capacity_overflow(),
@@ -533,6 +540,7 @@ fn alloc_guard(alloc_size: usize) -> Result<(), TryReserveError> {
 // One central function responsible for reporting capacity overflows. This'll
 // ensure that the code generation related to these panics is minimal as there's
 // only one location which panics rather than a bunch throughout the module.
+#[track_caller]
 fn capacity_overflow() -> ! {
     panic!("capacity overflow");
 }


### PR DESCRIPTION
When allocation fails, it's very helpful to know where in user code.