### PR TITLE
Update error to reflect that integer literals can have float suffixes

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1450,10 +1450,10 @@ impl<'a> Parser<'a> {
                         .help("valid widths are 8, 16, 32, 64 and 128")
                         .emit();
                 } else {
-                    let msg = format!("invalid suffix `{}` for integer literal", suf);
+                    let msg = format!("invalid suffix `{}` for number literal", suf);
                     self.struct_span_err(span, &msg)
                         .span_label(span, format!("invalid suffix `{}`", suf))
-                        .help("the suffix must be one of the integral types (`u32`, `isize`, etc)")
+                        .help("the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)")
                         .emit();
                 }
             }

--- a/src/test/ui/old-suffixes-are-really-forbidden.stderr
+++ b/src/test/ui/old-suffixes-are-really-forbidden.stderr
@@ -1,18 +1,18 @@
-error: invalid suffix `is` for integer literal
+error: invalid suffix `is` for number literal
   --> $DIR/old-suffixes-are-really-forbidden.rs:2:13
    |
 LL |     let a = 1_is;
    |             ^^^^ invalid suffix `is`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
-error: invalid suffix `us` for integer literal
+error: invalid suffix `us` for number literal
   --> $DIR/old-suffixes-are-really-forbidden.rs:3:13
    |
 LL |     let b = 2_us;
    |             ^^^^ invalid suffix `us`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/bad-lit-suffixes.rs
+++ b/src/test/ui/parser/bad-lit-suffixes.rs
@@ -19,8 +19,8 @@ fn main() {
     1234f1024; //~ ERROR invalid width `1024` for float literal
     1234.5f1024; //~ ERROR invalid width `1024` for float literal
 
-    1234suffix; //~ ERROR invalid suffix `suffix` for integer literal
-    0b101suffix; //~ ERROR invalid suffix `suffix` for integer literal
+    1234suffix; //~ ERROR invalid suffix `suffix` for number literal
+    0b101suffix; //~ ERROR invalid suffix `suffix` for number literal
     1.0suffix; //~ ERROR invalid suffix `suffix` for float literal
     1.0e10suffix; //~ ERROR invalid suffix `suffix` for float literal
 }

--- a/src/test/ui/parser/bad-lit-suffixes.stderr
+++ b/src/test/ui/parser/bad-lit-suffixes.stderr
@@ -78,21 +78,21 @@ LL |     1234.5f1024;
    |
    = help: valid widths are 32 and 64
 
-error: invalid suffix `suffix` for integer literal
+error: invalid suffix `suffix` for number literal
   --> $DIR/bad-lit-suffixes.rs:22:5
    |
 LL |     1234suffix;
    |     ^^^^^^^^^^ invalid suffix `suffix`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
-error: invalid suffix `suffix` for integer literal
+error: invalid suffix `suffix` for number literal
   --> $DIR/bad-lit-suffixes.rs:23:5
    |
 LL |     0b101suffix;
    |     ^^^^^^^^^^^ invalid suffix `suffix`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
 error: invalid suffix `suffix` for float literal
   --> $DIR/bad-lit-suffixes.rs:24:5

--- a/src/test/ui/parser/no-binary-float-literal.rs
+++ b/src/test/ui/parser/no-binary-float-literal.rs
@@ -4,5 +4,5 @@ fn main() {
     0b101.010;
     //~^ ERROR binary float literal is not supported
     0b101p4f64;
-    //~^ ERROR invalid suffix `p4f64` for integer literal
+    //~^ ERROR invalid suffix `p4f64` for number literal
 }

--- a/src/test/ui/parser/no-binary-float-literal.stderr
+++ b/src/test/ui/parser/no-binary-float-literal.stderr
@@ -10,13 +10,13 @@ error: binary float literal is not supported
 LL |     0b101010f64;
    |     ^^^^^^^^^^^ not supported
 
-error: invalid suffix `p4f64` for integer literal
+error: invalid suffix `p4f64` for number literal
   --> $DIR/no-binary-float-literal.rs:6:5
    |
 LL |     0b101p4f64;
    |     ^^^^^^^^^^ invalid suffix `p4f64`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/clippy/tests/ui/crashes/ice-3891.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-3891.stderr
@@ -1,10 +1,10 @@
-error: invalid suffix `x` for integer literal
+error: invalid suffix `x` for number literal
   --> $DIR/ice-3891.rs:2:5
    |
 LL |     1x;
    |     ^^ invalid suffix `x`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
 
 error: aborting due to previous error
 


### PR DESCRIPTION
For example, `1` is parsed as an integer literal, but it can be turned
into a float with the suffix `f32`. Now the error calls them "numeric
literals" and notes that you can add a float suffix since they can be
either integers or floats.
