### PR TITLE
Get rid of doctree::Function

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -1,4 +1,3 @@
-use rustc_attr as attr;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync::{self, Lrc};
 use rustc_driver::abort_on_err;
@@ -155,21 +154,6 @@ impl<'tcx> DocContext<'tcx> {
         } else {
             def_id.as_local().map(|def_id| self.tcx.hir().local_def_id_to_hir_id(def_id))
         }
-    }
-
-    crate fn stability(&self, id: HirId) -> Option<attr::Stability> {
-        self.tcx
-            .hir()
-            .opt_local_def_id(id)
-            .and_then(|def_id| self.tcx.lookup_stability(def_id.to_def_id()))
-            .cloned()
-    }
-
-    crate fn deprecation(&self, id: HirId) -> Option<attr::Deprecation> {
-        self.tcx
-            .hir()
-            .opt_local_def_id(id)
-            .and_then(|def_id| self.tcx.lookup_deprecation(def_id.to_def_id()))
     }
 }
 

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -23,7 +23,6 @@ crate struct Module<'hir> {
     // (item, renamed)
     crate items: Vec<(&'hir hir::Item<'hir>, Option<Ident>)>,
     crate traits: Vec<Trait<'hir>>,
-    crate impls: Vec<Impl<'hir>>,
     crate foreigns: Vec<ForeignItem<'hir>>,
     crate macros: Vec<Macro>,
     crate proc_macros: Vec<ProcMacro>,
@@ -44,7 +43,6 @@ impl Module<'hir> {
             mods: Vec::new(),
             items: Vec::new(),
             traits: Vec::new(),
-            impls: Vec::new(),
             foreigns: Vec::new(),
             macros: Vec::new(),
             proc_macros: Vec::new(),
@@ -86,22 +84,6 @@ crate struct Trait<'hir> {
     crate generics: &'hir hir::Generics<'hir>,
     crate bounds: &'hir [hir::GenericBound<'hir>],
     crate attrs: &'hir [ast::Attribute],
-    crate id: hir::HirId,
-}
-
-#[derive(Debug)]
-crate struct Impl<'hir> {
-    crate unsafety: hir::Unsafety,
-    crate polarity: hir::ImplPolarity,
-    crate defaultness: hir::Defaultness,
-    crate constness: hir::Constness,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate trait_: &'hir Option<hir::TraitRef<'hir>>,
-    crate for_: &'hir hir::Ty<'hir>,
-    crate items: Vec<&'hir hir::ImplItem<'hir>>,
-    crate attrs: &'hir [ast::Attribute],
-    crate span: Span,
-    crate vis: &'hir hir::Visibility<'hir>,
     crate id: hir::HirId,
 }
 

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -23,7 +23,7 @@ crate struct Module<'hir> {
     // (item, renamed)
     crate items: Vec<(&'hir hir::Item<'hir>, Option<Ident>)>,
     crate traits: Vec<Trait<'hir>>,
-    crate foreigns: Vec<ForeignItem<'hir>>,
+    crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Ident>)>,
     crate macros: Vec<Macro>,
     crate proc_macros: Vec<ProcMacro>,
     crate is_crate: bool,
@@ -85,12 +85,6 @@ crate struct Trait<'hir> {
     crate bounds: &'hir [hir::GenericBound<'hir>],
     crate attrs: &'hir [ast::Attribute],
     crate id: hir::HirId,
-}
-
-crate struct ForeignItem<'hir> {
-    crate id: hir::HirId,
-    crate name: Symbol,
-    crate kind: &'hir hir::ForeignItemKind<'hir>,
 }
 
 // For Macro we store the DefId instead of the NodeId, since we also create

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -3,7 +3,6 @@
 crate use self::StructType::*;
 
 use rustc_ast as ast;
-use rustc_span::hygiene::MacroKind;
 use rustc_span::{self, symbol::Ident, Span, Symbol};
 
 use rustc_hir as hir;
@@ -17,7 +16,6 @@ crate struct Module<'hir> {
     crate where_inner: Span,
     crate extern_crates: Vec<ExternCrate<'hir>>,
     crate imports: Vec<Import<'hir>>,
-    crate fns: Vec<Function<'hir>>,
     crate mods: Vec<Module<'hir>>,
     crate id: hir::HirId,
     // (item, renamed)
@@ -25,7 +23,6 @@ crate struct Module<'hir> {
     crate traits: Vec<Trait<'hir>>,
     crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Ident>)>,
     crate macros: Vec<Macro>,
-    crate proc_macros: Vec<ProcMacro>,
     crate is_crate: bool,
 }
 
@@ -39,13 +36,11 @@ impl Module<'hir> {
             attrs,
             extern_crates: Vec::new(),
             imports: Vec::new(),
-            fns: Vec::new(),
             mods: Vec::new(),
             items: Vec::new(),
             traits: Vec::new(),
             foreigns: Vec::new(),
             macros: Vec::new(),
-            proc_macros: Vec::new(),
             is_crate: false,
         }
     }
@@ -65,15 +60,6 @@ crate struct Variant<'hir> {
     crate name: Symbol,
     crate id: hir::HirId,
     crate def: &'hir hir::VariantData<'hir>,
-}
-
-crate struct Function<'hir> {
-    crate decl: &'hir hir::FnDecl<'hir>,
-    crate id: hir::HirId,
-    crate name: Symbol,
-    crate header: hir::FnHeader,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate body: hir::BodyId,
 }
 
 crate struct Trait<'hir> {
@@ -115,13 +101,6 @@ crate struct Import<'hir> {
     crate path: &'hir hir::Path<'hir>,
     crate glob: bool,
     crate span: Span,
-}
-
-crate struct ProcMacro {
-    crate name: Symbol,
-    crate id: hir::HirId,
-    crate kind: MacroKind,
-    crate helpers: Vec<Symbol>,
 }
 
 crate fn struct_type_from_def(vdata: &hir::VariantData<'_>) -> StructType {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -401,37 +401,11 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 };
                 om.traits.push(t);
             }
-            hir::ItemKind::Impl {
-                unsafety,
-                polarity,
-                defaultness,
-                constness,
-                defaultness_span: _,
-                ref generics,
-                ref of_trait,
-                self_ty,
-                ref items,
-            } => {
+            hir::ItemKind::Impl { ref of_trait, .. } => {
                 // Don't duplicate impls when inlining or if it's implementing a trait, we'll pick
                 // them up regardless of where they're located.
                 if !self.inlining && of_trait.is_none() {
-                    let items =
-                        items.iter().map(|item| self.cx.tcx.hir().impl_item(item.id)).collect();
-                    let i = Impl {
-                        unsafety,
-                        polarity,
-                        defaultness,
-                        constness,
-                        generics,
-                        trait_: of_trait,
-                        for_: self_ty,
-                        items,
-                        attrs: &item.attrs,
-                        id: item.hir_id,
-                        span: item.span,
-                        vis: &item.vis,
-                    };
-                    om.impls.push(i);
+                    om.items.push((item, None));
                 }
             }
         }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -418,15 +418,9 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         om: &mut Module<'tcx>,
     ) {
         // If inlining we only want to include public functions.
-        if self.inlining && !item.vis.node.is_pub() {
-            return;
+        if !self.inlining || item.vis.node.is_pub() {
+            om.foreigns.push((item, renamed));
         }
-
-        om.foreigns.push(ForeignItem {
-            id: item.hir_id,
-            name: renamed.unwrap_or(item.ident).name,
-            kind: &item.kind,
-        });
     }
 
     // Convert each `exported_macro` into a doc item.

--- a/src/test/rustdoc-ui/intra-link-errors.stderr
+++ b/src/test/rustdoc-ui/intra-link-errors.stderr
@@ -106,6 +106,15 @@ LL | /// [S!]
    |      this link resolves to the struct `S`, which is not in the macro namespace
    |      help: to link to the struct, prefix with `struct@`: `struct@S`
 
+error: unresolved link to `S::h`
+  --> $DIR/intra-link-errors.rs:78:6
+   |
+LL | /// [type@S::h]
+   |      ^^^^^^^^^
+   |      |
+   |      this link resolves to the associated function `h`, which is not in the type namespace
+   |      help: to link to the associated function, add parentheses: `S::h()`
+
 error: unresolved link to `T::g`
   --> $DIR/intra-link-errors.rs:86:6
    |
@@ -120,15 +129,6 @@ error: unresolved link to `T::h`
    |
 LL | /// [T::h!]
    |      ^^^^^ the trait `T` has no macro named `h`
-
-error: unresolved link to `S::h`
-  --> $DIR/intra-link-errors.rs:78:6
-   |
-LL | /// [type@S::h]
-   |      ^^^^^^^^^
-   |      |
-   |      this link resolves to the associated function `h`, which is not in the type namespace
-   |      help: to link to the associated function, add parentheses: `S::h()`
 
 error: unresolved link to `m`
   --> $DIR/intra-link-errors.rs:98:6

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -36,6 +36,14 @@ warning: unresolved link to `Qux::Z`
 LL |       //! , [Uniooon::X] and [Qux::Z].
    |                               ^^^^^^ no item named `Qux` in scope
 
+warning: unresolved link to `Qux:Y`
+  --> $DIR/intra-links-warning.rs:14:13
+   |
+LL |        /// [Qux:Y]
+   |             ^^^^^ no item named `Qux:Y` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
 warning: unresolved link to `BarA`
   --> $DIR/intra-links-warning.rs:21:10
    |
@@ -89,14 +97,6 @@ LL | f!("Foo\nbar [BarF] bar\nbaz");
    = note: no item named `BarF` in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: unresolved link to `Qux:Y`
-  --> $DIR/intra-links-warning.rs:14:13
-   |
-LL |        /// [Qux:Y]
-   |             ^^^^^ no item named `Qux:Y` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:58:30


### PR DESCRIPTION
Builds on https://github.com/rust-lang/rust/pull/79312 and https://github.com/rust-lang/rust/pull/79314 and should not be merged before. Follow-up to #79264, continues breaking up #78082. 

@GuillaumeGomez let me know if these would be easier to review as one PR - they're fairly independent, I just don't want to keep rebasing over the conflicts because git isn't smart.

r? @GuillaumeGomez 