### PR TITLE
Get rid of doctree::{ExternalCrate, ForeignItem, Trait, Function}

### DIFF
--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -23,7 +23,7 @@ crate struct Module<'hir> {
     // (item, renamed)
     crate items: Vec<(&'hir hir::Item<'hir>, Option<Ident>)>,
     crate traits: Vec<Trait<'hir>>,
-    crate foreigns: Vec<ForeignItem<'hir>>,
+    crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Ident>)>,
     crate macros: Vec<Macro>,
     crate proc_macros: Vec<ProcMacro>,
     crate is_crate: bool,
@@ -85,12 +85,6 @@ crate struct Trait<'hir> {
     crate bounds: &'hir [hir::GenericBound<'hir>],
     crate attrs: &'hir [ast::Attribute],
     crate id: hir::HirId,
-}
-
-crate struct ForeignItem<'hir> {
-    crate id: hir::HirId,
-    crate name: Symbol,
-    crate kind: &'hir hir::ForeignItemKind<'hir>,
 }
 
 // For Macro we store the DefId instead of the NodeId, since we also create

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -6,15 +6,12 @@ use rustc_ast as ast;
 use rustc_span::{self, symbol::Ident, Span, Symbol};
 
 use rustc_hir as hir;
-use rustc_hir::def_id::CrateNum;
-use rustc_hir::HirId;
 
 crate struct Module<'hir> {
     crate name: Option<Symbol>,
     crate attrs: &'hir [ast::Attribute],
     crate where_outer: Span,
     crate where_inner: Span,
-    crate extern_crates: Vec<ExternCrate<'hir>>,
     crate imports: Vec<Import<'hir>>,
     crate mods: Vec<Module<'hir>>,
     crate id: hir::HirId,
@@ -33,7 +30,6 @@ impl Module<'hir> {
             where_outer: rustc_span::DUMMY_SP,
             where_inner: rustc_span::DUMMY_SP,
             attrs,
-            extern_crates: Vec::new(),
             imports: Vec::new(),
             mods: Vec::new(),
             items: Vec::new(),
@@ -67,16 +63,6 @@ crate struct Macro {
     crate def_id: hir::def_id::DefId,
     crate matchers: Vec<Span>,
     crate imported_from: Option<Symbol>,
-}
-
-crate struct ExternCrate<'hir> {
-    crate name: Symbol,
-    crate hir_id: HirId,
-    crate cnum: CrateNum,
-    crate path: Option<String>,
-    crate vis: &'hir hir::Visibility<'hir>,
-    crate attrs: &'hir [ast::Attribute],
-    crate span: Span,
 }
 
 #[derive(Debug)]

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -20,7 +20,6 @@ crate struct Module<'hir> {
     crate id: hir::HirId,
     // (item, renamed)
     crate items: Vec<(&'hir hir::Item<'hir>, Option<Ident>)>,
-    crate traits: Vec<Trait<'hir>>,
     crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Ident>)>,
     crate macros: Vec<Macro>,
     crate is_crate: bool,
@@ -38,7 +37,6 @@ impl Module<'hir> {
             imports: Vec::new(),
             mods: Vec::new(),
             items: Vec::new(),
-            traits: Vec::new(),
             foreigns: Vec::new(),
             macros: Vec::new(),
             is_crate: false,
@@ -60,17 +58,6 @@ crate struct Variant<'hir> {
     crate name: Symbol,
     crate id: hir::HirId,
     crate def: &'hir hir::VariantData<'hir>,
-}
-
-crate struct Trait<'hir> {
-    crate is_auto: hir::IsAuto,
-    crate unsafety: hir::Unsafety,
-    crate name: Symbol,
-    crate items: Vec<&'hir hir::TraitItem<'hir>>,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate bounds: &'hir [hir::GenericBound<'hir>],
-    crate attrs: &'hir [ast::Attribute],
-    crate id: hir::HirId,
 }
 
 // For Macro we store the DefId instead of the NodeId, since we also create

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -3,7 +3,6 @@
 crate use self::StructType::*;
 
 use rustc_ast as ast;
-use rustc_span::hygiene::MacroKind;
 use rustc_span::{self, symbol::Ident, Span, Symbol};
 
 use rustc_hir as hir;
@@ -17,7 +16,6 @@ crate struct Module<'hir> {
     crate where_inner: Span,
     crate extern_crates: Vec<ExternCrate<'hir>>,
     crate imports: Vec<Import<'hir>>,
-    crate fns: Vec<Function<'hir>>,
     crate mods: Vec<Module<'hir>>,
     crate id: hir::HirId,
     // (item, renamed)
@@ -25,7 +23,6 @@ crate struct Module<'hir> {
     crate traits: Vec<Trait<'hir>>,
     crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Ident>)>,
     crate macros: Vec<Macro>,
-    crate proc_macros: Vec<ProcMacro>,
     crate is_crate: bool,
 }
 
@@ -39,13 +36,11 @@ impl Module<'hir> {
             attrs,
             extern_crates: Vec::new(),
             imports: Vec::new(),
-            fns: Vec::new(),
             mods: Vec::new(),
             items: Vec::new(),
             traits: Vec::new(),
             foreigns: Vec::new(),
             macros: Vec::new(),
-            proc_macros: Vec::new(),
             is_crate: false,
         }
     }
@@ -65,15 +60,6 @@ crate struct Variant<'hir> {
     crate name: Symbol,
     crate id: hir::HirId,
     crate def: &'hir hir::VariantData<'hir>,
-}
-
-crate struct Function<'hir> {
-    crate decl: &'hir hir::FnDecl<'hir>,
-    crate id: hir::HirId,
-    crate name: Symbol,
-    crate header: hir::FnHeader,
-    crate generics: &'hir hir::Generics<'hir>,
-    crate body: hir::BodyId,
 }
 
 crate struct Trait<'hir> {
@@ -115,13 +101,6 @@ crate struct Import<'hir> {
     crate path: &'hir hir::Path<'hir>,
     crate glob: bool,
     crate span: Span,
-}
-
-crate struct ProcMacro {
-    crate name: Symbol,
-    crate id: hir::HirId,
-    crate kind: MacroKind,
-    crate helpers: Vec<Symbol>,
 }
 
 crate fn struct_type_from_def(vdata: &hir::VariantData<'_>) -> StructType {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -418,15 +418,9 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         om: &mut Module<'tcx>,
     ) {
         // If inlining we only want to include public functions.
-        if self.inlining && !item.vis.node.is_pub() {
-            return;
+        if !self.inlining || item.vis.node.is_pub() {
+            om.foreigns.push((item, renamed));
         }
-
-        om.foreigns.push(ForeignItem {
-            id: item.hir_id,
-            name: renamed.unwrap_or(item.ident).name,
-            kind: &item.kind,
-        });
     }
 
     // Convert each `exported_macro` into a doc item.

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -5,7 +5,7 @@ use rustc_ast as ast;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefId, LOCAL_CRATE};
+use rustc_hir::def_id::DefId;
 use rustc_hir::Node;
 use rustc_middle::middle::privacy::AccessLevel;
 use rustc_middle::ty::TyCtxt;
@@ -248,18 +248,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             // If we're inlining, skip private items.
             _ if self.inlining && !item.vis.node.is_pub() => {}
             hir::ItemKind::GlobalAsm(..) => {}
-            hir::ItemKind::ExternCrate(orig_name) => {
-                let def_id = self.cx.tcx.hir().local_def_id(item.hir_id);
-                om.extern_crates.push(ExternCrate {
-                    cnum: self.cx.tcx.extern_mod_stmt_cnum(def_id).unwrap_or(LOCAL_CRATE),
-                    name: ident.name,
-                    hir_id: item.hir_id,
-                    path: orig_name.map(|x| x.to_string()),
-                    vis: &item.vis,
-                    attrs: &item.attrs,
-                    span: item.span,
-                })
-            }
             hir::ItemKind::Use(_, hir::UseKind::ListStem) => {}
             hir::ItemKind::Use(ref path, kind) => {
                 let is_glob = kind == hir::UseKind::Glob;
@@ -313,6 +301,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 ));
             }
             hir::ItemKind::Fn(..)
+            | hir::ItemKind::ExternCrate(..)
             | hir::ItemKind::Enum(..)
             | hir::ItemKind::Struct(..)
             | hir::ItemKind::Union(..)

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -319,6 +319,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             | hir::ItemKind::TyAlias(..)
             | hir::ItemKind::OpaqueTy(..)
             | hir::ItemKind::Static(..)
+            | hir::ItemKind::Trait(..)
             | hir::ItemKind::TraitAlias(..) => om.items.push((item, renamed)),
             hir::ItemKind::Const(..) => {
                 // Underscore constants do not correspond to a nameable item and
@@ -326,20 +327,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 if ident.name != kw::Underscore {
                     om.items.push((item, renamed));
                 }
-            }
-            hir::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, ref item_ids) => {
-                let items = item_ids.iter().map(|ti| self.cx.tcx.hir().trait_item(ti.id)).collect();
-                let t = Trait {
-                    is_auto,
-                    unsafety,
-                    name: ident.name,
-                    items,
-                    generics,
-                    bounds,
-                    id: item.hir_id,
-                    attrs: &item.attrs,
-                };
-                om.traits.push(t);
             }
             hir::ItemKind::Impl { ref of_trait, .. } => {
                 // Don't duplicate impls when inlining or if it's implementing a trait, we'll pick

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -36,6 +36,14 @@ warning: unresolved link to `Qux::Z`
 LL |       //! , [Uniooon::X] and [Qux::Z].
    |                               ^^^^^^ no item named `Qux` in scope
 
+warning: unresolved link to `Qux:Y`
+  --> $DIR/intra-links-warning.rs:14:13
+   |
+LL |        /// [Qux:Y]
+   |             ^^^^^ no item named `Qux:Y` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
 warning: unresolved link to `BarA`
   --> $DIR/intra-links-warning.rs:21:10
    |
@@ -89,14 +97,6 @@ LL | f!("Foo\nbar [BarF] bar\nbaz");
    = note: no item named `BarF` in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: unresolved link to `Qux:Y`
-  --> $DIR/intra-links-warning.rs:14:13
-   |
-LL |        /// [Qux:Y]
-   |             ^^^^^ no item named `Qux:Y` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 warning: unresolved link to `error`
   --> $DIR/intra-links-warning.rs:58:30


### PR DESCRIPTION
Closes #79314, closes #79331, closes #79332. Follow-up to #79264 and #79312, continues breaking up #78082.

r? @GuillaumeGomez 