### PR TITLE
BTreeMap: dig a moat around BoxedNode and NodeRef's raw pointer

### DIFF
--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -107,23 +107,28 @@ impl<K, V> InternalNode<K, V> {
     }
 }
 
-/// A managed, non-null pointer to a node. This is either an owned pointer to
-/// `LeafNode<K, V>` or an owned pointer to `InternalNode<K, V>`.
-///
-/// However, `BoxedNode` contains no information as to which of the two types
-/// of nodes it actually contains, and, partially due to this lack of information,
-/// has no destructor.
-struct BoxedNode<K, V> {
-    ptr: NonNull<LeafNode<K, V>>,
-}
+use ptr_fortress::*;
+mod ptr_fortress {
+    use super::{LeafNode, NonNull};
 
-impl<K, V> BoxedNode<K, V> {
-    fn from_owned(ptr: NonNull<LeafNode<K, V>>) -> Self {
-        BoxedNode { ptr }
+    /// A managed, non-null pointer to a node. This is either an owned pointer to
+    /// `LeafNode<K, V>` or an owned pointer to `InternalNode<K, V>`.
+    ///
+    /// However, `BoxedNode` contains no information as to which of the two types
+    /// of nodes it actually contains, and, partially due to this lack of information,
+    /// has no destructor.
+    pub(super) struct BoxedNode<K, V> {
+        ptr: NonNull<LeafNode<K, V>>,
     }
 
-    fn as_ptr(&self) -> NonNull<LeafNode<K, V>> {
-        self.ptr
+    impl<K, V> BoxedNode<K, V> {
+        pub(super) fn from_owned(ptr: NonNull<LeafNode<K, V>>) -> Self {
+            BoxedNode { ptr }
+        }
+
+        pub(super) fn as_ptr(&self) -> NonNull<LeafNode<K, V>> {
+            self.ptr
+        }
     }
 }
 

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -239,7 +239,8 @@ def children_of_btree_map(map):
         if root.type.name.startswith("core::option::Option<"):
             root = root.cast(gdb.lookup_type(root.type.name[21:-1]))
         node_ptr = root["node"]
-        if node_ptr.type.name.startswith("alloc::collections::btree::node::BoxedNode<"):
+        if node_ptr.type.name.startswith("alloc::collections::btree::node::BoxedNode<") \
+        or node_ptr.type.name.startswith("alloc::collections::btree::node::ptr_fortress::NodePtr<"):
             node_ptr = node_ptr["ptr"]
         node_ptr = unwrap_unique_or_non_null(node_ptr)
         height = root["height"]


### PR DESCRIPTION
Predecessor of #79093: moves `BoxedNode` and the heart of `NodeRef` to an island with the lowest layer of abstraction, where the casting of raw pointers happens.

r? @Mark-Simulacrum