### PR TITLE
Convert UNC path to local path to satisfy install script on Windows

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1183,7 +1183,11 @@ impl Step for PlainSourceTarball {
 // characters and on `C:\` paths, so normalize both of them away.
 pub fn sanitize_sh(path: &Path) -> String {
     let path = path.to_str().unwrap().replace("\\", "/");
-    return change_drive(&path).unwrap_or(path);
+    return change_drive(unc_to_lfs(&path)).unwrap_or(path);
+
+    fn unc_to_lfs(s: &str) -> &str {
+        if s.starts_with("//?/") { &s[4..] } else { s }
+    }
 
     fn change_drive(s: &str) -> Option<String> {
         let mut ch = s.chars();


### PR DESCRIPTION
`mkdir` with the `-p` flag attempts to create `//?` if passed a UNC path. This fails on both MSYS2 and Git Bash.

The UNC paths come from [canonicalizing](https://github.com/rust-lang/rust/blob/32da90b431919eedb3e281a91caea063ba4edb77/src/bootstrap/install.rs#L79) the install prefix path. `mkdir -p` gets invoked on the [install script](https://github.com/rust-lang/rust-installer/blob/d66f476b4d5e7fdf1ec215c9ac16c923dc292324/install-template.sh#L149).