### PR TITLE
Don't abort rustdoc tests if `tidy` isn't installed

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -327,6 +327,9 @@ pub struct Config {
     /// created in `/<build_base>/rustfix_missing_coverage.txt`
     pub rustfix_coverage: bool,
 
+    /// whether to run `tidy` when a rustdoc test fails
+    pub has_tidy: bool,
+
     // Configuration for various run-make tests frobbing things like C compilers
     // or querying about various LLVM component information.
     pub cc: String,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2437,7 +2437,8 @@ impl<'test> TestCx<'test> {
             })
         };
         let mut diff = Command::new("diff");
-        diff.args(&["-u", "-r"]).args(&[&compare_dir, out_dir]);
+        // diff recursively, showing context, and excluding .css files
+        diff.args(&["-u", "-r", "-x", "*.css"]).args(&[&compare_dir, out_dir]);
 
         let output = if let Some(pager) = pager {
             let diff_pid = diff.stdout(Stdio::piped()).spawn().expect("failed to run `diff`");


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/78752.

Before:

```
Check compiletest suite=rustdoc mode=rustdoc (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)

running 396 tests
..................................................2020-11-23T12:12:37.735649Z ERROR compiletest::runtest: fatal error, panic: "failed to run tidy - is it installed? - No such file or directory (os error 2)"
F................................................. 100/396
.................................................................................................... 200/396
.................................................................................................... 300/396
...............................i...............2020-11-23T12:15:00.271271Z ERROR compiletest::runtest: fatal error, panic: "failed to run tidy - is it installed? - No such file or directory (os error 2)"
F................................................
```

After:

```
Check compiletest suite=rustdoc mode=rustdoc (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)

running 4 tests
.FFF
failures:

---- [rustdoc] rustdoc/fn-pointer-arg-name.rs stdout ----

error: htmldocck failed!
status: exit code: 1
command: "/usr/bin/python" "/home/joshua/rustc/src/etc/htmldocck.py" "/home/joshua/rustc/build/x86_64-unknown-linux-gnu/test/rustdoc/fn-pointer-arg-name" "/home/joshua/rustc/src/test/rustdoc/fn-pointer-arg-name.rs"
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------
4: @has check failed
	`XPATH PATTERN` did not match
	// @has - '//*[@class="rust fn"]' 'pub fn f(callback: fn(len: usize, foo: u32))'

Encountered 1 errors

------------------------------------------

info: generating a diff against nightly rustdoc
failed to run tidy - is it installed? - Permission denied (os error 13)
failed to run tidy - is it installed? - Permission denied (os error 13)
 # a diff without running `tidy`
```

r? @GuillaumeGomez 