### PR TITLE
Show hidden elements by default when JS is disabled

### DIFF
--- a/src/librustdoc/html/static/noscript.css
+++ b/src/librustdoc/html/static/noscript.css
@@ -1,3 +1,9 @@
+/*
+This whole CSS file is used only in case rustdoc is rendered with javascript disabled. Since a lot
+of content is hidden by default (depending on the settings too), we have to overwrite some of the
+rules.
+*/
+
 #main > h2 + div, #main > h2 + h3, #main > h3 + div {
 	display: block;
 }
@@ -12,4 +18,8 @@
 
 #main > h2 + h3 {
 	display: flex;
+}
+
+#main .impl-items .hidden {
+	display: block !important;
 }


### PR DESCRIPTION
Fixes  #79301.

A lot of things are hidden by default which shouldn't when JS is disabled. This PR fixes it.

Before:

![Screenshot from 2020-11-24 14-10-16](https://user-images.githubusercontent.com/3050060/100099361-a16d5580-2e5f-11eb-891b-a4c005aeb1d0.png)

After:

![after](https://user-images.githubusercontent.com/3050060/100099382-a6caa000-2e5f-11eb-8190-14f330aff9a2.png)

r? @jyn514 