### PR TITLE
Test that core can be built with msan enabled

### DIFF
--- a/src/test/run-make-fulldeps/sanitizer-memory-build-core/.gitignore
+++ b/src/test/run-make-fulldeps/sanitizer-memory-build-core/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target/

--- a/src/test/run-make-fulldeps/sanitizer-memory-build-core/Cargo.toml
+++ b/src/test/run-make-fulldeps/sanitizer-memory-build-core/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2018"
+
+[workspace]

--- a/src/test/run-make-fulldeps/sanitizer-memory-build-core/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-memory-build-core/Makefile
@@ -1,0 +1,19 @@
+# needs-sanitizer-support
+# needs-sanitizer-memory
+
+# This test builds a trivial program with memory sanitizer
+# and rebuilds part of the standard library
+
+# -Clink-dead-code is a setting that sanitizer front-ends generally enable,
+# due to issues with certain linkers mangling sections used to track
+# coverage when trying to remove dead code
+# Linking dead code allows tracking more regressions generating code for the
+# standard library, eg for target features that are not currently enabled.
+
+# -Ccodegen-units=1 is also enabled by the front-ends, to work around
+# misoptimisations with ThinLTO.
+
+all:
+	RUSTFLAGS="-Cpasses=sancov -Clink-dead-code -Zsanitizer=memory -Ccodegen-units=1" \
+	cargo build --verbose --release -Zbuild-std=core --target $(TARGET)
+

--- a/src/test/run-make-fulldeps/sanitizer-memory-build-core/src/main.rs
+++ b/src/test/run-make-fulldeps/sanitizer-memory-build-core/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
See https://github.com/rust-fuzz/cargo-fuzz/issues/243

The test currently fails, since it highlights a regression in <https://github.com/rust-lang/stdarch>.

Reverting library/stdarch to <https://github.com/rust-lang/stdarch/commit/718175b34a39e4e3d59b40e35930326edc515b87>
(the problem commit being <https://github.com/rust-lang/stdarch/commit/3fa0f6a1316fcb9619d7e002ac4ed78a0c745cef>)
makes it pass again.