### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "atty",


### PR DESCRIPTION
10 commits in 2af662e22177a839763ac8fb70d245a680b15214..bfca1cd22bf514d5f2b6c1089b0ded0ba7dfaa6e
2020-11-12 19:04:56 +0000 to 2020-11-24 16:33:21 +0000
- Shrink the progress bar, to give more space after it. (rust-lang/cargo#8892)
- Add some comments to the toml code (rust-lang/cargo#8887)
- Start searching git config at new path (rust-lang/cargo#8886)
- Fix documentation for CARGO_PRIMARY_PACKAGE. (rust-lang/cargo#8891)
- Bump to 0.51.0, update changelog (rust-lang/cargo#8894)
- Publish target's "doc" setting when emitting metadata (rust-lang/cargo#8869)
- Relaxes expectation of `cargo test` tests to accept test execution time (rust-lang/cargo#8884)
- Finish implementation of `-Zextra-link-arg`. (rust-lang/cargo#8441)
- Reproducible crate builds (rust-lang/cargo#8864)
- Allow resolver="1" to explicitly use the old resolver behavior. (rust-lang/cargo#8857)