### PR TITLE
ext/ucred: Support PID in peer creds on macOS

### DIFF
--- a/library/std/src/sys/unix/ext/ucred.rs
+++ b/library/std/src/sys/unix/ext/ucred.rs
@@ -28,17 +28,10 @@ pub struct UCred {
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use self::impl_linux::peer_cred;
 
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "openbsd"
-))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 pub use self::impl_bsd::peer_cred;
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-))]
+#[cfg(any(target_os = "macos", target_os = "ios",))]
 pub use self::impl_mac::peer_cred;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -77,11 +70,7 @@ pub mod impl_linux {
     }
 }
 
-#[cfg(any(
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "openbsd"
-))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
 pub mod impl_bsd {
     use super::UCred;
     use crate::io;
@@ -98,16 +87,13 @@ pub mod impl_bsd {
     }
 }
 
-#[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
-))]
+#[cfg(any(target_os = "macos", target_os = "ios",))]
 pub mod impl_mac {
     use super::UCred;
-    use crate::{io, mem};
     use crate::os::unix::io::AsRawFd;
     use crate::os::unix::net::UnixStream;
-    use libc::{c_void, getpeereid, getsockopt, pid_t, socklen_t, SOL_LOCAL, LOCAL_PEERPID};
+    use crate::{io, mem};
+    use libc::{c_void, getpeereid, getsockopt, pid_t, socklen_t, LOCAL_PEERPID, SOL_LOCAL};
 
     pub fn peer_cred(socket: &UnixStream) -> io::Result<UCred> {
         let mut cred = UCred { uid: 1, gid: 1, pid: None };
@@ -126,7 +112,7 @@ pub mod impl_mac {
                 SOL_LOCAL,
                 LOCAL_PEERPID,
                 &mut pid as *mut pid_t as *mut c_void,
-                &mut pid_size
+                &mut pid_size,
             );
 
             if ret == 0 && pid_size as usize == mem::size_of::<pid_t>() {

--- a/library/std/src/sys/unix/ext/ucred/tests.rs
+++ b/library/std/src/sys/unix/ext/ucred/tests.rs
@@ -25,11 +25,7 @@ fn test_socket_pair() {
 }
 
 #[test]
-#[cfg(any(
-    target_os = "linux",
-    target_os = "ios",
-    target_os = "macos",
-))]
+#[cfg(any(target_os = "linux", target_os = "ios", target_os = "macos",))]
 fn test_socket_pair_pids(arg: Type) -> RetType {
     // Create two connected sockets and get their peer credentials.
     let (sock_a, sock_b) = UnixStream::pair().unwrap();

--- a/library/std/src/sys/unix/ext/ucred/tests.rs
+++ b/library/std/src/sys/unix/ext/ucred/tests.rs
@@ -1,5 +1,5 @@
 use crate::os::unix::net::UnixStream;
-use libc::{getegid, geteuid};
+use libc::{getegid, geteuid, getpid};
 
 #[test]
 #[cfg(any(
@@ -22,4 +22,21 @@ fn test_socket_pair() {
     let gid = unsafe { getegid() };
     assert_eq!(cred_a.uid, uid);
     assert_eq!(cred_a.gid, gid);
+}
+
+#[test]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "ios",
+    target_os = "macos",
+))]
+fn test_socket_pair_pids(arg: Type) -> RetType {
+    // Create two connected sockets and get their peer credentials.
+    let (sock_a, sock_b) = UnixStream::pair().unwrap();
+    let (cred_a, cred_b) = (sock_a.peer_cred().unwrap(), sock_b.peer_cred().unwrap());
+
+    // On supported platforms (see the cfg above), the credentials should always include the PID.
+    let pid = unsafe { getpid() };
+    assert_eq!(cred_a.pid, Some(pid));
+    assert_eq!(cred_b.pid, Some(pid));
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/rust-lang/rust/pull/75148 (RFC: https://github.com/rust-lang/rust/issues/42839).

The original PR used `getpeereid` on macOS and the BSDs, since they don't (generally) support the `SO_PEERCRED` mechanism that Linux supplies.

This PR splits the macOS/iOS implementation of `peer_cred()` from that of the BSDs, since macOS supplies the `LOCAL_PEERPID` sockopt as a source of the missing PID. It also adds a `cfg`-gated tests that ensures that platforms with support for PIDs in `UCred` have the expected data.

