### PR TITLE
Revert "linux: try to use libc getrandom to allow interposition"

### DIFF
--- a/library/std/src/sys/unix/kernel_copy.rs
+++ b/library/std/src/sys/unix/kernel_copy.rs
@@ -445,15 +445,15 @@ pub(super) fn copy_regular_files(reader: RawFd, writer: RawFd, max_len: u64) -> 
     // We store the availability in a global to avoid unnecessary syscalls
     static HAS_COPY_FILE_RANGE: AtomicBool = AtomicBool::new(true);
 
-    syscall! {
-        fn copy_file_range(
-            fd_in: libc::c_int,
-            off_in: *mut libc::loff_t,
-            fd_out: libc::c_int,
-            off_out: *mut libc::loff_t,
-            len: libc::size_t,
-            flags: libc::c_uint
-        ) -> libc::ssize_t
+    unsafe fn copy_file_range(
+        fd_in: libc::c_int,
+        off_in: *mut libc::loff_t,
+        fd_out: libc::c_int,
+        off_out: *mut libc::loff_t,
+        len: libc::size_t,
+        flags: libc::c_uint,
+    ) -> libc::c_long {
+        libc::syscall(libc::SYS_copy_file_range, fd_in, off_in, fd_out, off_out, len, flags)
     }
 
     let has_copy_file_range = HAS_COPY_FILE_RANGE.load(Ordering::Relaxed);

--- a/library/std/src/sys/unix/rand.rs
+++ b/library/std/src/sys/unix/rand.rs
@@ -25,19 +25,10 @@ mod imp {
     use crate::io::Read;
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn getrandom(buf: &mut [u8]) -> libc::ssize_t {
-        // A weak symbol allows interposition, e.g. for perf measurements that want to
-        // disable randomness for consistency. Otherwise, we'll try a raw syscall.
-        // (`getrandom` was added in glibc 2.25, musl 1.1.20, android API level 28)
-        syscall! {
-            fn getrandom(
-                buffer: *mut libc::c_void,
-                length: libc::size_t,
-                flags: libc::c_uint
-            ) -> libc::ssize_t
+    fn getrandom(buf: &mut [u8]) -> libc::c_long {
+        unsafe {
+            libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr(), buf.len(), libc::GRND_NONBLOCK)
         }
-
-        unsafe { getrandom(buf.as_mut_ptr().cast(), buf.len(), libc::GRND_NONBLOCK) }
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "android")))]


### PR DESCRIPTION
This measures the performance impact of https://github.com/rust-lang/rust/pull/78785 (see https://github.com/rust-lang/rust/pull/79167#issuecomment-733207145).

- Revert "Use syscall! for copy_file_range too"
- Revert "Try weak symbols for all linux syscall! wrappers"
- Revert "linux: try to use libc getrandom to allow interposition"

cc @cuviper 
r? @ghost