### PR TITLE
[WIP] incomplete attempt to inject additional coverage for unused MIR

### DIFF
--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(extern_types)]
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
+#![feature(option_expect_none)]
 #![feature(or_patterns)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_codegen_ssa/src/coverageinfo/map.rs
+++ b/compiler/rustc_codegen_ssa/src/coverageinfo/map.rs
@@ -28,6 +28,7 @@ pub struct Expression {
 /// only whitespace or comments). According to LLVM Code Coverage Mapping documentation, "A count
 /// for a gap area is only used as the line execution count if there are no other regions on a
 /// line."
+#[derive(Debug)]
 pub struct FunctionCoverage<'tcx> {
     instance: Instance<'tcx>,
     source_hash: u64,
@@ -55,6 +56,7 @@ impl<'tcx> FunctionCoverage<'tcx> {
     /// Sets the function source hash value. If called multiple times for the same function, all
     /// calls should have the same hash value.
     pub fn set_function_source_hash(&mut self, source_hash: u64) {
+        debug!("set_function_source_hash({}), for {:?}", source_hash, self.instance);
         if self.source_hash == 0 {
             self.source_hash = source_hash;
         } else {
@@ -64,6 +66,7 @@ impl<'tcx> FunctionCoverage<'tcx> {
 
     /// Adds a code region to be counted by an injected counter intrinsic.
     pub fn add_counter(&mut self, id: CounterValueReference, region: CodeRegion) {
+        debug!("add_counter({:?}) at {:?}, for {:?}", id, region, self.instance);
         self.counters[id].replace(region).expect_none("add_counter called with duplicate `id`");
     }
 
@@ -90,8 +93,8 @@ impl<'tcx> FunctionCoverage<'tcx> {
         region: Option<CodeRegion>,
     ) {
         debug!(
-            "add_counter_expression({:?}, lhs={:?}, op={:?}, rhs={:?} at {:?}",
-            expression_id, lhs, op, rhs, region
+            "add_counter_expression({:?}, lhs={:?}, op={:?}, rhs={:?}) at {:?}, for {:?}",
+            expression_id, lhs, op, rhs, region, self.instance
         );
         let expression_index = self.expression_index(u32::from(expression_id));
         self.expressions[expression_index]
@@ -101,6 +104,7 @@ impl<'tcx> FunctionCoverage<'tcx> {
 
     /// Add a region that will be marked as "unreachable", with a constant "zero counter".
     pub fn add_unreachable_region(&mut self, region: CodeRegion) {
+        debug!("add_unreachable_region() at {:?}, for {:?}", region, self.instance);
         self.unreachable_regions.push(region)
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -346,6 +346,14 @@ rustc_queries! {
             cache_on_disk_if { key.is_local() }
         }
 
+        /// Returns the function source hash and code region for the body of a function that is
+        /// uncovered, because it was unreachable and not codegen'ed.
+        query uncovered_function_hash_and_region(key: DefId) -> Option<(u64, mir::coverage::CodeRegion)> {
+            desc { |tcx| "retrieving uncovered function hash and code region from MIR for `{}`", tcx.def_path_str(key) }
+            storage(ArenaCacheSelector<'tcx>)
+            cache_on_disk_if { key.is_local() }
+        }
+
         /// The `DefId` is the `DefId` of the containing MIR body. Promoteds do not have their own
         /// `DefId`. This function returns all promoteds in the specified body. The body references
         /// promoteds by the `DefId` and the `mir::Promoted` index. This is necessary, because
@@ -1410,6 +1418,9 @@ rustc_queries! {
         }
         query codegen_unit(_: Symbol) -> &'tcx CodegenUnit<'tcx> {
             desc { "codegen_unit" }
+        }
+        query indexed_codegen_unit(_: Symbol) -> (usize, &'tcx CodegenUnit<'tcx>) {
+            desc { "indexed_codegen_unit" }
         }
         query unused_generic_params(key: DefId) -> FiniteBitSet<u32> {
             cache_on_disk_if { key.is_local() }

--- a/compiler/rustc_mir/src/monomorphize/partitioning/mod.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/mod.rs
@@ -430,4 +430,12 @@ pub fn provide(providers: &mut Providers) {
             .find(|cgu| cgu.name() == name)
             .unwrap_or_else(|| panic!("failed to find cgu with name {:?}", name))
     };
+
+    providers.indexed_codegen_unit = |tcx, name| {
+        let (_, all) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
+        all.iter()
+            .enumerate()
+            .find(|(_, cgu)| cgu.name() == name)
+            .unwrap_or_else(|| panic!("failed to find cgu with name {:?}", name))
+    };
 }

--- a/src/test/run-make-fulldeps/coverage/async.rs
+++ b/src/test/run-make-fulldeps/coverage/async.rs
@@ -1,0 +1,67 @@
+#![allow(unused_assignments)]
+
+// require-rust-edition-2018
+
+async fn f() -> u8 { 
+    println!("executed body of async fn f()");
+    1
+}
+
+async fn foo() -> [bool; 10] { [false; 10] }
+
+pub async fn g(x: u8) {
+    match x {
+        y if f().await == y => (),
+        _ => (),
+    }
+}
+
+// #78366: check the reference to the binding is recorded even if the binding is not autorefed
+
+async fn h(x: usize) {
+    match x {
+        y if foo().await[y] => (),
+        _ => (),
+    }
+}
+
+async fn i(x: u8) {
+    match x {
+        y if f().await == y + 1 => (),
+        _ => (),
+    }
+}
+
+fn main() {
+    let _ = g(10);
+    let _ = h(9);
+    let mut future = Box::pin(i(8));
+    executor::block_on(future.as_mut());
+}
+
+mod executor {
+    use core::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    };
+
+    pub fn block_on<F: Future>(mut future: F) -> F::Output {
+        let mut future = unsafe { Pin::new_unchecked(&mut future) };
+
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(
+            |_| unimplemented!("clone"),
+            |_| unimplemented!("wake"),
+            |_| unimplemented!("wake_by_ref"),
+            |_| (),
+        );
+        let waker = unsafe { Waker::from_raw(RawWaker::new(core::ptr::null(), &VTABLE)) };
+        let mut context = Context::from_waker(&waker);
+
+        loop {
+            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
+                break val;
+            }
+        }
+    }
+}

--- a/src/test/run-make-fulldeps/coverage/if.rs
+++ b/src/test/run-make-fulldeps/coverage/if.rs
@@ -1,6 +1,16 @@
-#![allow(unused_assignments, unused_variables)]
+// #![allow(unused_assignments, unused_variables)]
+
+fn notcalled() {
+    println!("pub never called");
+}
 
 fn main() {
+    // let unused = || {
+    //     println!("closure never called");
+    // };
+
+
+
     // Initialize test constants in a way that cannot be determined at compile time, to ensure
     // rustc and LLVM cannot optimize out statements (or coverage counters) downstream from
     // dependent conditions.


### PR DESCRIPTION
Functions (including generics and including async function bodies (which
mimic closures with generics/type parameters) that aren't invoked are
not appearing in coverage reports. They don't get a zero (0) execution
count. They get nothing, and they don't appear in reports as "not
covered" code to be addressed.

I attempted to inject "Zero" counters for each of these, but `llvm-cov`
fails if the coverage map has a counter for a function that is non
defined.

@tmandry 