### PR TITLE
Fix persisted doctests on Windows / when using workspaces

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -754,12 +754,14 @@ impl Tester for Collector {
             let folder_name = filename
                 .to_string()
                 .chars()
-                .map(|c| if c == '/' || c == '.' { '_' } else { c })
+                .map(|c| if c == '\\' || c == '/' || c == '.' { '_' } else { c })
                 .collect::<String>();
 
             path.push(format!(
-                "{name}_{line}_{number}",
-                name = folder_name,
+                "{krate}_{file}_{line}_{number}",
+                krate = cratename,
+                file = folder_name,
+                line = line,
                 number = {
                     // Increases the current test number, if this file already
                     // exists or it creates a new entry with a test number of 0.
@@ -768,7 +770,6 @@ impl Tester for Collector {
                         .and_modify(|v| *v += 1)
                         .or_insert(0)
                 },
-                line = line,
             ));
 
             std::fs::create_dir_all(&path)


### PR DESCRIPTION
When using the unstable `--persist-doctests` option,
Windows path separators were not escaped properly. Also when running
the command in a workspace, crate files can overwrite each other.

Before: `src\lib_rs_1_0\rust_out`
After: `\crate_a_src_lib_rs_1_0\rust_out`, `\crate_b_src_lib_rs_1_0\rust_out`