### PR TITLE
revert 74989 ("Implement `Index` and `IndexMut` for arrays")

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -12,7 +12,6 @@ use crate::convert::{Infallible, TryFrom};
 use crate::fmt;
 use crate::hash::{self, Hash};
 use crate::marker::Unsize;
-use crate::ops::{Index, IndexMut};
 use crate::slice::{Iter, IterMut};
 
 mod iter;
@@ -206,30 +205,6 @@ impl<'a, T, const N: usize> IntoIterator for &'a mut [T; N] {
 
     fn into_iter(self) -> IterMut<'a, T> {
         self.iter_mut()
-    }
-}
-
-#[stable(feature = "index_trait_on_arrays", since = "1.50.0")]
-impl<T, I, const N: usize> Index<I> for [T; N]
-where
-    [T]: Index<I>,
-{
-    type Output = <[T] as Index<I>>::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        Index::index(self as &[T], index)
-    }
-}
-
-#[stable(feature = "index_trait_on_arrays", since = "1.50.0")]
-impl<T, I, const N: usize> IndexMut<I> for [T; N]
-where
-    [T]: IndexMut<I>,
-{
-    #[inline]
-    fn index_mut(&mut self, index: I) -> &mut Self::Output {
-        IndexMut::index_mut(self as &mut [T], index)
     }
 }
 

--- a/src/test/ui/const_fn_vec_mutation_79152.rs
+++ b/src/test/ui/const_fn_vec_mutation_79152.rs
@@ -1,0 +1,11 @@
+// check-pass
+
+// https://github.com/rust-lang/rust/issues/79152
+const fn foo() {
+    let mut array = [[0; 1]; 1];
+    array[0][0] = 1;
+}
+
+pub fn main() {
+    foo()
+}


### PR DESCRIPTION
This PR reverts https://github.com/rust-lang/rust/pull/74989 and adds a testcase for 
````rust
const fn foo() {
    let mut array = [[0; 1]; 1];
    array[0][0] = 1;
}
````
which compiles on stable and beta but not on nightly due to #74989 .
The offending commit had a crater run but the breaking change was missed which means it probably would not have landed if the breaking change had been noticed in time.

This PR fixes compilation of real-world crates such as https://github.com/alacritty/vte/

Fixes #79152