### PR TITLE
Alternative implementation std::iter::Peekable::peek_mut

### DIFF
--- a/library/core/tests/iter.rs
+++ b/library/core/tests/iter.rs
@@ -1137,10 +1137,8 @@ fn test_iterator_peekable_next_if_eq() {
 #[test]
 fn test_iterator_peekable_mut() {
     let mut it = vec![1, 2, 3].into_iter().peekable();
-    if let Some(p) = it.peek_mut() {
-        if *p == 1 {
-            *p = 5;
-        }
+    if let p @ Some(1) = it.peek_mut() {
+        *p = Some(5);
     }
     assert_eq!(it.collect::<Vec<_>>(), vec![5, 2, 3]);
 }


### PR DESCRIPTION
This is an alternative implementation for `std::iter::Peekable::peek_mut()`, which has been added as an unstable feature `peekable_peek_mut`, tracked in #78302. Instead of returning an `Option<&mut Item>`, we return an `&mut Option<Item>`.

This allows us to control the iterator without advancing it. Namely, we can short-circuit the iterator (ending it) conditionally without advancing the underlying iterator during inspection. We can also rejuvenate an empty iterator after inspecting the next value. Both would not be possible without peeking, as there would be no way to place the new value back into the iterator if it doesn't fit the pattern. E.g.

```rust
// We must not advance the iterator in case it's next value is not actually `Some(&2)`.
if let p @ Some(&2) = iter.peek_mut() {
    *p = None;
}

// Without peeking, if `p` is `Some(T)`, there is no way to put it back
// Without `peek_mut`, we couldn't set the value.
if let p @ None = iter.peek_mut() {
    *p = Some(&10);
}
```

Both use-cases are already possible by simply calling `peek()` on the iterator and conditionally replacing the whole iterator (either the binding or through `std::mem::replace`) with a new iterator. This is cumbersome, though, as we need to know the exact type of the iterator in case it's unboxed (replacing with `std::iter::empty` or `::once` won't do).

Since it previously wasn't possible to modify the state of `Peekable` from the outside, more tests may be needed to ensure that it behaves properly after it's `peeked`-member was modified?!
