### PR TITLE
Resolve inference variables before trying to remove overloaded indexing

### DIFF
--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -194,7 +194,9 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             let mut typeck_results = self.fcx.typeck_results.borrow_mut();
 
             // All valid indexing looks like this; might encounter non-valid indexes at this point.
-            let base_ty = typeck_results.expr_ty_adjusted_opt(&base).map(|t| t.kind());
+            let base_ty = typeck_results
+                .expr_ty_adjusted_opt(&base)
+                .map(|t| self.fcx.resolve_vars_if_possible(t).kind());
             if base_ty.is_none() {
                 // When encountering `return [0][0]` outside of a `fn` body we can encounter a base
                 // that isn't in the type table. We assume more relevant errors have already been

--- a/src/test/ui/consts/issue-79152-const-array-index.rs
+++ b/src/test/ui/consts/issue-79152-const-array-index.rs
@@ -1,0 +1,11 @@
+// check-pass
+// Regression test for issue #79152
+//
+// Tests that we can index an array in a const function
+
+const fn foo() {
+    let mut array = [[0; 1]; 1];
+    array[0][0] = 1;
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #79152

This code was already set up to handle indexing an array. However, it
appears that we never end up with an inference variable for the slice
case, so the missing call to `resolve_vars_if_possible` had no effect
until now.