### PR TITLE
Add some convenience methods for locks.

### DIFF
--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -419,10 +419,11 @@ impl<T: ?Sized> Mutex<T> {
     /// # Example
     ///
     /// ```
+    /// #![feature(mutex_with)]
     /// use std::sync::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let result = mutex.with(|myint| { myint += 1; myint * 42 }).unwrap();
+    /// let result = mutex.with(|myint| { *myint += 1; *myint * 42 }).unwrap();
     /// assert_eq!(*mutex.lock().unwrap(), 1);
     /// assert_eq!(result, 42);
     /// ```
@@ -450,10 +451,11 @@ impl<T: ?Sized> Mutex<T> {
     ///
     /// # Examples
     /// ```
+    /// #![feature(mutex_with)]
     /// use std::sync::Mutex;
     ///
     /// let mutex = Mutex::new(0);
-    /// let result = mutex.try_with(|myint| { myint += 1; myint * 42 }).unwrap();
+    /// let result = mutex.try_with(|myint| { *myint += 1; *myint * 42 }).unwrap();
     /// assert_eq!(*mutex.lock().unwrap(), 1);
     /// assert_eq!(result, 42);
     /// ```


### PR DESCRIPTION
This PR adds three new methods (under two new features) for `Mutex` and `MutexGuard`:

- We add `MutexGuard::unlock`, which is equivalent to `drop(guard)` but more self-documenting. This method is useful for explicitly cutting short the duration for which a lock is held. It is often helpful to do this to shorten critical sections or avoid deadlocks.

- We add `Mutex::with` and `Mutex::try_with`, which accept closures and run the closures with the lock held, dropping the lock immediately after the closure returns. These methods are useful for running critical sections in a syntactically clear way and avoiding holding the lock for longer than needed.

This is my first PR adding a std feature, so please let me know if something is missing.