### PR TITLE
Improve rustdoc JS tests error output

### DIFF
--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -190,6 +190,30 @@ function loadThings(thingsToLoad, kindOfLoad, funcToCall, fileContent) {
     return content;
 }
 
+function contentToDiffLine(key, value) {
+    return `"${key}": "${value}",`;
+}
+
+// This function is only called when no matching result was found and therefore will only display
+// the diff between the two items.
+function betterLookingDiff(entry, data) {
+    let output = ' {\n';
+    let spaces = '     ';
+    for (let key in entry) {
+        if (!entry.hasOwnProperty(key)) {
+            continue;
+        }
+        let value = data[key];
+        if (value !== entry[key]) {
+            output += '-' + spaces + contentToDiffLine(key, entry[key]) + '\n';
+            output += '+' + spaces + contentToDiffLine(key, value) + '\n';
+        } else {
+            output += spaces + contentToDiffLine(key, value) + '\n';
+        }
+    }
+    return output + ' }';
+}
+
 function lookForEntry(entry, data) {
     for (var i = 0; i < data.length; ++i) {
         var allGood = true;
@@ -281,6 +305,13 @@ function runSearch(query, expected, index, loaded, loadedFile, queryName) {
             if (entry_pos === null) {
                 error_text.push(queryName + "==> Result not found in '" + key + "': '" +
                                 JSON.stringify(entry[i]) + "'");
+                // By default, we just compare the two first items.
+                let item_to_diff = 0;
+                if ((ignore_order === false || exact_check === true) && i < results[key].length) {
+                    item_to_diff = i;
+                }
+                error_text.push("Diff of first error:\n" +
+                    betterLookingDiff(entry[i], results[key][item_to_diff]));
             } else if (exact_check === true && prev_pos + 1 !== entry_pos) {
                 error_text.push(queryName + "==> Exact check failed at position " + (prev_pos + 1) +
                                 ": expected '" + JSON.stringify(entry[i]) + "' but found '" +


### PR DESCRIPTION
It's pretty common when starting to add new tests for rustdoc-js to have issues to understand the errors. With this, it should make things a bit simpler. So now, in case of an error, it displays:

```
---- [js-doc-test] rustdoc-js/basic.rs stdout ----

error: rustdoc-js test failed!
failed to decode compiler output as json: line: {
output: Checking "basic" ... FAILED
==> Result not found in 'others': '{"path":"basic","name":"Fo"}'
Diff of first error:
{
    "path": "basic",
    - "name": "Fo",
    + "name": "Foo",
}
thread '[js-doc-test] rustdoc-js/basic.rs' panicked at 'explicit panic', src/tools/compiletest/src/json.rs:126:21
```

I think it was @camelid who asked about it a few days ago?

r? @jyn514 