### PR TITLE
Switch x64 windows msvc target to use `lld` by default.

### DIFF
--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
@@ -5,6 +5,7 @@ pub fn target() -> Target {
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
     base.has_elf_tls = true;
+    base.linker = Some("rust-lld".to_string());
 
     Target {
         llvm_target: "x86_64-pc-windows-msvc".to_string(),


### PR DESCRIPTION
cc #71520 .