### PR TITLE
Remove doctree::Macro and distinguish between `macro_rules!` and `pub macro`

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2330,14 +2330,26 @@ impl Clean<Item> for (&hir::MacroDef<'_>, Option<Ident>) {
                     .collect::<String>(),
             )
         } else {
-            // This code currently assumes that there will only be one or zero matchers, as syntax
-            // for multiple is not currently defined.
-            format!(
-                "{}macro {}{} {{\n\t...\n}}",
-                item.vis.clean(cx).print_with_space(),
-                name,
-                matchers.iter().map(|span| span.to_src(cx)).collect::<String>(),
-            )
+            let vis = item.vis.clean(cx);
+
+            if matchers.len() <= 1 {
+                format!(
+                    "{}macro {}{} {{\n    ...\n}}",
+                    vis.print_with_space(),
+                    name,
+                    matchers.iter().map(|span| span.to_src(cx)).collect::<String>(),
+                )
+            } else {
+                format!(
+                    "{}macro {} {{\n{}}}",
+                    vis.print_with_space(),
+                    name,
+                    matchers
+                        .iter()
+                        .map(|span| { format!("    {} => {{ ... }},\n", span.to_src(cx)) })
+                        .collect::<String>(),
+                )
+            }
         };
 
         Item::from_hir_id_and_parts(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2333,7 +2333,8 @@ impl Clean<Item> for (&hir::MacroDef<'_>, Option<Ident>) {
             // This code currently assumes that there will only be one or zero matchers, as syntax
             // for multiple is not currently defined.
             format!(
-                "pub macro {}({}) {{\n\t...\n}}",
+                "{}macro {}{} {{\n\t...\n}}",
+                item.vis.clean(cx).print_with_space(),
                 name,
                 matchers.iter().map(|span| span.to_src(cx)).collect::<String>(),
             )
@@ -2341,7 +2342,7 @@ impl Clean<Item> for (&hir::MacroDef<'_>, Option<Ident>) {
 
         Item::from_hir_id_and_parts(
             item.hir_id,
-            Some(name.clean(cx)),
+            Some(name),
             MacroItem(Macro { source, imported_from: None }),
             cx,
         )

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -18,7 +18,7 @@ crate struct Module<'hir> {
     // (item, renamed)
     crate items: Vec<(&'hir hir::Item<'hir>, Option<Ident>)>,
     crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Ident>)>,
-    crate macros: Vec<Macro>,
+    crate macros: Vec<(&'hir hir::MacroDef<'hir>, Option<Ident>)>,
     crate is_crate: bool,
 }
 
@@ -54,15 +54,6 @@ crate struct Variant<'hir> {
     crate name: Symbol,
     crate id: hir::HirId,
     crate def: &'hir hir::VariantData<'hir>,
-}
-
-// For Macro we store the DefId instead of the NodeId, since we also create
-// these imported macro_rules (which only have a DUMMY_NODE_ID).
-crate struct Macro {
-    crate name: Symbol,
-    crate def_id: hir::def_id::DefId,
-    crate matchers: Vec<Span>,
-    crate imported_from: Option<Symbol>,
 }
 
 #[derive(Debug)]

--- a/src/test/rustdoc/decl_macro.rs
+++ b/src/test/rustdoc/decl_macro.rs
@@ -30,3 +30,10 @@ pub macro my_macro_multi {
 
     }
 }
+
+// @has decl_macro/macro.by_example_single.html //pre 'pub macro by_example_single($foo:expr) {'
+// @has - //pre '...'
+// @has - //pre '}'
+pub macro by_example_single {
+    ($foo:expr) => {}
+}

--- a/src/test/rustdoc/decl_macro.rs
+++ b/src/test/rustdoc/decl_macro.rs
@@ -13,3 +13,20 @@ pub macro my_macro() {
 pub macro my_macro_2($($tok:tt)*) {
 
 }
+
+// @has decl_macro/macro.my_macro_multi.html //pre 'pub macro my_macro_multi {'
+// @has - //pre '(_) => { ... },'
+// @has - //pre '($foo:ident . $bar:expr) => { ... },'
+// @has - //pre '($($foo:literal),+) => { ... }'
+// @has - //pre '}'
+pub macro my_macro_multi {
+    (_) => {
+
+    },
+    ($foo:ident . $bar:expr) => {
+
+    },
+    ($($foo:literal),+) => {
+
+    }
+}

--- a/src/test/rustdoc/decl_macro.rs
+++ b/src/test/rustdoc/decl_macro.rs
@@ -1,14 +1,13 @@
-
 #![feature(decl_macro)]
 
-// @has macros_2/macro.my_macro.html //pre 'pub macro my_macro() {'
+// @has decl_macro/macro.my_macro.html //pre 'pub macro my_macro() {'
 // @has - //pre '...'
 // @has - //pre '}'
 pub macro my_macro() {
 
 }
 
-// @has macros_2/macro.my_macro_2.html //pre 'pub macro my_macro_2($($tok:tt)*) {'
+// @has decl_macro/macro.my_macro_2.html //pre 'pub macro my_macro_2($($tok:tt)*) {'
 // @has - //pre '...'
 // @has - //pre '}'
 pub macro my_macro_2($($tok:tt)*) {

--- a/src/test/rustdoc/decl_macro_priv.rs
+++ b/src/test/rustdoc/decl_macro_priv.rs
@@ -1,0 +1,13 @@
+// compile-flags: --document-private-items
+
+#![feature(decl_macro)]
+
+// @has decl_macro_priv/macro.crate_macro.html //pre 'pub(crate) macro crate_macro() {'
+// @has - //pre '...'
+// @has - //pre '}'
+pub(crate) macro crate_macro() {}
+
+// @has decl_macro_priv/macro.priv_macro.html //pre 'macro priv_macro() {'
+// @has - //pre '...'
+// @has - //pre '}'
+macro priv_macro() {}

--- a/src/test/rustdoc/decl_macro_priv.rs
+++ b/src/test/rustdoc/decl_macro_priv.rs
@@ -8,6 +8,7 @@
 pub(crate) macro crate_macro() {}
 
 // @has decl_macro_priv/macro.priv_macro.html //pre 'macro priv_macro() {'
+// @!has - //pre 'pub macro priv_macro() {'
 // @has - //pre '...'
 // @has - //pre '}'
 macro priv_macro() {}

--- a/src/test/rustdoc/macros_2.rs
+++ b/src/test/rustdoc/macros_2.rs
@@ -1,0 +1,16 @@
+
+#![feature(decl_macro)]
+
+// @has macros_2/macro.my_macro.html //pre 'pub macro my_macro() {'
+// @has - //pre '...'
+// @has - //pre '}'
+pub macro my_macro() {
+
+}
+
+// @has macros_2/macro.my_macro_2.html //pre 'pub macro my_macro_2($($tok:tt)*) {'
+// @has - //pre '...'
+// @has - //pre '}'
+pub macro my_macro_2($($tok:tt)*) {
+
+}


### PR DESCRIPTION
This is a part of #78082, removing doctree::Macro. Uses the changes in #79372

Fixes #76761