### PR TITLE
Extend doc keyword feature by allowing any ident

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1589,11 +1589,6 @@ impl Symbol {
         self == kw::Try
     }
 
-    /// Used for sanity checking rustdoc keyword sections.
-    pub fn is_doc_keyword(self) -> bool {
-        self <= kw::Union
-    }
-
     /// A keyword or reserved identifier that can be used as a path segment.
     pub fn is_path_segment_keyword(self) -> bool {
         self == kw::Super

--- a/src/test/rustdoc-ui/invalid-keyword.rs
+++ b/src/test/rustdoc-ui/invalid-keyword.rs
@@ -1,0 +1,4 @@
+#![feature(doc_keyword)]
+
+#[doc(keyword = "foo df")] //~ ERROR
+mod foo {}

--- a/src/test/rustdoc-ui/invalid-keyword.stderr
+++ b/src/test/rustdoc-ui/invalid-keyword.stderr
@@ -1,0 +1,8 @@
+error: `foo df` is not a valid identifier
+  --> $DIR/invalid-keyword.rs:3:17
+   |
+LL | #[doc(keyword = "foo df")]
+   |                 ^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/rustdoc/keyword.rs
+++ b/src/test/rustdoc/keyword.rs
@@ -14,3 +14,8 @@
 #[doc(keyword = "match")]
 /// this is a test!
 mod foo{}
+
+// @has foo/keyword.foo.html '//section[@id="main"]//div[@class="docblock"]//p' 'hello'
+#[doc(keyword = "foo")]
+/// hello
+mod bar {}


### PR DESCRIPTION
Part of #51315.

As suggested by @danielhenrymantilla in [this comment](https://github.com/rust-lang/rust/issues/51315#issuecomment-733879934), this PR extends `#[doc(keyword = "...")]` to allow any ident to be used as keyword. The final goal is to allow (proc-)macro crates' owners to write documentation of the keywords they might introduce.

r? @jyn514 