### PR TITLE
Revert "Normalize `<X as Y>::T` for rustdoc"

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1503,7 +1503,9 @@ impl Clean<Type> for hir::Ty<'_> {
 }
 
 /// Returns `None` if the type could not be normalized
+#[allow(unreachable_code, unused_variables)]
 fn normalize(cx: &DocContext<'tcx>, ty: Ty<'_>) -> Option<Ty<'tcx>> {
+    return None; // HACK: low-churn fix for #79459 while we wait for a trait normalization fix
     use crate::rustc_trait_selection::infer::TyCtxtInferExt;
     use crate::rustc_trait_selection::traits::query::normalize::AtExt;
     use rustc_middle::traits::ObligationCause;

--- a/src/test/rustdoc/normalize-assoc-item.rs
+++ b/src/test/rustdoc/normalize-assoc-item.rs
@@ -1,6 +1,7 @@
 // ignore-tidy-linelength
 // aux-build:normalize-assoc-item.rs
 // build-aux-docs
+// ignore-test
 
 pub trait Trait {
     type X;


### PR DESCRIPTION
Reverts rust-lang/rust#77467 by disabling normalization. See https://github.com/rust-lang/rust/issues/79459; I intend to reland normalization once that's fixed.

r? @Aaron1011 
cc @oli-obk @GuillaumeGomez 