### PR TITLE
add enable-full-tools to freebsd builds to prevent occasional link er…

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-freebsd/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-freebsd/Dockerfile
@@ -30,5 +30,10 @@ ENV \
 
 ENV HOSTS=x86_64-unknown-freebsd
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --enable-profiler --enable-sanitizers --disable-docs
+ENV RUST_CONFIGURE_ARGS \
+    --enable-full-tools \
+    --enable-extended \
+    --enable-profiler \
+    --enable-sanitizers \
+    --disable-docs
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $HOSTS


### PR DESCRIPTION
On FreeBSD, there is sometimes an issue where linking a rust program will fail due to rust not finding a linker, even though lld is included in the base system. This seems to mostly affect bare metal/cross compilation things, such as wasm builds and arm/riscv bare metal work (eg. when trying to compile [this](https://github.com/quantumscraps/scraps)). On Linux and other operating systems, full tools are enabled for builds of rust, so there are no linking issues. This pr should enable fully functional builds on FreeBSD, assuming rust builds correctly with these options.