### PR TITLE
Do not visit ForeignItemRef for HIR indexing and validation.

### DIFF
--- a/compiler/rustc_middle/src/hir/map/collector.rs
+++ b/compiler/rustc_middle/src/hir/map/collector.rs
@@ -572,6 +572,14 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
 
         self.visit_nested_impl_item(id);
     }
+
+    fn visit_foreign_item_ref(&mut self, fi: &'hir ForeignItemRef<'hir>) {
+        // Do not visit the duplicate information in ForeignItemRef. We want to
+        // map the actual nodes, not the duplicate ones in the *Ref.
+        let ForeignItemRef { id, ident: _, span: _, vis: _ } = *fi;
+
+        self.visit_nested_foreign_item(id);
+    }
 }
 
 struct HirItemLike<T> {

--- a/compiler/rustc_passes/src/hir_id_validator.rs
+++ b/compiler/rustc_passes/src/hir_id_validator.rs
@@ -169,6 +169,13 @@ impl<'a, 'hir> intravisit::Visitor<'hir> for HirIdValidator<'a, 'hir> {
         // different owner.
     }
 
+    fn visit_foreign_item_ref(&mut self, _: &'hir hir::ForeignItemRef<'hir>) {
+        // Explicitly do nothing here. ForeignItemRefs contain hir::Visibility
+        // values that actually belong to an ForeignItem instead of the ItemKind::ForeignMod
+        // we are currently in. So for those it's correct that they have a
+        // different owner.
+    }
+
     fn visit_generic_param(&mut self, param: &'hir hir::GenericParam<'hir>) {
         if let hir::GenericParamKind::Type {
             synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),

--- a/src/test/ui/foreign/foreign-pub-super.rs
+++ b/src/test/ui/foreign/foreign-pub-super.rs
@@ -1,0 +1,12 @@
+// Test for #79487
+// check-pass
+
+#![allow(dead_code)]
+
+mod sha2 {
+    extern "C" {
+        pub(super) fn GFp_sha512_block_data_order();
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Similarly to what is done for ImplItemRef and TraitItemRef.

Fixes #79487

r? @lcnr 