### PR TITLE
Run `normalize_projection_ty` in Canonical mode

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -223,14 +223,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     }
 
     pub fn intercrate(infcx: &'cx InferCtxt<'cx, 'tcx>) -> SelectionContext<'cx, 'tcx> {
-        SelectionContext {
-            infcx,
-            freshener: infcx.freshener(),
-            intercrate: true,
-            intercrate_ambiguity_causes: None,
-            allow_negative_impls: false,
-            query_mode: TraitQueryMode::Standard,
-        }
+        SelectionContext { intercrate: true, ..SelectionContext::new(infcx) }
     }
 
     pub fn with_negative(

--- a/compiler/rustc_traits/src/normalize_projection_ty.rs
+++ b/compiler/rustc_traits/src/normalize_projection_ty.rs
@@ -24,7 +24,8 @@ fn normalize_projection_ty<'tcx>(
     tcx.infer_ctxt().enter_canonical_trait_query(
         &goal,
         |infcx, fulfill_cx, ParamEnvAnd { param_env, value: goal }| {
-            let selcx = &mut SelectionContext::new(infcx);
+            let selcx =
+                &mut SelectionContext::with_query_mode(infcx, traits::TraitQueryMode::Canonical);
             let cause = ObligationCause::dummy();
             let mut obligations = vec![];
             let answer = traits::normalize_projection_type(


### PR DESCRIPTION
This allows recovering from overflow errors when normalizing a type.

This would have prevented the regression in https://github.com/rust-lang/rust/issues/79506#issuecomment-735283913. I don't yet have a test, since normalization in rustdoc was reverted (#79469). If you want me to add one, I can add a `-Z normalize-docs` flag to rustdoc and use it in the test.

r? @Aaron1011 for review or reassignment.