### PR TITLE
Fix overlap detection of `usize`/`isize` range patterns

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -535,12 +535,20 @@ impl<'p, 'tcx> Matrix<'p, 'tcx> {
         self.patterns.iter().map(|r| r.head())
     }
 
-    /// Iterate over the first constructor of each row
+    /// Iterate over the first constructor of each row.
     pub(super) fn head_ctors<'a>(
         &'a self,
         cx: &'a MatchCheckCtxt<'p, 'tcx>,
-    ) -> impl Iterator<Item = &'a Constructor<'tcx>> + Captures<'a> + Captures<'p> {
+    ) -> impl Iterator<Item = &'a Constructor<'tcx>> + Captures<'p> {
         self.patterns.iter().map(move |r| r.head_ctor(cx))
+    }
+
+    /// Iterate over the first constructor and the corresponding span of each row.
+    pub(super) fn head_ctors_and_spans<'a>(
+        &'a self,
+        cx: &'a MatchCheckCtxt<'p, 'tcx>,
+    ) -> impl Iterator<Item = (&'a Constructor<'tcx>, Span)> + Captures<'p> {
+        self.patterns.iter().map(move |r| (r.head_ctor(cx), r.head().span))
     }
 
     /// This computes `S(constructor, self)`. See top of the file for explanations.

--- a/src/test/ui/pattern/usefulness/integer-ranges/reachability.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/reachability.rs
@@ -72,7 +72,7 @@ fn main() {
     match 0usize {
         0..10 => {},
         10..20 => {},
-        5..15 => {}, // FIXME: should be unreachable
+        5..15 => {}, //~ ERROR unreachable pattern
         _ => {},
     }
     // Chars between '\u{D7FF}' and '\u{E000}' are invalid even though ranges that contain them are

--- a/src/test/ui/pattern/usefulness/integer-ranges/reachability.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/reachability.stderr
@@ -125,6 +125,12 @@ LL |         5..25 => {},
    |         ^^^^^
 
 error: unreachable pattern
+  --> $DIR/reachability.rs:75:9
+   |
+LL |         5..15 => {},
+   |         ^^^^^
+
+error: unreachable pattern
   --> $DIR/reachability.rs:82:9
    |
 LL |         '\u{D7FF}'..='\u{E000}' => {},
@@ -142,5 +148,5 @@ error: unreachable pattern
 LL |         BAR => {}
    |         ^^^
 
-error: aborting due to 23 previous errors
+error: aborting due to 24 previous errors
 


### PR DESCRIPTION
`usize` and `isize` are a bit of a special case in the match usefulness algorithm, because the range of values they contain depends on the platform. Specifically, we don't want `0..usize::MAX` to count as an exhaustive match (see also [`precise_pointer_size_matching`](https://github.com/rust-lang/rust/issues/56354)). The way this was initially implemented is by treating those ranges like float ranges, i.e. with limited cleverness. This means we didn't catch the following as unreachable:
```rust
match 0usize {
    0..10 => {},
    10..20 => {},
    5..15 => {}, // oops, should be detected as unreachable
    _ => {},
}
```
This PRs fixes this oversight. Now the only difference between `usize` and `u64` range patterns is in what ranges count as exhaustive.

r? @varkor
@rustbot label +A-exhaustiveness-checking