### PR TITLE
Check projection predicates satisfy bounds

### DIFF
--- a/src/test/ui/associated-types/associate-type-bound-wf.rs
+++ b/src/test/ui/associated-types/associate-type-bound-wf.rs
@@ -1,0 +1,17 @@
+//Regression test for #78893
+
+trait TwoAssocTypes {
+    type X;
+    type Y;
+}
+
+fn object_iterator<T: Iterator<Item = dyn Fn()>>() {}
+//~^ ERROR the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+
+fn parameter_iterator(_: impl Iterator<Item = impl ?Sized>) {}
+//~^ ERROR the size for values of type `impl ?Sized` cannot be known at compilation time
+
+fn unsized_object<T: TwoAssocTypes<X = (), Y = dyn Fn()>>() {}
+//~^ ERROR the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+
+fn main() {}

--- a/src/test/ui/associated-types/associate-type-bound-wf.stderr
+++ b/src/test/ui/associated-types/associate-type-bound-wf.stderr
@@ -1,0 +1,41 @@
+error[E0277]: the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+  --> $DIR/associate-type-bound-wf.rs:8:32
+   |
+LL | fn object_iterator<T: Iterator<Item = dyn Fn()>>() {}
+   |                                ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     type Item;
+   |     ---------- required by this bound in `std::iter::Iterator::Item`
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
+
+error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
+  --> $DIR/associate-type-bound-wf.rs:11:40
+   |
+LL | fn parameter_iterator(_: impl Iterator<Item = impl ?Sized>) {}
+   |                                        ^^^^^^^-----------
+   |                                        |      |
+   |                                        |      this type parameter needs to be `Sized`
+   |                                        doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     type Item;
+   |     ---------- required by this bound in `std::iter::Iterator::Item`
+
+error[E0277]: the size for values of type `(dyn Fn() + 'static)` cannot be known at compilation time
+  --> $DIR/associate-type-bound-wf.rs:14:44
+   |
+LL |     type Y;
+   |     ------- required by this bound in `TwoAssocTypes::Y`
+...
+LL | fn unsized_object<T: TwoAssocTypes<X = (), Y = dyn Fn()>>() {}
+   |                                            ^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn Fn() + 'static)`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/generic-associated-types/collections-project-default.rs
+++ b/src/test/ui/generic-associated-types/collections-project-default.rs
@@ -9,7 +9,9 @@
 // check that we don't normalize with trait defaults.
 
 trait Collection<T> {
-    type Iter<'iter>: Iterator<Item=&'iter T> where T: 'iter;
+    type Iter<'iter>: Iterator<Item = &'iter T>
+    where
+        T: 'iter;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
     type Sibling<U>: Collection<U> =
@@ -22,7 +24,7 @@ trait Collection<T> {
     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
 }
 
-trait CollectionFamily {
+trait CollectionFamily: Sized {
     type Member<T>: Collection<T, Family = Self>;
 }
 
@@ -33,7 +35,10 @@ impl CollectionFamily for VecFamily {
 }
 
 impl<T> Collection<T> for Vec<T> {
-    type Iter<'iter> where T: 'iter = std::slice::Iter<'iter, T>;
+    type Iter<'iter>
+    where
+        T: 'iter,
+    = std::slice::Iter<'iter, T>;
     type Family = VecFamily;
 
     fn empty() -> Self {

--- a/src/test/ui/generic-associated-types/collections-project-default.stderr
+++ b/src/test/ui/generic-associated-types/collections-project-default.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/collections-project-default.rs:60:5
+  --> $DIR/collections-project-default.rs:65:5
    |
 LL | fn floatify_sibling<C>(ints: &C) -> <C as Collection<i32>>::Sibling<f32>
    |                                     ------------------------------------ expected `<C as Collection<i32>>::Sibling<f32>` because of return type

--- a/src/test/ui/generic-associated-types/collections.rs
+++ b/src/test/ui/generic-associated-types/collections.rs
@@ -9,7 +9,9 @@
 // run-pass
 
 trait Collection<T> {
-    type Iter<'iter>: Iterator<Item=&'iter T> where T: 'iter;
+    type Iter<'iter>: Iterator<Item = &'iter T>
+    where
+        T: 'iter;
     type Family: CollectionFamily;
     // Test associated type defaults with parameters
     type Sibling<U>: Collection<U> =
@@ -22,7 +24,7 @@ trait Collection<T> {
     fn iterate<'iter>(&'iter self) -> Self::Iter<'iter>;
 }
 
-trait CollectionFamily {
+trait CollectionFamily: Sized {
     type Member<T>: Collection<T, Family = Self>;
 }
 
@@ -33,7 +35,10 @@ impl CollectionFamily for VecFamily {
 }
 
 impl<T> Collection<T> for Vec<T> {
-    type Iter<'iter> where T: 'iter = std::slice::Iter<'iter, T>;
+    type Iter<'iter>
+    where
+        T: 'iter,
+    = std::slice::Iter<'iter, T>;
     type Family = VecFamily;
 
     fn empty() -> Self {


### PR DESCRIPTION
This restores the behavior from before #73905.

closes #78893

r? @nikomatsakis 