### PR TITLE
Show since when a function is const in stdlib

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -124,6 +124,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                     visibility: Inherited,
                     def_id: self.cx.next_def_id(param_env_def_id.krate),
                     stability: None,
+                    const_stability: None,
                     deprecation: None,
                     kind: ImplItem(Impl {
                         unsafety: hir::Unsafety::Normal,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -113,6 +113,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                     visibility: Inherited,
                     def_id: self.cx.next_def_id(impl_def_id.krate),
                     stability: None,
+                    const_stability: None,
                     deprecation: None,
                     kind: ImplItem(Impl {
                         unsafety: hir::Unsafety::Normal,

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -483,6 +483,7 @@ fn build_module(cx: &DocContext<'_>, did: DefId, visited: &mut FxHashSet<DefId>)
                         def_id: DefId::local(CRATE_DEF_INDEX),
                         visibility: clean::Public,
                         stability: None,
+                        const_stability: None,
                         deprecation: None,
                         kind: clean::ImportItem(clean::Import::new_simple(
                             item.ident.to_string(),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2189,6 +2189,7 @@ fn clean_extern_crate(
         def_id: crate_def_id,
         visibility: krate.vis.clean(cx),
         stability: None,
+        const_stability: None,
         deprecation: None,
         kind: ExternCrateItem(name.clean(cx), path),
     }]
@@ -2259,6 +2260,7 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
                         def_id: cx.tcx.hir().local_def_id(self.id).to_def_id(),
                         visibility: self.vis.clean(cx),
                         stability: None,
+                        const_stability: None,
                         deprecation: None,
                         kind: ImportItem(Import::new_simple(
                             self.name.clean(cx),
@@ -2279,6 +2281,7 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
             def_id: DefId::local(CRATE_DEF_INDEX),
             visibility: self.vis.clean(cx),
             stability: None,
+            const_stability: None,
             deprecation: None,
             kind: ImportItem(inner),
         }]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -12,7 +12,7 @@ use rustc_ast::attr;
 use rustc_ast::util::comments::beautify_doc_string;
 use rustc_ast::{self as ast, AttrStyle};
 use rustc_ast::{FloatTy, IntTy, UintTy};
-use rustc_attr::{Stability, StabilityLevel};
+use rustc_attr::{ConstStability, Stability, StabilityLevel};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_feature::UnstableFeatures;
 use rustc_hir as hir;
@@ -87,6 +87,7 @@ crate struct Item {
     crate def_id: DefId,
     crate stability: Option<Stability>,
     crate deprecation: Option<Deprecation>,
+    crate const_stability: Option<ConstStability>,
 }
 
 impl fmt::Debug for Item {
@@ -155,6 +156,7 @@ impl Item {
             visibility: cx.tcx.visibility(def_id).clean(cx),
             stability: cx.tcx.lookup_stability(def_id).cloned(),
             deprecation: cx.tcx.lookup_deprecation(def_id).clean(cx),
+            const_stability: cx.tcx.lookup_const_stability(def_id).cloned(),
         }
     }
 
@@ -257,6 +259,13 @@ impl Item {
 
     crate fn stable_since(&self) -> Option<SymbolStr> {
         match self.stability?.level {
+            StabilityLevel::Stable { since, .. } => Some(since.as_str()),
+            StabilityLevel::Unstable { .. } => None,
+        }
+    }
+
+    crate fn const_stable_since(&self) -> Option<SymbolStr> {
+        match self.const_stability?.level {
             StabilityLevel::Stable { since, .. } => Some(since.as_str()),
             StabilityLevel::Unstable { .. } => None,
         }

--- a/src/test/rustdoc/const-display.rs
+++ b/src/test/rustdoc/const-display.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-linelength
+
 #![crate_name = "foo"]
 
 #![unstable(feature = "humans",
@@ -17,6 +19,7 @@ pub const unsafe fn foo() -> u32 { 42 }
 pub const fn foo2() -> u32 { 42 }
 
 // @has 'foo/fn.bar2.html' '//pre' 'pub const fn bar2() -> u32'
+// @has - //span '1.0.0 (const: 1.0.0)'
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
 pub const fn bar2() -> u32 { 42 }
@@ -26,6 +29,7 @@ pub const fn bar2() -> u32 { 42 }
 pub const unsafe fn foo2_gated() -> u32 { 42 }
 
 // @has 'foo/fn.bar2_gated.html' '//pre' 'pub const unsafe fn bar2_gated() -> u32'
+// @has - '//span[@class="since"]' '1.0.0 (const: 1.0.0)'
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "rust1", since = "1.0.0")]
 pub const unsafe fn bar2_gated() -> u32 { 42 }
@@ -40,4 +44,10 @@ impl Foo {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature="foo", issue = "none")]
     pub const unsafe fn gated() -> u32 { 42 }
+
+    // @has 'foo/struct.Foo.html' '//h4[@id="method.stable_impl"]/code' 'pub const fn stable_impl() -> u32'
+    // @has - '//span[@class="since"]' '1.0.0 (const: 1.2.0)'
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_stable(feature = "rust1", since = "1.2.0")]
+    pub const fn stable_impl() -> u32 { 42 }
 }


### PR DESCRIPTION
Fixes #76998

This makes it so that functions with the `#[rustc_const_stable()]` attribute now show from what version they were stably declared const, alongside what version they were declared stable. Example from `Result`:
![image](https://user-images.githubusercontent.com/13342132/100561194-1be60d00-3286-11eb-99ff-1e81201218a9.png)

r? @jyn514 