### PR TITLE
Make char and u8 methods const

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -390,7 +390,7 @@ impl char {
     /// assert_eq!('❤'.escape_unicode().to_string(), "\\u{2764}");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[stable(feature = "const_char_escape_unicode", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_char_escape_unicode", since = "1.48.0")]
     #[inline]
     pub const fn escape_unicode(self) -> EscapeUnicode {
         let c = self as u32;
@@ -518,7 +518,7 @@ impl char {
     /// assert_eq!('"'.escape_default().to_string(), "\\\"");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[stable(feature = "const_char_escape_default", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_char_escape_default", since = "1.48.0")]
     #[inline]
     pub const fn escape_default(self) -> EscapeDefault {
         let init_state = match self {

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -390,7 +390,7 @@ impl char {
     /// assert_eq!('❤'.escape_unicode().to_string(), "\\u{2764}");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_escape_unicode", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_char_escape_unicode", since = "1.49.0")]
     #[inline]
     pub const fn escape_unicode(self) -> EscapeUnicode {
         let c = self as u32;
@@ -518,7 +518,7 @@ impl char {
     /// assert_eq!('"'.escape_default().to_string(), "\\\"");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_escape_default", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_char_escape_default", since = "1.49.0")]
     #[inline]
     pub const fn escape_default(self) -> EscapeDefault {
         let init_state = match self {
@@ -578,7 +578,7 @@ impl char {
     /// assert_eq!(len, tokyo.len());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.49.0")]
     #[inline]
     pub const fn len_utf8(self) -> usize {
         len_utf8(self as u32)
@@ -604,7 +604,7 @@ impl char {
     /// assert_eq!(len, 2);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.49.0")]
     #[inline]
     pub const fn len_utf16(self) -> usize {
         let ch = self as u32;
@@ -1097,7 +1097,7 @@ impl char {
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     /// [`to_uppercase`]: #method.to_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
     #[inline]
     pub const fn to_ascii_uppercase(&self) -> char {
         if self.is_ascii() { (*self as u8).to_ascii_uppercase() as char } else { *self }
@@ -1126,7 +1126,7 @@ impl char {
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     /// [`to_lowercase`]: #method.to_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
     #[inline]
     pub const fn to_ascii_lowercase(&self) -> char {
         if self.is_ascii() { (*self as u8).to_ascii_lowercase() as char } else { *self }
@@ -1148,7 +1148,7 @@ impl char {
     /// assert!(!upper_a.eq_ignore_ascii_case(&lower_z));
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
     #[inline]
     pub const fn eq_ignore_ascii_case(&self, other: &char) -> bool {
         self.to_ascii_lowercase() == other.to_ascii_lowercase()

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -390,6 +390,7 @@ impl char {
     /// assert_eq!('❤'.escape_unicode().to_string(), "\\u{2764}");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[stable(feature = "const_char_escape_unicode", since = "1.48.0")]
     #[inline]
     pub const fn escape_unicode(self) -> EscapeUnicode {
         let c = self as u32;
@@ -517,6 +518,7 @@ impl char {
     /// assert_eq!('"'.escape_default().to_string(), "\\\"");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[stable(feature = "const_char_escape_default", since = "1.48.0")]
     #[inline]
     pub const fn escape_default(self) -> EscapeDefault {
         let init_state = match self {
@@ -576,6 +578,7 @@ impl char {
     /// assert_eq!(len, tokyo.len());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.48.0")]
     #[inline]
     pub const fn len_utf8(self) -> usize {
         len_utf8(self as u32)
@@ -601,6 +604,7 @@ impl char {
     /// assert_eq!(len, 2);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.48.0")]
     #[inline]
     pub const fn len_utf16(self) -> usize {
         let ch = self as u32;
@@ -1093,8 +1097,9 @@ impl char {
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     /// [`to_uppercase`]: #method.to_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
     #[inline]
-    pub fn to_ascii_uppercase(&self) -> char {
+    pub const fn to_ascii_uppercase(&self) -> char {
         if self.is_ascii() { (*self as u8).to_ascii_uppercase() as char } else { *self }
     }
 
@@ -1121,8 +1126,9 @@ impl char {
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     /// [`to_lowercase`]: #method.to_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
     #[inline]
-    pub fn to_ascii_lowercase(&self) -> char {
+    pub const fn to_ascii_lowercase(&self) -> char {
         if self.is_ascii() { (*self as u8).to_ascii_lowercase() as char } else { *self }
     }
 
@@ -1142,8 +1148,9 @@ impl char {
     /// assert!(!upper_a.eq_ignore_ascii_case(&lower_z));
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
     #[inline]
-    pub fn eq_ignore_ascii_case(&self, other: &char) -> bool {
+    pub const fn eq_ignore_ascii_case(&self, other: &char) -> bool {
         self.to_ascii_lowercase() == other.to_ascii_lowercase()
     }
 

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -390,7 +390,7 @@ impl char {
     /// assert_eq!('❤'.escape_unicode().to_string(), "\\u{2764}");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_escape_unicode", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_char_escape_unicode", since = "1.50.0")]
     #[inline]
     pub const fn escape_unicode(self) -> EscapeUnicode {
         let c = self as u32;
@@ -518,7 +518,7 @@ impl char {
     /// assert_eq!('"'.escape_default().to_string(), "\\\"");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_escape_default", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_char_escape_default", since = "1.50.0")]
     #[inline]
     pub const fn escape_default(self) -> EscapeDefault {
         let init_state = match self {
@@ -578,7 +578,7 @@ impl char {
     /// assert_eq!(len, tokyo.len());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.50.0")]
     #[inline]
     pub const fn len_utf8(self) -> usize {
         len_utf8(self as u32)
@@ -604,7 +604,7 @@ impl char {
     /// assert_eq!(len, 2);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_char_len_utf", since = "1.50.0")]
     #[inline]
     pub const fn len_utf16(self) -> usize {
         let ch = self as u32;
@@ -1097,7 +1097,7 @@ impl char {
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     /// [`to_uppercase`]: #method.to_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.50.0")]
     #[inline]
     pub const fn to_ascii_uppercase(&self) -> char {
         if self.is_ascii() { (*self as u8).to_ascii_uppercase() as char } else { *self }
@@ -1126,7 +1126,7 @@ impl char {
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     /// [`to_lowercase`]: #method.to_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.50.0")]
     #[inline]
     pub const fn to_ascii_lowercase(&self) -> char {
         if self.is_ascii() { (*self as u8).to_ascii_lowercase() as char } else { *self }
@@ -1148,7 +1148,7 @@ impl char {
     /// assert!(!upper_a.eq_ignore_ascii_case(&lower_z));
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.50.0")]
     #[inline]
     pub const fn eq_ignore_ascii_case(&self, other: &char) -> bool {
         self.to_ascii_lowercase() == other.to_ascii_lowercase()

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -391,7 +391,7 @@ impl char {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn escape_unicode(self) -> EscapeUnicode {
+    pub const fn escape_unicode(self) -> EscapeUnicode {
         let c = self as u32;
 
         // or-ing 1 ensures that for c==0 the code computes that one
@@ -518,7 +518,7 @@ impl char {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn escape_default(self) -> EscapeDefault {
+    pub const fn escape_default(self) -> EscapeDefault {
         let init_state = match self {
             '\t' => EscapeDefaultState::Backslash('t'),
             '\r' => EscapeDefaultState::Backslash('r'),
@@ -577,7 +577,7 @@ impl char {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn len_utf8(self) -> usize {
+    pub const fn len_utf8(self) -> usize {
         len_utf8(self as u32)
     }
 
@@ -602,7 +602,7 @@ impl char {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn len_utf16(self) -> usize {
+    pub const fn len_utf16(self) -> usize {
         let ch = self as u32;
         if (ch & 0xFFFF) == ch { 1 } else { 2 }
     }
@@ -1560,7 +1560,7 @@ impl char {
 }
 
 #[inline]
-fn len_utf8(code: u32) -> usize {
+const fn len_utf8(code: u32) -> usize {
     if code < MAX_ONE_B {
         1
     } else if code < MAX_TWO_B {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -199,6 +199,7 @@ impl u8 {
     ///
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
     #[inline]
     pub const fn to_ascii_uppercase(&self) -> u8 {
         // Unset the fifth bit if this is a lowercase letter
@@ -222,6 +223,7 @@ impl u8 {
     ///
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
     #[inline]
     pub const fn to_ascii_lowercase(&self) -> u8 {
         // Set the fifth bit if this is an uppercase letter
@@ -241,6 +243,7 @@ impl u8 {
     /// assert!(lowercase_a.eq_ignore_ascii_case(&uppercase_a));
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
     #[inline]
     pub const fn eq_ignore_ascii_case(&self, other: &u8) -> bool {
         self.to_ascii_lowercase() == other.to_ascii_lowercase()

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -199,7 +199,7 @@ impl u8 {
     ///
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.50.0")]
     #[inline]
     pub const fn to_ascii_uppercase(&self) -> u8 {
         // Unset the fifth bit if this is a lowercase letter
@@ -223,7 +223,7 @@ impl u8 {
     ///
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.50.0")]
     #[inline]
     pub const fn to_ascii_lowercase(&self) -> u8 {
         // Set the fifth bit if this is an uppercase letter
@@ -243,7 +243,7 @@ impl u8 {
     /// assert!(lowercase_a.eq_ignore_ascii_case(&uppercase_a));
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.50.0")]
     #[inline]
     pub const fn eq_ignore_ascii_case(&self, other: &u8) -> bool {
         self.to_ascii_lowercase() == other.to_ascii_lowercase()

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -200,7 +200,7 @@ impl u8 {
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
-    pub fn to_ascii_uppercase(&self) -> u8 {
+    pub const fn to_ascii_uppercase(&self) -> u8 {
         // Unset the fifth bit if this is a lowercase letter
         *self & !((self.is_ascii_lowercase() as u8) << 5)
     }
@@ -223,7 +223,7 @@ impl u8 {
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
-    pub fn to_ascii_lowercase(&self) -> u8 {
+    pub const fn to_ascii_lowercase(&self) -> u8 {
         // Set the fifth bit if this is an uppercase letter
         *self | ((self.is_ascii_uppercase() as u8) << 5)
     }
@@ -242,7 +242,7 @@ impl u8 {
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
-    pub fn eq_ignore_ascii_case(&self, other: &u8) -> bool {
+    pub const fn eq_ignore_ascii_case(&self, other: &u8) -> bool {
         self.to_ascii_lowercase() == other.to_ascii_lowercase()
     }
 

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -199,7 +199,7 @@ impl u8 {
     ///
     /// [`make_ascii_uppercase`]: #method.make_ascii_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
     #[inline]
     pub const fn to_ascii_uppercase(&self) -> u8 {
         // Unset the fifth bit if this is a lowercase letter
@@ -223,7 +223,7 @@ impl u8 {
     ///
     /// [`make_ascii_lowercase`]: #method.make_ascii_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
     #[inline]
     pub const fn to_ascii_lowercase(&self) -> u8 {
         // Set the fifth bit if this is an uppercase letter
@@ -243,7 +243,7 @@ impl u8 {
     /// assert!(lowercase_a.eq_ignore_ascii_case(&uppercase_a));
     /// ```
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
-    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.48.0")]
+    #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.49.0")]
     #[inline]
     pub const fn eq_ignore_ascii_case(&self, other: &u8) -> bool {
         self.to_ascii_lowercase() == other.to_ascii_lowercase()


### PR DESCRIPTION
char methods `escape_unicode`, `escape_default`, `len_utf8`, `len_utf16`, `to_ascii_lowercase`, `eq_ignore_ascii_case` can be made const.

`u8` methods `to_ascii_lowercase`, `to_ascii_uppercase` are required to be const as well.

`u8::eq_ignore_ascii_case` was additionally made const.