### PR TITLE
Add unstable #[may_ignore] attribute to cancel #[must_use]

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -620,6 +620,9 @@ declare_features! (
     /// Allows capturing disjoint fields in a closure/generator (RFC 2229).
     (active, capture_disjoint_fields, "1.49.0", Some(53488), None),
 
+    /// Allow `#[may_ignore]` attribute.
+    (active, may_ignore, "1.50.0", Some(99999999), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -207,6 +207,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ungated!(forbid, Normal, template!(List: r#"lint1, lint2, ..., /*opt*/ reason = "...""#)),
     ungated!(deny, Normal, template!(List: r#"lint1, lint2, ..., /*opt*/ reason = "...""#)),
     ungated!(must_use, AssumedUsed, template!(Word, NameValueStr: "reason")),
+    gated!(may_ignore, AssumedUsed, template!(Word), experimental!(may_ignore)),
     // FIXME(#14407)
     ungated!(
         deprecated, Normal,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -681,6 +681,7 @@ symbols! {
         maxnumf32,
         maxnumf64,
         may_dangle,
+        may_ignore,
         maybe_uninit,
         maybe_uninit_uninit,
         maybe_uninit_zeroed,

--- a/src/test/ui/feature-gate-may_ignore.rs
+++ b/src/test/ui/feature-gate-may_ignore.rs
@@ -1,0 +1,4 @@
+#[may_ignore]
+//~^ ERROR the `#[may_ignore]` attribute is an experimental feature [E0658]
+fn main() {
+}

--- a/src/test/ui/feature-gate-may_ignore.stderr
+++ b/src/test/ui/feature-gate-may_ignore.stderr
@@ -1,0 +1,12 @@
+error[E0658]: the `#[may_ignore]` attribute is an experimental feature
+  --> $DIR/feature-gate-may_ignore.rs:1:1
+   |
+LL | #[may_ignore]
+   | ^^^^^^^^^^^^^
+   |
+   = note: see issue #99999999 <https://github.com/rust-lang/rust/issues/99999999> for more information
+   = help: add `#![feature(may_ignore)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/may_ignore.rs
+++ b/src/test/ui/may_ignore.rs
@@ -1,0 +1,18 @@
+// check-pass
+
+#![feature(may_ignore)]
+#![warn(unused_must_use)]
+
+fn warn() -> Result<i32, i32> {
+    Err(1)
+}
+
+#[may_ignore]
+fn no_warn() -> Result<i32, i32> {
+    Err(2)
+}
+
+fn main() {
+    warn(); //~ WARN [unused_must_use]
+    no_warn();
+}

--- a/src/test/ui/may_ignore.stderr
+++ b/src/test/ui/may_ignore.stderr
@@ -1,0 +1,15 @@
+warning: unused `std::result::Result` that must be used
+  --> $DIR/may_ignore.rs:16:5
+   |
+LL |     warn();
+   |     ^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/may_ignore.rs:4:9
+   |
+LL | #![warn(unused_must_use)]
+   |         ^^^^^^^^^^^^^^^
+   = note: this `Result` may be an `Err` variant, which should be handled
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This adds an unstable #[may_ignore] attribute, that can cancel the effect of a #[must_use] attribute. This is useful when the result of a function can be safely ignored, but it returns a #[must_use] type such as a Result.

---

Edit: Example usage of this: https://github.com/rust-lang/rust/pull/78822/