### PR TITLE
Don't time `emit_ignored_resolution_errors`

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -412,9 +412,7 @@ crate fn run_core(
                 let hir = tcx.hir();
                 let body = hir.body(hir.body_owned_by(hir.local_def_id_to_hir_id(def_id)));
                 debug!("visiting body for {:?}", def_id);
-                tcx.sess.time("emit_ignored_resolution_errors", || {
-                    EmitIgnoredResolutionErrors::new(tcx).visit_body(body);
-                });
+                EmitIgnoredResolutionErrors::new(tcx).visit_body(body);
                 (rustc_interface::DEFAULT_QUERY_PROVIDERS.typeck)(tcx, def_id)
             };
         }),


### PR DESCRIPTION
This printed several hundred lines each time rustdoc was run, almost all
of which rounded to 0.000. Since this isn't useful info, don't print it
everywhere, so other perf info is easier to read.

r? @Mark-Simulacrum 