### PR TITLE
Do not expose PollFn struct

### DIFF
--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -27,7 +27,7 @@ pub use pending::{pending, Pending};
 pub use ready::{ready, Ready};
 
 #[unstable(feature = "future_poll_fn", issue = "72302")]
-pub use poll_fn::{poll_fn, PollFn};
+pub use poll_fn::poll_fn;
 
 /// This type is needed because:
 ///

--- a/library/core/src/future/poll_fn.rs
+++ b/library/core/src/future/poll_fn.rs
@@ -24,7 +24,7 @@ use crate::task::{Context, Poll};
 /// # }
 /// ```
 #[unstable(feature = "future_poll_fn", issue = "72302")]
-pub fn poll_fn<T, F>(f: F) -> PollFn<F>
+pub fn poll_fn<T, F>(f: F) -> impl Future<Output = T>
 where
     F: FnMut(&mut Context<'_>) -> Poll<T>,
 {
@@ -37,7 +37,7 @@ where
 /// documentation for more.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[unstable(feature = "future_poll_fn", issue = "72302")]
-pub struct PollFn<F> {
+struct PollFn<F> {
     f: F,
 }
 


### PR DESCRIPTION
Tracking issue: #72302.

We don't need to expose PollFn struct to the public, returning `impl Future` is enough