### PR TITLE
Adding diesel to the cargetest suite

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -9,6 +9,8 @@ struct Test {
     sha: &'static str,
     lock: Option<&'static str>,
     packages: &'static [&'static str],
+    features: Option<&'static [&'static str]>,
+    manifest_path: Option<&'static str>,
 }
 
 const TEST_REPOS: &[Test] = &[
@@ -18,6 +20,8 @@ const TEST_REPOS: &[Test] = &[
         sha: "cf056ea5e8052c1feea6141e40ab0306715a2c33",
         lock: None,
         packages: &[],
+        features: None,
+        manifest_path: None,
     },
     Test {
         name: "ripgrep",
@@ -25,6 +29,8 @@ const TEST_REPOS: &[Test] = &[
         sha: "3de31f752729525d85a3d1575ac1978733b3f7e7",
         lock: None,
         packages: &[],
+        features: None,
+        manifest_path: None,
     },
     Test {
         name: "tokei",
@@ -32,6 +38,8 @@ const TEST_REPOS: &[Test] = &[
         sha: "fdf3f8cb279a7aeac0696c87e5d8b0cd946e4f9e",
         lock: None,
         packages: &[],
+        features: None,
+        manifest_path: None,
     },
     Test {
         name: "xsv",
@@ -39,6 +47,8 @@ const TEST_REPOS: &[Test] = &[
         sha: "66956b6bfd62d6ac767a6b6499c982eae20a2c9f",
         lock: None,
         packages: &[],
+        features: None,
+        manifest_path: None,
     },
     Test {
         name: "servo",
@@ -48,6 +58,23 @@ const TEST_REPOS: &[Test] = &[
         // Only test Stylo a.k.a. Quantum CSS, the parts of Servo going into Firefox.
         // This takes much less time to build than all of Servo and supports stable Rust.
         packages: &["selectors"],
+        features: None,
+        manifest_path: None,
+    },
+    Test {
+        name: "diesel",
+        repo: "https://github.com/diesel-rs/diesel",
+        sha: "91493fe47175076f330ce5fc518f0196c0476f56",
+        lock: None,
+        packages: &[],
+        // Test the embeded sqlite variant of diesel
+        // This does not require any dependency to be present,
+        // sqlite will be compiled as part of the build process
+        features: Some(&["sqlite", "libsqlite3-sys/bundled"]),
+        // We are only interested in testing diesel itself
+        // not any other crate present in the diesel workspace
+        // (This is required to set the feature flags above)
+        manifest_path: Some("diesel/Cargo.toml"),
     },
 ];
 
@@ -68,7 +95,7 @@ fn test_repo(cargo: &Path, out_dir: &Path, test: &Test) {
     if let Some(lockfile) = test.lock {
         fs::write(&dir.join("Cargo.lock"), lockfile).unwrap();
     }
-    if !run_cargo_test(cargo, &dir, test.packages) {
+    if !run_cargo_test(cargo, &dir, test.packages, test.features, test.manifest_path) {
         panic!("tests failed for {}", test.repo);
     }
 }
@@ -120,12 +147,31 @@ fn clone_repo(test: &Test, out_dir: &Path) -> PathBuf {
     out_dir
 }
 
-fn run_cargo_test(cargo_path: &Path, crate_path: &Path, packages: &[&str]) -> bool {
+fn run_cargo_test(
+    cargo_path: &Path,
+    crate_path: &Path,
+    packages: &[&str],
+    features: Option<&[&str]>,
+    manifest_path: Option<&str>,
+) -> bool {
     let mut command = Command::new(cargo_path);
     command.arg("test");
+
+    if let Some(path) = manifest_path {
+        command.arg(format!("--manifest-path={}", path));
+    }
+
+    if let Some(features) = features {
+        command.arg("--no-default-features");
+        for feature in features {
+            command.arg(format!("--features={}", feature));
+        }
+    }
+
     for name in packages {
         command.arg("-p").arg(name);
     }
+
     let status = command
         // Disable rust-lang/cargo's cross-compile tests
         .env("CFG_DISABLE_CROSS_TESTS", "1")


### PR DESCRIPTION
This was proposed in #79459 and #79560.
Diesel stresses the trait system implementation quite a lot and there
have been various regressions regarding that in the past.