### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -182,7 +182,9 @@ impl Attribute {
 
     pub fn name_value_literal_span(&self) -> Option<Span> {
         match self.kind {
-            AttrKind::Normal(ref item, _) => item.meta(self.span).and_then(|meta| meta.name_value_literal_span()),
+            AttrKind::Normal(ref item, _) => {
+                item.meta(self.span).and_then(|meta| meta.name_value_literal_span())
+            }
             AttrKind::DocComment(..) => None,
         }
     }

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -180,6 +180,13 @@ impl Attribute {
         self.value_str().is_some()
     }
 
+    /// This is used in case you want the value span instead of the whole attribute. Example:
+    ///
+    /// ```text
+    /// #[doc(alias = "foo")]
+    /// ```
+    ///
+    /// In here, it'll return a span for `"foo"`.
     pub fn name_value_literal_span(&self) -> Option<Span> {
         match self.kind {
             AttrKind::Normal(ref item, _) => {
@@ -241,6 +248,13 @@ impl MetaItem {
         self.value_str().is_some()
     }
 
+    /// This is used in case you want the value span instead of the whole attribute. Example:
+    ///
+    /// ```text
+    /// #[doc(alias = "foo")]
+    /// ```
+    ///
+    /// In here, it'll return a span for `"foo"`.
     pub fn name_value_literal_span(&self) -> Option<Span> {
         Some(self.name_value_literal()?.span)
     }

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -115,6 +115,10 @@ impl NestedMetaItem {
     pub fn is_meta_item_list(&self) -> bool {
         self.meta_item_list().is_some()
     }
+
+    pub fn name_value_literal_span(&self) -> Option<Span> {
+        self.meta_item()?.name_value_literal_span()
+    }
 }
 
 impl Attribute {
@@ -175,6 +179,13 @@ impl Attribute {
     pub fn is_value_str(&self) -> bool {
         self.value_str().is_some()
     }
+
+    pub fn name_value_literal_span(&self) -> Option<Span> {
+        match self.kind {
+            AttrKind::Normal(ref item, _) => item.meta(self.span).and_then(|meta| meta.name_value_literal_span()),
+            AttrKind::DocComment(..) => None,
+        }
+    }
 }
 
 impl MetaItem {
@@ -226,6 +237,10 @@ impl MetaItem {
 
     pub fn is_value_str(&self) -> bool {
         self.value_str().is_some()
+    }
+
+    pub fn name_value_literal_span(&self) -> Option<Span> {
+        Some(self.name_value_literal()?.span)
     }
 }
 

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -294,7 +294,7 @@ where
                                                     or \"none\"",
                                                 )
                                                 .span_label(
-                                                    mi.name_value_literal().unwrap().span,
+                                                    mi.name_value_literal_span().unwrap(),
                                                     msg,
                                                 )
                                                 .emit();

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1603,23 +1603,22 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
                             items.push(ast::NestedMetaItem::MetaItem(item));
                         }
                         Err(e) => {
-                            let lit =
-                                it.meta_item().and_then(|item| item.name_value_literal()).unwrap();
+                            let lit_span = it.name_value_literal_span().unwrap();
 
                             if e.kind() == ErrorKind::InvalidData {
                                 self.cx
                                     .struct_span_err(
-                                        lit.span,
+                                        lit_span,
                                         &format!("{} wasn't a utf-8 file", filename.display()),
                                     )
-                                    .span_label(lit.span, "contains invalid utf-8")
+                                    .span_label(lit_span, "contains invalid utf-8")
                                     .emit();
                             } else {
                                 let mut err = self.cx.struct_span_err(
-                                    lit.span,
+                                    lit_span,
                                     &format!("couldn't read {}: {}", filename.display(), e),
                                 );
-                                err.span_label(lit.span, "couldn't read file");
+                                err.span_label(lit_span, "couldn't read file");
 
                                 err.emit();
                             }

--- a/compiler/rustc_middle/src/middle/limits.rs
+++ b/compiler/rustc_middle/src/middle/limits.rs
@@ -43,8 +43,7 @@ fn update_limit(
 
                     let value_span = attr
                         .meta()
-                        .and_then(|meta| meta.name_value_literal().cloned())
-                        .map(|lit| lit.span)
+                        .and_then(|meta| meta.name_value_literal_span())
                         .unwrap_or(attr.span);
 
                     let error_str = match e.kind() {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -319,7 +319,7 @@ impl CheckAttrVisitor<'tcx> {
                             self.tcx
                                 .sess
                                 .struct_span_err(
-                                    meta.span(),
+                                    meta.name_value_literal_span().unwrap_or_else(|| meta.span()),
                                     &format!(
                                         "{:?} character isn't allowed in `#[doc(alias = \"...\")]`",
                                         c,
@@ -332,7 +332,7 @@ impl CheckAttrVisitor<'tcx> {
                             self.tcx
                                 .sess
                                 .struct_span_err(
-                                    meta.span(),
+                                    meta.name_value_literal_span().unwrap_or_else(|| meta.span()),
                                     "`#[doc(alias = \"...\")]` cannot start or end with ' '",
                                 )
                                 .emit();

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -214,7 +214,7 @@ pub enum SymbolManglingVersion {
 
 impl_stable_hash_via_hash!(SymbolManglingVersion);
 
-#[derive(Clone, Copy, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum DebugInfo {
     None,
     Limited,

--- a/library/std/tests/env.rs
+++ b/library/std/tests/env.rs
@@ -1,6 +1,5 @@
 use std::env::*;
 use std::ffi::{OsStr, OsString};
-use std::path::PathBuf;
 
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -82,6 +81,8 @@ fn test_env_set_var() {
 #[cfg_attr(any(target_os = "emscripten", target_env = "sgx"), ignore)]
 #[allow(deprecated)]
 fn env_home_dir() {
+    use std::path::PathBuf;
+
     fn var_to_os_string(var: Result<String, VarError>) -> Option<OsString> {
         match var {
             Ok(var) => Some(OsString::from(var)),

--- a/src/test/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.stderr
@@ -17,42 +17,42 @@ LL | #[doc(alias("bar"))]
    |       ^^^^^^^^^^^^
 
 error: '\"' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:9:7
+  --> $DIR/check-doc-alias-attr.rs:9:15
    |
 LL | #[doc(alias = "\"")]
-   |       ^^^^^^^^^^^^
+   |               ^^^^
 
 error: '\n' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:10:7
+  --> $DIR/check-doc-alias-attr.rs:10:15
    |
 LL | #[doc(alias = "\n")]
-   |       ^^^^^^^^^^^^
+   |               ^^^^
 
 error: '\n' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:11:7
+  --> $DIR/check-doc-alias-attr.rs:11:15
    |
 LL |   #[doc(alias = "
-   |  _______^
+   |  _______________^
 LL | | ")]
    | |_^
 
 error: '\t' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:13:7
+  --> $DIR/check-doc-alias-attr.rs:13:15
    |
 LL | #[doc(alias = "\t")]
-   |       ^^^^^^^^^^^^
+   |               ^^^^
 
 error: `#[doc(alias = "...")]` cannot start or end with ' '
-  --> $DIR/check-doc-alias-attr.rs:14:7
+  --> $DIR/check-doc-alias-attr.rs:14:15
    |
 LL | #[doc(alias = " hello")]
-   |       ^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^
 
 error: `#[doc(alias = "...")]` cannot start or end with ' '
-  --> $DIR/check-doc-alias-attr.rs:15:7
+  --> $DIR/check-doc-alias-attr.rs:15:15
    |
 LL | #[doc(alias = "hello ")]
-   |       ^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^
 
 error: aborting due to 9 previous errors
 

--- a/src/test/rustdoc-ui/doc-alias-crate-level.stderr
+++ b/src/test/rustdoc-ui/doc-alias-crate-level.stderr
@@ -1,8 +1,8 @@
 error: '\'' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/doc-alias-crate-level.rs:5:7
+  --> $DIR/doc-alias-crate-level.rs:5:15
    |
 LL | #[doc(alias = "shouldn't work!")]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^
 
 error: `#![doc(alias = "...")]` isn't allowed as a crate level attribute
   --> $DIR/doc-alias-crate-level.rs:3:8

--- a/src/test/ui/check-doc-alias-attr.stderr
+++ b/src/test/ui/check-doc-alias-attr.stderr
@@ -17,42 +17,42 @@ LL | #[doc(alias("bar"))]
    |       ^^^^^^^^^^^^
 
 error: '\"' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:10:7
+  --> $DIR/check-doc-alias-attr.rs:10:15
    |
 LL | #[doc(alias = "\"")]
-   |       ^^^^^^^^^^^^
+   |               ^^^^
 
 error: '\n' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:11:7
+  --> $DIR/check-doc-alias-attr.rs:11:15
    |
 LL | #[doc(alias = "\n")]
-   |       ^^^^^^^^^^^^
+   |               ^^^^
 
 error: '\n' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:12:7
+  --> $DIR/check-doc-alias-attr.rs:12:15
    |
 LL |   #[doc(alias = "
-   |  _______^
+   |  _______________^
 LL | | ")]
    | |_^
 
 error: '\t' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:14:7
+  --> $DIR/check-doc-alias-attr.rs:14:15
    |
 LL | #[doc(alias = "\t")]
-   |       ^^^^^^^^^^^^
+   |               ^^^^
 
 error: `#[doc(alias = "...")]` cannot start or end with ' '
-  --> $DIR/check-doc-alias-attr.rs:15:7
+  --> $DIR/check-doc-alias-attr.rs:15:15
    |
 LL | #[doc(alias = " hello")]
-   |       ^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^
 
 error: `#[doc(alias = "...")]` cannot start or end with ' '
-  --> $DIR/check-doc-alias-attr.rs:16:7
+  --> $DIR/check-doc-alias-attr.rs:16:15
    |
 LL | #[doc(alias = "hello ")]
-   |       ^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/doc-alias-crate-level.stderr
+++ b/src/test/ui/doc-alias-crate-level.stderr
@@ -1,8 +1,8 @@
 error: '\'' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/doc-alias-crate-level.rs:7:8
+  --> $DIR/doc-alias-crate-level.rs:7:16
    |
 LL | #![doc(alias = "shouldn't work!")]
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #79508 (Warn if `dsymutil` returns an error code)
 - #79509 (Improve attribute message error spans)
 - #79602 (Fix SGX CI)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=79508,79509,79602)
<!-- homu-ignore:end -->