### PR TITLE
Use more std:: instead of core:: in docs for consistency

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -403,7 +403,7 @@ impl<'a> Arguments<'a> {
     /// ```rust
     /// #![feature(fmt_as_str)]
     ///
-    /// use core::fmt::Arguments;
+    /// use std::fmt::Arguments;
     ///
     /// fn write_str(_: &str) { /* ... */ }
     ///

--- a/library/core/src/future/pending.rs
+++ b/library/core/src/future/pending.rs
@@ -21,7 +21,7 @@ pub struct Pending<T> {
 /// # Examples
 ///
 /// ```no_run
-/// use core::future;
+/// use std::future;
 ///
 /// # async fn run() {
 /// let future = future::pending();

--- a/library/core/src/future/poll_fn.rs
+++ b/library/core/src/future/poll_fn.rs
@@ -3,7 +3,7 @@ use crate::future::Future;
 use crate::pin::Pin;
 use crate::task::{Context, Poll};
 
-/// Creates a future that wraps a function returning `Poll`.
+/// Creates a future that wraps a function returning [`Poll`].
 ///
 /// Polling the future delegates to the wrapped function.
 ///
@@ -13,7 +13,7 @@ use crate::task::{Context, Poll};
 /// #![feature(future_poll_fn)]
 /// # async fn run() {
 /// use core::future::poll_fn;
-/// use core::task::{Context, Poll};
+/// use std::task::{Context, Poll};
 ///
 /// fn read_line(_cx: &mut Context<'_>) -> Poll<String> {
 ///     Poll::Ready("Hello, World!".into())
@@ -31,7 +31,7 @@ where
     PollFn { f }
 }
 
-/// A Future that wraps a function returning `Poll`.
+/// A Future that wraps a function returning [`Poll`].
 ///
 /// This `struct` is created by [`poll_fn()`]. See its
 /// documentation for more.

--- a/library/core/src/future/ready.rs
+++ b/library/core/src/future/ready.rs
@@ -33,7 +33,7 @@ impl<T> Future for Ready<T> {
 /// # Examples
 ///
 /// ```
-/// use core::future;
+/// use std::future;
 ///
 /// # async fn run() {
 /// let a = future::ready(1);

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -189,7 +189,7 @@ impl<'a> Location<'a> {
     /// # Examples
     ///
     /// ```
-    /// use core::panic::Location;
+    /// use std::panic::Location;
     ///
     /// /// Returns the [`Location`] at which it is called.
     /// #[track_caller]

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -1,15 +1,18 @@
-/// Extracts the successful type of a `Poll<T>`.
+/// Extracts the successful type of a [`Poll<T>`].
 ///
-/// This macro bakes in propagation of `Pending` signals by returning early.
+/// This macro bakes in propagation of [`Pending`] signals by returning early.
+///
+/// [`Poll<T>`]: crate::task::Poll
+/// [`Pending`]: crate::task::Poll::Pending
 ///
 /// # Examples
 ///
 /// ```
 /// #![feature(ready_macro)]
 ///
-/// use core::task::{ready, Context, Poll};
-/// use core::future::{self, Future};
-/// use core::pin::Pin;
+/// use std::task::{ready, Context, Poll};
+/// use std::future::{self, Future};
+/// use std::pin::Pin;
 ///
 /// pub fn do_poll(cx: &mut Context<'_>) -> Poll<()> {
 ///     let mut fut = future::ready(42);
@@ -28,9 +31,9 @@
 /// ```
 /// # #![feature(ready_macro)]
 /// #
-/// # use core::task::{Context, Poll};
-/// # use core::future::{self, Future};
-/// # use core::pin::Pin;
+/// # use std::task::{Context, Poll};
+/// # use std::future::{self, Future};
+/// # use std::pin::Pin;
 /// #
 /// # pub fn do_poll(cx: &mut Context<'_>) -> Poll<()> {
 ///     # let mut fut = future::ready(42);

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -198,7 +198,7 @@ mod prim_bool {}
 /// words, they can't return `!` from every code path. As an example, this code doesn't compile:
 ///
 /// ```compile_fail
-/// use core::ops::Add;
+/// use std::ops::Add;
 ///
 /// fn foo() -> impl Add<u32> {
 ///     unimplemented!()
@@ -208,7 +208,7 @@ mod prim_bool {}
 /// But this code does:
 ///
 /// ```
-/// use core::ops::Add;
+/// use std::ops::Add;
 ///
 /// fn foo() -> impl Add<u32> {
 ///     if true {


### PR DESCRIPTION
@rustbot label T-doc

Some cleanup work to use `std::` instead of `core::` in docs as much as possible. This helps with terminology and consistency, especially for newcomers from other languages that have often heard of `std` to describe the standard library but not of `core`.

Edit: I also added more intra doc links when I saw the opportunity.