### PR TITLE
Pass around Symbols instead of Idents in doctree

### DIFF
--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -3,7 +3,7 @@
 crate use self::StructType::*;
 
 use rustc_ast as ast;
-use rustc_span::{self, symbol::Ident, Span, Symbol};
+use rustc_span::{self, Span, Symbol};
 
 use rustc_hir as hir;
 
@@ -16,9 +16,9 @@ crate struct Module<'hir> {
     crate mods: Vec<Module<'hir>>,
     crate id: hir::HirId,
     // (item, renamed)
-    crate items: Vec<(&'hir hir::Item<'hir>, Option<Ident>)>,
-    crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Ident>)>,
-    crate macros: Vec<(&'hir hir::MacroDef<'hir>, Option<Ident>)>,
+    crate items: Vec<(&'hir hir::Item<'hir>, Option<Symbol>)>,
+    crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Symbol>)>,
+    crate macros: Vec<(&'hir hir::MacroDef<'hir>, Option<Symbol>)>,
     crate is_crate: bool,
 }
 


### PR DESCRIPTION
The span was unused.

Vaguely related to https://github.com/rust-lang/rust/pull/78082 - currently working on converting `visit_ast` to use `hir::intravisit` and this makes that a little easier.

r? @GuillaumeGomez 