### PR TITLE
disable a ptr equality test on Miri

### DIFF
--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1978,9 +1978,13 @@ fn const_str_ptr() {
     const B: &'static [u8; 2] = &A;
     const C: *const u8 = B as *const u8;
 
-    unsafe {
+    #[cfg(not(miri))] // Miri does not deduplicate consts (https://github.com/rust-lang/miri/issues/131)
+    {
         let foo = &A as *const u8;
         assert_eq!(foo, C);
+    }
+
+    unsafe {
         assert_eq!(from_utf8_unchecked(&A), "hi");
         assert_eq!(*C, A[0]);
         assert_eq!(*(&B[0] as *const u8), A[0]);

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1978,7 +1978,8 @@ fn const_str_ptr() {
     const B: &'static [u8; 2] = &A;
     const C: *const u8 = B as *const u8;
 
-    #[cfg(not(miri))] // Miri does not deduplicate consts (https://github.com/rust-lang/miri/issues/131)
+    // Miri does not deduplicate consts (https://github.com/rust-lang/miri/issues/131)
+    #[cfg(not(miri))]
     {
         let foo = &A as *const u8;
         assert_eq!(foo, C);


### PR DESCRIPTION
This test relies on deduplication of constants. I do not think that this is a *guarantee* that Rust currently makes, and indeed Miri does not deduplicate constants the same way that rustc does, leading to different behavior in this test.

For now, I propose we simply disable this test in Miri.