### PR TITLE
const_evaluatable_checked: fix occurs check

### DIFF
--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -543,6 +543,10 @@ impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
         true
     }
 
+    fn visit_ct_substs(&self) -> bool {
+        true
+    }
+
     fn binders<T>(
         &mut self,
         a: ty::Binder<T>,
@@ -716,7 +720,10 @@ impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
                 let variable_table = &mut inner.const_unification_table();
                 let var_value = variable_table.probe_value(vid);
                 match var_value.val {
-                    ConstVariableValue::Known { value: u } => self.relate(u, u),
+                    ConstVariableValue::Known { value: u } => {
+                        drop(inner);
+                        self.relate(u, u)
+                    }
                     ConstVariableValue::Unknown { universe } => {
                         if self.for_universe.can_name(universe) {
                             Ok(c)
@@ -815,6 +822,10 @@ impl TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
         true
     }
 
+    fn visit_ct_substs(&self) -> bool {
+        true
+    }
+
     fn relate_with_variance<T: Relate<'tcx>>(
         &mut self,
         _variance: ty::Variance,
@@ -869,6 +880,9 @@ impl TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
                         Ok(u)
                     }
                 }
+            }
+            ty::Infer(ty::IntVar(_) | ty::FloatVar(_)) => {
+                Ok(t)
             }
             _ => relate::super_relate_tys(self, t, t),
         }

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -881,9 +881,7 @@ impl TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
                     }
                 }
             }
-            ty::Infer(ty::IntVar(_) | ty::FloatVar(_)) => {
-                Ok(t)
-            }
+            ty::Infer(ty::IntVar(_) | ty::FloatVar(_)) => Ok(t),
             _ => relate::super_relate_tys(self, t, t),
         }
     }

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -33,6 +33,11 @@ pub trait TypeRelation<'tcx>: Sized {
     /// relation. Just affects error messages.
     fn a_is_expected(&self) -> bool;
 
+    /// Whether we should look into the substs of unevaluated constants
+    /// even if `feature(const_evaluatable_checked)` is active.
+    ///
+    /// This is needed in `combine` to prevent accidentially creating
+    /// infinite types as we abuse `TypeRelation` to walk a type there.
     fn visit_ct_substs(&self) -> bool {
         false
     }

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -33,6 +33,10 @@ pub trait TypeRelation<'tcx>: Sized {
     /// relation. Just affects error messages.
     fn a_is_expected(&self) -> bool;
 
+    fn visit_ct_substs(&self) -> bool {
+        false
+    }
+
     fn with_cause<F, R>(&mut self, _cause: Cause, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
@@ -579,7 +583,7 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
         (
             ty::ConstKind::Unevaluated(a_def, a_substs, None),
             ty::ConstKind::Unevaluated(b_def, b_substs, None),
-        ) if tcx.features().const_evaluatable_checked => {
+        ) if tcx.features().const_evaluatable_checked && !relation.visit_ct_substs() => {
             if tcx.try_unify_abstract_consts(((a_def, a_substs), (b_def, b_substs))) {
                 Ok(a.val)
             } else {

--- a/src/test/ui/const-generics/occurs-check/unused-substs-5.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-5.rs
@@ -1,0 +1,20 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+// `N + 1` also depends on `T` here even if it doesn't use it.
+fn q<T, const N: usize>(_: T) -> [u8; N + 1] {
+    todo!()
+}
+
+fn supplier<T>() -> T {
+    todo!()
+}
+
+fn catch_me<const N: usize>() where [u8; N + 1]: Default {
+    let mut x = supplier();
+    x = q::<_, N>(x); //~ ERROR mismatched types
+}
+
+fn main() {
+    catch_me::<3>();
+}

--- a/src/test/ui/const-generics/occurs-check/unused-substs-5.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-5.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-5.rs:15:9
+   |
+LL |     x = q::<_, N>(x);
+   |         ^^^^^^^^^^^^
+   |         |
+   |         cyclic type of infinite size
+   |         help: try using a conversion method: `q::<_, N>(x).to_vec()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
fixes #79615 

this is kind of a hack because we use `TypeRelation` for both the `Generalizer` and the `ConstInferUnifier` but i am not sure if there is a useful way to disentangle this without unnecessarily duplicating some code.

The error in the added test is kind of unavoidable until we erase the unused substs of `ConstKind::Unevaluated`. We talked a bit about this in the cg lazy norm meeting (https://rust-lang.zulipchat.com/#narrow/stream/260443-project-const-generics/topic/lazy_normalization_consts)