### PR TITLE
Use `item_name` instead of pretty printing for resolving `Self` on intra-doc links

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -847,12 +847,17 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
 
         // FIXME(jynelson): this shouldn't go through stringification, rustdoc should just use the DefId directly
         let self_name = self_id.and_then(|self_id| {
+            use ty::TyKind;
             if matches!(self.cx.tcx.def_kind(self_id), DefKind::Impl) {
-                // using `ty.to_string()` directly has issues with shortening paths
+                // using `ty.to_string()` (or any variant) has issues with raw idents
                 let ty = self.cx.tcx.type_of(self_id);
-                let name = ty::print::with_crate_prefix(|| ty.to_string());
-                debug!("using type_of(): {}", name);
-                Some(name)
+                let name = match ty.kind() {
+                    TyKind::Adt(def, _) => Some(self.cx.tcx.item_name(def.did).to_string()),
+                    other if other.is_primitive() => Some(ty.to_string()),
+                    _ => None,
+                };
+                debug!("using type_of(): {:?}", name);
+                name
             } else {
                 let name = self.cx.tcx.opt_item_name(self_id).map(|sym| sym.to_string());
                 debug!("using item_name(): {:?}", name);

--- a/src/test/rustdoc/intra-doc/raw-ident-self.rs
+++ b/src/test/rustdoc/intra-doc/raw-ident-self.rs
@@ -1,0 +1,13 @@
+#![deny(broken_intra_doc_links)]
+pub mod r#impl {
+    pub struct S;
+
+    impl S {
+        /// See [Self::b].
+        // @has raw_ident_self/impl/struct.S.html
+        // @has - '//a[@href="../../raw_ident_self/impl/struct.S.html#method.b"]' 'Self::b'
+        pub fn a() {}
+
+        pub fn b() {}
+    }
+}


### PR DESCRIPTION
Pretty printing would add a `r#` prefix to raw identifiers, which was
not correct. In general I think this change makes sense -
pretty-printing is for showing to the *user*, `item_name` is suitable to
pass to resolve.

Fixes https://github.com/rust-lang/rust/issues/79633.

r? @Manishearth 