### PR TITLE
rustdoc: stabilise --default-theme command line option

### DIFF
--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -237,6 +237,26 @@ for a target triple that's different than your host triple.
 
 All of the usual caveats of cross-compiling code apply.
 
+## `--default-theme`: set the default theme
+
+Using this flag looks like this:
+
+```bash
+$ rustdoc src/lib.rs --default-theme=ayu
+```
+
+Sets the default theme (for users whose browser has not remembered a
+previous theme selection from the on-page theme picker).
+
+The supplied value should be the lowercase version of the theme name.
+The set of available themes can be seen in the theme picker in the
+gneerated output.
+
+Note that the set of available themes - and their appearance - is not
+necessarily stable from one rustdoc version to the next.  If the
+requested theme does not exist, the builtin default (currently
+`light`) is used instead.
+
 ## `--markdown-css`: include more CSS files when rendering markdown
 
 Using this flag looks like this:

--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -250,7 +250,7 @@ previous theme selection from the on-page theme picker).
 
 The supplied value should be the lowercase version of the theme name.
 The set of available themes can be seen in the theme picker in the
-gneerated output.
+generated output.
 
 Note that the set of available themes - and their appearance - is not
 necessarily stable from one rustdoc version to the next.  If the

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -269,7 +269,7 @@ fn opts() -> Vec<RustcOptGroup> {
                 "sort modules by where they appear in the program, rather than alphabetically",
             )
         }),
-        unstable("default-theme", |o| {
+        stable("default-theme", |o| {
             o.optopt(
                 "",
                 "default-theme",

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -275,7 +275,7 @@ fn opts() -> Vec<RustcOptGroup> {
                 "default-theme",
                 "Set the default theme. THEME should be the theme name, generally lowercase. \
                  If an unknown default theme is specified, the builtin default is used. \
-                 The set of themes, and the rustdoc built-in default is not stable.",
+                 The set of themes, and the rustdoc built-in default, are not stable.",
                 "THEME",
             )
         }),


### PR DESCRIPTION
As discussed in #77213, this seems like it has bedded in and can be safely and usefully made stable.

(rustdoc already has other stable options that interact quite intimately with the rustdoc-supplied CSS, and also an option for supplying entirely different CSS, so exposing the theme names this way seems a very minor step.)

There is also a commit to do some minor grammar fixes to the help message.