### PR TITLE
Add Vec visualization to understand capacity

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -253,26 +253,6 @@ mod spec_extend;
 /// can be slow. For this reason, it is recommended to use [`Vec::with_capacity`]
 /// whenever possible to specify how big the vector is expected to get.
 ///
-/// A vector containing the elements `'a'` and `'b'` with capacity 4 can be
-/// visualized as:
-///
-/// ```text
-/// Stack       ptr      len  capacity
-/// /Heap  +--------+--------+--------+
-///        | 0x0123 |      2 |      4 |
-///        +--------+--------+--------+
-///             |
-///             v
-/// Heap   +--------+--------+--------+--------+
-///        |    'a' |    'b' | uninit | uninit |
-///        +--------+--------+--------+--------+
-/// ```
-///
-/// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
-/// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory 
-///   layout (including the order of fields). See [the section about 
-///   guarantees](#guarantees).
-///
 /// # Guarantees
 ///
 /// Due to its incredibly fundamental nature, `Vec` makes a lot of guarantees
@@ -304,6 +284,28 @@ mod spec_extend;
 /// pointer points to [`len`] initialized, contiguous elements in order (what
 /// you would see if you coerced it to a slice), followed by [`capacity`]` -
 /// `[`len`] logically uninitialized, contiguous elements.
+///
+/// A vector containing the elements `'a'` and `'b'` with capacity 4 can be
+/// visualized as below. The top part is the `Vec` struct, it contains a
+/// pointer to the head of the allocation in the heap, length and capacity.
+/// The bottom part is the allocation on the heap, a contiguous memory block.
+///
+/// ```text
+///             ptr      len  capacity
+///        +--------+--------+--------+
+///        | 0x0123 |      2 |      4 |
+///        +--------+--------+--------+
+///             |
+///             v
+/// Heap   +--------+--------+--------+--------+
+///        |    'a' |    'b' | uninit | uninit |
+///        +--------+--------+--------+--------+
+/// ```
+///
+/// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
+/// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory
+///   layout (including the order of fields). See [the section about
+///   guarantees](#guarantees).
 ///
 /// `Vec` will never perform a "small optimization" where elements are actually
 /// stored on the stack for two reasons:

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -253,6 +253,26 @@ mod spec_extend;
 /// can be slow. For this reason, it is recommended to use [`Vec::with_capacity`]
 /// whenever possible to specify how big the vector is expected to get.
 ///
+/// A vector containing the elements `'a'` and `'b'` with capacity 4 can be
+/// visualized as:
+///
+/// ```text
+/// Stack       ptr      len  capacity
+/// /Heap  +--------+--------+--------+
+///        | 0x0123 |      2 |      4 |
+///        +--------+--------+--------+
+///             |
+///             v
+/// Heap   +--------+--------+--------+--------+
+///        |    'a' |    'b' | uninit | uninit |
+///        +--------+--------+--------+--------+
+/// ```
+///
+/// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
+/// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory 
+///   layout (including the order of fields). See [the section about 
+///   guarantees](#guarantees).
+///
 /// # Guarantees
 ///
 /// Due to its incredibly fundamental nature, `Vec` makes a lot of guarantees
@@ -345,6 +365,7 @@ mod spec_extend;
 /// [`push`]: Vec::push
 /// [`insert`]: Vec::insert
 /// [`reserve`]: Vec::reserve
+/// [`MaybeUninit`]: core::mem::MaybeUninit
 /// [owned slice]: Box
 /// [slice]: ../../std/primitive.slice.html
 /// [`&`]: ../../std/primitive.reference.html

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -304,8 +304,7 @@ mod spec_extend;
 ///
 /// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
 /// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory
-///   layout (including the order of fields). See [the section about
-///   guarantees](#guarantees).
+///   layout (including the order of fields).
 ///
 /// `Vec` will never perform a "small optimization" where elements are actually
 /// stored on the stack for two reasons:


### PR DESCRIPTION
Visualize vector while differentiating between stack and heap.

Inspired by cheats.rs, as this is probably the first place beginner go,
they could understand stack and heap, length and capacity with this. Not
sure if adding this means we should add to other places too.

Superseeds #76066

r? @m-ou-se

cc @the8472 I put back the order of the fields as it feels weird, the note already explains that the order of fields is not guaranteed