### PR TITLE
Add `Arc::into_inner` for safely discarding `Arc`s without calling the destructor on the inner type.

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -640,9 +640,6 @@ impl<T> Arc<T> {
 
         acquire!(this.inner().strong);
 
-        // FIXME: should the part below this be moved into a seperate #[inline(never)]
-        // function, like it's done with drop_slow in drop?
-
         // SAFETY: This mirrors the line
         //
         //     unsafe { ptr::drop_in_place(Self::get_mut_unchecked(self)) };

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -540,7 +540,7 @@ impl<T> Arc<T> {
     ///
     /// The similar expression `Arc::try_unwrap(this).ok()` does not
     /// offer such a guarantee. See the last example below and the documentation
-    /// of `try_unwrap`[`Arc::try_unwrap`].
+    /// of [`try_unwrap`][`Arc::try_unwrap`].
     ///
     /// # Examples
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -544,6 +544,7 @@ impl<T> Arc<T> {
     ///
     /// # Examples
     ///
+    /// Minimal example demonstrating the guarantee that `unwrap_or_drop` gives.
     /// ```
     /// #![feature(unwrap_or_drop)]
     ///
@@ -564,11 +565,17 @@ impl<T> Arc<T> {
     ///     (x_unwrapped_value, y_unwrapped_value),
     ///     (None, Some(3)) | (Some(3), None)
     /// ));
+    /// // The result could also be `(None, None)` if the threads called
+    /// // `Arc::try_unwrap(x).ok()` and `Arc::try_unwrap(y).ok()` instead.
+    /// ```
     ///
+    /// A more practical example demonstrating the need for `unwrap_or_drop`:
+    /// ```
+    /// #![feature(unwrap_or_drop)]
     ///
+    /// use std::sync::Arc;
     ///
-    /// // For a somewhat more practical example,
-    /// // we define a singly linked list using `Arc`:
+    /// // Definition of a simple singly linked list using `Arc`:
     /// #[derive(Clone)]
     /// struct LinkedList<T>(Option<Arc<Node<T>>>);
     /// struct Node<T>(T, Option<Arc<Node<T>>>);

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -485,9 +485,9 @@ impl<T> Arc<T> {
     ///
     /// This will succeed even if there are outstanding weak references.
     ///
-    // FIXME: when `Arc::unwrap_or_drop` is stabilized, add this paragraph:
+    // FIXME: when `Arc::into_inner` is stabilized, add this paragraph:
     /*
-    /// It is strongly recommended to use [`Arc::unwrap_or_drop`] instead if you don't
+    /// It is strongly recommended to use [`Arc::into_inner`] instead if you don't
     /// want to keep the `Arc` in the [`Err`] case.
     /// Immediately dropping the [`Err`] payload, like in the expression
     /// `Arc::try_unwrap(this).ok()`, can still cause the strong count to
@@ -537,7 +537,7 @@ impl<T> Arc<T> {
     ///
     /// This will succeed even if there are outstanding weak references.
     ///
-    /// If `unwrap_or_drop` is called on every clone of this `Arc`,
+    /// If `into_inner` is called on every clone of this `Arc`,
     /// it is guaranteed that exactly one of the calls returns the inner value.
     /// This means in particular that the inner value is not dropped.
     ///
@@ -547,18 +547,18 @@ impl<T> Arc<T> {
     ///
     /// # Examples
     ///
-    /// Minimal example demonstrating the guarantee that `unwrap_or_drop` gives.
+    /// Minimal example demonstrating the guarantee that `into_inner` gives.
     /// ```
-    /// #![feature(unwrap_or_drop)]
+    /// #![feature(arc_into_inner)]
     ///
     /// use std::sync::Arc;
     ///
     /// let x = Arc::new(3);
     /// let y = Arc::clone(&x);
     ///
-    /// // Two threads calling `unwrap_or_drop` on both clones of an `Arc`:
-    /// let x_unwrap_thread = std::thread::spawn(|| Arc::unwrap_or_drop(x));
-    /// let y_unwrap_thread = std::thread::spawn(|| Arc::unwrap_or_drop(y));
+    /// // Two threads calling `into_inner` on both clones of an `Arc`:
+    /// let x_unwrap_thread = std::thread::spawn(|| Arc::into_inner(x));
+    /// let y_unwrap_thread = std::thread::spawn(|| Arc::into_inner(y));
     ///
     /// let x_unwrapped_value = x_unwrap_thread.join().unwrap();
     /// let y_unwrapped_value = y_unwrap_thread.join().unwrap();
@@ -572,9 +572,9 @@ impl<T> Arc<T> {
     /// // `Arc::try_unwrap(x).ok()` and `Arc::try_unwrap(y).ok()` instead.
     /// ```
     ///
-    /// A more practical example demonstrating the need for `unwrap_or_drop`:
+    /// A more practical example demonstrating the need for `into_inner`:
     /// ```
-    /// #![feature(unwrap_or_drop)]
+    /// #![feature(arc_into_inner)]
     ///
     /// use std::sync::Arc;
     ///
@@ -590,7 +590,7 @@ impl<T> Arc<T> {
     ///     fn drop(&mut self) {
     ///         let mut x = self.0.take();
     ///         while let Some(arc) = x.take() {
-    ///             Arc::unwrap_or_drop(arc).map(|node| x = node.1);
+    ///             Arc::into_inner(arc).map(|node| x = node.1);
     ///         }
     ///     }
     /// }
@@ -608,7 +608,7 @@ impl<T> Arc<T> {
     ///
     /// // The following code could still cause a stack overflow
     /// // despite the manual `Drop` impl if that `Drop` impl used
-    /// // `Arc::try_unwrap(arc).ok()` instead of `Arc::unwrap_or_drop(arc)`.
+    /// // `Arc::try_unwrap(arc).ok()` instead of `Arc::into_inner(arc)`.
     /// {
     ///     // Create a long list and clone it
     ///     let mut x = LinkedList::new();
@@ -625,11 +625,11 @@ impl<T> Arc<T> {
     /// }
     /// ```
 
-    // FIXME: when `Arc::unwrap_or_drop` is stabilized, adjust the documentation of
+    // FIXME: when `Arc::into_inner` is stabilized, adjust the documentation of
     // `Arc::try_unwrap` according to the `FIXME` presented there.
     #[inline]
-    #[unstable(feature = "unwrap_or_drop", issue = "none")] // FIXME: add issue
-    pub fn unwrap_or_drop(this: Self) -> Option<T> {
+    #[unstable(feature = "arc_into_inner", issue = "none")] // FIXME: create and add issue
+    pub fn into_inner(this: Self) -> Option<T> {
         // Make sure that the ordinary `Drop` implementation isn’t called as well
         let mut this = mem::ManuallyDrop::new(this);
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -609,20 +609,19 @@ impl<T> Arc<T> {
     /// // The following code could still cause a stack overflow
     /// // despite the manual `Drop` impl if that `Drop` impl used
     /// // `Arc::try_unwrap(arc).ok()` instead of `Arc::into_inner(arc)`.
-    /// {
-    ///     // Create a long list and clone it
-    ///     let mut x = LinkedList::new();
-    ///     for i in 0..100000 {
-    ///         x.push(i); // Adds i to the front of x
-    ///     }
-    ///     let y = x.clone();
     ///
-    ///     // Drop the clones in parallel
-    ///     let t1 = std::thread::spawn(|| drop(x));
-    ///     let t2 = std::thread::spawn(|| drop(y));
-    ///     t1.join().unwrap();
-    ///     t2.join().unwrap();
+    /// // Create a long list and clone it
+    /// let mut x = LinkedList::new();
+    /// for i in 0..100000 {
+    ///     x.push(i); // Adds i to the front of x
     /// }
+    /// let y = x.clone();
+    ///
+    /// // Drop the clones in parallel
+    /// let t1 = std::thread::spawn(|| drop(x));
+    /// let t2 = std::thread::spawn(|| drop(y));
+    /// t1.join().unwrap();
+    /// t2.join().unwrap();
     /// ```
 
     // FIXME: when `Arc::into_inner` is stabilized, adjust the documentation of

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -498,7 +498,7 @@ impl<T> Arc<T> {
     /// both drop their `Arc` in the call to [`ok`][`Result::ok`],
     /// taking the strong count from two down to zero.
     ///
-    */
+     */
     /// # Examples
     ///
     /// ```

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -494,7 +494,7 @@ impl<T> Arc<T> {
     /// drop to zero and the inner value of the `Arc` to be dropped:
     /// For instance if two threads execute this expression in parallel, then
     /// there is a race condition. The threads could first both check whether they
-    /// have the last clone of their `Arc` via `try_unwrap`, and then
+    /// have the last clone of their `Arc` via `Arc::try_unwrap`, and then
     /// both drop their `Arc` in the call to [`ok`][`Result::ok`],
     /// taking the strong count from two down to zero.
     ///
@@ -537,17 +537,17 @@ impl<T> Arc<T> {
     ///
     /// This will succeed even if there are outstanding weak references.
     ///
-    /// If `into_inner` is called on every clone of this `Arc`,
+    /// If `Arc::into_inner` is called on every clone of this `Arc`,
     /// it is guaranteed that exactly one of the calls returns the inner value.
     /// This means in particular that the inner value is not dropped.
     ///
     /// The similar expression `Arc::try_unwrap(this).ok()` does not
     /// offer such a guarantee. See the last example below and the documentation
-    /// of [`try_unwrap`][`Arc::try_unwrap`].
+    /// of [`Arc::try_unwrap`].
     ///
     /// # Examples
     ///
-    /// Minimal example demonstrating the guarantee that `into_inner` gives.
+    /// Minimal example demonstrating the guarantee that `Arc::into_inner` gives.
     /// ```
     /// #![feature(arc_into_inner)]
     ///
@@ -556,7 +556,7 @@ impl<T> Arc<T> {
     /// let x = Arc::new(3);
     /// let y = Arc::clone(&x);
     ///
-    /// // Two threads calling `into_inner` on both clones of an `Arc`:
+    /// // Two threads calling `Arc::into_inner` on both clones of an `Arc`:
     /// let x_unwrap_thread = std::thread::spawn(|| Arc::into_inner(x));
     /// let y_unwrap_thread = std::thread::spawn(|| Arc::into_inner(y));
     ///
@@ -572,7 +572,7 @@ impl<T> Arc<T> {
     /// // `Arc::try_unwrap(x).ok()` and `Arc::try_unwrap(y).ok()` instead.
     /// ```
     ///
-    /// A more practical example demonstrating the need for `into_inner`:
+    /// A more practical example demonstrating the need for `Arc::into_inner`:
     /// ```
     /// #![feature(arc_into_inner)]
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -485,6 +485,8 @@ impl<T> Arc<T> {
     ///
     /// This will succeed even if there are outstanding weak references.
     ///
+    // FIXME: when `Arc::unwrap_or_drop` is stabilized, add this paragraph:
+    /*
     /// It is strongly recommended to use [`Arc::unwrap_or_drop`] instead if you don't
     /// want to keep the `Arc` in the [`Err`] case.
     /// Immediately dropping the [`Err`] payload, like in the expression
@@ -496,6 +498,7 @@ impl<T> Arc<T> {
     /// both drop their `Arc` in the call to [`ok`][`Result::ok`],
     /// taking the strong count from two down to zero.
     ///
+    */
     /// # Examples
     ///
     /// ```
@@ -621,11 +624,14 @@ impl<T> Arc<T> {
     ///     t2.join().unwrap();
     /// }
     /// ```
+
+    // FIXME: when `Arc::unwrap_or_drop` is stabilized, adjust the documentation of
+    // `Arc::try_unwrap` according to the `FIXME` presented there.
     #[inline]
     #[unstable(feature = "unwrap_or_drop", issue = "none")] // FIXME: add issue
     pub fn unwrap_or_drop(this: Self) -> Option<T> {
         // Make sure that the ordinary `Drop` implementation isn’t called as well
-        let mut this = core::mem::ManuallyDrop::new(this);
+        let mut this = mem::ManuallyDrop::new(this);
 
         // Following the implementation of `drop` and `drop_slow`
         if this.inner().strong.fetch_sub(1, Release) != 1 {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -588,9 +588,11 @@ impl<T> Arc<T> {
     /// // manual `Drop` implementation that does the destruction in a loop:
     /// impl<T> Drop for LinkedList<T> {
     ///     fn drop(&mut self) {
-    ///         let mut x = self.0.take();
-    ///         while let Some(arc) = x.take() {
-    ///             Arc::into_inner(arc).map(|node| x = node.1);
+    ///         let mut link = self.0.take();
+    ///         while let Some(arc_node) = link.take() {
+    ///             if let Some(Node(_value, next)) = Arc::into_inner(arc_node) {
+    ///                 link = next;
+    ///             }
     ///         }
     ///     }
     /// }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -595,7 +595,7 @@ impl<T> Arc<T> {
     ///     }
     /// }
     ///
-    /// // implementation of `new` and `push` omitted
+    /// // Implementation of `new` and `push` omitted
     /// impl<T> LinkedList<T> {
     ///     /* ... */
     /// #   fn new() -> Self {
@@ -610,14 +610,14 @@ impl<T> Arc<T> {
     /// // despite the manual `Drop` impl if that `Drop` impl used
     /// // `Arc::try_unwrap(arc).ok()` instead of `Arc::unwrap_or_drop(arc)`.
     /// {
-    ///     // create a long list and clone it
+    ///     // Create a long list and clone it
     ///     let mut x = LinkedList::new();
     ///     for i in 0..100000 {
-    ///         x.push(i); // adds i to the front of x
+    ///         x.push(i); // Adds i to the front of x
     ///     }
     ///     let y = x.clone();
     ///
-    ///     // drop the clones in parallel
+    ///     // Drop the clones in parallel
     ///     let t1 = std::thread::spawn(|| drop(x));
     ///     let t2 = std::thread::spawn(|| drop(y));
     ///     t1.join().unwrap();

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -112,11 +112,10 @@ fn unwrap_or_drop() {
     for _ in 0..100
     // ^ increase chances of hitting uncommon race conditions
     {
-        use std::sync::Arc;
         let x = Arc::new(3);
         let y = Arc::clone(&x);
-        let r_thread = std::thread::spawn(|| Arc::try_unwrap(x).ok());
-        let s_thread = std::thread::spawn(|| Arc::try_unwrap(y).ok());
+        let r_thread = std::thread::spawn(|| Arc::unwrap_or_drop(x));
+        let s_thread = std::thread::spawn(|| Arc::unwrap_or_drop(y));
         let r = r_thread.join().expect("r_thread panicked");
         let s = s_thread.join().expect("s_thread panicked");
         assert!(

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -104,7 +104,7 @@ fn try_unwrap() {
 #[test]
 fn unwrap_or_drop() {
     for _ in 0..100
-    // ^ increase chances of hitting potential race conditions
+    // ^ Increase chances of hitting potential race conditions
     {
         let x = Arc::new(3);
         let y = Arc::clone(&x);

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -141,41 +141,6 @@ fn unwrap_or_drop() {
 }
 
 #[test]
-fn unwrap_or_drop_linked_list() {
-    #[derive(Clone)]
-    struct LinkedList<T>(Option<Arc<Node<T>>>);
-    struct Node<T>(T, Option<Arc<Node<T>>>);
-
-    impl<T> Drop for LinkedList<T> {
-        fn drop(&mut self) {
-            let mut x = self.0.take();
-            while let Some(arc) = x.take() {
-                Arc::unwrap_or_drop(arc).map(|node| x = node.1);
-            }
-        }
-    }
-
-    impl<T> LinkedList<T> {
-        fn push(&mut self, x: T) {
-            self.0 = Some(Arc::new(Node(x, self.0.take())));
-        }
-    }
-
-    use std::thread;
-    for _ in 0..25 {
-        let mut x = LinkedList(None);
-        for i in 0..100000 {
-            x.push(i);
-        }
-        let y = x.clone();
-        let t1 = thread::spawn(|| drop(x));
-        let t2 = thread::spawn(|| drop(y));
-        t1.join().unwrap();
-        t2.join().unwrap();
-    }
-}
-
-#[test]
 fn into_from_raw() {
     let x = Arc::new(box "hello");
     let y = x.clone();

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -141,6 +141,41 @@ fn unwrap_or_drop() {
 }
 
 #[test]
+fn unwrap_or_drop_linked_list() {
+    #[derive(Clone)]
+    struct LinkedList<T>(Option<Arc<Node<T>>>);
+    struct Node<T>(T, Option<Arc<Node<T>>>);
+
+    impl<T> Drop for LinkedList<T> {
+        fn drop(&mut self) {
+            let mut x = self.0.take();
+            while let Some(arc) = x.take() {
+                Arc::unwrap_or_drop(arc).map(|node| x = node.1);
+            }
+        }
+    }
+
+    impl<T> LinkedList<T> {
+        fn push(&mut self, x: T) {
+            self.0 = Some(Arc::new(Node(x, self.0.take())));
+        }
+    }
+
+    use std::thread;
+    for _ in 0..25 {
+        let mut x = LinkedList(None);
+        for i in 0..100000 {
+            x.push(i);
+        }
+        let y = x.clone();
+        let t1 = thread::spawn(|| drop(x));
+        let t2 = thread::spawn(|| drop(y));
+        t1.join().unwrap();
+        t2.join().unwrap();
+    }
+}
+
+#[test]
 fn into_from_raw() {
     let x = Arc::new(box "hello");
     let y = x.clone();

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -103,14 +103,8 @@ fn try_unwrap() {
 
 #[test]
 fn unwrap_or_drop() {
-    // FIXME: Is doing this kind of loop reasonable? I tested `Arc::try_unwrap(x).ok()`
-    // and it makes this kind of assertion fail in roughly every second run somewhere
-    // between 1000 and 5000 iterations; I feel like doing a single iteration is too
-    // unlikely to catch anything interesting but doing too many is way too slow
-    // for a test that wouldn't ever fail for any reasonable implementation
-
     for _ in 0..100
-    // ^ increase chances of hitting uncommon race conditions
+    // ^ increase chances of hitting potential race conditions
     {
         let x = Arc::new(3);
         let y = Arc::clone(&x);

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -102,14 +102,14 @@ fn try_unwrap() {
 }
 
 #[test]
-fn unwrap_or_drop() {
+fn into_inner() {
     for _ in 0..100
     // ^ Increase chances of hitting potential race conditions
     {
         let x = Arc::new(3);
         let y = Arc::clone(&x);
-        let r_thread = std::thread::spawn(|| Arc::unwrap_or_drop(x));
-        let s_thread = std::thread::spawn(|| Arc::unwrap_or_drop(y));
+        let r_thread = std::thread::spawn(|| Arc::into_inner(x));
+        let s_thread = std::thread::spawn(|| Arc::into_inner(y));
         let r = r_thread.join().expect("r_thread panicked");
         let s = s_thread.join().expect("s_thread panicked");
         assert!(
@@ -121,16 +121,16 @@ fn unwrap_or_drop() {
     }
 
     let x = Arc::new(3);
-    assert_eq!(Arc::unwrap_or_drop(x), Some(3));
+    assert_eq!(Arc::into_inner(x), Some(3));
 
     let x = Arc::new(4);
     let y = Arc::clone(&x);
-    assert_eq!(Arc::unwrap_or_drop(x), None);
-    assert_eq!(Arc::unwrap_or_drop(y), Some(4));
+    assert_eq!(Arc::into_inner(x), None);
+    assert_eq!(Arc::into_inner(y), Some(4));
 
     let x = Arc::new(5);
     let _w = Arc::downgrade(&x);
-    assert_eq!(Arc::unwrap_or_drop(x), Some(5));
+    assert_eq!(Arc::into_inner(x), Some(5));
 }
 
 #[test]


### PR DESCRIPTION
Re-opening #75911 after it was closed due to inactivity (sorry for having been so inactive)
* New commits since since previous PR are starting from 5d81f76712ea2b9a06d3814ec3d553b51ceedbbe:
  * For now that’s:
5d81f76712ea2b9a06d3814ec3d553b51ceedbbe
00d50fe0288a3caeb65787a0ca8a146e9a39c7da
ca7066d5d959cea81c33738572f365728e85ac2b
948e4020e35fc898f7d253ca7b61f4317b067b4c
7d43bcbde582afc44185a1c72a4b18c4916aa9c0
1e28132c733546c2cc9b8dde7b2462deab35e18c
81623f4452c7d9468fb75005bdd53cd9313d9294
f57de565adf027312a0c9632be97aa0a71e3e7af
cd444ca6f65264062dbb873cd2e38a75a8b34dfe
ecb85f03bac849c13f8af371dee816ba9a82d595

  * earlier commits were already present in the previous PR and are only updated due to a rebase to the current master
* In particular
  * [regarding this review](https://github.com/rust-lang/rust/pull/75911#pullrequestreview-475850068), @poliorcetics @CAD97 - 5d81f76712ea2b9a06d3814ec3d553b51ceedbbe adds a `// SAFETY` comment
  * [regarding this review](https://github.com/rust-lang/rust/pull/75911#discussion_r491677967), @LukasKalbertodt - 7d43bcbde582afc44185a1c72a4b18c4916aa9c0 (and 5d81f76712ea2b9a06d3814ec3d553b51ceedbbe) addresses this
  * [regarding this review](https://github.com/rust-lang/rust/pull/75911#discussion_r491678125), @LukasKalbertodt - 948e4020e35fc898f7d253ca7b61f4317b067b4c addresses this
* I’m planning to also implement an `Rc::into_inner` version for `Rc`, accordingly. [Last previous comment on that topic.](https://github.com/rust-lang/rust/pull/75911#issuecomment-703232889) Probably being added to this PR very soon. 
* For now, the only remaining things I’m not 100% sure about yet are:
  * Are we are keeping the name be `into_inner` for now or are there people preferring something different?
  * What is the correct way to write documentation in the standard library? I used to have a section in `try_unwrap` documentation referring to `into_inner`. I commented that paragraph out for now with a `FIXME` to make sure it gets re-introduced once `into_inner` is stabilized; otherwise, it would be confusing if we had a stable function recommended using an unstable one, right? On the other hand the fact that `into_inner` is not stable doesn’t help the fact that using `try_unwrap` _can_ introduce bugs... (relevant commit: 00d50fe0288a3caeb65787a0ca8a146e9a39c7da)
  * How do tracking issues work? When are they created, what’s the timeline? I would guess, perhaps, maybe(?), right before merging this PR would be a good time because then we could still include the issue in the `#[unstable(..)]` attribute. And perhaps also create a page in the Unstable Book? Or is that supposed to be in a seperate PR?

cc @danielhenrymantilla @Diggsey
<hr>

#### _This section comes from the previous PR, #75911:_

<br>

There was previously some [discussion on IRLO](https://internals.rust-lang.org/t/de-facto-linear-types-and-arc-need-for-an-unwrap-or-drop-api/12939).

### Motivation
The functionality provided by this new “method” on `Arc` was previously not archievable with the `Arc` API. The function `into_inner` is related to (and hence similarly named similar to) `try_unwrap`. The expression `Arc::into_inner(x)` is almost the same as `Arc::try_unwrap(x).ok()`, however the latter includes two steps, the `try_unwrap` call and dropping the `Arc`, whereas `into_inner` accesses the `Arc` atomically. Since this is an issue in multi-threaded settings only, a similar function on `Rc` is not strictly necessary but could be wanted nontheless for ergonomic and API-similarity reasons. (This PR currently only offers the function on `Arc`, but I could add one for `Rc` if wanted.) In the IRLO discussion, I also mentioned two more functions that could possibly extend this API.

The function `Arc::into_inner(this: Arc<T>) -> Option<T>` offers a way to “drop” an `Arc` without calling the destructor on the contained type. When the `Arc` provided was the last strong pointer to its target, the target value is returned. Being able to do this is valueable around linear(-ish) types that should not or cannot just be dropped ordinarity, but require extra arguments, or operations that can fail or are `async` to properly get rid of.

### Rendered Documentation
![Screenshot_20201203_190752](https://user-images.githubusercontent.com/3986214/101069890-e77e9380-359a-11eb-8ace-fc3374d0ca03.png)
