### PR TITLE
Make sure rust-call errors occur correctly for traits

### DIFF
--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -103,6 +103,9 @@ pub(super) fn check_fn<'a, 'tcx>(
                 Node::ImplItem(hir::ImplItem {
                     kind: hir::ImplItemKind::Fn(header, ..), ..
                 }) => Some(header),
+                Node::TraitItem(hir::TraitItem {
+                    kind: hir::TraitItemKind::Fn(header, .. ), ..
+                }) => Some(header),
                 // Closures are RustCall, but they tuple their arguments, so shouldn't be checked
                 Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(..), .. }) => None,
                 node => bug!("Item being checked wasn't a function/closure: {:?}", node),

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -104,7 +104,8 @@ pub(super) fn check_fn<'a, 'tcx>(
                     kind: hir::ImplItemKind::Fn(header, ..), ..
                 }) => Some(header),
                 Node::TraitItem(hir::TraitItem {
-                    kind: hir::TraitItemKind::Fn(header, .. ), ..
+                    kind: hir::TraitItemKind::Fn(header, ..),
+                    ..
                 }) => Some(header),
                 // Closures are RustCall, but they tuple their arguments, so shouldn't be checked
                 Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(..), .. }) => None,

--- a/src/test/ui/abi/issues/issue-22565-rust-call.rs
+++ b/src/test/ui/abi/issues/issue-22565-rust-call.rs
@@ -3,6 +3,31 @@
 extern "rust-call" fn b(_i: i32) {}
 //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument that is a tuple
 
+trait Tr {
+    extern "rust-call" fn a();
+    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+
+    extern "rust-call" fn b() {}
+    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+}
+
+struct Foo;
+
+impl Foo {
+    extern "rust-call" fn bar() {}
+    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+}
+
+impl Tr for Foo {
+    fn a() {}
+    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+}
+
 fn main () {
     b(10);
+
+    Foo::bar();
+
+    <Foo as Tr>::a();
+    <Foo as Tr>::b();
 }

--- a/src/test/ui/abi/issues/issue-22565-rust-call.rs
+++ b/src/test/ui/abi/issues/issue-22565-rust-call.rs
@@ -5,7 +5,6 @@ extern "rust-call" fn b(_i: i32) {}
 
 trait Tr {
     extern "rust-call" fn a();
-    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
 
     extern "rust-call" fn b() {}
     //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
@@ -19,7 +18,7 @@ impl Foo {
 }
 
 impl Tr for Foo {
-    fn a() {}
+    extern "rust-call" fn a() {}
     //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
 }
 

--- a/src/test/ui/abi/issues/issue-22565-rust-call.stderr
+++ b/src/test/ui/abi/issues/issue-22565-rust-call.stderr
@@ -4,5 +4,23 @@ error: A function with the "rust-call" ABI must take a single non-self argument 
 LL | extern "rust-call" fn b(_i: i32) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+  --> $DIR/issue-22565-rust-call.rs:9:5
+   |
+LL |     extern "rust-call" fn b() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+  --> $DIR/issue-22565-rust-call.rs:16:5
+   |
+LL |     extern "rust-call" fn bar() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+  --> $DIR/issue-22565-rust-call.rs:21:5
+   |
+LL |     extern "rust-call" fn a() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes #79669 

Adds trait method resolution to the error, and adds UI tests to ensure it doesn't happen again. Opening as draft because I'm getting weird link errors from unrelated code on my machine, and want to see what CI thinks.