### PR TITLE
Add warning sections in rustdoc

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -332,8 +332,21 @@ nav.sub {
 
 .rustdoc:not(.source) .example-wrap {
 	display: inline-flex;
+}
+.rustdoc:not(.source) .example-wrap, #main div.rustdoc-warning {
 	margin-bottom: 10px;
 	position: relative;
+}
+
+#main div.rustdoc-warning {
+	padding: 10px;
+	border-left: 2px solid;
+}
+#main div.rustdoc-warning::before {
+	content: "⚠";
+	position: absolute;
+	left: -25px;
+	font-size: 20px;
 }
 
 .example-wrap {

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -53,7 +53,7 @@ span code {
 .docblock code, .docblock-short code {
 	background-color: #191f26;
 }
-pre {
+pre, #main div.rustdoc-warning {
 	color: #e6e1cf;
 	background-color: #191f26;
 }
@@ -334,6 +334,13 @@ a.test-arrow:hover {
 :target > code, :target > .in-band {
 	background: rgba(255, 236, 164, 0.06);
 	border-right: 3px solid rgba(255, 180, 76, 0.85);
+}
+
+#main div.rustdoc-warning {
+	border-left-color: #f00;
+}
+#main div.rustdoc-warning::before {
+	color: #f00;
 }
 
 pre.compile_fail {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -26,7 +26,7 @@ h4:not(.method):not(.type):not(.tymethod) {
 .docblock code, .docblock-short code {
 	background-color: #2A2A2A;
 }
-pre {
+pre, #main div.rustdoc-warning {
 	background-color: #2A2A2A;
 }
 
@@ -283,6 +283,13 @@ a.test-arrow:hover{
 :target > code, :target > .in-band {
 	background-color: #494a3d;
 	border-right: 3px solid #bb7410;
+}
+
+#main div.rustdoc-warning {
+	border-left-color: #f00;
+}
+#main div.rustdoc-warning::before {
+	color: #f00;
 }
 
 pre.compile_fail {

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -28,7 +28,7 @@ h4:not(.method):not(.type):not(.tymethod) {
 .docblock code, .docblock-short code {
 	background-color: #F5F5F5;
 }
-pre {
+pre, #main div.rustdoc-warning {
 	background-color: #F5F5F5;
 }
 
@@ -275,6 +275,13 @@ a.test-arrow:hover{
 :target > code, :target > .in-band {
 	background: #FDFFD3;
 	border-right: 3px solid #ffb44c;
+}
+
+#main div.rustdoc-warning {
+	border-left-color: #f00;
+}
+#main div.rustdoc-warning::before {
+	color: #f00;
 }
 
 pre.compile_fail {


### PR DESCRIPTION
Fixes #73935.

It looks like this:

![Screenshot from 2020-12-03 22-27-21](https://user-images.githubusercontent.com/3050060/101090917-af397e00-35b7-11eb-977c-bf5626c50440.png)

I used the same style than code blocks in case. :)

r? @jyn514 