### PR TITLE
Don't look for blanket impls in intra-doc links

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -21,7 +21,7 @@ use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::Mutability;
 use rustc_index::vec::IndexVec;
-use rustc_middle::ty::{AssocKind, TyCtxt};
+use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::hygiene::MacroKind;
 use rustc_span::source_map::DUMMY_SP;
@@ -373,15 +373,6 @@ impl ItemKind {
         match *self {
             ItemKind::TypedefItem(_, _) | ItemKind::AssocTypeItem(_, _) => true,
             _ => false,
-        }
-    }
-
-    crate fn as_assoc_kind(&self) -> Option<AssocKind> {
-        match *self {
-            ItemKind::AssocConstItem(..) => Some(AssocKind::Const),
-            ItemKind::AssocTypeItem(..) => Some(AssocKind::Type),
-            ItemKind::TyMethodItem(..) | ItemKind::MethodItem(..) => Some(AssocKind::Fn),
-            _ => None,
         }
     }
 }


### PR DESCRIPTION
This never worked and has been causing severe performance problems.
Hopefully it will be re-landed at some point in the future when it
actually works, but in the meantime it makes no sense to have the code
around when it does nothing and actively makes rustdoc harder to use.

Closes https://github.com/rust-lang/rust/issues/78761. Does *not* affect https://github.com/rust-lang/rust/issues/78800.

r? @Manishearth 
cc @seeplusplus