### PR TITLE
Update tests of "unused_lifetimes" lint for async functions and corresponding source code

### DIFF
--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -644,17 +644,17 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                             } else {
                                 bug!();
                             };
-                            if let hir::ParamName::Plain(param_name) = name {
-                                if param_name.name == kw::UnderscoreLifetime {
-                                    // Pick the elided lifetime "definition" if one exists
-                                    // and use it to make an elision scope.
-                                    self.lifetime_uses.insert(def_id, LifetimeUseSet::Many);
-                                    elision = Some(reg);
-                                } else {
-                                    lifetimes.insert(name, reg);
-                                }
+                            // We cannot predict what lifetimes are unused in opaque type.
+                            self.lifetime_uses.insert(def_id, LifetimeUseSet::Many);
+                            if let hir::ParamName::Plain(Ident {
+                                name: kw::UnderscoreLifetime,
+                                ..
+                            }) = name
+                            {
+                                // Pick the elided lifetime "definition" if one exists
+                                // and use it to make an elision scope.
+                                elision = Some(reg);
                             } else {
-                                self.lifetime_uses.insert(def_id, LifetimeUseSet::Many);
                                 lifetimes.insert(name, reg);
                             }
                         }

--- a/src/test/ui/async-await/unused-lifetime.rs
+++ b/src/test/ui/async-await/unused-lifetime.rs
@@ -1,42 +1,47 @@
+// Check "unused_lifetimes" lint on both async and sync functions
+
 // edition:2018
 
-// Avoid spurious warnings of unused lifetime. The below async functions
-// are desugered to have an unused lifetime
-// but we don't want to warn about that as there's nothing they can do about it.
-
 #![deny(unused_lifetimes)]
-#![allow(dead_code)]
 
-pub async fn october(s: &str) {
-    println!("{}", s);
-}
 
-pub async fn async_fn(&mut ref s: &mut[i32]) {
-    println!("{:?}", s);
-}
+// Async part with unused lifetimes
+//
+// Even wrong cases don't cause errors because async functions are desugared with all lifetimes
+// involved in the signature. So, we cannot predict what lifetimes are unused in async function.
+async fn async_wrong_without_args<'a>() {}
 
-macro_rules! foo_macro {
-    () => {
-        pub async fn async_fn_in_macro(&mut ref _s: &mut[i32]) {}
-    };
-}
+async fn async_wrong_1_lifetime<'a>(_: &i32) {}
 
-foo_macro!();
+async fn async_wrong_2_lifetimes<'a, 'b>(_: &'a i32, _: &i32) {}
 
-pub async fn func_with_unused_lifetime<'a>(s: &'a str) {
-    //~^ ERROR lifetime parameter `'a` never used
-    println!("{}", s);
-}
+async fn async_right_1_lifetime<'a>(_: &'a i32) {}
 
-pub async fn func_with_two_unused_lifetime<'a, 'b>(s: &'a str, t: &'b str) {
-    //~^ ERROR lifetime parameter `'a` never used
-    //~^^ ERROR lifetime parameter `'b` never used
-    println!("{}", s);
-}
+async fn async_right_2_lifetimes<'a, 'b>(_: &'a i32, _: &'b i32) {}
 
-pub async fn func_with_unused_lifetime_in_two_params<'c>(s: &'c str, t: &'c str) {
-    //~^ ERROR lifetime parameter `'c` never used
-    println!("{}", s);
-}
+async fn async_right_trait_bound_lifetime<'a, I>(_: I)
+where
+    I: Iterator<Item = &'a i32>
+{}
+
+
+// Sync part with unused lifetimes
+//
+// These functions are compiled as supposed
+fn wrong_without_args<'a>() {} //~ ERROR lifetime parameter `'a` never used
+
+fn wrong_1_lifetime<'a>(_: &i32) {} //~ ERROR lifetime parameter `'a` never used
+
+fn wrong_2_lifetimes<'a, 'b>(_: &'a i32, _: &i32) {} //~ ERROR lifetime parameter `'b` never used
+
+fn right_1_lifetime<'a>(_: &'a i32) {}
+
+fn right_2_lifetimes<'a, 'b>(_: &'a i32, _: &'b i32) {}
+
+fn right_trait_bound_lifetime<'a, I>(_: I)
+where
+    I: Iterator<Item = &'a i32>
+{}
+
 
 fn main() {}

--- a/src/test/ui/async-await/unused-lifetime.stderr
+++ b/src/test/ui/async-await/unused-lifetime.stderr
@@ -1,32 +1,28 @@
 error: lifetime parameter `'a` never used
-  --> $DIR/unused-lifetime.rs:26:40
+  --> $DIR/unused-lifetime.rs:31:23
    |
-LL | pub async fn func_with_unused_lifetime<'a>(s: &'a str) {
-   |                                        ^^
+LL | fn wrong_without_args<'a>() {}
+   |                      -^^- help: elide the unused lifetime
    |
 note: the lint level is defined here
-  --> $DIR/unused-lifetime.rs:7:9
+  --> $DIR/unused-lifetime.rs:5:9
    |
 LL | #![deny(unused_lifetimes)]
    |         ^^^^^^^^^^^^^^^^
 
 error: lifetime parameter `'a` never used
-  --> $DIR/unused-lifetime.rs:31:44
+  --> $DIR/unused-lifetime.rs:33:21
    |
-LL | pub async fn func_with_two_unused_lifetime<'a, 'b>(s: &'a str, t: &'b str) {
-   |                                            ^^
+LL | fn wrong_1_lifetime<'a>(_: &i32) {}
+   |                    -^^- help: elide the unused lifetime
 
 error: lifetime parameter `'b` never used
-  --> $DIR/unused-lifetime.rs:31:48
+  --> $DIR/unused-lifetime.rs:35:26
    |
-LL | pub async fn func_with_two_unused_lifetime<'a, 'b>(s: &'a str, t: &'b str) {
-   |                                                ^^
+LL | fn wrong_2_lifetimes<'a, 'b>(_: &'a i32, _: &i32) {}
+   |                        --^^
+   |                        |
+   |                        help: elide the unused lifetime
 
-error: lifetime parameter `'c` never used
-  --> $DIR/unused-lifetime.rs:37:54
-   |
-LL | pub async fn func_with_unused_lifetime_in_two_params<'c>(s: &'c str, t: &'c str) {
-   |                                                      ^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Before this PR the following code would cause an error:
```
#![deny(unused_lifetimes)]
async fn f<'a>(_: &'a i32) {}
fn main() {}
```
It was happening because of the desugaring of return type in async functions. As a result of the desugaring, the return type contains all lifetimes involved in the function signature. And these lifetimes were interpreted separately from the same in the function scope => so they are unused.

Now, all lifetimes from the return type are interpreted as used. It is also not perfect, but at least this lint doesn't cause wrong errors now.

This PR connected to issues #78522, #77217