### PR TITLE
Format symbols under shared frames

### DIFF
--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -381,12 +381,11 @@ impl fmt::Display for Backtrace {
         let mut f = backtrace_rs::BacktraceFmt::new(fmt, style, &mut print_path);
         f.add_context()?;
         for frame in frames {
-            let mut f = f.frame();
             if frame.symbols.is_empty() {
-                f.print_raw(frame.frame.ip(), None, None, None)?;
+                f.frame().print_raw(frame.frame.ip(), None, None, None)?;
             } else {
                 for symbol in frame.symbols.iter() {
-                    f.print_raw_with_column(
+                    f.frame().print_raw_with_column(
                         frame.frame.ip(),
                         symbol.name.as_ref().map(|b| backtrace_rs::SymbolName::new(b)),
                         symbol.filename.as_ref().map(|b| match b {

--- a/library/std/src/sys_common/backtrace.rs
+++ b/library/std/src/sys_common/backtrace.rs
@@ -71,6 +71,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
 
         let mut hit = false;
         let mut stop = false;
+        let mut frame_fmt = bt_fmt.frame();
         backtrace_rs::resolve_frame_unsynchronized(frame, |symbol| {
             hit = true;
             if print_fmt == PrintFmt::Short {
@@ -87,7 +88,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
             }
 
             if start {
-                res = bt_fmt.frame().symbol(frame, symbol);
+                res = frame_fmt.symbol(frame, symbol);
             }
         });
         if stop {
@@ -95,7 +96,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
         }
         if !hit {
             if start {
-                res = bt_fmt.frame().print_raw(frame.ip(), None, None, None);
+                res = frame_fmt.print_raw(frame.ip(), None, None, None);
             }
         }
 

--- a/library/std/src/sys_common/backtrace.rs
+++ b/library/std/src/sys_common/backtrace.rs
@@ -71,7 +71,6 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
 
         let mut hit = false;
         let mut stop = false;
-        let mut frame_fmt = bt_fmt.frame();
         backtrace_rs::resolve_frame_unsynchronized(frame, |symbol| {
             hit = true;
             if print_fmt == PrintFmt::Short {
@@ -88,7 +87,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
             }
 
             if start {
-                res = frame_fmt.symbol(frame, symbol);
+                res = bt_fmt.frame().symbol(frame, symbol);
             }
         });
         if stop {
@@ -96,7 +95,7 @@ unsafe fn _print_fmt(fmt: &mut fmt::Formatter<'_>, print_fmt: PrintFmt) -> fmt::
         }
         if !hit {
             if start {
-                res = frame_fmt.print_raw(frame.ip(), None, None, None);
+                res = bt_fmt.frame().print_raw(frame.ip(), None, None, None);
             }
         }
 


### PR DESCRIPTION
Part of #71706
Also related to #72981

This changes the format used for backtraces in the currently unstable `std::backtrace` to align them with backtraces produced by `panic!`. It involves un-nesting symbols that share frames in `std::backtrace` to appear as if they belong under individual frames.

before:

```text
  14: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
      std::panicking::try::do_call
             at src/libstd/panicking.rs:297
      std::panicking::try
             at src/libstd/panicking.rs:274
      std::panic::catch_unwind
             at src/libstd/panic.rs:394
      std::rt::lang_start_internal
             at src/libstd/rt.rs:51
```

after:

```text
  14: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
  15: std::panicking::try::do_call
             at src/libstd/panicking.rs:297
  16: std::panicking::try
             at src/libstd/panicking.rs:274
  17: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  18: std::rt::lang_start_internal
             at src/libstd/rt.rs:51
```

Since we don't share too much code between these formats right now or really check the `Display` formats for backtraces, they might end up diverging again.