### PR TITLE
[const_panic] Report const_panic diagnostics identically to compiler_error invocations

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -7,7 +7,7 @@ use rustc_data_structures::sync::Lock;
 use rustc_errors::{pluralize, struct_span_err, DiagnosticBuilder, ErrorReported};
 use rustc_macros::HashStable;
 use rustc_session::CtfeBacktrace;
-use rustc_span::def_id::DefId;
+use rustc_span::{def_id::DefId, Symbol};
 use rustc_target::abi::{Align, Size};
 use std::{any::Any, backtrace::Backtrace, fmt, mem};
 
@@ -439,6 +439,8 @@ pub enum InterpError<'tcx> {
     /// The program exhausted the interpreter's resources (stack/heap too big,
     /// execution takes too long, ...).
     ResourceExhaustion(ResourceExhaustionInfo),
+    /// The program terminated immediately from a panic.
+    Panic(Symbol),
     /// Stop execution for a machine-controlled reason. This is never raised by
     /// the core engine itself.
     MachineStop(Box<dyn MachineStopType>),
@@ -454,6 +456,7 @@ impl fmt::Display for InterpError<'_> {
             InvalidProgram(ref msg) => write!(f, "{}", msg),
             UndefinedBehavior(ref msg) => write!(f, "{}", msg),
             ResourceExhaustion(ref msg) => write!(f, "{}", msg),
+            Panic(ref msg) => write!(f, "{}", msg),
             MachineStop(ref msg) => write!(f, "{}", msg),
         }
     }


### PR DESCRIPTION
Given

```rust
const _ = panic!("Hello");
```

**Before**

```
error: any use of this value will cause an error
 --> const_panic.rs:3:15
  |
3 | const _: () = panic!("hello");
  | --------------^^^^^^^^^^^^^^^-
  |               |
  |               the evaluated program panicked at 'hello', const_panic.rs:3:15
  |
```

**After**

```
error: hello
 --> const_panic.rs:3:15
  |
3 | const _: () = panic!("hello");
  | --------------^^^^^^^^^^^^^^^-
  |
```

Ref: https://github.com/rust-lang/rust/issues/51999#issuecomment-651022782


---

If this is accepted, I believe that along with the recently merged https://github.com/rust-lang/rust/pull/78069, the `const_panic` feature should be unblocked and could be stabilized.

I'm not super happy with how the implementation of this was done; any pointers on how to clean that up would be appreciated.


