### PR TITLE
A slightly clearer diagnostic when misusing const

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -264,7 +264,7 @@ impl TokenType {
             TokenType::Ident => "identifier".to_string(),
             TokenType::Path => "path".to_string(),
             TokenType::Type => "type".to_string(),
-            TokenType::Const => "const".to_string(),
+            TokenType::Const => "a const expression".to_string(),
         }
     }
 }

--- a/src/test/ui/generic-associated-types/parse/trait-path-missing-gen_arg.rs
+++ b/src/test/ui/generic-associated-types/parse/trait-path-missing-gen_arg.rs
@@ -7,7 +7,7 @@ trait X {
 
 const _: () = {
   fn f1<'a>(arg : Box<dyn X< : 32 >>) {}
-      //~^ ERROR: expected one of `>`, const, lifetime, or type, found `:`
+      //~^ ERROR: expected one of `>`, a const expression, lifetime, or type, found `:`
       //~| ERROR: expected parameter name, found `>`
       //~| ERROR: expected one of `!`, `)`, `+`, `,`, or `::`, found `>`
       //~| ERROR: constant provided when a type was expected
@@ -15,7 +15,7 @@ const _: () = {
 
 const _: () = {
   fn f1<'a>(arg : Box<dyn X< = 32 >>) {}
-      //~^ ERROR: expected one of `>`, const, lifetime, or type, found `=`
+      //~^ ERROR: expected one of `>`, a const expression, lifetime, or type, found `=`
 };
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/parse/trait-path-missing-gen_arg.stderr
+++ b/src/test/ui/generic-associated-types/parse/trait-path-missing-gen_arg.stderr
@@ -1,8 +1,8 @@
-error: expected one of `>`, const, lifetime, or type, found `:`
+error: expected one of `>`, a const expression, lifetime, or type, found `:`
   --> $DIR/trait-path-missing-gen_arg.rs:9:30
    |
 LL |   fn f1<'a>(arg : Box<dyn X< : 32 >>) {}
-   |                              ^ expected one of `>`, const, lifetime, or type
+   |                              ^ expected one of `>`, a const expression, lifetime, or type
    |
 help: expressions must be enclosed in braces to be used as const generic arguments
    |
@@ -24,11 +24,11 @@ LL |   fn f1<'a>(arg : Box<dyn X< : 32 >>) {}
    |                                    expected one of `!`, `)`, `+`, `,`, or `::`
    |                                    help: missing `,`
 
-error: expected one of `>`, const, lifetime, or type, found `=`
+error: expected one of `>`, a const expression, lifetime, or type, found `=`
   --> $DIR/trait-path-missing-gen_arg.rs:17:30
    |
 LL |   fn f1<'a>(arg : Box<dyn X< = 32 >>) {}
-   |                              ^ expected one of `>`, const, lifetime, or type
+   |                              ^ expected one of `>`, a const expression, lifetime, or type
 
 warning: the feature `generic_associated_types` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/trait-path-missing-gen_arg.rs:1:12

--- a/src/test/ui/issues/issue-20616-3.rs
+++ b/src/test/ui/issues/issue-20616-3.rs
@@ -11,7 +11,7 @@ type Type_1_<'a, T> = &'a T;
 
 
 type Type_3<T> = Box<T,,>;
-//~^ error: expected one of `>`, const, lifetime, or type, found `,`
+//~^ error: expected one of `>`, a const expression, lifetime, or type, found `,`
 
 
 //type Type_4<T> = Type_1_<'static,, T>; // error: expected type, found `,`

--- a/src/test/ui/issues/issue-20616-3.stderr
+++ b/src/test/ui/issues/issue-20616-3.stderr
@@ -1,8 +1,8 @@
-error: expected one of `>`, const, lifetime, or type, found `,`
+error: expected one of `>`, a const expression, lifetime, or type, found `,`
   --> $DIR/issue-20616-3.rs:13:24
    |
 LL | type Type_3<T> = Box<T,,>;
-   |                        ^ expected one of `>`, const, lifetime, or type
+   |                        ^ expected one of `>`, a const expression, lifetime, or type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20616-4.rs
+++ b/src/test/ui/issues/issue-20616-4.rs
@@ -14,7 +14,7 @@ type Type_1_<'a, T> = &'a T;
 
 
 type Type_4<T> = Type_1_<'static,, T>;
-//~^ error: expected one of `>`, const, lifetime, or type, found `,`
+//~^ error: expected one of `>`, a const expression, lifetime, or type, found `,`
 
 
 type Type_5_<'a> = Type_1_<'a, ()>;

--- a/src/test/ui/issues/issue-20616-4.stderr
+++ b/src/test/ui/issues/issue-20616-4.stderr
@@ -1,8 +1,8 @@
-error: expected one of `>`, const, lifetime, or type, found `,`
+error: expected one of `>`, a const expression, lifetime, or type, found `,`
   --> $DIR/issue-20616-4.rs:16:34
    |
 LL | type Type_4<T> = Type_1_<'static,, T>;
-   |                                  ^ expected one of `>`, const, lifetime, or type
+   |                                  ^ expected one of `>`, a const expression, lifetime, or type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20616-5.rs
+++ b/src/test/ui/issues/issue-20616-5.rs
@@ -20,7 +20,7 @@ type Type_5_<'a> = Type_1_<'a, ()>;
 
 
 type Type_5<'a> = Type_1_<'a, (),,>;
-//~^ error: expected one of `>`, const, lifetime, or type, found `,`
+//~^ error: expected one of `>`, a const expression, lifetime, or type, found `,`
 
 
 //type Type_6 = Type_5_<'a,,>; // error: expected type, found `,`

--- a/src/test/ui/issues/issue-20616-5.stderr
+++ b/src/test/ui/issues/issue-20616-5.stderr
@@ -1,8 +1,8 @@
-error: expected one of `>`, const, lifetime, or type, found `,`
+error: expected one of `>`, a const expression, lifetime, or type, found `,`
   --> $DIR/issue-20616-5.rs:22:34
    |
 LL | type Type_5<'a> = Type_1_<'a, (),,>;
-   |                                  ^ expected one of `>`, const, lifetime, or type
+   |                                  ^ expected one of `>`, a const expression, lifetime, or type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20616-6.rs
+++ b/src/test/ui/issues/issue-20616-6.rs
@@ -23,7 +23,7 @@ type Type_5_<'a> = Type_1_<'a, ()>;
 
 
 type Type_6 = Type_5_<'a,,>;
-//~^ error: expected one of `>`, const, lifetime, or type, found `,`
+//~^ error: expected one of `>`, a const expression, lifetime, or type, found `,`
 
 
 //type Type_7 = Box<(),,>; // error: expected type, found `,`

--- a/src/test/ui/issues/issue-20616-6.stderr
+++ b/src/test/ui/issues/issue-20616-6.stderr
@@ -1,8 +1,8 @@
-error: expected one of `>`, const, lifetime, or type, found `,`
+error: expected one of `>`, a const expression, lifetime, or type, found `,`
   --> $DIR/issue-20616-6.rs:25:26
    |
 LL | type Type_6 = Type_5_<'a,,>;
-   |                          ^ expected one of `>`, const, lifetime, or type
+   |                          ^ expected one of `>`, a const expression, lifetime, or type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20616-7.rs
+++ b/src/test/ui/issues/issue-20616-7.rs
@@ -26,7 +26,7 @@ type Type_5_<'a> = Type_1_<'a, ()>;
 
 
 type Type_7 = Box<(),,>;
-//~^ error: expected one of `>`, const, lifetime, or type, found `,`
+//~^ error: expected one of `>`, a const expression, lifetime, or type, found `,`
 
 
 //type Type_8<'a,,> = &'a (); // error: expected ident, found `,`

--- a/src/test/ui/issues/issue-20616-7.stderr
+++ b/src/test/ui/issues/issue-20616-7.stderr
@@ -1,8 +1,8 @@
-error: expected one of `>`, const, lifetime, or type, found `,`
+error: expected one of `>`, a const expression, lifetime, or type, found `,`
   --> $DIR/issue-20616-7.rs:28:22
    |
 LL | type Type_7 = Box<(),,>;
-   |                      ^ expected one of `>`, const, lifetime, or type
+   |                      ^ expected one of `>`, a const expression, lifetime, or type
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/removed-syntax-uniq-mut-ty.rs
+++ b/src/test/ui/parser/removed-syntax-uniq-mut-ty.rs
@@ -1,2 +1,2 @@
 type mut_box = Box<mut isize>;
-//~^ ERROR expected one of `>`, const, lifetime, or type, found keyword `mut`
+//~^ ERROR expected one of `>`, a const expression, lifetime, or type, found keyword `mut`

--- a/src/test/ui/parser/removed-syntax-uniq-mut-ty.stderr
+++ b/src/test/ui/parser/removed-syntax-uniq-mut-ty.stderr
@@ -1,8 +1,8 @@
-error: expected one of `>`, const, lifetime, or type, found keyword `mut`
+error: expected one of `>`, a const expression, lifetime, or type, found keyword `mut`
   --> $DIR/removed-syntax-uniq-mut-ty.rs:1:20
    |
 LL | type mut_box = Box<mut isize>;
-   |                    ^^^ expected one of `>`, const, lifetime, or type
+   |                    ^^^ expected one of `>`, a const expression, lifetime, or type
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #79598

This produces the following diagnostic: 
"expected one of `>`, a const expression, lifetime, or type, found keyword `const`"

Instead of the previous, more confusing:
"expected one of `>`, const, lifetime, or type, found keyword `const`"

This might not be completely clear as some users might not understand what a const expression is, but I do believe this is an improvement.  