### PR TITLE
BufWriter: Provide into_raw_parts

### DIFF
--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -382,7 +382,7 @@ impl fmt::Display for WriterPanicked {
 #[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
 impl fmt::Debug for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("WriterPanicked")
+        f.debug_struct("WriterPanicked")
             .field("buffer", &format_args!("{}/{}", self.buf.len(), self.buf.capacity()))
             .finish()
     }

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -313,7 +313,7 @@ impl<W: Write> BufWriter<W> {
     /// assert_eq!(recovered_writer.len(), 0);
     /// assert_eq!(&buffered_data.unwrap(), b"ata");
     /// ```
-    #[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
+    #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
     pub fn into_raw_parts(mut self) -> (W, Result<Vec<u8>, WriterPanicked>) {
         let buf = mem::take(&mut self.buf);
         let buf = if !self.panicked { Ok(buf) } else { Err(WriterPanicked { buf }) };
@@ -321,7 +321,7 @@ impl<W: Write> BufWriter<W> {
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
+#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
 /// Error returned for the buffered data from `BufWriter::into_raw_parts`, when the underlying
 /// writer has previously panicked.  Contains the (possibly partly written) buffered data.
 ///
@@ -355,7 +355,7 @@ pub struct WriterPanicked {
 impl WriterPanicked {
     /// Returns the perhaps-unwritten data.  Some of this data may have been written by the
     /// panicking call(s) to the underlying writer, so simply writing it again is not a good idea.
-    #[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
+    #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
     pub fn into_inner(self) -> Vec<u8> {
         self.buf
     }
@@ -364,7 +364,7 @@ impl WriterPanicked {
         "BufWriter inner writer panicked, what data remains unwritten is not known";
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
+#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
 impl error::Error for WriterPanicked {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
@@ -372,14 +372,14 @@ impl error::Error for WriterPanicked {
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
+#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
 impl fmt::Display for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::DESCRIPTION)
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
+#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
 impl fmt::Debug for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WriterPanicked")

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -382,7 +382,9 @@ impl fmt::Display for WriterPanicked {
 #[unstable(feature = "bufwriter_into_raw_parts", issue = "none")]
 impl fmt::Debug for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "WriterPanicked{{..buf.len={}..}}", self.buf.len())
+        fmt.debug_struct("WriterPanicked")
+            .field("buffer", &format_args!("{}/{}", self.buf.len(), self.buf.capacity()))
+            .finish()
     }
 }
 


### PR DESCRIPTION
If something goes wrong, one might want to unpeel the layers of nested
Writers to perform recovery actions on the underlying writer, or reuse
its resources.

`into_inner` can be used for this when the inner writer is still
working.  But when the inner writer is broken, and returning errors,
`into_inner` simply gives you the error from flush, and the same
`Bufwriter` back again.

Here I provide the necessary function, which I have chosen to call
`into_raw_parts`.

I had to do something with `panicked`.  Returning it to the caller as
a boolean seemed rather bare.  Throwing the buffered data away in this
situation also seems unfriendly: maybe the programmer knows something
about the underlying writer and can recover somehow.

So I went for a custom Error.  This may be overkill, but it does have
the nice property that a caller who actually wants to look at the
buffered data, rather than simply extracting the inner writer, will be
told by the type system if they forget to handle the panicked case.

If a caller doesn't need the buffer, it can just be discarded.  That
WriterPanicked is a newtype around Vec<u8> means that hopefully the
layouts of the Ok and Err variants can be very similar, with just a
boolean discriminant.  So this custom error type should compile down
to nearly no code.

*If this general idea is felt appropriate, I will open a tracking issue, etc.*