### PR TITLE
[DO NOT MERGE] Enable parallel compiler by default

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1103,7 +1103,7 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
     // a sequential compiler for now. This'll likely be adjusted
     // in the future. Note that -Zthreads=0 is the way to get
     // the num_cpus behavior.
-    threads: usize = (12, parse_threads, [UNTRACKED],
+    threads: usize = (1, parse_threads, [UNTRACKED],
         "use a thread pool with N threads"),
     time: bool = (false, parse_bool, [UNTRACKED],
         "measure time of rustc processes (default: no)"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1103,7 +1103,7 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
     // a sequential compiler for now. This'll likely be adjusted
     // in the future. Note that -Zthreads=0 is the way to get
     // the num_cpus behavior.
-    threads: usize = (1, parse_threads, [UNTRACKED],
+    threads: usize = (12, parse_threads, [UNTRACKED],
         "use a thread pool with N threads"),
     time: bool = (false, parse_bool, [UNTRACKED],
         "measure time of rustc processes (default: no)"),

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -853,7 +853,7 @@ impl Config {
             set(&mut config.use_lld, rust.use_lld);
             set(&mut config.lld_enabled, rust.lld);
             set(&mut config.llvm_tools_enabled, rust.llvm_tools);
-            config.rustc_parallel = rust.parallel_compiler.unwrap_or(false);
+            config.rustc_parallel = rust.parallel_compiler.unwrap_or(true);
             config.rustc_default_linker = rust.default_linker;
             config.musl_root = rust.musl_root.map(PathBuf::from);
             config.save_toolstates = rust.save_toolstates.map(PathBuf::from);


### PR DESCRIPTION
This is a rebase of #75651.

#78201 may have reduced the overhead of parallel rustc.