### PR TITLE
[Experiment] Add `never` as a type alias for `!`

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -342,7 +342,7 @@ extern "Rust" {
     // it to call `__rg_oom` if there is a `#[alloc_error_handler]`, or to call the
     // default implementations below (`__rdl_oom`) otherwise.
     #[rustc_allocator_nounwind]
-    fn __rust_alloc_error_handler(size: usize, align: usize) -> !;
+    fn __rust_alloc_error_handler(size: usize, align: usize) -> never;
 }
 
 /// Abort on memory allocation error or failure.
@@ -361,7 +361,7 @@ extern "Rust" {
 #[cfg(not(test))]
 #[rustc_allocator_nounwind]
 #[cold]
-pub fn handle_alloc_error(layout: Layout) -> ! {
+pub fn handle_alloc_error(layout: Layout) -> never {
     unsafe {
         __rust_alloc_error_handler(layout.size(), layout.align());
     }
@@ -382,17 +382,17 @@ pub mod __alloc_error_handler {
 
     // if there is no `#[alloc_error_handler]`
     #[rustc_std_internal_symbol]
-    pub unsafe extern "C" fn __rdl_oom(size: usize, _align: usize) -> ! {
+    pub unsafe extern "C" fn __rdl_oom(size: usize, _align: usize) -> never {
         panic!("memory allocation of {} bytes failed", size)
     }
 
     // if there is a `#[alloc_error_handler]`
     #[rustc_std_internal_symbol]
-    pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> ! {
+    pub unsafe extern "C" fn __rg_oom(size: usize, align: usize) -> never {
         let layout = unsafe { Layout::from_size_align_unchecked(size, align) };
         extern "Rust" {
             #[lang = "oom"]
-            fn oom_impl(layout: Layout) -> !;
+            fn oom_impl(layout: Layout) -> never;
         }
         unsafe { oom_impl(layout) }
     }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -710,7 +710,7 @@ extern "rust-intrinsic" {
     ///
     /// A more user-friendly and stable version of this operation is
     /// [`std::process::abort`](../../std/process/fn.abort.html).
-    pub fn abort() -> !;
+    pub fn abort() -> crate::primitive::never;
 
     /// Tells LLVM that this point in the code is not reachable, enabling
     /// further optimizations.
@@ -721,7 +721,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is [`core::hint::unreachable_unchecked`](crate::hint::unreachable_unchecked).
     #[rustc_const_unstable(feature = "const_unreachable_unchecked", issue = "53188")]
-    pub fn unreachable() -> !;
+    pub fn unreachable() -> crate::primitive::never;
 
     /// Informs the optimizer that a condition is always true.
     /// If the condition is false, the behavior is undefined.

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -818,8 +818,10 @@ mod copy_impls {
         bool char
     }
 
-    #[unstable(feature = "never_type", issue = "35121")]
-    impl Copy for ! {}
+    // A stable attribute works, but unstable not. Interesting.
+    //#[unstable(feature = "never_type", issue = "35121")]
+    #[stable(feature = "haven't made a feature gate yet", since = "1.50.0")]
+    impl Copy for never {}
 
     #[stable(feature = "rust1", since = "1.0.0")]
     impl<T: ?Sized> Copy for *const T {}

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -76,3 +76,6 @@ pub use crate::macros::builtin::{
 )]
 #[doc(no_inline)]
 pub use crate::macros::builtin::cfg_accessible;
+
+#[stable(feature = "haven't made a feature gate yet", since = "1.50.0")]
+pub use crate::primitive::never;

--- a/library/core/src/primitive.rs
+++ b/library/core/src/primitive.rs
@@ -65,3 +65,9 @@ pub use u64;
 pub use u8;
 #[stable(feature = "core_primitive", since = "1.43.0")]
 pub use usize;
+
+// Haven't looked into how to make this a compiler buildin,
+// or if that is even needed.
+#[stable(feature = "haven't made a feature gate yet", since = "1.50.0")]
+#[allow(non_camel_case_types, missing_docs)]
+pub type never = !;

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -30,35 +30,35 @@ where
 #[inline(never)]
 #[cold]
 #[track_caller]
-fn slice_start_index_len_fail(index: usize, len: usize) -> ! {
+fn slice_start_index_len_fail(index: usize, len: usize) -> never {
     panic!("range start index {} out of range for slice of length {}", index, len);
 }
 
 #[inline(never)]
 #[cold]
 #[track_caller]
-pub(crate) fn slice_end_index_len_fail(index: usize, len: usize) -> ! {
+pub(crate) fn slice_end_index_len_fail(index: usize, len: usize) -> never {
     panic!("range end index {} out of range for slice of length {}", index, len);
 }
 
 #[inline(never)]
 #[cold]
 #[track_caller]
-pub(crate) fn slice_index_order_fail(index: usize, end: usize) -> ! {
+pub(crate) fn slice_index_order_fail(index: usize, end: usize) -> never {
     panic!("slice index starts at {} but ends at {}", index, end);
 }
 
 #[inline(never)]
 #[cold]
 #[track_caller]
-pub(crate) fn slice_start_index_overflow_fail() -> ! {
+pub(crate) fn slice_start_index_overflow_fail() -> never {
     panic!("attempted to index slice from after maximum usize");
 }
 
 #[inline(never)]
 #[cold]
 #[track_caller]
-pub(crate) fn slice_end_index_overflow_fail() -> ! {
+pub(crate) fn slice_end_index_overflow_fail() -> never {
     panic!("attempted to index slice up to maximum usize");
 }
 

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -56,7 +56,7 @@ extern "C" {
 /// with our panic count.
 #[cfg(not(test))]
 #[rustc_std_internal_symbol]
-extern "C" fn __rust_drop_panic() -> ! {
+extern "C" fn __rust_drop_panic() -> never {
     rtabort!("Rust panics must be rethrown");
 }
 
@@ -64,7 +64,7 @@ extern "C" fn __rust_drop_panic() -> ! {
 /// object which does not correspond to a Rust panic.
 #[cfg(not(test))]
 #[rustc_std_internal_symbol]
-extern "C" fn __rust_foreign_exception() -> ! {
+extern "C" fn __rust_foreign_exception() -> never {
     rtabort!("Rust cannot catch foreign exceptions");
 }
 
@@ -426,7 +426,7 @@ pub fn panicking() -> bool {
 #[cfg_attr(not(feature = "panic_immediate_abort"), track_caller)]
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never))]
 #[cfg_attr(feature = "panic_immediate_abort", inline)]
-pub fn begin_panic_fmt(msg: &fmt::Arguments<'_>) -> ! {
+pub fn begin_panic_fmt(msg: &fmt::Arguments<'_>) -> never {
     if cfg!(feature = "panic_immediate_abort") {
         intrinsics::abort()
     }
@@ -438,7 +438,7 @@ pub fn begin_panic_fmt(msg: &fmt::Arguments<'_>) -> ! {
 /// Entry point of panics from the libcore crate (`panic_impl` lang item).
 #[cfg_attr(not(test), panic_handler)]
 #[unwind(allowed)]
-pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
+pub fn begin_panic_handler(info: &PanicInfo<'_>) -> never {
     struct PanicPayload<'a> {
         inner: &'a fmt::Arguments<'a>,
         string: Option<String>,
@@ -510,7 +510,7 @@ pub fn begin_panic_handler(info: &PanicInfo<'_>) -> ! {
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never))]
 #[cold]
 #[track_caller]
-pub fn begin_panic<M: Any + Send>(msg: M) -> ! {
+pub fn begin_panic<M: Any + Send>(msg: M) -> never {
     if cfg!(feature = "panic_immediate_abort") {
         intrinsics::abort()
     }
@@ -562,7 +562,7 @@ fn rust_panic_with_hook(
     payload: &mut dyn BoxMeUp,
     message: Option<&fmt::Arguments<'_>>,
     location: &Location<'_>,
-) -> ! {
+) -> never {
     let panics = panic_count::increase();
 
     // If this is the third nested call (e.g., panics == 2, this is 0-indexed),
@@ -612,7 +612,7 @@ fn rust_panic_with_hook(
 
 /// This is the entry point for `resume_unwind`.
 /// It just forwards the payload to the panic runtime.
-pub fn rust_panic_without_hook(payload: Box<dyn Any + Send>) -> ! {
+pub fn rust_panic_without_hook(payload: Box<dyn Any + Send>) -> never {
     panic_count::increase();
 
     struct RewrapBox(Box<dyn Any + Send>);
@@ -634,7 +634,7 @@ pub fn rust_panic_without_hook(payload: Box<dyn Any + Send>) -> ! {
 /// yer breakpoints.
 #[inline(never)]
 #[cfg_attr(not(test), rustc_std_internal_symbol)]
-fn rust_panic(mut msg: &mut dyn BoxMeUp) -> ! {
+fn rust_panic(mut msg: &mut dyn BoxMeUp) -> never {
     let code = unsafe {
         let obj = &mut msg as *mut &mut dyn BoxMeUp;
         __rust_start_panic(obj as usize)

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -79,3 +79,6 @@ pub use crate::string::{String, ToString};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::vec::Vec;
+
+#[stable(feature = "haven't made a feature gate yet", since = "1.50.0")]
+pub use core::primitive::never;

--- a/src/test/ui/never_type/adjust_never.rs
+++ b/src/test/ui/never_type/adjust_never.rs
@@ -8,3 +8,8 @@ fn main() {
     let x: ! = panic!();
     let y: u32 = x;
 }
+
+fn foo() {
+    let x: never = panic!();
+    let y: u32 = x;
+}

--- a/src/test/ui/never_type/call-fn-never-arg.rs
+++ b/src/test/ui/never_type/call-fn-never-arg.rs
@@ -9,6 +9,11 @@ fn foo(x: !) -> ! {
     x
 }
 
+fn bar(x: never) -> never {
+    x
+}
+
 fn main() {
-    foo(panic!("wowzers!"))
+    foo(panic!("wowzers!"));
+    bar(panic!("wowzers!"))
 }

--- a/src/test/ui/never_type/diverging-fallback-control-flow.rs
+++ b/src/test/ui/never_type/diverging-fallback-control-flow.rs
@@ -23,7 +23,7 @@ impl BadDefault for u32 {
     }
 }
 
-impl BadDefault for ! {
+impl BadDefault for never {
     fn default() -> ! {
         panic!()
     }

--- a/src/test/ui/never_type/impl-for-never.rs
+++ b/src/test/ui/never_type/impl-for-never.rs
@@ -8,7 +8,7 @@ trait StringifyType {
     fn stringify_type() -> &'static str;
 }
 
-impl StringifyType for ! {
+impl StringifyType for never {
     fn stringify_type() -> &'static str {
         "!"
     }
@@ -22,6 +22,6 @@ fn maybe_stringify<T: StringifyType>(opt: Option<T>) -> &'static str {
 }
 
 fn main() {
-    println!("! is {}", <!>::stringify_type());
-    println!("None is {}", maybe_stringify(None::<!>));
+    println!("! is {}", <never>::stringify_type());
+    println!("None is {}", maybe_stringify(None::<never>));
 }

--- a/src/test/ui/never_type/issue-51506.rs
+++ b/src/test/ui/never_type/issue-51506.rs
@@ -10,7 +10,7 @@ trait Trait {
 }
 
 impl<T> Trait for T {
-    default type Out = !; //~ ERROR: `!` is not an iterator
+    default type Out = never; //~ ERROR: `!` is not an iterator
 
     default fn f(&self) -> Option<Self::Out> {
         None

--- a/src/test/ui/never_type/issue-51506.stderr
+++ b/src/test/ui/never_type/issue-51506.stderr
@@ -4,8 +4,8 @@ error[E0277]: `!` is not an iterator
 LL |     type Out: Iterator<Item = u32>;
    |               -------------------- required by this bound in `Trait::Out`
 ...
-LL |     default type Out = !;
-   |     ^^^^^^^^^^^^^^^^^^^^^ `!` is not an iterator
+LL |     default type Out = never;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ `!` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `!`
 

--- a/src/test/ui/never_type/never-assign-wrong-type.rs
+++ b/src/test/ui/never_type/never-assign-wrong-type.rs
@@ -4,5 +4,5 @@
 #![deny(warnings)]
 
 fn main() {
-    let x: ! = "hello"; //~ ERROR mismatched types
+    let x: never = "hello"; //~ ERROR mismatched types
 }

--- a/src/test/ui/never_type/never-assign-wrong-type.stderr
+++ b/src/test/ui/never_type/never-assign-wrong-type.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/never-assign-wrong-type.rs:7:16
+  --> $DIR/never-assign-wrong-type.rs:7:20
    |
-LL |     let x: ! = "hello";
-   |            -   ^^^^^^^ expected `!`, found `&str`
+LL |     let x: never = "hello";
+   |            -----   ^^^^^^^ expected `!`, found `&str`
    |            |
    |            expected due to this
    |

--- a/src/test/ui/never_type/never-result.rs
+++ b/src/test/ui/never_type/never-result.rs
@@ -8,7 +8,7 @@
 #![feature(never_type)]
 
 fn main() {
-    let x: Result<u32, !> = Ok(123);
+    let x: Result<u32, never> = Ok(123);
     match x {
         Ok(z) => (),
         Err(y) => {

--- a/src/test/ui/never_type/never_primitive.rs
+++ b/src/test/ui/never_type/never_primitive.rs
@@ -1,0 +1,13 @@
+// check-pass
+
+// For backwards compatibility, test if a type definition that is
+// named `never` shadows the new `never` from the prelude.
+#[allow(non_camel_case_types)]
+struct never { x: u32 }
+
+fn foo(never: never) -> u32 {
+    let never { x } = never;
+    x
+}
+
+fn main() { }

--- a/src/test/ui/never_type/never_transmute_never.rs
+++ b/src/test/ui/never_type/never_transmute_never.rs
@@ -21,3 +21,12 @@ pub fn ub() {
     };
     f(x)
 }
+
+pub fn ub2() {
+    // This is completely undefined behaviour,
+    // but we still want to make sure it compiles.
+    let x: ! = unsafe {
+        std::mem::transmute::<Foo, never>(Foo)
+    };
+    f(x)
+}


### PR DESCRIPTION
This effectively renames the never-type `!` to `never`, but should be fully backwards compatible.
This is an idea I had and I just tried it out. It was surprisingly simple to implement. Example:
```
fn foo() -> never {
    let x: never = panic!();
}
```

# Motivation

The never-type `!` is an essential feature in Rust to make type inference in eg. `match` work:
```
let x = match some_enum {
    Variant1 => 42u32,
    Variant2 => return true,
    _ => panic!(),
}
```
Here `x` can be inferred to have the type `u32`, because the other two match arms have the type `!`, meaning that they never yield a value that would need to be stored in `x`. So in some sense, `!` is a _primitive type_ that marks control flow.

Currently though, you never need to write the `!`, besides the return type of a diverging function. This makes it an "niche" or "advanced" language feature. With the stabilization of the never-type this might change though.

The syntax of using the `!` symbol is **confusing** though, when you first stumble on it as someone learning Rust. Any intuition for what the `!` symbol might mean is misleading, since it's already used with macros, top-level attributes and doc comments in Rust. This is made worse by the fact that you can't even google it. The `!` symbol is just filtered out of any search query, and I even get amusingly unrelated result like hotel bookings when searching for "Rust !". 

# Solution Idea

To fix that I had the idea introduce a primitive type whose name is what we have been calling this feature since [2016](https://github.com/rust-lang/rfcs/pull/1216#issuecomment-236866474): `never`.
Actually, it is just a type alias `pub type never = !` in `core::primitive` that is exported in the prelude.
This should make it fully backwards compatible, since you can use `never` and `!` interchangeably, and the new prelude export is shadowed if somebody made their own type called `never`.

I changed some return types of core and std functions, and some never-type tests to verify that this proof-of-concept works. To my own surprise, bootstrapping works and all UI tests pass. There was one weird interaction with a stability attribute and one case where I had to use the full path `crate::primitive::never`, indicating that there are issues in some corner cases, but I haven't investigated further.

# Downsides

The biggest downside is that existing stable Rust code should be migrated to `never`, since there shouldn't be two ways to express exactly the same. An edition migration would be a good fit: Warn on 2018 and below, error on 2021. But even if the change is straightforward and probably easy to implement in rustfix, the ecosystem impact should be carefully considered.

I'd argue it's a relatively small cost, but also only a small gain. 
Apparently the Syntax for diverging functions has always been low-priority, so it was overlooked in the rush to Rust 1.0, and again ignored in 2018. Even in the long discussion of the [never type RFC](https://github.com/rust-lang/rfcs/pull/1216) the syntax was barely mentioned. Though it's said where it comes from (["Yes, it was a bottom type, that's what `bot` and the bang sign refer to (`!` is supposed to look like `⊥`)"](https://github.com/rust-lang/rfcs/pull/1216#discussion_r34956199)) and [it was decided](https://github.com/rust-lang/rfcs/pull/1216#issuecomment-236866474) to call the feature `never`.

Another issue is that it becomes bad practice to name a variable `never`. You _can_ do it, just like you can name a variable `u32` or `char`, but it will look ugly when syntax highlighters color it like the other primitives. This will impact existing code that uses `never` as a name. I guess it won't be a problem for types, other than someone defining their own `enum never {}` type.

Also, diagnostics would need changes. They mention `!` in type errors when `never` is used.

# What now?

First of all, I'm curious what other people think.
Does this make sense? 
Is it to late to make such a change to the never-type? 
Is it worth the downsides?

If there is interest, should I write a more detailed proposal?
