### PR TITLE
Carry index of InvalidDigit on IntErrorKind

### DIFF
--- a/compiler/rustc_middle/src/middle/limits.rs
+++ b/compiler/rustc_middle/src/middle/limits.rs
@@ -49,7 +49,7 @@ fn update_limit(
                     let error_str = match e.kind() {
                         IntErrorKind::PosOverflow => "`limit` is too large",
                         IntErrorKind::Empty => "`limit` must be a non-negative integer",
-                        IntErrorKind::InvalidDigit => "not a valid integer",
+                        IntErrorKind::InvalidDigit(_) => "not a valid integer",
                         IntErrorKind::NegOverflow => {
                             bug!("`limit` should never negatively overflow")
                         }

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1588,7 +1588,7 @@ pub trait Iterator {
     /// This will print:
     ///
     /// ```text
-    /// Parsing error: invalid digit found in string
+    /// Parsing error: invalid digit found at index 0
     /// Sum: 3
     /// ```
     #[inline]

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -95,14 +95,14 @@ pub enum IntErrorKind {
     ///
     /// Among other causes, this variant will be constructed when parsing an empty string.
     Empty,
-    /// Contains an invalid digit in its context.
+    /// Contains an invalid digit at the index provided.
     ///
     /// Among other causes, this variant will be constructed when parsing a string that
     /// contains a non-ASCII char.
     ///
     /// This variant is also constructed when a `+` or `-` is misplaced within a string
     /// either on its own or in the middle of a number.
-    InvalidDigit,
+    InvalidDigit(usize),
     /// Integer is too large to store in target integer type.
     PosOverflow,
     /// Integer is too small to store in target integer type.
@@ -135,7 +135,7 @@ impl ParseIntError {
     pub fn __description(&self) -> &str {
         match self.kind {
             IntErrorKind::Empty => "cannot parse integer from empty string",
-            IntErrorKind::InvalidDigit => "invalid digit found in string",
+            IntErrorKind::InvalidDigit(_) => "invalid digit found in string",
             IntErrorKind::PosOverflow => "number too large to fit in target type",
             IntErrorKind::NegOverflow => "number too small to fit in target type",
             IntErrorKind::Zero => "number would be zero for non-zero type",

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -146,6 +146,11 @@ impl ParseIntError {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for ParseIntError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.__description().fmt(f)
+        match self.kind {
+            IntErrorKind::InvalidDigit(i) => {
+                write!(f, "invalid digit found at index {}", i)
+            }
+            _ => self.__description().fmt(f),
+        }
     }
 }

--- a/library/core/tests/nonzero.rs
+++ b/library/core/tests/nonzero.rs
@@ -134,7 +134,7 @@ fn test_from_str() {
     assert_eq!("0".parse::<NonZeroU8>().err().map(|e| e.kind().clone()), Some(IntErrorKind::Zero));
     assert_eq!(
         "-1".parse::<NonZeroU8>().err().map(|e| e.kind().clone()),
-        Some(IntErrorKind::InvalidDigit)
+        Some(IntErrorKind::InvalidDigit(0))
     );
     assert_eq!(
         "-129".parse::<NonZeroI8>().err().map(|e| e.kind().clone()),

--- a/library/core/tests/num/mod.rs
+++ b/library/core/tests/num/mod.rs
@@ -124,14 +124,14 @@ fn test_leading_plus() {
 
 #[test]
 fn test_invalid() {
-    test_parse::<i8>("--129", Err(IntErrorKind::InvalidDigit));
-    test_parse::<i8>("++129", Err(IntErrorKind::InvalidDigit));
-    test_parse::<u8>("Съешь", Err(IntErrorKind::InvalidDigit));
-    test_parse::<u8>("123Hello", Err(IntErrorKind::InvalidDigit));
-    test_parse::<i8>("--", Err(IntErrorKind::InvalidDigit));
-    test_parse::<i8>("-", Err(IntErrorKind::InvalidDigit));
-    test_parse::<i8>("+", Err(IntErrorKind::InvalidDigit));
-    test_parse::<u8>("-1", Err(IntErrorKind::InvalidDigit));
+    test_parse::<i8>("--129", Err(IntErrorKind::InvalidDigit(1)));
+    test_parse::<i8>("++129", Err(IntErrorKind::InvalidDigit(1)));
+    test_parse::<u8>("Съешь", Err(IntErrorKind::InvalidDigit(0)));
+    test_parse::<u8>("123Hello", Err(IntErrorKind::InvalidDigit(3)));
+    test_parse::<i8>("--", Err(IntErrorKind::InvalidDigit(1)));
+    test_parse::<i8>("-", Err(IntErrorKind::InvalidDigit(0)));
+    test_parse::<i8>("+", Err(IntErrorKind::InvalidDigit(0)));
+    test_parse::<u8>("-1", Err(IntErrorKind::InvalidDigit(0)));
 }
 
 #[test]

--- a/src/test/ui/feature-gates/unstable-attribute-allow-issue-0.stderr
+++ b/src/test/ui/feature-gates/unstable-attribute-allow-issue-0.stderr
@@ -12,7 +12,7 @@ error[E0545]: `issue` must be a non-zero numeric string or "none"
 LL | #[unstable(feature = "unstable_test_feature", issue = "something")]
    |                                               ^^^^^^^^-----------
    |                                                       |
-   |                                                       invalid digit found in string
+   |                                                       invalid digit found at index 0
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-2.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-2.stderr
@@ -16,7 +16,7 @@ error[E0545]: `issue` must be a non-zero numeric string or "none"
 LL | #[unstable(feature = "a", issue = "no")]
    |                           ^^^^^^^^----
    |                                   |
-   |                                   invalid digit found in string
+   |                                   invalid digit found at index 0
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
@Lucretiel  https://github.com/rust-lang/rust/issues/22639#issuecomment-737079729

> Before stabilizing, would it be very complicated to additionally add the byte index where parsing failed? I can imagine that information being useful to an introspector (for example, to print a verbose rust-like arrow pointing to the exact location of the parse failure).

@ethanboxx https://github.com/rust-lang/rust/issues/22639#issuecomment-739072541
> Should be easy to do. I will probably open a PR with that soon so people discuss it.