### PR TITLE
minor stylistic clippy cleanups

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -121,7 +121,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
 
                 (Some(ret_span), _) => {
                     let sup_future = self.future_return_type(scope_def_id_sup);
-                    let (return_type, action) = if let Some(_) = sup_future {
+                    let (return_type, action) = if sup_future.is_some() {
                         ("returned future", "held across an await point")
                     } else {
                         ("return type", "returned")
@@ -140,7 +140,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                 }
                 (_, Some(ret_span)) => {
                     let sub_future = self.future_return_type(scope_def_id_sub);
-                    let (return_type, action) = if let Some(_) = sub_future {
+                    let (return_type, action) = if sub_future.is_some() {
                         ("returned future", "held across an await point")
                     } else {
                         ("return type", "returned")

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -131,7 +131,7 @@ impl NonCamelCaseTypes {
                 let cc = to_camel_case(name);
                 // We cannot provide meaningful suggestions
                 // if the characters are in the category of "Lowercase Letter".
-                if name.to_string() != cc {
+                if *name != cc {
                     err.span_suggestion(
                         ident.span,
                         "convert the identifier to upper camel case",
@@ -271,7 +271,7 @@ impl NonSnakeCase {
                 let mut err = lint.build(&msg);
                 // We cannot provide meaningful suggestions
                 // if the characters are in the category of "Uppercase Letter".
-                if name.to_string() != sc {
+                if *name != sc {
                     // We have a valid span in almost all cases, but we don't have one when linting a crate
                     // name provided via the command line.
                     if !ident.span.is_dummy() {
@@ -455,7 +455,7 @@ impl NonUpperCaseGlobals {
                     lint.build(&format!("{} `{}` should have an upper case name", sort, name));
                 // We cannot provide meaningful suggestions
                 // if the characters are in the category of "Lowercase Letter".
-                if name.to_string() != uc {
+                if *name != uc {
                     err.span_suggestion(
                         ident.span,
                         "convert the identifier to upper case",

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/region_name.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/region_name.rs
@@ -445,7 +445,7 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             "highlight_if_we_cannot_match_hir_ty: type_name={:?} needle_fr={:?}",
             type_name, needle_fr
         );
-        if type_name.find(&format!("'{}", counter)).is_some() {
+        if type_name.contains(&format!("'{}", counter)) {
             // Only add a label if we can confirm that a region was labelled.
             RegionNameHighlight::CannotMatchHirTy(span, type_name)
         } else {

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -198,7 +198,7 @@ simply delete the `pre-commit` file from .git/hooks."
         };
     };
 
-    Ok(if should_install {
+    if should_install {
         let src = src_path.join("src").join("etc").join("pre-commit.sh");
         let git = t!(Command::new("git").args(&["rev-parse", "--git-common-dir"]).output().map(
             |output| {
@@ -217,5 +217,6 @@ simply delete the `pre-commit` file from .git/hooks."
         };
     } else {
         println!("Ok, skipping installation!");
-    })
+    }
+    Ok(())
 }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -391,7 +391,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for LinkReplacer<'a, I> {
                 _,
             ))) => {
                 debug!("saw end of shortcut link to {}", dest);
-                if self.links.iter().find(|&link| *link.href == **dest).is_some() {
+                if self.links.iter().any(|link| *link.href == **dest) {
                     assert!(self.shortcut_link.is_some(), "saw closing link without opening tag");
                     self.shortcut_link = None;
                 }


### PR DESCRIPTION
simplify if let Some(_) = x  to  if x.is_some()  (clippy::redundant_pattern_matching)
don't create owned values for comparison (clippy::cmp_owned)
use .contains() or .any() instead of find(x).is_some() (clippy::search_is_some)
don't wrap code block in Ok()  (clipppy::unit_arg)