### PR TITLE
Const parameters can not be inferred with `_` help note

### DIFF
--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -44,6 +44,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             // the match is non-exhaustive.
             _ => bug!("invalid generic parameter kind {}", kind),
         };
+
+        if let ParamKindOrd::Const { .. } = kind_ord {
+            if let GenericArg::Type(hir::Ty { kind: hir::TyKind::Infer, .. }) = arg {
+                err.help("const arguments cannot yet be inferred with `_`");
+            }
+        }
+
         let arg_ord = match arg {
             GenericArg::Lifetime(_) => ParamKindOrd::Lifetime,
             GenericArg::Type(_) => ParamKindOrd::Type,

--- a/src/test/ui/const-generics/issues/issue-62878.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-62878.full.stderr
@@ -9,6 +9,8 @@ error[E0747]: type provided when a constant was expected
    |
 LL |     foo::<_, {[1]}>();
    |           ^
+   |
+   = help: const arguments cannot yet be inferred with `_`
 
 error[E0308]: mismatched types
   --> $DIR/issue-62878.rs:11:15

--- a/src/test/ui/const-generics/min_const_generics/inferred_const.rs
+++ b/src/test/ui/const-generics/min_const_generics/inferred_const.rs
@@ -1,0 +1,8 @@
+#![feature(min_const_generics)]
+fn foo<const N: usize, const K: usize>(data: [u32; N]) -> [u32; K] {
+    [0; K]
+}
+fn main() {
+    let a = foo::<_, 2>([0, 1, 2]);
+               //~^ ERROR type provided when a constant was expected
+}

--- a/src/test/ui/const-generics/min_const_generics/inferred_const.stderr
+++ b/src/test/ui/const-generics/min_const_generics/inferred_const.stderr
@@ -1,0 +1,11 @@
+error[E0747]: type provided when a constant was expected
+  --> $DIR/inferred_const.rs:6:19
+   |
+LL |     let a = foo::<_, 2>([0, 1, 2]);
+   |                   ^
+   |
+   = help: const arguments cannot yet be inferred with `_`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0747`.


### PR DESCRIPTION
This should close: #79557

# Example output
```
error[E0747]: type provided when a constant was expected
 --> inferred_const_note.rs:6:19
  |
6 |     let a = foo::<_, 2>([0, 1, 2]);
  |                   ^
  |
  = help: Const parameters can not be inferred with `_`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0747`.
```

r? @lcnr 