### PR TITLE
Close all tags when rendering rustdoc summaries

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1059,11 +1059,14 @@ fn markdown_summary_with_limit(md: &str, length_limit: usize) -> (String, bool) 
 
     'outer: for event in Parser::new_ext(md, Options::ENABLE_STRIKETHROUGH) {
         match &event {
+            // Note: update this if more text (not style) nodes are added.
+            // This is needed so that all tags are closed before we stop.
+            Event::Text(_) | Event::Code(_) if stopped_early => break,
             Event::Text(text) => {
                 for word in text.split_inclusive(char::is_whitespace) {
                     if text_length + word.len() >= length_limit {
                         stopped_early = true;
-                        break 'outer;
+                        continue 'outer;
                     }
 
                     push(&mut s, &mut text_length, word);
@@ -1072,7 +1075,7 @@ fn markdown_summary_with_limit(md: &str, length_limit: usize) -> (String, bool) 
             Event::Code(code) => {
                 if text_length + code.len() >= length_limit {
                     stopped_early = true;
-                    break;
+                    continue;
                 }
 
                 s.push_str("<code>");
@@ -1094,7 +1097,7 @@ fn markdown_summary_with_limit(md: &str, length_limit: usize) -> (String, bool) 
             Event::HardBreak | Event::SoftBreak => {
                 if text_length + 1 >= length_limit {
                     stopped_early = true;
-                    break;
+                    continue;
                 }
 
                 push(&mut s, &mut text_length, " ");


### PR DESCRIPTION
Otherwise we may generate HTML like `<em>hello<b>` if the text after the
`<b>` tag is too long. Now it should correctly generate
`<em>hello<b></b></em>`. It's perhaps not "ideal" that we generate an
empty `<b>` tag, but it's at least valid HTML.

It isn't a *huge* deal that we didn't close all the tags because the
browser is probably smart enough to figure out where the tags should
end, but it's still good to fix :)

r? @GuillaumeGomez
cc @jyn514
