### PR TITLE
Rustdoc: Use correct def_id for doctree::Import

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2263,7 +2263,7 @@ impl Clean<Vec<Item>> for doctree::Import<'_> {
             name: None,
             attrs: self.attrs.clean(cx),
             source: self.span.clean(cx),
-            def_id: DefId::local(CRATE_DEF_INDEX),
+            def_id: cx.tcx.hir().local_def_id(self.id).to_def_id(),
             visibility: self.vis.clean(cx),
             stability: None,
             const_stability: None,

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -151,7 +151,12 @@ impl FormatRenderer for JsonRenderer {
             } else if let types::ItemEnum::EnumItem(ref mut e) = new_item.inner {
                 e.impls = self.get_impls(id, cache)
             }
-            self.index.borrow_mut().insert(id.into(), new_item);
+            let removed = self.index.borrow_mut().insert(id.into(), new_item.clone());
+            // FIXME(adotinthevoid): Currently, the index is duplicated. This is a sanity check
+            // to make sure the items are unique.
+            if let Some(old_item) = removed {
+                assert_eq!(old_item, new_item);
+            }
         }
 
         Ok(())

--- a/src/librustdoc/json/types.rs
+++ b/src/librustdoc/json/types.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
 /// tools to find or link to them.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Crate {
     /// The id of the root [`Module`] item of the local crate.
     pub root: Id,
@@ -31,7 +31,7 @@ pub struct Crate {
     pub format_version: u32,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ExternalCrate {
     pub name: String,
     pub html_root_url: Option<String>,
@@ -41,7 +41,7 @@ pub struct ExternalCrate {
 /// information. This struct should contain enough to generate a link/reference to the item in
 /// question, or can be used by a tool that takes the json output of multiple crates to find
 /// the actual item definition with all the relevant info.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ItemSummary {
     /// Can be used to look up the name and html_root_url of the crate this item came from in the
     /// `external_crates` map.
@@ -53,7 +53,7 @@ pub struct ItemSummary {
     pub kind: ItemKind,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Item {
     /// The unique identifier of this item. Can be used to find this item in various mappings.
     pub id: Id,
@@ -79,7 +79,7 @@ pub struct Item {
     pub inner: ItemEnum,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Span {
     /// The path to the source file for this span relative to the path `rustdoc` was invoked with.
     pub filename: PathBuf,
@@ -89,14 +89,14 @@ pub struct Span {
     pub end: (usize, usize),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Deprecation {
     pub since: Option<String>,
     pub note: Option<String>,
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Visibility {
     Public,
     /// For the most part items are private by default. The exceptions are associated items of
@@ -112,7 +112,7 @@ pub enum Visibility {
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum GenericArgs {
     /// <'a, 32, B: Copy, C = u32>
     AngleBracketed { args: Vec<GenericArg>, bindings: Vec<TypeBinding> },
@@ -121,14 +121,14 @@ pub enum GenericArgs {
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum GenericArg {
     Lifetime(String),
     Type(Type),
     Const(Constant),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Constant {
     #[serde(rename = "type")]
     pub type_: Type,
@@ -137,14 +137,14 @@ pub struct Constant {
     pub is_literal: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct TypeBinding {
     pub name: String,
     pub binding: TypeBindingKind,
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum TypeBindingKind {
     Equality(Type),
     Constraint(Vec<GenericBound>),
@@ -154,7 +154,7 @@ pub enum TypeBindingKind {
 pub struct Id(pub String);
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum ItemKind {
     Module,
     ExternCrate,
@@ -184,7 +184,7 @@ pub enum ItemKind {
 }
 
 #[serde(untagged)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum ItemEnum {
     ModuleItem(Module),
     ExternCrateItem {
@@ -231,13 +231,13 @@ pub enum ItemEnum {
     },
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Module {
     pub is_crate: bool,
     pub items: Vec<Id>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Struct {
     pub struct_type: StructType,
     pub generics: Generics,
@@ -246,7 +246,7 @@ pub struct Struct {
     pub impls: Vec<Id>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Enum {
     pub generics: Generics,
     pub variants_stripped: bool,
@@ -256,7 +256,7 @@ pub struct Enum {
 
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "variant_kind", content = "variant_inner")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Variant {
     Plain,
     Tuple(Vec<Type>),
@@ -264,14 +264,14 @@ pub enum Variant {
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum StructType {
     Plain,
     Tuple,
     Unit,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Function {
     pub decl: FnDecl,
     pub generics: Generics,
@@ -279,7 +279,7 @@ pub struct Function {
     pub abi: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Method {
     pub decl: FnDecl,
     pub generics: Generics,
@@ -287,20 +287,20 @@ pub struct Method {
     pub has_body: bool,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Generics {
     pub params: Vec<GenericParamDef>,
     pub where_predicates: Vec<WherePredicate>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct GenericParamDef {
     pub name: String,
     pub kind: GenericParamDefKind,
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum GenericParamDefKind {
     Lifetime,
     Type { bounds: Vec<GenericBound>, default: Option<Type> },
@@ -308,7 +308,7 @@ pub enum GenericParamDefKind {
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum WherePredicate {
     BoundPredicate { ty: Type, bounds: Vec<GenericBound> },
     RegionPredicate { lifetime: String, bounds: Vec<GenericBound> },
@@ -316,7 +316,7 @@ pub enum WherePredicate {
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum GenericBound {
     TraitBound {
         #[serde(rename = "trait")]
@@ -329,7 +329,7 @@ pub enum GenericBound {
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum TraitBoundModifier {
     None,
     Maybe,
@@ -338,7 +338,7 @@ pub enum TraitBoundModifier {
 
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "kind", content = "inner")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum Type {
     /// Structs, enums, and traits
     ResolvedPath {
@@ -391,7 +391,7 @@ pub enum Type {
     },
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FunctionPointer {
     pub is_unsafe: bool,
     pub generic_params: Vec<GenericParamDef>,
@@ -399,14 +399,14 @@ pub struct FunctionPointer {
     pub abi: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FnDecl {
     pub inputs: Vec<(String, Type)>,
     pub output: Option<Type>,
     pub c_variadic: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Trait {
     pub is_auto: bool,
     pub is_unsafe: bool,
@@ -416,13 +416,13 @@ pub struct Trait {
     pub implementors: Vec<Id>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct TraitAlias {
     pub generics: Generics,
     pub params: Vec<GenericBound>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Impl {
     pub is_unsafe: bool,
     pub generics: Generics,
@@ -438,7 +438,7 @@ pub struct Impl {
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Import {
     /// The full path being imported.
     pub span: String,
@@ -451,14 +451,14 @@ pub struct Import {
     pub glob: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ProcMacro {
     pub kind: MacroKind,
     pub helpers: Vec<String>,
 }
 
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum MacroKind {
     /// A bang macro `foo!()`.
     Bang,
@@ -468,20 +468,20 @@ pub enum MacroKind {
     Derive,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Typedef {
     #[serde(rename = "type")]
     pub type_: Type,
     pub generics: Generics,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct OpaqueTy {
     pub bounds: Vec<GenericBound>,
     pub generics: Generics,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Static {
     #[serde(rename = "type")]
     pub type_: Type,

--- a/src/test/rustdoc-json/nested.expected
+++ b/src/test/rustdoc-json/nested.expected
@@ -1,0 +1,196 @@
+{
+  "crate_version": null,
+  "external_crates": {},
+  "format_version": 1,
+  "includes_private": false,
+  "index": {
+    "0:0": {
+      "attrs": [],
+      "crate_id": 0,
+      "deprecation": null,
+      "docs": "",
+      "id": "0:0",
+      "inner": {
+        "is_crate": true,
+        "items": [
+          "0:3"
+        ]
+      },
+      "kind": "module",
+      "links": {},
+      "name": "nested",
+      "source": {
+        "begin": [
+          2,
+          0
+        ],
+        "end": [
+          7,
+          1
+        ],
+        "filename": "$TEST_BASE_DIR/nested.rs"
+      },
+      "visibility": "public"
+    },
+    "0:3": {
+      "attrs": [],
+      "crate_id": 0,
+      "deprecation": null,
+      "docs": "",
+      "id": "0:3",
+      "inner": {
+        "is_crate": false,
+        "items": [
+          "0:7",
+          "0:4"
+        ]
+      },
+      "kind": "module",
+      "links": {},
+      "name": "l1",
+      "source": {
+        "begin": [
+          2,
+          0
+        ],
+        "end": [
+          7,
+          1
+        ],
+        "filename": "$TEST_BASE_DIR/nested.rs"
+      },
+      "visibility": "public"
+    },
+    "0:4": {
+      "attrs": [],
+      "crate_id": 0,
+      "deprecation": null,
+      "docs": "",
+      "id": "0:4",
+      "inner": {
+        "is_crate": false,
+        "items": [
+          "0:5"
+        ]
+      },
+      "kind": "module",
+      "links": {},
+      "name": "l3",
+      "source": {
+        "begin": [
+          3,
+          4
+        ],
+        "end": [
+          5,
+          5
+        ],
+        "filename": "$TEST_BASE_DIR/nested.rs"
+      },
+      "visibility": "public"
+    },
+    "0:5": {
+      "attrs": [],
+      "crate_id": 0,
+      "deprecation": null,
+      "docs": "",
+      "id": "0:5",
+      "inner": {
+        "fields": [],
+        "fields_stripped": false,
+        "generics": {
+          "params": [],
+          "where_predicates": []
+        },
+        "impls": [
+          "0:10",
+          "0:11",
+          "0:12",
+          "0:14",
+          "0:15"
+        ],
+        "struct_type": "unit"
+      },
+      "kind": "struct",
+      "links": {},
+      "name": "L4",
+      "source": {
+        "begin": [
+          4,
+          8
+        ],
+        "end": [
+          4,
+          22
+        ],
+        "filename": "$TEST_BASE_DIR/nested.rs"
+      },
+      "visibility": "public"
+    },
+    "0:7": {
+      "attrs": [],
+      "crate_id": 0,
+      "deprecation": null,
+      "docs": "",
+      "id": "0:7",
+      "inner": {
+        "glob": false,
+        "id": "0:5",
+        "name": "L4",
+        "span": "l3::L4"
+      },
+      "kind": "import",
+      "links": {},
+      "name": null,
+      "source": {
+        "begin": [
+          6,
+          4
+        ],
+        "end": [
+          6,
+          19
+        ],
+        "filename": "$TEST_BASE_DIR/nested.rs"
+      },
+      "visibility": "public"
+    }
+  },
+  "paths": {
+    "0:0": {
+      "crate_id": 0,
+      "kind": "module",
+      "path": [
+        "nested"
+      ]
+    },
+    "0:3": {
+      "crate_id": 0,
+      "kind": "module",
+      "path": [
+        "nested",
+        "l1"
+      ]
+    },
+    "0:4": {
+      "crate_id": 0,
+      "kind": "module",
+      "path": [
+        "nested",
+        "l1",
+        "l3"
+      ]
+    },
+    "0:5": {
+      "crate_id": 0,
+      "kind": "struct",
+      "path": [
+        "nested",
+        "l1",
+        "l3",
+        "L4"
+      ]
+    }
+  },
+  "root": "0:0"
+}

--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -1,0 +1,7 @@
+// edition:2018
+pub mod l1 {
+    pub mod l3 {
+        pub struct L4;
+    }
+    pub use l3::L4;
+}


### PR DESCRIPTION
The default overwrites the crate root, which crashes rustdoc-json.

While investigating this, It turns out somehow, some items are being documented twice. I'm not sure how this is happening but for now, we just make sure they were the same if they have the same id.

[Zulip descussion](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Panic.20in.20json-format/near/218899256)

[Bless script](https://gist.github.com/aDotInTheVoid/2dfce0d241338def3f033f941b7c183d) (Once this is more pollished I'll submit it)

r? @jyn514 