### PR TITLE
unix: Non-mutable bufs in send_vectored_with_ancillary_to

### DIFF
--- a/library/std/src/sys/unix/ext/net/ancillary.rs
+++ b/library/std/src/sys/unix/ext/net/ancillary.rs
@@ -1,6 +1,6 @@
 use super::{sockaddr_un, SocketAddr};
 use crate::convert::TryFrom;
-use crate::io::{self, IoSliceMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::marker::PhantomData;
 use crate::mem::{size_of, zeroed};
 use crate::os::unix::io::RawFd;
@@ -68,7 +68,7 @@ pub(super) fn recv_vectored_with_ancillary_from(
 pub(super) fn send_vectored_with_ancillary_to(
     socket: &Socket,
     path: Option<&Path>,
-    bufs: &mut [IoSliceMut<'_>],
+    bufs: &[IoSlice<'_>],
     ancillary: &mut SocketAncillary<'_>,
 ) -> io::Result<usize> {
     unsafe {
@@ -78,7 +78,7 @@ pub(super) fn send_vectored_with_ancillary_to(
         let mut msg: libc::msghdr = zeroed();
         msg.msg_name = &mut msg_name as *mut _ as *mut _;
         msg.msg_namelen = msg_namelen;
-        msg.msg_iov = bufs.as_mut_ptr().cast();
+        msg.msg_iov = bufs as *const _ as *mut _;
         msg.msg_control = ancillary.buffer.as_mut_ptr().cast();
         cfg_if::cfg_if! {
             if #[cfg(any(target_os = "android", all(target_os = "linux", target_env = "gnu")))] {
@@ -563,7 +563,7 @@ impl<'a> SocketAncillary<'a> {
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary};
     /// use std::os::unix::io::AsRawFd;
-    /// use std::io::IoSliceMut;
+    /// use std::io::IoSlice;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let sock = UnixStream::connect("/tmp/sock")?;
@@ -573,7 +573,7 @@ impl<'a> SocketAncillary<'a> {
     ///     ancillary.add_fds(&[sock.as_raw_fd()][..]);
     ///
     ///     let mut buf = [1; 8];
-    ///     let mut bufs = &mut [IoSliceMut::new(&mut buf[..])][..];
+    ///     let mut bufs = &[IoSlice::new(&mut buf[..])][..];
     ///     sock.send_vectored_with_ancillary(bufs, &mut ancillary)?;
     ///     Ok(())
     /// }

--- a/library/std/src/sys/unix/ext/net/datagram.rs
+++ b/library/std/src/sys/unix/ext/net/datagram.rs
@@ -19,7 +19,7 @@ use super::{sockaddr_un, SocketAddr};
     target_os = "netbsd",
     target_os = "openbsd",
 ))]
-use crate::io::IoSliceMut;
+use crate::io::{IoSlice, IoSliceMut};
 use crate::net::Shutdown;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::path::Path;
@@ -506,17 +506,17 @@ impl UnixDatagram {
     /// ```no_run
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixDatagram, SocketAncillary};
-    /// use std::io::IoSliceMut;
+    /// use std::io::IoSlice;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let sock = UnixDatagram::unbound()?;
     ///     let mut buf1 = [1; 8];
     ///     let mut buf2 = [2; 16];
     ///     let mut buf3 = [3; 8];
-    ///     let mut bufs = &mut [
-    ///         IoSliceMut::new(&mut buf1),
-    ///         IoSliceMut::new(&mut buf2),
-    ///         IoSliceMut::new(&mut buf3),
+    ///     let mut bufs = &[
+    ///         IoSlice::new(&mut buf1),
+    ///         IoSlice::new(&mut buf2),
+    ///         IoSlice::new(&mut buf3),
     ///     ][..];
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
@@ -538,7 +538,7 @@ impl UnixDatagram {
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn send_vectored_with_ancillary_to<P: AsRef<Path>>(
         &self,
-        bufs: &mut [IoSliceMut<'_>],
+        bufs: &[IoSlice<'_>],
         ancillary: &mut SocketAncillary<'_>,
         path: P,
     ) -> io::Result<usize> {
@@ -554,17 +554,17 @@ impl UnixDatagram {
     /// ```no_run
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixDatagram, SocketAncillary};
-    /// use std::io::IoSliceMut;
+    /// use std::io::IoSlice;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let sock = UnixDatagram::unbound()?;
     ///     let mut buf1 = [1; 8];
     ///     let mut buf2 = [2; 16];
     ///     let mut buf3 = [3; 8];
-    ///     let mut bufs = &mut [
-    ///         IoSliceMut::new(&mut buf1),
-    ///         IoSliceMut::new(&mut buf2),
-    ///         IoSliceMut::new(&mut buf3),
+    ///     let mut bufs = &[
+    ///         IoSlice::new(&mut buf1),
+    ///         IoSlice::new(&mut buf2),
+    ///         IoSlice::new(&mut buf3),
     ///     ][..];
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
@@ -586,7 +586,7 @@ impl UnixDatagram {
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn send_vectored_with_ancillary(
         &self,
-        bufs: &mut [IoSliceMut<'_>],
+        bufs: &[IoSlice<'_>],
         ancillary: &mut SocketAncillary<'_>,
     ) -> io::Result<usize> {
         send_vectored_with_ancillary_to(&self.0, None, bufs, ancillary)

--- a/library/std/src/sys/unix/ext/net/stream.rs
+++ b/library/std/src/sys/unix/ext/net/stream.rs
@@ -530,17 +530,17 @@ impl UnixStream {
     /// ```no_run
     /// #![feature(unix_socket_ancillary_data)]
     /// use std::os::unix::net::{UnixStream, SocketAncillary};
-    /// use std::io::IoSliceMut;
+    /// use std::io::IoSlice;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let socket = UnixStream::connect("/tmp/sock")?;
     ///     let mut buf1 = [1; 8];
     ///     let mut buf2 = [2; 16];
     ///     let mut buf3 = [3; 8];
-    ///     let mut bufs = &mut [
-    ///         IoSliceMut::new(&mut buf1),
-    ///         IoSliceMut::new(&mut buf2),
-    ///         IoSliceMut::new(&mut buf3),
+    ///     let mut bufs = &[
+    ///         IoSlice::new(&mut buf1),
+    ///         IoSlice::new(&mut buf2),
+    ///         IoSlice::new(&mut buf3),
     ///     ][..];
     ///     let fds = [0, 1, 2];
     ///     let mut ancillary_buffer = [0; 128];
@@ -562,7 +562,7 @@ impl UnixStream {
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn send_vectored_with_ancillary(
         &self,
-        bufs: &mut [IoSliceMut<'_>],
+        bufs: &[IoSlice<'_>],
         ancillary: &mut SocketAncillary<'_>,
     ) -> io::Result<usize> {
         send_vectored_with_ancillary_to(&self.0, None, bufs, ancillary)

--- a/library/std/src/sys/unix/ext/net/tests.rs
+++ b/library/std/src/sys/unix/ext/net/tests.rs
@@ -486,7 +486,7 @@ fn test_send_vectored_fds_unix_stream() {
     let (s1, s2) = or_panic!(UnixStream::pair());
 
     let mut buf1 = [1; 8];
-    let mut bufs_send = &mut [IoSliceMut::new(&mut buf1[..])][..];
+    let mut bufs_send = &[IoSlice::new(&mut buf1[..])][..];
 
     let mut ancillary1_buffer = [0; 128];
     let mut ancillary1 = SocketAncillary::new(&mut ancillary1_buffer[..]);
@@ -543,7 +543,7 @@ fn test_send_vectored_with_ancillary_to_unix_datagram() {
     or_panic!(bsock2.set_passcred(true));
 
     let mut buf1 = [1; 8];
-    let mut bufs_send = &mut [IoSliceMut::new(&mut buf1[..])][..];
+    let mut bufs_send = &[IoSlice::new(&mut buf1[..])][..];
 
     let mut ancillary1_buffer = [0; 128];
     let mut ancillary1 = SocketAncillary::new(&mut ancillary1_buffer[..]);
@@ -604,7 +604,7 @@ fn test_send_vectored_with_ancillary_unix_datagram() {
     let bsock2 = or_panic!(UnixDatagram::bind(&path2));
 
     let mut buf1 = [1; 8];
-    let mut bufs_send = &mut [IoSliceMut::new(&mut buf1[..])][..];
+    let mut bufs_send = &[IoSlice::new(&mut buf1[..])][..];
 
     let mut ancillary1_buffer = [0; 128];
     let mut ancillary1 = SocketAncillary::new(&mut ancillary1_buffer[..]);


### PR DESCRIPTION
`send_vectored_with_ancillary_to` uses `struct msghdr` internally, which contains a `*mut iovec`. [That's why](https://github.com/rust-lang/rust/pull/69864#issuecomment-739335107) this function currently takes a mutable reference to `bufs`. However, these buffers aren't actually modified on sendmsg, so let this function take a non-mutable reference instead and cast the raw `iovec` pointer to mutable as an implementation detail.