### PR TITLE
Use the correct file/line for doctests on both inner and outer attributes

### DIFF
--- a/src/test/rustdoc-ui/issue-79764/a/another_mod.rs
+++ b/src/test/rustdoc-ui/issue-79764/a/another_mod.rs
@@ -1,0 +1,4 @@
+//! ```
+//! // ^ a/another_mod.rs line 1
+//! assert_eq!(1, 1);
+//! ```

--- a/src/test/rustdoc-ui/issue-79764/a/mod.rs
+++ b/src/test/rustdoc-ui/issue-79764/a/mod.rs
@@ -1,0 +1,10 @@
+//! ```
+//! // ^ a/mod.rs line 1
+//! assert_eq!(1, 1);
+//! ```
+
+/// ```
+/// // ^ a/mod.rs line 6
+/// assert_eq!(1, 1);
+/// ```
+pub mod another_mod;

--- a/src/test/rustdoc-ui/issue-79764/mod.rs
+++ b/src/test/rustdoc-ui/issue-79764/mod.rs
@@ -1,0 +1,14 @@
+// check-pass
+// compile-flags:--test
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+// The literal `mod` in the doctest comments makes rustdoc emit a bogus
+// `extern crate mod;` line which would break the doctests.
+#![doc(test(no_crate_inject))]
+
+/// ```
+/// // ^ mod.rs line 10
+/// assert_eq!(1, 1);
+/// ```
+pub mod a;

--- a/src/test/rustdoc-ui/issue-79764/mod.stdout
+++ b/src/test/rustdoc-ui/issue-79764/mod.stdout
@@ -1,0 +1,9 @@
+
+running 4 tests
+test $DIR/issue-79764/mod.rs - a (line 14) ... ok
+test $DIR/issue-79764/mod.rs - a (line 10) ... ok
+test $DIR/issue-79764/a/mod.rs - a::another_mod (line 6) ... ok
+test $DIR/issue-79764/a/mod.rs - a::another_mod (line 10) ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
When adding two separate doc comments to a `mod`, one item-level doc
for the `mod` statement, and one file-level doc for the module file,
doctests that are defined in the module file get the wrong filename/line
assigned to them.

does not yet fix issue #79764, as I still have to figure out how all of this fits together ;-) So far, I just created a testcase for this.