### PR TITLE
[experiment] add loop deletion llvm pass

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,8 +36,8 @@
 	url = https://github.com/rust-lang/edition-guide.git
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/11.0-2020-10-12
+	url = https://github.com/the8472/llvm-project.git
+	branch = loop-delete-pass
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git

--- a/library/alloc/benches/vec.rs
+++ b/library/alloc/benches/vec.rs
@@ -548,6 +548,16 @@ fn bench_in_place_zip_iter_mut(b: &mut Bencher) {
     black_box(data);
 }
 
+#[inline(never)]
+pub fn vec_cast(input: Vec<usize>) -> Vec<isize> {
+    input.into_iter().map(|e| e as isize).collect()
+}
+
+#[bench]
+fn bench_transmute(b: &mut Bencher) {
+    b.iter(|| vec_cast(black_box(Vec::with_capacity(100))));
+}
+
 #[derive(Clone)]
 struct Droppable(usize);
 


### PR DESCRIPTION
My findings in #79308 suggest that adding one extra loop deletion pass in the right place can eliminate some loops such that the algorithmic complexity of a function improves categorically. Adding it via `-Cpasses` doesn't quite work on its own (at least for x86_64 defaults), probably due to pass ordering. So this PR just hacks it directly [into the llvm pass manager builder](https://github.com/the8472/llvm-project/commit/77cd40769254491ad3497d2e7e0221619499d8a0).
I'm probably not doing this the right way, but locally that's the way that requires the fewest extra passes to get the desired assembly.

If the checks pass I'd like a perf run to see what the impact is.