### PR TITLE
Use `summary_opts()` in another spot

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1057,7 +1057,7 @@ fn markdown_summary_with_limit(md: &str, length_limit: usize) -> (String, bool) 
         *text_length += text.len();
     };
 
-    'outer: for event in Parser::new_ext(md, Options::ENABLE_STRIKETHROUGH) {
+    'outer: for event in Parser::new_ext(md, summary_opts()) {
         match &event {
             Event::Text(text) => {
                 for word in text.split_inclusive(char::is_whitespace) {


### PR DESCRIPTION
I added `summary_opts()` before I cut the branch for #77686 (2 months
ago!), so this "slipped through the cracks".
