### PR TITLE
Refactor dist tarballs generation

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1024,13 +1024,10 @@ impl Step for Cargo {
         tarball.set_overlay(OverlayKind::Cargo);
 
         tarball.add_file(&cargo, "bin", 0o755);
-        tarball.add_file(src.join("README.md"), "share/doc/cargo", 0o644);
-        tarball.add_file(src.join("LICENSE-MIT"), "share/doc/cargo", 0o644);
-        tarball.add_file(src.join("LICENSE-APACHE"), "share/doc/cargo", 0o644);
-        tarball.add_file(src.join("LICENSE-THIRD-PARTY"), "share/doc/cargo", 0o644);
         tarball.add_file(etc.join("_cargo"), "share/zsh/site-functions", 0o644);
         tarball.add_renamed_file(etc.join("cargo.bashcomp.sh"), "etc/bash_completion.d", "cargo");
         tarball.add_dir(etc.join("man"), "share/man/man1");
+        tarball.add_legal_and_readme_to("share/doc/cargo");
 
         for dirent in fs::read_dir(cargo.parent().unwrap()).expect("read_dir") {
             let dirent = dirent.expect("read dir entry");
@@ -1265,16 +1262,13 @@ impl Step for Clippy {
         let cargoclippy = builder
             .ensure(tool::CargoClippy { compiler, target, extra_features: Vec::new() })
             .expect("clippy expected to build - essential tool");
-        let src = builder.src.join("src/tools/clippy");
 
         let mut tarball = Tarball::new(builder, "clippy", &target.triple);
         tarball.set_overlay(OverlayKind::Clippy);
         tarball.is_preview(true);
         tarball.add_file(clippy, "bin", 0o755);
         tarball.add_file(cargoclippy, "bin", 0o755);
-        tarball.add_file(src.join("README.md"), "share/doc/clippy", 0o644);
-        tarball.add_file(src.join("LICENSE-APACHE"), "share/doc/clippy", 0o644);
-        tarball.add_file(src.join("LICENSE-MIT"), "share/doc/clippy", 0o644);
+        tarball.add_legal_and_readme_to("share/doc/clippy");
         tarball.generate()
     }
 }

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1283,8 +1283,7 @@ impl Step for Extended {
         let analysis_installer = builder.ensure(Analysis { compiler, target });
 
         let docs_installer = builder.ensure(Docs { host: target });
-        let std_installer =
-            builder.ensure(Std { compiler: builder.compiler(stage, target), target });
+        let std_installer = builder.ensure(Std { compiler, target });
 
         let etc = builder.src.join("src/etc/installer");
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -72,11 +72,7 @@ impl Step for Docs {
         if !builder.config.docs {
             return None;
         }
-
         builder.default_doc(None);
-
-        builder.info(&format!("Dist docs ({})", host));
-        let _time = timeit(builder);
 
         let dest = "share/doc/rust/html";
 
@@ -84,7 +80,6 @@ impl Step for Docs {
         tarball.set_product_name("Rust Documentation");
         tarball.add_dir(&builder.doc_out(host), dest);
         tarball.add_file(&builder.src.join("src/doc/robots.txt"), dest, 0o644);
-
         Some(tarball.generate())
     }
 }
@@ -112,15 +107,11 @@ impl Step for RustcDocs {
         if !builder.config.compiler_docs {
             return None;
         }
-
         builder.default_doc(None);
-        builder.info(&format!("Dist compiler docs ({})", host));
-        let _time = timeit(builder);
 
         let mut tarball = Tarball::new(builder, "rustc-docs", &host.triple);
         tarball.set_product_name("Rustc Documentation");
         tarball.add_dir(&builder.compiler_doc_out(host), "share/doc/rust/html/rustc");
-
         Some(tarball.generate())
     }
 }
@@ -301,9 +292,6 @@ impl Step for Mingw {
             return None;
         }
 
-        builder.info(&format!("Dist mingw ({})", host));
-        let _time = timeit(builder);
-
         let mut tarball = Tarball::new(builder, "rust-mingw", &host.triple);
         tarball.set_product_name("Rust MinGW");
 
@@ -340,9 +328,6 @@ impl Step for Rustc {
     fn run(self, builder: &Builder<'_>) -> PathBuf {
         let compiler = self.compiler;
         let host = self.compiler.host;
-
-        builder.info(&format!("Dist rustc stage{} ({})", compiler.stage, host.triple));
-        let _time = timeit(builder);
 
         let tarball = Tarball::new(builder, "rustc", &host.triple);
 
@@ -2318,9 +2303,6 @@ impl Step for LlvmTools {
             }
         }
 
-        builder.info(&format!("Dist LlvmTools ({})", target));
-        let _time = timeit(builder);
-
         let mut tarball = Tarball::new(builder, "llvm-tools", &target.triple);
         tarball.set_overlay(OverlayKind::LLVM);
         tarball.is_preview(true);
@@ -2374,9 +2356,6 @@ impl Step for RustDev {
                 return None;
             }
         }
-
-        builder.info(&format!("Dist RustDev ({})", target));
-        let _time = timeit(builder);
 
         let mut tarball = Tarball::new(builder, "rust-dev", &target.triple);
         tarball.set_overlay(OverlayKind::LLVM);

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1122,60 +1122,16 @@ impl Step for RustAnalyzer {
             return None;
         }
 
-        let src = builder.src.join("src/tools/rust-analyzer");
-        let release_num = builder.release_num("rust-analyzer/crates/rust-analyzer");
-        let name = pkgname(builder, "rust-analyzer");
-        let version = builder.rust_analyzer_info.version(builder, &release_num);
-
-        let tmp = tmpdir(builder);
-        let image = tmp.join("rust-analyzer-image");
-        drop(fs::remove_dir_all(&image));
-        builder.create_dir(&image);
-
-        // Prepare the image directory
-        // We expect rust-analyer to always build, as it doesn't depend on rustc internals
-        // and doesn't have associated toolstate.
         let rust_analyzer = builder
             .ensure(tool::RustAnalyzer { compiler, target, extra_features: Vec::new() })
             .expect("rust-analyzer always builds");
 
-        builder.install(&rust_analyzer, &image.join("bin"), 0o755);
-        let doc = image.join("share/doc/rust-analyzer");
-        builder.install(&src.join("README.md"), &doc, 0o644);
-        builder.install(&src.join("LICENSE-APACHE"), &doc, 0o644);
-        builder.install(&src.join("LICENSE-MIT"), &doc, 0o644);
-
-        // Prepare the overlay
-        let overlay = tmp.join("rust-analyzer-overlay");
-        drop(fs::remove_dir_all(&overlay));
-        t!(fs::create_dir_all(&overlay));
-        builder.install(&src.join("README.md"), &overlay, 0o644);
-        builder.install(&src.join("LICENSE-APACHE"), &doc, 0o644);
-        builder.install(&src.join("LICENSE-MIT"), &doc, 0o644);
-        builder.create(&overlay.join("version"), &version);
-
-        // Generate the installer tarball
-        let mut cmd = rust_installer(builder);
-        cmd.arg("generate")
-            .arg("--product-name=Rust")
-            .arg("--rel-manifest-dir=rustlib")
-            .arg("--success-message=rust-analyzer-ready-to-serve.")
-            .arg("--image-dir")
-            .arg(&image)
-            .arg("--work-dir")
-            .arg(&tmpdir(builder))
-            .arg("--output-dir")
-            .arg(&distdir(builder))
-            .arg("--non-installed-overlay")
-            .arg(&overlay)
-            .arg(format!("--package-name={}-{}", name, target.triple))
-            .arg("--legacy-manifest-dirs=rustlib,cargo")
-            .arg("--component-name=rust-analyzer-preview");
-
-        builder.info(&format!("Dist rust-analyzer stage{} ({})", compiler.stage, target));
-        let _time = timeit(builder);
-        builder.run(&mut cmd);
-        Some(distdir(builder).join(format!("{}-{}.tar.gz", name, target.triple)))
+        let mut tarball = Tarball::new(builder, "rust-analyzer", &target.triple);
+        tarball.set_overlay(OverlayKind::RustAnalyzer);
+        tarball.is_preview(true);
+        tarball.add_file(rust_analyzer, "bin", 0o755);
+        tarball.add_legal_and_readme_to("share/doc/rust-analyzer");
+        Some(tarball.generate())
     }
 }
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -1288,6 +1288,11 @@ impl Step for Extended {
 
         let etc = builder.src.join("src/etc/installer");
 
+        // Avoid producing tarballs during a dry run.
+        if builder.config.dry_run {
+            return;
+        }
+
         // When rust-std package split from rustc, we needed to ensure that during
         // upgrades rustc was upgraded before rust-std. To avoid rustc clobbering
         // the std files during uninstall. To do this ensure that rustc comes

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -142,6 +142,7 @@ mod native;
 mod run;
 mod sanity;
 mod setup;
+mod tarball;
 mod test;
 mod tool;
 mod toolstate;

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1069,10 +1069,6 @@ impl Build {
         self.package_vers(&self.version)
     }
 
-    fn llvm_tools_vers(&self) -> String {
-        self.rust_version()
-    }
-
     fn llvm_link_tools_dynamically(&self, target: TargetSelection) -> bool {
         target.contains("linux-gnu") || target.contains("apple-darwin")
     }

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -13,6 +13,7 @@ pub(crate) enum OverlayKind {
     Miri,
     Rustfmt,
     RLS,
+    RustAnalyzer,
 }
 
 impl OverlayKind {
@@ -48,6 +49,11 @@ impl OverlayKind {
                 "src/tools/rls/LICENSE-APACHE",
                 "src/tools/rls/LICENSE-MIT",
             ],
+            OverlayKind::RustAnalyzer => &[
+                "src/tools/rust-analyzer/README.md",
+                "src/tools/rust-analyzer/LICENSE-APACHE",
+                "src/tools/rust-analyzer/LICENSE-MIT",
+            ],
         }
     }
 
@@ -66,6 +72,9 @@ impl OverlayKind {
                 builder.rustfmt_info.version(builder, &builder.release_num("rustfmt"))
             }
             OverlayKind::RLS => builder.rls_info.version(builder, &builder.release_num("rls")),
+            OverlayKind::RustAnalyzer => builder
+                .rust_analyzer_info
+                .version(builder, &builder.release_num("rust-analyzer/crates/rust-analyzer")),
         }
     }
 }

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -13,7 +13,7 @@ pub(crate) enum OverlayKind {
 }
 
 impl OverlayKind {
-    fn included_files(&self) -> &[&str] {
+    fn legal_and_readme(&self) -> &[&str] {
         match self {
             OverlayKind::Rust => &["COPYRIGHT", "LICENSE-APACHE", "LICENSE-MIT", "README.md"],
             OverlayKind::LLVM => {
@@ -140,6 +140,12 @@ impl<'a> Tarball<'a> {
         self.builder.copy(src.as_ref(), &destdir.join(new_name));
     }
 
+    pub(crate) fn add_legal_and_readme_to(&self, destdir: impl AsRef<Path>) {
+        for file in self.overlay.legal_and_readme() {
+            self.add_file(self.builder.src.join(file), destdir.as_ref(), 0o644);
+        }
+    }
+
     pub(crate) fn add_dir(&self, src: impl AsRef<Path>, dest: impl AsRef<Path>) {
         let dest = self.image_dir.join(dest.as_ref());
 
@@ -153,7 +159,7 @@ impl<'a> Tarball<'a> {
         if let Some(sha) = self.builder.rust_sha() {
             self.builder.create(&self.overlay_dir.join("git-commit-hash"), &sha);
         }
-        for file in self.overlay.included_files() {
+        for file in self.overlay.legal_and_readme() {
             self.builder.install(&self.builder.src.join(file), &self.overlay_dir, 0o644);
         }
 

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -11,6 +11,7 @@ pub(crate) enum OverlayKind {
     Cargo,
     Clippy,
     Miri,
+    Rustfmt,
 }
 
 impl OverlayKind {
@@ -36,6 +37,11 @@ impl OverlayKind {
                 "src/tools/miri/LICENSE-APACHE",
                 "src/tools/miri/LICENSE-MIT",
             ],
+            OverlayKind::Rustfmt => &[
+                "src/tools/rustfmt/README.md",
+                "src/tools/rustfmt/LICENSE-APACHE",
+                "src/tools/rustfmt/LICENSE-MIT",
+            ],
         }
     }
 
@@ -50,6 +56,9 @@ impl OverlayKind {
                 builder.clippy_info.version(builder, &builder.release_num("clippy"))
             }
             OverlayKind::Miri => builder.miri_info.version(builder, &builder.release_num("miri")),
+            OverlayKind::Rustfmt => {
+                builder.rustfmt_info.version(builder, &builder.release_num("rustfmt"))
+            }
         }
     }
 }

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -12,6 +12,7 @@ pub(crate) enum OverlayKind {
     Clippy,
     Miri,
     Rustfmt,
+    RLS,
 }
 
 impl OverlayKind {
@@ -42,6 +43,11 @@ impl OverlayKind {
                 "src/tools/rustfmt/LICENSE-APACHE",
                 "src/tools/rustfmt/LICENSE-MIT",
             ],
+            OverlayKind::RLS => &[
+                "src/tools/rls/README.md",
+                "src/tools/rls/LICENSE-APACHE",
+                "src/tools/rls/LICENSE-MIT",
+            ],
         }
     }
 
@@ -59,6 +65,7 @@ impl OverlayKind {
             OverlayKind::Rustfmt => {
                 builder.rustfmt_info.version(builder, &builder.release_num("rustfmt"))
             }
+            OverlayKind::RLS => builder.rls_info.version(builder, &builder.release_num("rls")),
         }
     }
 }

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -35,6 +35,7 @@ pub(crate) struct Tarball<'a> {
     overlay_dir: PathBuf,
     work_dir: PathBuf,
 
+    include_target_in_component_name: bool,
     is_preview: bool,
 }
 
@@ -63,6 +64,7 @@ impl<'a> Tarball<'a> {
             overlay_dir,
             work_dir,
 
+            include_target_in_component_name: false,
             is_preview: false,
         }
     }
@@ -73,6 +75,10 @@ impl<'a> Tarball<'a> {
 
     pub(crate) fn set_product_name(&mut self, name: &str) {
         self.product_name = name.into();
+    }
+
+    pub(crate) fn include_target_in_component_name(&mut self, include: bool) {
+        self.include_target_in_component_name = include;
     }
 
     pub(crate) fn is_preview(&mut self, is: bool) {
@@ -122,6 +128,10 @@ impl<'a> Tarball<'a> {
         let mut component_name = self.component.clone();
         if self.is_preview {
             component_name.push_str("-preview");
+        }
+        if self.include_target_in_component_name {
+            component_name.push('-');
+            component_name.push_str(&self.target);
         }
 
         let distdir = crate::dist::distdir(self.builder);

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -1,0 +1,124 @@
+use std::path::{Path, PathBuf};
+
+use build_helper::t;
+
+use crate::builder::Builder;
+
+#[derive(Copy, Clone)]
+pub(crate) enum OverlayKind {
+    Rust,
+    LLVM,
+}
+
+impl OverlayKind {
+    fn included_files(&self) -> &[&str] {
+        match self {
+            OverlayKind::Rust => &["COPYRIGHT", "LICENSE-APACHE", "LICENSE-MIT", "README.md"],
+            OverlayKind::LLVM => {
+                &["src/llvm-project/llvm/LICENSE.TXT", "src/llvm-project/llvm/README.txt"]
+            }
+        }
+    }
+}
+
+pub(crate) struct Tarball<'a> {
+    builder: &'a Builder<'a>,
+
+    pkgname: String,
+    component: String,
+    target: String,
+    overlay: OverlayKind,
+
+    temp_dir: PathBuf,
+    image_dir: PathBuf,
+    overlay_dir: PathBuf,
+    work_dir: PathBuf,
+}
+
+impl<'a> Tarball<'a> {
+    pub(crate) fn new(builder: &'a Builder<'a>, component: &str, target: &str) -> Self {
+        let pkgname = crate::dist::pkgname(builder, component);
+
+        let temp_dir = builder.out.join("tmp").join("tarball").join(component);
+        let _ = std::fs::remove_dir_all(&temp_dir);
+
+        let image_dir = temp_dir.join("image");
+        let overlay_dir = temp_dir.join("overlay");
+        let work_dir = temp_dir.join("work");
+
+        Self {
+            builder,
+
+            pkgname,
+            component: component.into(),
+            target: target.into(),
+            overlay: OverlayKind::Rust,
+
+            temp_dir,
+            image_dir,
+            overlay_dir,
+            work_dir,
+        }
+    }
+
+    pub(crate) fn set_overlay(&mut self, overlay: OverlayKind) {
+        self.overlay = overlay;
+    }
+
+    pub(crate) fn image_dir(&self) -> &Path {
+        t!(std::fs::create_dir_all(&self.image_dir));
+        &self.image_dir
+    }
+
+    pub(crate) fn add_file(&self, src: impl AsRef<Path>, destdir: impl AsRef<Path>, perms: u32) {
+        // create_dir_all fails to create `foo/bar/.`, so when the destination is "." this simply
+        // uses the base directory as the destination directory.
+        let destdir = if destdir.as_ref() == Path::new(".") {
+            self.image_dir.clone()
+        } else {
+            self.image_dir.join(destdir.as_ref())
+        };
+
+        t!(std::fs::create_dir_all(&destdir));
+        self.builder.install(src.as_ref(), &destdir, perms);
+    }
+
+    pub(crate) fn add_dir(&self, src: impl AsRef<Path>, destdir: impl AsRef<Path>) {
+        t!(std::fs::create_dir_all(destdir.as_ref()));
+        self.builder.cp_r(
+            src.as_ref(),
+            &self.image_dir.join(destdir.as_ref()).join(src.as_ref().file_name().unwrap()),
+        );
+    }
+
+    pub(crate) fn generate(self) -> PathBuf {
+        t!(std::fs::create_dir_all(&self.overlay_dir));
+        self.builder.create(&self.overlay_dir.join("version"), &self.builder.rust_version());
+        for file in self.overlay.included_files() {
+            self.builder.install(&self.builder.src.join(file), &self.overlay_dir, 0o644);
+        }
+
+        let distdir = crate::dist::distdir(self.builder);
+        let mut cmd = self.builder.tool_cmd(crate::tool::Tool::RustInstaller);
+        cmd.arg("generate")
+            .arg("--product-name=Rust")
+            .arg("--rel-manifest-dir=rustlib")
+            .arg(format!("--success-message={} installed.", self.component))
+            .arg("--image-dir")
+            .arg(self.image_dir)
+            .arg("--work-dir")
+            .arg(self.work_dir)
+            .arg("--output-dir")
+            .arg(&distdir)
+            .arg("--non-installed-overlay")
+            .arg(self.overlay_dir)
+            .arg(format!("--package-name={}-{}", self.pkgname, self.target))
+            .arg("--legacy-manifest-dirs=rustlib,cargo")
+            .arg(format!("--component-name={}", self.component));
+        self.builder.run(&mut cmd);
+
+        t!(std::fs::remove_dir_all(&self.temp_dir));
+
+        distdir.join(format!("{}-{}.tar.gz", self.pkgname, self.target))
+    }
+}

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -114,13 +114,17 @@ impl<'a> Tarball<'a> {
             self.builder.install(&self.builder.src.join(file), &self.overlay_dir, 0o644);
         }
 
+        let mut cmd = self.builder.tool_cmd(crate::tool::Tool::RustInstaller);
+
+        self.builder.info(&format!("Dist {} ({})", self.component, self.target));
+        let _time = crate::util::timeit(self.builder);
+
         let mut component_name = self.component.clone();
         if self.is_preview {
             component_name.push_str("-preview");
         }
 
         let distdir = crate::dist::distdir(self.builder);
-        let mut cmd = self.builder.tool_cmd(crate::tool::Tool::RustInstaller);
         cmd.arg("generate")
             .arg(format!("--product-name={}", self.product_name))
             .arg("--rel-manifest-dir=rustlib")
@@ -137,7 +141,6 @@ impl<'a> Tarball<'a> {
             .arg("--legacy-manifest-dirs=rustlib,cargo")
             .arg(format!("--component-name={}", component_name));
         self.builder.run(&mut cmd);
-
         t!(std::fs::remove_dir_all(&self.temp_dir));
 
         distdir.join(format!("{}-{}.tar.gz", self.pkgname, self.target))

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -10,6 +10,7 @@ pub(crate) enum OverlayKind {
     LLVM,
     Cargo,
     Clippy,
+    Miri,
 }
 
 impl OverlayKind {
@@ -30,6 +31,11 @@ impl OverlayKind {
                 "src/tools/clippy/LICENSE-APACHE",
                 "src/tools/clippy/LICENSE-MIT",
             ],
+            OverlayKind::Miri => &[
+                "src/tools/miri/README.md",
+                "src/tools/miri/LICENSE-APACHE",
+                "src/tools/miri/LICENSE-MIT",
+            ],
         }
     }
 
@@ -43,6 +49,7 @@ impl OverlayKind {
             OverlayKind::Clippy => {
                 builder.clippy_info.version(builder, &builder.release_num("clippy"))
             }
+            OverlayKind::Miri => builder.miri_info.version(builder, &builder.release_num("miri")),
         }
     }
 }

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -9,6 +9,7 @@ pub(crate) enum OverlayKind {
     Rust,
     LLVM,
     Cargo,
+    Clippy,
 }
 
 impl OverlayKind {
@@ -24,6 +25,11 @@ impl OverlayKind {
                 "src/tools/cargo/LICENSE-APACHE",
                 "src/tools/cargo/LICENSE-THIRD-PARTY",
             ],
+            OverlayKind::Clippy => &[
+                "src/tools/clippy/README.md",
+                "src/tools/clippy/LICENSE-APACHE",
+                "src/tools/clippy/LICENSE-MIT",
+            ],
         }
     }
 
@@ -33,6 +39,9 @@ impl OverlayKind {
             OverlayKind::LLVM => builder.rust_version(),
             OverlayKind::Cargo => {
                 builder.cargo_info.version(builder, &builder.release_num("cargo"))
+            }
+            OverlayKind::Clippy => {
+                builder.clippy_info.version(builder, &builder.release_num("clippy"))
             }
         }
     }

--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -107,6 +107,9 @@ impl<'a> Tarball<'a> {
     pub(crate) fn generate(self) -> PathBuf {
         t!(std::fs::create_dir_all(&self.overlay_dir));
         self.builder.create(&self.overlay_dir.join("version"), &self.builder.rust_version());
+        if let Some(sha) = self.builder.rust_sha() {
+            self.builder.create(&self.overlay_dir.join("git-commit-hash"), &sha);
+        }
         for file in self.overlay.included_files() {
             self.builder.install(&self.builder.src.join(file), &self.overlay_dir, 0o644);
         }


### PR DESCRIPTION
Before this PR, each tarball we ship as part of a release was generated by manually creating the directory structure and invoking `rust-installer generate`. This means each tarball was slightly different, adding new ones meant copy-pasting the code generating another tarball and removing the useless parts, and more importantly refactoring how tarballs are generated is extremely time-consuming.

This PR introduces a new abstraction in rustbuild, `Tarball`. The `Tarball` struct provides a trivial API to generate simple tarballs, and can get out of the way when more complex tarballs have to generate. For example, the whole code to generate the `build-manifest` tarball is now the following:

```rust
let tarball = Tarball::new(builder, "build-manifest", &self.target.triple);
tarball.add_file(&build_manifest, "bin", 0o755);
tarball.generate()
```

One notable change between the old tarballs and the new ones is that the "overlay" (README.md, COPYRIGHT, LICENSE-APACHE and LICENSE-MIT) is now available in every produced tarball, while before each tarball inconsistently had or didn't have those files. Tarballs that need a different overlay have a way to change which files to include (with the `set_overlay` method):

```rust
let mut tarball = Tarball::new(builder, "rustfmt", &target.triple);
tarball.set_overlay(OverlayKind::Rustfmt);
tarball.add_file(rustfmt, "bin", 0o755);
tarball.add_file(cargofmt, "bin", 0o755);
tarball.add_legal_and_readme_to("share/doc/rustfmt");
Some(tarball.generate())
```

The PR should be reviewed commit-by-commit, as each commit migrated a separate tarball to use `Tarball`. During development i made sure every tarball can still be generated, and for the most compex tarballs I manually ensured the list of files between the old and new tarballs did not have unexpected changes.

r? @Mark-Simulacrum 