### PR TITLE
Privatize some of libcore unicode_internals

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -388,7 +388,7 @@ impl str {
         }
 
         fn case_ignoreable_then_cased<I: Iterator<Item = char>>(iter: I) -> bool {
-            use core::unicode::derived_property::{Case_Ignorable, Cased};
+            use core::unicode::{Case_Ignorable, Cased};
             match iter.skip_while(|&c| Case_Ignorable(c)).next() {
                 Some(c) => Cased(c),
                 None => false,

--- a/library/core/src/unicode/mod.rs
+++ b/library/core/src/unicode/mod.rs
@@ -18,17 +18,14 @@ mod unicode_data;
 pub const UNICODE_VERSION: (u8, u8, u8) = unicode_data::UNICODE_VERSION;
 
 // For use in liballoc, not re-exported in libstd.
-pub mod derived_property {
-    pub use super::{Case_Ignorable, Cased};
-}
+pub use unicode_data::{
+    case_ignorable::lookup as Case_Ignorable, cased::lookup as Cased, conversions,
+};
 
-pub use unicode_data::alphabetic::lookup as Alphabetic;
-pub use unicode_data::case_ignorable::lookup as Case_Ignorable;
-pub use unicode_data::cased::lookup as Cased;
-pub use unicode_data::cc::lookup as Cc;
-pub use unicode_data::conversions;
-pub use unicode_data::grapheme_extend::lookup as Grapheme_Extend;
-pub use unicode_data::lowercase::lookup as Lowercase;
-pub use unicode_data::n::lookup as N;
-pub use unicode_data::uppercase::lookup as Uppercase;
-pub use unicode_data::white_space::lookup as White_Space;
+pub(crate) use unicode_data::alphabetic::lookup as Alphabetic;
+pub(crate) use unicode_data::cc::lookup as Cc;
+pub(crate) use unicode_data::grapheme_extend::lookup as Grapheme_Extend;
+pub(crate) use unicode_data::lowercase::lookup as Lowercase;
+pub(crate) use unicode_data::n::lookup as N;
+pub(crate) use unicode_data::uppercase::lookup as Uppercase;
+pub(crate) use unicode_data::white_space::lookup as White_Space;


### PR DESCRIPTION
My understanding is that these API are perma unstable, so it doesn't
make sense to pollute docs & IDE completion[1] with them.

[1]: https://github.com/rust-analyzer/rust-analyzer/issues/6738