### PR TITLE
Update xsv to prevent random CI failures

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -36,7 +36,7 @@ const TEST_REPOS: &[Test] = &[
     Test {
         name: "xsv",
         repo: "https://github.com/BurntSushi/xsv",
-        sha: "66956b6bfd62d6ac767a6b6499c982eae20a2c9f",
+        sha: "3de6c04269a7d315f7e9864b9013451cd9580a08",
         lock: None,
         packages: &[],
     },


### PR DESCRIPTION
This fixes occasional proptest failures due to a bug in xsv, which
aren't related to bugs in the rust compiler.

See https://github.com/rust-lang/rust/pull/79751#issuecomment-740027046 for context.