### PR TITLE
Account for gaps in def path table during decoding

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1553,6 +1553,8 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
             return Some(DefId { krate, index: def_index_guess });
         }
 
+        let is_proc_macro = self.is_proc_macro_crate();
+
         // Slow path: We need to find out the new `DefIndex` of the provided
         // `DefPathHash`, if its still exists. This requires decoding every `DefPathHash`
         // stored in this crate.
@@ -1561,9 +1563,12 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
             let mut map = FxHashMap::with_capacity_and_hasher(end_id as usize, Default::default());
             for i in 0..end_id {
                 let def_index = DefIndex::from_u32(i);
-                let hash =
-                    self.root.tables.def_path_hashes.get(self, def_index).unwrap().decode(self);
-                map.insert(hash, def_index);
+                // There may be gaps in the encoded table if we're decoding a proc-macro crate
+                if let Some(hash) = self.root.tables.def_path_hashes.get(self, def_index) {
+                    map.insert(hash.decode(self), def_index);
+                } else if !is_proc_macro {
+                    panic!("Missing def_path_hashes entry for {:?}", def_index);
+                }
             }
             map
         });


### PR DESCRIPTION
When encoding a proc-macro crate, there may be gaps in the table (since
we only encode the crate root and proc-macro items). Account for this by
checking if the entry is present, rather than using `unwrap()`