### PR TITLE
Lint on redundant trailing semicolon after item

### DIFF
--- a/compiler/rustc_lint/src/redundant_semicolon.rs
+++ b/compiler/rustc_lint/src/redundant_semicolon.rs
@@ -28,37 +28,23 @@ declare_lint_pass!(RedundantSemicolons => [REDUNDANT_SEMICOLONS]);
 
 impl EarlyLintPass for RedundantSemicolons {
     fn check_block(&mut self, cx: &EarlyContext<'_>, block: &Block) {
-        let mut after_item_stmt = false;
         let mut seq = None;
         for stmt in block.stmts.iter() {
             match (&stmt.kind, &mut seq) {
                 (StmtKind::Empty, None) => seq = Some((stmt.span, false)),
                 (StmtKind::Empty, Some(seq)) => *seq = (seq.0.to(stmt.span), true),
-                (_, seq) => {
-                    maybe_lint_redundant_semis(cx, seq, after_item_stmt);
-                    after_item_stmt = matches!(stmt.kind, StmtKind::Item(_));
-                }
+                (_, seq) => maybe_lint_redundant_semis(cx, seq),
             }
         }
-        maybe_lint_redundant_semis(cx, &mut seq, after_item_stmt);
+        maybe_lint_redundant_semis(cx, &mut seq);
     }
 }
 
-fn maybe_lint_redundant_semis(
-    cx: &EarlyContext<'_>,
-    seq: &mut Option<(Span, bool)>,
-    after_item_stmt: bool,
-) {
+fn maybe_lint_redundant_semis(cx: &EarlyContext<'_>, seq: &mut Option<(Span, bool)>) {
     if let Some((span, multiple)) = seq.take() {
         // FIXME: Find a better way of ignoring the trailing
         // semicolon from macro expansion
         if span == rustc_span::DUMMY_SP {
-            return;
-        }
-
-        // FIXME: Lint on semicolons after item statements
-        // once doing so doesn't break bootstrapping
-        if after_item_stmt {
             return;
         }
 

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -558,12 +558,12 @@ crate fn make_test(
                     "fn main() {{ {}fn {}() -> Result<(), impl core::fmt::Debug> {{\n",
                     inner_attr, inner_fn_name
                 ),
-                format!("\n}}; {}().unwrap() }}", inner_fn_name),
+                format!("\n}} {}().unwrap() }}", inner_fn_name),
             )
         } else if test_id.is_some() {
             (
                 format!("fn main() {{ {}fn {}() {{\n", inner_attr, inner_fn_name),
-                format!("\n}}; {}() }}", inner_fn_name),
+                format!("\n}} {}() }}", inner_fn_name),
             )
         } else {
             ("fn main() {\n".into(), "\n}".into())

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -292,7 +292,7 @@ use std::io;
 let mut input = String::new();
 io::stdin().read_line(&mut input)?;
 Ok::<(), io:Error>(())
-}; _inner().unwrap() }"
+} _inner().unwrap() }"
         .to_string();
     let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION, None);
     assert_eq!((output, len), (expected, 2));
@@ -306,7 +306,7 @@ fn make_test_named_wrapper() {
     let expected = "#![allow(unused)]
 fn main() { #[allow(non_snake_case)] fn _doctest_main__some_unique_name() {
 assert_eq!(2+2, 4);
-}; _doctest_main__some_unique_name() }"
+} _doctest_main__some_unique_name() }"
         .to_string();
     let (output, len, _) =
         make_test(input, None, false, &opts, DEFAULT_EDITION, Some("_some_unique_name"));

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1027,7 +1027,7 @@ fn markdown_summary_with_limit(md: &str, length_limit: usize) -> (String, bool) 
     fn push(s: &mut String, text_length: &mut usize, text: &str) {
         s.push_str(text);
         *text_length += text.len();
-    };
+    }
 
     'outer: for event in Parser::new_ext(md, summary_opts()) {
         match &event {

--- a/src/test/ui/lint/redundant-semicolon/item-stmt-semi.rs
+++ b/src/test/ui/lint/redundant-semicolon/item-stmt-semi.rs
@@ -1,10 +1,6 @@
-// check-pass
-// This test should stop compiling
-// we decide to enable this lint for item statements.
-
 #![deny(redundant_semicolons)]
 
 fn main() {
-    fn inner() {};
-    struct Bar {};
+    fn inner() {}; //~ ERROR unnecessary
+    struct Bar {}; //~ ERROR unnecessary
 }

--- a/src/test/ui/lint/redundant-semicolon/item-stmt-semi.stderr
+++ b/src/test/ui/lint/redundant-semicolon/item-stmt-semi.stderr
@@ -1,0 +1,20 @@
+error: unnecessary trailing semicolon
+  --> $DIR/item-stmt-semi.rs:4:18
+   |
+LL |     fn inner() {};
+   |                  ^ help: remove this semicolon
+   |
+note: the lint level is defined here
+  --> $DIR/item-stmt-semi.rs:1:9
+   |
+LL | #![deny(redundant_semicolons)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unnecessary trailing semicolon
+  --> $DIR/item-stmt-semi.rs:5:18
+   |
+LL |     struct Bar {};
+   |                  ^ help: remove this semicolon
+
+error: aborting due to 2 previous errors
+

--- a/src/tools/clippy/tests/ui/match_expr_like_matches_macro.fixed
+++ b/src/tools/clippy/tests/ui/match_expr_like_matches_macro.fixed
@@ -39,7 +39,7 @@ fn main() {
         B(i32),
         C,
         D,
-    };
+    }
     let x = E::A(2);
     {
         // lint

--- a/src/tools/clippy/tests/ui/match_expr_like_matches_macro.rs
+++ b/src/tools/clippy/tests/ui/match_expr_like_matches_macro.rs
@@ -51,7 +51,7 @@ fn main() {
         B(i32),
         C,
         D,
-    };
+    }
     let x = E::A(2);
     {
         // lint


### PR DESCRIPTION
We now lint on code like this:

```rust
fn main() {
    fn foo() {};
    struct Bar {};
}
```

Previously, this caused warnings in Cargo, so it was disabled.