### PR TITLE
Replace simple `if let` constructs with Option::map

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -361,11 +361,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn replace_prefix(&self, s: &str, old: &str, new: &str) -> Option<String> {
-        if let Some(stripped) = s.strip_prefix(old) {
-            Some(new.to_string() + stripped)
-        } else {
-            None
-        }
+        s.strip_prefix(old).map(|stripped| new.to_string() + stripped)
     }
 
     /// This function is used to determine potential "simple" improvements or users' errors and
@@ -587,47 +583,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 hir::Mutability::Mut => {
                                     let new_prefix = "&mut ".to_owned() + derefs;
                                     match mutbl_a {
-                                        hir::Mutability::Mut => {
-                                            if let Some(s) =
-                                                self.replace_prefix(&src, "&mut ", &new_prefix)
-                                            {
-                                                Some((s, Applicability::MachineApplicable))
-                                            } else {
-                                                None
-                                            }
-                                        }
-                                        hir::Mutability::Not => {
-                                            if let Some(s) =
-                                                self.replace_prefix(&src, "&", &new_prefix)
-                                            {
-                                                Some((s, Applicability::Unspecified))
-                                            } else {
-                                                None
-                                            }
-                                        }
+                                        hir::Mutability::Mut => self
+                                            .replace_prefix(&src, "&mut ", &new_prefix)
+                                            .map(|s| (s, Applicability::MachineApplicable)),
+                                        hir::Mutability::Not => self
+                                            .replace_prefix(&src, "&", &new_prefix)
+                                            .map(|s| (s, Applicability::Unspecified)),
                                     }
                                 }
                                 hir::Mutability::Not => {
                                     let new_prefix = "&".to_owned() + derefs;
                                     match mutbl_a {
-                                        hir::Mutability::Mut => {
-                                            if let Some(s) =
-                                                self.replace_prefix(&src, "&mut ", &new_prefix)
-                                            {
-                                                Some((s, Applicability::MachineApplicable))
-                                            } else {
-                                                None
-                                            }
-                                        }
-                                        hir::Mutability::Not => {
-                                            if let Some(s) =
-                                                self.replace_prefix(&src, "&", &new_prefix)
-                                            {
-                                                Some((s, Applicability::MachineApplicable))
-                                            } else {
-                                                None
-                                            }
-                                        }
+                                        hir::Mutability::Mut => self
+                                            .replace_prefix(&src, "&mut ", &new_prefix)
+                                            .map(|s| (s, Applicability::MachineApplicable)),
+                                        hir::Mutability::Not => self
+                                            .replace_prefix(&src, "&", &new_prefix)
+                                            .map(|s| (s, Applicability::MachineApplicable)),
                                     }
                                 }
                             } {


### PR DESCRIPTION
Replaces a few constructs of the form

```
if let Some(x) = var {
    Some(...)
} else {
    None
}
```

with calls to `Option::map`.

@rustbot modify labels +C-cleanup +T-compiler