### PR TITLE
Simplify visit_{foreign,trait}_item

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -423,15 +423,11 @@ impl<'v, 'k, 'tcx> ItemLikeVisitor<'v> for LifeSeeder<'k, 'tcx> {
     }
 
     fn visit_trait_item(&mut self, trait_item: &hir::TraitItem<'_>) {
-        match trait_item.kind {
-            hir::TraitItemKind::Const(_, Some(_))
-            | hir::TraitItemKind::Fn(_, hir::TraitFn::Provided(_)) => {
-                if has_allow_dead_code_or_lang_attr(self.tcx, trait_item.hir_id, &trait_item.attrs)
-                {
-                    self.worklist.push(trait_item.hir_id);
-                }
-            }
-            _ => {}
+        use hir::TraitItemKind::{Const, Fn};
+        if matches!(trait_item.kind, Const(_, Some(_)) | Fn(_, hir::TraitFn::Provided(_)))
+            && has_allow_dead_code_or_lang_attr(self.tcx, trait_item.hir_id, &trait_item.attrs)
+        {
+            self.worklist.push(trait_item.hir_id);
         }
     }
 
@@ -440,17 +436,11 @@ impl<'v, 'k, 'tcx> ItemLikeVisitor<'v> for LifeSeeder<'k, 'tcx> {
     }
 
     fn visit_foreign_item(&mut self, foreign_item: &hir::ForeignItem<'_>) {
-        match foreign_item.kind {
-            hir::ForeignItemKind::Static(..) | hir::ForeignItemKind::Fn(..) => {
-                if has_allow_dead_code_or_lang_attr(
-                    self.tcx,
-                    foreign_item.hir_id,
-                    &foreign_item.attrs,
-                ) {
-                    self.worklist.push(foreign_item.hir_id);
-                }
-            }
-            _ => {}
+        use hir::ForeignItemKind::{Fn, Static};
+        if matches!(foreign_item.kind, Static(..) | Fn(..))
+            && has_allow_dead_code_or_lang_attr(self.tcx, foreign_item.hir_id, &foreign_item.attrs)
+        {
+            self.worklist.push(foreign_item.hir_id);
         }
     }
 }


### PR DESCRIPTION
Using an `if` seems like a better semantic fit and saves a few lines.

Noticed while looking at https://github.com/rust-lang/rust/pull/79752, but that's already merged.
r? @lcnr, cc @cjgillot 

@rustbot modify labels +C-cleanup +T-compiler