### PR TITLE
Clarify docs regarding sleep of zero duration

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -775,6 +775,14 @@ pub fn sleep_ms(ms: u32) {
 /// Platforms which do not support nanosecond precision for sleeping will
 /// have `dur` rounded up to the nearest granularity of time they can sleep for.
 ///
+/// Currently, specifying a zero duration on Unix platforms returns immediately
+/// without invoking the underlying [`nanosleep`] syscall, whereas on Windows
+/// platforms the underlying [`Sleep`] syscall is always invoked.
+/// If the intention is to yield the current time-slice you may want to use
+/// [`yield_now`] instead.
+/// [`nanosleep`]: https://linux.die.net/man/2/nanosleep
+/// [`Sleep`]: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep
+///
 /// # Examples
 ///
 /// ```no_run

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -780,6 +780,7 @@ pub fn sleep_ms(ms: u32) {
 /// platforms the underlying [`Sleep`] syscall is always invoked.
 /// If the intention is to yield the current time-slice you may want to use
 /// [`yield_now`] instead.
+///
 /// [`nanosleep`]: https://linux.die.net/man/2/nanosleep
 /// [`Sleep`]: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleep
 ///


### PR DESCRIPTION
Clarify that the behaviour of sleep() when given a duration of zero is actually platform specific.