### PR TITLE
Clarify the 'default is only allowed on...' error

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -400,7 +400,7 @@ impl<'a> AstValidator<'a> {
         if let Defaultness::Default(def_span) = defaultness {
             let span = self.session.source_map().guess_head_span(span);
             self.err_handler()
-                .struct_span_err(span, "`default` is only allowed on items in `impl` definitions")
+                .struct_span_err(span, "`default` is only allowed on items in trait impls")
                 .span_label(def_span, "`default` because of this")
                 .emit();
         }

--- a/src/test/ui/parser/trait-item-with-defaultness-fail-semantic.rs
+++ b/src/test/ui/parser/trait-item-with-defaultness-fail-semantic.rs
@@ -3,10 +3,10 @@
 fn main() {}
 
 trait X {
-    default const A: u8; //~ ERROR `default` is only allowed on items in `impl` definitions
-    default const B: u8 = 0;  //~ ERROR `default` is only allowed on items in `impl` definitions
-    default type D; //~ ERROR `default` is only allowed on items in `impl` definitions
-    default type C: Ord; //~ ERROR `default` is only allowed on items in `impl` definitions
-    default fn f1(); //~ ERROR `default` is only allowed on items in `impl` definitions
-    default fn f2() {} //~ ERROR `default` is only allowed on items in `impl` definitions
+    default const A: u8; //~ ERROR `default` is only allowed on items in trait impls
+    default const B: u8 = 0;  //~ ERROR `default` is only allowed on items in trait impls
+    default type D; //~ ERROR `default` is only allowed on items in trait impls
+    default type C: Ord; //~ ERROR `default` is only allowed on items in trait impls
+    default fn f1(); //~ ERROR `default` is only allowed on items in trait impls
+    default fn f2() {} //~ ERROR `default` is only allowed on items in trait impls
 }

--- a/src/test/ui/parser/trait-item-with-defaultness-fail-semantic.stderr
+++ b/src/test/ui/parser/trait-item-with-defaultness-fail-semantic.stderr
@@ -1,4 +1,4 @@
-error: `default` is only allowed on items in `impl` definitions
+error: `default` is only allowed on items in trait impls
   --> $DIR/trait-item-with-defaultness-fail-semantic.rs:6:5
    |
 LL |     default const A: u8;
@@ -6,7 +6,7 @@ LL |     default const A: u8;
    |     |
    |     `default` because of this
 
-error: `default` is only allowed on items in `impl` definitions
+error: `default` is only allowed on items in trait impls
   --> $DIR/trait-item-with-defaultness-fail-semantic.rs:7:5
    |
 LL |     default const B: u8 = 0;
@@ -14,7 +14,7 @@ LL |     default const B: u8 = 0;
    |     |
    |     `default` because of this
 
-error: `default` is only allowed on items in `impl` definitions
+error: `default` is only allowed on items in trait impls
   --> $DIR/trait-item-with-defaultness-fail-semantic.rs:8:5
    |
 LL |     default type D;
@@ -22,7 +22,7 @@ LL |     default type D;
    |     |
    |     `default` because of this
 
-error: `default` is only allowed on items in `impl` definitions
+error: `default` is only allowed on items in trait impls
   --> $DIR/trait-item-with-defaultness-fail-semantic.rs:9:5
    |
 LL |     default type C: Ord;
@@ -30,7 +30,7 @@ LL |     default type C: Ord;
    |     |
    |     `default` because of this
 
-error: `default` is only allowed on items in `impl` definitions
+error: `default` is only allowed on items in trait impls
   --> $DIR/trait-item-with-defaultness-fail-semantic.rs:10:5
    |
 LL |     default fn f1();
@@ -38,7 +38,7 @@ LL |     default fn f1();
    |     |
    |     `default` because of this
 
-error: `default` is only allowed on items in `impl` definitions
+error: `default` is only allowed on items in trait impls
   --> $DIR/trait-item-with-defaultness-fail-semantic.rs:11:5
    |
 LL |     default fn f2() {}


### PR DESCRIPTION
Code like

    impl Foo {
        default fn foo() {}
    }

will trigger the error

    error: `default` is only allowed on items in `impl` definitions
     --> src/lib.rs:5:5
      |
    5 |     default fn foo() {}
      |     -------^^^^^^^^^
      |     |
      |     `default` because of this

but that's very confusing! I *did* put it on an item in an impl!

So this commit changes the message to

    error: `default` is only allowed on items in trait impls
     --> src/lib.rs:5:5
      |
    5 |     default fn foo() {}
      |     -------^^^^^^^^^
      |     |
      |     `default` because of this
