### PR TITLE
Update const-fn doc in unstable-book

### DIFF
--- a/src/doc/unstable-book/src/language-features/const-fn.md
+++ b/src/doc/unstable-book/src/language-features/const-fn.md
@@ -6,24 +6,5 @@ The tracking issue for this feature is: [#57563]
 
 ------------------------
 
-The `const_fn` feature allows marking free functions and inherent methods as
-`const`, enabling them to be called in constants contexts, with constant
-arguments.
-
-## Examples
-
-```rust
-#![feature(const_fn)]
-
-const fn double(x: i32) -> i32 {
-    x * 2
-}
-
-const FIVE: i32 = 5;
-const TEN: i32 = double(FIVE);
-
-fn main() {
-    assert_eq!(5, FIVE);
-    assert_eq!(10, TEN);
-}
-```
+The `const_fn` feature enables additional functionality not stabilized in the
+[minimal subset of `const_fn`](https://github.com/rust-lang/rust/issues/53555)


### PR DESCRIPTION
Fix #79691 

I couldn't find suitable examples. It seems that `const_fn` feature-gate used only following place. https://github.com/rust-lang/rust/blob/810324d1f31eb8d75e8f0044df720652986ef133/compiler/rustc_ast_passes/src/feature_gate.rs#L560-L562

And example like following emits [E0379](https://doc.rust-lang.org/error-index.html#E0379).

```rust
#![feature(const_fn)]

trait Foo {
    const fn bar() -> Self;
}
```

Any other suitable example exists, please let me know.