### PR TITLE
Add docs note about `Any::type_id` on smart pointers

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -14,6 +14,29 @@
 //!
 //! [`Box`]: ../../std/boxed/struct.Box.html
 //!
+//! # Smart pointers and `dyn Any`
+//!
+//! One piece of behavior to keep in mind when using `Any` as a trait object,
+//! especially with types like `Box<dyn Any>` or `Arc<dyn Any>` is that simply
+//! calling `.type_id()` on the value will produce the `TypeId` of the
+//! container, and not the underlying trait object. This can be avoided
+//! converting the smart pointer into a `&dyn Any` instead, which will return
+//! the object's type id. For example:
+//! ```
+//! use std::any::{Any, TypeId};
+//!
+//! let boxed: Box<dyn Any> = Box::new(3_i32);
+//!
+//! // You're more likely to want this:
+//! let actual_id = (&*boxed).type_id();
+//! // ... than this:
+//! let boxed_id = boxed.type_id();
+//!
+//! // Both of these assertions pass
+//! assert_eq!(actual_id, TypeId::of::<i32>());
+//! assert_eq!(boxed_id, TypeId::of::<Box<dyn Any>>());
+//! ```
+//!
 //! # Examples
 //!
 //! Consider a situation where we want to log out a value passed to a function.

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -17,11 +17,12 @@
 //! # Smart pointers and `dyn Any`
 //!
 //! One piece of behavior to keep in mind when using `Any` as a trait object,
-//! especially with types like `Box<dyn Any>` or `Arc<dyn Any>` is that simply
+//! especially with types like `Box<dyn Any>` or `Arc<dyn Any>`, is that simply
 //! calling `.type_id()` on the value will produce the `TypeId` of the
-//! container, and not the underlying trait object. This can be avoided
+//! *container*, not the underlying trait object. This can be avoided by
 //! converting the smart pointer into a `&dyn Any` instead, which will return
-//! the object's type id. For example:
+//! the object's `TypeId`. For example:
+//!
 //! ```
 //! use std::any::{Any, TypeId};
 //!
@@ -32,7 +33,6 @@
 //! // ... than this:
 //! let boxed_id = boxed.type_id();
 //!
-//! // Both of these assertions pass
 //! assert_eq!(actual_id, TypeId::of::<i32>());
 //! assert_eq!(boxed_id, TypeId::of::<Box<dyn Any>>());
 //! ```


### PR DESCRIPTION
Fixes #79868.

There's an issue I've run into a couple times while using values of type `Box<dyn Any>` - essentially, calling `value.type_id()` doesn't dereference to the trait object, but uses the implementation of `Any` for `Box<dyn Any>`, giving us the `TypeId` of the container instead of the object inside it.

I couldn't find any notes about this in the documentation and - while it could be inferred from existing knowledge of Rust and the blanket implemenation of `Any` - I think it'd be nice to have a note about it in the documentation for the `any` module.

Anyways, here's a first draft of a section about it. I'm happy to revise wording :)