### PR TITLE
Fix issue #78496

### DIFF
--- a/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
+++ b/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
@@ -283,6 +283,34 @@ impl<'a, 'tcx> Helper<'a, 'tcx> {
                 return None;
             }
 
+            // when one place is the projection of the other, it's not safe to calculate their discriminant values sequentially.
+            // for example, this should not be optimized:
+            //
+            // ```rust
+            // enum E<'a> { Empty, Some(&'a E<'a>), }
+            // let Some(Some(_)) = e;
+            // ```
+            //
+            // ```mir
+            // bb0: {
+            //   _2 = discriminant(*_1)
+            //   switchInt(move _2) -> [...]
+            // }
+            // bb1: {
+            //   _3 = discriminant(*(((*_1) as Some).0: &E))
+            //   switchInt(move _3) -> [...]
+            // }
+            // ```
+            let discr_place = discr_info.place_of_adt_discr_read;
+            let this_discr_place = this_bb_discr_info.place_of_adt_discr_read;
+            if discr_place.local == this_discr_place.local
+                && (discr_place.projection.starts_with(this_discr_place.projection)
+                    || this_discr_place.projection.starts_with(discr_place.projection))
+            {
+                trace!("NO: one target is the projection of another");
+                return None;
+            }
+
             // if we reach this point, the optimization applies, and we should be able to optimize this case
             // store the info that is needed to apply the optimization
 

--- a/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
+++ b/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
@@ -283,7 +283,7 @@ impl<'a, 'tcx> Helper<'a, 'tcx> {
                 return None;
             }
 
-            // when one place is the projection of the other, it's not safe to calculate their discriminant values sequentially.
+            // when the second place is a projection of the first one, it's not safe to calculate their discriminant values sequentially.
             // for example, this should not be optimized:
             //
             // ```rust
@@ -294,18 +294,17 @@ impl<'a, 'tcx> Helper<'a, 'tcx> {
             // ```mir
             // bb0: {
             //   _2 = discriminant(*_1)
-            //   switchInt(move _2) -> [...]
+            //   switchInt(_2) -> [...]
             // }
             // bb1: {
             //   _3 = discriminant(*(((*_1) as Some).0: &E))
-            //   switchInt(move _3) -> [...]
+            //   switchInt(_3) -> [...]
             // }
             // ```
             let discr_place = discr_info.place_of_adt_discr_read;
             let this_discr_place = this_bb_discr_info.place_of_adt_discr_read;
             if discr_place.local == this_discr_place.local
-                && (discr_place.projection.starts_with(this_discr_place.projection)
-                    || this_discr_place.projection.starts_with(discr_place.projection))
+                && this_discr_place.projection.starts_with(discr_place.projection)
             {
                 trace!("NO: one target is the projection of another");
                 return None;

--- a/src/test/ui/mir/issue-78496.rs
+++ b/src/test/ui/mir/issue-78496.rs
@@ -1,7 +1,7 @@
 // run-pass
 // compile-flags: -Z mir-opt-level=2 -C opt-level=0
 
-// example from #68867
+// example from #78496
 pub enum E<'a> {
     Empty,
     Some(&'a E<'a>),

--- a/src/test/ui/mir/issue-78496.rs
+++ b/src/test/ui/mir/issue-78496.rs
@@ -1,0 +1,16 @@
+// run-pass
+// compile-flags: -Z mir-opt-level=2 -C opt-level=0
+
+// example from #68867
+pub enum E<'a> {
+    Empty,
+    Some(&'a E<'a>),
+}
+
+fn f(e: &E) -> u32 {
+   if let E::Some(E::Some(_)) = e { 1 } else { 2 }
+}
+
+fn main() {
+   assert_eq!(f(&E::Empty), 2);
+}


### PR DESCRIPTION
EarlyOtherwiseBranch finds MIR structures like:

```
bb0: {
  ...
  _2 = discriminant(X)
  ...
  switchInt(_2) -> [1_isize: bb1, otherwise: bb3]
}
bb1: {
  ...
  _3 = discriminant(Y)
  ...
  switchInt(_3) -> [1_isize: bb2, otherwise: bb3]
}
bb2: {...}
bb3: {...}
```

And transforms them into something like:

```
bb0: {
  ...
  _2 = discriminant(X)
  _3 = discriminant(Y)
  _4 = Eq(_2, _3)
  switchInt(_4) -> [true: bb4, otherwise: bb3]
}
bb2: {...} // unchanged
bb3: {...} // unchanged
bb4: {
  switchInt(_2) -> [1_isize: bb2, otherwise: bb3]
}
```

But that is not always a safe thing to do -- sometimes the early `otherwise` branch is necessary so the later block could assume the value of `discriminant(X)`.

I am not totally sure what's the best way to detect that, but fixing #78496 should be easy -- we just check if `X` is a sub-expression of `Y`. A more precise test might be to check if `Y` contains a `Downcast(1)` of `X`, but I think this might be good enough.

Fix #78496