### PR TITLE
Add extend_from_array

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -99,6 +99,7 @@
 #![feature(dropck_eyepatch)]
 #![feature(exact_size_is_empty)]
 #![feature(exclusive_range_pattern)]
+#![feature(extend_from_array)]
 #![feature(extend_one)]
 #![feature(fmt_internals)]
 #![feature(fn_traits)]

--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2274,7 +2274,7 @@ impl<T, A: Allocator> Extend<T> for Vec<T, A> {
     /// ```
     /// just simpler to type and easier on the optimizer.
     ///
-    /// You should continue to use [`push`] if you only have one element;
+    /// You should continue to use [`push`](Self::push) if you only have one element;
     /// There's no advantage to doing `.extend_from_array([x])` instead.
     #[inline]
     fn extend_from_array<const N: usize>(&mut self, array: [T; N]) {

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -4,6 +4,7 @@
 #![feature(const_cow_is_borrowed)]
 #![feature(drain_filter)]
 #![feature(exact_size_is_empty)]
+#![feature(extend_from_array)]
 #![feature(new_uninit)]
 #![feature(pattern)]
 #![feature(str_split_once)]

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1954,3 +1954,17 @@ fn test_vec_swap() {
     assert_eq!(a[0], 42);
     assert_eq!(n, 0);
 }
+
+#[test]
+fn test_vec_extend_from_array() {
+    let mut v = Vec::from("Hello");
+    v.extend_from_array(*b" ");
+    v.extend_from_array(*b"World");
+    v.push(b'!');
+    assert_eq!(v, b"Hello World!");
+
+    // And use a Drop type to check for obvious use-after-free or similar
+    let mut v = vec![String::from("Hello")];
+    v.extend_from_array([String::from(" "), String::from("world")]);
+    assert_eq!(v.concat(), "Hello world");
+}

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -1728,3 +1728,34 @@ fn test_zero_sized_push() {
         }
     }
 }
+
+#[test]
+fn test_vecdeque_extend_from_array() {
+    // Easy case where it's just adding to the end
+    let mut v = VecDeque::with_capacity(15);
+    v.extend_from_array(*b"12345");
+    v.extend_from_array(*b"67890");
+    v.extend_from_array(*b"abcde");
+    assert_eq!(v, b"1234567890abcde");
+
+    // Check that the head hitting the end wraps it back to the correct place
+    let mut v = VecDeque::with_capacity(7);
+    v.extend_from_array(*b"1234");
+    v.pop_front();
+    v.extend_from_array(*b"5678");
+    assert_eq!(v.as_slices(), (&b"2345678"[..], &b""[..]));
+    v.pop_front();
+    v.push_back(b'!');
+    assert_eq!(v.as_slices(), (&b"345678"[..], &b"!"[..]));
+
+    // The version that needs two copies because it wraps around
+    let mut v = VecDeque::with_capacity(15);
+    v.extend_from_array(*b"1234567890");
+    for _ in 0..5 {
+        v.pop_front().unwrap();
+    }
+    v.extend_from_array(*b"ABCDEFGHIJ");
+    assert_eq!(v, b"67890ABCDEFGHIJ");
+    assert_eq!(v.capacity(), 15);
+    assert_eq!(v.as_slices(), (&b"67890ABCDEF"[..], &b"GHIJ"[..]));
+}

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -341,6 +341,40 @@ pub trait Extend<A> {
         self.extend(Some(item));
     }
 
+    /// Extends a collection by moving the elements from the array.
+    ///
+    /// You should call this if you have multiple elements to add and have them all already,
+    /// as it allows the container to optimize that where possible.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(extend_from_array)]
+    /// let mut v = vec![0; 3];
+    /// v.extend_from_array([1, 1, 2, 3, 5]);
+    /// assert_eq!(v, [0, 0, 0, 1, 1, 2, 3, 5]);
+    /// ```
+    ///
+    /// Extending from an empty array is allowed, but of course doesn't affect the collection:
+    /// ```rust
+    /// #![feature(extend_from_array)]
+    /// let mut v = vec![3, 5, 4];
+    /// v.extend_from_array([] as [i32; 0]);
+    /// assert_eq!(v, [3, 5, 4]);
+    /// ```
+    ///
+    /// # Note to Implementors
+    ///
+    /// The default implementation of this will pass the array iterator to your `extend` implementation,
+    /// which is likely optimal for many cases.
+    ///
+    /// You should override this, however, if you can take advantage of the array elements being contiguous in memory.
+    /// ([`Vec<T>`] does, for example, but there's no advantage of doing so in [`LinkedList<T>`].)
+    #[unstable(feature = "extend_from_array", issue = "88888888")]
+    fn extend_from_array<const N: usize>(&mut self, array: [A; N]) {
+        self.extend(crate::array::IntoIter::new(array));
+    }
+
     /// Reserves capacity in a collection for the given number of additional elements.
     ///
     /// The default implementation does nothing.

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -369,7 +369,7 @@ pub trait Extend<A> {
     /// which is likely optimal for many cases.
     ///
     /// You should override this, however, if you can take advantage of the array elements being contiguous in memory.
-    /// ([`Vec<T>`] does, for example, but there's no advantage of doing so in [`LinkedList<T>`].)
+    /// (`Vec<T>` does, for example, but there's no way to do so in `LinkedList<T>`.)
     #[unstable(feature = "extend_from_array", issue = "88888888")]
     fn extend_from_array<const N: usize>(&mut self, array: [A; N]) {
         self.extend(crate::array::IntoIter::new(array));

--- a/src/test/codegen/vec-extend_from_array.rs
+++ b/src/test/codegen/vec-extend_from_array.rs
@@ -1,4 +1,5 @@
 // compile-flags: -O -C panic=abort
+// ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 #![feature(extend_from_array)]

--- a/src/test/codegen/vec-extend_from_array.rs
+++ b/src/test/codegen/vec-extend_from_array.rs
@@ -1,0 +1,24 @@
+// compile-flags: -O -C panic=abort
+
+#![crate_type = "lib"]
+#![feature(extend_from_array)]
+
+// This test is here to ensure that LLVM is optimizing out the `ManuallyDrop` construction,
+// since we really don't want to copy the whole array to the stack and then again to the Vec.
+
+// CHECK-LABEL: @vec_extend_from_array_demo
+#[no_mangle]
+pub fn vec_extend_from_array_demo(v: &mut Vec<String>, a: [String; 400]) {
+    // CHECK-NOT: alloca
+    // CHECK: call alloc::vec::Vec<T,A>::reserve
+    // CHECK-NOT: alloca
+    // CHECK: call void @llvm.memcpy
+    // CHECK-NOT: alloca
+    // CHECK: ret
+    v.extend_from_array(a);
+}
+
+// No validation against this one; it just keeps `reserve` from having only a single caller.
+pub fn please_do_not_inline_the_reserve_call_llvm(v: &mut Vec<String>, s: String) {
+    v.push(s);
+}


### PR DESCRIPTION
This PR inspired by noticing that the following, while it seems reasonable, actually contains 4 calls to `reserve` in the ASM:
```rust
pub fn push3_demo(v: &mut Vec<i32>, a: i32, b: i32, c: i32) {
    v.reserve(3);
    v.push(a);
    v.push(b);
    v.push(c);
}
```
https://rust.godbolt.org/z/EWExYP

Like there's `extend_from_slice` for cloning, it seems like it would be logical to have an `extend_from_array` to encapsulate the obvious `unsafe` code for _moving_ the elements to the end of the vector.  And, indeed, that turns out to generate tighter assembly than any of the other options I tried, including `array::IntoIter` and `chain`s-of-`once`s: https://rust.godbolt.org/z/Wq7qah

I ended up putting this on `Extend`, as it makes particular sense on anything that can take advantage of the memory continuity of the array -- this PR implements it for `Vec` and `VecDeque` -- but would also be handy as a way to tersely add a known number of elements to _any_ collection by move.  It has the nice default implementation in terms of the array `IntoIter`, so that things without special overrides for it can still do something reasonable, as that provides an exact `size_hint`.

But touching a trait means it should probably get some libs eyes on it even to go in unstable, so let's try
r? @m-ou-se 

(A different approach for this could be something like `push_chunk`, in the sense of [`as_chunks`](https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.as_chunks).)