### PR TITLE
The return of the GroupBy and GroupByMut iterators on slice

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -140,6 +140,7 @@
 #![feature(try_trait)]
 #![feature(type_alias_impl_trait)]
 #![feature(associated_type_bounds)]
+#![feature(slice_group_by)]
 // Allow testing this library
 
 #[cfg(test)]

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -110,6 +110,8 @@ pub use core::slice::{Chunks, Windows};
 pub use core::slice::{ChunksExact, ChunksExactMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{ChunksMut, Split, SplitMut};
+#[unstable(feature = "slice_group_by", issue = "none")]
+pub use core::slice::{GroupBy, GroupByMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{Iter, IterMut};
 #[stable(feature = "rchunks", since = "1.31.0")]
@@ -118,8 +120,6 @@ pub use core::slice::{RChunks, RChunksExact, RChunksExactMut, RChunksMut};
 pub use core::slice::{RSplit, RSplitMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{RSplitN, RSplitNMut, SplitN, SplitNMut};
-#[unstable(feature = "slice_group_by", issue = "none")]
-pub use core::slice::{GroupBy, GroupByMut};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Basic slice extension methods

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -118,6 +118,8 @@ pub use core::slice::{RChunks, RChunksExact, RChunksExactMut, RChunksMut};
 pub use core::slice::{RSplit, RSplitMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{RSplitN, RSplitNMut, SplitN, SplitNMut};
+#[unstable(feature = "slice_group_by", issue = "0")]
+pub use core::slice::{GroupBy, GroupByMut};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Basic slice extension methods

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -118,7 +118,7 @@ pub use core::slice::{RChunks, RChunksExact, RChunksExactMut, RChunksMut};
 pub use core::slice::{RSplit, RSplitMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{RSplitN, RSplitNMut, SplitN, SplitNMut};
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 pub use core::slice::{GroupBy, GroupByMut};
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -110,7 +110,7 @@ pub use core::slice::{Chunks, Windows};
 pub use core::slice::{ChunksExact, ChunksExactMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{ChunksMut, Split, SplitMut};
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 pub use core::slice::{GroupBy, GroupByMut};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{Iter, IterMut};

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -21,6 +21,7 @@
 #![feature(iter_map_while)]
 #![feature(int_bits_const)]
 #![feature(vecdeque_binary_search)]
+#![feature(slice_group_by)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1898,3 +1898,30 @@ fn subslice_patterns() {
     m!(&mut v, [..] => ());
     m!(&mut v, [x, .., y] => c!((x, y), (&mut N, &mut N), (&mut N(0), &mut N(4))));
 }
+
+#[test]
+fn test_group_by() {
+    let slice = &[1, 1, 1, 3, 3, 2, 2, 2];
+
+    let mut iter = slice.group_by(|a, b| a == b);
+
+    assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
+
+    assert_eq!(iter.remaining(), &[3, 3, 2, 2, 2]);
+
+    assert_eq!(iter.next(), Some(&[3, 3][..]));
+    assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn test_group_by_rev() {
+    let slice = &[1, 1, 1, 3, 3, 2, 2, 2];
+
+    let mut iter = slice.group_by(|a, b| a == b);
+
+    assert_eq!(iter.next_back(), Some(&[2, 2, 2][..]));
+    assert_eq!(iter.next_back(), Some(&[3, 3][..]));
+    assert_eq!(iter.next_back(), Some(&[1, 1, 1][..]));
+    assert_eq!(iter.next_back(), None);
+}

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1904,24 +1904,43 @@ fn test_group_by() {
     let slice = &[1, 1, 1, 3, 3, 2, 2, 2];
 
     let mut iter = slice.group_by(|a, b| a == b);
-
     assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
-
-    assert_eq!(iter.remaining(), &[3, 3, 2, 2, 2]);
-
     assert_eq!(iter.next(), Some(&[3, 3][..]));
     assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
     assert_eq!(iter.next(), None);
-}
-
-#[test]
-fn test_group_by_rev() {
-    let slice = &[1, 1, 1, 3, 3, 2, 2, 2];
 
     let mut iter = slice.group_by(|a, b| a == b);
-
     assert_eq!(iter.next_back(), Some(&[2, 2, 2][..]));
     assert_eq!(iter.next_back(), Some(&[3, 3][..]));
     assert_eq!(iter.next_back(), Some(&[1, 1, 1][..]));
+    assert_eq!(iter.next_back(), None);
+
+    let mut iter = slice.group_by(|a, b| a == b);
+    assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
+    assert_eq!(iter.next_back(), Some(&[2, 2, 2][..]));
+    assert_eq!(iter.next(), Some(&[3, 3][..]));
+    assert_eq!(iter.next_back(), None);
+}
+
+#[test]
+fn test_group_by_mut() {
+    let slice = &mut [1, 1, 1, 3, 3, 2, 2, 2];
+
+    let mut iter = slice.group_by_mut(|a, b| a == b);
+    assert_eq!(iter.next(), Some(&mut [1, 1, 1][..]));
+    assert_eq!(iter.next(), Some(&mut [3, 3][..]));
+    assert_eq!(iter.next(), Some(&mut [2, 2, 2][..]));
+    assert_eq!(iter.next(), None);
+
+    let mut iter = slice.group_by_mut(|a, b| a == b);
+    assert_eq!(iter.next_back(), Some(&mut [2, 2, 2][..]));
+    assert_eq!(iter.next_back(), Some(&mut [3, 3][..]));
+    assert_eq!(iter.next_back(), Some(&mut [1, 1, 1][..]));
+    assert_eq!(iter.next_back(), None);
+
+    let mut iter = slice.group_by_mut(|a, b| a == b);
+    assert_eq!(iter.next(), Some(&mut [1, 1, 1][..]));
+    assert_eq!(iter.next_back(), Some(&mut [2, 2, 2][..]));
+    assert_eq!(iter.next(), Some(&mut [3, 3][..]));
     assert_eq!(iter.next_back(), None);
 }

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1901,15 +1901,19 @@ fn subslice_patterns() {
 
 #[test]
 fn test_group_by() {
-    let slice = &[1, 1, 1, 3, 3, 2, 2, 2];
+    let slice = &[1, 1, 1, 3, 3, 2, 2, 2, 1, 0];
 
     let mut iter = slice.group_by(|a, b| a == b);
     assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
     assert_eq!(iter.next(), Some(&[3, 3][..]));
     assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
+    assert_eq!(iter.next(), Some(&[1][..]));
+    assert_eq!(iter.next(), Some(&[0][..]));
     assert_eq!(iter.next(), None);
 
     let mut iter = slice.group_by(|a, b| a == b);
+    assert_eq!(iter.next_back(), Some(&[0][..]));
+    assert_eq!(iter.next_back(), Some(&[1][..]));
     assert_eq!(iter.next_back(), Some(&[2, 2, 2][..]));
     assert_eq!(iter.next_back(), Some(&[3, 3][..]));
     assert_eq!(iter.next_back(), Some(&[1, 1, 1][..]));
@@ -1917,22 +1921,28 @@ fn test_group_by() {
 
     let mut iter = slice.group_by(|a, b| a == b);
     assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
-    assert_eq!(iter.next_back(), Some(&[2, 2, 2][..]));
+    assert_eq!(iter.next_back(), Some(&[0][..]));
     assert_eq!(iter.next(), Some(&[3, 3][..]));
+    assert_eq!(iter.next_back(), Some(&[1][..]));
+    assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
     assert_eq!(iter.next_back(), None);
 }
 
 #[test]
 fn test_group_by_mut() {
-    let slice = &mut [1, 1, 1, 3, 3, 2, 2, 2];
+    let slice = &mut [1, 1, 1, 3, 3, 2, 2, 2, 1, 0];
 
     let mut iter = slice.group_by_mut(|a, b| a == b);
     assert_eq!(iter.next(), Some(&mut [1, 1, 1][..]));
     assert_eq!(iter.next(), Some(&mut [3, 3][..]));
     assert_eq!(iter.next(), Some(&mut [2, 2, 2][..]));
+    assert_eq!(iter.next(), Some(&mut [1][..]));
+    assert_eq!(iter.next(), Some(&mut [0][..]));
     assert_eq!(iter.next(), None);
 
     let mut iter = slice.group_by_mut(|a, b| a == b);
+    assert_eq!(iter.next_back(), Some(&mut [0][..]));
+    assert_eq!(iter.next_back(), Some(&mut [1][..]));
     assert_eq!(iter.next_back(), Some(&mut [2, 2, 2][..]));
     assert_eq!(iter.next_back(), Some(&mut [3, 3][..]));
     assert_eq!(iter.next_back(), Some(&mut [1, 1, 1][..]));
@@ -1940,7 +1950,9 @@ fn test_group_by_mut() {
 
     let mut iter = slice.group_by_mut(|a, b| a == b);
     assert_eq!(iter.next(), Some(&mut [1, 1, 1][..]));
-    assert_eq!(iter.next_back(), Some(&mut [2, 2, 2][..]));
+    assert_eq!(iter.next_back(), Some(&mut [0][..]));
     assert_eq!(iter.next(), Some(&mut [3, 3][..]));
+    assert_eq!(iter.next_back(), Some(&mut [1][..]));
+    assert_eq!(iter.next(), Some(&mut [2, 2, 2][..]));
     assert_eq!(iter.next_back(), None);
 }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -3009,6 +3009,15 @@ where P: FnMut(&T, &T) -> bool,
             Some(head)
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.slice.is_empty() {
+            (0, Some(0))
+        } else {
+            (1, Some(self.slice.len()))
+        }
+    }
 }
 
 #[unstable(feature = "slice_group_by", issue = "0")]
@@ -3078,6 +3087,15 @@ where P: FnMut(&T, &T) -> bool,
             let (head, tail) = slice.split_at_mut(len);
             self.slice = tail;
             Some(head)
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.slice.is_empty() {
+            (0, Some(0))
+        } else {
+            (1, Some(self.slice.len()))
         }
     }
 }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2974,21 +2974,21 @@ unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
 ///
 /// [`group_by`]: ../../std/primitive.slice.html#method.group_by
 /// [slices]: ../../std/primitive.slice.html
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 #[derive(Debug)] // FIXME implement Debug to be more user friendly
 pub struct GroupBy<'a, T: 'a, P> {
     slice: &'a [T],
     predicate: P,
 }
 
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> GroupBy<'a, T, P> {
     pub(super) fn new(slice: &'a [T], predicate: P) -> Self {
         GroupBy { slice, predicate }
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> Iterator for GroupBy<'a, T, P>
 where P: FnMut(&T, &T) -> bool,
 {
@@ -3025,7 +3025,7 @@ where P: FnMut(&T, &T) -> bool,
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> DoubleEndedIterator for GroupBy<'a, T, P>
 where P: FnMut(&T, &T) -> bool,
 {
@@ -3046,7 +3046,7 @@ where P: FnMut(&T, &T) -> bool,
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> FusedIterator for GroupBy<'a, T, P>
 where P: FnMut(&T, &T) -> bool,
 { }
@@ -3058,21 +3058,21 @@ where P: FnMut(&T, &T) -> bool,
 ///
 /// [`group_by_mut`]: ../../std/primitive.slice.html#method.group_by_mut
 /// [slices]: ../../std/primitive.slice.html
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 #[derive(Debug)] // FIXME implement Debug to be more user friendly
 pub struct GroupByMut<'a, T: 'a, P> {
     slice: &'a mut [T],
     predicate: P,
 }
 
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> GroupByMut<'a, T, P> {
     pub(super) fn new(slice: &'a mut [T], predicate: P) -> Self {
         GroupByMut { slice, predicate }
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> Iterator for GroupByMut<'a, T, P>
 where P: FnMut(&T, &T) -> bool,
 {
@@ -3110,7 +3110,7 @@ where P: FnMut(&T, &T) -> bool,
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "0")]
+#[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> DoubleEndedIterator for GroupByMut<'a, T, P>
 where P: FnMut(&T, &T) -> bool,
 {

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -3018,6 +3018,11 @@ where P: FnMut(&T, &T) -> bool,
             (1, Some(self.slice.len()))
         }
     }
+
+    #[inline]
+    fn last(self) -> Option<Self::Item> {
+        self.next_back()
+    }
 }
 
 #[unstable(feature = "slice_group_by", issue = "0")]
@@ -3097,6 +3102,11 @@ where P: FnMut(&T, &T) -> bool,
         } else {
             (1, Some(self.slice.len()))
         }
+    }
+
+    #[inline]
+    fn last(self) -> Option<Self::Item> {
+        self.next_back()
     }
 }
 

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2991,7 +2991,8 @@ impl<'a, T: 'a, P> GroupBy<'a, T, P> {
 
 #[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> Iterator for GroupBy<'a, T, P>
-where P: FnMut(&T, &T) -> bool,
+where
+    P: FnMut(&T, &T) -> bool,
 {
     type Item = &'a [T];
 
@@ -3013,11 +3014,7 @@ where P: FnMut(&T, &T) -> bool,
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.slice.is_empty() {
-            (0, Some(0))
-        } else {
-            (1, Some(self.slice.len()))
-        }
+        if self.slice.is_empty() { (0, Some(0)) } else { (1, Some(self.slice.len())) }
     }
 
     #[inline]
@@ -3028,7 +3025,8 @@ where P: FnMut(&T, &T) -> bool,
 
 #[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> DoubleEndedIterator for GroupBy<'a, T, P>
-where P: FnMut(&T, &T) -> bool,
+where
+    P: FnMut(&T, &T) -> bool,
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -3048,9 +3046,7 @@ where P: FnMut(&T, &T) -> bool,
 }
 
 #[unstable(feature = "slice_group_by", issue = "none")]
-impl<'a, T: 'a, P> FusedIterator for GroupBy<'a, T, P>
-where P: FnMut(&T, &T) -> bool,
-{ }
+impl<'a, T: 'a, P> FusedIterator for GroupBy<'a, T, P> where P: FnMut(&T, &T) -> bool {}
 
 /// An iterator over slice in (non-overlapping) mutable chunks separated
 /// by a predicate.
@@ -3075,7 +3071,8 @@ impl<'a, T: 'a, P> GroupByMut<'a, T, P> {
 
 #[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> Iterator for GroupByMut<'a, T, P>
-where P: FnMut(&T, &T) -> bool,
+where
+    P: FnMut(&T, &T) -> bool,
 {
     type Item = &'a mut [T];
 
@@ -3098,11 +3095,7 @@ where P: FnMut(&T, &T) -> bool,
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        if self.slice.is_empty() {
-            (0, Some(0))
-        } else {
-            (1, Some(self.slice.len()))
-        }
+        if self.slice.is_empty() { (0, Some(0)) } else { (1, Some(self.slice.len())) }
     }
 
     #[inline]
@@ -3113,7 +3106,8 @@ where P: FnMut(&T, &T) -> bool,
 
 #[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> DoubleEndedIterator for GroupByMut<'a, T, P>
-where P: FnMut(&T, &T) -> bool,
+where
+    P: FnMut(&T, &T) -> bool,
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -3132,3 +3126,6 @@ where P: FnMut(&T, &T) -> bool,
         }
     }
 }
+
+#[unstable(feature = "slice_group_by", issue = "none")]
+impl<'a, T: 'a, P> FusedIterator for GroupByMut<'a, T, P> where P: FnMut(&T, &T) -> bool {}

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2968,127 +2968,6 @@ unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
     }
 }
 
-macro_rules! group_by {
-    (struct $name:ident, $elem:ty, $mkslice:ident) => {
-        #[unstable(feature = "slice_group_by", issue = "0")]
-        impl<'a, T: 'a, P> $name<'a, T, P> {
-            #[inline]
-            fn is_empty(&self) -> bool {
-                self.ptr == self.end
-            }
-
-            #[inline]
-            fn remaining_len(&self) -> usize {
-                unsafe { self.end.offset_from(self.ptr) as usize }
-            }
-        }
-
-        #[unstable(feature = "slice_group_by", issue = "0")]
-        impl<'a, T: 'a, P> Iterator for $name<'a, T, P>
-        where P: FnMut(&T, &T) -> bool,
-        {
-            type Item = $elem;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                // we use an unsafe block to avoid bounds checking here.
-                // this is safe because the only thing we do here is to get
-                // two elements at `ptr` and `ptr + 1`, bounds checking is done by hand.
-                unsafe {
-                    if self.is_empty() { return None }
-
-                    let mut i = 0;
-                    let mut ptr = self.ptr;
-
-                    // we need to get *two* contiguous elements so we check that:
-                    //  - the first element is at the `end - 1` position because
-                    //  - the second one will be read from `ptr + 1` that must
-                    //    be lower or equal to `end`
-                    while ptr != self.end.sub(1) {
-                        let a = &*ptr;
-                        ptr = ptr.add(1);
-                        let b = &*ptr;
-
-                        i += 1;
-
-                        if !(self.predicate)(a, b) {
-                            let slice = $mkslice(self.ptr, i);
-                            self.ptr = ptr;
-                            return Some(slice)
-                        }
-                    }
-
-                    // `i` is either `0` or the slice `length - 1` because either:
-                    //  - we have not entered the loop and so `i` is equal to `0`
-                    //    the slice length is necessarily `1` because we ensure it is not empty
-                    //  - we have entered the loop and we have not early returned
-                    //    so `i` is equal to the slice `length - 1`
-                    let slice = $mkslice(self.ptr, i + 1);
-                    self.ptr = self.end;
-                    Some(slice)
-                }
-            }
-
-            fn size_hint(&self) -> (usize, Option<usize>) {
-                if self.is_empty() { return (0, Some(0)) }
-                let len = self.remaining_len();
-                (1, Some(len))
-            }
-
-            fn last(mut self) -> Option<Self::Item> {
-                self.next_back()
-            }
-        }
-
-        #[unstable(feature = "slice_group_by", issue = "0")]
-        impl<'a, T: 'a, P> DoubleEndedIterator for $name<'a, T, P>
-        where P: FnMut(&T, &T) -> bool,
-        {
-            fn next_back(&mut self) -> Option<Self::Item> {
-                // during the loop we retrieve two elements at `ptr` and `ptr - 1`.
-                unsafe {
-                    if self.is_empty() { return None }
-
-                    let mut i = 0;
-                    // we ensure that the first element that will be read
-                    // is not under `end` because `end` is out of bound.
-                    let mut ptr = self.end.sub(1);
-
-                    while ptr != self.ptr {
-                        // we first get `a` that is at the left of `ptr`
-                        // then `b` that is under the `ptr` position.
-                        let a = &*ptr.sub(1);
-                        let b = &*ptr;
-
-                        i += 1;
-
-                        if !(self.predicate)(a, b) {
-                            // the slice to return starts at the `ptr` position
-                            // and `i` is the length of it.
-                            let slice = $mkslice(ptr, i);
-
-                            // because `end` is always an invalid bound
-                            // we use `ptr` as `end` for the future call to `next`.
-                            self.end = ptr;
-                            return Some(slice)
-                        }
-
-                        ptr = ptr.sub(1);
-                    }
-
-                    let slice = $mkslice(self.ptr, i + 1);
-                    self.ptr = self.end;
-                    Some(slice)
-                }
-            }
-        }
-
-        #[unstable(feature = "slice_group_by", issue = "0")]
-        impl<'a, T: 'a, P> FusedIterator for $name<'a, T, P>
-        where P: FnMut(&T, &T) -> bool,
-        { }
-    }
-}
-
 /// An iterator over slice in (non-overlapping) chunks separated by a predicate.
 ///
 /// This struct is created by the [`group_by`] method on [slices].
@@ -3098,25 +2977,65 @@ macro_rules! group_by {
 #[unstable(feature = "slice_group_by", issue = "0")]
 #[derive(Debug)] // FIXME implement Debug to be more user friendly
 pub struct GroupBy<'a, T: 'a, P> {
-    ptr: *const T,
-    end: *const T,
+    slice: &'a [T],
     predicate: P,
-    _phantom: marker::PhantomData<&'a T>,
 }
 
 #[unstable(feature = "slice_group_by", issue = "0")]
-impl<'a, T: 'a, P> GroupBy<'a, T, P>
-where P: FnMut(&T, &T) -> bool,
-{
-    /// Returns the remainder of the original slice that is going to be
-    /// returned by the iterator.
-    pub fn remaining(&self) -> &[T] {
-        let len = self.remaining_len();
-        unsafe { from_raw_parts(self.ptr, len) }
+impl<'a, T: 'a, P> GroupBy<'a, T, P> {
+    pub(super) fn new(slice: &'a [T], predicate: P) -> Self {
+        GroupBy { slice, predicate }
     }
 }
 
-group_by!{ struct GroupBy, &'a [T], from_raw_parts }
+#[unstable(feature = "slice_group_by", issue = "0")]
+impl<'a, T: 'a, P> Iterator for GroupBy<'a, T, P>
+where P: FnMut(&T, &T) -> bool,
+{
+    type Item = &'a [T];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.slice.is_empty() {
+            None
+        } else {
+            let mut len = 1;
+            let mut iter = self.slice.windows(2);
+            while let Some([l, r]) = iter.next() {
+                if (self.predicate)(l, r) { len += 1 } else { break }
+            }
+            let (head, tail) = self.slice.split_at(len);
+            self.slice = tail;
+            Some(head)
+        }
+    }
+}
+
+#[unstable(feature = "slice_group_by", issue = "0")]
+impl<'a, T: 'a, P> DoubleEndedIterator for GroupBy<'a, T, P>
+where P: FnMut(&T, &T) -> bool,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.slice.is_empty() {
+            None
+        } else {
+            let mut len = 1;
+            let mut iter = self.slice.windows(2);
+            while let Some([l, r]) = iter.next_back() {
+                if (self.predicate)(l, r) { len += 1 } else { break }
+            }
+            let (head, tail) = self.slice.split_at(self.slice.len() - len);
+            self.slice = head;
+            Some(tail)
+        }
+    }
+}
+
+#[unstable(feature = "slice_group_by", issue = "0")]
+impl<'a, T: 'a, P> FusedIterator for GroupBy<'a, T, P>
+where P: FnMut(&T, &T) -> bool,
+{ }
 
 /// An iterator over slice in (non-overlapping) mutable chunks separated
 /// by a predicate.
@@ -3128,22 +3047,59 @@ group_by!{ struct GroupBy, &'a [T], from_raw_parts }
 #[unstable(feature = "slice_group_by", issue = "0")]
 #[derive(Debug)] // FIXME implement Debug to be more user friendly
 pub struct GroupByMut<'a, T: 'a, P> {
-    ptr: *mut T,
-    end: *mut T,
+    slice: &'a mut [T],
     predicate: P,
-    _phantom: marker::PhantomData<&'a T>,
 }
 
 #[unstable(feature = "slice_group_by", issue = "0")]
-impl<'a, T: 'a, P> GroupByMut<'a, T, P>
-where P: FnMut(&T, &T) -> bool,
-{
-    /// Returns the remainder of the original slice that is going to be
-    /// returned by the iterator.
-    pub fn into_remaining(self) -> &'a mut [T] {
-        let len = self.remaining_len();
-        unsafe { from_raw_parts_mut(self.ptr, len) }
+impl<'a, T: 'a, P> GroupByMut<'a, T, P> {
+    pub(super) fn new(slice: &'a mut [T], predicate: P) -> Self {
+        GroupByMut { slice, predicate }
     }
 }
 
-group_by!{ struct GroupByMut, &'a mut [T], from_raw_parts_mut }
+#[unstable(feature = "slice_group_by", issue = "0")]
+impl<'a, T: 'a, P> Iterator for GroupByMut<'a, T, P>
+where P: FnMut(&T, &T) -> bool,
+{
+    type Item = &'a mut [T];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.slice.is_empty() {
+            None
+        } else {
+            let mut len = 1;
+            let mut iter = self.slice.windows(2);
+            while let Some([l, r]) = iter.next() {
+                if (self.predicate)(l, r) { len += 1 } else { break }
+            }
+            let slice = mem::take(&mut self.slice);
+            let (head, tail) = slice.split_at_mut(len);
+            self.slice = tail;
+            Some(head)
+        }
+    }
+}
+
+#[unstable(feature = "slice_group_by", issue = "0")]
+impl<'a, T: 'a, P> DoubleEndedIterator for GroupByMut<'a, T, P>
+where P: FnMut(&T, &T) -> bool,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.slice.is_empty() {
+            None
+        } else {
+            let mut len = 1;
+            let mut iter = self.slice.windows(2);
+            while let Some([l, r]) = iter.next_back() {
+                if (self.predicate)(l, r) { len += 1 } else { break }
+            }
+            let slice = mem::take(&mut self.slice);
+            let (head, tail) = slice.split_at_mut(slice.len() - len);
+            self.slice = head;
+            Some(tail)
+        }
+    }
+}

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-filelength
 //! Definitions of a bunch of iterators for `[T]`.
 
 #[macro_use] // import iterator! and forward_iterator!

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2967,3 +2967,183 @@ unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
         false
     }
 }
+
+macro_rules! group_by {
+    (struct $name:ident, $elem:ty, $mkslice:ident) => {
+        #[unstable(feature = "slice_group_by", issue = "0")]
+        impl<'a, T: 'a, P> $name<'a, T, P> {
+            #[inline]
+            fn is_empty(&self) -> bool {
+                self.ptr == self.end
+            }
+
+            #[inline]
+            fn remaining_len(&self) -> usize {
+                unsafe { self.end.offset_from(self.ptr) as usize }
+            }
+        }
+
+        #[unstable(feature = "slice_group_by", issue = "0")]
+        impl<'a, T: 'a, P> Iterator for $name<'a, T, P>
+        where P: FnMut(&T, &T) -> bool,
+        {
+            type Item = $elem;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                // we use an unsafe block to avoid bounds checking here.
+                // this is safe because the only thing we do here is to get
+                // two elements at `ptr` and `ptr + 1`, bounds checking is done by hand.
+                unsafe {
+                    if self.is_empty() { return None }
+
+                    let mut i = 0;
+                    let mut ptr = self.ptr;
+
+                    // we need to get *two* contiguous elements so we check that:
+                    //  - the first element is at the `end - 1` position because
+                    //  - the second one will be read from `ptr + 1` that must
+                    //    be lower or equal to `end`
+                    while ptr != self.end.sub(1) {
+                        let a = &*ptr;
+                        ptr = ptr.add(1);
+                        let b = &*ptr;
+
+                        i += 1;
+
+                        if !(self.predicate)(a, b) {
+                            let slice = $mkslice(self.ptr, i);
+                            self.ptr = ptr;
+                            return Some(slice)
+                        }
+                    }
+
+                    // `i` is either `0` or the slice `length - 1` because either:
+                    //  - we have not entered the loop and so `i` is equal to `0`
+                    //    the slice length is necessarily `1` because we ensure it is not empty
+                    //  - we have entered the loop and we have not early returned
+                    //    so `i` is equal to the slice `length - 1`
+                    let slice = $mkslice(self.ptr, i + 1);
+                    self.ptr = self.end;
+                    Some(slice)
+                }
+            }
+
+            fn size_hint(&self) -> (usize, Option<usize>) {
+                if self.is_empty() { return (0, Some(0)) }
+                let len = self.remaining_len();
+                (1, Some(len))
+            }
+
+            fn last(mut self) -> Option<Self::Item> {
+                self.next_back()
+            }
+        }
+
+        #[unstable(feature = "slice_group_by", issue = "0")]
+        impl<'a, T: 'a, P> DoubleEndedIterator for $name<'a, T, P>
+        where P: FnMut(&T, &T) -> bool,
+        {
+            fn next_back(&mut self) -> Option<Self::Item> {
+                // during the loop we retrieve two elements at `ptr` and `ptr - 1`.
+                unsafe {
+                    if self.is_empty() { return None }
+
+                    let mut i = 0;
+                    // we ensure that the first element that will be read
+                    // is not under `end` because `end` is out of bound.
+                    let mut ptr = self.end.sub(1);
+
+                    while ptr != self.ptr {
+                        // we first get `a` that is at the left of `ptr`
+                        // then `b` that is under the `ptr` position.
+                        let a = &*ptr.sub(1);
+                        let b = &*ptr;
+
+                        i += 1;
+
+                        if !(self.predicate)(a, b) {
+                            // the slice to return starts at the `ptr` position
+                            // and `i` is the length of it.
+                            let slice = $mkslice(ptr, i);
+
+                            // because `end` is always an invalid bound
+                            // we use `ptr` as `end` for the future call to `next`.
+                            self.end = ptr;
+                            return Some(slice)
+                        }
+
+                        ptr = ptr.sub(1);
+                    }
+
+                    let slice = $mkslice(self.ptr, i + 1);
+                    self.ptr = self.end;
+                    Some(slice)
+                }
+            }
+        }
+
+        #[unstable(feature = "slice_group_by", issue = "0")]
+        impl<'a, T: 'a, P> FusedIterator for $name<'a, T, P>
+        where P: FnMut(&T, &T) -> bool,
+        { }
+    }
+}
+
+/// An iterator over slice in (non-overlapping) chunks separated by a predicate.
+///
+/// This struct is created by the [`group_by`] method on [slices].
+///
+/// [`group_by`]: ../../std/primitive.slice.html#method.group_by
+/// [slices]: ../../std/primitive.slice.html
+#[unstable(feature = "slice_group_by", issue = "0")]
+#[derive(Debug)] // FIXME implement Debug to be more user friendly
+pub struct GroupBy<'a, T: 'a, P> {
+    ptr: *const T,
+    end: *const T,
+    predicate: P,
+    _phantom: marker::PhantomData<&'a T>,
+}
+
+#[unstable(feature = "slice_group_by", issue = "0")]
+impl<'a, T: 'a, P> GroupBy<'a, T, P>
+where P: FnMut(&T, &T) -> bool,
+{
+    /// Returns the remainder of the original slice that is going to be
+    /// returned by the iterator.
+    pub fn remaining(&self) -> &[T] {
+        let len = self.remaining_len();
+        unsafe { from_raw_parts(self.ptr, len) }
+    }
+}
+
+group_by!{ struct GroupBy, &'a [T], from_raw_parts }
+
+/// An iterator over slice in (non-overlapping) mutable chunks separated
+/// by a predicate.
+///
+/// This struct is created by the [`group_by_mut`] method on [slices].
+///
+/// [`group_by_mut`]: ../../std/primitive.slice.html#method.group_by_mut
+/// [slices]: ../../std/primitive.slice.html
+#[unstable(feature = "slice_group_by", issue = "0")]
+#[derive(Debug)] // FIXME implement Debug to be more user friendly
+pub struct GroupByMut<'a, T: 'a, P> {
+    ptr: *mut T,
+    end: *mut T,
+    predicate: P,
+    _phantom: marker::PhantomData<&'a T>,
+}
+
+#[unstable(feature = "slice_group_by", issue = "0")]
+impl<'a, T: 'a, P> GroupByMut<'a, T, P>
+where P: FnMut(&T, &T) -> bool,
+{
+    /// Returns the remainder of the original slice that is going to be
+    /// returned by the iterator.
+    pub fn into_remaining(self) -> &'a mut [T] {
+        let len = self.remaining_len();
+        unsafe { from_raw_parts_mut(self.ptr, len) }
+    }
+}
+
+group_by!{ struct GroupByMut, &'a mut [T], from_raw_parts_mut }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -3020,7 +3020,7 @@ where P: FnMut(&T, &T) -> bool,
     }
 
     #[inline]
-    fn last(self) -> Option<Self::Item> {
+    fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 }
@@ -3105,7 +3105,7 @@ where P: FnMut(&T, &T) -> bool,
     }
 
     #[inline]
-    fn last(self) -> Option<Self::Item> {
+    fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2976,7 +2976,6 @@ unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
 /// [`group_by`]: ../../std/primitive.slice.html#method.group_by
 /// [slices]: ../../std/primitive.slice.html
 #[unstable(feature = "slice_group_by", issue = "none")]
-#[derive(Debug)] // FIXME implement Debug to be more user friendly
 pub struct GroupBy<'a, T: 'a, P> {
     slice: &'a [T],
     predicate: P,
@@ -3048,6 +3047,13 @@ where
 #[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> FusedIterator for GroupBy<'a, T, P> where P: FnMut(&T, &T) -> bool {}
 
+#[unstable(feature = "slice_group_by", issue = "none")]
+impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for GroupBy<'a, T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GroupBy").field("slice", &self.slice).finish()
+    }
+}
+
 /// An iterator over slice in (non-overlapping) mutable chunks separated
 /// by a predicate.
 ///
@@ -3056,7 +3062,6 @@ impl<'a, T: 'a, P> FusedIterator for GroupBy<'a, T, P> where P: FnMut(&T, &T) ->
 /// [`group_by_mut`]: ../../std/primitive.slice.html#method.group_by_mut
 /// [slices]: ../../std/primitive.slice.html
 #[unstable(feature = "slice_group_by", issue = "none")]
-#[derive(Debug)] // FIXME implement Debug to be more user friendly
 pub struct GroupByMut<'a, T: 'a, P> {
     slice: &'a mut [T],
     predicate: P,
@@ -3129,3 +3134,10 @@ where
 
 #[unstable(feature = "slice_group_by", issue = "none")]
 impl<'a, T: 'a, P> FusedIterator for GroupByMut<'a, T, P> where P: FnMut(&T, &T) -> bool {}
+
+#[unstable(feature = "slice_group_by", issue = "none")]
+impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for GroupByMut<'a, T, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GroupByMut").field("slice", &self.slice).finish()
+    }
+}

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -2975,20 +2975,20 @@ unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
 ///
 /// [`group_by`]: ../../std/primitive.slice.html#method.group_by
 /// [slices]: ../../std/primitive.slice.html
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 pub struct GroupBy<'a, T: 'a, P> {
     slice: &'a [T],
     predicate: P,
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> GroupBy<'a, T, P> {
     pub(super) fn new(slice: &'a [T], predicate: P) -> Self {
         GroupBy { slice, predicate }
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> Iterator for GroupBy<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
@@ -3022,7 +3022,7 @@ where
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> DoubleEndedIterator for GroupBy<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
@@ -3044,10 +3044,10 @@ where
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> FusedIterator for GroupBy<'a, T, P> where P: FnMut(&T, &T) -> bool {}
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for GroupBy<'a, T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GroupBy").field("slice", &self.slice).finish()
@@ -3061,20 +3061,20 @@ impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for GroupBy<'a, T, P> {
 ///
 /// [`group_by_mut`]: ../../std/primitive.slice.html#method.group_by_mut
 /// [slices]: ../../std/primitive.slice.html
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 pub struct GroupByMut<'a, T: 'a, P> {
     slice: &'a mut [T],
     predicate: P,
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> GroupByMut<'a, T, P> {
     pub(super) fn new(slice: &'a mut [T], predicate: P) -> Self {
         GroupByMut { slice, predicate }
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> Iterator for GroupByMut<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
@@ -3109,7 +3109,7 @@ where
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> DoubleEndedIterator for GroupByMut<'a, T, P>
 where
     P: FnMut(&T, &T) -> bool,
@@ -3132,10 +3132,10 @@ where
     }
 }
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a, P> FusedIterator for GroupByMut<'a, T, P> where P: FnMut(&T, &T) -> bool {}
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for GroupByMut<'a, T, P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GroupByMut").field("slice", &self.slice).finish()

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -57,7 +57,7 @@ pub use iter::{ArrayChunks, ArrayChunksMut};
 #[unstable(feature = "array_windows", issue = "75027")]
 pub use iter::ArrayWindows;
 
-#[unstable(feature = "slice_group_by", issue = "none")]
+#[unstable(feature = "slice_group_by", issue = "80552")]
 pub use iter::{GroupBy, GroupByMut};
 
 #[unstable(feature = "split_inclusive", issue = "72360")]
@@ -1246,7 +1246,7 @@ impl<T> [T] {
     /// assert_eq!(iter.next(), Some(&[2, 3, 4][..]));
     /// assert_eq!(iter.next(), None);
     /// ```
-    #[unstable(feature = "slice_group_by", issue = "none")]
+    #[unstable(feature = "slice_group_by", issue = "80552")]
     #[inline]
     pub fn group_by<F>(&self, pred: F) -> GroupBy<'_, T, F>
     where
@@ -1291,7 +1291,7 @@ impl<T> [T] {
     /// assert_eq!(iter.next(), Some(&mut [2, 3, 4][..]));
     /// assert_eq!(iter.next(), None);
     /// ```
-    #[unstable(feature = "slice_group_by", issue = "none")]
+    #[unstable(feature = "slice_group_by", issue = "80552")]
     #[inline]
     pub fn group_by_mut<F>(&mut self, pred: F) -> GroupByMut<'_, T, F>
     where

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1234,7 +1234,8 @@ impl<T> [T] {
     #[unstable(feature = "slice_group_by", issue = "none")]
     #[inline]
     pub fn group_by<F>(&self, pred: F) -> GroupBy<'_, T, F>
-    where F: FnMut(&T, &T) -> bool
+    where
+        F: FnMut(&T, &T) -> bool,
     {
         GroupBy::new(self, pred)
     }
@@ -1263,7 +1264,8 @@ impl<T> [T] {
     #[unstable(feature = "slice_group_by", issue = "none")]
     #[inline]
     pub fn group_by_mut<F>(&mut self, pred: F) -> GroupByMut<'_, T, F>
-    where F: FnMut(&T, &T) -> bool
+    where
+        F: FnMut(&T, &T) -> bool,
     {
         GroupByMut::new(self, pred)
     }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1207,6 +1207,74 @@ impl<T> [T] {
         RChunksExactMut::new(self, chunk_size)
     }
 
+    /// Returns an iterator over the slice producing non-overlapping runs
+    /// of elements using the predicate to separate them.
+    ///
+    /// The predicate is called on two elements following themselves,
+    /// it means the predicate is called on `slice[0]` and `slice[1]`
+    /// then on `slice[1]` and `slice[2]` and so on.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_group_by)]
+    ///
+    /// let slice = &[1, 1, 1, 3, 3, 2, 2, 2];
+    ///
+    /// let mut iter = slice.group_by(|a, b| a == b);
+    ///
+    /// assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
+    /// assert_eq!(iter.next(), Some(&[3, 3][..]));
+    /// assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    #[unstable(feature = "slice_group_by", issue = "0")]
+    #[inline]
+    pub fn group_by<F>(&self, pred: F) -> GroupBy<T, F>
+    where F: FnMut(&T, &T) -> bool
+    {
+        GroupBy {
+            ptr: self.as_ptr(),
+            end: unsafe { self.as_ptr().add(self.len()) },
+            predicate: pred,
+            _phantom: marker::PhantomData,
+        }
+    }
+
+    /// Returns an iterator over the slice producing non-overlapping mutable
+    /// runs of elements using the predicate to separate them.
+    ///
+    /// The predicate is called on two elements following themselves,
+    /// it means the predicate is called on `slice[0]` and `slice[1]`
+    /// then on `slice[1]` and `slice[2]` and so on.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_group_by)]
+    ///
+    /// let slice = &mut [1, 1, 1, 3, 3, 2, 2, 2];
+    ///
+    /// let mut iter = slice.group_by_mut(|a, b| a == b);
+    ///
+    /// assert_eq!(iter.next(), Some(&mut [1, 1, 1][..]));
+    /// assert_eq!(iter.next(), Some(&mut [3, 3][..]));
+    /// assert_eq!(iter.next(), Some(&mut [2, 2, 2][..]));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    #[unstable(feature = "slice_group_by", issue = "0")]
+    #[inline]
+    pub fn group_by_mut<F>(&mut self, pred: F) -> GroupByMut<T, F>
+    where F: FnMut(&T, &T) -> bool
+    {
+        GroupByMut {
+            ptr: self.as_mut_ptr(),
+            end: unsafe { self.as_mut_ptr().add(self.len()) },
+            predicate: pred,
+            _phantom: marker::PhantomData,
+        }
+    }
+
     /// Divides one slice into two at an index.
     ///
     /// The first will contain all indices from `[0, mid)` (excluding

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1228,7 +1228,7 @@ impl<T> [T] {
     /// assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
     /// assert_eq!(iter.next(), None);
     /// ```
-    #[unstable(feature = "slice_group_by", issue = "0")]
+    #[unstable(feature = "slice_group_by", issue = "none")]
     #[inline]
     pub fn group_by<F>(&self, pred: F) -> GroupBy<T, F>
     where F: FnMut(&T, &T) -> bool
@@ -1257,7 +1257,7 @@ impl<T> [T] {
     /// assert_eq!(iter.next(), Some(&mut [2, 2, 2][..]));
     /// assert_eq!(iter.next(), None);
     /// ```
-    #[unstable(feature = "slice_group_by", issue = "0")]
+    #[unstable(feature = "slice_group_by", issue = "none")]
     #[inline]
     pub fn group_by_mut<F>(&mut self, pred: F) -> GroupByMut<T, F>
     where F: FnMut(&T, &T) -> bool

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1233,7 +1233,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_group_by", issue = "none")]
     #[inline]
-    pub fn group_by<F>(&self, pred: F) -> GroupBy<T, F>
+    pub fn group_by<F>(&self, pred: F) -> GroupBy<'_, T, F>
     where F: FnMut(&T, &T) -> bool
     {
         GroupBy::new(self, pred)
@@ -1262,7 +1262,7 @@ impl<T> [T] {
     /// ```
     #[unstable(feature = "slice_group_by", issue = "none")]
     #[inline]
-    pub fn group_by_mut<F>(&mut self, pred: F) -> GroupByMut<T, F>
+    pub fn group_by_mut<F>(&mut self, pred: F) -> GroupByMut<'_, T, F>
     where F: FnMut(&T, &T) -> bool
     {
         GroupByMut::new(self, pred)

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1231,6 +1231,21 @@ impl<T> [T] {
     /// assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
     /// assert_eq!(iter.next(), None);
     /// ```
+    ///
+    /// This method can be used to extract the sorted subslices:
+    ///
+    /// ```
+    /// #![feature(slice_group_by)]
+    ///
+    /// let slice = &[1, 1, 2, 3, 2, 3, 2, 3, 4];
+    ///
+    /// let mut iter = slice.group_by(|a, b| a <= b);
+    ///
+    /// assert_eq!(iter.next(), Some(&[1, 1, 2, 3][..]));
+    /// assert_eq!(iter.next(), Some(&[2, 3][..]));
+    /// assert_eq!(iter.next(), Some(&[2, 3, 4][..]));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     #[unstable(feature = "slice_group_by", issue = "none")]
     #[inline]
     pub fn group_by<F>(&self, pred: F) -> GroupBy<'_, T, F>
@@ -1259,6 +1274,21 @@ impl<T> [T] {
     /// assert_eq!(iter.next(), Some(&mut [1, 1, 1][..]));
     /// assert_eq!(iter.next(), Some(&mut [3, 3][..]));
     /// assert_eq!(iter.next(), Some(&mut [2, 2, 2][..]));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    ///
+    /// This method can be used to extract the sorted subslices:
+    ///
+    /// ```
+    /// #![feature(slice_group_by)]
+    ///
+    /// let slice = &mut [1, 1, 2, 3, 2, 3, 2, 3, 4];
+    ///
+    /// let mut iter = slice.group_by_mut(|a, b| a <= b);
+    ///
+    /// assert_eq!(iter.next(), Some(&mut [1, 1, 2, 3][..]));
+    /// assert_eq!(iter.next(), Some(&mut [2, 3][..]));
+    /// assert_eq!(iter.next(), Some(&mut [2, 3, 4][..]));
     /// assert_eq!(iter.next(), None);
     /// ```
     #[unstable(feature = "slice_group_by", issue = "none")]

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -57,6 +57,9 @@ pub use iter::{ArrayChunks, ArrayChunksMut};
 #[unstable(feature = "array_windows", issue = "75027")]
 pub use iter::ArrayWindows;
 
+#[unstable(feature = "slice_group_by", issue = "none")]
+pub use iter::{GroupBy, GroupByMut};
+
 #[unstable(feature = "split_inclusive", issue = "72360")]
 pub use iter::{SplitInclusive, SplitInclusiveMut};
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1233,12 +1233,7 @@ impl<T> [T] {
     pub fn group_by<F>(&self, pred: F) -> GroupBy<T, F>
     where F: FnMut(&T, &T) -> bool
     {
-        GroupBy {
-            ptr: self.as_ptr(),
-            end: unsafe { self.as_ptr().add(self.len()) },
-            predicate: pred,
-            _phantom: marker::PhantomData,
-        }
+        GroupBy::new(self, pred)
     }
 
     /// Returns an iterator over the slice producing non-overlapping mutable
@@ -1267,12 +1262,7 @@ impl<T> [T] {
     pub fn group_by_mut<F>(&mut self, pred: F) -> GroupByMut<T, F>
     where F: FnMut(&T, &T) -> bool
     {
-        GroupByMut {
-            ptr: self.as_mut_ptr(),
-            end: unsafe { self.as_mut_ptr().add(self.len()) },
-            predicate: pred,
-            _phantom: marker::PhantomData,
-        }
+        GroupByMut::new(self, pred)
     }
 
     /// Divides one slice into two at an index.

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -65,6 +65,7 @@
 #![feature(nonzero_leading_trailing_zeros)]
 #![feature(const_option)]
 #![feature(integer_atomics)]
+#![feature(slice_group_by)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate test;


### PR DESCRIPTION
According to https://github.com/rust-lang/rfcs/pull/2477#issuecomment-742034372, I am opening this PR again, this time I implemented it in safe Rust only, it is therefore much easier to read and is completely safe.

This PR proposes to add two new methods to the slice, the `group_by` and `group_by_mut`. These two methods provide a way to iterate over non-overlapping sub-slices of a base slice that are separated by the predicate given by the user (e.g. `Partial::eq`, `|a, b| a.abs() < b.abs()`).

```rust
let slice = &[1, 1, 1, 3, 3, 2, 2, 2];

let mut iter = slice.group_by(|a, b| a == b);
assert_eq!(iter.next(), Some(&[1, 1, 1][..]));
assert_eq!(iter.next(), Some(&[3, 3][..]));
assert_eq!(iter.next(), Some(&[2, 2, 2][..]));
assert_eq!(iter.next(), None);
```

[An RFC](https://github.com/rust-lang/rfcs/pull/2477) was open 2 years ago but wasn't necessary.