### PR TITLE
Add post-init hook for static memory for miri.

### DIFF
--- a/compiler/rustc_mir/src/interpret/machine.rs
+++ b/compiler/rustc_mir/src/interpret/machine.rs
@@ -304,7 +304,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     fn after_static_mem_initialized(
         _ecx: &mut InterpCx<'mir, 'tcx, Self>,
         _ptr: Pointer<Self::PointerTag>,
-        _size: Size
+        _size: Size,
     ) -> InterpResult<'tcx> {
         Ok(())
     }

--- a/compiler/rustc_mir/src/interpret/machine.rs
+++ b/compiler/rustc_mir/src/interpret/machine.rs
@@ -9,6 +9,7 @@ use std::hash::Hash;
 use rustc_middle::mir;
 use rustc_middle::ty::{self, Ty};
 use rustc_span::def_id::DefId;
+use rustc_target::abi::Size;
 
 use super::{
     AllocId, Allocation, AllocationExtra, CheckInAllocMsg, Frame, ImmTy, InterpCx, InterpResult,
@@ -295,6 +296,15 @@ pub trait Machine<'mir, 'tcx>: Sized {
     fn before_deallocation(
         _memory_extra: &mut Self::MemoryExtra,
         _id: AllocId,
+    ) -> InterpResult<'tcx> {
+        Ok(())
+    }
+
+    /// Called after initializing static memory using the interpreter.
+    fn after_static_mem_initialized(
+        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        _ptr: Pointer<Self::PointerTag>,
+        _size: Size
     ) -> InterpResult<'tcx> {
         Ok(())
     }

--- a/compiler/rustc_mir/src/interpret/traits.rs
+++ b/compiler/rustc_mir/src/interpret/traits.rs
@@ -57,11 +57,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // `get_vtable` in `rust_codegen_llvm/meth.rs`.
         // /////////////////////////////////////////////////////////////////////////////////////////
         let vtable_size = ptr_size * u64::try_from(methods.len()).unwrap().checked_add(3).unwrap();
-        let vtable = self.memory.allocate(
-            vtable_size,
-            ptr_align,
-            MemoryKind::Vtable,
-        );
+        let vtable = self.memory.allocate(vtable_size, ptr_align, MemoryKind::Vtable);
 
         let drop = Instance::resolve_drop_in_place(tcx, ty);
         let drop = self.memory.create_fn_alloc(FnVal::Instance(drop));


### PR DESCRIPTION
Adds a post-initialization hook to treat memory initialized using the interpreter as if it was initialized in a static context.

See: https://github.com/rust-lang/miri/pull/1644 & https://github.com/rust-lang/miri/issues/1643