### PR TITLE
Add take as alias for remove in collection methods

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -824,6 +824,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// assert_eq!(map.remove(&1), None);
     /// ```
     #[doc(alias = "delete")]
+    #[doc(alias = "take")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
     where
@@ -851,6 +852,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     /// assert_eq!(map.remove_entry(&1), Some((1, "a")));
     /// assert_eq!(map.remove_entry(&1), None);
     /// ```
+    #[doc(alias = "take_entry")]
     #[stable(feature = "btreemap_remove_entry", since = "1.45.0")]
     pub fn remove_entry<Q: ?Sized>(&mut self, key: &Q) -> Option<(K, V)>
     where

--- a/library/alloc/src/collections/btree/map/entry.rs
+++ b/library/alloc/src/collections/btree/map/entry.rs
@@ -336,6 +336,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// // println!("{}", map["poneyland"]);
     /// ```
     #[stable(feature = "map_entry_recover_keys2", since = "1.12.0")]
+    #[doc(alias = "take_entry")]
     pub fn remove_entry(self) -> (K, V) {
         self.remove_kv()
     }
@@ -457,6 +458,7 @@ impl<'a, K: Ord, V> OccupiedEntry<'a, K, V> {
     /// // println!("{}", map["poneyland"]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "take")]
     pub fn remove(self) -> V {
         self.remove_kv().1
     }

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -909,6 +909,7 @@ impl<T> LinkedList<T> {
     /// assert_eq!(d.remove(0), 3);
     /// assert_eq!(d.remove(0), 1);
     /// ```
+    #[doc(alias = "take")]
     #[unstable(feature = "linked_list_remove", issue = "69210")]
     pub fn remove(&mut self, at: usize) -> T {
         let len = self.len();
@@ -1406,6 +1407,7 @@ impl<'a, T> CursorMut<'a, T> {
     ///
     /// If the cursor is currently pointing to the "ghost" non-element then no element
     /// is removed and `None` is returned.
+    #[doc(alias = "take_current")]
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn remove_current(&mut self) -> Option<T> {
         let unlinked_node = self.current?;
@@ -1424,6 +1426,7 @@ impl<'a, T> CursorMut<'a, T> {
     ///
     /// If the cursor is currently pointing to the "ghost" non-element then no element
     /// is removed and `None` is returned.
+    #[doc(alias = "take_current_as_list")]
     #[unstable(feature = "linked_list_cursors", issue = "58533")]
     pub fn remove_current_as_list(&mut self) -> Option<LinkedList<T>> {
         let mut unlinked_node = self.current?;

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1492,6 +1492,7 @@ impl<T> VecDeque<T> {
     /// assert_eq!(buf.swap_remove_front(2), Some(3));
     /// assert_eq!(buf, [2, 1]);
     /// ```
+    #[doc(alias = "swap_take_front")]
     #[stable(feature = "deque_extras_15", since = "1.5.0")]
     pub fn swap_remove_front(&mut self, index: usize) -> Option<T> {
         let length = self.len();
@@ -1527,6 +1528,7 @@ impl<T> VecDeque<T> {
     /// assert_eq!(buf.swap_remove_back(0), Some(1));
     /// assert_eq!(buf, [3, 2]);
     /// ```
+    #[doc(alias = "swap_take_back")]
     #[stable(feature = "deque_extras_15", since = "1.5.0")]
     pub fn swap_remove_back(&mut self, index: usize) -> Option<T> {
         let length = self.len();

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1783,6 +1783,7 @@ impl<T> VecDeque<T> {
     /// assert_eq!(buf.remove(1), Some(2));
     /// assert_eq!(buf, [1, 3]);
     /// ```
+    #[doc(alias = "take")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove(&mut self, index: usize) -> Option<T> {
         if self.is_empty() || self.len() <= index {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1254,6 +1254,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(v, ["baz", "qux"]);
     /// ```
     #[inline]
+    #[doc(alias = "swap_take")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn swap_remove(&mut self, index: usize) -> T {
         #[cold]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1341,6 +1341,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(v.remove(1), 2);
     /// assert_eq!(v, [1, 3]);
     /// ```
+    #[doc(alias = "take")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove(&mut self, index: usize) -> T {
         #[cold]

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -860,6 +860,7 @@ where
     /// assert_eq!(map.remove(&1), None);
     /// ```
     #[doc(alias = "delete")]
+    #[doc(alias = "take")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<V>
@@ -889,6 +890,7 @@ where
     /// assert_eq!(map.remove(&1), None);
     /// # }
     /// ```
+    #[doc(alias = "take_entry")]
     #[inline]
     #[stable(feature = "hash_map_remove_entry", since = "1.27.0")]
     pub fn remove_entry<Q: ?Sized>(&mut self, k: &Q) -> Option<(K, V)>
@@ -1717,6 +1719,7 @@ impl<'a, K, V, S> RawOccupiedEntryMut<'a, K, V, S> {
 
     /// Takes the value out of the entry, and returns it.
     #[inline]
+    #[doc(alias = "take")]
     #[unstable(feature = "hash_raw_entry", issue = "56167")]
     pub fn remove(self) -> V {
         self.base.remove()
@@ -1724,6 +1727,7 @@ impl<'a, K, V, S> RawOccupiedEntryMut<'a, K, V, S> {
 
     /// Take the ownership of the key and value from the map.
     #[inline]
+    #[doc(alias = "take_entry")]
     #[unstable(feature = "hash_raw_entry", issue = "56167")]
     pub fn remove_entry(self) -> (K, V) {
         self.base.remove_entry()
@@ -2541,6 +2545,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// assert_eq!(map.contains_key("poneyland"), false);
     /// ```
     #[inline]
+    #[doc(alias = "take")]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn remove(self) -> V {
         self.base.remove()


### PR DESCRIPTION
This partially alleviates the issues described in RFC 3034 \[0\] by adding
a doc alias to `take` and `take_xxx` for `remove` and `remove_xxx`.

\[0\]: https://github.com/rust-lang/rfcs/issues/3034

r? @sfackler