### PR TITLE
Remove `#![cfg(not(test))]` from libcore

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -38,17 +38,6 @@
 //!    which do not trigger a panic can be assured that this function is never
 //!    called. The `lang` attribute is called `eh_personality`.
 
-// Since libcore defines many fundamental lang items, all tests live in a
-// separate crate, libcoretest, to avoid bizarre issues.
-//
-// Here we explicitly #[cfg]-out this whole crate when testing. If we don't do
-// this, both the generated test artifact and the linked libtest (which
-// transitively includes libcore) will both define the same set of lang items,
-// and this will cause the E0152 "found duplicate lang item" error. See
-// discussion in #50466 for details.
-//
-// This cfg won't affect doc tests.
-#![cfg(not(test))]
 #![stable(feature = "core", since = "1.6.0")]
 #![doc(
     html_root_url = "https://doc.rust-lang.org/nightly/",


### PR DESCRIPTION
This cfg breaks rust-analyzer, since that always sets `--cfg test` and hence sees an empty libcore.

Luckily, it does not seem to be needed anymore, so just remove it.