### PR TITLE
Fix building compiler docs with stage 0

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -732,10 +732,13 @@ impl<'a> Builder<'a> {
             .env("CFG_RELEASE_CHANNEL", &self.config.channel)
             .env("RUSTDOC_REAL", self.rustdoc(compiler))
             .env("RUSTC_BOOTSTRAP", "1")
-            .arg("-Znormalize_docs")
             .arg("-Winvalid_codeblock_attributes");
         if self.config.deny_warnings {
             cmd.arg("-Dwarnings");
+        }
+        // cfg(not(bootstrap)), can be removed on the next beta bump
+        if compiler.stage != 0 {
+            cmd.arg("-Znormalize-docs");
         }
 
         // Remove make-related flags that can cause jobserver problems.

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -527,7 +527,10 @@ impl Step for Rustc {
         cargo.rustdocflag("--document-private-items");
         cargo.rustdocflag("--enable-index-page");
         cargo.rustdocflag("-Zunstable-options");
-        cargo.rustdocflag("-Znormalize-docs");
+        // cfg(not(bootstrap)), can be removed on the next beta bump
+        if stage != 0 {
+            cargo.rustdocflag("-Znormalize-docs");
+        }
         compile::rustc_cargo(builder, &mut cargo, target);
 
         // Only include compiler crates, no dependencies of those, such as `libc`.


### PR DESCRIPTION
This regressed in https://github.com/rust-lang/rust/pull/79525 (see https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Can't.20document.20single.20crate).

r? @Mark-Simulacrum 