### PR TITLE
Improve core::ptr::drop_in_place debuginfo

### DIFF
--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -55,28 +55,16 @@ pub(super) fn mangle(
 
     let hash = get_symbol_hash(tcx, instance, instance_ty, instantiating_crate);
 
-    if let ty::InstanceDef::DropGlue(_drop_in_place, ty) = instance.def {
-        // Use `{{drop}}::<$TYPE>::$hash` as name for the drop glue instead of
-        // `core::mem::drop_in_place::$hash`.
-        let mut printer =
-            SymbolPrinter { tcx, path: SymbolPath::new(), keep_within_component: false };
-        printer.write_str("{{drop}}").unwrap();
-        printer.path.finalize_pending_component();
-        let printer = printer
-            .generic_delimiters(|mut printer| {
-                if let Some(ty) = ty {
-                    printer.print_type(ty)
-                } else {
-                    printer.write_str("_")?;
-                    Ok(printer)
-                }
-            })
-            .unwrap();
-        return printer.path.finish(hash);
-    }
-
     let mut printer = SymbolPrinter { tcx, path: SymbolPath::new(), keep_within_component: false }
-        .print_def_path(def_id, &[])
+        .print_def_path(
+            def_id,
+            if let ty::InstanceDef::DropGlue(_, _) = instance.def {
+                // Add the name of the dropped type to the symbol name
+                &*instance.substs
+            } else {
+                &[]
+            },
+        )
         .unwrap();
 
     if let ty::InstanceDef::VtableShim(..) = instance.def {


### PR DESCRIPTION
* Use span of the dropped type as function span when possible.
* Rename symbol from `core::ptr::drop_in_place::$hash` to `{{drop}}::<$TYPE>::$hash`.

Fixes #77465

(I haven't yet updated the tests)