### PR TITLE
tidy: Re-enable check for inline unit tests

### DIFF
--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -36,16 +36,13 @@ crate mod mbe;
 mod tests;
 #[cfg(test)]
 mod parse {
-    #[cfg(test)]
     mod tests;
 }
 #[cfg(test)]
 mod tokenstream {
-    #[cfg(test)]
     mod tests;
 }
 #[cfg(test)]
 mod mut_visit {
-    #[cfg(test)]
     mod tests;
 }

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -18,6 +18,9 @@ mod active;
 mod builtin_attrs;
 mod removed;
 
+#[cfg(test)]
+mod tests;
+
 use rustc_span::{edition::Edition, symbol::Symbol, Span};
 use std::fmt;
 use std::num::NonZeroU32;
@@ -149,30 +152,3 @@ pub use builtin_attrs::{
     AttributeType, BuiltinAttribute, GatedCfg, BUILTIN_ATTRIBUTES, BUILTIN_ATTRIBUTE_MAP,
 };
 pub use removed::{REMOVED_FEATURES, STABLE_REMOVED_FEATURES};
-
-#[cfg(test)]
-mod test {
-    use super::UnstableFeatures;
-
-    #[test]
-    fn rustc_bootstrap_parsing() {
-        let is_bootstrap = |env, krate| {
-            std::env::set_var("RUSTC_BOOTSTRAP", env);
-            matches!(UnstableFeatures::from_environment(krate), UnstableFeatures::Cheat)
-        };
-        assert!(is_bootstrap("1", None));
-        assert!(is_bootstrap("1", Some("x")));
-        // RUSTC_BOOTSTRAP allows specifying a specific crate
-        assert!(is_bootstrap("x", Some("x")));
-        // RUSTC_BOOTSTRAP allows multiple comma-delimited crates
-        assert!(is_bootstrap("x,y,z", Some("x")));
-        assert!(is_bootstrap("x,y,z", Some("y")));
-        // Crate that aren't specified do not get unstable features
-        assert!(!is_bootstrap("x", Some("a")));
-        assert!(!is_bootstrap("x,y,z", Some("a")));
-        assert!(!is_bootstrap("x,y,z", None));
-
-        // this is technically a breaking change, but there are no stability guarantees for RUSTC_BOOTSTRAP
-        assert!(!is_bootstrap("0", None));
-    }
-}

--- a/compiler/rustc_feature/src/tests.rs
+++ b/compiler/rustc_feature/src/tests.rs
@@ -1,0 +1,23 @@
+use super::UnstableFeatures;
+
+#[test]
+fn rustc_bootstrap_parsing() {
+    let is_bootstrap = |env, krate| {
+        std::env::set_var("RUSTC_BOOTSTRAP", env);
+        matches!(UnstableFeatures::from_environment(krate), UnstableFeatures::Cheat)
+    };
+    assert!(is_bootstrap("1", None));
+    assert!(is_bootstrap("1", Some("x")));
+    // RUSTC_BOOTSTRAP allows specifying a specific crate
+    assert!(is_bootstrap("x", Some("x")));
+    // RUSTC_BOOTSTRAP allows multiple comma-delimited crates
+    assert!(is_bootstrap("x,y,z", Some("x")));
+    assert!(is_bootstrap("x,y,z", Some("y")));
+    // Crate that aren't specified do not get unstable features
+    assert!(!is_bootstrap("x", Some("a")));
+    assert!(!is_bootstrap("x,y,z", Some("a")));
+    assert!(!is_bootstrap("x,y,z", None));
+
+    // this is technically a breaking change, but there are no stability guarantees for RUSTC_BOOTSTRAP
+    assert!(!is_bootstrap("0", None));
+}

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -35,9 +35,12 @@ fn main() {
 
     // Checks that only make sense for the std libs.
     pal::check(&library_path, &mut bad);
-    unit_tests::check(&library_path, &mut bad);
 
     // Checks that need to be done for both the compiler and std libraries.
+    unit_tests::check(&src_path, &mut bad);
+    unit_tests::check(&compiler_path, &mut bad);
+    unit_tests::check(&library_path, &mut bad);
+
     bins::check(&src_path, &output_directory, &mut bad);
     bins::check(&compiler_path, &output_directory, &mut bad);
     bins::check(&library_path, &output_directory, &mut bad);


### PR DESCRIPTION
It regressed in https://github.com/rust-lang/rust/pull/73265 and compiler crates are no longer checked.