### PR TITLE
rustdoc light theme: Fix CSS for selected buttons

### DIFF
--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -349,8 +349,8 @@ pre.ignore:hover, .information:hover + pre.ignore {
 }
 
 #titles > button:hover, #titles > button.selected {
+	background-color: #ffffff;
 	border-top-color: #0089ff;
-	background-color: #353535;
 }
 
 #titles > button > div.count {


### PR DESCRIPTION
Fixes #79961.

The background was dark before, which made the text impossible to read.
Now the button doesn't override the background, and the only thing it
does is add a light-blue top border.

Ultimately, the search results tabs now look very similar to how they
used to look.

r? @GuillaumeGomez
