### PR TITLE
Remove incorrect assert

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -436,8 +436,8 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
         // Try looking for methods and associated items.
         let mut split = path_str.rsplitn(2, "::");
         // NB: `split`'s first element is always defined, even if the delimiter was not present.
+        // NB: `item_str` could be empty when resolving in the root namespace (e.g. `::std`).
         let item_str = split.next().unwrap();
-        assert!(!item_str.is_empty());
         let item_name = Symbol::intern(item_str);
         let path_root = split
             .next()


### PR DESCRIPTION
Fixes an assertion failure when resolving `::std` (or any other crate that uses the `::` style, see https://github.com/rust-lang/rust/pull/79809/files#r541776478, https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Perf.20failing).

Unblocks https://github.com/rust-lang/rustc-perf/pull/806.

r? @ghost - this is a trivial fix and breaking rustc-perf so I'm going to approve it unilaterally. cc @Mark-Simulacrum @Eric-Arellano 