### PR TITLE
Add 'consider using' message to overflowing_literals

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -225,7 +225,7 @@ fn report_bin_hex_error(
                 (t.name_str(), actually.to_string())
             }
         };
-        let mut err = lint.build(&format!("literal out of range for {}", t));
+        let mut err = lint.build(&format!("literal out of range for `{}`", t));
         err.note(&format!(
             "the literal `{}` (decimal `{}`) does not fit into \
              the type `{}` and will become `{}{}`",
@@ -238,12 +238,12 @@ fn report_bin_hex_error(
                 let (sans_suffix, _) = repr_str.split_at(pos);
                 err.span_suggestion(
                     expr.span,
-                    &format!("consider using `{}` instead", sugg_ty),
+                    &format!("consider using the type `{}` instead", sugg_ty),
                     format!("{}{}", sans_suffix, sugg_ty),
                     Applicability::MachineApplicable,
                 );
             } else {
-                err.help(&format!("consider using `{}` instead", sugg_ty));
+                err.help(&format!("consider using the type `{}` instead", sugg_ty));
             }
         }
         err.emit();
@@ -345,7 +345,7 @@ fn lint_int_literal<'tcx>(
             if let Some(sugg_ty) =
                 get_type_suggestion(&cx.typeck_results().node_type(e.hir_id), v, negative)
             {
-                err.help(&format!("consider using `{}` instead", sugg_ty));
+                err.help(&format!("consider using the type `{}` instead", sugg_ty));
             }
             err.emit();
         });

--- a/src/test/ui/enum/enum-discrim-too-small2.stderr
+++ b/src/test/ui/enum/enum-discrim-too-small2.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `223` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 error: literal out of range for `i16`
   --> $DIR/enum-discrim-too-small2.rs:15:12
@@ -18,6 +19,7 @@ LL |     Ci16 = 55555,
    |            ^^^^^
    |
    = note: the literal `55555` does not fit into the type `i16` whose range is `-32768..=32767`
+   = help: consider using `u16` instead
 
 error: literal out of range for `i32`
   --> $DIR/enum-discrim-too-small2.rs:22:12
@@ -26,6 +28,7 @@ LL |     Ci32 = 3_000_000_000,
    |            ^^^^^^^^^^^^^
    |
    = note: the literal `3_000_000_000` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
+   = help: consider using `u32` instead
 
 error: literal out of range for `i64`
   --> $DIR/enum-discrim-too-small2.rs:29:12
@@ -34,6 +37,7 @@ LL |     Ci64 = 9223372036854775809,
    |            ^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775809` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
+   = help: consider using `u64` instead
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/enum/enum-discrim-too-small2.stderr
+++ b/src/test/ui/enum/enum-discrim-too-small2.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `223` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: literal out of range for `i16`
   --> $DIR/enum-discrim-too-small2.rs:15:12
@@ -19,7 +19,7 @@ LL |     Ci16 = 55555,
    |            ^^^^^
    |
    = note: the literal `55555` does not fit into the type `i16` whose range is `-32768..=32767`
-   = help: consider using `u16` instead
+   = help: consider using the type `u16` instead
 
 error: literal out of range for `i32`
   --> $DIR/enum-discrim-too-small2.rs:22:12
@@ -28,7 +28,7 @@ LL |     Ci32 = 3_000_000_000,
    |            ^^^^^^^^^^^^^
    |
    = note: the literal `3_000_000_000` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
-   = help: consider using `u32` instead
+   = help: consider using the type `u32` instead
 
 error: literal out of range for `i64`
   --> $DIR/enum-discrim-too-small2.rs:29:12
@@ -37,7 +37,7 @@ LL |     Ci64 = 9223372036854775809,
    |            ^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775809` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
-   = help: consider using `u64` instead
+   = help: consider using the type `u64` instead
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-79744.rs
+++ b/src/test/ui/issues/issue-79744.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let elem = 6i8;
+    let e2 = 230;
+    //~^ ERROR literal out of range for `i8`
+    //~| HELP consider using `u8` instead
+
+    let mut vec = Vec::new();
+
+    vec.push(e2);
+    vec.push(elem);
+
+    println!("{:?}", vec);
+}

--- a/src/test/ui/issues/issue-79744.rs
+++ b/src/test/ui/issues/issue-79744.rs
@@ -2,7 +2,7 @@ fn main() {
     let elem = 6i8;
     let e2 = 230;
     //~^ ERROR literal out of range for `i8`
-    //~| HELP consider using `u8` instead
+    //~| HELP consider using the type `u8` instead
 
     let mut vec = Vec::new();
 

--- a/src/test/ui/issues/issue-79744.stderr
+++ b/src/test/ui/issues/issue-79744.stderr
@@ -1,0 +1,12 @@
+error: literal out of range for `i8`
+  --> $DIR/issue-79744.rs:3:14
+   |
+LL |     let e2 = 230;
+   |              ^^^
+   |
+   = note: `#[deny(overflowing_literals)]` on by default
+   = note: the literal `230` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
+
+error: aborting due to previous error
+

--- a/src/test/ui/issues/issue-79744.stderr
+++ b/src/test/ui/issues/issue-79744.stderr
@@ -6,7 +6,7 @@ LL |     let e2 = 230;
    |
    = note: `#[deny(overflowing_literals)]` on by default
    = note: the literal `230` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-type-limits2.stderr
+++ b/src/test/ui/lint/lint-type-limits2.stderr
@@ -18,6 +18,7 @@ note: the lint level is defined here
 LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-type-limits2.stderr
+++ b/src/test/ui/lint/lint-type-limits2.stderr
@@ -18,7 +18,7 @@ note: the lint level is defined here
 LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-type-limits3.stderr
+++ b/src/test/ui/lint/lint-type-limits3.stderr
@@ -18,6 +18,7 @@ note: the lint level is defined here
 LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `200` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-type-limits3.stderr
+++ b/src/test/ui/lint/lint-type-limits3.stderr
@@ -18,7 +18,7 @@ note: the lint level is defined here
 LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `200` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/lint-type-overflow.stderr
+++ b/src/test/ui/lint/lint-type-overflow.stderr
@@ -26,6 +26,7 @@ LL |     let x1: i8 = 128;
    |                  ^^^
    |
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:18:19
@@ -34,6 +35,7 @@ LL |     let x3: i8 = -129;
    |                   ^^^
    |
    = note: the literal `129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `i16` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:19:19
@@ -42,6 +44,7 @@ LL |     let x3: i8 = -(129);
    |                   ^^^^^
    |
    = note: the literal `129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `i16` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:20:20
@@ -50,6 +53,7 @@ LL |     let x3: i8 = -{129};
    |                    ^^^
    |
    = note: the literal `129` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:22:10
@@ -58,6 +62,7 @@ LL |     test(1000);
    |          ^^^^
    |
    = note: the literal `1000` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `i16` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:24:13
@@ -66,6 +71,7 @@ LL |     let x = 128_i8;
    |             ^^^^^^
    |
    = note: the literal `128_i8` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:28:14
@@ -74,6 +80,7 @@ LL |     let x = -129_i8;
    |              ^^^^^^
    |
    = note: the literal `129_i8` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `i16` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:32:18
@@ -82,6 +89,7 @@ LL |     let x: i32 = 2147483648;
    |                  ^^^^^^^^^^
    |
    = note: the literal `2147483648` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
+   = help: consider using `u32` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:33:13
@@ -90,6 +98,7 @@ LL |     let x = 2147483648_i32;
    |             ^^^^^^^^^^^^^^
    |
    = note: the literal `2147483648_i32` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
+   = help: consider using `u32` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:36:19
@@ -98,6 +107,7 @@ LL |     let x: i32 = -2147483649;
    |                   ^^^^^^^^^^
    |
    = note: the literal `2147483649` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
+   = help: consider using `i64` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:37:14
@@ -106,6 +116,7 @@ LL |     let x = -2147483649_i32;
    |              ^^^^^^^^^^^^^^
    |
    = note: the literal `2147483649_i32` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
+   = help: consider using `i64` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:38:13
@@ -114,6 +125,7 @@ LL |     let x = 2147483648;
    |             ^^^^^^^^^^
    |
    = note: the literal `2147483648` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
+   = help: consider using `u32` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:40:13
@@ -122,6 +134,7 @@ LL |     let x = 9223372036854775808_i64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775808_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
+   = help: consider using `u64` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:42:13
@@ -130,6 +143,7 @@ LL |     let x = 18446744073709551615_i64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `18446744073709551615_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
+   = help: consider using `u64` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:43:19
@@ -138,6 +152,7 @@ LL |     let x: i64 = -9223372036854775809;
    |                   ^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775809` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
+   = help: consider using `i128` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:44:14
@@ -146,6 +161,7 @@ LL |     let x = -9223372036854775809_i64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775809_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
+   = help: consider using `i128` instead
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/lint/lint-type-overflow.stderr
+++ b/src/test/ui/lint/lint-type-overflow.stderr
@@ -26,7 +26,7 @@ LL |     let x1: i8 = 128;
    |                  ^^^
    |
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:18:19
@@ -35,7 +35,7 @@ LL |     let x3: i8 = -129;
    |                   ^^^
    |
    = note: the literal `129` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `i16` instead
+   = help: consider using the type `i16` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:19:19
@@ -44,7 +44,7 @@ LL |     let x3: i8 = -(129);
    |                   ^^^^^
    |
    = note: the literal `129` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `i16` instead
+   = help: consider using the type `i16` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:20:20
@@ -53,7 +53,7 @@ LL |     let x3: i8 = -{129};
    |                    ^^^
    |
    = note: the literal `129` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:22:10
@@ -62,7 +62,7 @@ LL |     test(1000);
    |          ^^^^
    |
    = note: the literal `1000` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `i16` instead
+   = help: consider using the type `i16` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:24:13
@@ -71,7 +71,7 @@ LL |     let x = 128_i8;
    |             ^^^^^^
    |
    = note: the literal `128_i8` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: literal out of range for `i8`
   --> $DIR/lint-type-overflow.rs:28:14
@@ -80,7 +80,7 @@ LL |     let x = -129_i8;
    |              ^^^^^^
    |
    = note: the literal `129_i8` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `i16` instead
+   = help: consider using the type `i16` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:32:18
@@ -89,7 +89,7 @@ LL |     let x: i32 = 2147483648;
    |                  ^^^^^^^^^^
    |
    = note: the literal `2147483648` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
-   = help: consider using `u32` instead
+   = help: consider using the type `u32` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:33:13
@@ -98,7 +98,7 @@ LL |     let x = 2147483648_i32;
    |             ^^^^^^^^^^^^^^
    |
    = note: the literal `2147483648_i32` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
-   = help: consider using `u32` instead
+   = help: consider using the type `u32` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:36:19
@@ -107,7 +107,7 @@ LL |     let x: i32 = -2147483649;
    |                   ^^^^^^^^^^
    |
    = note: the literal `2147483649` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
-   = help: consider using `i64` instead
+   = help: consider using the type `i64` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:37:14
@@ -116,7 +116,7 @@ LL |     let x = -2147483649_i32;
    |              ^^^^^^^^^^^^^^
    |
    = note: the literal `2147483649_i32` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
-   = help: consider using `i64` instead
+   = help: consider using the type `i64` instead
 
 error: literal out of range for `i32`
   --> $DIR/lint-type-overflow.rs:38:13
@@ -125,7 +125,7 @@ LL |     let x = 2147483648;
    |             ^^^^^^^^^^
    |
    = note: the literal `2147483648` does not fit into the type `i32` whose range is `-2147483648..=2147483647`
-   = help: consider using `u32` instead
+   = help: consider using the type `u32` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:40:13
@@ -134,7 +134,7 @@ LL |     let x = 9223372036854775808_i64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775808_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
-   = help: consider using `u64` instead
+   = help: consider using the type `u64` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:42:13
@@ -143,7 +143,7 @@ LL |     let x = 18446744073709551615_i64;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `18446744073709551615_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
-   = help: consider using `u64` instead
+   = help: consider using the type `u64` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:43:19
@@ -152,7 +152,7 @@ LL |     let x: i64 = -9223372036854775809;
    |                   ^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775809` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
-   = help: consider using `i128` instead
+   = help: consider using the type `i128` instead
 
 error: literal out of range for `i64`
   --> $DIR/lint-type-overflow.rs:44:14
@@ -161,7 +161,7 @@ LL |     let x = -9223372036854775809_i64;
    |              ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `9223372036854775809_i64` does not fit into the type `i64` whose range is `-9223372036854775808..=9223372036854775807`
-   = help: consider using `i128` instead
+   = help: consider using the type `i128` instead
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/lint/lint-type-overflow2.stderr
+++ b/src/test/ui/lint/lint-type-overflow2.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![deny(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 error: literal out of range for `f32`
   --> $DIR/lint-type-overflow2.rs:9:14

--- a/src/test/ui/lint/lint-type-overflow2.stderr
+++ b/src/test/ui/lint/lint-type-overflow2.stderr
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `128` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
 error: literal out of range for `f32`
   --> $DIR/lint-type-overflow2.rs:9:14

--- a/src/test/ui/lint/type-overflow.rs
+++ b/src/test/ui/lint/type-overflow.rs
@@ -7,16 +7,16 @@ fn main() {
     let ok = 0b1000_0001; // should be ok -> i32
     let ok = 0b0111_1111i8; // should be ok -> 127i8
 
-    let fail = 0b1000_0001i8; //~WARNING literal out of range for i8
+    let fail = 0b1000_0001i8; //~WARNING literal out of range for `i8`
 
-    let fail = 0x8000_0000_0000_0000i64; //~WARNING literal out of range for i64
+    let fail = 0x8000_0000_0000_0000i64; //~WARNING literal out of range for `i64`
 
-    let fail = 0x1_FFFF_FFFFu32; //~WARNING literal out of range for u32
+    let fail = 0x1_FFFF_FFFFu32; //~WARNING literal out of range for `u32`
 
     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
-    //~^ WARNING literal out of range for i128
+    //~^ WARNING literal out of range for `i128`
 
-    let fail = 0x8FFF_FFFF_FFFF_FFFE; //~WARNING literal out of range for i32
+    let fail = 0x8FFF_FFFF_FFFF_FFFE; //~WARNING literal out of range for `i32`
 
-    let fail = -0b1111_1111i8; //~WARNING literal out of range for i8
+    let fail = -0b1111_1111i8; //~WARNING literal out of range for `i8`
 }

--- a/src/test/ui/lint/type-overflow.stderr
+++ b/src/test/ui/lint/type-overflow.stderr
@@ -10,6 +10,7 @@ note: the lint level is defined here
 LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `255i8` does not fit into the type `i8` whose range is `-128..=127`
+   = help: consider using `u8` instead
 
 warning: literal out of range for i8
   --> $DIR/type-overflow.rs:10:16

--- a/src/test/ui/lint/type-overflow.stderr
+++ b/src/test/ui/lint/type-overflow.stderr
@@ -10,55 +10,55 @@ note: the lint level is defined here
 LL | #![warn(overflowing_literals)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = note: the literal `255i8` does not fit into the type `i8` whose range is `-128..=127`
-   = help: consider using `u8` instead
+   = help: consider using the type `u8` instead
 
-warning: literal out of range for i8
+warning: literal out of range for `i8`
   --> $DIR/type-overflow.rs:10:16
    |
 LL |     let fail = 0b1000_0001i8;
-   |                ^^^^^^^^^^^^^ help: consider using `u8` instead: `0b1000_0001u8`
+   |                ^^^^^^^^^^^^^ help: consider using the type `u8` instead: `0b1000_0001u8`
    |
    = note: the literal `0b1000_0001i8` (decimal `129`) does not fit into the type `i8` and will become `-127i8`
 
-warning: literal out of range for i64
+warning: literal out of range for `i64`
   --> $DIR/type-overflow.rs:12:16
    |
 LL |     let fail = 0x8000_0000_0000_0000i64;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `u64` instead: `0x8000_0000_0000_0000u64`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using the type `u64` instead: `0x8000_0000_0000_0000u64`
    |
    = note: the literal `0x8000_0000_0000_0000i64` (decimal `9223372036854775808`) does not fit into the type `i64` and will become `-9223372036854775808i64`
 
-warning: literal out of range for u32
+warning: literal out of range for `u32`
   --> $DIR/type-overflow.rs:14:16
    |
 LL |     let fail = 0x1_FFFF_FFFFu32;
-   |                ^^^^^^^^^^^^^^^^ help: consider using `u64` instead: `0x1_FFFF_FFFFu64`
+   |                ^^^^^^^^^^^^^^^^ help: consider using the type `u64` instead: `0x1_FFFF_FFFFu64`
    |
    = note: the literal `0x1_FFFF_FFFFu32` (decimal `8589934591`) does not fit into the type `u32` and will become `4294967295u32`
 
-warning: literal out of range for i128
+warning: literal out of range for `i128`
   --> $DIR/type-overflow.rs:16:22
    |
 LL |     let fail: i128 = 0x8000_0000_0000_0000_0000_0000_0000_0000;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `0x8000_0000_0000_0000_0000_0000_0000_0000` (decimal `170141183460469231731687303715884105728`) does not fit into the type `i128` and will become `-170141183460469231731687303715884105728i128`
-   = help: consider using `u128` instead
+   = help: consider using the type `u128` instead
 
-warning: literal out of range for i32
+warning: literal out of range for `i32`
   --> $DIR/type-overflow.rs:19:16
    |
 LL |     let fail = 0x8FFF_FFFF_FFFF_FFFE;
    |                ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: the literal `0x8FFF_FFFF_FFFF_FFFE` (decimal `10376293541461622782`) does not fit into the type `i32` and will become `-2i32`
-   = help: consider using `i128` instead
+   = help: consider using the type `i128` instead
 
-warning: literal out of range for i8
+warning: literal out of range for `i8`
   --> $DIR/type-overflow.rs:21:17
    |
 LL |     let fail = -0b1111_1111i8;
-   |                 ^^^^^^^^^^^^^ help: consider using `i16` instead: `0b1111_1111i16`
+   |                 ^^^^^^^^^^^^^ help: consider using the type `i16` instead: `0b1111_1111i16`
    |
    = note: the literal `0b1111_1111i8` (decimal `255`) does not fit into the type `i8` and will become `-1i8`
 


### PR DESCRIPTION
Fixes #79744.

Ironically, the `overflowing_literals` handler for binary or hex already
had this message! You would think it would be the other way around :)

cc @scottmcm
