### PR TITLE
Remove an unused dependency that made `rustdoc` crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,6 @@ checksum = "9a21fa21941700a3cd8fcb4091f361a6a712fac632f85d9f487cc892045d55c6"
 [[package]]
 name = "coverage_test_macros"
 version = "0.0.0"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "cpuid-bool"

--- a/compiler/rustc_mir/src/transform/coverage/test_macros/Cargo.toml
+++ b/compiler/rustc_mir/src/transform/coverage/test_macros/Cargo.toml
@@ -7,6 +7,3 @@ edition = "2018"
 [lib]
 proc-macro = true
 doctest = false
-
-[dependencies]
-proc-macro2 = "1"


### PR DESCRIPTION
Whilst struggling with https://github.com/rust-lang/rust/issues/79980 I discovered that this dependency was unused, and that made rustdoc crash. This PR removes it.