### PR TITLE
BTreeMap: detect bulk_steal's count-1 underflow in release builds too

### DIFF
--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -1469,6 +1469,7 @@ impl<'a, K: 'a, V: 'a> BalancingContext<'a, K, V> {
 
     /// This does stealing similar to `steal_left` but steals multiple elements at once.
     pub fn bulk_steal_left(&mut self, count: usize) {
+        assert!(count > 0);
         unsafe {
             let left_node = &mut self.left_child;
             let old_left_len = left_node.len();
@@ -1526,6 +1527,7 @@ impl<'a, K: 'a, V: 'a> BalancingContext<'a, K, V> {
 
     /// The symmetric clone of `bulk_steal_left`.
     pub fn bulk_steal_right(&mut self, count: usize) {
+        assert!(count > 0);
         unsafe {
             let left_node = &mut self.left_child;
             let old_left_len = left_node.len();


### PR DESCRIPTION
r? @Mark-Simulacrum 