### PR TITLE
Stop generating code in mem::forget

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -838,8 +838,11 @@ extern "rust-intrinsic" {
 
     /// Moves a value out of scope without running drop glue.
     ///
-    /// This exists solely for [`mem::forget_unsized`]; normal `forget` uses
-    /// `ManuallyDrop` instead.
+    /// This is only strictly needed for [`mem::forget_unsized`]; normal [`mem::forget`]
+    /// compiles fine just using `ManuallyDrop` instead.
+    ///
+    /// As this does literally nothing, it's trivially const-safe.
+    #[rustc_const_stable(feature = "const_forget_intrinsic", since = "1.50")]
     pub fn forget<T: ?Sized>(_: T);
 
     /// Reinterprets the bits of a value of one type as another type.

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -141,7 +141,16 @@ pub use crate::intrinsics::transmute;
 #[rustc_const_stable(feature = "const_forget", since = "1.46.0")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const fn forget<T>(t: T) {
-    let _ = ManuallyDrop::new(t);
+    // Ideally this would just be
+    // ```
+    // let _ = ManuallyDrop::new(t);
+    // ```
+    // but as of 2020-12-12 that actually codegens the construction of the type,
+    // which there's no reason to do.  Please switch it back if things have changed and
+    // the forget-is-nop codegen test confirms the intrinsic is no longer needed here.
+
+    // SAFETY: Forgetting is safe; it's just the intrinsic that isn't.
+    unsafe { intrinsics::forget(t) }
 }
 
 /// Like [`forget`], but also accepts unsized values.

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -137,3 +137,16 @@ fn assume_init_good() {
 
     assert!(TRUE);
 }
+
+#[test]
+#[cfg(not(bootstrap))]
+fn forget_works_in_const_fn() {
+    const fn forget_arg_and_return_4(x: Vec<i32>) -> i32 {
+        std::mem::forget(x);
+        4
+    }
+
+    const FOUR_THE_HARD_WAY: i32 = forget_arg_and_return_4(Vec::new());
+
+    assert_eq!(FOUR_THE_HARD_WAY, 4);
+}

--- a/src/test/codegen/forget-is-nop.rs
+++ b/src/test/codegen/forget-is-nop.rs
@@ -1,0 +1,21 @@
+// compile-flags: -C opt-level=0
+
+#![crate_type = "lib"]
+
+// CHECK-LABEL: mem6forget{{.+}}[100 x %"std::string::String"]*
+    // CHECK-NOT: alloca
+    // CHECK-NOT: memcpy
+    // CHECK: ret
+
+// CHECK-LABEL: mem6forget{{.+}}[100 x i64]*
+    // CHECK-NOT: alloca
+    // CHECK-NOT: memcpy
+    // CHECK: ret
+
+pub fn forget_large_copy_type(whatever: [i64; 100]) {
+    std::mem::forget(whatever)
+}
+
+pub fn forget_large_drop_type(whatever: [String; 100]) {
+    std::mem::forget(whatever)
+}


### PR DESCRIPTION
Yes, the optimizer can remove it, but there's really no reason to bother emitting it in the first place.  Not to mention that it all gets run in debug mode...

Preemptively cc @RalfJung, who probably wouldn't be happy about me doing this.

Tangentially related to #79914, though that's more about used ones where optimizing it away is harder than it is here.