### PR TITLE
rustdoc: Render HRTB correctly for bare functions

### DIFF
--- a/src/test/rustdoc/fn-type.rs
+++ b/src/test/rustdoc/fn-type.rs
@@ -1,0 +1,15 @@
+// ignore-tidy-linelength
+
+#![crate_name = "foo"]
+#![crate_type = "lib"]
+
+pub struct Foo<'a, T> {
+    pub generic: fn(val: &T) -> T,
+
+    pub lifetime: fn(val: &'a i32) -> i32,
+    pub hrtb_lifetime: for<'b, 'c> fn(one: &'b i32, two: &'c &'b i32) -> (&'b i32, &'c i32),
+}
+
+// @has 'foo/struct.Foo.html' '//span[@id="structfield.generic"]' "generic: fn(val: &T) -> T"
+// @has 'foo/struct.Foo.html' '//span[@id="structfield.lifetime"]' "lifetime: fn(val: &'a i32) -> i32"
+// @has 'foo/struct.Foo.html' '//span[@id="structfield.hrtb_lifetime"]' "hrtb_lifetime: for<'b, 'c> fn(one: &'b i32, two: &'c &'b i32) -> (&'b i32, &'c i32)"

--- a/src/test/rustdoc/for-lifetime.rs
+++ b/src/test/rustdoc/for-lifetime.rs
@@ -1,0 +1,14 @@
+// ignore-tidy-linelength
+
+#![crate_name = "foo"]
+#![crate_type = "lib"]
+
+pub struct Foo {
+    pub some_func: for<'a> fn(val: &'a i32) -> i32,
+    pub some_trait: dyn for<'a> Trait<'a>,
+}
+
+// @has foo/struct.Foo.html '//span[@id="structfield.some_func"]' "some_func: for<'a> fn(val: &'a i32) -> i32"
+// @has foo/struct.Foo.html '//span[@id="structfield.some_trait"]' "some_trait: dyn Trait<'a>"
+
+pub trait Trait<'a> {}


### PR DESCRIPTION
The angle brackets were not rendered, so code like this:

    some_func: for<'a> fn(val: &'a i32) -> i32

would be rendered as:

    some_func: fn'a(val: &'a i32) -> i32

However, rendering with angle brackets is still invalid syntax:

    some_func: fn<'a>(val: &'a i32) -> i32

so now it renders correctly as:

    some_func: for<'a> fn(val: &'a i32) -> i32

-----

However, note that this code:

    some_trait: dyn for<'a> Trait<'a>

will still render as:

    some_trait: dyn Trait<'a>

which is not invalid syntax, but is still unclear. Unfortunately I think
it's hard to fix that case because there isn't enough information in the
`rustdoc::clean::Type` that this code operates on. Perhaps that case can
be fixed in a later PR.

r? @jyn514
