### PR TITLE
Fix overflow when converting ZST Vec to VecDeque

### DIFF
--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2796,7 +2796,7 @@ impl<T> From<Vec<T>> for VecDeque<T> {
             // or doesn't have at least one free space.
             // We check if `T` is a ZST in the first condition,
             // because `usize::MAX` (the capacity returned by `capacity()` for ZST)
-            // is not a power of zero and thus it'll always try
+            // is not a power of two and thus it'll always try
             // to reserve more memory which will panic for ZST (rust-lang/rust#78532)
             if (!buf.capacity().is_power_of_two() && mem::size_of::<T>() != 0)
                 || (buf.capacity() < (MINIMUM_CAPACITY + 1))

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2793,8 +2793,12 @@ impl<T> From<Vec<T>> for VecDeque<T> {
             let len = other.len();
 
             // We need to extend the buf if it's not a power of two, too small
-            // or doesn't have at least one free space
-            if !buf.capacity().is_power_of_two()
+            // or doesn't have at least one free space.
+            // We check if `T` is a ZST in the first condition,
+            // because `usize::MAX` (the capacity returned by `capacity()` for ZST)
+            // is not a power of zero and thus it'll always try
+            // to reserve more memory which will panic for ZST (rust-lang/rust#78532)
+            if (!buf.capacity().is_power_of_two() && mem::size_of::<T>() != 0)
                 || (buf.capacity() < (MINIMUM_CAPACITY + 1))
                 || (buf.capacity() == len)
             {

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -1728,3 +1728,10 @@ fn test_zero_sized_push() {
         }
     }
 }
+
+#[test]
+fn test_from_zero_sized_vec() {
+    let v = vec![(); 100];
+    let queue = VecDeque::from(v);
+    assert!(queue.len(), 100);
+}

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -1733,5 +1733,5 @@ fn test_zero_sized_push() {
 fn test_from_zero_sized_vec() {
     let v = vec![(); 100];
     let queue = VecDeque::from(v);
-    assert!(queue.len(), 100);
+    assert_eq!(queue.len(), 100);
 }


### PR DESCRIPTION
```rust
let v = vec![(); 100];
let queue = VecDeque::from(v);
println!("{:?}", queue);
```
This code will currently panic with a capacity overflow.
This PR resolves this issue and makes the code run fine.

Resolves #78532