### PR TITLE
Add Mutex::arc and RwLock::arc

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -282,6 +282,7 @@
 #![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_slice)]
 #![feature(min_specialization)]
+#![feature(mutex_arc)]
 #![feature(needs_panic_runtime)]
 #![feature(negative_impls)]
 #![feature(never_type)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -282,7 +282,7 @@
 #![feature(maybe_uninit_ref)]
 #![feature(maybe_uninit_slice)]
 #![feature(min_specialization)]
-#![feature(mutex_arc)]
+#![cfg_attr(test, feature(mutex_arc))]
 #![feature(needs_panic_runtime)]
 #![feature(negative_impls)]
 #![feature(never_type)]

--- a/library/std/src/sync/condvar/tests.rs
+++ b/library/std/src/sync/condvar/tests.rs
@@ -14,7 +14,7 @@ fn smoke() {
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)]
 fn notify_one() {
-    let m = Arc::new(Mutex::new(()));
+    let m = Mutex::arc(());
     let m2 = m.clone();
     let c = Arc::new(Condvar::new());
     let c2 = c.clone();
@@ -89,7 +89,7 @@ fn wait_while() {
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)]
 fn wait_timeout_wait() {
-    let m = Arc::new(Mutex::new(()));
+    let m = Mutex::arc(());
     let c = Arc::new(Condvar::new());
 
     loop {
@@ -108,7 +108,7 @@ fn wait_timeout_wait() {
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)]
 fn wait_timeout_while_wait() {
-    let m = Arc::new(Mutex::new(()));
+    let m = Mutex::arc(());
     let c = Arc::new(Condvar::new());
 
     let g = m.lock().unwrap();
@@ -120,7 +120,7 @@ fn wait_timeout_while_wait() {
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)]
 fn wait_timeout_while_instant_satisfy() {
-    let m = Arc::new(Mutex::new(()));
+    let m = Mutex::arc(());
     let c = Arc::new(Condvar::new());
 
     let g = m.lock().unwrap();
@@ -155,7 +155,7 @@ fn wait_timeout_while_wake() {
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)]
 fn wait_timeout_wake() {
-    let m = Arc::new(Mutex::new(()));
+    let m = Mutex::arc(());
     let c = Arc::new(Condvar::new());
 
     loop {
@@ -193,7 +193,7 @@ fn wait_timeout_wake() {
 #[should_panic]
 #[cfg_attr(not(unix), ignore)]
 fn two_mutexes() {
-    let m = Arc::new(Mutex::new(()));
+    let m = Mutex::arc(());
     let m2 = m.clone();
     let c = Arc::new(Condvar::new());
     let c2 = c.clone();

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -6,6 +6,7 @@ use crate::fmt;
 use crate::mem;
 use crate::ops::{Deref, DerefMut};
 use crate::ptr;
+use crate::sync::Arc;
 use crate::sys_common::mutex as sys;
 use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 
@@ -218,6 +219,23 @@ impl<T> Mutex<T> {
             poison: poison::Flag::new(),
             data: UnsafeCell::new(t),
         }
+    }
+
+    /// Constructs a new `Arc<Mutex<T>>`.
+    ///
+    /// This function is a shorthand for `Arc::new(Mutex::new(t))`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(mutex_arc)]
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// let mutex: Arc<Mutex<_>> = Mutex::arc(0);
+    /// ```
+    #[unstable(feature = "mutex_arc", issue = "74866")]
+    pub fn arc(t: T) -> Arc<Mutex<T>> {
+        Arc::new(Mutex::new(t))
     }
 }
 

--- a/library/std/src/sync/mutex/tests.rs
+++ b/library/std/src/sync/mutex/tests.rs
@@ -20,7 +20,7 @@ fn lots_and_lots() {
     const J: u32 = 1000;
     const K: u32 = 3;
 
-    let m = Arc::new(Mutex::new(0));
+    let m = Mutex::arc(0);
 
     fn inc(m: &Mutex<u32>) {
         for _ in 0..J {
@@ -83,7 +83,7 @@ fn test_into_inner_drop() {
 
 #[test]
 fn test_into_inner_poison() {
-    let m = Arc::new(Mutex::new(NonCopy(10)));
+    let m = Mutex::arc(NonCopy(10));
     let m2 = m.clone();
     let _ = thread::spawn(move || {
         let _lock = m2.lock().unwrap();
@@ -107,7 +107,7 @@ fn test_get_mut() {
 
 #[test]
 fn test_get_mut_poison() {
-    let m = Arc::new(Mutex::new(NonCopy(10)));
+    let m = Mutex::arc(NonCopy(10));
     let m2 = m.clone();
     let _ = thread::spawn(move || {
         let _lock = m2.lock().unwrap();
@@ -176,7 +176,7 @@ fn test_arc_condvar_poison() {
 
 #[test]
 fn test_mutex_arc_poison() {
-    let arc = Arc::new(Mutex::new(1));
+    let arc = Mutex::arc(1);
     assert!(!arc.is_poisoned());
     let arc2 = arc.clone();
     let _ = thread::spawn(move || {
@@ -192,8 +192,8 @@ fn test_mutex_arc_poison() {
 fn test_mutex_arc_nested() {
     // Tests nested mutexes and access
     // to underlying data.
-    let arc = Arc::new(Mutex::new(1));
-    let arc2 = Arc::new(Mutex::new(arc));
+    let arc = Mutex::arc(1);
+    let arc2 = Mutex::arc(arc);
     let (tx, rx) = channel();
     let _t = thread::spawn(move || {
         let lock = arc2.lock().unwrap();
@@ -206,7 +206,7 @@ fn test_mutex_arc_nested() {
 
 #[test]
 fn test_mutex_arc_access_in_unwind() {
-    let arc = Arc::new(Mutex::new(1));
+    let arc = Mutex::arc(1);
     let arc2 = arc.clone();
     let _ = thread::spawn(move || -> () {
         struct Unwinder {

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -6,6 +6,7 @@ use crate::fmt;
 use crate::mem;
 use crate::ops::{Deref, DerefMut};
 use crate::ptr;
+use crate::sync::Arc;
 use crate::sys_common::poison::{self, LockResult, TryLockError, TryLockResult};
 use crate::sys_common::rwlock as sys;
 
@@ -132,6 +133,23 @@ impl<T> RwLock<T> {
             poison: poison::Flag::new(),
             data: UnsafeCell::new(t),
         }
+    }
+
+    /// Constructs a new `Arc<RwLock<T>>`.
+    ///
+    /// This function is a shorthand for `Arc::new(RwLock::new(t))`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(mutex_arc)]
+    /// use std::sync::{Arc, RwLock};
+    ///
+    /// let mutex: Arc<RwLock<_>> = RwLock::arc(0);
+    /// ```
+    #[unstable(feature = "mutex_arc", issue = "74866")]
+    pub fn arc(t: T) -> Arc<RwLock<T>> {
+        Arc::new(RwLock::new(t))
     }
 }
 

--- a/library/std/src/sync/rwlock/tests.rs
+++ b/library/std/src/sync/rwlock/tests.rs
@@ -21,7 +21,7 @@ fn frob() {
     const N: u32 = 10;
     const M: usize = 1000;
 
-    let r = Arc::new(RwLock::new(()));
+    let r = RwLock::arc(());
 
     let (tx, rx) = channel::<()>();
     for _ in 0..N {
@@ -45,7 +45,7 @@ fn frob() {
 
 #[test]
 fn test_rw_arc_poison_wr() {
-    let arc = Arc::new(RwLock::new(1));
+    let arc = RwLock::arc(1);
     let arc2 = arc.clone();
     let _: Result<(), _> = thread::spawn(move || {
         let _lock = arc2.write().unwrap();
@@ -57,7 +57,7 @@ fn test_rw_arc_poison_wr() {
 
 #[test]
 fn test_rw_arc_poison_ww() {
-    let arc = Arc::new(RwLock::new(1));
+    let arc = RwLock::arc(1);
     assert!(!arc.is_poisoned());
     let arc2 = arc.clone();
     let _: Result<(), _> = thread::spawn(move || {
@@ -71,7 +71,7 @@ fn test_rw_arc_poison_ww() {
 
 #[test]
 fn test_rw_arc_no_poison_rr() {
-    let arc = Arc::new(RwLock::new(1));
+    let arc = RwLock::arc(1);
     let arc2 = arc.clone();
     let _: Result<(), _> = thread::spawn(move || {
         let _lock = arc2.read().unwrap();
@@ -83,7 +83,7 @@ fn test_rw_arc_no_poison_rr() {
 }
 #[test]
 fn test_rw_arc_no_poison_rw() {
-    let arc = Arc::new(RwLock::new(1));
+    let arc = RwLock::arc(1);
     let arc2 = arc.clone();
     let _: Result<(), _> = thread::spawn(move || {
         let _lock = arc2.read().unwrap();
@@ -96,7 +96,7 @@ fn test_rw_arc_no_poison_rw() {
 
 #[test]
 fn test_rw_arc() {
-    let arc = Arc::new(RwLock::new(0));
+    let arc = RwLock::arc(0);
     let arc2 = arc.clone();
     let (tx, rx) = channel();
 
@@ -134,7 +134,7 @@ fn test_rw_arc() {
 
 #[test]
 fn test_rw_arc_access_in_unwind() {
-    let arc = Arc::new(RwLock::new(1));
+    let arc = RwLock::arc(1);
     let arc2 = arc.clone();
     let _ = thread::spawn(move || -> () {
         struct Unwinder {
@@ -207,7 +207,7 @@ fn test_into_inner_drop() {
 
 #[test]
 fn test_into_inner_poison() {
-    let m = Arc::new(RwLock::new(NonCopy(10)));
+    let m = RwLock::arc(NonCopy(10));
     let m2 = m.clone();
     let _ = thread::spawn(move || {
         let _lock = m2.write().unwrap();
@@ -231,7 +231,7 @@ fn test_get_mut() {
 
 #[test]
 fn test_get_mut_poison() {
-    let m = Arc::new(RwLock::new(NonCopy(10)));
+    let m = RwLock::arc(NonCopy(10));
     let m2 = m.clone();
     let _ = thread::spawn(move || {
         let _lock = m2.write().unwrap();

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -1,11 +1,13 @@
-use std::sync::{Arc, Mutex};
+#![feature(mutex_arc)]
+
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
 #[test]
 #[cfg_attr(target_os = "emscripten", ignore)]
 fn sleep() {
-    let finished = Arc::new(Mutex::new(false));
+    let finished = Mutex::arc(false);
     let t_finished = finished.clone();
     thread::spawn(move || {
         thread::sleep(Duration::new(u64::MAX, 0));


### PR DESCRIPTION
This PR introduces the `arc` function for `RwLock` and `Mutex`.
`Mutex::arc`/`RwLock::arc` is a shorthand for `Arc::new(Mutex::new(t))`

Resolves #74866