### PR TITLE
Use tcx.symbol_name when determining clashing extern declarations.

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2596,6 +2596,11 @@ declare_lint! {
 }
 
 pub struct ClashingExternDeclarations {
+    /// Map of function symbol name to the first-seen hir id for that symbol name.. If seen_decls
+    /// contains an entry for key K, it means a symbol with name K has been seen by this lint and
+    /// the symbol should be reported as a clashing declaration.
+    // FIXME: Technically, we could just store a &'tcx str here without issue; however, the
+    // `impl_lint_pass` macro doesn't currently support lints parametric over a lifetime.
     seen_decls: FxHashMap<String, HirId>,
 }
 

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -43,6 +43,7 @@ use rustc_index::vec::Idx;
 use rustc_middle::lint::LintDiagnosticBuilder;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::subst::{GenericArgKind, Subst};
+use rustc_middle::ty::Instance;
 use rustc_middle::ty::{self, layout::LayoutError, Ty, TyCtxt};
 use rustc_session::Session;
 use rustc_span::edition::Edition;
@@ -2595,7 +2596,7 @@ declare_lint! {
 }
 
 pub struct ClashingExternDeclarations {
-    seen_decls: FxHashMap<Symbol, HirId>,
+    seen_decls: FxHashMap<String, HirId>,
 }
 
 /// Differentiate between whether the name for an extern decl came from the link_name attribute or
@@ -2626,16 +2627,17 @@ impl ClashingExternDeclarations {
     fn insert(&mut self, tcx: TyCtxt<'_>, fi: &hir::ForeignItem<'_>) -> Option<HirId> {
         let hid = fi.hir_id;
 
-        let name =
-            &tcx.codegen_fn_attrs(tcx.hir().local_def_id(hid)).link_name.unwrap_or(fi.ident.name);
-
-        if self.seen_decls.contains_key(name) {
+        let local_did = tcx.hir().local_def_id(fi.hir_id);
+        let did = local_did.to_def_id();
+        let instance = Instance::new(did, ty::List::identity_for_item(tcx, did));
+        let name = tcx.symbol_name(instance).name.to_string();
+        if self.seen_decls.contains_key(&name) {
             // Avoid updating the map with the new entry when we do find a collision. We want to
             // make sure we're always pointing to the first definition as the previous declaration.
             // This lets us avoid emitting "knock-on" diagnostics.
-            Some(*self.seen_decls.get(name).unwrap())
+            Some(*self.seen_decls.get(&name).unwrap())
         } else {
-            self.seen_decls.insert(*name, hid)
+            self.seen_decls.insert(name, hid)
         }
     }
 

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -2630,14 +2630,14 @@ impl ClashingExternDeclarations {
         let local_did = tcx.hir().local_def_id(fi.hir_id);
         let did = local_did.to_def_id();
         let instance = Instance::new(did, ty::List::identity_for_item(tcx, did));
-        let name = tcx.symbol_name(instance).name.to_string();
-        if self.seen_decls.contains_key(&name) {
+        let name = tcx.symbol_name(instance).name;
+        if let Some(&hir_id) = self.seen_decls.get(name) {
             // Avoid updating the map with the new entry when we do find a collision. We want to
             // make sure we're always pointing to the first definition as the previous declaration.
             // This lets us avoid emitting "knock-on" diagnostics.
-            Some(*self.seen_decls.get(&name).unwrap())
+            Some(hir_id)
         } else {
-            self.seen_decls.insert(name, hid)
+            self.seen_decls.insert(name.to_owned(), hid)
         }
     }
 

--- a/src/test/ui/lint/clashing-extern-fn-wasm.rs
+++ b/src/test/ui/lint/clashing-extern-fn-wasm.rs
@@ -1,0 +1,21 @@
+// check-pass
+#![crate_type = "lib"]
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_non_clash {
+    mod a {
+        #[link(wasm_import_module = "a")]
+        extern "C" {
+            pub fn foo();
+        }
+    }
+
+    mod b {
+        #[link(wasm_import_module = "b")]
+        extern "C" {
+            pub fn foo() -> usize;
+            // #79581: These declarations shouldn't clash because foreign fn names are mangled
+            // on wasm32.
+        }
+    }
+}


### PR DESCRIPTION
Fixes #79581.

r? @alexcrichton