### PR TITLE
Suggest `_` and `..` if a pattern has too few fields

### DIFF
--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1061,27 +1061,30 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 wildcard_sugg = String::from(", ") + &wildcard_sugg;
             }
 
-            err.span_suggestion(
+            err.span_suggestion_short(
                 after_fields_span,
                 "use `_` to explicitly ignore each field",
                 wildcard_sugg,
                 Applicability::MaybeIncorrect,
             );
 
-            if subpats.is_empty() || all_wildcards {
-                err.span_suggestion(
-                    all_fields_span,
-                    "use `..` to ignore all fields",
-                    String::from(".."),
-                    Applicability::MaybeIncorrect,
-                );
-            } else {
-                err.span_suggestion(
-                    after_fields_span,
-                    "use `..` to ignore the rest of the fields",
-                    String::from(", .."),
-                    Applicability::MaybeIncorrect,
-                );
+            // Only suggest `..` if more than one field is missing.
+            if fields.len() - subpats.len() > 1 {
+                if subpats.is_empty() || all_wildcards {
+                    err.span_suggestion_short(
+                        all_fields_span,
+                        "use `..` to ignore all fields",
+                        String::from(".."),
+                        Applicability::MaybeIncorrect,
+                    );
+                } else {
+                    err.span_suggestion_short(
+                        after_fields_span,
+                        "use `..` to ignore the rest of the fields",
+                        String::from(", .."),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
             }
         }
 

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1061,7 +1061,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 wildcard_sugg = String::from(", ") + &wildcard_sugg;
             }
 
-            err.span_suggestion_short(
+            err.span_suggestion_verbose(
                 after_fields_span,
                 "use `_` to explicitly ignore each field",
                 wildcard_sugg,
@@ -1071,14 +1071,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // Only suggest `..` if more than one field is missing.
             if fields.len() - subpats.len() > 1 {
                 if subpats.is_empty() || all_wildcards {
-                    err.span_suggestion_short(
+                    err.span_suggestion_verbose(
                         all_fields_span,
                         "use `..` to ignore all fields",
                         String::from(".."),
                         Applicability::MaybeIncorrect,
                     );
                 } else {
-                    err.span_suggestion_short(
+                    err.span_suggestion_verbose(
                         after_fields_span,
                         "use `..` to ignore the rest of the fields",
                         String::from(", .."),

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1068,8 +1068,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Applicability::MaybeIncorrect,
             );
 
-            // Only suggest `..` if more than one field is missing.
-            if fields.len() - subpats.len() > 1 {
+            // Only suggest `..` if more than one field is missing
+            // or the pattern consists of all wildcards.
+            if fields.len() - subpats.len() > 1 || all_wildcards {
                 if subpats.is_empty() || all_wildcards {
                     err.span_suggestion_verbose(
                         all_fields_span,

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1071,14 +1071,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             if subpats.is_empty() || all_wildcards {
                 err.span_suggestion(
                     all_fields_span,
-                    "use `..` to ignore all unmentioned fields",
+                    "use `..` to ignore all fields",
                     String::from(".."),
                     Applicability::MaybeIncorrect,
                 );
             } else {
                 err.span_suggestion(
                     after_fields_span,
-                    "use `..` to ignore all unmentioned fields",
+                    "use `..` to ignore the rest of the fields",
                     String::from(", .."),
                     Applicability::MaybeIncorrect,
                 );

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1049,8 +1049,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 pat_span.with_hi(pat_span.hi() - BytePos(1)).shrink_to_hi()
             };
 
-            let mut wildcard_sugg =
-                iter::repeat("_").take(fields.len() - subpats.len()).collect::<Vec<_>>().join(", ");
+            let mut wildcard_sugg = vec!["_"; fields.len() - subpats.len()].join(", ");
             if !subpats.is_empty() {
                 wildcard_sugg = String::from(", ") + &wildcard_sugg;
             }

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1002,7 +1002,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // More generally, the expected type wants a tuple variant with one field of an
         // N-arity-tuple, e.g., `V_i((p_0, .., p_N))`. Meanwhile, the user supplied a pattern
         // with the subpatterns directly in the tuple variant pattern, e.g., `V_i(p_0, .., p_N)`.
-        let missing_parenthesis = match (&expected.kind(), fields, had_err) {
+        let missing_parentheses = match (&expected.kind(), fields, had_err) {
             // #67037: only do this if we could successfully type-check the expected type against
             // the tuple struct pattern. Otherwise the substs could get out of range on e.g.,
             // `let P() = U;` where `P != U` with `struct P<T>(T);`.
@@ -1015,13 +1015,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             _ => false,
         };
-        if missing_parenthesis {
+        if missing_parentheses {
             let (left, right) = match subpats {
                 // This is the zero case; we aim to get the "hi" part of the `QPath`'s
                 // span as the "lo" and then the "hi" part of the pattern's span as the "hi".
                 // This looks like:
                 //
-                // help: missing parenthesis
+                // help: missing parentheses
                 //   |
                 // L |     let A(()) = A(());
                 //   |          ^  ^
@@ -1030,14 +1030,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // last sub-pattern. In the case of `A(x)` the first and last may coincide.
                 // This looks like:
                 //
-                // help: missing parenthesis
+                // help: missing parentheses
                 //   |
                 // L |     let A((x, y)) = A((1, 2));
                 //   |           ^    ^
                 [first, ..] => (first.span.shrink_to_lo(), subpats.last().unwrap().span),
             };
             err.multipart_suggestion(
-                "missing parenthesis",
+                "missing parentheses",
                 vec![(left, "(".to_string()), (right.shrink_to_hi(), ")".to_string())],
                 Applicability::MachineApplicable,
             );

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -36,6 +36,10 @@ help: use `_` to explicitly ignore each field
    |
 LL |     TupleStruct(_, _) = TupleStruct(1, 2);
    |                  ^^^
+help: use `..` to ignore all fields
+   |
+LL |     TupleStruct(..) = TupleStruct(1, 2);
+   |                 ^^
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/tuple_struct_destructure_fail.rs:34:5
@@ -59,6 +63,10 @@ help: use `_` to explicitly ignore each field
    |
 LL |     Enum::SingleVariant(_, _) = Enum::SingleVariant(1, 2);
    |                          ^^^
+help: use `..` to ignore all fields
+   |
+LL |     Enum::SingleVariant(..) = Enum::SingleVariant(1, 2);
+   |                         ^^
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/tuple_struct_destructure_fail.rs:40:12

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -36,7 +36,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |     TupleStruct(_, _) = TupleStruct(1, 2);
    |                  ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |     TupleStruct(..) = TupleStruct(1, 2);
    |                 ^^
@@ -63,7 +63,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |     Enum::SingleVariant(_, _) = Enum::SingleVariant(1, 2);
    |                          ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |     Enum::SingleVariant(..) = Enum::SingleVariant(1, 2);
    |                         ^^

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -31,6 +31,15 @@ LL | struct TupleStruct<S, T>(S, T);
 ...
 LL |     TupleStruct(_) = TupleStruct(1, 2);
    |     ^^^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |     TupleStruct(_, _) = TupleStruct(1, 2);
+   |                  ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |     TupleStruct(_, ..) = TupleStruct(1, 2);
+   |                  ^^^^
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/tuple_struct_destructure_fail.rs:34:5
@@ -49,6 +58,15 @@ LL |     SingleVariant(S, T)
 ...
 LL |     Enum::SingleVariant(_) = Enum::SingleVariant(1, 2);
    |     ^^^^^^^^^^^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |     Enum::SingleVariant(_, _) = Enum::SingleVariant(1, 2);
+   |                          ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |     Enum::SingleVariant(_, ..) = Enum::SingleVariant(1, 2);
+   |                          ^^^^
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/tuple_struct_destructure_fail.rs:40:12

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -30,16 +30,10 @@ LL | struct TupleStruct<S, T>(S, T);
    | ------------------------------- tuple struct defined here
 ...
 LL |     TupleStruct(_) = TupleStruct(1, 2);
-   |     ^^^^^^^^^^^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |     TupleStruct(_, _) = TupleStruct(1, 2);
-   |                  ^^^
-help: use `..` to ignore all fields
-   |
-LL |     TupleStruct(..) = TupleStruct(1, 2);
-   |                 ^^
+   |     ^^^^^^^^^^^^^-
+   |     |            |
+   |     |            help: use `_` to explicitly ignore each field
+   |     expected 2 fields, found 1
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/tuple_struct_destructure_fail.rs:34:5
@@ -57,16 +51,10 @@ LL |     SingleVariant(S, T)
    |     ------------------- tuple variant defined here
 ...
 LL |     Enum::SingleVariant(_) = Enum::SingleVariant(1, 2);
-   |     ^^^^^^^^^^^^^^^^^^^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |     Enum::SingleVariant(_, _) = Enum::SingleVariant(1, 2);
-   |                          ^^^
-help: use `..` to ignore all fields
-   |
-LL |     Enum::SingleVariant(..) = Enum::SingleVariant(1, 2);
-   |                         ^^
+   |     ^^^^^^^^^^^^^^^^^^^^^-
+   |     |                    |
+   |     |                    help: use `_` to explicitly ignore each field
+   |     expected 2 fields, found 1
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/tuple_struct_destructure_fail.rs:40:12

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -30,10 +30,12 @@ LL | struct TupleStruct<S, T>(S, T);
    | ------------------------------- tuple struct defined here
 ...
 LL |     TupleStruct(_) = TupleStruct(1, 2);
-   |     ^^^^^^^^^^^^^-
-   |     |            |
-   |     |            help: use `_` to explicitly ignore each field
-   |     expected 2 fields, found 1
+   |     ^^^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |     TupleStruct(_, _) = TupleStruct(1, 2);
+   |                  ^^^
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/tuple_struct_destructure_fail.rs:34:5
@@ -51,10 +53,12 @@ LL |     SingleVariant(S, T)
    |     ------------------- tuple variant defined here
 ...
 LL |     Enum::SingleVariant(_) = Enum::SingleVariant(1, 2);
-   |     ^^^^^^^^^^^^^^^^^^^^^-
-   |     |                    |
-   |     |                    help: use `_` to explicitly ignore each field
-   |     expected 2 fields, found 1
+   |     ^^^^^^^^^^^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |     Enum::SingleVariant(_, _) = Enum::SingleVariant(1, 2);
+   |                          ^^^
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/tuple_struct_destructure_fail.rs:40:12

--- a/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_struct_destructure_fail.stderr
@@ -38,8 +38,8 @@ LL |     TupleStruct(_, _) = TupleStruct(1, 2);
    |                  ^^^
 help: use `..` to ignore all unmentioned fields
    |
-LL |     TupleStruct(_, ..) = TupleStruct(1, 2);
-   |                  ^^^^
+LL |     TupleStruct(..) = TupleStruct(1, 2);
+   |                 ^^
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/tuple_struct_destructure_fail.rs:34:5
@@ -65,8 +65,8 @@ LL |     Enum::SingleVariant(_, _) = Enum::SingleVariant(1, 2);
    |                          ^^^
 help: use `..` to ignore all unmentioned fields
    |
-LL |     Enum::SingleVariant(_, ..) = Enum::SingleVariant(1, 2);
-   |                          ^^^^
+LL |     Enum::SingleVariant(..) = Enum::SingleVariant(1, 2);
+   |                         ^^
 
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/tuple_struct_destructure_fail.rs:40:12

--- a/src/test/ui/error-codes/E0023.stderr
+++ b/src/test/ui/error-codes/E0023.stderr
@@ -11,7 +11,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         Fruit::Apple(a, _) => {},
    |                       ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore the rest of the fields
    |
 LL |         Fruit::Apple(a, ..) => {},
    |                       ^^^^

--- a/src/test/ui/error-codes/E0023.stderr
+++ b/src/test/ui/error-codes/E0023.stderr
@@ -5,10 +5,12 @@ LL |     Apple(String, String),
    |     --------------------- tuple variant defined here
 ...
 LL |         Fruit::Apple(a) => {},
-   |         ^^^^^^^^^^^^^^-
-   |         |             |
-   |         |             help: use `_` to explicitly ignore each field
-   |         expected 2 fields, found 1
+   |         ^^^^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         Fruit::Apple(a, _) => {},
+   |                       ^^^
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/E0023.rs:12:9

--- a/src/test/ui/error-codes/E0023.stderr
+++ b/src/test/ui/error-codes/E0023.stderr
@@ -6,6 +6,15 @@ LL |     Apple(String, String),
 ...
 LL |         Fruit::Apple(a) => {},
    |         ^^^^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         Fruit::Apple(a, _) => {},
+   |                       ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         Fruit::Apple(a, ..) => {},
+   |                       ^^^^
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/E0023.rs:12:9

--- a/src/test/ui/error-codes/E0023.stderr
+++ b/src/test/ui/error-codes/E0023.stderr
@@ -5,16 +5,10 @@ LL |     Apple(String, String),
    |     --------------------- tuple variant defined here
 ...
 LL |         Fruit::Apple(a) => {},
-   |         ^^^^^^^^^^^^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |         Fruit::Apple(a, _) => {},
-   |                       ^^^
-help: use `..` to ignore the rest of the fields
-   |
-LL |         Fruit::Apple(a, ..) => {},
-   |                       ^^^^
+   |         ^^^^^^^^^^^^^^-
+   |         |             |
+   |         |             help: use `_` to explicitly ignore each field
+   |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 3 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/E0023.rs:12:9

--- a/src/test/ui/error-codes/E0023.stderr
+++ b/src/test/ui/error-codes/E0023.stderr
@@ -43,7 +43,7 @@ LL |     Orange((String, String)),
 LL |         Fruit::Orange(a, b) => {},
    |         ^^^^^^^^^^^^^^^^^^^ expected 1 field, found 2
    |
-help: missing parenthesis
+help: missing parentheses
    |
 LL |         Fruit::Orange((a, b)) => {},
    |                       ^    ^
@@ -57,7 +57,7 @@ LL |     Banana(()),
 LL |         Fruit::Banana() => {},
    |         ^^^^^^^^^^^^^^^ expected 1 field, found 0
    |
-help: missing parenthesis
+help: missing parentheses
    |
 LL |         Fruit::Banana(()) => {},
    |                      ^  ^

--- a/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
+++ b/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
@@ -16,10 +16,12 @@ LL | struct P<T>(T); // 1 type parameter wanted
    | --------------- tuple struct defined here
 ...
 LL |     let P() = U {};
-   |         ^^-
-   |         | |
-   |         | help: use `_` to explicitly ignore each field
-   |         expected 1 field, found 0
+   |         ^^^ expected 1 field, found 0
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |     let P(_) = U {};
+   |           ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
+++ b/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
@@ -16,16 +16,10 @@ LL | struct P<T>(T); // 1 type parameter wanted
    | --------------- tuple struct defined here
 ...
 LL |     let P() = U {};
-   |         ^^^ expected 1 field, found 0
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |     let P(_) = U {};
-   |           ^
-help: use `..` to ignore all fields
-   |
-LL |     let P(..) = U {};
-   |           ^^
+   |         ^^-
+   |         | |
+   |         | help: use `_` to explicitly ignore each field
+   |         expected 1 field, found 0
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
+++ b/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
@@ -22,6 +22,10 @@ help: use `_` to explicitly ignore each field
    |
 LL |     let P(_) = U {};
    |           ^
+help: use `..` to ignore all fields
+   |
+LL |     let P(..) = U {};
+   |           ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
+++ b/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
@@ -17,6 +17,15 @@ LL | struct P<T>(T); // 1 type parameter wanted
 ...
 LL |     let P() = U {};
    |         ^^^ expected 1 field, found 0
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |     let P(_) = U {};
+   |           ^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |     let P(..) = U {};
+   |           ^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
+++ b/src/test/ui/issues/issue-67037-pat-tup-scrut-ty-diff-less-fields.stderr
@@ -22,7 +22,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |     let P(_) = U {};
    |           ^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |     let P(..) = U {};
    |           ^^

--- a/src/test/ui/issues/issue-72574-2.stderr
+++ b/src/test/ui/issues/issue-72574-2.stderr
@@ -31,7 +31,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         Binder(_a, _x @ .., _) => {}
    |                           ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore the rest of the fields
    |
 LL |         Binder(_a, _x @ .., ..) => {}
    |                           ^^^^

--- a/src/test/ui/issues/issue-72574-2.stderr
+++ b/src/test/ui/issues/issue-72574-2.stderr
@@ -25,16 +25,10 @@ LL | struct Binder(i32, i32, i32);
    | ----------------------------- tuple struct defined here
 ...
 LL |         Binder(_a, _x @ ..) => {}
-   |         ^^^^^^^^^^^^^^^^^^^ expected 3 fields, found 2
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |         Binder(_a, _x @ .., _) => {}
-   |                           ^^^
-help: use `..` to ignore the rest of the fields
-   |
-LL |         Binder(_a, _x @ .., ..) => {}
-   |                           ^^^^
+   |         ^^^^^^^^^^^^^^^^^^-
+   |         |                 |
+   |         |                 help: use `_` to explicitly ignore each field
+   |         expected 3 fields, found 2
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-72574-2.stderr
+++ b/src/test/ui/issues/issue-72574-2.stderr
@@ -25,10 +25,12 @@ LL | struct Binder(i32, i32, i32);
    | ----------------------------- tuple struct defined here
 ...
 LL |         Binder(_a, _x @ ..) => {}
-   |         ^^^^^^^^^^^^^^^^^^-
-   |         |                 |
-   |         |                 help: use `_` to explicitly ignore each field
-   |         expected 3 fields, found 2
+   |         ^^^^^^^^^^^^^^^^^^^ expected 3 fields, found 2
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         Binder(_a, _x @ .., _) => {}
+   |                           ^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-72574-2.stderr
+++ b/src/test/ui/issues/issue-72574-2.stderr
@@ -26,6 +26,15 @@ LL | struct Binder(i32, i32, i32);
 ...
 LL |         Binder(_a, _x @ ..) => {}
    |         ^^^^^^^^^^^^^^^^^^^ expected 3 fields, found 2
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         Binder(_a, _x @ .., _) => {}
+   |                           ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         Binder(_a, _x @ .., ..) => {}
+   |                           ^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -11,7 +11,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |           Color::Rgb(_, _, _) => { }
    |                          ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |           Color::Rgb(..) => { }
    |                      ^^

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -6,6 +6,15 @@ LL |         Rgb(usize, usize, usize),
 ...
 LL |           Color::Rgb(_, _) => { }
    |           ^^^^^^^^^^^^^^^^ expected 3 fields, found 2
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |           Color::Rgb(_, _, _) => { }
+   |                          ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |           Color::Rgb(_, _, ..) => { }
+   |                          ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -5,16 +5,10 @@ LL |         Rgb(usize, usize, usize),
    |         ------------------------ tuple variant defined here
 ...
 LL |           Color::Rgb(_, _) => { }
-   |           ^^^^^^^^^^^^^^^^ expected 3 fields, found 2
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |           Color::Rgb(_, _, _) => { }
-   |                          ^^^
-help: use `..` to ignore all fields
-   |
-LL |           Color::Rgb(..) => { }
-   |                      ^^
+   |           ^^^^^^^^^^^^^^^-
+   |           |              |
+   |           |              help: use `_` to explicitly ignore each field
+   |           expected 3 fields, found 2
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -5,10 +5,12 @@ LL |         Rgb(usize, usize, usize),
    |         ------------------------ tuple variant defined here
 ...
 LL |           Color::Rgb(_, _) => { }
-   |           ^^^^^^^^^^^^^^^-
-   |           |              |
-   |           |              help: use `_` to explicitly ignore each field
-   |           expected 3 fields, found 2
+   |           ^^^^^^^^^^^^^^^^ expected 3 fields, found 2
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |           Color::Rgb(_, _, _) => { }
+   |                          ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -11,6 +11,10 @@ help: use `_` to explicitly ignore each field
    |
 LL |           Color::Rgb(_, _, _) => { }
    |                          ^^^
+help: use `..` to ignore all fields
+   |
+LL |           Color::Rgb(..) => { }
+   |                      ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-pattern-field-mismatch.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch.stderr
@@ -13,8 +13,8 @@ LL |           Color::Rgb(_, _, _) => { }
    |                          ^^^
 help: use `..` to ignore all unmentioned fields
    |
-LL |           Color::Rgb(_, _, ..) => { }
-   |                          ^^^^
+LL |           Color::Rgb(..) => { }
+   |                      ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/issue-74539.stderr
+++ b/src/test/ui/pattern/issue-74539.stderr
@@ -25,16 +25,10 @@ LL |     A(u8, u8),
    |     --------- tuple variant defined here
 ...
 LL |         E::A(x @ ..) => {
-   |         ^^^^^^^^^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |         E::A(x @ .., _) => {
-   |                    ^^^
-help: use `..` to ignore the rest of the fields
-   |
-LL |         E::A(x @ .., ..) => {
-   |                    ^^^^
+   |         ^^^^^^^^^^^-
+   |         |          |
+   |         |          help: use `_` to explicitly ignore each field
+   |         expected 2 fields, found 1
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/pattern/issue-74539.stderr
+++ b/src/test/ui/pattern/issue-74539.stderr
@@ -26,6 +26,15 @@ LL |     A(u8, u8),
 ...
 LL |         E::A(x @ ..) => {
    |         ^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         E::A(x @ .., _) => {
+   |                    ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         E::A(x @ .., ..) => {
+   |                    ^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/pattern/issue-74539.stderr
+++ b/src/test/ui/pattern/issue-74539.stderr
@@ -31,7 +31,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         E::A(x @ .., _) => {
    |                    ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore the rest of the fields
    |
 LL |         E::A(x @ .., ..) => {
    |                    ^^^^

--- a/src/test/ui/pattern/issue-74539.stderr
+++ b/src/test/ui/pattern/issue-74539.stderr
@@ -25,10 +25,12 @@ LL |     A(u8, u8),
    |     --------- tuple variant defined here
 ...
 LL |         E::A(x @ ..) => {
-   |         ^^^^^^^^^^^-
-   |         |          |
-   |         |          help: use `_` to explicitly ignore each field
-   |         expected 2 fields, found 1
+   |         ^^^^^^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         E::A(x @ .., _) => {
+   |                    ^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/pattern/pat-tuple-underfield.rs
+++ b/src/test/ui/pattern/pat-tuple-underfield.rs
@@ -14,6 +14,7 @@ fn main() {
         S(_) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
         //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all fields
     }
     match S(0, 1.0) {
         S() => {}
@@ -31,6 +32,7 @@ fn main() {
         E::S(_) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple variant has 2 fields
         //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all fields
     }
     match E::S(0, 1.0) {
         E::S() => {}

--- a/src/test/ui/pattern/pat-tuple-underfield.rs
+++ b/src/test/ui/pattern/pat-tuple-underfield.rs
@@ -1,0 +1,49 @@
+struct S(i32, f32);
+enum E {
+    S(i32, f32),
+}
+
+fn main() {
+    match S(0, 1.0) {
+        S(x) => {}
+        //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
+        //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all unmentioned fields
+    }
+    match S(0, 1.0) {
+        S(_) => {}
+        //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
+        //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all unmentioned fields
+    }
+    match S(0, 1.0) {
+        S() => {}
+        //~^ ERROR this pattern has 0 fields, but the corresponding tuple struct has 2 fields
+        //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all unmentioned fields
+    }
+
+    match E::S(0, 1.0) {
+        E::S(x) => {}
+        //~^ ERROR this pattern has 1 field, but the corresponding tuple variant has 2 fields
+        //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all unmentioned fields
+    }
+    match E::S(0, 1.0) {
+        E::S(_) => {}
+        //~^ ERROR this pattern has 1 field, but the corresponding tuple variant has 2 fields
+        //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all unmentioned fields
+    }
+    match E::S(0, 1.0) {
+        E::S() => {}
+        //~^ ERROR this pattern has 0 fields, but the corresponding tuple variant has 2 fields
+        //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore all unmentioned fields
+    }
+    match E::S(0, 1.0) {
+        E::S => {}
+        //~^ ERROR expected unit struct, unit variant or constant, found tuple variant `E::S`
+        //~| HELP use the tuple variant pattern syntax instead
+    }
+}

--- a/src/test/ui/pattern/pat-tuple-underfield.rs
+++ b/src/test/ui/pattern/pat-tuple-underfield.rs
@@ -8,38 +8,38 @@ fn main() {
         S(x) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all unmentioned fields
+        //~| HELP use `..` to ignore the rest of the fields
     }
     match S(0, 1.0) {
         S(_) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all unmentioned fields
+        //~| HELP use `..` to ignore all fields
     }
     match S(0, 1.0) {
         S() => {}
         //~^ ERROR this pattern has 0 fields, but the corresponding tuple struct has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all unmentioned fields
+        //~| HELP use `..` to ignore all fields
     }
 
     match E::S(0, 1.0) {
         E::S(x) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple variant has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all unmentioned fields
+        //~| HELP use `..` to ignore the rest of the fields
     }
     match E::S(0, 1.0) {
         E::S(_) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple variant has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all unmentioned fields
+        //~| HELP use `..` to ignore all fields
     }
     match E::S(0, 1.0) {
         E::S() => {}
         //~^ ERROR this pattern has 0 fields, but the corresponding tuple variant has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all unmentioned fields
+        //~| HELP use `..` to ignore all fields
     }
     match E::S(0, 1.0) {
         E::S => {}

--- a/src/test/ui/pattern/pat-tuple-underfield.rs
+++ b/src/test/ui/pattern/pat-tuple-underfield.rs
@@ -2,6 +2,7 @@ struct S(i32, f32);
 enum E {
     S(i32, f32),
 }
+struct Point4(i32, i32, i32, i32);
 
 fn main() {
     match S(0, 1.0) {
@@ -41,5 +42,12 @@ fn main() {
         E::S => {}
         //~^ ERROR expected unit struct, unit variant or constant, found tuple variant `E::S`
         //~| HELP use the tuple variant pattern syntax instead
+    }
+
+    match Point4(0, 1, 2, 3) {
+        Point4(   a   ,     _    ) => {}
+        //~^ ERROR this pattern has 2 fields, but the corresponding tuple struct has 4 fields
+        //~| HELP use `_` to explicitly ignore each field
+        //~| HELP use `..` to ignore the rest of the fields
     }
 }

--- a/src/test/ui/pattern/pat-tuple-underfield.rs
+++ b/src/test/ui/pattern/pat-tuple-underfield.rs
@@ -8,13 +8,11 @@ fn main() {
         S(x) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore the rest of the fields
     }
     match S(0, 1.0) {
         S(_) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple struct has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all fields
     }
     match S(0, 1.0) {
         S() => {}
@@ -27,13 +25,11 @@ fn main() {
         E::S(x) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple variant has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore the rest of the fields
     }
     match E::S(0, 1.0) {
         E::S(_) => {}
         //~^ ERROR this pattern has 1 field, but the corresponding tuple variant has 2 fields
         //~| HELP use `_` to explicitly ignore each field
-        //~| HELP use `..` to ignore all fields
     }
     match E::S(0, 1.0) {
         E::S() => {}

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -1,5 +1,5 @@
 error[E0532]: expected unit struct, unit variant or constant, found tuple variant `E::S`
-  --> $DIR/pat-tuple-underfield.rs:42:9
+  --> $DIR/pat-tuple-underfield.rs:44:9
    |
 LL |     S(i32, f32),
    |     ----------- `E::S` defined here
@@ -34,9 +34,13 @@ help: use `_` to explicitly ignore each field
    |
 LL |         S(_, _) => {}
    |            ^^^
+help: use `..` to ignore all fields
+   |
+LL |         S(..) => {}
+   |           ^^
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple struct has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:19:9
+  --> $DIR/pat-tuple-underfield.rs:20:9
    |
 LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
@@ -54,7 +58,7 @@ LL |         S(..) => {}
    |           ^^
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:26:9
+  --> $DIR/pat-tuple-underfield.rs:27:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
@@ -68,7 +72,7 @@ LL |         E::S(x, _) => {}
    |               ^^^
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:31:9
+  --> $DIR/pat-tuple-underfield.rs:32:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
@@ -80,9 +84,13 @@ help: use `_` to explicitly ignore each field
    |
 LL |         E::S(_, _) => {}
    |               ^^^
+help: use `..` to ignore all fields
+   |
+LL |         E::S(..) => {}
+   |              ^^
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:36:9
+  --> $DIR/pat-tuple-underfield.rs:38:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
@@ -100,7 +108,7 @@ LL |         E::S(..) => {}
    |              ^^
 
 error[E0023]: this pattern has 2 fields, but the corresponding tuple struct has 4 fields
-  --> $DIR/pat-tuple-underfield.rs:48:9
+  --> $DIR/pat-tuple-underfield.rs:50:9
    |
 LL | struct Point4(i32, i32, i32, i32);
    | ---------------------------------- tuple struct defined here

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -20,7 +20,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         S(x, _) => {}
    |            ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore the rest of the fields
    |
 LL |         S(x, ..) => {}
    |            ^^^^
@@ -38,7 +38,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         S(_, _) => {}
    |            ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |         S(..) => {}
    |           ^^
@@ -56,7 +56,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         S(_, _) => {}
    |           ^^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |         S(..) => {}
    |           ^^
@@ -74,7 +74,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         E::S(x, _) => {}
    |               ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore the rest of the fields
    |
 LL |         E::S(x, ..) => {}
    |               ^^^^
@@ -92,7 +92,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         E::S(_, _) => {}
    |               ^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |         E::S(..) => {}
    |              ^^
@@ -110,7 +110,7 @@ help: use `_` to explicitly ignore each field
    |
 LL |         E::S(_, _) => {}
    |              ^^^^
-help: use `..` to ignore all unmentioned fields
+help: use `..` to ignore all fields
    |
 LL |         E::S(..) => {}
    |              ^^

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -14,10 +14,12 @@ LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
 ...
 LL |         S(x) => {}
-   |         ^^^-
-   |         |  |
-   |         |  help: use `_` to explicitly ignore each field
-   |         expected 2 fields, found 1
+   |         ^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         S(x, _) => {}
+   |            ^^^
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
   --> $DIR/pat-tuple-underfield.rs:14:9
@@ -26,10 +28,12 @@ LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
 ...
 LL |         S(_) => {}
-   |         ^^^-
-   |         |  |
-   |         |  help: use `_` to explicitly ignore each field
-   |         expected 2 fields, found 1
+   |         ^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         S(_, _) => {}
+   |            ^^^
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple struct has 2 fields
   --> $DIR/pat-tuple-underfield.rs:19:9
@@ -56,10 +60,12 @@ LL |     S(i32, f32),
    |     ----------- tuple variant defined here
 ...
 LL |         E::S(x) => {}
-   |         ^^^^^^-
-   |         |     |
-   |         |     help: use `_` to explicitly ignore each field
-   |         expected 2 fields, found 1
+   |         ^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         E::S(x, _) => {}
+   |               ^^^
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
   --> $DIR/pat-tuple-underfield.rs:31:9
@@ -68,10 +74,12 @@ LL |     S(i32, f32),
    |     ----------- tuple variant defined here
 ...
 LL |         E::S(_) => {}
-   |         ^^^^^^-
-   |         |     |
-   |         |     help: use `_` to explicitly ignore each field
-   |         expected 2 fields, found 1
+   |         ^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         E::S(_, _) => {}
+   |               ^^^
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/pat-tuple-underfield.rs:36:9

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -1,0 +1,121 @@
+error[E0532]: expected unit struct, unit variant or constant, found tuple variant `E::S`
+  --> $DIR/pat-tuple-underfield.rs:45:9
+   |
+LL |     S(i32, f32),
+   |     ----------- `E::S` defined here
+...
+LL |         E::S => {}
+   |         ^^^^ help: use the tuple variant pattern syntax instead: `E::S(_, _)`
+
+error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
+  --> $DIR/pat-tuple-underfield.rs:8:9
+   |
+LL | struct S(i32, f32);
+   | ------------------- tuple struct defined here
+...
+LL |         S(x) => {}
+   |         ^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         S(x, _) => {}
+   |            ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         S(x, ..) => {}
+   |            ^^^^
+
+error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
+  --> $DIR/pat-tuple-underfield.rs:14:9
+   |
+LL | struct S(i32, f32);
+   | ------------------- tuple struct defined here
+...
+LL |         S(_) => {}
+   |         ^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         S(_, _) => {}
+   |            ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         S(_, ..) => {}
+   |            ^^^^
+
+error[E0023]: this pattern has 0 fields, but the corresponding tuple struct has 2 fields
+  --> $DIR/pat-tuple-underfield.rs:20:9
+   |
+LL | struct S(i32, f32);
+   | ------------------- tuple struct defined here
+...
+LL |         S() => {}
+   |         ^^^ expected 2 fields, found 0
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         S(_, _) => {}
+   |           ^^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         S(..) => {}
+   |           ^^
+
+error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
+  --> $DIR/pat-tuple-underfield.rs:27:9
+   |
+LL |     S(i32, f32),
+   |     ----------- tuple variant defined here
+...
+LL |         E::S(x) => {}
+   |         ^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         E::S(x, _) => {}
+   |               ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         E::S(x, ..) => {}
+   |               ^^^^
+
+error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
+  --> $DIR/pat-tuple-underfield.rs:33:9
+   |
+LL |     S(i32, f32),
+   |     ----------- tuple variant defined here
+...
+LL |         E::S(_) => {}
+   |         ^^^^^^^ expected 2 fields, found 1
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         E::S(_, _) => {}
+   |               ^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         E::S(_, ..) => {}
+   |               ^^^^
+
+error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has 2 fields
+  --> $DIR/pat-tuple-underfield.rs:39:9
+   |
+LL |     S(i32, f32),
+   |     ----------- tuple variant defined here
+...
+LL |         E::S() => {}
+   |         ^^^^^^ expected 2 fields, found 0
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         E::S(_, _) => {}
+   |              ^^^^
+help: use `..` to ignore all unmentioned fields
+   |
+LL |         E::S(..) => {}
+   |              ^^
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0023, E0532.
+For more information about an error, try `rustc --explain E0023`.

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -1,5 +1,5 @@
 error[E0532]: expected unit struct, unit variant or constant, found tuple variant `E::S`
-  --> $DIR/pat-tuple-underfield.rs:45:9
+  --> $DIR/pat-tuple-underfield.rs:41:9
    |
 LL |     S(i32, f32),
    |     ----------- `E::S` defined here
@@ -14,37 +14,25 @@ LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
 ...
 LL |         S(x) => {}
-   |         ^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |         S(x, _) => {}
-   |            ^^^
-help: use `..` to ignore the rest of the fields
-   |
-LL |         S(x, ..) => {}
-   |            ^^^^
+   |         ^^^-
+   |         |  |
+   |         |  help: use `_` to explicitly ignore each field
+   |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:14:9
+  --> $DIR/pat-tuple-underfield.rs:13:9
    |
 LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
 ...
 LL |         S(_) => {}
-   |         ^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |         S(_, _) => {}
-   |            ^^^
-help: use `..` to ignore all fields
-   |
-LL |         S(..) => {}
-   |           ^^
+   |         ^^^-
+   |         |  |
+   |         |  help: use `_` to explicitly ignore each field
+   |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple struct has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:20:9
+  --> $DIR/pat-tuple-underfield.rs:18:9
    |
 LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
@@ -62,43 +50,31 @@ LL |         S(..) => {}
    |           ^^
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:27:9
+  --> $DIR/pat-tuple-underfield.rs:25:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
 ...
 LL |         E::S(x) => {}
-   |         ^^^^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |         E::S(x, _) => {}
-   |               ^^^
-help: use `..` to ignore the rest of the fields
-   |
-LL |         E::S(x, ..) => {}
-   |               ^^^^
+   |         ^^^^^^-
+   |         |     |
+   |         |     help: use `_` to explicitly ignore each field
+   |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:33:9
+  --> $DIR/pat-tuple-underfield.rs:30:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
 ...
 LL |         E::S(_) => {}
-   |         ^^^^^^^ expected 2 fields, found 1
-   |
-help: use `_` to explicitly ignore each field
-   |
-LL |         E::S(_, _) => {}
-   |               ^^^
-help: use `..` to ignore all fields
-   |
-LL |         E::S(..) => {}
-   |              ^^
+   |         ^^^^^^-
+   |         |     |
+   |         |     help: use `_` to explicitly ignore each field
+   |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:39:9
+  --> $DIR/pat-tuple-underfield.rs:35:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -40,8 +40,8 @@ LL |         S(_, _) => {}
    |            ^^^
 help: use `..` to ignore all unmentioned fields
    |
-LL |         S(_, ..) => {}
-   |            ^^^^
+LL |         S(..) => {}
+   |           ^^
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple struct has 2 fields
   --> $DIR/pat-tuple-underfield.rs:20:9
@@ -94,8 +94,8 @@ LL |         E::S(_, _) => {}
    |               ^^^
 help: use `..` to ignore all unmentioned fields
    |
-LL |         E::S(_, ..) => {}
-   |               ^^^^
+LL |         E::S(..) => {}
+   |              ^^
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has 2 fields
   --> $DIR/pat-tuple-underfield.rs:39:9

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -1,5 +1,5 @@
 error[E0532]: expected unit struct, unit variant or constant, found tuple variant `E::S`
-  --> $DIR/pat-tuple-underfield.rs:41:9
+  --> $DIR/pat-tuple-underfield.rs:42:9
    |
 LL |     S(i32, f32),
    |     ----------- `E::S` defined here
@@ -8,7 +8,7 @@ LL |         E::S => {}
    |         ^^^^ help: use the tuple variant pattern syntax instead: `E::S(_, _)`
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:8:9
+  --> $DIR/pat-tuple-underfield.rs:9:9
    |
 LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
@@ -20,7 +20,7 @@ LL |         S(x) => {}
    |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:13:9
+  --> $DIR/pat-tuple-underfield.rs:14:9
    |
 LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
@@ -32,7 +32,7 @@ LL |         S(_) => {}
    |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple struct has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:18:9
+  --> $DIR/pat-tuple-underfield.rs:19:9
    |
 LL | struct S(i32, f32);
    | ------------------- tuple struct defined here
@@ -50,7 +50,7 @@ LL |         S(..) => {}
    |           ^^
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:25:9
+  --> $DIR/pat-tuple-underfield.rs:26:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
@@ -62,7 +62,7 @@ LL |         E::S(x) => {}
    |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:30:9
+  --> $DIR/pat-tuple-underfield.rs:31:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
@@ -74,7 +74,7 @@ LL |         E::S(_) => {}
    |         expected 2 fields, found 1
 
 error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has 2 fields
-  --> $DIR/pat-tuple-underfield.rs:35:9
+  --> $DIR/pat-tuple-underfield.rs:36:9
    |
 LL |     S(i32, f32),
    |     ----------- tuple variant defined here
@@ -91,7 +91,25 @@ help: use `..` to ignore all fields
 LL |         E::S(..) => {}
    |              ^^
 
-error: aborting due to 7 previous errors
+error[E0023]: this pattern has 2 fields, but the corresponding tuple struct has 4 fields
+  --> $DIR/pat-tuple-underfield.rs:48:9
+   |
+LL | struct Point4(i32, i32, i32, i32);
+   | ---------------------------------- tuple struct defined here
+...
+LL |         Point4(   a   ,     _    ) => {}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 4 fields, found 2
+   |
+help: use `_` to explicitly ignore each field
+   |
+LL |         Point4(   a   ,     _    , _, _) => {}
+   |                                  ^^^^^^
+help: use `..` to ignore the rest of the fields
+   |
+LL |         Point4(   a   ,     _    , ..) => {}
+   |                                  ^^^^
+
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0023, E0532.
 For more information about an error, try `rustc --explain E0023`.


### PR DESCRIPTION
Fixes #80010.
