### PR TITLE
impl AsMut<[T]> for vec::IntoIter<T>

### DIFF
--- a/library/alloc/src/vec.rs
+++ b/library/alloc/src/vec.rs
@@ -2665,6 +2665,13 @@ impl<T> AsRef<[T]> for IntoIter<T> {
     }
 }
 
+#[stable(feature = "vec_intoiter_as_mut", since = "1.50.0")]
+impl<T> AsMut<[T]> for IntoIter<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for IntoIter<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
Adds `impl<T> AsMut<[T]> for vec::IntoIter<T>`, exposing the same
behavior as `vec::IntoIter::as_mut_slice`, which has been stable since
1.15.0.

https://doc.rust-lang.org/std/vec/struct.IntoIter.html#method.as_mut_slice

See rust-lang/rust#72583, which added the `AsRef<[T]>` impl to
`vec::IntoIter`. Adding this symmetric API.

As a trait impl, this will be insta-stable.