### PR TITLE
Only derive PartialOrd::partial_cmp when also deriving PartialEq

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -4,7 +4,7 @@ use crate::deriving::path_std;
 
 use rustc_ast::ptr::P;
 use rustc_ast::{self as ast, Expr, GenericArg, Generics, ItemKind, MetaItem, VariantData};
-use rustc_expand::base::{Annotatable, ExtCtxt};
+use rustc_expand::base::{Annotatable, BuiltinDerive, ExtCtxt};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::Span;
 
@@ -37,7 +37,7 @@ pub fn expand_deriving_clone(
             ItemKind::Struct(_, Generics { ref params, .. })
             | ItemKind::Enum(_, Generics { ref params, .. }) => {
                 let container_id = cx.current_expansion.id.expn_data().parent;
-                if cx.resolver.has_derive_copy(container_id)
+                if cx.resolver.has_derive(container_id, BuiltinDerive::Copy)
                     && !params.iter().any(|param| match param.kind {
                         ast::GenericParamKind::Type { .. } => true,
                         _ => false,

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -186,7 +186,7 @@ use rustc_ast::{self as ast, BinOpKind, EnumDef, Expr, Generics, PatKind};
 use rustc_ast::{GenericArg, GenericParamKind, VariantData};
 use rustc_attr as attr;
 use rustc_data_structures::map_in_place::MapInPlace;
-use rustc_expand::base::{Annotatable, ExtCtxt};
+use rustc_expand::base::{Annotatable, BuiltinDerive, ExtCtxt};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::Span;
 
@@ -410,7 +410,8 @@ impl<'a> TraitDef<'a> {
                     _ => unreachable!(),
                 };
                 let container_id = cx.current_expansion.id.expn_data().parent;
-                let always_copy = has_no_type_params && cx.resolver.has_derive_copy(container_id);
+                let always_copy =
+                    has_no_type_params && cx.resolver.has_derive(container_id, BuiltinDerive::Copy);
                 let use_temporaries = is_packed && always_copy;
 
                 let newitem = match item.kind {

--- a/src/test/ui/derives/derives-span-Hash-enum.rs
+++ b/src/test/ui/derives/derives-span-Hash-enum.rs
@@ -1,5 +1,6 @@
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
+
 struct Error;
 
 #[derive(Hash)]

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Error: Hash` is not satisfied
-  --> $DIR/derives-span-Hash-enum.rs:8:6
+  --> $DIR/derives-span-Hash-enum.rs:9:6
    |
 LL |      Error
    |      ^^^^^ the trait `Hash` is not implemented for `Error`

--- a/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.rs
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.rs
@@ -6,11 +6,7 @@ struct Error;
 #[derive(PartialOrd,PartialEq)]
 enum Enum {
    A {
-     x: Error //~ ERROR can't compare `Error` with `Error`
-              //~| ERROR can't compare `Error` with `Error`
-              //~| ERROR can't compare `Error` with `Error`
-              //~| ERROR can't compare `Error` with `Error`
-              //~| ERROR can't compare `Error` with `Error`
+     x: Error //~ ERROR
    }
 }
 

--- a/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
@@ -8,46 +8,6 @@ LL |      x: Error
    = note: required by `std::cmp::PartialOrd::partial_cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum-struct-variant.rs:9:6
-   |
-LL |      x: Error
-   |      ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum-struct-variant.rs:9:6
-   |
-LL |      x: Error
-   |      ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum-struct-variant.rs:9:6
-   |
-LL |      x: Error
-   |      ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum-struct-variant.rs:9:6
-   |
-LL |      x: Error
-   |      ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 5 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/derives/derives-span-PartialOrd-enum.rs
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum.rs
@@ -6,11 +6,7 @@ struct Error;
 #[derive(PartialOrd,PartialEq)]
 enum Enum {
    A(
-     Error //~ ERROR can't compare `Error` with `Error`
-           //~| ERROR can't compare `Error` with `Error`
-           //~| ERROR can't compare `Error` with `Error`
-           //~| ERROR can't compare `Error` with `Error`
-           //~| ERROR can't compare `Error` with `Error`
+     Error //~ ERROR
      )
 }
 

--- a/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
@@ -8,46 +8,6 @@ LL |      Error
    = note: required by `std::cmp::PartialOrd::partial_cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum.rs:9:6
-   |
-LL |      Error
-   |      ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum.rs:9:6
-   |
-LL |      Error
-   |      ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum.rs:9:6
-   |
-LL |      Error
-   |      ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-enum.rs:9:6
-   |
-LL |      Error
-   |      ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 5 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/derives/derives-span-PartialOrd-struct.rs
+++ b/src/test/ui/derives/derives-span-PartialOrd-struct.rs
@@ -5,11 +5,7 @@ struct Error;
 
 #[derive(PartialOrd,PartialEq)]
 struct Struct {
-    x: Error //~ ERROR can't compare `Error` with `Error`
-             //~| ERROR can't compare `Error` with `Error`
-             //~| ERROR can't compare `Error` with `Error`
-             //~| ERROR can't compare `Error` with `Error`
-             //~| ERROR can't compare `Error` with `Error`
+    x: Error //~ ERROR
 }
 
 fn main() {}

--- a/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
@@ -8,46 +8,6 @@ LL |     x: Error
    = note: required by `std::cmp::PartialOrd::partial_cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-struct.rs:8:5
-   |
-LL |     x: Error
-   |     ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-struct.rs:8:5
-   |
-LL |     x: Error
-   |     ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-struct.rs:8:5
-   |
-LL |     x: Error
-   |     ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-struct.rs:8:5
-   |
-LL |     x: Error
-   |     ^^^^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 5 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.rs
+++ b/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.rs
@@ -5,11 +5,7 @@ struct Error;
 
 #[derive(PartialOrd,PartialEq)]
 struct Struct(
-    Error //~ ERROR can't compare `Error` with `Error`
-          //~| ERROR can't compare `Error` with `Error`
-          //~| ERROR can't compare `Error` with `Error`
-          //~| ERROR can't compare `Error` with `Error`
-          //~| ERROR can't compare `Error` with `Error`
+    Error //~ ERROR
 );
 
 fn main() {}

--- a/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
@@ -8,46 +8,6 @@ LL |     Error
    = note: required by `std::cmp::PartialOrd::partial_cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-tuple-struct.rs:8:5
-   |
-LL |     Error
-   |     ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-tuple-struct.rs:8:5
-   |
-LL |     Error
-   |     ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-tuple-struct.rs:8:5
-   |
-LL |     Error
-   |     ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Error` with `Error`
-  --> $DIR/derives-span-PartialOrd-tuple-struct.rs:8:5
-   |
-LL |     Error
-   |     ^^^^^ no implementation for `Error < Error` and `Error > Error`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Error`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 5 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-34229.rs
+++ b/src/test/ui/issues/issue-34229.rs
@@ -1,9 +1,7 @@
-#[derive(PartialEq)] struct Comparable;
-#[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
+#[derive(PartialEq)]
+struct Comparable;
+#[derive(PartialEq, PartialOrd)]
+struct Nope(Comparable);
 //~^ ERROR can't compare `Comparable`
-//~| ERROR can't compare `Comparable`
-//~| ERROR can't compare `Comparable`
-//~| ERROR can't compare `Comparable`
-//~| ERROR can't compare `Comparable`
 
 fn main() {}

--- a/src/test/ui/issues/issue-34229.stderr
+++ b/src/test/ui/issues/issue-34229.stderr
@@ -1,53 +1,13 @@
 error[E0277]: can't compare `Comparable` with `Comparable`
-  --> $DIR/issue-34229.rs:2:46
+  --> $DIR/issue-34229.rs:4:13
    |
-LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
-   |                                              ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Comparable`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Comparable` with `Comparable`
-  --> $DIR/issue-34229.rs:2:46
-   |
-LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
-   |                                              ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
+LL | struct Nope(Comparable);
+   |             ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
    |
    = help: the trait `PartialOrd` is not implemented for `Comparable`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: can't compare `Comparable` with `Comparable`
-  --> $DIR/issue-34229.rs:2:46
-   |
-LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
-   |                                              ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Comparable`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Comparable` with `Comparable`
-  --> $DIR/issue-34229.rs:2:46
-   |
-LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
-   |                                              ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Comparable`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `Comparable` with `Comparable`
-  --> $DIR/issue-34229.rs:2:46
-   |
-LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
-   |                                              ^^^^^^^^^^ no implementation for `Comparable < Comparable` and `Comparable > Comparable`
-   |
-   = help: the trait `PartialOrd` is not implemented for `Comparable`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 5 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/range/range_traits-1.rs
+++ b/src/test/ui/range/range_traits-1.rs
@@ -4,45 +4,21 @@ use std::ops::*;
 struct AllTheRanges {
     a: Range<usize>,
     //~^ ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
     //~| ERROR Ord
     b: RangeTo<usize>,
     //~^ ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
     //~| ERROR Ord
     c: RangeFrom<usize>,
     //~^ ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
     //~| ERROR Ord
     d: RangeFull,
     //~^ ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
     //~| ERROR Ord
     e: RangeInclusive<usize>,
     //~^ ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
     //~| ERROR Ord
     f: RangeToInclusive<usize>,
     //~^ ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
-    //~| ERROR can't compare
     //~| ERROR Ord
 }
 

--- a/src/test/ui/range/range_traits-1.stderr
+++ b/src/test/ui/range/range_traits-1.stderr
@@ -9,7 +9,7 @@ LL |     a: Range<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
-  --> $DIR/range_traits-1.rs:12:5
+  --> $DIR/range_traits-1.rs:8:5
    |
 LL |     b: RangeTo<usize>,
    |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
@@ -19,7 +19,7 @@ LL |     b: RangeTo<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
-  --> $DIR/range_traits-1.rs:19:5
+  --> $DIR/range_traits-1.rs:11:5
    |
 LL |     c: RangeFrom<usize>,
    |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
@@ -29,7 +29,7 @@ LL |     c: RangeFrom<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
-  --> $DIR/range_traits-1.rs:26:5
+  --> $DIR/range_traits-1.rs:14:5
    |
 LL |     d: RangeFull,
    |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
@@ -39,7 +39,7 @@ LL |     d: RangeFull,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
-  --> $DIR/range_traits-1.rs:33:5
+  --> $DIR/range_traits-1.rs:17:5
    |
 LL |     e: RangeInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
@@ -49,247 +49,7 @@ LL |     e: RangeInclusive<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
-  --> $DIR/range_traits-1.rs:40:5
-   |
-LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize>`
-  --> $DIR/range_traits-1.rs:5:5
-   |
-LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
-  --> $DIR/range_traits-1.rs:12:5
-   |
-LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
-  --> $DIR/range_traits-1.rs:19:5
-   |
-LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
-  --> $DIR/range_traits-1.rs:26:5
-   |
-LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
-  --> $DIR/range_traits-1.rs:33:5
-   |
-LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
-  --> $DIR/range_traits-1.rs:40:5
-   |
-LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize>`
-  --> $DIR/range_traits-1.rs:5:5
-   |
-LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
-  --> $DIR/range_traits-1.rs:12:5
-   |
-LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
-  --> $DIR/range_traits-1.rs:19:5
-   |
-LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
-  --> $DIR/range_traits-1.rs:26:5
-   |
-LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
-  --> $DIR/range_traits-1.rs:33:5
-   |
-LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
-  --> $DIR/range_traits-1.rs:40:5
-   |
-LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize>`
-  --> $DIR/range_traits-1.rs:5:5
-   |
-LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
-  --> $DIR/range_traits-1.rs:12:5
-   |
-LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
-  --> $DIR/range_traits-1.rs:19:5
-   |
-LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
-  --> $DIR/range_traits-1.rs:26:5
-   |
-LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
-  --> $DIR/range_traits-1.rs:33:5
-   |
-LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
-  --> $DIR/range_traits-1.rs:40:5
-   |
-LL |     f: RangeToInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::Range<usize>` with `std::ops::Range<usize>`
-  --> $DIR/range_traits-1.rs:5:5
-   |
-LL |     a: Range<usize>,
-   |     ^^^^^^^^^^^^^^^ no implementation for `std::ops::Range<usize> < std::ops::Range<usize>` and `std::ops::Range<usize> > std::ops::Range<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
-  --> $DIR/range_traits-1.rs:12:5
-   |
-LL |     b: RangeTo<usize>,
-   |     ^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeTo<usize> < std::ops::RangeTo<usize>` and `std::ops::RangeTo<usize> > std::ops::RangeTo<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
-  --> $DIR/range_traits-1.rs:19:5
-   |
-LL |     c: RangeFrom<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeFrom<usize> < std::ops::RangeFrom<usize>` and `std::ops::RangeFrom<usize> > std::ops::RangeFrom<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
-  --> $DIR/range_traits-1.rs:26:5
-   |
-LL |     d: RangeFull,
-   |     ^^^^^^^^^^^^ no implementation for `std::ops::RangeFull < std::ops::RangeFull` and `std::ops::RangeFull > std::ops::RangeFull`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
-  --> $DIR/range_traits-1.rs:33:5
-   |
-LL |     e: RangeInclusive<usize>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeInclusive<usize> < std::ops::RangeInclusive<usize>` and `std::ops::RangeInclusive<usize> > std::ops::RangeInclusive<usize>`
-   |
-   = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
-   = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
-  --> $DIR/range_traits-1.rs:40:5
+  --> $DIR/range_traits-1.rs:20:5
    |
 LL |     f: RangeToInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `std::ops::RangeToInclusive<usize> < std::ops::RangeToInclusive<usize>` and `std::ops::RangeToInclusive<usize> > std::ops::RangeToInclusive<usize>`
@@ -308,7 +68,7 @@ LL |     a: Range<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeTo<usize>: Ord` is not satisfied
-  --> $DIR/range_traits-1.rs:12:5
+  --> $DIR/range_traits-1.rs:8:5
    |
 LL |     b: RangeTo<usize>,
    |     ^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeTo<usize>`
@@ -317,7 +77,7 @@ LL |     b: RangeTo<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFrom<usize>: Ord` is not satisfied
-  --> $DIR/range_traits-1.rs:19:5
+  --> $DIR/range_traits-1.rs:11:5
    |
 LL |     c: RangeFrom<usize>,
    |     ^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFrom<usize>`
@@ -326,7 +86,7 @@ LL |     c: RangeFrom<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFull: Ord` is not satisfied
-  --> $DIR/range_traits-1.rs:26:5
+  --> $DIR/range_traits-1.rs:14:5
    |
 LL |     d: RangeFull,
    |     ^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFull`
@@ -335,7 +95,7 @@ LL |     d: RangeFull,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeInclusive<usize>: Ord` is not satisfied
-  --> $DIR/range_traits-1.rs:33:5
+  --> $DIR/range_traits-1.rs:17:5
    |
 LL |     e: RangeInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeInclusive<usize>`
@@ -344,7 +104,7 @@ LL |     e: RangeInclusive<usize>,
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeToInclusive<usize>: Ord` is not satisfied
-  --> $DIR/range_traits-1.rs:40:5
+  --> $DIR/range_traits-1.rs:20:5
    |
 LL |     f: RangeToInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeToInclusive<usize>`
@@ -352,6 +112,6 @@ LL |     f: RangeToInclusive<usize>,
    = note: required by `std::cmp::Ord::cmp`
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 36 previous errors
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This adds the ability to tell whether the user is deriving `PartialEq` and if so only derives `partial_cmp` when deriving `PartialOrd`. This builds on previous special casing of built-in derive macros which change how deriving `Clone` is handled when the user is also deriving `Copy`. Because the full implementation of `PartialOrd` is expensive to compile, this leaner `PartialOrd` might see some perf gains in code bases that derive `PartialOrd` a lot. For instance, this increases the derive perf benchmark from rustc-perf by ~45% on my machine.

This has the aided side effect of making some diagnostics a little less noisy. 

r? @petrochenkov  