### PR TITLE
Add `&mut` as an alias for 'reference' primitive

### DIFF
--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -920,6 +920,7 @@ mod prim_usize {}
 
 #[doc(primitive = "reference")]
 #[doc(alias = "&")]
+#[doc(alias = "&mut")]
 //
 /// References, both shared and mutable.
 ///


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/46075.