### PR TITLE
Add more timing info to rustdoc

### DIFF
--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -551,10 +551,13 @@ crate fn get_auto_trait_and_blanket_impls(
     ty: Ty<'tcx>,
     param_env_def_id: DefId,
 ) -> impl Iterator<Item = Item> {
-    AutoTraitFinder::new(cx)
-        .get_auto_trait_impls(ty, param_env_def_id)
-        .into_iter()
-        .chain(BlanketImplFinder::new(cx).get_blanket_impls(ty, param_env_def_id))
+    let auto_impls = cx.sess().time("get_auto_trait_impls", || {
+        AutoTraitFinder::new(cx).get_auto_trait_impls(ty, param_env_def_id)
+    });
+    let blanket_impls = cx.sess().time("get_blanket_impls", || {
+        BlanketImplFinder::new(cx).get_blanket_impls(ty, param_env_def_id)
+    });
+    auto_impls.into_iter().chain(blanket_impls)
 }
 
 crate fn register_res(cx: &DocContext<'_>, res: Res) -> DefId {


### PR DESCRIPTION
This helped me confirm in https://github.com/rust-lang/rust/issues/79103#issuecomment-745737864 that get_blanket_impls is indeed what's taking all the time on stm32.

r? @Mark-Simulacrum 