### PR TITLE
[RFC] Add --output-location option to the test runner

### DIFF
--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -46,6 +46,7 @@ impl TestOpts {
             nocapture: false,
             color: AutoColor,
             format: OutputFormat::Pretty,
+            output_location: None,
             test_threads: None,
             skip: vec![],
             time_options: None,

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -467,6 +467,7 @@ pub fn test_opts(config: &Config) -> test::TestOpts {
         filter_exact: config.filter_exact,
         run_ignored: if config.run_ignored { test::RunIgnored::Yes } else { test::RunIgnored::No },
         format: if config.quiet { test::OutputFormat::Terse } else { test::OutputFormat::Pretty },
+        output_location: None,
         logfile: config.logfile.clone(),
         run_tests: true,
         bench_benchmarks: true,


### PR DESCRIPTION
This unstable option allows the user to specify the location to which
the test output should be written. By "test output" I mean

    running 1 test
    test it_works ... ok
    [...]

Before this commit, this output was always written to stdout. If the
user used the --nocapture flag, this output would get mixed with the
test's own stdout. Even without --nocapture, some programs write
straight to /dev/stdout, bypassing the capture functionality.

IDEs want to parse the test output (usually with --format=json) to
display it in a structured form. This new option enhances the interface
between IDEs and the test runner in two ways:

1) IDEs can rely on the output being purely the output of the test
   runner.
2) IDEs can use the --nocapture flag to allow test output to become
   visible immediately.

In this case, the output location is likely going to be a named pipe or
similar.