### PR TITLE
Fix failing build of std on armv5te-unknown-linux-uclibceabi due to missing cmsg_len_zero

### DIFF
--- a/library/std/src/sys/unix/ext/net/ancillary.rs
+++ b/library/std/src/sys/unix/ext/net/ancillary.rs
@@ -360,7 +360,11 @@ impl<'a> AncillaryData<'a> {
     fn try_from_cmsghdr(cmsg: &'a libc::cmsghdr) -> Result<Self, AncillaryError> {
         unsafe {
             cfg_if::cfg_if! {
-                if #[cfg(any(target_os = "android", all(target_os = "linux", target_env = "gnu")))] {
+                if #[cfg(any(
+                        target_os = "android",
+                        all(target_os = "linux", target_env = "gnu"),
+                        all(target_os = "linux", target_env = "uclibc"),
+                   ))] {
                     let cmsg_len_zero = libc::CMSG_LEN(0) as libc::size_t;
                 } else if #[cfg(any(
                               target_os = "dragonfly",


### PR DESCRIPTION
I'm getting the following error when trying to build `std` on `armv5te-unknown-linux-uclibceabi`:

```
error[E0425]: cannot find value `cmsg_len_zero` in this scope
   --> /home/operutka/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/ext/net/ancillary.rs:376:47
    |
376 |             let data_len = (*cmsg).cmsg_len - cmsg_len_zero;
    |                                               ^^^^^^^^^^^^^ not found in this scope
```

Obviously, this branch:
```rust
cfg_if::cfg_if! {
    if #[cfg(any(target_os = "android", all(target_os = "linux", target_env = "gnu")))] {
        let cmsg_len_zero = libc::CMSG_LEN(0) as libc::size_t;
    } else if #[cfg(any(
                  target_os = "dragonfly",
                  target_os = "emscripten",
                  target_os = "freebsd",
                  all(target_os = "linux", target_env = "musl",),
                  target_os = "netbsd",
                  target_os = "openbsd",
              ))] {
        let cmsg_len_zero = libc::CMSG_LEN(0) as libc::socklen_t;
    }
}
```

does not cover the case `all(target_os = "linux", target_env = "uclibc")`.