### PR TITLE
Add `popcount` and `popcnt` as doc aliases for `count_ones` methods.

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -92,6 +92,8 @@ $EndFeature, "
 "),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_stable(feature = "const_int_methods", since = "1.32.0")]
+            #[doc(alias = "popcount")]
+            #[doc(alias = "popcnt")]
             #[inline]
             pub const fn count_ones(self) -> u32 { (self as $UnsignedT).count_ones() }
         }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -90,6 +90,8 @@ assert_eq!(n.count_ones(), 3);", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
+            #[doc(alias = "popcount")]
+            #[doc(alias = "popcnt")]
             #[inline]
             pub const fn count_ones(self) -> u32 {
                 intrinsics::ctpop(self as $ActualT) as u32

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -453,6 +453,8 @@ let n = Wrapping(0b01001100", stringify!($t), ");
 assert_eq!(n.count_ones(), 3);
 ```"),
                 #[inline]
+                #[doc(alias = "popcount")]
+                #[doc(alias = "popcnt")]
                 #[unstable(feature = "wrapping_int_impl", issue = "32463")]
                 pub const fn count_ones(self) -> u32 {
                     self.0.count_ones()


### PR DESCRIPTION
Integer types have a `count_ones` method that end up calling `intrinsics::ctpop`. On some architectures, that intrinsic is translated as a corresponding CPU instruction know as "popcount" or "popcnt".

This PR makes it so that searching for those names in rustdoc shows those methods.

CC https://blog.rust-lang.org/2020/11/19/Rust-1.48.html#adding-search-aliases