### PR TITLE
Revert change to trait evaluation order

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -336,7 +336,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     fn vtable_impl(
         &mut self,
         impl_def_id: DefId,
-        mut substs: Normalized<'tcx, SubstsRef<'tcx>>,
+        substs: Normalized<'tcx, SubstsRef<'tcx>>,
         cause: ObligationCause<'tcx>,
         recursion_depth: usize,
         param_env: ty::ParamEnv<'tcx>,
@@ -358,9 +358,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // relying on projections in the impl-trait-ref.
         //
         // e.g., `impl<U: Tr, V: Iterator<Item=U>> Foo<<U as Tr>::T> for V`
-        substs.obligations.append(&mut impl_obligations);
+        impl_obligations.extend(substs.obligations);
 
-        ImplSourceUserDefinedData { impl_def_id, substs: substs.value, nested: substs.obligations }
+        ImplSourceUserDefinedData { impl_def_id, substs: substs.value, nested: impl_obligations }
     }
 
     fn confirm_object_candidate(

--- a/src/test/ui/traits/impl-evaluation-order.rs
+++ b/src/test/ui/traits/impl-evaluation-order.rs
@@ -1,0 +1,39 @@
+// Regression test for #79902
+
+// Check that evaluation (which is used to determine whether to copy a type in
+// MIR building) evaluates bounds from normalizing an impl after evaluating
+// any bounds on the impl.
+
+// check-pass
+
+trait A {
+    type B;
+}
+trait M {}
+
+struct G<T, U>(*const T, *const U);
+
+impl<T, U> Clone for G<T, U> {
+    fn clone(&self) -> Self {
+        G { ..*self }
+    }
+}
+
+impl<T, U> Copy for G<T, U::B>
+where
+    T: A<B = U>,
+    U: A,
+{
+}
+
+impl A for () {
+    type B = ();
+}
+
+fn is_m<T: M>(_: T) {}
+
+fn main() {
+    let x = G(&(), &());
+    drop(x);
+    drop(x);
+}


### PR DESCRIPTION
This change breaks some code and doesn't appear to enable any new code.

closes #79902

r? @nikomatsakis 