### PR TITLE
Add missing punctuation to std::alloc docs

### DIFF
--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -1,4 +1,4 @@
-//! Memory allocation APIs
+//! Memory allocation APIs.
 //!
 //! In a given program, the standard library has one “global” memory allocator
 //! that is used for example by `Box<T>` and `Vec<T>`.


### PR DESCRIPTION
Add a period to first line of module docs to match other modules in std.