### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -620,7 +620,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
             }
         };
     }
-    gate_all!(if_let_guard, "`if let` guard is not implemented");
+    gate_all!(if_let_guard, "`if let` guards are experimental");
     gate_all!(let_chains, "`let` expressions in this position are experimental");
     gate_all!(async_closure, "async closures are unstable");
     gate_all!(generators, "yield syntax is experimental");

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -27,6 +27,8 @@ impl<'a> Parser<'a> {
                 token.can_begin_expr()
                 // This exception is here for backwards compatibility.
                 && !token.is_keyword(kw::Let)
+                // This exception is here for backwards compatibility.
+                && !token.is_keyword(kw::Const)
             }
             NonterminalKind::Ty => token.can_begin_type(),
             NonterminalKind::Ident => get_macro_ident(token).is_some(),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1632,7 +1632,7 @@ impl Symbol {
         self == kw::True || self == kw::False
     }
 
-    /// This symbol can be a raw identifier.
+    /// Returns `true` if this symbol can be a raw identifier.
     pub fn can_be_raw(self) -> bool {
         self != kw::Invalid && self != kw::Underscore && !self.is_path_segment_keyword()
     }

--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -270,7 +270,7 @@ fn adt_destructor(tcx: TyCtxt<'_>, def_id: DefId) -> Option<ty::Destructor> {
 
 /// If this `DefId` is a "primary tables entry", returns
 /// `Some((body_id, header, decl))` with information about
-/// it's body-id, fn-header and fn-decl (if any). Otherwise,
+/// its body-id, fn-header and fn-decl (if any). Otherwise,
 /// returns `None`.
 ///
 /// If this function returns `Some`, then `typeck_results(def_id)` will

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -250,14 +250,19 @@ fn uninit_write_slice_cloned_mid_panic() {
 
 #[test]
 fn uninit_write_slice_cloned_no_drop() {
-    let rc = Rc::new(());
+    #[derive(Clone)]
+    struct Bomb;
+
+    impl Drop for Bomb {
+        fn drop(&mut self) {
+            panic!("dropped a bomb! kaboom")
+        }
+    }
 
     let mut dst = [MaybeUninit::uninit()];
-    let src = [rc.clone()];
+    let src = [Bomb];
 
     MaybeUninit::write_slice_cloned(&mut dst, &src);
 
-    drop(src);
-
-    assert_eq!(Rc::strong_count(&rc), 2);
+    forget(src);
 }

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -1,4 +1,4 @@
-//! Memory allocation APIs
+//! Memory allocation APIs.
 //!
 //! In a given program, the standard library has one “global” memory allocator
 //! that is used for example by `Box<T>` and `Vec<T>`.

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -26,38 +26,37 @@
 //! # Prelude contents
 //!
 //! The current version of the prelude (version 1) lives in
-//! [`std::prelude::v1`], and re-exports the following.
+//! [`std::prelude::v1`], and re-exports the following:
 //!
-//! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`], [`Unpin`]}. The
-//!   marker traits indicate fundamental properties of types.
-//! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}. Various
+//! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`], [`Unpin`]},
+//!   marker traits that indicate fundamental properties of types.
+//! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}, various
 //!   operations for both destructors and overloading `()`.
 //! * [`std::mem`]::[`drop`][`mem::drop`], a convenience function for explicitly
 //!   dropping a value.
 //! * [`std::boxed`]::[`Box`], a way to allocate values on the heap.
-//! * [`std::borrow`]::[`ToOwned`], The conversion trait that defines
+//! * [`std::borrow`]::[`ToOwned`], the conversion trait that defines
 //!   [`to_owned`], the generic method for creating an owned type from a
 //!   borrowed type.
 //! * [`std::clone`]::[`Clone`], the ubiquitous trait that defines
 //!   [`clone`][`Clone::clone`], the method for producing a copy of a value.
-//! * [`std::cmp`]::{[`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`] }. The
+//! * [`std::cmp`]::{[`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`] }, the
 //!   comparison traits, which implement the comparison operators and are often
 //!   seen in trait bounds.
-//! * [`std::convert`]::{[`AsRef`], [`AsMut`], [`Into`], [`From`]}. Generic
+//! * [`std::convert`]::{[`AsRef`], [`AsMut`], [`Into`], [`From`]}, generic
 //!   conversions, used by savvy API authors to create overloaded methods.
 //! * [`std::default`]::[`Default`], types that have default values.
-//! * [`std::iter`]::{[`Iterator`], [`Extend`], [`IntoIterator`],
-//!   [`DoubleEndedIterator`], [`ExactSizeIterator`]}. Iterators of various
+//! * [`std::iter`]::{[`Iterator`], [`Extend`], [`IntoIterator`]
+//!   [`DoubleEndedIterator`], [`ExactSizeIterator`]}, iterators of various
 //!   kinds.
-//! * [`std::option`]::[`Option`]::{[`self`][`Option`], [`Some`], [`None`]}. A
+//! * [`std::option`]::[`Option`]::{[`self`][`Option`], [`Some`], [`None`]}, a
 //!   type which expresses the presence or absence of a value. This type is so
 //!   commonly used, its variants are also exported.
-//! * [`std::result`]::[`Result`]::{[`self`][`Result`], [`Ok`], [`Err`]}. A type
+//! * [`std::result`]::[`Result`]::{[`self`][`Result`], [`Ok`], [`Err`]}, a type
 //!   for functions that may succeed or fail. Like [`Option`], its variants are
 //!   exported as well.
 //! * [`std::string`]::{[`String`], [`ToString`]}, heap allocated strings.
-//! * [`std::vec`]::[`Vec`], a growable, heap-allocated
-//!   vector.
+//! * [`std::vec`]::[`Vec`], a growable, heap-allocated vector.
 //!
 //! [`mem::drop`]: crate::mem::drop
 //! [`std::borrow`]: crate::borrow

--- a/src/test/ui/inline-const/macro-with-const.rs
+++ b/src/test/ui/inline-const/macro-with-const.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+macro_rules! exp {
+    (const $n:expr) => {
+        $n
+    };
+}
+
+macro_rules! stmt {
+    (exp $e:expr) => {
+        $e
+    };
+    (exp $($t:tt)+) => {
+        exp!($($t)+)
+    };
+}
+
+fn main() {
+    stmt!(exp const 1);
+}

--- a/src/test/ui/rfc-2294-if-let-guard/feature-gate.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/feature-gate.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 fn _if_let_guard() {
     match () {
         () if let 0 = 1 => {}
-        //~^ ERROR `if let` guard is not implemented
+        //~^ ERROR `if let` guards are experimental
 
         () if (let 0 = 1) => {}
         //~^ ERROR `let` expressions in this position are experimental
@@ -74,7 +74,7 @@ fn _macros() {
     match () {
         #[cfg(FALSE)]
         () if let 0 = 1 => {}
-        //~^ ERROR `if let` guard is not implemented
+        //~^ ERROR `if let` guards are experimental
         _ => {}
     }
     use_expr!(let 0 = 1);

--- a/src/test/ui/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/feature-gate.stderr
@@ -7,7 +7,7 @@ LL |     macro_rules! use_expr {
 LL |     use_expr!(let 0 = 1);
    |               ^^^ no rules expected this token in macro call
 
-error[E0658]: `if let` guard is not implemented
+error[E0658]: `if let` guards are experimental
   --> $DIR/feature-gate.rs:7:12
    |
 LL |         () if let 0 = 1 => {}
@@ -16,7 +16,7 @@ LL |         () if let 0 = 1 => {}
    = note: see issue #51114 <https://github.com/rust-lang/rust/issues/51114> for more information
    = help: add `#![feature(if_let_guard)]` to the crate attributes to enable
 
-error[E0658]: `if let` guard is not implemented
+error[E0658]: `if let` guards are experimental
   --> $DIR/feature-gate.rs:76:12
    |
 LL |         () if let 0 = 1 => {}


### PR DESCRIPTION
Successful merges:

 - #80121 (Change the message for `if_let_guard` feature gate)
 - #80123 (Fix memory leak in test "mem::uninit_write_slice_cloned_no_drop")
 - #80130 (docs: Edit rustc_span::symbol::Symbol method)
 - #80135 (Don't allow `const` to begin a nonterminal)
 - #80145 (Fix typo in rustc_typeck docs)
 - #80146 (Edit formatting in Rust Prelude docs)
 - #80147 (Add missing punctuation to std::alloc docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=80121,80123,80130,80135,80145,80146,80147)
<!-- homu-ignore:end -->