### PR TITLE
Convert primitives in the standard library to intra-doc links

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -103,6 +103,11 @@
 #![feature(fundamental)]
 #![feature(inplace_iteration)]
 #![feature(int_bits_const)]
+// Technically, this is a bug in rustdoc: rustdoc sees the documentation on `#[lang = slice_alloc]`
+// blocks is for `&[T]`, which also has documentation using this feature in `core`, and gets mad
+// that the feature-gate isn't enabled. Ideally, it wouldn't check for the feature gate for docs
+// from other crates, but since this can only appear for lang items, it doesn't seem worth fixing.
+#![feature(intra_doc_pointers)]
 #![feature(lang_items)]
 #![feature(layout_for_ptr)]
 #![feature(maybe_uninit_ref)]

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -1,6 +1,6 @@
 //! A dynamically-sized view into a contiguous sequence, `[T]`.
 //!
-//! *[See also the slice primitive type](../../std/primitive.slice.html).*
+//! *[See also the slice primitive type](slice).*
 //!
 //! Slices are a view into a block of memory represented as a pointer and a
 //! length.
@@ -71,12 +71,12 @@
 //!   [`.chunks`], [`.windows`] and more.
 //!
 //! [`Hash`]: core::hash::Hash
-//! [`.iter`]: ../../std/primitive.slice.html#method.iter
-//! [`.iter_mut`]: ../../std/primitive.slice.html#method.iter_mut
-//! [`.split`]: ../../std/primitive.slice.html#method.split
-//! [`.splitn`]: ../../std/primitive.slice.html#method.splitn
-//! [`.chunks`]: ../../std/primitive.slice.html#method.chunks
-//! [`.windows`]: ../../std/primitive.slice.html#method.windows
+//! [`.iter`]: slice::iter
+//! [`.iter_mut`]: slice::iter_mut
+//! [`.split`]: slice::split
+//! [`.splitn`]: slice::splitn
+//! [`.chunks`]: slice::chunks
+//! [`.windows`]: slice::windows
 #![stable(feature = "rust1", since = "1.0.0")]
 // Many of the usings in this module are only used in the test configuration.
 // It's cleaner to just turn off the unused_imports warning than to fix them.
@@ -673,7 +673,7 @@ impl [u8] {
 // Extension traits for slices over specific kinds of data
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Helper trait for [`[T]::concat`](../../std/primitive.slice.html#method.concat).
+/// Helper trait for [`[T]::concat`](slice::concat).
 ///
 /// Note: the `Item` type parameter is not used in this trait,
 /// but it allows impls to be more generic.
@@ -708,19 +708,19 @@ pub trait Concat<Item: ?Sized> {
     /// The resulting type after concatenation
     type Output;
 
-    /// Implementation of [`[T]::concat`](../../std/primitive.slice.html#method.concat)
+    /// Implementation of [`[T]::concat`](slice::concat)
     #[unstable(feature = "slice_concat_trait", issue = "27747")]
     fn concat(slice: &Self) -> Self::Output;
 }
 
-/// Helper trait for [`[T]::join`](../../std/primitive.slice.html#method.join)
+/// Helper trait for [`[T]::join`](slice::join)
 #[unstable(feature = "slice_concat_trait", issue = "27747")]
 pub trait Join<Separator> {
     #[unstable(feature = "slice_concat_trait", issue = "27747")]
     /// The resulting type after concatenation
     type Output;
 
-    /// Implementation of [`[T]::join`](../../std/primitive.slice.html#method.join)
+    /// Implementation of [`[T]::join`](slice::join)
     #[unstable(feature = "slice_concat_trait", issue = "27747")]
     fn join(slice: &Self, sep: Separator) -> Self::Output;
 }

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -1,6 +1,6 @@
 //! Unicode string slices.
 //!
-//! *[See also the `str` primitive type](../../std/primitive.str.html).*
+//! *[See also the `str` primitive type](str).*
 //!
 //! The `&str` type is one of the two main string types, the other being `String`.
 //! Unlike its `String` counterpart, its contents are borrowed.

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -495,7 +495,7 @@ impl String {
     /// `from_utf8_lossy()` will replace any invalid UTF-8 sequences with
     /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD], which looks like this: �
     ///
-    /// [byteslice]: ../../std/primitive.slice.html
+    /// [byteslice]: prim@slice
     /// [U+FFFD]: core::char::REPLACEMENT_CHARACTER
     ///
     /// If you are sure that the byte slice is valid UTF-8, and you don't want

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -216,7 +216,7 @@ mod spec_extend;
 /// # Slicing
 ///
 /// A `Vec` can be mutable. Slices, on the other hand, are read-only objects.
-/// To get a [slice], use [`&`]. Example:
+/// To get a [slice][prim@slice], use [`&`]. Example:
 ///
 /// ```
 /// fn read_slice(slice: &[usize]) {
@@ -369,8 +369,6 @@ mod spec_extend;
 /// [`reserve`]: Vec::reserve
 /// [`MaybeUninit`]: core::mem::MaybeUninit
 /// [owned slice]: Box
-/// [slice]: ../../std/primitive.slice.html
-/// [`&`]: ../../std/primitive.reference.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "vec_type")]
 pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
@@ -2517,7 +2515,7 @@ impl<T, A: Allocator> Vec<T, A> {
 /// This implementation is specialized for slice iterators, where it uses [`copy_from_slice`] to
 /// append the entire slice at once.
 ///
-/// [`copy_from_slice`]: ../../std/primitive.slice.html#method.copy_from_slice
+/// [`copy_from_slice`]: slice::copy_from_slice
 #[stable(feature = "extend_ref", since = "1.2.0")]
 impl<'a, T: Copy + 'a, A: Allocator + 'a> Extend<&'a T> for Vec<T, A> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -164,7 +164,6 @@ impl Layout {
     ///       [`Layout::for_value`] on a reference to an extern type tail.
     ///     - otherwise, it is conservatively not allowed to call this function.
     ///
-    /// [slice]: ../../std/primitive.slice.html
     /// [trait object]: ../../book/ch17-02-trait-objects.html
     /// [extern type]: ../../unstable-book/language-features/extern-types.html
     #[unstable(feature = "layout_for_ptr", issue = "69835")]

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -9,8 +9,6 @@ use crate::{
 };
 
 /// A by-value [array] iterator.
-///
-/// [array]: ../../std/primitive.array.html
 #[stable(feature = "array_value_iter", since = "1.51.0")]
 pub struct IntoIter<T, const N: usize> {
     /// This is the array we are iterating over.

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -2,7 +2,7 @@
 //! up to a certain length. Eventually, we should be able to generalize
 //! to all lengths.
 //!
-//! *[See also the array primitive type](../../std/primitive.array.html).*
+//! *[See also the array primitive type](array).*
 
 #![stable(feature = "core_array", since = "1.36.0")]
 

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -9,8 +9,7 @@
 //! [Unicode code point]: http://www.unicode.org/glossary/#code_point
 //!
 //! This module exists for technical reasons, the primary documentation for
-//! `char` is directly on [the `char` primitive type](../../std/primitive.char.html)
-//! itself.
+//! `char` is directly on [the `char` primitive type][char] itself.
 //!
 //! This module is the home of the iterator implementations for the iterators
 //! implemented on `char`, as well as some useful constants and conversion

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -463,7 +463,6 @@ pub trait TryInto<T>: Sized {
 /// ```
 ///
 /// [`try_from`]: TryFrom::try_from
-/// [`!`]: ../../std/primitive.never.html
 #[rustc_diagnostic_item = "try_from_trait"]
 #[stable(feature = "try_from", since = "1.34.0")]
 pub trait TryFrom<T>: Sized {
@@ -673,8 +672,6 @@ impl AsMut<str> for str {
 /// However when `Infallible` becomes an alias for the never type,
 /// the two `impl`s will start to overlap
 /// and therefore will be disallowed by the language’s trait coherence rules.
-///
-/// [never]: ../../std/primitive.never.html
 #[stable(feature = "convert_infallible", since = "1.34.0")]
 #[derive(Copy)]
 pub enum Infallible {}

--- a/library/core/src/ffi.rs
+++ b/library/core/src/ffi.rs
@@ -21,7 +21,6 @@ use crate::ops::{Deref, DerefMut};
 /// compiler down to 1.1.0. After Rust 1.30.0, it was re-exported by
 /// this definition. For more information, please read [RFC 2521].
 ///
-/// [pointer]: ../../std/primitive.pointer.html
 /// [Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
 /// [RFC 2521]: https://github.com/rust-lang/rfcs/blob/master/text/2521-c_void-reunification.md
 // N.B., for LLVM to recognize the void pointer type and by extension

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1093,8 +1093,7 @@ extern "rust-intrinsic" {
     /// bounds or arithmetic overflow occurs then any further use of the
     /// returned value will result in undefined behavior.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::pointer::offset`](../../std/primitive.pointer.html#method.offset).
+    /// The stabilized version of this intrinsic is [`pointer::offset`].
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_unstable(feature = "const_ptr_offset", issue = "71499")]
     pub fn offset<T>(dst: *const T, offset: isize) -> *const T;
@@ -1111,8 +1110,7 @@ extern "rust-intrinsic" {
     /// object, and it wraps with two's complement arithmetic. The resulting
     /// value is not necessarily valid to be used to actually access memory.
     ///
-    /// The stabilized version of this intrinsic is
-    /// [`std::pointer::wrapping_offset`](../../std/primitive.pointer.html#method.wrapping_offset).
+    /// The stabilized version of this intrinsic is [`pointer::wrapping_offset`].
     #[must_use = "returns a new pointer rather than modifying its argument"]
     #[rustc_const_unstable(feature = "const_ptr_offset", issue = "71499")]
     pub fn arith_offset<T>(dst: *const T, offset: isize) -> *const T;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -114,7 +114,7 @@
 #![feature(extended_key_value_attributes)]
 #![feature(extern_types)]
 #![feature(fundamental)]
-#![cfg_attr(not(bootstrap), feature(intra_doc_pointers))]
+#![feature(intra_doc_pointers)]
 #![feature(intrinsics)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -976,7 +976,6 @@ impl<T> MaybeUninit<T> {
     /// ```
     ///
     /// [`write_slice_cloned`]: MaybeUninit::write_slice_cloned
-    /// [`slice::copy_from_slice`]: ../../std/primitive.slice.html#method.copy_from_slice
     #[unstable(feature = "maybe_uninit_write_slice", issue = "79995")]
     pub fn write_slice<'a>(this: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
     where
@@ -1037,7 +1036,6 @@ impl<T> MaybeUninit<T> {
     /// ```
     ///
     /// [`write_slice`]: MaybeUninit::write_slice
-    /// [`slice::clone_from_slice`]: ../../std/primitive.slice.html#method.clone_from_slice
     #[unstable(feature = "maybe_uninit_write_slice", issue = "79995")]
     pub fn write_slice_cloned<'a>(this: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
     where

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -308,7 +308,6 @@ pub const fn size_of<T>() -> usize {
 /// statically-known size, e.g., a slice [`[T]`][slice] or a [trait object],
 /// then `size_of_val` can be used to get the dynamically-known size.
 ///
-/// [slice]: ../../std/primitive.slice.html
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 ///
 /// # Examples
@@ -355,7 +354,6 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///       [`size_of_val`] on a reference to a type with an extern type tail.
 ///     - otherwise, it is conservatively not allowed to call this function.
 ///
-/// [slice]: ../../std/primitive.slice.html
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html
 ///
@@ -494,7 +492,6 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///       [`align_of_val`] on a reference to a type with an extern type tail.
 ///     - otherwise, it is conservatively not allowed to call this function.
 ///
-/// [slice]: ../../std/primitive.slice.html
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 /// [extern type]: ../../unstable-book/language-features/extern-types.html
 ///

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1,6 +1,6 @@
 //! Constants specific to the `f32` single-precision floating point type.
 //!
-//! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
+//! *[See also the `f32` primitive type][f32].*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
@@ -35,7 +35,7 @@ use crate::num::FpCategory;
 pub const RADIX: u32 = f32::RADIX;
 
 /// Number of significant digits in base 2.
-/// Use [`f32::MANTISSA_DIGITS`](../../std/primitive.f32.html#associatedconstant.MANTISSA_DIGITS) instead.
+/// Use [`f32::MANTISSA_DIGITS`] instead.
 ///
 /// # Examples
 ///
@@ -55,7 +55,7 @@ pub const RADIX: u32 = f32::RADIX;
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
-/// Use [`f32::DIGITS`](../../std/primitive.f32.html#associatedconstant.DIGITS) instead.
+/// Use [`f32::DIGITS`] instead.
 ///
 /// # Examples
 ///
@@ -72,7 +72,7 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 pub const DIGITS: u32 = f32::DIGITS;
 
 /// [Machine epsilon] value for `f32`.
-/// Use [`f32::EPSILON`](../../std/primitive.f32.html#associatedconstant.EPSILON) instead.
+/// Use [`f32::EPSILON`] instead.
 ///
 /// This is the difference between `1.0` and the next larger representable number.
 ///
@@ -96,7 +96,7 @@ pub const DIGITS: u32 = f32::DIGITS;
 pub const EPSILON: f32 = f32::EPSILON;
 
 /// Smallest finite `f32` value.
-/// Use [`f32::MIN`](../../std/primitive.f32.html#associatedconstant.MIN) instead.
+/// Use [`f32::MIN`] instead.
 ///
 /// # Examples
 ///
@@ -113,7 +113,7 @@ pub const EPSILON: f32 = f32::EPSILON;
 pub const MIN: f32 = f32::MIN;
 
 /// Smallest positive normal `f32` value.
-/// Use [`f32::MIN_POSITIVE`](../../std/primitive.f32.html#associatedconstant.MIN_POSITIVE) instead.
+/// Use [`f32::MIN_POSITIVE`] instead.
 ///
 /// # Examples
 ///
@@ -133,7 +133,7 @@ pub const MIN: f32 = f32::MIN;
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 
 /// Largest finite `f32` value.
-/// Use [`f32::MAX`](../../std/primitive.f32.html#associatedconstant.MAX) instead.
+/// Use [`f32::MAX`] instead.
 ///
 /// # Examples
 ///
@@ -150,7 +150,7 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 pub const MAX: f32 = f32::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
-/// Use [`f32::MIN_EXP`](../../std/primitive.f32.html#associatedconstant.MIN_EXP) instead.
+/// Use [`f32::MIN_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -170,7 +170,7 @@ pub const MAX: f32 = f32::MAX;
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
-/// Use [`f32::MAX_EXP`](../../std/primitive.f32.html#associatedconstant.MAX_EXP) instead.
+/// Use [`f32::MAX_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -190,7 +190,7 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
-/// Use [`f32::MIN_10_EXP`](../../std/primitive.f32.html#associatedconstant.MIN_10_EXP) instead.
+/// Use [`f32::MIN_10_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -210,7 +210,7 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
-/// Use [`f32::MAX_10_EXP`](../../std/primitive.f32.html#associatedconstant.MAX_10_EXP) instead.
+/// Use [`f32::MAX_10_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -230,7 +230,7 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
 /// Not a Number (NaN).
-/// Use [`f32::NAN`](../../std/primitive.f32.html#associatedconstant.NAN) instead.
+/// Use [`f32::NAN`] instead.
 ///
 /// # Examples
 ///
@@ -247,7 +247,7 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 pub const NAN: f32 = f32::NAN;
 
 /// Infinity (∞).
-/// Use [`f32::INFINITY`](../../std/primitive.f32.html#associatedconstant.INFINITY) instead.
+/// Use [`f32::INFINITY`] instead.
 ///
 /// # Examples
 ///
@@ -267,7 +267,7 @@ pub const NAN: f32 = f32::NAN;
 pub const INFINITY: f32 = f32::INFINITY;
 
 /// Negative infinity (−∞).
-/// Use [`f32::NEG_INFINITY`](../../std/primitive.f32.html#associatedconstant.NEG_INFINITY) instead.
+/// Use [`f32::NEG_INFINITY`] instead.
 ///
 /// # Examples
 ///

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1,6 +1,6 @@
 //! Constants specific to the `f64` double-precision floating point type.
 //!
-//! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
+//! *[See also the `f64` primitive type][f64].*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
@@ -18,7 +18,7 @@ use crate::mem;
 use crate::num::FpCategory;
 
 /// The radix or base of the internal representation of `f64`.
-/// Use [`f64::RADIX`](../../std/primitive.f64.html#associatedconstant.RADIX) instead.
+/// Use [`f64::RADIX`] instead.
 ///
 /// # Examples
 ///
@@ -35,7 +35,7 @@ use crate::num::FpCategory;
 pub const RADIX: u32 = f64::RADIX;
 
 /// Number of significant digits in base 2.
-/// Use [`f64::MANTISSA_DIGITS`](../../std/primitive.f64.html#associatedconstant.MANTISSA_DIGITS) instead.
+/// Use [`f64::MANTISSA_DIGITS`] instead.
 ///
 /// # Examples
 ///
@@ -55,7 +55,7 @@ pub const RADIX: u32 = f64::RADIX;
 pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
-/// Use [`f64::DIGITS`](../../std/primitive.f64.html#associatedconstant.DIGITS) instead.
+/// Use [`f64::DIGITS`] instead.
 ///
 /// # Examples
 ///
@@ -72,7 +72,7 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 pub const DIGITS: u32 = f64::DIGITS;
 
 /// [Machine epsilon] value for `f64`.
-/// Use [`f64::EPSILON`](../../std/primitive.f64.html#associatedconstant.EPSILON) instead.
+/// Use [`f64::EPSILON`] instead.
 ///
 /// This is the difference between `1.0` and the next larger representable number.
 ///
@@ -96,7 +96,7 @@ pub const DIGITS: u32 = f64::DIGITS;
 pub const EPSILON: f64 = f64::EPSILON;
 
 /// Smallest finite `f64` value.
-/// Use [`f64::MIN`](../../std/primitive.f64.html#associatedconstant.MIN) instead.
+/// Use [`f64::MIN`] instead.
 ///
 /// # Examples
 ///
@@ -113,7 +113,7 @@ pub const EPSILON: f64 = f64::EPSILON;
 pub const MIN: f64 = f64::MIN;
 
 /// Smallest positive normal `f64` value.
-/// Use [`f64::MIN_POSITIVE`](../../std/primitive.f64.html#associatedconstant.MIN_POSITIVE) instead.
+/// Use [`f64::MIN_POSITIVE`] instead.
 ///
 /// # Examples
 ///
@@ -133,7 +133,7 @@ pub const MIN: f64 = f64::MIN;
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 
 /// Largest finite `f64` value.
-/// Use [`f64::MAX`](../../std/primitive.f64.html#associatedconstant.MAX) instead.
+/// Use [`f64::MAX`] instead.
 ///
 /// # Examples
 ///
@@ -150,7 +150,7 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 pub const MAX: f64 = f64::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
-/// Use [`f64::MIN_EXP`](../../std/primitive.f64.html#associatedconstant.MIN_EXP) instead.
+/// Use [`f64::MIN_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -170,7 +170,7 @@ pub const MAX: f64 = f64::MAX;
 pub const MIN_EXP: i32 = f64::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
-/// Use [`f64::MAX_EXP`](../../std/primitive.f64.html#associatedconstant.MAX_EXP) instead.
+/// Use [`f64::MAX_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -190,7 +190,7 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
-/// Use [`f64::MIN_10_EXP`](../../std/primitive.f64.html#associatedconstant.MIN_10_EXP) instead.
+/// Use [`f64::MIN_10_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -210,7 +210,7 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
-/// Use [`f64::MAX_10_EXP`](../../std/primitive.f64.html#associatedconstant.MAX_10_EXP) instead.
+/// Use [`f64::MAX_10_EXP`] instead.
 ///
 /// # Examples
 ///
@@ -230,7 +230,7 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
 /// Not a Number (NaN).
-/// Use [`f64::NAN`](../../std/primitive.f64.html#associatedconstant.NAN) instead.
+/// Use [`f64::NAN`] instead.
 ///
 /// # Examples
 ///
@@ -247,7 +247,7 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 pub const NAN: f64 = f64::NAN;
 
 /// Infinity (∞).
-/// Use [`f64::INFINITY`](../../std/primitive.f64.html#associatedconstant.INFINITY) instead.
+/// Use [`f64::INFINITY`] instead.
 ///
 /// # Examples
 ///
@@ -267,7 +267,7 @@ pub const NAN: f64 = f64::NAN;
 pub const INFINITY: f64 = f64::INFINITY;
 
 /// Negative infinity (−∞).
-/// Use [`f64::NEG_INFINITY`](../../std/primitive.f64.html#associatedconstant.NEG_INFINITY) instead.
+/// Use [`f64::NEG_INFINITY`] instead.
 ///
 /// # Examples
 ///

--- a/library/core/src/num/shells/i128.rs
+++ b/library/core/src/num/shells/i128.rs
@@ -1,6 +1,6 @@
 //! Constants for the 128-bit signed integer type.
 //!
-//! *[See also the `i128` primitive type](../../std/primitive.i128.html).*
+//! *[See also the `i128` primitive type][i128].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i16.rs
+++ b/library/core/src/num/shells/i16.rs
@@ -1,6 +1,6 @@
 //! Constants for the 16-bit signed integer type.
 //!
-//! *[See also the `i16` primitive type](../../std/primitive.i16.html).*
+//! *[See also the `i16` primitive type][i16].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i32.rs
+++ b/library/core/src/num/shells/i32.rs
@@ -1,6 +1,6 @@
 //! Constants for the 32-bit signed integer type.
 //!
-//! *[See also the `i32` primitive type](../../std/primitive.i32.html).*
+//! *[See also the `i32` primitive type][i32].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i64.rs
+++ b/library/core/src/num/shells/i64.rs
@@ -1,6 +1,6 @@
 //! Constants for the 64-bit signed integer type.
 //!
-//! *[See also the `i64` primitive type](../../std/primitive.i64.html).*
+//! *[See also the `i64` primitive type][i64].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/i8.rs
+++ b/library/core/src/num/shells/i8.rs
@@ -1,6 +1,6 @@
 //! Constants for the 8-bit signed integer type.
 //!
-//! *[See also the `i8` primitive type](../../std/primitive.i8.html).*
+//! *[See also the `i8` primitive type][i8].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/int_macros.rs
+++ b/library/core/src/num/shells/int_macros.rs
@@ -5,8 +5,7 @@ macro_rules! int_module {
     ($T:ident, #[$attr:meta]) => (
         #[doc = concat!(
             "The smallest value that can be represented by this integer type. Use ",
-            "[`", stringify!($T), "::MIN", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MIN)",
-            " instead.",
+            "[`", stringify!($T), "::MIN", "`] instead."
         )]
         ///
         /// # Examples
@@ -25,8 +24,7 @@ macro_rules! int_module {
 
         #[doc = concat!(
             "The largest value that can be represented by this integer type. Use ",
-            "[`", stringify!($T), "::MAX", "`](../../std/primitive.", stringify!($T), ".html#associatedconstant.MAX)",
-            " instead.",
+            "[`", stringify!($T), "::MAX", "`] instead."
         )]
         ///
         /// # Examples

--- a/library/core/src/num/shells/isize.rs
+++ b/library/core/src/num/shells/isize.rs
@@ -1,6 +1,6 @@
 //! Constants for the pointer-sized signed integer type.
 //!
-//! *[See also the `isize` primitive type](../../std/primitive.isize.html).*
+//! *[See also the `isize` primitive type][isize].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u128.rs
+++ b/library/core/src/num/shells/u128.rs
@@ -1,6 +1,6 @@
 //! Constants for the 128-bit unsigned integer type.
 //!
-//! *[See also the `u128` primitive type](../../std/primitive.u128.html).*
+//! *[See also the `u128` primitive type][u128].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u16.rs
+++ b/library/core/src/num/shells/u16.rs
@@ -1,6 +1,6 @@
 //! Constants for the 16-bit unsigned integer type.
 //!
-//! *[See also the `u16` primitive type](../../std/primitive.u16.html).*
+//! *[See also the `u16` primitive type][u16].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u32.rs
+++ b/library/core/src/num/shells/u32.rs
@@ -1,6 +1,6 @@
 //! Constants for the 32-bit unsigned integer type.
 //!
-//! *[See also the `u32` primitive type](../../std/primitive.u32.html).*
+//! *[See also the `u32` primitive type][u32].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u64.rs
+++ b/library/core/src/num/shells/u64.rs
@@ -1,6 +1,6 @@
 //! Constants for the 64-bit unsigned integer type.
 //!
-//! *[See also the `u64` primitive type](../../std/primitive.u64.html).*
+//! *[See also the `u64` primitive type][u64].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/u8.rs
+++ b/library/core/src/num/shells/u8.rs
@@ -1,6 +1,6 @@
 //! Constants for the 8-bit unsigned integer type.
 //!
-//! *[See also the `u8` primitive type](../../std/primitive.u8.html).*
+//! *[See also the `u8` primitive type][u8].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/num/shells/usize.rs
+++ b/library/core/src/num/shells/usize.rs
@@ -1,6 +1,6 @@
 //! Constants for the pointer-sized unsigned integer type.
 //!
-//! *[See also the `usize` primitive type](../../std/primitive.usize.html).*
+//! *[See also the `usize` primitive type][usize].*
 //!
 //! New code should use the associated constants directly on the primitive type.
 

--- a/library/core/src/ops/function.rs
+++ b/library/core/src/ops/function.rs
@@ -28,7 +28,7 @@
 /// this can refer to [the relevant section in the *Rustonomicon*][nomicon].
 ///
 /// [book]: ../../book/ch13-01-closures.html
-/// [function pointers]: ../../std/primitive.fn.html
+/// [function pointers]: fn
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples
@@ -97,7 +97,7 @@ pub trait Fn<Args>: FnMut<Args> {
 /// this can refer to [the relevant section in the *Rustonomicon*][nomicon].
 ///
 /// [book]: ../../book/ch13-01-closures.html
-/// [function pointers]: ../../std/primitive.fn.html
+/// [function pointers]: fn
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples
@@ -176,7 +176,7 @@ pub trait FnMut<Args>: FnOnce<Args> {
 /// this can refer to [the relevant section in the *Rustonomicon*][nomicon].
 ///
 /// [book]: ../../book/ch13-01-closures.html
-/// [function pointers]: ../../std/primitive.fn.html
+/// [function pointers]: fn
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1011,8 +1011,6 @@ impl<T> *const [T] {
     /// See also [`slice::from_raw_parts`][].
     ///
     /// [valid]: crate::ptr#safety
-    /// [`NonNull::dangling()`]: NonNull::dangling
-    /// [`pointer::offset`]: ../std/primitive.pointer.html#method.offset
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
     pub unsafe fn as_uninit_slice<'a>(self) -> Option<&'a [MaybeUninit<T>]> {

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1,6 +1,6 @@
 //! Manually manage memory through raw pointers.
 //!
-//! *[See also the pointer primitive types](../../std/primitive.pointer.html).*
+//! *[See also the pointer primitive types](pointer).*
 //!
 //! # Safety
 //!
@@ -60,7 +60,7 @@
 //! [ub]: ../../reference/behavior-considered-undefined.html
 //! [zst]: ../../nomicon/exotic-sizes.html#zero-sized-types-zsts
 //! [atomic operations]: crate::sync::atomic
-//! [`offset`]: ../../std/primitive.pointer.html#method.offset
+//! [`offset`]: pointer::offset
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1273,8 +1273,6 @@ impl<T> *mut [T] {
     /// See also [`slice::from_raw_parts`][].
     ///
     /// [valid]: crate::ptr#safety
-    /// [`NonNull::dangling()`]: NonNull::dangling
-    /// [`pointer::offset`]: ../std/primitive.pointer.html#method.offset
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
     pub unsafe fn as_uninit_slice<'a>(self) -> Option<&'a [MaybeUninit<T>]> {
@@ -1325,8 +1323,6 @@ impl<T> *mut [T] {
     /// See also [`slice::from_raw_parts_mut`][].
     ///
     /// [valid]: crate::ptr#safety
-    /// [`NonNull::dangling()`]: NonNull::dangling
-    /// [`pointer::offset`]: ../std/primitive.pointer.html#method.offset
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
     pub unsafe fn as_uninit_slice_mut<'a>(self) -> Option<&'a mut [MaybeUninit<T>]> {

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -425,7 +425,6 @@ impl<T> NonNull<[T]> {
     /// See also [`slice::from_raw_parts`].
     ///
     /// [valid]: crate::ptr#safety
-    /// [`pointer::offset`]: ../../std/primitive.pointer.html#method.offset
     #[inline]
     #[unstable(feature = "ptr_as_uninit", issue = "75402")]
     pub unsafe fn as_uninit_slice(&self) -> &[MaybeUninit<T>] {
@@ -470,7 +469,6 @@ impl<T> NonNull<[T]> {
     /// See also [`slice::from_raw_parts_mut`].
     ///
     /// [valid]: crate::ptr#safety
-    /// [`pointer::offset`]: ../../std/primitive.pointer.html#method.offset
     ///
     /// # Examples
     ///

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1285,11 +1285,10 @@ impl<T> Result<T, T> {
     /// `Err`.
     ///
     /// This can be useful in conjunction with APIs such as
-    /// [`Atomic*::compare_exchange`], or [`slice::binary_search`][binary_search], but only in
+    /// [`Atomic*::compare_exchange`], or [`slice::binary_search`], but only in
     /// cases where you don't care if the result was `Ok` or not.
     ///
     /// [`Atomic*::compare_exchange`]: crate::sync::atomic::AtomicBool::compare_exchange
-    /// [binary_search]: ../../std/primitive.slice.html#method.binary_search
     ///
     /// # Examples
     ///

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -464,8 +464,8 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeToInclusive<usize> {
 ///
 /// [`Range`]: ops::Range
 /// [`RangeTo`]: ops::RangeTo
-/// [`slice::get_unchecked`]: ../../std/primitive.slice.html#method.get_unchecked
-/// [`slice::get_unchecked_mut`]: ../../std/primitive.slice.html#method.get_unchecked_mut
+/// [`slice::get_unchecked`]: slice::get_unchecked
+/// [`slice::get_unchecked_mut`]: slice::get_unchecked_mut
 ///
 /// # Panics
 ///

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -60,8 +60,8 @@ fn size_from_ptr<T>(_: *const T) -> usize {
 /// }
 /// ```
 ///
-/// [`iter`]: ../../std/primitive.slice.html#method.iter
-/// [slices]: ../../std/primitive.slice.html
+/// [`iter`]: slice::iter
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Iter<'a, T: 'a> {
     ptr: NonNull<T>,
@@ -179,8 +179,8 @@ impl<T> AsRef<[T]> for Iter<'_, T> {
 /// println!("{:?}", slice);
 /// ```
 ///
-/// [`iter_mut`]: ../../std/primitive.slice.html#method.iter_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`iter_mut`]: slice::iter_mut
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IterMut<'a, T: 'a> {
     ptr: NonNull<T>,
@@ -328,8 +328,8 @@ pub(super) trait SplitIter: DoubleEndedIterator {
 /// let mut iter = slice.split(|num| num % 3 == 0);
 /// ```
 ///
-/// [`split`]: ../../std/primitive.slice.html#method.split
-/// [slices]: ../../std/primitive.slice.html
+/// [`split`]: slice::split
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Split<'a, T: 'a, P>
 where
@@ -450,8 +450,8 @@ impl<T, P> FusedIterator for Split<'_, T, P> where P: FnMut(&T) -> bool {}
 /// let mut iter = slice.split_inclusive(|num| num % 3 == 0);
 /// ```
 ///
-/// [`split_inclusive`]: ../../std/primitive.slice.html#method.split_inclusive
-/// [slices]: ../../std/primitive.slice.html
+/// [`split_inclusive`]: slice::split_inclusive
+/// [slices]: slice
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub struct SplitInclusive<'a, T: 'a, P>
 where
@@ -562,8 +562,8 @@ impl<T, P> FusedIterator for SplitInclusive<'_, T, P> where P: FnMut(&T) -> bool
 /// let iter = v.split_mut(|num| *num % 3 == 0);
 /// ```
 ///
-/// [`split_mut`]: ../../std/primitive.slice.html#method.split_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`split_mut`]: slice::split_mut
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SplitMut<'a, T: 'a, P>
 where
@@ -691,8 +691,8 @@ impl<T, P> FusedIterator for SplitMut<'_, T, P> where P: FnMut(&T) -> bool {}
 /// let iter = v.split_inclusive_mut(|num| *num % 3 == 0);
 /// ```
 ///
-/// [`split_inclusive_mut`]: ../../std/primitive.slice.html#method.split_inclusive_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`split_inclusive_mut`]: slice::split_inclusive_mut
+/// [slices]: slice
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub struct SplitInclusiveMut<'a, T: 'a, P>
 where
@@ -812,8 +812,8 @@ impl<T, P> FusedIterator for SplitInclusiveMut<'_, T, P> where P: FnMut(&T) -> b
 /// let iter = slice.rsplit(|num| *num == 0);
 /// ```
 ///
-/// [`rsplit`]: ../../std/primitive.slice.html#method.rsplit
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplit`]: slice::rsplit
+/// [slices]: slice
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
 #[derive(Clone)] // Is this correct, or does it incorrectly require `T: Clone`?
 pub struct RSplit<'a, T: 'a, P>
@@ -898,8 +898,8 @@ impl<T, P> FusedIterator for RSplit<'_, T, P> where P: FnMut(&T) -> bool {}
 /// let iter = slice.rsplit_mut(|num| *num == 0);
 /// ```
 ///
-/// [`rsplit_mut`]: ../../std/primitive.slice.html#method.rsplit_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplit_mut`]: slice::rsplit_mut
+/// [slices]: slice
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
 pub struct RSplitMut<'a, T: 'a, P>
 where
@@ -1017,8 +1017,8 @@ impl<T, I: SplitIter<Item = T>> Iterator for GenericSplitN<I> {
 /// let iter = slice.splitn(2, |num| *num % 3 == 0);
 /// ```
 ///
-/// [`splitn`]: ../../std/primitive.slice.html#method.splitn
-/// [slices]: ../../std/primitive.slice.html
+/// [`splitn`]: slice::splitn
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SplitN<'a, T: 'a, P>
 where
@@ -1057,8 +1057,8 @@ where
 /// let iter = slice.rsplitn(2, |num| *num % 3 == 0);
 /// ```
 ///
-/// [`rsplitn`]: ../../std/primitive.slice.html#method.rsplitn
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplitn`]: slice::rsplitn
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RSplitN<'a, T: 'a, P>
 where
@@ -1096,8 +1096,8 @@ where
 /// let iter = slice.splitn_mut(2, |num| *num % 3 == 0);
 /// ```
 ///
-/// [`splitn_mut`]: ../../std/primitive.slice.html#method.splitn_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`splitn_mut`]: slice::splitn_mut
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SplitNMut<'a, T: 'a, P>
 where
@@ -1136,8 +1136,8 @@ where
 /// let iter = slice.rsplitn_mut(2, |num| *num % 3 == 0);
 /// ```
 ///
-/// [`rsplitn_mut`]: ../../std/primitive.slice.html#method.rsplitn_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplitn_mut`]: slice::rsplitn_mut
+/// [slices]: slice
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RSplitNMut<'a, T: 'a, P>
 where
@@ -1179,8 +1179,8 @@ forward_iterator! { RSplitNMut: T, &'a mut [T] }
 /// let iter = slice.windows(2);
 /// ```
 ///
-/// [`windows`]: ../../std/primitive.slice.html#method.windows
-/// [slices]: ../../std/primitive.slice.html
+/// [`windows`]: slice::windows
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Windows<'a, T: 'a> {
@@ -1325,8 +1325,8 @@ unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {
 /// let iter = slice.chunks(2);
 /// ```
 ///
-/// [`chunks`]: ../../std/primitive.slice.html#method.chunks
-/// [slices]: ../../std/primitive.slice.html
+/// [`chunks`]: slice::chunks
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Chunks<'a, T: 'a> {
@@ -1493,8 +1493,8 @@ unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {
 /// let iter = slice.chunks_mut(2);
 /// ```
 ///
-/// [`chunks_mut`]: ../../std/primitive.slice.html#method.chunks_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`chunks_mut`]: slice::chunks_mut
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ChunksMut<'a, T: 'a> {
@@ -1659,9 +1659,9 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {
 /// let iter = slice.chunks_exact(2);
 /// ```
 ///
-/// [`chunks_exact`]: ../../std/primitive.slice.html#method.chunks_exact
+/// [`chunks_exact`]: slice::chunks_exact
 /// [`remainder`]: ChunksExact::remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 pub struct ChunksExact<'a, T: 'a> {
@@ -1815,9 +1815,9 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {
 /// let iter = slice.chunks_exact_mut(2);
 /// ```
 ///
-/// [`chunks_exact_mut`]: ../../std/primitive.slice.html#method.chunks_exact_mut
+/// [`chunks_exact_mut`]: slice::chunks_exact_mut
 /// [`into_remainder`]: ChunksExactMut::into_remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 pub struct ChunksExactMut<'a, T: 'a> {
@@ -1966,8 +1966,8 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {
 /// let iter = slice.array_windows::<2>();
 /// ```
 ///
-/// [`array_windows`]: ../../std/primitive.slice.html#method.array_windows
-/// [slices]: ../../std/primitive.slice.html
+/// [`array_windows`]: slice::array_windows
+/// [slices]: slice
 #[derive(Debug, Clone, Copy)]
 #[unstable(feature = "array_windows", issue = "75027")]
 pub struct ArrayWindows<'a, T: 'a, const N: usize> {
@@ -2087,9 +2087,9 @@ impl<T, const N: usize> ExactSizeIterator for ArrayWindows<'_, T, N> {
 /// let iter = slice.array_chunks::<2>();
 /// ```
 ///
-/// [`array_chunks`]: ../../std/primitive.slice.html#method.array_chunks
+/// [`array_chunks`]: slice::array_chunks
 /// [`remainder`]: ArrayChunks::remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [slices]: slice
 #[derive(Debug)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 pub struct ArrayChunks<'a, T: 'a, const N: usize> {
@@ -2209,9 +2209,9 @@ unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunks<'a, T, N>
 /// let iter = slice.array_chunks_mut::<2>();
 /// ```
 ///
-/// [`array_chunks_mut`]: ../../std/primitive.slice.html#method.array_chunks_mut
+/// [`array_chunks_mut`]: slice::array_chunks_mut
 /// [`into_remainder`]: ../../std/slice/struct.ArrayChunksMut.html#method.into_remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [slices]: slice
 #[derive(Debug)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 pub struct ArrayChunksMut<'a, T: 'a, const N: usize> {
@@ -2320,8 +2320,8 @@ unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunksMut<'a, T,
 /// let iter = slice.rchunks(2);
 /// ```
 ///
-/// [`rchunks`]: ../../std/primitive.slice.html#method.rchunks
-/// [slices]: ../../std/primitive.slice.html
+/// [`rchunks`]: slice::rchunks
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunks<'a, T: 'a> {
@@ -2484,8 +2484,8 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {
 /// let iter = slice.rchunks_mut(2);
 /// ```
 ///
-/// [`rchunks_mut`]: ../../std/primitive.slice.html#method.rchunks_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`rchunks_mut`]: slice::rchunks_mut
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunksMut<'a, T: 'a> {
@@ -2648,9 +2648,9 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {
 /// let iter = slice.rchunks_exact(2);
 /// ```
 ///
-/// [`rchunks_exact`]: ../../std/primitive.slice.html#method.rchunks_exact
+/// [`rchunks_exact`]: slice::rchunks_exact
 /// [`remainder`]: ChunksExact::remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunksExact<'a, T: 'a> {
@@ -2808,9 +2808,9 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {
 /// let iter = slice.rchunks_exact_mut(2);
 /// ```
 ///
-/// [`rchunks_exact_mut`]: ../../std/primitive.slice.html#method.rchunks_exact_mut
+/// [`rchunks_exact_mut`]: slice::rchunks_exact_mut
 /// [`into_remainder`]: ChunksExactMut::into_remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [slices]: slice
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunksExactMut<'a, T: 'a> {
@@ -2969,8 +2969,8 @@ unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
 ///
 /// This struct is created by the [`group_by`] method on [slices].
 ///
-/// [`group_by`]: ../../std/primitive.slice.html#method.group_by
-/// [slices]: ../../std/primitive.slice.html
+/// [`group_by`]: slice::group_by
+/// [slices]: slice
 #[unstable(feature = "slice_group_by", issue = "80552")]
 pub struct GroupBy<'a, T: 'a, P> {
     slice: &'a [T],
@@ -3055,8 +3055,8 @@ impl<'a, T: 'a + fmt::Debug, P> fmt::Debug for GroupBy<'a, T, P> {
 ///
 /// This struct is created by the [`group_by_mut`] method on [slices].
 ///
-/// [`group_by_mut`]: ../../std/primitive.slice.html#method.group_by_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`group_by_mut`]: slice::group_by_mut
+/// [slices]: slice
 #[unstable(feature = "slice_group_by", issue = "80552")]
 pub struct GroupByMut<'a, T: 'a, P> {
     slice: &'a mut [T],

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -83,7 +83,6 @@ use crate::ptr;
 ///
 /// [valid]: ptr#safety
 /// [`NonNull::dangling()`]: ptr::NonNull::dangling
-/// [`pointer::offset`]: ../../std/primitive.pointer.html#method.offset
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
@@ -125,7 +124,6 @@ pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
 ///
 /// [valid]: ptr#safety
 /// [`NonNull::dangling()`]: ptr::NonNull::dangling
-/// [`pointer::offset`]: ../../std/primitive.pointer.html#method.offset
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {

--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -14,7 +14,7 @@ use super::Utf8Error;
 /// UTF-8, and then does the conversion.
 ///
 /// [`&str`]: str
-/// [byteslice]: ../../std/primitive.slice.html
+/// [byteslice]: slice
 ///
 /// If you are sure that the byte slice is valid UTF-8, and you don't want to
 /// incur the overhead of the validity check, there is an unsafe version of
@@ -31,7 +31,7 @@ use super::Utf8Error;
 /// stack-allocated string. There is an example of this in the
 /// examples section below.
 ///
-/// [byteslice]: ../../std/primitive.slice.html
+/// [byteslice]: slice
 ///
 /// # Errors
 ///

--- a/library/core/src/str/traits.rs
+++ b/library/core/src/str/traits.rs
@@ -540,9 +540,7 @@ pub trait FromStr: Sized {
     ///
     /// # Examples
     ///
-    /// Basic usage with [`i32`][ithirtytwo], a type that implements `FromStr`:
-    ///
-    /// [ithirtytwo]: ../../std/primitive.i32.html
+    /// Basic usage with [`i32`], a type that implements `FromStr`:
     ///
     /// ```
     /// use std::str::FromStr;

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1307,7 +1307,7 @@ macro_rules! atomic_int {
      $stable_nand:meta,
      $const_stable:meta,
      $stable_init_const:meta,
-     $s_int_type:literal, $int_ref:expr,
+     $s_int_type:literal,
      $extra_feature:expr,
      $min_fn:ident, $max_fn:ident,
      $align:expr,
@@ -1318,18 +1318,14 @@ macro_rules! atomic_int {
         /// This type has the same in-memory representation as the underlying
         /// integer type, [`
         #[doc = $s_int_type]
-        /// `](
-        #[doc = $int_ref]
-        /// ). For more about the differences between atomic types and
+        /// `]. For more about the differences between atomic types and
         /// non-atomic types as well as information about the portability of
         /// this type, please see the [module-level documentation].
         ///
         /// **Note:** This type is only available on platforms that support
         /// atomic loads and stores of [`
         #[doc = $s_int_type]
-        /// `](
-        #[doc = $int_ref]
-        /// ).
+        /// `].
         ///
         /// [module-level documentation]: crate::sync::atomic
         #[$stable]
@@ -1525,7 +1521,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1557,7 +1553,7 @@ macro_rules! atomic_int {
             /// happens, and using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Migrating to `compare_exchange` and `compare_exchange_weak`
             ///
@@ -1626,7 +1622,7 @@ macro_rules! atomic_int {
             /// and must be equivalent to or weaker than the success ordering.
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1678,7 +1674,7 @@ macro_rules! atomic_int {
             /// and must be equivalent to or weaker than the success ordering.
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1720,7 +1716,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1749,7 +1745,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1781,7 +1777,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1813,7 +1809,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1845,7 +1841,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1877,7 +1873,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1916,7 +1912,7 @@ macro_rules! atomic_int {
             /// and must be equivalent to or weaker than the success ordering.
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -1960,7 +1956,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -2003,7 +1999,7 @@ macro_rules! atomic_int {
             /// using [`Release`] makes the load part [`Relaxed`].
             ///
             /// **Note**: This method is only available on platforms that support atomic operations on
-            #[doc = concat!("[`", $s_int_type, "`](", $int_ref, ").")]
+            #[doc = concat!("[`", $s_int_type, "`].")]
             ///
             /// # Examples
             ///
@@ -2088,7 +2084,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i8", "../../../std/primitive.i8.html",
+    "i8",
     "",
     atomic_min, atomic_max,
     1,
@@ -2107,7 +2103,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u8", "../../../std/primitive.u8.html",
+    "u8",
     "",
     atomic_umin, atomic_umax,
     1,
@@ -2126,7 +2122,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i16", "../../../std/primitive.i16.html",
+    "i16",
     "",
     atomic_min, atomic_max,
     2,
@@ -2145,7 +2141,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u16", "../../../std/primitive.u16.html",
+    "u16",
     "",
     atomic_umin, atomic_umax,
     2,
@@ -2164,7 +2160,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i32", "../../../std/primitive.i32.html",
+    "i32",
     "",
     atomic_min, atomic_max,
     4,
@@ -2183,7 +2179,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u32", "../../../std/primitive.u32.html",
+    "u32",
     "",
     atomic_umin, atomic_umax,
     4,
@@ -2202,7 +2198,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i64", "../../../std/primitive.i64.html",
+    "i64",
     "",
     atomic_min, atomic_max,
     8,
@@ -2221,7 +2217,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u64", "../../../std/primitive.u64.html",
+    "u64",
     "",
     atomic_umin, atomic_umax,
     8,
@@ -2240,7 +2236,7 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i128", "../../../std/primitive.i128.html",
+    "i128",
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
     16,
@@ -2259,7 +2255,7 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u128", "../../../std/primitive.u128.html",
+    "u128",
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
     16,
@@ -2282,7 +2278,7 @@ macro_rules! atomic_int_ptr_sized {
             stable(feature = "atomic_nand", since = "1.27.0"),
             rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
             stable(feature = "rust1", since = "1.0.0"),
-            "isize", "../../../std/primitive.isize.html",
+            "isize",
             "",
             atomic_min, atomic_max,
             $align,
@@ -2302,7 +2298,7 @@ macro_rules! atomic_int_ptr_sized {
             stable(feature = "atomic_nand", since = "1.27.0"),
             rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
             stable(feature = "rust1", since = "1.0.0"),
-            "usize", "../../../std/primitive.usize.html",
+            "usize",
             "",
             atomic_umin, atomic_umax,
             $align,

--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -62,20 +62,18 @@ use crate::sys;
 /// u8` argument which is not necessarily nul-terminated, plus another
 /// argument with the length of the string — like C's `strndup()`.
 /// You can of course get the slice's length with its
-/// [`len`][slice.len] method.
+/// [`len`][slice::len] method.
 ///
 /// If you need a `&[`[`u8`]`]` slice *with* the nul terminator, you
 /// can use [`CString::as_bytes_with_nul`] instead.
 ///
 /// Once you have the kind of slice you need (with or without a nul
 /// terminator), you can call the slice's own
-/// [`as_ptr`][slice.as_ptr] method to get a read-only raw pointer to pass to
+/// [`as_ptr`][slice::as_ptr] method to get a read-only raw pointer to pass to
 /// extern functions. See the documentation for that function for a
 /// discussion on ensuring the lifetime of the raw pointer.
 ///
 /// [`&str`]: prim@str
-/// [slice.as_ptr]: ../primitive.slice.html#method.as_ptr
-/// [slice.len]: ../primitive.slice.html#method.len
 /// [`Deref`]: ops::Deref
 /// [`&CStr`]: CStr
 ///

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -482,7 +482,7 @@ pub(crate) fn default_read_exact<R: Read + ?Sized>(this: &mut R, mut buf: &mut [
 /// }
 /// ```
 ///
-/// Read from [`&str`] because [`&[u8]`][slice] implements `Read`:
+/// Read from [`&str`] because [`&[u8]`][prim@slice] implements `Read`:
 ///
 /// ```no_run
 /// # use std::io;
@@ -504,7 +504,6 @@ pub(crate) fn default_read_exact<R: Read + ?Sized>(this: &mut R, mut buf: &mut [
 /// [`&str`]: prim@str
 /// [`std::io`]: self
 /// [`File`]: crate::fs::File
-/// [slice]: ../../std/primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(spotlight)]
 pub trait Read {

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -42,7 +42,7 @@
 /// [Reference]: ../reference/expressions/operator-expr.html#type-cast-expressions
 /// [`crate`]: keyword.crate.html
 /// [`use`]: keyword.use.html
-/// [const-cast]: primitive.pointer.html#method.cast
+/// [const-cast]: pointer::cast
 /// [mut-cast]: primitive.pointer.html#method.cast-1
 mod as_keyword {}
 
@@ -181,9 +181,8 @@ mod break_keyword {}
 /// The `const` keyword is also used in raw pointers in combination with `mut`, as seen in `*const
 /// T` and `*mut T`. More about `const` as used in raw pointers can be read at the Rust docs for the [pointer primitive].
 ///
-/// [pointer primitive]: primitive.pointer.html
-/// [Rust Book]:
-/// ../book/ch03-01-variables-and-mutability.html#differences-between-variables-and-constants
+/// [pointer primitive]: pointer
+/// [Rust Book]: ../book/ch03-01-variables-and-mutability.html#differences-between-variables-and-constants
 /// [Reference]: ../reference/items/constant-items.html
 /// [const-eval]: ../reference/const_eval.html
 mod const_keyword {}
@@ -371,7 +370,6 @@ mod else_keyword {}
 /// [ADT]: https://en.wikipedia.org/wiki/Algebraic_data_type
 /// [Rust Book]: ../book/ch06-01-defining-an-enum.html
 /// [Reference]: ../reference/items/enumerations.html
-/// [`!`]: primitive.never.html
 mod enum_keyword {}
 
 #[doc(keyword = "extern")]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -61,14 +61,14 @@
 //!    type, but not the all-important methods.
 //!
 //! So for example there is a [page for the primitive type
-//! `i32`](primitive.i32.html) that lists all the methods that can be called on
+//! `i32`](primitive::i32) that lists all the methods that can be called on
 //! 32-bit integers (very useful), and there is a [page for the module
 //! `std::i32`] that documents the constant values [`MIN`] and [`MAX`] (rarely
 //! useful).
 //!
-//! Note the documentation for the primitives [`str`] and [`[T]`][slice] (also
+//! Note the documentation for the primitives [`str`] and [`[T]`][prim@slice] (also
 //! called 'slice'). Many method calls on [`String`] and [`Vec<T>`] are actually
-//! calls to methods on [`str`] and [`[T]`][slice] respectively, via [deref
+//! calls to methods on [`str`] and [`[T]`][prim@slice] respectively, via [deref
 //! coercions][deref-coercions].
 //!
 //! Third, the standard library defines [The Rust Prelude], a small collection
@@ -111,8 +111,8 @@
 //! regions of memory:
 //!
 //! * [`Vec<T>`] - A heap-allocated *vector* that is resizable at runtime.
-//! * [`[T; n]`][array] - An inline *array* with a fixed size at compile time.
-//! * [`[T]`][slice] - A dynamically sized *slice* into any other kind of contiguous
+//! * [`[T; N]`][prim@array] - An inline *array* with a fixed size at compile time.
+//! * [`[T]`][prim@slice] - A dynamically sized *slice* into any other kind of contiguous
 //!   storage, whether heap-allocated or not.
 //!
 //! Slices can only be handled through some kind of *pointer*, and as such come
@@ -275,7 +275,7 @@
 #![feature(int_error_matching)]
 #![feature(integer_atomics)]
 #![feature(into_future)]
-#![cfg_attr(not(bootstrap), feature(intra_doc_pointers))]
+#![feature(intra_doc_pointers)]
 #![feature(lang_items)]
 #![feature(link_args)]
 #![feature(linkage)]

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -468,8 +468,8 @@ mod prim_unit {}
 ///
 /// [`null`]: ptr::null
 /// [`null_mut`]: ptr::null_mut
-/// [`is_null`]: ../std/primitive.pointer.html#method.is_null
-/// [`offset`]: ../std/primitive.pointer.html#method.offset
+/// [`is_null`]: pointer::is_null
+/// [`offset`]: pointer::offset
 /// [`into_raw`]: Box::into_raw
 /// [`drop`]: mem::drop
 /// [`write`]: ptr::write
@@ -564,7 +564,7 @@ mod prim_pointer {}
 /// move_away(roa);
 /// ```
 ///
-/// [slice]: primitive.slice.html
+/// [slice]: prim@slice
 /// [`Debug`]: fmt::Debug
 /// [`Hash`]: hash::Hash
 /// [`Borrow`]: borrow::Borrow


### PR DESCRIPTION
Blocked on https://github.com/rust-lang/rust/pull/80181. I forgot that this needs to wait for the beta bump so the standard library can be documented with `doc --stage 0`.

Notably I didn't convert `core::slice` because it's like 50 links and I got scared :fearful: 