### PR TITLE
Querify InternalSubsts::identity_for_item

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -136,6 +136,11 @@ rustc_queries! {
             }
         }
 
+        /// Maps from the `DefId` to a list of substitutions that maps each generic parameter to itself.
+        query identity_substs_of(key: DefId) -> ty::subst::SubstsRef<'tcx> {
+            desc { |tcx| "computing identity substitutions of `{}`", tcx.def_path_str(key) }
+        }
+
         /// Maps from the `DefId` of an item (trait/struct/enum/fn) to the
         /// predicates (where-clauses) that must be proven true in order
         /// to reference it. This is almost always the "predicates query"

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -205,7 +205,7 @@ impl<'a, 'tcx> InternalSubsts<'tcx> {
 
     /// Creates a `InternalSubsts` that maps each generic parameter to itself.
     pub fn identity_for_item(tcx: TyCtxt<'tcx>, def_id: DefId) -> SubstsRef<'tcx> {
-        Self::for_item(tcx, def_id, |param, _| tcx.mk_param_from_def(param))
+        tcx.identity_substs_of(def_id)
     }
 
     /// Creates a `InternalSubsts` for generic parameter definitions,

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -84,6 +84,7 @@ pub fn provide(providers: &mut Providers) {
         trait_def,
         adt_def,
         fn_sig,
+        identity_substs_of,
         impl_trait_ref,
         impl_polarity,
         is_foreign_item,
@@ -1209,6 +1210,10 @@ impl<'v> Visitor<'v> for AnonConstInParamListDetector {
             intravisit::walk_anon_const(self, c)
         }
     }
+}
+
+fn identity_substs_of(tcx: TyCtxt<'tcx>, def_id: DefId) -> ty::subst::SubstsRef<'tcx> {
+    InternalSubsts::for_item(tcx, def_id, |param, _| tcx.mk_param_from_def(param))
 }
 
 fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {


### PR DESCRIPTION
This PR changes `InternalSubsts::identity_for_item` into a query to (hopefully) reduce duplicate memory that is allocated by each use. `InternalSubsts::identity_for_item` seems rather widely used, in some cases (like in explicit_predicates_of) "only" to create a short lived list.

I'm looking for suggestions in case there is a better way to cache data for `DefId`s.
