### PR TITLE
also const-check FakeRead

### DIFF
--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -722,17 +722,16 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
     fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
         trace!("visit_statement: statement={:?} location={:?}", statement, location);
 
-        match statement.kind {
-            StatementKind::Assign(..) | StatementKind::SetDiscriminant { .. } => {
-                self.super_statement(statement, location);
-            }
+        self.super_statement(statement, location);
 
+        match statement.kind {
             StatementKind::LlvmInlineAsm { .. } => {
-                self.super_statement(statement, location);
                 self.check_op(ops::InlineAsm);
             }
 
-            StatementKind::FakeRead(..)
+            StatementKind::Assign(..)
+            | StatementKind::SetDiscriminant { .. }
+            | StatementKind::FakeRead(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Retag { .. }

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -146,6 +146,11 @@ help: skipping check that does not even have a feature gate
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+   |
+LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_panic` feature
   --> $DIR/const_refers_to_static_cross_crate.rs:32:77
    |

--- a/src/test/ui/error-codes/E0396.rs
+++ b/src/test/ui/error-codes/E0396.rs
@@ -5,5 +5,16 @@ const REG_ADDR: *const u8 = 0x5f3759df as *const u8;
 const VALUE: u8 = unsafe { *REG_ADDR };
 //~^ ERROR dereferencing raw pointers in constants is unstable
 
+const unsafe fn unreachable() -> ! {
+    use std::convert::Infallible;
+
+    const INFALLIBLE: *const Infallible = [].as_ptr();
+    match *INFALLIBLE {}
+    //~^ ERROR dereferencing raw pointers in constant functions is unstable
+
+    const BAD: () = unsafe { match *INFALLIBLE {} };
+    //~^ ERROR dereferencing raw pointers in constants is unstable
+}
+
 fn main() {
 }

--- a/src/test/ui/error-codes/E0396.stderr
+++ b/src/test/ui/error-codes/E0396.stderr
@@ -7,6 +7,24 @@ LL | const VALUE: u8 = unsafe { *REG_ADDR };
    = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
    = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: dereferencing raw pointers in constant functions is unstable
+  --> $DIR/E0396.rs:12:11
+   |
+LL |     match *INFALLIBLE {}
+   |           ^^^^^^^^^^^
+   |
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
+
+error[E0658]: dereferencing raw pointers in constants is unstable
+  --> $DIR/E0396.rs:15:36
+   |
+LL |     const BAD: () = unsafe { match *INFALLIBLE {} };
+   |                                    ^^^^^^^^^^^
+   |
+   = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
We need to const-check all statements, including `FakeRead`, to avoid issues like https://github.com/rust-lang/rust/issues/77694.

Fixes https://github.com/rust-lang/rust/issues/77694.
r? @oli-obk 