### PR TITLE
Fix pretty printing an AST representing `&(mut ident)`

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2420,7 +2420,15 @@ impl<'a> State<'a> {
                 if mutbl == ast::Mutability::Mut {
                     self.s.word("mut ");
                 }
-                self.print_pat(inner);
+                if let PatKind::Ident(ast::BindingMode::ByValue(ast::Mutability::Mut), ..) =
+                    inner.kind
+                {
+                    self.popen();
+                    self.print_pat(inner);
+                    self.pclose();
+                } else {
+                    self.print_pat(inner);
+                }
             }
             PatKind::Lit(ref e) => self.print_expr(&**e),
             PatKind::Range(ref begin, ref end, Spanned { node: ref end_kind, .. }) => {

--- a/src/test/ui/pattern/issue-80186-mut-binding-help-suggestion.rs
+++ b/src/test/ui/pattern/issue-80186-mut-binding-help-suggestion.rs
@@ -1,0 +1,9 @@
+// Regression test for correct pretty-printing of an AST representing `&(mut x)` in help
+// suggestion diagnostic.
+
+fn main() {
+    let mut &x = &0;
+    //~^ ERROR `mut` must be attached to each individual binding
+    //~| HELP add `mut` to each binding
+    //~| SUGGESTION &(mut x)
+}

--- a/src/test/ui/pattern/issue-80186-mut-binding-help-suggestion.stderr
+++ b/src/test/ui/pattern/issue-80186-mut-binding-help-suggestion.stderr
@@ -1,0 +1,10 @@
+error: `mut` must be attached to each individual binding
+  --> $DIR/issue-80186-mut-binding-help-suggestion.rs:5:9
+   |
+LL |     let mut &x = &0;
+   |         ^^^^^^ help: add `mut` to each binding: `&(mut x)`
+   |
+   = note: `mut` may be followed by `variable` and `variable @ pattern`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
The PR fixes a misguiding help diagnostic in the parser that I reported in #80186. I discovered that the parsers recovery and reporting logic was correct but the pretty printer produced wrong code for the example. (Details in https://github.com/rust-lang/rust/issues/80186#issuecomment-748498676)

Example:
```rust
#![allow(unused_variables)]
fn main() {
    let mut &x = &0;
}
```

The AST fragment

`PatKind::Ref(PatKind::Ident(BindingMode::ByValue(Mutability::Mut), ..), Mutability::Not)`

was printed to be `&mut ident`. But this wouldn't round trip through parsing again, because then it would be:

`PatKind::Ref(PatKind::Ident(BindingMode::ByValue(Mutability::Not), ..), Mutability::Mut)`

Now the pretty-printer prints `&(mut ident)`. Reparsing that code results in the AST fragment

`PatKind::Ref(PatKind::Paren(PatKind::Ident(BindingMode::ByValue(Mutability::Mut), ..)), Mutability::Not)`

which I think should behave like the original pattern.

Old diagnostic:
```
error: `mut` must be attached to each individual binding
 --> src/main.rs:3:9
  |
3 |     let mut &x = &0;
  |         ^^^^^^ help: add `mut` to each binding: `&mut x`
  |
  = note: `mut` may be followed by `variable` and `variable @ pattern`
```

New diagnostic:

```
error: `mut` must be attached to each individual binding
 --> src/main.rs:3:9
  |
3 |     let mut &x = &0;
  |         ^^^^^^ help: add `mut` to each binding: `&(mut x)`
  |
  = note: `mut` may be followed by `variable` and `variable @ pattern`
```

Fixes #80186