### PR TITLE
Fix labels for 'Library Tracking Issue' template

### DIFF
--- a/.github/ISSUE_TEMPLATE/library_tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/library_tracking_issue.md
@@ -2,7 +2,7 @@
 name: Library Tracking Issue
 about: A tracking issue for an unstable library feature.
 title: Tracking Issue for XXX
-labels: C-tracking-issue T-libs
+labels: C-tracking-issue, T-libs
 ---
 <!--
 Thank you for creating a tracking issue!


### PR DESCRIPTION
Each label needs to be separated by a comma (see the ICE issue template
for an example of correct usage).

r? @m-ou-se
