### PR TITLE
Add support for range params to rustdoc

### DIFF
--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -249,6 +249,10 @@ pub fn enum_def_to_string(
     to_string(NO_ANN, |s| s.print_enum_def(enum_definition, generics, name, span, visibility))
 }
 
+pub fn pat_to_string(pat: &hir::Pat<'_>) -> String {
+    to_string(NO_ANN, |s| s.print_pat(pat))
+}
+
 impl<'a> State<'a> {
     pub fn cbox(&mut self, u: usize) {
         self.s.cbox(u);

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -413,10 +413,7 @@ crate fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
             );
             return Symbol::intern("()");
         }
-        PatKind::Range(..) => panic!(
-            "tried to get argument name from PatKind::Range, \
-             which is not allowed in function arguments"
-        ),
+        PatKind::Range(..) => rustc_hir_pretty::pat_to_string(p),
         PatKind::Slice(ref begin, ref mid, ref end) => {
             let begin = begin.iter().map(|p| name_from_pat(&**p).to_string());
             let mid = mid.as_ref().map(|p| format!("..{}", name_from_pat(&**p))).into_iter();

--- a/src/test/rustdoc-ui/range-pattern.rs
+++ b/src/test/rustdoc-ui/range-pattern.rs
@@ -1,0 +1,3 @@
+// check-pass
+
+fn func(0u8..=255: u8) {}

--- a/src/test/rustdoc/range-arg-pattern.rs
+++ b/src/test/rustdoc/range-arg-pattern.rs
@@ -1,0 +1,5 @@
+#![crate_name = "foo"]
+
+// @has foo/fn.f.html
+// @has - '//*[@class="rust fn"]' 'pub fn f(0u8 ...255: u8)'
+pub fn f(0u8...255: u8) {}


### PR DESCRIPTION
Fixes #79497

There's future work to use rustc_hir_pretty for more of what the function does, but this fixes the ICE.