### PR TITLE
Fix typo

### DIFF
--- a/compiler/rustc_middle/src/ty/inhabitedness/def_id_forest.rs
+++ b/compiler/rustc_middle/src/ty/inhabitedness/def_id_forest.rs
@@ -17,7 +17,7 @@ pub struct DefIdForest {
     /// If A and B are DefIds in the `DefIdForest`, and A is a descendant
     /// of B, then only B will be in `root_ids`.
     /// We use a `SmallVec` here because (for its use for caching inhabitedness)
-    /// its rare that this will contain even two IDs.
+    /// it's rare that this will contain even two IDs.
     root_ids: SmallVec<[DefId; 1]>,
 }
 


### PR DESCRIPTION
Fix typo in rustc_middle::ty::inhabitedness::DefIdForest docs.