### PR TITLE
Remove `I-prioritize` from Zulip topic

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -90,7 +90,7 @@ exclude_labels = [
 
 [notify-zulip."I-prioritize"]
 zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
-topic = "I-prioritize #{number} {title}"
+topic = "#{number} {title}"
 message_on_add = """\
 @*WG-prioritization/alerts* issue #{number} has been requested for prioritization.
 


### PR DESCRIPTION
It doesn't add anything since every topic in
`t-compiler/wg-prioritization/alerts` is about prioritization.
And it makes it harder to see the issue title, which is what the topic
is actually about.

cc @rust-lang/wg-prioritization 