### PR TITLE
update rustfmt to v1.4.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.29"
+version = "1.4.30"
 dependencies = [
  "annotate-snippets 0.6.1",
  "anyhow",
@@ -5342,7 +5342,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.0",
+ "parking_lot 0.9.0",
  "regex",
  "serde",
  "serde_json",


### PR DESCRIPTION
Contains fixes for a few reported bugs on current nightly (1.4.29)

Notes in: https://github.com/rust-lang/rustfmt/releases/tag/v1.4.30