### PR TITLE
Don't try to add nested predicate to Rustdoc auto-trait `ParamEnv`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -642,12 +642,10 @@ impl AutoTraitFinder<'tcx> {
             let bound_predicate = predicate.bound_atom();
             match bound_predicate.skip_binder() {
                 ty::PredicateAtom::Trait(p, _) => {
-                    if self.is_param_no_infer(p.trait_ref.substs)
-                        && !only_projections
-                        && is_new_pred
-                    {
-                        self.add_user_pred(computed_preds, predicate);
-                    }
+                    // Add this to `predicates` so that we end up calling `select`
+                    // with it. If this predicate ends up being unimplemented,
+                    // then `evaluate_predicates` will handle adding it the `ParamEnv`
+                    // if possible.
                     predicates.push_back(bound_predicate.rebind(p));
                 }
                 ty::PredicateAtom::Projection(p) => {

--- a/src/test/rustdoc/issue-80233-normalize-auto-trait.rs
+++ b/src/test/rustdoc/issue-80233-normalize-auto-trait.rs
@@ -1,0 +1,37 @@
+// Regression test for issue #80233
+// Tests that we don't ICE when processing auto traits
+
+#![crate_type = "lib"]
+pub trait Trait1 {}
+
+pub trait Trait2 {
+    type Type2;
+}
+
+pub trait Trait3 {
+    type Type3;
+}
+
+impl Trait2 for Struct1 {
+    type Type2 = Struct1;
+}
+
+impl<I: Trait2> Trait2 for Vec<I> {
+    type Type2 = Vec<I::Type2>;
+}
+
+impl<T: Trait1> Trait3 for T {
+    type Type3 = Struct1;
+}
+
+impl<T: Trait3> Trait3 for Vec<T> {
+    type Type3 = Vec<T::Type3>;
+}
+
+pub struct Struct1 {}
+
+// @has issue_80233_normalize_auto_trait/struct.Question.html
+// @has - '//code' 'impl<T> Send for Question<T>'
+pub struct Question<T: Trait1> {
+    pub ins: <<Vec<T> as Trait3>::Type3 as Trait2>::Type2,
+}


### PR DESCRIPTION
Fixes #80233

We already have logic in `evaluate_predicates` that tries to add
unimplemented predicates to our `ParamEnv`. Trying to add a predicate
that already holds can lead to errors later on, since projection
will prefer trait candidates from the `ParamEnv` to predicates from an
impl.