### PR TITLE
std::process::unix: Command: Do not unwind past fork(), in child

### DIFF
--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -1,0 +1,22 @@
+#[test]
+fn test_command_fork_no_unwind() {
+    use crate::os::unix::process::CommandExt;
+    use crate::os::unix::process::ExitStatusExt;
+    use crate::panic::catch_unwind;
+    use crate::process::Command;
+
+    let got = catch_unwind(|| {
+        let mut c = Command::new("echo");
+        c.arg("hi");
+        unsafe {
+            c.pre_exec(|| panic!("crash now!"));
+        }
+        let st = c.status().expect("failed to get command status");
+        eprintln!("{:?}", st);
+        st
+    });
+    eprintln!("got={:?}", &got);
+    let estatus = got.expect("panic unexpectedly propagated");
+    let signal = estatus.signal().expect("expected child to die of signal");
+    assert!(signal == libc::SIGABRT || signal == libc::SIGILL);
+}


### PR DESCRIPTION
Unwinding past fork() in the child causes whatever traps the unwind
to return twice.  This is very strange and clearly not desirable.

With the default behaviour of the thread library, this can even result
in a panic in the child being transformed into zero exit status (ie,
success) as seen in the parent!

If unwinding reaches the fork point, the child should abort.