### PR TITLE
docs: Edit rustc_middle::middle::privacy

### DIFF
--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -8,7 +8,9 @@ use rustc_macros::HashStable;
 use std::fmt;
 use std::hash::Hash;
 
-// Accessibility levels, sorted in ascending order
+/// Represents the levels of accessibility an item can have.
+///
+/// The variants are sorted in ascending order of accessibility.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, HashStable)]
 pub enum AccessLevel {
     /// Superset of `AccessLevel::Reachable` used to mark impl Trait items.
@@ -18,13 +20,13 @@ pub enum AccessLevel {
     /// public, then type `T` is reachable. Its values can be obtained by other crates
     /// even if the type itself is not nameable.
     Reachable,
-    /// Public items + items accessible to other crates with help of `pub use` re-exports
+    /// Public items + items accessible to other crates with the help of `pub use` re-exports.
     Exported,
-    /// Items accessible to other crates directly, without help of re-exports
+    /// Items accessible to other crates directly, without the help of re-exports.
     Public,
 }
 
-// Accessibility levels for reachable HIR nodes
+/// Holds a map of accessibility levels for reachable HIR nodes.
 #[derive(Clone)]
 pub struct AccessLevels<Id = HirId> {
     pub map: FxHashMap<Id, AccessLevel>,


### PR DESCRIPTION
Add descriptions of `AccessLevel` and `AccessLevels`.

Add missing punctuation.