### PR TITLE
Add `as_{,mut_}ptr` methods to `Option`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1035,7 +1035,7 @@ impl<T> Option<&mut T> {
         }
     }
 
-    /// Converts from `Option<&mut T>` (or `&mut Option<&T>`) to `*mut T`.
+    /// Converts from `Option<&mut T>` (or `&mut Option<&mut T>`) to `*mut T`.
     ///
     /// This is the opposite of `<*mut T>::as_mut`.
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -152,6 +152,7 @@ use crate::pin::Pin;
 use crate::{
     convert, fmt, hint, mem,
     ops::{self, Deref, DerefMut},
+    ptr,
 };
 
 /// The `Option` type. See [the module level documentation](self) for more.
@@ -982,6 +983,83 @@ impl<T> Option<T> {
         F: FnOnce(T, U) -> R,
     {
         Some(f(self?, other?))
+    }
+}
+
+impl<T> Option<&T> {
+    /// Converts from `Option<&T>` (or `&Option<&T>`) to `*const T`.
+    ///
+    /// This is the opposite of `<*const T>::as_ref`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_as_ptr)]
+    ///
+    /// let opt = Some(&3);
+    /// let ptr = opt.as_ptr();
+    ///
+    /// assert_eq!(opt, unsafe { ptr.as_ref() });
+    /// ```
+    #[unstable(feature = "option_as_ptr", issue = "none")]
+    #[inline]
+    pub const fn as_ptr(&self) -> *const T {
+        match self {
+            Some(x) => *x,
+            None => ptr::null(),
+        }
+    }
+}
+
+impl<T> Option<&mut T> {
+    /// Converts from `Option<&mut T>` (or `&Option<&mut T>`) to `*const T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_as_ptr)]
+    ///
+    /// let mut x = 3;
+    /// let opt = Some(&mut x);
+    /// let ptr = opt.as_ptr();
+    ///
+    /// assert_eq!(x, unsafe { *ptr });
+    /// ```
+    #[unstable(feature = "option_as_ptr", issue = "none")]
+    #[rustc_const_unstable(feature = "option_as_ptr", issue = "none")]
+    #[inline]
+    pub const fn as_ptr(&self) -> *const T {
+        match self {
+            Some(x) => *x,
+            None => ptr::null(),
+        }
+    }
+
+    /// Converts from `Option<&mut T>` (or `&mut Option<&T>`) to `*mut T`.
+    ///
+    /// This is the opposite of `<*mut T>::as_mut`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_as_ptr)]
+    ///
+    /// let mut x = 3;
+    /// let mut opt = Some(&mut x);
+    ///
+    /// let ptr = opt.as_mut_ptr();
+    /// unsafe { *ptr = 4 };
+    ///
+    /// assert_eq!(x, 4);
+    /// ```
+    #[unstable(feature = "option_as_ptr", issue = "none")]
+    #[rustc_const_unstable(feature = "option_as_ptr", issue = "none")]
+    #[inline]
+    pub const fn as_mut_ptr(&mut self) -> *mut T {
+        match self {
+            Some(x) => *x,
+            None => ptr::null_mut(),
+        }
     }
 }
 


### PR DESCRIPTION
These enable simpler conversion from `Option<&{,mut} T>` to `*const T` and `Option<&mut T>` to `*mut T`.

These operations are the opposite of [`<*const T>::as_ref`](https://doc.rust-lang.org/std/primitive.pointer.html#method.as_ref) and [`<*mut T>::as_mut`](https://doc.rust-lang.org/std/primitive.pointer.html#method.as_mut).

In FFI, the types `Option<&T>` and `Option<&mut T>` are semantically equivalent to `*const T` and `*mut T`, and they can even be safely used in place of those types.

The `self` type in each method is a reference because `Option<&mut T>` does not implement `Copy`. These methods would otherwise move `self`, making them inconvenient or sometimes impossible to use.