### PR TITLE
Include rustdoc in the compiler docs index.

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -628,6 +628,8 @@ impl Step for Rustdoc {
         cargo.arg("-p").arg("rustdoc");
 
         cargo.rustdocflag("--document-private-items");
+        cargo.rustdocflag("--enable-index-page");
+        cargo.rustdocflag("-Zunstable-options");
         builder.run(&mut cargo.into());
     }
 }


### PR DESCRIPTION
This should help ensure that the index page at https://doc.rust-lang.org/nightly/nightly-rustc/ includes a link to the rustdoc docs as well.

Fixes #80307