### PR TITLE
[Rustdoc] Render tuple fields in structs correctly

### DIFF
--- a/src/test/rustdoc/tuple_struct_fields.rs
+++ b/src/test/rustdoc/tuple_struct_fields.rs
@@ -1,0 +1,9 @@
+// @has tuple_struct_fields/struct.Tooople.html
+// @has - //span '0: usize'
+// @has - 'Wow! i love tuple fields!'
+
+pub struct Tooople(
+    /// Wow! i love tuple fields!
+    pub usize,
+    u8,
+);

--- a/src/test/rustdoc/tuple_struct_fields.rs
+++ b/src/test/rustdoc/tuple_struct_fields.rs
@@ -1,9 +1,11 @@
 // @has tuple_struct_fields/struct.Tooople.html
 // @has - //span '0: usize'
 // @has - 'Wow! i love tuple fields!'
+// @!has - 'I should be invisible'
 
 pub struct Tooople(
     /// Wow! i love tuple fields!
     pub usize,
+    /// I should be invisible
     u8,
 );


### PR DESCRIPTION
This PR makes rustdoc render public tuple fields correctly similar to normal fields, previously no rendering would happen and the description of the field was effectively discarded.

Before:
![before](https://imgur.com/Yx7KpNn.png)

After:
![after](https://imgur.com/DSq2Gqd.png)

I was thinking about coloring the `0` a different color, maybe the color of primitives so it stands out more, but id like to hear opinions on that first.