### PR TITLE
Use a bitset in is_local_ever_initialized

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -712,6 +712,18 @@ impl<T: Idx> GrowableBitSet<T> {
         let (word_index, mask) = word_index_and_mask(elem);
         if let Some(word) = self.bit_set.words.get(word_index) { (word & mask) != 0 } else { false }
     }
+
+    /// Count the number of set bits in the set.
+    #[inline]
+    pub fn count(&self) -> usize {
+        self.bit_set.count()
+    }
+
+    /// Iterates over the indices of set bits in a sorted order.
+    #[inline]
+    pub fn iter(&self) -> BitIter<'_, T> {
+        self.bit_set.iter()
+    }
 }
 
 /// A fixed-size 2D bit matrix type with a dense representation.

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
@@ -436,8 +436,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             LookupResult::Exact(mpi) | LookupResult::Parent(Some(mpi)) => {
                 debug!("borrowed_content_source: mpi={:?}", mpi);
 
-                for i in &self.move_data.init_path_map[mpi] {
-                    let init = &self.move_data.inits[*i];
+                for i in self.move_data.init_path_map[mpi].iter() {
+                    let init = &self.move_data.inits[i];
                     debug!("borrowed_content_source: init={:?}", init);
                     // We're only interested in statements that initialized a value, not the
                     // initializations from arguments.

--- a/compiler/rustc_mir/src/dataflow/impls/mod.rs
+++ b/compiler/rustc_mir/src/dataflow/impls/mod.rs
@@ -632,7 +632,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
                 "stmt {:?} at loc {:?} clears the ever initialized status of {:?}",
                 stmt, location, &init_path_map[move_path_index]
             );
-            trans.kill_all(init_path_map[move_path_index].iter().copied());
+            trans.kill_all(init_path_map[move_path_index].iter());
         }
     }
 

--- a/compiler/rustc_mir/src/dataflow/move_paths/mod.rs
+++ b/compiler/rustc_mir/src/dataflow/move_paths/mod.rs
@@ -1,6 +1,9 @@
 use core::slice::Iter;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_index::vec::{Enumerated, IndexVec};
+use rustc_index::{
+    bit_set::GrowableBitSet,
+    vec::{Enumerated, IndexVec},
+};
 use rustc_middle::mir::*;
 use rustc_middle::ty::{ParamEnv, Ty, TyCtxt};
 use rustc_span::Span;
@@ -177,7 +180,7 @@ pub struct MoveData<'tcx> {
     /// Each Location `l` is mapped to the Inits that are effects
     /// of executing the code at `l`.
     pub init_loc_map: LocationMap<SmallVec<[InitIndex; 4]>>,
-    pub init_path_map: IndexVec<MovePathIndex, SmallVec<[InitIndex; 4]>>,
+    pub init_path_map: IndexVec<MovePathIndex, GrowableBitSet<InitIndex>>,
 }
 
 pub trait HasMoveData<'tcx> {


### PR DESCRIPTION
Reduces instructions executed locally by ~1% on unicode_normalization-Check.

Let's see what it does for the rest of the benchmarks.