### PR TITLE
Don't panic when an external crate can't be resolved

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -428,16 +428,15 @@ crate fn create_resolver<'a>(
         sess.time("load_extern_crates", || {
             for extern_name in &extern_names {
                 debug!("loading extern crate {}", extern_name);
-                resolver
+                if let Err(()) = resolver
                     .resolve_str_path_error(
                         DUMMY_SP,
                         extern_name,
                         TypeNS,
                         LocalDefId { local_def_index: CRATE_DEF_INDEX }.to_def_id(),
-                    )
-                    .unwrap_or_else(|()| {
-                        panic!("Unable to resolve external crate {}", extern_name)
-                    });
+                  ) {
+                    warn!("unable to resolve external crate {} (do you have an unused `--extern` crate?)", extern_name)
+                  }
             }
         });
     });

--- a/src/test/rustdoc-ui/intra-doc/unused-extern-crate.rs
+++ b/src/test/rustdoc-ui/intra-doc/unused-extern-crate.rs
@@ -1,0 +1,5 @@
+// compile-flags: --extern zip=whatever.rlib
+#![deny(broken_intra_doc_links)]
+/// See [zip] crate.
+//~^ ERROR unresolved
+pub struct ArrayZip;

--- a/src/test/rustdoc-ui/intra-doc/unused-extern-crate.stderr
+++ b/src/test/rustdoc-ui/intra-doc/unused-extern-crate.stderr
@@ -1,0 +1,15 @@
+error: unresolved link to `zip`
+  --> $DIR/unused-extern-crate.rs:3:10
+   |
+LL | /// See [zip] crate.
+   |          ^^^ no item named `zip` in scope
+   |
+note: the lint level is defined here
+  --> $DIR/unused-extern-crate.rs:2:9
+   |
+LL | #![deny(broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This isn't actually a bug, it can occur when rustdoc tries to resolve a
crate that isn't used in the main code.

Fixes #72381.

r? @kinnison if you have time, otherwise @Manishearth 