### PR TITLE
Add a static analysis that prevents references to inner mutability only in the trailing expression of a constant

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0492.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0492.md
@@ -3,10 +3,11 @@ A borrow of a constant containing interior mutability was attempted.
 Erroneous code example:
 
 ```compile_fail,E0492
+#![feature(const_refs_to_cell)]
 use std::sync::atomic::AtomicUsize;
 
 const A: AtomicUsize = AtomicUsize::new(0);
-static B: &'static AtomicUsize = &A;
+const B: &'static AtomicUsize = &A;
 // error: cannot borrow a constant which may contain interior mutability,
 //        create a static instead
 ```
@@ -18,7 +19,7 @@ can't be changed via a shared `&` pointer, but interior mutability would allow
 it. That is, a constant value could be mutated. On the other hand, a `static` is
 explicitly a single memory location, which can be mutated at will.
 
-So, in order to solve this error, either use statics which are `Sync`:
+So, in order to solve this error, use statics which are `Sync`:
 
 ```
 use std::sync::atomic::AtomicUsize;
@@ -30,6 +31,7 @@ static B: &'static AtomicUsize = &A; // ok!
 You can also have this error while using a cell type:
 
 ```compile_fail,E0492
+#![feature(const_refs_to_cell)]
 use std::cell::Cell;
 
 const A: Cell<usize> = Cell::new(1);

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -623,6 +623,9 @@ declare_features! (
     /// Allows arbitrary expressions in key-value attributes at parse time.
     (active, extended_key_value_attributes, "1.50.0", Some(78835), None),
 
+    /// Allows references to types with interior mutability within constants
+    (active, const_refs_to_cell, "1.51.0", Some(80384), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -697,6 +697,7 @@ impl<'hir> Map<'hir> {
             | Node::ForeignItem(ForeignItem { kind: ForeignItemKind::Fn(..), .. })
             | Node::TraitItem(TraitItem { kind: TraitItemKind::Fn(..), .. })
             | Node::ImplItem(ImplItem { kind: ImplItemKind::Fn(..), .. })
+            | Node::AnonConst(..)
             | Node::Block(_) = node
             {
                 return Some(hir_id);

--- a/compiler/rustc_mir/src/dataflow/framework/fmt.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/fmt.rs
@@ -139,18 +139,16 @@ where
     V: DebugWithContext<C> + Eq,
 {
     fn fmt_with(&self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_set().entries(self.iter_enumerated().map(|this| DebugWithAdapter { this, ctxt })).finish()
+        f.debug_set()
+            .entries(self.iter_enumerated().map(|this| DebugWithAdapter { this, ctxt }))
+            .finish()
     }
 
     fn fmt_diff_with(&self, old: &Self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         assert_eq!(self.len(), old.len());
 
         for (new, old) in self.iter_enumerated().zip(old.iter_enumerated()) {
-            write!(f, "{:?}", DebugDiffWithAdapter {
-                new,
-                old,
-                ctxt,
-            })?;
+            write!(f, "{:?}", DebugDiffWithAdapter { new, old, ctxt })?;
         }
 
         Ok(())
@@ -201,7 +199,8 @@ impl<T, U, C> DebugWithContext<C> for (T, U)
 where
     T: DebugWithContext<C>,
     U: DebugWithContext<C>,
-{}
+{
+}
 
 impl<C> DebugWithContext<C> for rustc_middle::mir::Local {}
 impl<C> DebugWithContext<C> for crate::dataflow::move_paths::InitIndex {}

--- a/compiler/rustc_mir/src/dataflow/framework/lattice.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/lattice.rs
@@ -89,6 +89,35 @@ impl JoinSemiLattice for bool {
     }
 }
 
+/// Just for completion, we implement `JoinSemiLattice` for `()`, where top and bottom are
+/// the same value.
+impl JoinSemiLattice for () {
+    fn join(&mut self, _: &Self) -> bool {
+        false
+    }
+}
+
+/// An `Option` is a "two-point" lattice with `Some as the top element and `None` as the bottom:
+///
+/// ```text
+///      Some(T)
+///        |
+///      None
+/// ```
+impl<T: JoinSemiLattice + Clone> JoinSemiLattice for Option<T> {
+    fn join(&mut self, other: &Self) -> bool {
+        match (self, other) {
+            (None, None) |
+            (Some(_), None) => false,
+            (this @ None, Some(val)) => {
+                *this = Some(val.clone());
+                true
+            }
+            (Some(a), Some(b)) => a.join(b),
+        }
+    }
+}
+
 impl MeetSemiLattice for bool {
     fn meet(&mut self, other: &Self) -> bool {
         if let (true, false) = (*self, *other) {

--- a/compiler/rustc_mir/src/dataflow/framework/lattice.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/lattice.rs
@@ -107,8 +107,7 @@ impl JoinSemiLattice for () {
 impl<T: JoinSemiLattice + Clone> JoinSemiLattice for Option<T> {
     fn join(&mut self, other: &Self) -> bool {
         match (self, other) {
-            (None, None) |
-            (Some(_), None) => false,
+            (None, None) | (Some(_), None) => false,
             (this @ None, Some(val)) => {
                 *this = Some(val.clone());
                 true

--- a/compiler/rustc_mir/src/transform/check_consts/mod.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/mod.rs
@@ -11,7 +11,7 @@ use rustc_middle::mir;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::Symbol;
 
-pub use self::qualifs::Qualif;
+pub(super) use self::qualifs::Qualif;
 
 mod ops;
 pub mod post_drop_elaboration;

--- a/compiler/rustc_mir/src/transform/check_consts/post_drop_elaboration.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/post_drop_elaboration.rs
@@ -78,7 +78,7 @@ impl Visitor<'tcx> for CheckLiveDrops<'mir, 'tcx> {
         match &terminator.kind {
             mir::TerminatorKind::Drop { place: dropped_place, .. } => {
                 let dropped_ty = dropped_place.ty(self.body, self.tcx).ty;
-                if !NeedsDrop::in_any_value_of_ty(self.ccx, dropped_ty) {
+                if NeedsDrop::in_any_value_of_ty(self.ccx, dropped_ty).is_none() {
                     return;
                 }
 
@@ -87,7 +87,7 @@ impl Visitor<'tcx> for CheckLiveDrops<'mir, 'tcx> {
                     return;
                 }
 
-                if self.qualifs.needs_drop(self.ccx, dropped_place.local, location) {
+                if self.qualifs.needs_drop(self.ccx, dropped_place.local, location).is_some() {
                     // Use the span where the dropped local was declared for the error.
                     let span = self.body.local_decls[dropped_place.local].source_info.span;
                     self.check_live_drop(span);

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -21,12 +21,15 @@ use std::mem;
 use std::ops::Deref;
 
 use super::ops::{self, NonConstOp, Status};
-use super::qualifs::{self, CustomEq, HasMutInterior, NeedsDrop, QualifsPerLocal, HasMutInteriorBehindRef, HasMutInteriorBehindRefState};
+use super::qualifs::{
+    self, CustomEq, HasMutInterior, HasMutInteriorBehindRef, HasMutInteriorBehindRefState,
+    NeedsDrop, QualifsPerLocal,
+};
 use super::resolver::FlowSensitiveAnalysis;
 use super::{is_lang_panic_fn, ConstCx, Qualif};
 use crate::const_eval::is_unstable_const_fn;
 use crate::dataflow::impls::MaybeMutBorrowedLocals;
-use crate::dataflow::{self, Analysis, lattice::JoinSemiLattice};
+use crate::dataflow::{self, lattice::JoinSemiLattice, Analysis};
 
 // We are using `MaybeMutBorrowedLocals` as a proxy for whether an item may have been mutated
 // through a pointer prior to the given point. This is okay even though `MaybeMutBorrowedLocals`
@@ -290,7 +293,9 @@ impl Validator<'mir, 'tcx> {
 
         if let hir::ConstContext::Const = self.const_kind() {
             // Ensure that we do not produce references with interior mutability behind them
-            if let Some(HasMutInteriorBehindRefState::Yes) = self.qualifs.return_place_has_mut_interior_behind_ref(self.ccx) {
+            if let Some(HasMutInteriorBehindRefState::Yes) =
+                self.qualifs.return_place_has_mut_interior_behind_ref(self.ccx)
+            {
                 // FIXME: Trace the source of the `Yes` in dataflow
                 self.span = body.local_decls[RETURN_PLACE].source_info.span;
                 self.check_op(ops::CellBorrow)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -380,6 +380,7 @@ symbols! {
         const_ptr,
         const_raw_ptr_deref,
         const_raw_ptr_to_usize_cast,
+        const_refs_to_cell,
         const_slice_ptr,
         const_trait_bound_opt_out,
         const_trait_impl,

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -1,43 +1,20 @@
-error[E0391]: cycle detected when simplifying constant for the type system `IMPL_REF_BAR`
+error[E0391]: cycle detected when const checking `IMPL_REF_BAR`
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:27
+   |
+LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
+   |                           ^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires const checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:22
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |                      ^^^^^^^^^^^^
+   = note: ...which again requires const checking `IMPL_REF_BAR`, completing the cycle
+note: cycle used when processing `IMPL_REF_BAR`
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
    |
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: ...which requires simplifying constant for the type system `IMPL_REF_BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
-   |
-LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
-   |
-LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which requires normalizing `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
-note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
-   |
-LL |     const BAR: u32 = IMPL_REF_BAR;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
-   |
-LL |     const BAR: u32 = IMPL_REF_BAR;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
-   |
-LL |     const BAR: u32 = IMPL_REF_BAR;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires optimizing MIR for `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
-  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
-   |
-LL |     const BAR: u32 = IMPL_REF_BAR;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which requires normalizing `IMPL_REF_BAR`...
-   = note: ...which again requires simplifying constant for the type system `IMPL_REF_BAR`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-address-of-interior-mut.stderr
+++ b/src/test/ui/consts/const-address-of-interior-mut.stderr
@@ -1,27 +1,39 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:5:39
    |
 LL | const A: () = { let x = Cell::new(2); &raw const x; };
    |                                       ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:7:40
    |
 LL | static B: () = { let x = Cell::new(2); &raw const x; };
    |                                        ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:9:44
    |
 LL | static mut C: () = { let x = Cell::new(2); &raw const x; };
    |                                            ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:13:13
    |
 LL |     let y = &raw const x;
    |             ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0492`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const-multi-ref.rs
+++ b/src/test/ui/consts/const-multi-ref.rs
@@ -13,7 +13,7 @@ const _: i32 = {
 
 const _: std::cell::Cell<i32> = {
     let mut a = std::cell::Cell::new(5);
-    let p = &a; //~ ERROR cannot borrow a constant which may contain interior mutability
+    let p = &a; //~ ERROR borrowed element may contain interior mutability
 
     let reborrow = {p};
     let pp = &reborrow;

--- a/src/test/ui/consts/const-multi-ref.stderr
+++ b/src/test/ui/consts/const-multi-ref.stderr
@@ -4,13 +4,16 @@ error[E0764]: mutable references are not allowed in constants
 LL |     let p = &mut a;
    |             ^^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-multi-ref.rs:16:13
    |
 LL |     let p = &a;
    |             ^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0492, E0764.
-For more information about an error, try `rustc --explain E0492`.
+Some errors have detailed explanations: E0658, E0764.
+For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static.stderr
@@ -19,6 +19,11 @@ LL |     READ_MUT;
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
+  --> $DIR/const_refers_to_static.rs:11:28
+   |
+LL | const MUTATE_INTERIOR_MUT: usize = {
+   |                            ^^^^^
+help: skipping check that does not even have a feature gate
   --> $DIR/const_refers_to_static.rs:13:5
    |
 LL |     FOO.fetch_add(1, Ordering::Relaxed)

--- a/src/test/ui/consts/miri_unleashed/mutable_references.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references.stderr
@@ -21,7 +21,7 @@ help: skipping check that does not even have a feature gate
    |
 LL | static BOO: &mut Foo<()> = &mut Foo(());
    |                            ^^^^^^^^^^^^
-help: skipping check that does not even have a feature gate
+help: skipping check for `const_refs_to_cell` feature
   --> $DIR/mutable_references.rs:26:8
    |
 LL |     x: &UnsafeCell::new(42),

--- a/src/test/ui/consts/miri_unleashed/mutable_references_err.stderr
+++ b/src/test/ui/consts/miri_unleashed/mutable_references_err.stderr
@@ -27,11 +27,21 @@ LL | const BLUNT: &mut i32 = &mut 42;
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
+  --> $DIR/mutable_references_err.rs:16:12
+   |
+LL | const MUH: Meh = Meh {
+   |            ^^^
+help: skipping check for `const_refs_to_cell` feature
   --> $DIR/mutable_references_err.rs:17:8
    |
 LL |     x: &UnsafeCell::new(42),
    |        ^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
+  --> $DIR/mutable_references_err.rs:26:15
+   |
+LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };
+   |               ^^^^^^^^^
+help: skipping check for `const_refs_to_cell` feature
   --> $DIR/mutable_references_err.rs:26:27
    |
 LL | const SNEAKY: &dyn Sync = &Synced { x: UnsafeCell::new(42) };

--- a/src/test/ui/consts/miri_unleashed/raw_mutable_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/raw_mutable_const.stderr
@@ -7,6 +7,11 @@ LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *m
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
+  --> $DIR/raw_mutable_const.rs:7:27
+   |
+LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;
+   |                           ^^^^^^^^
+help: skipping check for `const_refs_to_cell` feature
   --> $DIR/raw_mutable_const.rs:7:38
    |
 LL | const MUTABLE_BEHIND_RAW: *mut i32 = &UnsafeCell::new(42) as *const _ as *mut _;

--- a/src/test/ui/consts/partial_qualif.rs
+++ b/src/test/ui/consts/partial_qualif.rs
@@ -1,9 +1,11 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::Cell;
 
-const FOO: &(Cell<usize>, bool) = {
+const FOO: &(Cell<usize>, bool) = { //~ ERROR may contain interior mutability
     let mut a = (Cell::new(0), false);
     a.1 = true; // sets `qualif(a)` to `qualif(a) | qualif(true)`
-    &{a} //~ ERROR cannot borrow a constant which may contain interior mutability
+    &{a}
 };
 
 fn main() {}

--- a/src/test/ui/consts/partial_qualif.stderr
+++ b/src/test/ui/consts/partial_qualif.stderr
@@ -1,8 +1,8 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/partial_qualif.rs:6:5
+  --> $DIR/partial_qualif.rs:5:12
    |
-LL |     &{a}
-   |     ^^^^
+LL | const FOO: &(Cell<usize>, bool) = {
+   |            ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/qualif_overwrite.rs
+++ b/src/test/ui/consts/qualif_overwrite.rs
@@ -1,13 +1,15 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::Cell;
 
 // this is overly conservative. The reset to `None` should clear `a` of all qualifications
 // while we could fix this, it would be inconsistent with `qualif_overwrite_2.rs`.
 // We can fix this properly in the future by allowing constants that do not depend on generics
 // to be checked by an analysis on the final value instead of looking at the body.
-const FOO: &Option<Cell<usize>> = {
+const FOO: &Option<Cell<usize>> = { //~ ERROR may contain interior mutability
     let mut a = Some(Cell::new(0));
     a = None; // sets `qualif(a)` to `qualif(a) | qualif(None)`
-    &{a} //~ ERROR cannot borrow a constant which may contain interior mutability
+    &{a}
 };
 
 fn main() {}

--- a/src/test/ui/consts/qualif_overwrite.stderr
+++ b/src/test/ui/consts/qualif_overwrite.stderr
@@ -1,8 +1,8 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/qualif_overwrite.rs:10:5
+  --> $DIR/qualif_overwrite.rs:9:12
    |
-LL |     &{a}
-   |     ^^^^
+LL | const FOO: &Option<Cell<usize>> = {
+   |            ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/qualif_overwrite_2.rs
+++ b/src/test/ui/consts/qualif_overwrite_2.rs
@@ -1,11 +1,13 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::Cell;
 
 // const qualification is not smart enough to know about fields and always assumes that there might
 // be other fields that caused the qualification
-const FOO: &Option<Cell<usize>> = {
+const FOO: &Option<Cell<usize>> = { //~ ERROR may contain interior mutability
     let mut a = (Some(Cell::new(0)),);
     a.0 = None; // sets `qualif(a)` to `qualif(a) | qualif(None)`
-    &{a.0} //~ ERROR cannot borrow a constant which may contain interior mutability
+    &{a.0}
 };
 
 fn main() {}

--- a/src/test/ui/consts/qualif_overwrite_2.stderr
+++ b/src/test/ui/consts/qualif_overwrite_2.stderr
@@ -1,8 +1,8 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/qualif_overwrite_2.rs:8:5
+  --> $DIR/qualif_overwrite_2.rs:7:12
    |
-LL |     &{a.0}
-   |     ^^^^^^
+LL | const FOO: &Option<Cell<usize>> = {
+   |            ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/std/cell.rs
+++ b/src/test/ui/consts/std/cell.rs
@@ -1,24 +1,31 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::*;
 
-// not ok, because this would create a silent constant with interior mutability.
-// the rules could be relaxed in the future
 static FOO: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
-//~^ ERROR cannot borrow a constant which may contain interior mutability
+// not ok in a constant, because this would create a silent constant with interior mutability.
+const FOO_CONST: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
+//~^ ERROR may contain interior mutability
 
 static FOO3: Wrap<Cell<u32>> = Wrap(Cell::new(42));
+const FOO3_CONST: Wrap<Cell<u32>> = Wrap(Cell::new(42));
+
 // ok
 static FOO4: Wrap<*mut u32> = Wrap(FOO3.0.as_ptr());
+const FOO4_CONST: Wrap<*mut u32> = Wrap(FOO3_CONST.0.as_ptr());
+//~^ ERROR may contain interior mutability
 
 // not ok, because the `as_ptr` call takes a reference to a type with interior mutability
 // which is not allowed in constants
 const FOO2: *mut u32 = Cell::new(42).as_ptr();
-//~^ ERROR cannot borrow a constant which may contain interior mutability
+//~^ ERROR may contain interior mutability
 
 struct IMSafeTrustMe(UnsafeCell<u32>);
 unsafe impl Send for IMSafeTrustMe {}
 unsafe impl Sync for IMSafeTrustMe {}
 
 static BAR: IMSafeTrustMe = IMSafeTrustMe(UnsafeCell::new(5));
+
 
 
 struct Wrap<T>(T);

--- a/src/test/ui/consts/std/cell.stderr
+++ b/src/test/ui/consts/std/cell.stderr
@@ -1,15 +1,21 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/cell.rs:5:35
+  --> $DIR/cell.rs:7:18
    |
-LL | static FOO: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
-   |                                   ^^^^^^^^^^^^^
+LL | const FOO_CONST: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
+   |                  ^^^^^^^^^^^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/cell.rs:14:24
+  --> $DIR/cell.rs:15:19
+   |
+LL | const FOO4_CONST: Wrap<*mut u32> = Wrap(FOO3_CONST.0.as_ptr());
+   |                   ^^^^^^^^^^^^^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+  --> $DIR/cell.rs:20:13
    |
 LL | const FOO2: *mut u32 = Cell::new(42).as_ptr();
-   |                        ^^^^^^^^^^^^^
+   |             ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0492`.

--- a/src/test/ui/error-codes/E0492.rs
+++ b/src/test/ui/error-codes/E0492.rs
@@ -1,7 +1,13 @@
+#![feature(const_refs_to_cell)]
+
 use std::sync::atomic::AtomicUsize;
 
 const A: AtomicUsize = AtomicUsize::new(0);
-static B: &'static AtomicUsize = &A; //~ ERROR E0492
+const B: &'static AtomicUsize = &A; //~ ERROR E0492
+// We allow this, because we would allow it *anyway* if `A` were a `static`.
+static C: &'static AtomicUsize = &A;
+
+const NONE: &'static Option<AtomicUsize> = &None;
 
 fn main() {
 }

--- a/src/test/ui/error-codes/E0492.stderr
+++ b/src/test/ui/error-codes/E0492.stderr
@@ -1,8 +1,8 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/E0492.rs:4:34
+  --> $DIR/E0492.rs:6:10
    |
-LL | static B: &'static AtomicUsize = &A;
-   |                                  ^^
+LL | const B: &'static AtomicUsize = &A;
+   |          ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/feature-gate-const_refs_to_cell.rs
+++ b/src/test/ui/feature-gate/feature-gate-const_refs_to_cell.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![feature(const_refs_to_cell)]
+
+const FOO: () = {
+    let x = std::cell::Cell::new(42);
+    let y = &x;
+};
+
+fn main() {
+    FOO;
+}

--- a/src/test/ui/impl-trait/issues/issue-78722.rs
+++ b/src/test/ui/impl-trait/issues/issue-78722.rs
@@ -5,6 +5,7 @@
 //~^ WARN the feature `impl_trait_in_bindings` is incomplete
 
 type F = impl core::future::Future<Output = u8>;
+//~^ ERROR type mismatch
 
 struct Bug {
     V1: [(); {

--- a/src/test/ui/impl-trait/issues/issue-78722.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.stderr
@@ -14,13 +14,13 @@ LL | type F = impl core::future::Future<Output = u8>;
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `u8`
 
 error: `async` blocks are not allowed in constants
-  --> $DIR/issue-78722.rs:14:20
+  --> $DIR/issue-78722.rs:15:20
    |
 LL |         let f: F = async { 1 };
    |                    ^^^^^^^^^^^
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/issue-78722.rs:14:13
+  --> $DIR/issue-78722.rs:15:13
    |
 LL |         let f: F = async { 1 };
    |             ^ constants cannot evaluate destructors

--- a/src/test/ui/impl-trait/issues/issue-78722.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.stderr
@@ -7,6 +7,12 @@ LL | #![feature(impl_trait_in_bindings)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
+error[E0271]: type mismatch resolving `<impl Future as Future>::Output == u8`
+  --> $DIR/issue-78722.rs:7:10
+   |
+LL | type F = impl core::future::Future<Output = u8>;
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `u8`
+
 error: `async` blocks are not allowed in constants
   --> $DIR/issue-78722.rs:14:20
    |
@@ -22,6 +28,7 @@ LL |         let f: F = async { 1 };
 LL |     }],
    |     - value is dropped here
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0271, E0493.
+For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/issues/issue-17252.stderr
+++ b/src/test/ui/issues/issue-17252.stderr
@@ -1,22 +1,11 @@
-error[E0391]: cycle detected when normalizing `FOO`
-   |
-note: ...which requires simplifying constant for the type system `FOO`...
-  --> $DIR/issue-17252.rs:1:1
+error[E0391]: cycle detected when const checking `FOO`
+  --> $DIR/issue-17252.rs:1:20
    |
 LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires simplifying constant for the type system `FOO`...
-  --> $DIR/issue-17252.rs:1:1
+   |                    ^^^
    |
-LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `FOO`...
-  --> $DIR/issue-17252.rs:1:1
-   |
-LL | const FOO: usize = FOO;
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which again requires normalizing `FOO`, completing the cycle
-note: cycle used when const-evaluating + checking `main::{constant#0}`
+   = note: ...which again requires const checking `FOO`, completing the cycle
+note: cycle used when const checking `main::{constant#0}`
   --> $DIR/issue-17252.rs:4:18
    |
 LL |     let _x: [u8; FOO]; // caused stack overflow prior to fix

--- a/src/test/ui/issues/issue-17718-const-borrow.rs
+++ b/src/test/ui/issues/issue-17718-const-borrow.rs
@@ -1,14 +1,16 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::UnsafeCell;
 
 const A: UnsafeCell<usize> = UnsafeCell::new(1);
 const B: &'static UnsafeCell<usize> = &A;
-//~^ ERROR: cannot borrow a constant which may contain interior mutability
+//~^ ERROR: may contain interior mutability
 
 struct C { a: UnsafeCell<usize> }
 const D: C = C { a: UnsafeCell::new(1) };
 const E: &'static UnsafeCell<usize> = &D.a;
-//~^ ERROR: cannot borrow a constant which may contain interior mutability
+//~^ ERROR: may contain interior mutability
 const F: &'static C = &D;
-//~^ ERROR: cannot borrow a constant which may contain interior mutability
+//~^ ERROR: may contain interior mutability
 
 fn main() {}

--- a/src/test/ui/issues/issue-17718-const-borrow.stderr
+++ b/src/test/ui/issues/issue-17718-const-borrow.stderr
@@ -1,20 +1,20 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:4:39
+  --> $DIR/issue-17718-const-borrow.rs:6:10
    |
 LL | const B: &'static UnsafeCell<usize> = &A;
-   |                                       ^^
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:9:39
+  --> $DIR/issue-17718-const-borrow.rs:11:10
    |
 LL | const E: &'static UnsafeCell<usize> = &D.a;
-   |                                       ^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:11:23
+  --> $DIR/issue-17718-const-borrow.rs:13:10
    |
 LL | const F: &'static C = &D;
-   |                       ^^
+   |          ^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-23302-1.stderr
+++ b/src/test/ui/issues/issue-23302-1.stderr
@@ -1,26 +1,15 @@
-error[E0391]: cycle detected when simplifying constant for the type system `X::A::{constant#0}`
+error[E0391]: cycle detected when const checking `X::A::{constant#0}`
   --> $DIR/issue-23302-1.rs:4:9
    |
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
    |
-note: ...which requires simplifying constant for the type system `X::A::{constant#0}`...
+   = note: ...which again requires const checking `X::A::{constant#0}`, completing the cycle
+note: cycle used when const-evaluating + checking `X::A::{constant#0}`
   --> $DIR/issue-23302-1.rs:4:9
    |
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `X::A::{constant#0}`...
-  --> $DIR/issue-23302-1.rs:4:9
-   |
-LL |     A = X::A as isize,
-   |         ^^^^^^^^^^^^^
-   = note: ...which requires normalizing `X::A as isize`...
-   = note: ...which again requires simplifying constant for the type system `X::A::{constant#0}`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-23302-1.rs:3:1
-   |
-LL | enum X {
-   | ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23302-2.stderr
+++ b/src/test/ui/issues/issue-23302-2.stderr
@@ -1,26 +1,15 @@
-error[E0391]: cycle detected when simplifying constant for the type system `Y::A::{constant#0}`
+error[E0391]: cycle detected when const checking `Y::A::{constant#0}`
   --> $DIR/issue-23302-2.rs:4:9
    |
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
    |
-note: ...which requires simplifying constant for the type system `Y::A::{constant#0}`...
+   = note: ...which again requires const checking `Y::A::{constant#0}`, completing the cycle
+note: cycle used when const-evaluating + checking `Y::A::{constant#0}`
   --> $DIR/issue-23302-2.rs:4:9
    |
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `Y::A::{constant#0}`...
-  --> $DIR/issue-23302-2.rs:4:9
-   |
-LL |     A = Y::B as isize,
-   |         ^^^^^^^^^^^^^
-   = note: ...which requires normalizing `Y::B as isize`...
-   = note: ...which again requires simplifying constant for the type system `Y::A::{constant#0}`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-23302-2.rs:3:1
-   |
-LL | enum Y {
-   | ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -1,38 +1,20 @@
-error[E0391]: cycle detected when simplifying constant for the type system `A`
+error[E0391]: cycle detected when const checking `A`
+  --> $DIR/issue-23302-3.rs:1:16
+   |
+LL | const A: i32 = B;
+   |                ^
+   |
+note: ...which requires const checking `B`...
+  --> $DIR/issue-23302-3.rs:3:16
+   |
+LL | const B: i32 = A;
+   |                ^
+   = note: ...which again requires const checking `A`, completing the cycle
+note: cycle used when processing `A`
   --> $DIR/issue-23302-3.rs:1:1
    |
 LL | const A: i32 = B;
    | ^^^^^^^^^^^^^^^^^
-   |
-note: ...which requires simplifying constant for the type system `A`...
-  --> $DIR/issue-23302-3.rs:1:1
-   |
-LL | const A: i32 = B;
-   | ^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `A`...
-  --> $DIR/issue-23302-3.rs:1:1
-   |
-LL | const A: i32 = B;
-   | ^^^^^^^^^^^^^^^^^
-   = note: ...which requires normalizing `B`...
-note: ...which requires simplifying constant for the type system `B`...
-  --> $DIR/issue-23302-3.rs:3:1
-   |
-LL | const B: i32 = A;
-   | ^^^^^^^^^^^^^^^^^
-note: ...which requires simplifying constant for the type system `B`...
-  --> $DIR/issue-23302-3.rs:3:1
-   |
-LL | const B: i32 = A;
-   | ^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `B`...
-  --> $DIR/issue-23302-3.rs:3:1
-   |
-LL | const B: i32 = A;
-   | ^^^^^^^^^^^^^^^^^
-   = note: ...which requires normalizing `A`...
-   = note: ...which again requires simplifying constant for the type system `A`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-36163.stderr
+++ b/src/test/ui/issues/issue-36163.stderr
@@ -1,48 +1,20 @@
-error[E0391]: cycle detected when simplifying constant for the type system `Foo::B::{constant#0}`
+error[E0391]: cycle detected when const checking `Foo::B::{constant#0}`
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
    |         ^
    |
-note: ...which requires simplifying constant for the type system `Foo::B::{constant#0}`...
+note: ...which requires const checking `A`...
+  --> $DIR/issue-36163.rs:1:18
+   |
+LL | const A: isize = Foo::B as isize;
+   |                  ^^^^^^^^^^^^^^^
+   = note: ...which again requires const checking `Foo::B::{constant#0}`, completing the cycle
+note: cycle used when const-evaluating + checking `Foo::B::{constant#0}`
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
    |         ^
-note: ...which requires const-evaluating + checking `Foo::B::{constant#0}`...
-  --> $DIR/issue-36163.rs:4:9
-   |
-LL |     B = A,
-   |         ^
-   = note: ...which requires normalizing `A`...
-note: ...which requires simplifying constant for the type system `A`...
-  --> $DIR/issue-36163.rs:1:1
-   |
-LL | const A: isize = Foo::B as isize;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires simplifying constant for the type system `A`...
-  --> $DIR/issue-36163.rs:1:1
-   |
-LL | const A: isize = Foo::B as isize;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires const-evaluating + checking `A`...
-  --> $DIR/issue-36163.rs:1:1
-   |
-LL | const A: isize = Foo::B as isize;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: ...which requires normalizing `A`...
-   = note: ...which again requires simplifying constant for the type system `Foo::B::{constant#0}`, completing the cycle
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-36163.rs:1:1
-   |
-LL | / const A: isize = Foo::B as isize;
-LL | |
-LL | | enum Foo {
-LL | |     B = A,
-LL | | }
-LL | |
-LL | | fn main() {}
-   | |____________^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/ranged_ints3_const.rs
+++ b/src/test/ui/unsafe/ranged_ints3_const.rs
@@ -9,13 +9,13 @@ fn main() {}
 
 const fn foo() -> NonZero<Cell<u32>> {
     let mut x = unsafe { NonZero(Cell::new(1)) };
-    let y = &x.0; //~ ERROR cannot borrow a constant which may contain interior mutability
+    let y = &x.0; //~ ERROR the borrowed element may contain interior mutability
     //~^ ERROR borrow of layout constrained field with interior mutability
     unsafe { NonZero(Cell::new(1)) }
 }
 
 const fn bar() -> NonZero<Cell<u32>> {
     let mut x = unsafe { NonZero(Cell::new(1)) };
-    let y = unsafe { &x.0 }; //~ ERROR cannot borrow a constant which may contain interior mut
+    let y = unsafe { &x.0 }; //~ ERROR the borrowed element may contain interior mutability
     unsafe { NonZero(Cell::new(1)) }
 }

--- a/src/test/ui/unsafe/ranged_ints3_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints3_const.stderr
@@ -1,14 +1,20 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/ranged_ints3_const.rs:12:13
    |
 LL |     let y = &x.0;
    |             ^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/ranged_ints3_const.rs:19:22
    |
 LL |     let y = unsafe { &x.0 };
    |                      ^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
 error[E0133]: borrow of layout constrained field with interior mutability is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints3_const.rs:12:13
@@ -20,5 +26,5 @@ LL |     let y = &x.0;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0133, E0492.
+Some errors have detailed explanations: E0133, E0658.
 For more information about an error, try `rustc --explain E0133`.


### PR DESCRIPTION
r? @RalfJung 

I also added a feature gate at the same time so we can disable the old check that prevented 

```rust
const FOO: () = {
    let x = Cell::new(42);
    let y = &x;
};
```

I believe we can use the same scheme for mutable references.