### PR TITLE
make const_err a future incompat lint

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -255,6 +255,10 @@ declare_lint! {
     pub CONST_ERR,
     Deny,
     "constant evaluation encountered erroneous expression",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #71800 <https://github.com/rust-lang/rust/issues/71800>",
+        edition: None,
+    };
     report_in_external_macro
 }
 

--- a/src/test/ui/array-slice-vec/array_const_index-0.rs
+++ b/src/test/ui/array-slice-vec/array_const_index-0.rs
@@ -2,6 +2,7 @@ const A: &'static [i32] = &[];
 const B: i32 = (&A)[1];
 //~^ index out of bounds: the length is 0 but the index is 1
 //~| ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let _ = B;

--- a/src/test/ui/array-slice-vec/array_const_index-0.stderr
+++ b/src/test/ui/array-slice-vec/array_const_index-0.stderr
@@ -7,6 +7,8 @@ LL | const B: i32 = (&A)[1];
    |                index out of bounds: the length is 0 but the index is 1
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/array-slice-vec/array_const_index-1.rs
+++ b/src/test/ui/array-slice-vec/array_const_index-1.rs
@@ -2,6 +2,7 @@ const A: [i32; 0] = [];
 const B: i32 = A[1];
 //~^ index out of bounds: the length is 0 but the index is 1
 //~| ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let _ = B;

--- a/src/test/ui/array-slice-vec/array_const_index-1.stderr
+++ b/src/test/ui/array-slice-vec/array_const_index-1.stderr
@@ -7,6 +7,8 @@ LL | const B: i32 = A[1];
    |                index out of bounds: the length is 0 but the index is 1
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-consts/defaults-not-assumed-fail.rs
+++ b/src/test/ui/associated-consts/defaults-not-assumed-fail.rs
@@ -7,6 +7,7 @@ trait Tr {
     // `Self::A` must not be assumed to hold inside the trait.
     const B: u8 = Self::A + 1;
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 // An impl that doesn't override any constant will NOT cause a const eval error
@@ -33,6 +34,7 @@ fn main() {
     assert_eq!(<() as Tr>::B, 0);    // causes the error above
     //~^ ERROR evaluation of constant value failed
     //~| ERROR erroneous constant used
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     assert_eq!(<u8 as Tr>::A, 254);
     assert_eq!(<u8 as Tr>::B, 255);

--- a/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -7,19 +7,23 @@ LL |     const B: u8 = Self::A + 1;
    |                   attempt to compute `u8::MAX + 1_u8`, which would overflow
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/defaults-not-assumed-fail.rs:33:16
+  --> $DIR/defaults-not-assumed-fail.rs:34:16
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |                ^^^^^^^^^^^^^ referenced constant has errors
 
 error: erroneous constant used
-  --> $DIR/defaults-not-assumed-fail.rs:33:5
+  --> $DIR/defaults-not-assumed-fail.rs:34:5
    |
 LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/const-ptr/out_of_bounds_read.stderr
+++ b/src/test/ui/const-ptr/out_of_bounds_read.stderr
@@ -15,6 +15,8 @@ LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
    |     ------------------------------------------------------
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
@@ -32,6 +34,9 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |
 LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
    |     --------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/intrinsics.rs:LL:COL
@@ -49,6 +54,9 @@ LL |     unsafe { copy_nonoverlapping(src, dst, count) }
    |
 LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
    |     --------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/assoc_const_generic_impl.rs
+++ b/src/test/ui/consts/assoc_const_generic_impl.rs
@@ -9,6 +9,7 @@ trait ZeroSized: Sized {
 
 impl<T: Sized> ZeroSized for T {
     const I_AM_ZERO_SIZED: ()  = [()][std::mem::size_of::<Self>()]; //~ WARN any use of this value
+    //~| WARN this was previously accepted by the compiler but is being phased out
     fn requires_zero_size(self) {
         let () = Self::I_AM_ZERO_SIZED; //~ ERROR erroneous constant encountered
         println!("requires_zero_size called");

--- a/src/test/ui/consts/assoc_const_generic_impl.stderr
+++ b/src/test/ui/consts/assoc_const_generic_impl.stderr
@@ -11,9 +11,11 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: erroneous constant encountered
-  --> $DIR/assoc_const_generic_impl.rs:13:18
+  --> $DIR/assoc_const_generic_impl.rs:14:18
    |
 LL |         let () = Self::I_AM_ZERO_SIZED;
    |                  ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/assume-type-intrinsics.stderr
+++ b/src/test/ui/consts/assume-type-intrinsics.stderr
@@ -16,6 +16,8 @@ LL | |     };
    | |______-
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-err-early.rs
+++ b/src/test/ui/consts/const-err-early.rs
@@ -1,10 +1,15 @@
 #![deny(const_err)]
 
 pub const A: i8 = -i8::MIN; //~ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 pub const B: u8 = 200u8 + 200u8; //~ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 pub const C: u8 = 200u8 * 4; //~ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 pub const D: u8 = 42u8 - (42u8 + 1); //~ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 pub const E: u8 = [5u8][1]; //~ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let _a = A;

--- a/src/test/ui/consts/const-err-early.stderr
+++ b/src/test/ui/consts/const-err-early.stderr
@@ -11,38 +11,52 @@ note: the lint level is defined here
    |
 LL | #![deny(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:4:19
+  --> $DIR/const-err-early.rs:5:19
    |
 LL | pub const B: u8 = 200u8 + 200u8;
    | ------------------^^^^^^^^^^^^^-
    |                   |
    |                   attempt to compute `200_u8 + 200_u8`, which would overflow
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:5:19
+  --> $DIR/const-err-early.rs:7:19
    |
 LL | pub const C: u8 = 200u8 * 4;
    | ------------------^^^^^^^^^-
    |                   |
    |                   attempt to compute `200_u8 * 4_u8`, which would overflow
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:6:19
+  --> $DIR/const-err-early.rs:9:19
    |
 LL | pub const D: u8 = 42u8 - (42u8 + 1);
    | ------------------^^^^^^^^^^^^^^^^^-
    |                   |
    |                   attempt to compute `42_u8 - 43_u8`, which would overflow
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-early.rs:7:19
+  --> $DIR/const-err-early.rs:11:19
    |
 LL | pub const E: u8 = [5u8][1];
    | ------------------^^^^^^^^-
    |                   |
    |                   index out of bounds: the length is 1 but the index is 1
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-err-multi.rs
+++ b/src/test/ui/consts/const-err-multi.rs
@@ -2,12 +2,16 @@
 
 pub const A: i8 = -i8::MIN;
 //~^ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 pub const B: i8 = A;
 //~^ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 pub const C: u8 = A as u8;
 //~^ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 pub const D: i8 = 50 - A;
 //~^ ERROR const_err
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let _ = (A, B, C, D);

--- a/src/test/ui/consts/const-err-multi.stderr
+++ b/src/test/ui/consts/const-err-multi.stderr
@@ -11,30 +11,41 @@ note: the lint level is defined here
    |
 LL | #![deny(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-multi.rs:5:19
+  --> $DIR/const-err-multi.rs:6:19
    |
 LL | pub const B: i8 = A;
    | ------------------^-
    |                   |
    |                   referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-multi.rs:7:19
+  --> $DIR/const-err-multi.rs:9:19
    |
 LL | pub const C: u8 = A as u8;
    | ------------------^-------
    |                   |
    |                   referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-err-multi.rs:9:24
+  --> $DIR/const-err-multi.rs:12:24
    |
 LL | pub const D: i8 = 50 - A;
    | -----------------------^-
    |                        |
    |                        referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-err.rs
+++ b/src/test/ui/consts/const-err.rs
@@ -10,6 +10,7 @@ fn black_box<T>(_: T) {
 
 const FOO: u8 = [5u8][1];
 //~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     black_box((FOO, FOO));

--- a/src/test/ui/consts/const-err.stderr
+++ b/src/test/ui/consts/const-err.stderr
@@ -11,15 +11,17 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: erroneous constant used
-  --> $DIR/const-err.rs:15:16
+  --> $DIR/const-err.rs:16:16
    |
 LL |     black_box((FOO, FOO));
    |                ^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const-err.rs:15:21
+  --> $DIR/const-err.rs:16:21
    |
 LL |     black_box((FOO, FOO));
    |                     ^^^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/conditional_array_execution.rs
+++ b/src/test/ui/consts/const-eval/conditional_array_execution.rs
@@ -6,9 +6,11 @@ const X: u32 = 5;
 const Y: u32 = 6;
 const FOO: u32 = [X - Y, Y - X][(X < Y) as usize];
 //~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     println!("{}", FOO);
     //~^ ERROR
     //~| WARN erroneous constant used [const_err]
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }

--- a/src/test/ui/consts/const-eval/conditional_array_execution.stderr
+++ b/src/test/ui/consts/const-eval/conditional_array_execution.stderr
@@ -11,18 +11,23 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/conditional_array_execution.rs:11:20
+  --> $DIR/conditional_array_execution.rs:12:20
    |
 LL |     println!("{}", FOO);
    |                    ^^^ referenced constant has errors
 
 warning: erroneous constant used
-  --> $DIR/conditional_array_execution.rs:11:20
+  --> $DIR/conditional_array_execution.rs:12:20
    |
 LL |     println!("{}", FOO);
    |                    ^^^ referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.rs
@@ -14,46 +14,54 @@ const VALS_I8: (i8,) =
      i8::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I16: (i16,) =
     (
      i16::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I32: (i32,) =
     (
      i32::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I64: (i64,) =
     (
      i64::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U8: (u8,) =
     (
      u8::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U16: (u16,) = (
      u16::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U32: (u32,) = (
      u32::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U64: (u64,) =
     (
      u64::MIN - 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     foo(VALS_I8);

--- a/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2.stderr
@@ -13,9 +13,11 @@ note: the lint level is defined here
    |
 LL | #![deny(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:20:6
+  --> $DIR/const-eval-overflow2.rs:21:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
@@ -23,9 +25,12 @@ LL | |      i16::MIN - 1,
    | |      ^^^^^^^^^^^^ attempt to compute `i16::MIN - 1_i16`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:26:6
+  --> $DIR/const-eval-overflow2.rs:28:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
@@ -33,9 +38,12 @@ LL | |      i32::MIN - 1,
    | |      ^^^^^^^^^^^^ attempt to compute `i32::MIN - 1_i32`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:32:6
+  --> $DIR/const-eval-overflow2.rs:35:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
@@ -43,9 +51,12 @@ LL | |      i64::MIN - 1,
    | |      ^^^^^^^^^^^^ attempt to compute `i64::MIN - 1_i64`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:38:6
+  --> $DIR/const-eval-overflow2.rs:42:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
@@ -53,27 +64,36 @@ LL | |      u8::MIN - 1,
    | |      ^^^^^^^^^^^ attempt to compute `0_u8 - 1_u8`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:43:6
+  --> $DIR/const-eval-overflow2.rs:48:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MIN - 1,
    | |      ^^^^^^^^^^^^ attempt to compute `0_u16 - 1_u16`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:48:6
+  --> $DIR/const-eval-overflow2.rs:54:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MIN - 1,
    | |      ^^^^^^^^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2.rs:54:6
+  --> $DIR/const-eval-overflow2.rs:61:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (
@@ -81,6 +101,9 @@ LL | |      u64::MIN - 1,
    | |      ^^^^^^^^^^^^ attempt to compute `0_u64 - 1_u64`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.rs
@@ -14,46 +14,54 @@ const VALS_I8: (i8,) =
      i8::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I16: (i16,) =
     (
      i16::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I32: (i32,) =
     (
      i32::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I64: (i64,) =
     (
      i64::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U8: (u8,) =
     (
      u8::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U16: (u16,) = (
      u16::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U32: (u32,) = (
      u32::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U64: (u64,) =
     (
      u64::MAX + 1,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     foo(VALS_I8);

--- a/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2b.stderr
@@ -13,9 +13,11 @@ note: the lint level is defined here
    |
 LL | #![deny(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:20:6
+  --> $DIR/const-eval-overflow2b.rs:21:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
@@ -23,9 +25,12 @@ LL | |      i16::MAX + 1,
    | |      ^^^^^^^^^^^^ attempt to compute `i16::MAX + 1_i16`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:26:6
+  --> $DIR/const-eval-overflow2b.rs:28:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
@@ -33,9 +38,12 @@ LL | |      i32::MAX + 1,
    | |      ^^^^^^^^^^^^ attempt to compute `i32::MAX + 1_i32`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:32:6
+  --> $DIR/const-eval-overflow2b.rs:35:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
@@ -43,9 +51,12 @@ LL | |      i64::MAX + 1,
    | |      ^^^^^^^^^^^^ attempt to compute `i64::MAX + 1_i64`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:38:6
+  --> $DIR/const-eval-overflow2b.rs:42:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
@@ -53,27 +64,36 @@ LL | |      u8::MAX + 1,
    | |      ^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:43:6
+  --> $DIR/const-eval-overflow2b.rs:48:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX + 1,
    | |      ^^^^^^^^^^^^ attempt to compute `u16::MAX + 1_u16`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:48:6
+  --> $DIR/const-eval-overflow2b.rs:54:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX + 1,
    | |      ^^^^^^^^^^^^ attempt to compute `u32::MAX + 1_u32`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2b.rs:54:6
+  --> $DIR/const-eval-overflow2b.rs:61:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (
@@ -81,6 +101,9 @@ LL | |      u64::MAX + 1,
    | |      ^^^^^^^^^^^^ attempt to compute `u64::MAX + 1_u64`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.rs
@@ -14,46 +14,54 @@ const VALS_I8: (i8,) =
      i8::MIN * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I16: (i16,) =
     (
      i16::MIN * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I32: (i32,) =
     (
      i32::MIN * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_I64: (i64,) =
     (
      i64::MIN * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U8: (u8,) =
     (
      u8::MAX * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U16: (u16,) = (
      u16::MAX * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U32: (u32,) = (
      u32::MAX * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 const VALS_U64: (u64,) =
     (
      u64::MAX * 2,
      );
  //~^^ ERROR any use of this value will cause an error
+ //~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     foo(VALS_I8);

--- a/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow2c.stderr
@@ -13,9 +13,11 @@ note: the lint level is defined here
    |
 LL | #![deny(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:20:6
+  --> $DIR/const-eval-overflow2c.rs:21:6
    |
 LL | / const VALS_I16: (i16,) =
 LL | |     (
@@ -23,9 +25,12 @@ LL | |      i16::MIN * 2,
    | |      ^^^^^^^^^^^^ attempt to compute `i16::MIN * 2_i16`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:26:6
+  --> $DIR/const-eval-overflow2c.rs:28:6
    |
 LL | / const VALS_I32: (i32,) =
 LL | |     (
@@ -33,9 +38,12 @@ LL | |      i32::MIN * 2,
    | |      ^^^^^^^^^^^^ attempt to compute `i32::MIN * 2_i32`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:32:6
+  --> $DIR/const-eval-overflow2c.rs:35:6
    |
 LL | / const VALS_I64: (i64,) =
 LL | |     (
@@ -43,9 +51,12 @@ LL | |      i64::MIN * 2,
    | |      ^^^^^^^^^^^^ attempt to compute `i64::MIN * 2_i64`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:38:6
+  --> $DIR/const-eval-overflow2c.rs:42:6
    |
 LL | / const VALS_U8: (u8,) =
 LL | |     (
@@ -53,27 +64,36 @@ LL | |      u8::MAX * 2,
    | |      ^^^^^^^^^^^ attempt to compute `u8::MAX * 2_u8`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:43:6
+  --> $DIR/const-eval-overflow2c.rs:48:6
    |
 LL | / const VALS_U16: (u16,) = (
 LL | |      u16::MAX * 2,
    | |      ^^^^^^^^^^^^ attempt to compute `u16::MAX * 2_u16`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:48:6
+  --> $DIR/const-eval-overflow2c.rs:54:6
    |
 LL | / const VALS_U32: (u32,) = (
 LL | |      u32::MAX * 2,
    | |      ^^^^^^^^^^^^ attempt to compute `u32::MAX * 2_u32`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-eval-overflow2c.rs:54:6
+  --> $DIR/const-eval-overflow2c.rs:61:6
    |
 LL | / const VALS_U64: (u64,) =
 LL | |     (
@@ -81,6 +101,9 @@ LL | |      u64::MAX * 2,
    | |      ^^^^^^^^^^^^ attempt to compute `u64::MAX * 2_u64`, which would overflow
 LL | |      );
    | |_______-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.rs
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.rs
@@ -18,6 +18,7 @@
 
 #[warn(const_err)]
 const X: i32 = 1 / 0; //~WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let x: &'static i32 = &X;

--- a/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-query-stack.stderr
@@ -11,9 +11,11 @@ note: the lint level is defined here
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-eval-query-stack.rs:23:28
+  --> $DIR/const-eval-query-stack.rs:24:28
    |
 LL |     let x: &'static i32 = &X;
    |                            ^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.rs
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.rs
@@ -27,12 +27,15 @@ fn main() {
 
     const I32_REF_U8_UNION: u8 = unsafe { Nonsense { int_32_ref: &3 }.uint_8 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_U16_UNION: u16 = unsafe { Nonsense { int_32_ref: &3 }.uint_16 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_U32_UNION: u32 = unsafe { Nonsense { int_32_ref: &3 }.uint_32 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
     //~^ ERROR it is undefined behavior to use this value
@@ -42,12 +45,15 @@ fn main() {
 
     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_I16_UNION: i16 = unsafe { Nonsense { int_32_ref: &3 }.int_16 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_I32_UNION: i32 = unsafe { Nonsense { int_32_ref: &3 }.int_32 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
     //~^ ERROR it is undefined behavior to use this value
@@ -57,55 +63,69 @@ fn main() {
 
     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
     //~^ ERROR it is undefined behavior to use this value
 
     const I32_REF_BOOL_UNION: bool = unsafe { Nonsense { int_32_ref: &3 }.truthy_falsey };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_CHAR_UNION: char = unsafe { Nonsense { int_32_ref: &3 }.character };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_U8_UNION: u8 = unsafe { Nonsense { stringy: "3" }.uint_8 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_U16_UNION: u16 = unsafe { Nonsense { stringy: "3" }.uint_16 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_U32_UNION: u32 = unsafe { Nonsense { stringy: "3" }.uint_32 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
     //~^ ERROR it is undefined behavior to use this value
 
     const STR_U128_UNION: u128 = unsafe { Nonsense { stringy: "3" }.uint_128 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_I8_UNION: i8 = unsafe { Nonsense { stringy: "3" }.int_8 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_I16_UNION: i16 = unsafe { Nonsense { stringy: "3" }.int_16 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_I32_UNION: i32 = unsafe { Nonsense { stringy: "3" }.int_32 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
     //~^ ERROR it is undefined behavior to use this value
 
     const STR_I128_UNION: i128 = unsafe { Nonsense { stringy: "3" }.int_128 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_F32_UNION: f32 = unsafe { Nonsense { stringy: "3" }.float_32 };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
     //~^ ERROR it is undefined behavior to use this value
 
     const STR_BOOL_UNION: bool = unsafe { Nonsense { stringy: "3" }.truthy_falsey };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_CHAR_UNION: char = unsafe { Nonsense { stringy: "3" }.character };
     //~^ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
@@ -15,25 +15,33 @@ LL |     const I32_REF_U8_UNION: u8 = unsafe { Nonsense { int_32_ref: &3 }.uint_
    |                                           unable to turn pointer into raw bytes
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:31:45
+  --> $DIR/const-pointer-values-in-various-types.rs:32:45
    |
 LL |     const I32_REF_U16_UNION: u16 = unsafe { Nonsense { int_32_ref: &3 }.uint_16 };
    |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:34:45
+  --> $DIR/const-pointer-values-in-various-types.rs:36:45
    |
 LL |     const I32_REF_U32_UNION: u32 = unsafe { Nonsense { int_32_ref: &3 }.uint_32 };
    |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:37:5
+  --> $DIR/const-pointer-values-in-various-types.rs:40:5
    |
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc18, but expected initialized plain (non-pointer) bytes
@@ -41,7 +49,7 @@ LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uin
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:40:5
+  --> $DIR/const-pointer-values-in-various-types.rs:43:5
    |
 LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
@@ -49,31 +57,40 @@ LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.u
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:43:43
+  --> $DIR/const-pointer-values-in-various-types.rs:46:43
    |
 LL |     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
    |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:46:45
+  --> $DIR/const-pointer-values-in-various-types.rs:50:45
    |
 LL |     const I32_REF_I16_UNION: i16 = unsafe { Nonsense { int_32_ref: &3 }.int_16 };
    |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:49:45
+  --> $DIR/const-pointer-values-in-various-types.rs:54:45
    |
 LL |     const I32_REF_I32_UNION: i32 = unsafe { Nonsense { int_32_ref: &3 }.int_32 };
    |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:52:5
+  --> $DIR/const-pointer-values-in-various-types.rs:58:5
    |
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc38, but expected initialized plain (non-pointer) bytes
@@ -81,7 +98,7 @@ LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:55:5
+  --> $DIR/const-pointer-values-in-various-types.rs:61:5
    |
 LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
@@ -89,15 +106,18 @@ LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.i
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:58:45
+  --> $DIR/const-pointer-values-in-various-types.rs:64:45
    |
 LL |     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
    |     ----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                             |
    |                                             unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:61:5
+  --> $DIR/const-pointer-values-in-various-types.rs:68:5
    |
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc50, but expected initialized plain (non-pointer) bytes
@@ -105,47 +125,62 @@ LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.flo
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:64:47
+  --> $DIR/const-pointer-values-in-various-types.rs:71:47
    |
 LL |     const I32_REF_BOOL_UNION: bool = unsafe { Nonsense { int_32_ref: &3 }.truthy_falsey };
    |     ------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                               |
    |                                               unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:67:47
+  --> $DIR/const-pointer-values-in-various-types.rs:75:47
    |
 LL |     const I32_REF_CHAR_UNION: char = unsafe { Nonsense { int_32_ref: &3 }.character };
    |     ------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                               |
    |                                               unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:70:39
+  --> $DIR/const-pointer-values-in-various-types.rs:79:39
    |
 LL |     const STR_U8_UNION: u8 = unsafe { Nonsense { stringy: "3" }.uint_8 };
    |     ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                       |
    |                                       unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:73:41
+  --> $DIR/const-pointer-values-in-various-types.rs:83:41
    |
 LL |     const STR_U16_UNION: u16 = unsafe { Nonsense { stringy: "3" }.uint_16 };
    |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:76:41
+  --> $DIR/const-pointer-values-in-various-types.rs:87:41
    |
 LL |     const STR_U32_UNION: u32 = unsafe { Nonsense { stringy: "3" }.uint_32 };
    |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:79:5
+  --> $DIR/const-pointer-values-in-various-types.rs:91:5
    |
 LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc71, but expected initialized plain (non-pointer) bytes
@@ -153,39 +188,51 @@ LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 }
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:82:43
+  --> $DIR/const-pointer-values-in-various-types.rs:94:43
    |
 LL |     const STR_U128_UNION: u128 = unsafe { Nonsense { stringy: "3" }.uint_128 };
    |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:85:39
+  --> $DIR/const-pointer-values-in-various-types.rs:98:39
    |
 LL |     const STR_I8_UNION: i8 = unsafe { Nonsense { stringy: "3" }.int_8 };
    |     ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                       |
    |                                       unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:88:41
+  --> $DIR/const-pointer-values-in-various-types.rs:102:41
    |
 LL |     const STR_I16_UNION: i16 = unsafe { Nonsense { stringy: "3" }.int_16 };
    |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:91:41
+  --> $DIR/const-pointer-values-in-various-types.rs:106:41
    |
 LL |     const STR_I32_UNION: i32 = unsafe { Nonsense { stringy: "3" }.int_32 };
    |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:94:5
+  --> $DIR/const-pointer-values-in-various-types.rs:110:5
    |
 LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc86, but expected initialized plain (non-pointer) bytes
@@ -193,23 +240,29 @@ LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:97:43
+  --> $DIR/const-pointer-values-in-various-types.rs:113:43
    |
 LL |     const STR_I128_UNION: i128 = unsafe { Nonsense { stringy: "3" }.int_128 };
    |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:100:41
+  --> $DIR/const-pointer-values-in-various-types.rs:117:41
    |
 LL |     const STR_F32_UNION: f32 = unsafe { Nonsense { stringy: "3" }.float_32 };
    |     ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                         |
    |                                         unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:103:5
+  --> $DIR/const-pointer-values-in-various-types.rs:121:5
    |
 LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc95, but expected initialized plain (non-pointer) bytes
@@ -217,20 +270,26 @@ LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:106:43
+  --> $DIR/const-pointer-values-in-various-types.rs:124:43
    |
 LL |     const STR_BOOL_UNION: bool = unsafe { Nonsense { stringy: "3" }.truthy_falsey };
    |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-pointer-values-in-various-types.rs:109:43
+  --> $DIR/const-pointer-values-in-various-types.rs:128:43
    |
 LL |     const STR_CHAR_UNION: char = unsafe { Nonsense { stringy: "3" }.character };
    |     --------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                           |
    |                                           unable to turn pointer into raw bytes
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 29 previous errors
 

--- a/src/test/ui/consts/const-eval/const_panic.rs
+++ b/src/test/ui/consts/const-eval/const_panic.rs
@@ -5,30 +5,40 @@ const MSG: &str = "hello";
 
 const Z: () = std::panic!("cheese");
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Z2: () = std::panic!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Y: () = std::unreachable!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const X: () = std::unimplemented!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 //
 const W: () = std::panic!(MSG);
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Z_CORE: () = core::panic!("cheese");
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Z2_CORE: () = core::panic!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Y_CORE: () = core::unreachable!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const X_CORE: () = core::unimplemented!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const W_CORE: () = core::panic!(MSG);
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out

--- a/src/test/ui/consts/const-eval/const_panic.stderr
+++ b/src/test/ui/consts/const-eval/const_panic.stderr
@@ -7,96 +7,116 @@ LL | const Z: () = std::panic!("cheese");
    |               the evaluated program panicked at 'cheese', $DIR/const_panic.rs:6:15
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:9:16
+  --> $DIR/const_panic.rs:10:16
    |
 LL | const Z2: () = std::panic!();
    | ---------------^^^^^^^^^^^^^-
    |                |
-   |                the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:9:16
+   |                the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:10:16
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:12:15
+  --> $DIR/const_panic.rs:14:15
    |
 LL | const Y: () = std::unreachable!();
    | --------------^^^^^^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:12:15
+   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:14:15
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:15:15
-   |
-LL | const X: () = std::unimplemented!();
-   | --------------^^^^^^^^^^^^^^^^^^^^^-
-   |               |
-   |               the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:15:15
-   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:18:15
    |
-LL | const W: () = std::panic!(MSG);
-   | --------------^^^^^^^^^^^^^^^^-
+LL | const X: () = std::unimplemented!();
+   | --------------^^^^^^^^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'hello', $DIR/const_panic.rs:18:15
+   |               the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:18:15
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:21:20
+  --> $DIR/const_panic.rs:22:15
+   |
+LL | const W: () = std::panic!(MSG);
+   | --------------^^^^^^^^^^^^^^^^-
+   |               |
+   |               the evaluated program panicked at 'hello', $DIR/const_panic.rs:22:15
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: any use of this value will cause an error
+  --> $DIR/const_panic.rs:26:20
    |
 LL | const Z_CORE: () = core::panic!("cheese");
    | -------------------^^^^^^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'cheese', $DIR/const_panic.rs:21:20
+   |                    the evaluated program panicked at 'cheese', $DIR/const_panic.rs:26:20
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:24:21
+  --> $DIR/const_panic.rs:30:21
    |
 LL | const Z2_CORE: () = core::panic!();
    | --------------------^^^^^^^^^^^^^^-
    |                     |
-   |                     the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:24:21
+   |                     the evaluated program panicked at 'explicit panic', $DIR/const_panic.rs:30:21
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:27:20
+  --> $DIR/const_panic.rs:34:20
    |
 LL | const Y_CORE: () = core::unreachable!();
    | -------------------^^^^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:27:20
+   |                    the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic.rs:34:20
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:30:20
+  --> $DIR/const_panic.rs:38:20
    |
 LL | const X_CORE: () = core::unimplemented!();
    | -------------------^^^^^^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:30:20
+   |                    the evaluated program panicked at 'not implemented', $DIR/const_panic.rs:38:20
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic.rs:33:20
+  --> $DIR/const_panic.rs:42:20
    |
 LL | const W_CORE: () = core::panic!(MSG);
    | -------------------^^^^^^^^^^^^^^^^^-
    |                    |
-   |                    the evaluated program panicked at 'hello', $DIR/const_panic.rs:33:20
+   |                    the evaluated program panicked at 'hello', $DIR/const_panic.rs:42:20
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.rs
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.rs
@@ -8,12 +8,15 @@ use core::panic::PanicInfo;
 
 const Z: () = panic!("cheese");
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const Y: () = unreachable!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const X: () = unimplemented!();
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 #[lang = "eh_personality"]
 fn eh() {}

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -7,26 +7,32 @@ LL | const Z: () = panic!("cheese");
    |               the evaluated program panicked at 'cheese', $DIR/const_panic_libcore_bin.rs:9:15
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore_bin.rs:12:15
+  --> $DIR/const_panic_libcore_bin.rs:13:15
    |
 LL | const Y: () = unreachable!();
    | --------------^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:12:15
+   |               the evaluated program panicked at 'internal error: entered unreachable code', $DIR/const_panic_libcore_bin.rs:13:15
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
-  --> $DIR/const_panic_libcore_bin.rs:15:15
+  --> $DIR/const_panic_libcore_bin.rs:17:15
    |
 LL | const X: () = unimplemented!();
    | --------------^^^^^^^^^^^^^^^^-
    |               |
-   |               the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:15:15
+   |               the evaluated program panicked at 'not implemented', $DIR/const_panic_libcore_bin.rs:17:15
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops2.rs
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops2.rs
@@ -6,8 +6,11 @@ fn main() {}
 const Y: usize = unsafe { 42usize as *const i32 as usize + 1 };
 // unconst and bad, will thus error in miri
 const Y2: usize = unsafe { &1 as *const i32 as usize + 1 }; //~ ERROR any use of this
+//~| WARN this was previously accepted by the compiler but is being phased out
 // unconst and fine
 const Z: i32 = unsafe { *(&1 as *const i32) };
 // unconst and bad, will thus error in miri
 const Z2: i32 = unsafe { *(42 as *const i32) }; //~ ERROR any use of this value will cause
+//~| WARN this was previously accepted by the compiler but is being phased out
 const Z3: i32 = unsafe { *(44 as *const i32) }; //~ ERROR any use of this value will cause
+//~| WARN this was previously accepted by the compiler but is being phased out

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops2.stderr
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops2.stderr
@@ -7,22 +7,30 @@ LL | const Y2: usize = unsafe { &1 as *const i32 as usize + 1 };
    |                            "pointer-to-integer cast" needs an rfc before being allowed inside constants
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const_raw_ptr_ops2.rs:12:26
+  --> $DIR/const_raw_ptr_ops2.rs:13:26
    |
 LL | const Z2: i32 = unsafe { *(42 as *const i32) };
    | -------------------------^^^^^^^^^^^^^^^^^^^---
    |                          |
    |                          unable to turn bytes into a pointer
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const_raw_ptr_ops2.rs:13:26
+  --> $DIR/const_raw_ptr_ops2.rs:15:26
    |
 LL | const Z3: i32 = unsafe { *(44 as *const i32) };
    | -------------------------^^^^^^^^^^^^^^^^^^^---
    |                          |
    |                          unable to turn bytes into a pointer
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/dangling.rs
+++ b/src/test/ui/consts/const-eval/dangling.rs
@@ -6,8 +6,10 @@ use std::mem;
 const TEST: () = { unsafe { //~ NOTE
     let slice: *const [u8] = mem::transmute((1usize, usize::MAX));
     let _val = &*slice; //~ ERROR: any use of this value will cause an error
-    //~^ NOTE: slice is bigger than largest supported object
-    //~^^ on by default
+    //~| NOTE: slice is bigger than largest supported object
+    //~| on by default
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    //~| NOTE
 } };
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/dangling.stderr
+++ b/src/test/ui/consts/const-eval/dangling.stderr
@@ -6,11 +6,14 @@ LL | |     let slice: *const [u8] = mem::transmute((1usize, usize::MAX));
 LL | |     let _val = &*slice;
    | |                ^^^^^^^ invalid metadata in wide pointer: slice is bigger than largest supported object
 LL | |
+...  |
 LL | |
 LL | | } };
    | |____-
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/erroneous-const.rs
+++ b/src/test/ui/consts/const-eval/erroneous-const.rs
@@ -5,6 +5,7 @@ struct PrintName<T>(T);
 impl<T> PrintName<T> {
     const VOID: () = [()][2]; //~WARN any use of this value will cause an error
     //~^ WARN this operation will panic at runtime
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 const fn no_codegen<T>() {

--- a/src/test/ui/consts/const-eval/erroneous-const.stderr
+++ b/src/test/ui/consts/const-eval/erroneous-const.stderr
@@ -23,18 +23,20 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err, unconditional_panic)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/erroneous-const.rs:12:17
+  --> $DIR/erroneous-const.rs:13:17
    |
 LL |         let _ = PrintName::<T>::VOID;
    |                 ^^^^^^^^^^^^^^^^^^^^
    |                 |
    |                 referenced constant has errors
-   |                 inside `no_codegen::<i32>` at $DIR/erroneous-const.rs:12:17
+   |                 inside `no_codegen::<i32>` at $DIR/erroneous-const.rs:13:17
 ...
 LL | pub static FOO: () = no_codegen::<i32>();
-   |                      ------------------- inside `FOO` at $DIR/erroneous-const.rs:16:22
+   |                      ------------------- inside `FOO` at $DIR/erroneous-const.rs:17:22
 
 error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
+++ b/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.rs
@@ -9,6 +9,7 @@ const fn foo() -> i32 {
     unsafe {
         let _ = intrinsics::const_allocate(4, 3) as * mut i32;
         //~^ error: any use of this value will cause an error [const_err]
+        //~| WARN this was previously accepted by the compiler but is being phased out
     }
     1
 

--- a/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
+++ b/src/test/ui/consts/const-eval/heap/alloc_intrinsic_errors.stderr
@@ -12,6 +12,8 @@ LL |         let _ = intrinsics::const_allocate(4, 3) as * mut i32;
    |                 inside `FOO` at $DIR/alloc_intrinsic_errors.rs:7:18
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.rs
+++ b/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.rs
@@ -9,6 +9,7 @@ struct PrintName<T>(T);
 impl<T> PrintName<T> {
     const VOID: ! = { let x = 0 * std::mem::size_of::<T>(); [][x] };
     //~^ WARN any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 
 }
 

--- a/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
+++ b/src/test/ui/consts/const-eval/index-out-of-bounds-never-type.stderr
@@ -11,9 +11,11 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err, unconditional_panic)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: erroneous constant encountered
-  --> $DIR/index-out-of-bounds-never-type.rs:16:13
+  --> $DIR/index-out-of-bounds-never-type.rs:17:13
    |
 LL |     let _ = PrintName::<T>::VOID;
    |             ^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/const-eval/issue-43197.rs
+++ b/src/test/ui/consts/const-eval/issue-43197.rs
@@ -9,11 +9,15 @@ const fn foo(x: u32) -> u32 {
 fn main() {
     const X: u32 = 0 - 1;
     //~^ WARN any use of this value will cause
+    //~| WARN this was previously accepted by the compiler but is being phased out
     const Y: u32 = foo(0 - 1);
     //~^ WARN any use of this value will cause
+    //~| WARN this was previously accepted by the compiler but is being phased out
     println!("{} {}", X, Y);
     //~^ ERROR evaluation of constant value failed
     //~| ERROR evaluation of constant value failed
     //~| WARN erroneous constant used [const_err]
     //~| WARN erroneous constant used [const_err]
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }

--- a/src/test/ui/consts/const-eval/issue-43197.stderr
+++ b/src/test/ui/consts/const-eval/issue-43197.stderr
@@ -11,38 +11,49 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: any use of this value will cause an error
-  --> $DIR/issue-43197.rs:12:24
+  --> $DIR/issue-43197.rs:13:24
    |
 LL |     const Y: u32 = foo(0 - 1);
    |     -------------------^^^^^--
    |                        |
    |                        attempt to compute `0_u32 - 1_u32`, which would overflow
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-43197.rs:14:23
+  --> $DIR/issue-43197.rs:16:23
    |
 LL |     println!("{} {}", X, Y);
    |                       ^ referenced constant has errors
 
 warning: erroneous constant used
-  --> $DIR/issue-43197.rs:14:23
+  --> $DIR/issue-43197.rs:16:23
    |
 LL |     println!("{} {}", X, Y);
    |                       ^ referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-43197.rs:14:26
+  --> $DIR/issue-43197.rs:16:26
    |
 LL |     println!("{} {}", X, Y);
    |                          ^ referenced constant has errors
 
 warning: erroneous constant used
-  --> $DIR/issue-43197.rs:14:26
+  --> $DIR/issue-43197.rs:16:26
    |
 LL |     println!("{} {}", X, Y);
    |                          ^ referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 2 previous errors; 4 warnings emitted
 

--- a/src/test/ui/consts/const-eval/issue-49296.rs
+++ b/src/test/ui/consts/const-eval/issue-49296.rs
@@ -18,6 +18,7 @@ const fn wat(x: u64) -> &'static u64 {
 }
 const X: u64 = *wat(42);
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     println!("{}", X);

--- a/src/test/ui/consts/const-eval/issue-49296.stderr
+++ b/src/test/ui/consts/const-eval/issue-49296.stderr
@@ -7,6 +7,8 @@ LL | const X: u64 = *wat(42);
    |                pointer to alloc1 was dereferenced after this allocation got freed
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/issue-50814-2.rs
+++ b/src/test/ui/consts/const-eval/issue-50814-2.rs
@@ -12,6 +12,7 @@ struct A<T>(T);
 
 impl<T: C> Foo<T> for A<T> {
     const BAR: usize = [5, 6, 7][T::BOO]; //~ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 fn foo<T: C>() -> &'static usize {

--- a/src/test/ui/consts/const-eval/issue-50814-2.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814-2.stderr
@@ -7,9 +7,11 @@ LL |     const BAR: usize = [5, 6, 7][T::BOO];
    |                        index out of bounds: the length is 3 but the index is 42
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-50814-2.rs:18:6
+  --> $DIR/issue-50814-2.rs:19:6
    |
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/issue-50814.rs
+++ b/src/test/ui/consts/const-eval/issue-50814.rs
@@ -14,6 +14,7 @@ struct Sum<A,B>(A,B);
 impl<A: Unsigned, B: Unsigned> Unsigned for Sum<A,B> {
     const MAX: u8 = A::MAX + B::MAX;
     //~^ ERROR any use of this value will cause an error [const_err]
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 fn foo<T>(_: T) -> &'static u8 {

--- a/src/test/ui/consts/const-eval/issue-50814.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814.stderr
@@ -7,9 +7,11 @@ LL |     const MAX: u8 = A::MAX + B::MAX;
    |                     attempt to compute `u8::MAX + u8::MAX`, which would overflow
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-50814.rs:20:6
+  --> $DIR/issue-50814.rs:21:6
    |
 LL |     &Sum::<U8,U8>::MAX
    |      ^^^^^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.rs
@@ -10,6 +10,7 @@ struct PrintName;
 impl PrintName {
     const VOID: ! = panic!();
     //~^ WARN any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -11,10 +11,12 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
-  --> $DIR/panic-assoc-never-type.rs:16:13
+  --> $DIR/panic-assoc-never-type.rs:17:13
    |
 LL |     let _ = PrintName::VOID;
    |             ^^^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/panic-never-type.rs
+++ b/src/test/ui/consts/const-eval/panic-never-type.rs
@@ -7,6 +7,7 @@
 
 const VOID: ! = panic!();
 //~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let _ = VOID;

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -11,10 +11,12 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
-  --> $DIR/panic-never-type.rs:12:13
+  --> $DIR/panic-never-type.rs:13:13
    |
 LL |     let _ = VOID;
    |             ^^^^ referenced constant has errors

--- a/src/test/ui/consts/const-eval/promoted_errors.noopt.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.noopt.stderr
@@ -6,12 +6,12 @@ LL |       0 - 1
    |       |
    |       attempt to compute `0_u32 - 1_u32`, which would overflow
    |       inside `overflow` at $DIR/promoted_errors.rs:13:5
-   |       inside `X` at $DIR/promoted_errors.rs:31:29
+   |       inside `X` at $DIR/promoted_errors.rs:33:29
 ...
 LL | / const X: () = {
 LL | |     let _x: &'static u32 = &overflow();
 LL | |
-LL | |     let _x: &'static i32 = &div_by_zero1();
+LL | |
 ...  |
 LL | |     let _x: &'static i32 = &oob();
 LL | | };
@@ -22,19 +22,24 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err, arithmetic_overflow, unconditional_panic)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: any use of this value will cause an error
-  --> $DIR/promoted_errors.rs:31:28
+  --> $DIR/promoted_errors.rs:33:28
    |
 LL | / const X: () = {
 LL | |     let _x: &'static u32 = &overflow();
    | |                            ^^^^^^^^^^^ referenced constant has errors
 LL | |
-LL | |     let _x: &'static i32 = &div_by_zero1();
+LL | |
 ...  |
 LL | |     let _x: &'static i32 = &oob();
 LL | | };
    | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/consts/const-eval/promoted_errors.opt.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.opt.stderr
@@ -1,17 +1,17 @@
 warning: any use of this value will cause an error
-  --> $DIR/promoted_errors.rs:17:5
+  --> $DIR/promoted_errors.rs:18:5
    |
 LL |       1 / 0
    |       ^^^^^
    |       |
    |       attempt to divide `1_i32` by zero
-   |       inside `div_by_zero1` at $DIR/promoted_errors.rs:17:5
-   |       inside `X` at $DIR/promoted_errors.rs:33:29
+   |       inside `div_by_zero1` at $DIR/promoted_errors.rs:18:5
+   |       inside `X` at $DIR/promoted_errors.rs:36:29
 ...
 LL | / const X: () = {
 LL | |     let _x: &'static u32 = &overflow();
 LL | |
-LL | |     let _x: &'static i32 = &div_by_zero1();
+LL | |
 ...  |
 LL | |     let _x: &'static i32 = &oob();
 LL | | };
@@ -22,12 +22,15 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err, arithmetic_overflow, unconditional_panic)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: any use of this value will cause an error
-  --> $DIR/promoted_errors.rs:33:28
+  --> $DIR/promoted_errors.rs:36:28
    |
 LL | / const X: () = {
 LL | |     let _x: &'static u32 = &overflow();
+LL | |
 LL | |
 LL | |     let _x: &'static i32 = &div_by_zero1();
    | |                            ^^^^^^^^^^^^^^^ referenced constant has errors
@@ -35,6 +38,9 @@ LL | |     let _x: &'static i32 = &div_by_zero1();
 LL | |     let _x: &'static i32 = &oob();
 LL | | };
    | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/consts/const-eval/promoted_errors.opt_with_overflow_checks.stderr
+++ b/src/test/ui/consts/const-eval/promoted_errors.opt_with_overflow_checks.stderr
@@ -6,12 +6,12 @@ LL |       0 - 1
    |       |
    |       attempt to compute `0_u32 - 1_u32`, which would overflow
    |       inside `overflow` at $DIR/promoted_errors.rs:13:5
-   |       inside `X` at $DIR/promoted_errors.rs:31:29
+   |       inside `X` at $DIR/promoted_errors.rs:33:29
 ...
 LL | / const X: () = {
 LL | |     let _x: &'static u32 = &overflow();
 LL | |
-LL | |     let _x: &'static i32 = &div_by_zero1();
+LL | |
 ...  |
 LL | |     let _x: &'static i32 = &oob();
 LL | | };
@@ -22,19 +22,24 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err, arithmetic_overflow, unconditional_panic)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: any use of this value will cause an error
-  --> $DIR/promoted_errors.rs:31:28
+  --> $DIR/promoted_errors.rs:33:28
    |
 LL | / const X: () = {
 LL | |     let _x: &'static u32 = &overflow();
    | |                            ^^^^^^^^^^^ referenced constant has errors
 LL | |
-LL | |     let _x: &'static i32 = &div_by_zero1();
+LL | |
 ...  |
 LL | |     let _x: &'static i32 = &oob();
 LL | | };
    | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/consts/const-eval/promoted_errors.rs
+++ b/src/test/ui/consts/const-eval/promoted_errors.rs
@@ -12,30 +12,33 @@
 const fn overflow() -> u32 {
     0 - 1
     //[opt_with_overflow_checks,noopt]~^ WARN any use of this value will cause an error
+    //[opt_with_overflow_checks,noopt]~| WARN this was previously accepted by the compiler
 }
 const fn div_by_zero1() -> i32 {
     1 / 0
     //[opt]~^ WARN any use of this value will cause an error
+    //[opt]~| WARN this was previously accepted by the compiler but is being phased out
 }
 const fn div_by_zero2() -> i32 {
-    1 / (1-1)
+    1 / (1 - 1)
 }
 const fn div_by_zero3() -> i32 {
     1 / (false as i32)
 }
 const fn oob() -> i32 {
-    [1,2,3][4]
+    [1, 2, 3][4]
 }
 
 const X: () = {
     let _x: &'static u32 = &overflow();
     //[opt_with_overflow_checks,noopt]~^ WARN any use of this value will cause an error
+    //[opt_with_overflow_checks,noopt]~| WARN this was previously accepted by the compiler
     let _x: &'static i32 = &div_by_zero1();
     //[opt]~^ WARN any use of this value will cause an error
+    //[opt]~| WARN this was previously accepted by the compiler but is being phased out
     let _x: &'static i32 = &div_by_zero2();
     let _x: &'static i32 = &div_by_zero3();
     let _x: &'static i32 = &oob();
 };
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/consts/const-eval/pub_const_err.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err.rs
@@ -5,5 +5,6 @@
 
 pub const Z: u32 = 0 - 1;
 //~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 pub type Foo = [i32; 0 - 1];

--- a/src/test/ui/consts/const-eval/pub_const_err.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err.stderr
@@ -11,6 +11,8 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.rs
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.rs
@@ -3,6 +3,7 @@
 
 pub const Z: u32 = 0 - 1;
 //~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 pub type Foo = [i32; 0 - 1];
 

--- a/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
+++ b/src/test/ui/consts/const-eval/pub_const_err_bin.stderr
@@ -11,6 +11,8 @@ note: the lint level is defined here
    |
 LL | #![warn(const_err)]
    |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: 1 warning emitted
 

--- a/src/test/ui/consts/const-eval/ub-nonnull.rs
+++ b/src/test/ui/consts/const-eval/ub-nonnull.rs
@@ -16,6 +16,7 @@ const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
     // Use address-of-element for pointer arithmetic. This could wrap around to NULL!
     let out_of_bounds_ptr = &ptr[255]; //~ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
     mem::transmute(out_of_bounds_ptr)
 } };
 

--- a/src/test/ui/consts/const-eval/ub-nonnull.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.stderr
@@ -14,6 +14,7 @@ LL | |     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it
 LL | |     // Use address-of-element for pointer arithmetic. This could wrap around to NULL!
 LL | |     let out_of_bounds_ptr = &ptr[255];
    | |                              ^^^^^^^^ memory access failed: pointer must be in-bounds at offset 256, but is outside bounds of alloc10 which has size 1
+LL | |
 LL | |     mem::transmute(out_of_bounds_ptr)
 LL | | } };
    | |____-
@@ -23,9 +24,11 @@ note: the lint level is defined here
    |
 LL | #[deny(const_err)] // this triggers a `const_err` so validation does not even happen
    |        ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:22:1
+  --> $DIR/ub-nonnull.rs:23:1
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -33,7 +36,7 @@ LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:24:1
+  --> $DIR/ub-nonnull.rs:25:1
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -41,7 +44,7 @@ LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:32:1
+  --> $DIR/ub-nonnull.rs:33:1
    |
 LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes at .0, but expected initialized plain (non-pointer) bytes
@@ -49,7 +52,7 @@ LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:40:1
+  --> $DIR/ub-nonnull.rs:41:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 10..=30
@@ -57,7 +60,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:46:1
+  --> $DIR/ub-nonnull.rs:47:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 20, but expected something less or equal to 10, or greater or equal to 30

--- a/src/test/ui/consts/const-eval/unused-broken-const.rs
+++ b/src/test/ui/consts/const-eval/unused-broken-const.rs
@@ -4,5 +4,6 @@
 
 const FOO: i32 = [][0];
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/unused-broken-const.stderr
+++ b/src/test/ui/consts/const-eval/unused-broken-const.stderr
@@ -7,6 +7,8 @@ LL | const FOO: i32 = [][0];
    |                  index out of bounds: the length is 0 but the index is 0
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/unwind-abort.rs
+++ b/src/test/ui/consts/const-eval/unwind-abort.rs
@@ -3,6 +3,7 @@
 #[unwind(aborts)]
 const fn foo() {
     panic!() //~ ERROR any use of this value will cause an error [const_err]
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 const _: () = foo();

--- a/src/test/ui/consts/const-eval/unwind-abort.stderr
+++ b/src/test/ui/consts/const-eval/unwind-abort.stderr
@@ -6,12 +6,14 @@ LL |     panic!()
    |     |
    |     the evaluated program panicked at 'explicit panic', $DIR/unwind-abort.rs:5:5
    |     inside `foo` at $SRC_DIR/std/src/panic.rs:LL:COL
-   |     inside `_` at $DIR/unwind-abort.rs:8:15
+   |     inside `_` at $DIR/unwind-abort.rs:9:15
 ...
 LL | const _: () = foo();
    | --------------------
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -5,6 +5,7 @@ const fn foo() -> ! {
     unsafe { std::mem::transmute(()) }
     //~^ WARN any use of this value will cause an error [const_err]
     //~| WARN the type `!` does not permit zero-initialization [invalid_value]
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 #[derive(Clone, Copy)]

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.stderr
@@ -6,19 +6,21 @@ LL |     unsafe { std::mem::transmute(()) }
    |              |
    |              transmuting to uninhabited type
    |              inside `foo` at $DIR/validate_uninhabited_zsts.rs:5:14
-   |              inside `FOO` at $DIR/validate_uninhabited_zsts.rs:14:26
+   |              inside `FOO` at $DIR/validate_uninhabited_zsts.rs:15:26
 ...
 LL | const FOO: [Empty; 3] = [foo(); 3];
    | -----------------------------------
    |
 note: the lint level is defined here
-  --> $DIR/validate_uninhabited_zsts.rs:13:8
+  --> $DIR/validate_uninhabited_zsts.rs:14:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_uninhabited_zsts.rs:17:1
+  --> $DIR/validate_uninhabited_zsts.rs:18:1
    |
 LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of uninhabited type Empty at [0]
@@ -38,7 +40,7 @@ LL |     unsafe { std::mem::transmute(()) }
    = note: the `!` type has no valid value
 
 warning: the type `Empty` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:17:35
+  --> $DIR/validate_uninhabited_zsts.rs:18:35
    |
 LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/const-external-macro-const-err.rs
+++ b/src/test/ui/consts/const-external-macro-const-err.rs
@@ -10,4 +10,5 @@ use external_macro::static_assert;
 
 fn main() {
     static_assert!(2 + 2 == 5); //~ ERROR
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }

--- a/src/test/ui/consts/const-external-macro-const-err.stderr
+++ b/src/test/ui/consts/const-external-macro-const-err.stderr
@@ -5,6 +5,8 @@ LL |     static_assert!(2 + 2 == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ index out of bounds: the length is 1 but the index is 1
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -14,54 +14,74 @@ use std::intrinsics;
 
 const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // signed types:
 
 const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // and make sure we capture y < 0:
 
 const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // and that there's no special relation to the value -1 by picking some
 // negative values at random:
 
 const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // Repeat it all over for `unchecked_shr`
 
@@ -69,74 +89,101 @@ const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93
 
 const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // signed types:
 
 const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // and make sure we capture y < 0:
 
 const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // and that there's no special relation to the value -1 by picking some
 // negative values at random:
 
 const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // Other arithmetic functions:
 
 const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::MIN, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {}

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -7,374 +7,514 @@ LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
    |                             overflowing shift by 8 in `unchecked_shl`
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:17:31
+  --> $DIR/const-int-unchecked.rs:18:31
    |
 LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 16 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:19:31
+  --> $DIR/const-int-unchecked.rs:21:31
    |
 LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 32 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:21:31
+  --> $DIR/const-int-unchecked.rs:24:31
    |
 LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 64 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:23:33
+  --> $DIR/const-int-unchecked.rs:27:33
    |
 LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 overflowing shift by 128 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:28:29
+  --> $DIR/const-int-unchecked.rs:33:29
    |
 LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
    |                             overflowing shift by 8 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:30:31
+  --> $DIR/const-int-unchecked.rs:36:31
    |
 LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 16 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:32:31
+  --> $DIR/const-int-unchecked.rs:39:31
    |
 LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 32 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:34:31
+  --> $DIR/const-int-unchecked.rs:42:31
    |
 LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 64 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:36:33
+  --> $DIR/const-int-unchecked.rs:45:33
    |
 LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 overflowing shift by 128 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:41:33
+  --> $DIR/const-int-unchecked.rs:51:33
    |
 LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 overflowing shift by 255 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:43:35
+  --> $DIR/const-int-unchecked.rs:54:35
    |
 LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   overflowing shift by 65535 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:45:35
+  --> $DIR/const-int-unchecked.rs:57:35
    |
 LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   overflowing shift by 4294967295 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:47:35
+  --> $DIR/const-int-unchecked.rs:60:35
    |
 LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   overflowing shift by 18446744073709551615 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:49:37
+  --> $DIR/const-int-unchecked.rs:63:37
    |
 LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
    | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                     |
    |                                     overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:55:40
+  --> $DIR/const-int-unchecked.rs:70:40
    |
 LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
    | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                        |
    |                                        overflowing shift by 250 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:57:42
+  --> $DIR/const-int-unchecked.rs:73:42
    |
 LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          overflowing shift by 65523 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:59:42
+  --> $DIR/const-int-unchecked.rs:76:42
    |
 LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          overflowing shift by 4294967271 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:61:42
+  --> $DIR/const-int-unchecked.rs:79:42
    |
 LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          overflowing shift by 18446744073709551586 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:63:44
+  --> $DIR/const-int-unchecked.rs:82:44
    |
 LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
    | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                            |
    |                                            overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shl`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:70:29
+  --> $DIR/const-int-unchecked.rs:90:29
    |
 LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
    |                             overflowing shift by 8 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:72:31
+  --> $DIR/const-int-unchecked.rs:93:31
    |
 LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 16 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:74:31
+  --> $DIR/const-int-unchecked.rs:96:31
    |
 LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 32 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:76:31
+  --> $DIR/const-int-unchecked.rs:99:31
    |
 LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 64 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:78:33
+  --> $DIR/const-int-unchecked.rs:102:33
    |
 LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 overflowing shift by 128 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:83:29
+  --> $DIR/const-int-unchecked.rs:108:29
    |
 LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
    |                             overflowing shift by 8 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:85:31
+  --> $DIR/const-int-unchecked.rs:111:31
    |
 LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 16 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:87:31
+  --> $DIR/const-int-unchecked.rs:114:31
    |
 LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 32 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:89:31
+  --> $DIR/const-int-unchecked.rs:117:31
    |
 LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
    |                               overflowing shift by 64 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:91:33
+  --> $DIR/const-int-unchecked.rs:120:33
    |
 LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 overflowing shift by 128 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:96:33
+  --> $DIR/const-int-unchecked.rs:126:33
    |
 LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
    |                                 overflowing shift by 255 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:98:35
+  --> $DIR/const-int-unchecked.rs:129:35
    |
 LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   overflowing shift by 65535 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:100:35
+  --> $DIR/const-int-unchecked.rs:132:35
    |
 LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   overflowing shift by 4294967295 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:102:35
+  --> $DIR/const-int-unchecked.rs:135:35
    |
 LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
    |                                   overflowing shift by 18446744073709551615 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:104:37
+  --> $DIR/const-int-unchecked.rs:138:37
    |
 LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
    | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                     |
    |                                     overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:110:40
+  --> $DIR/const-int-unchecked.rs:145:40
    |
 LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
    | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                        |
    |                                        overflowing shift by 250 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:112:42
+  --> $DIR/const-int-unchecked.rs:148:42
    |
 LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          overflowing shift by 65523 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:114:42
+  --> $DIR/const-int-unchecked.rs:151:42
    |
 LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          overflowing shift by 4294967271 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:116:42
+  --> $DIR/const-int-unchecked.rs:154:42
    |
 LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
    |                                          overflowing shift by 18446744073709551586 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:118:44
+  --> $DIR/const-int-unchecked.rs:157:44
    |
 LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
    | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                            |
    |                                            overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shr`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:123:25
+  --> $DIR/const-int-unchecked.rs:163:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
    | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         overflow executing `unchecked_add`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:126:25
+  --> $DIR/const-int-unchecked.rs:167:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
    | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         overflow executing `unchecked_sub`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:129:25
+  --> $DIR/const-int-unchecked.rs:171:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
    | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         overflow executing `unchecked_mul`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:132:25
+  --> $DIR/const-int-unchecked.rs:175:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
    | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         dividing by zero
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:134:25
+  --> $DIR/const-int-unchecked.rs:178:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::MIN, -1) };
    | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         overflow executing `unchecked_div`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:137:25
+  --> $DIR/const-int-unchecked.rs:182:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
    | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         calculating the remainder with a divisor of zero
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-int-unchecked.rs:139:25
+  --> $DIR/const-int-unchecked.rs:185:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
    | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                         |
    |                         overflow executing `unchecked_rem`
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 47 previous errors
 

--- a/src/test/ui/consts/const-len-underflow-separate-spans.rs
+++ b/src/test/ui/consts/const-len-underflow-separate-spans.rs
@@ -6,6 +6,7 @@ const ONE: usize = 1;
 const TWO: usize = 2;
 const LEN: usize = ONE - TWO;
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let a: [i8; LEN] = unimplemented!();

--- a/src/test/ui/consts/const-len-underflow-separate-spans.stderr
+++ b/src/test/ui/consts/const-len-underflow-separate-spans.stderr
@@ -7,9 +7,11 @@ LL | const LEN: usize = ONE - TWO;
    |                    attempt to compute `1_usize - 2_usize`, which would overflow
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-len-underflow-separate-spans.rs:11:17
+  --> $DIR/const-len-underflow-separate-spans.rs:12:17
    |
 LL |     let a: [i8; LEN] = unimplemented!();
    |                 ^^^ referenced constant has errors

--- a/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
+++ b/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
@@ -13,6 +13,7 @@ const fn helper() -> Option<&'static mut i32> { unsafe {
     // Undefined behaviour (integer as pointer), who doesn't love tests like this.
     // This code never gets executed, because the static checks fail before that.
     Some(&mut *(42 as *mut i32)) //~ ERROR any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
 } }
 // The error is an evaluation error and not a validation error, so the error is reported
 // directly at the site where it occurs.

--- a/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.stderr
+++ b/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.stderr
@@ -6,15 +6,17 @@ LL |     Some(&mut *(42 as *mut i32))
    |          |
    |          unable to turn bytes into a pointer
    |          inside `helper` at $DIR/mut_ref_in_final_dynamic_check.rs:15:10
-   |          inside `A` at $DIR/mut_ref_in_final_dynamic_check.rs:19:29
+   |          inside `A` at $DIR/mut_ref_in_final_dynamic_check.rs:20:29
 ...
 LL | const A: Option<&mut i32> = helper();
    | -------------------------------------
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: encountered dangling pointer in final constant
-  --> $DIR/mut_ref_in_final_dynamic_check.rs:26:1
+  --> $DIR/mut_ref_in_final_dynamic_check.rs:27:1
    |
 LL | const B: Option<&mut i32> = helper2();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/const-prop-read-static-in-const.rs
+++ b/src/test/ui/consts/const-prop-read-static-in-const.rs
@@ -3,6 +3,7 @@
 #![allow(dead_code)]
 
 const TEST: u8 = MY_STATIC; //~ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 static MY_STATIC: u8 = 4;
 

--- a/src/test/ui/consts/const-prop-read-static-in-const.stderr
+++ b/src/test/ui/consts/const-prop-read-static-in-const.stderr
@@ -7,6 +7,8 @@ LL | const TEST: u8 = MY_STATIC;
    |                  constant accesses static
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 warning: skipping const checks
    |

--- a/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.rs
+++ b/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.rs
@@ -9,6 +9,8 @@ extern "C" {
 }
 
 const _SIZE: usize = unsafe { size_of_val(&4 as *const i32 as *const Opaque) }; //~ ERROR
+//~| WARN this was previously accepted by the compiler but is being phased out
 const _ALIGN: usize = unsafe { min_align_of_val(&4 as *const i32 as *const Opaque) }; //~ ERROR
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {}

--- a/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
+++ b/src/test/ui/consts/const-size_of_val-align_of_val-extern-type.stderr
@@ -7,14 +7,19 @@ LL | const _SIZE: usize = unsafe { size_of_val(&4 as *const i32 as *const Opaque
    |                               `extern type` does not have known layout
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:12:32
+  --> $DIR/const-size_of_val-align_of_val-extern-type.rs:13:32
    |
 LL | const _ALIGN: usize = unsafe { min_align_of_val(&4 as *const i32 as *const Opaque) };
    | -------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                |
    |                                `extern type` does not have known layout
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-slice-oob.rs
+++ b/src/test/ui/consts/const-slice-oob.rs
@@ -4,6 +4,7 @@ const FOO: &'static[u32] = &[1, 2, 3];
 const BAR: u32 = FOO[5];
 //~^ index out of bounds: the length is 3 but the index is 5
 //~| ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
     let _ = BAR;

--- a/src/test/ui/consts/const-slice-oob.stderr
+++ b/src/test/ui/consts/const-slice-oob.stderr
@@ -7,6 +7,8 @@ LL | const BAR: u32 = FOO[5];
    |                  index out of bounds: the length is 3 but the index is 5
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-unwrap.stderr
+++ b/src/test/ui/consts/const-unwrap.stderr
@@ -14,6 +14,8 @@ LL | const BAR: i32 = Option::<i32>::None.unwrap();
    | ----------------------------------------------
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const_limit/const_eval_limit_reached.rs
+++ b/src/test/ui/consts/const_limit/const_eval_limit_reached.rs
@@ -5,6 +5,7 @@ const X: usize = {
     let mut x = 0;
     while x != 1000 {
         //~^ ERROR any use of this value will cause an error
+        //~| WARN this was previously accepted by the compiler but is being phased out
         x += 1;
     }
 

--- a/src/test/ui/consts/const_limit/const_eval_limit_reached.stderr
+++ b/src/test/ui/consts/const_limit/const_eval_limit_reached.stderr
@@ -6,6 +6,7 @@ LL |  |     let mut x = 0;
 LL |  |     while x != 1000 {
    |  |_____^
 LL | ||
+LL | ||
 LL | ||         x += 1;
 LL | ||     }
    | ||_____^ exceeded interpreter step limit (see `#[const_eval_limit]`)
@@ -15,6 +16,8 @@ LL |  | };
    |  |__-
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.rs
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.rs
@@ -17,4 +17,5 @@ fn main() {
   assert_eq!(BAR, true);
   //~^ ERROR E0080
   //~| ERROR erroneous constant
+  //~| WARN this was previously accepted by the compiler but is being phased out
 }

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -19,6 +19,8 @@ note: the lint level is defined here
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const_unsafe_unreachable_ub.rs:17:14
@@ -33,6 +35,8 @@ LL |   assert_eq!(BAR, true);
    |   ^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors; 1 warning emitted

--- a/src/test/ui/consts/control-flow/assert.const_panic.stderr
+++ b/src/test/ui/consts/control-flow/assert.const_panic.stderr
@@ -7,6 +7,8 @@ LL | const _: () = assert!(false);
    |               the evaluated program panicked at 'assertion failed: false', $DIR/assert.rs:10:15
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/consts/control-flow/assert.rs
+++ b/src/test/ui/consts/control-flow/assert.rs
@@ -10,5 +10,6 @@ const _: () = assert!(true);
 const _: () = assert!(false);
 //[stock]~^ ERROR panicking in constants is unstable
 //[const_panic]~^^ ERROR any use of this value will cause an error
+//[const_panic]~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {}

--- a/src/test/ui/consts/issue-51559.rs
+++ b/src/test/ui/consts/issue-51559.rs
@@ -3,5 +3,6 @@
 const BAR: *mut () = ((|| 3) as fn() -> i32) as *mut ();
 pub const FOO: usize = unsafe { BAR as usize };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {}

--- a/src/test/ui/consts/issue-51559.stderr
+++ b/src/test/ui/consts/issue-51559.stderr
@@ -7,6 +7,8 @@ LL | pub const FOO: usize = unsafe { BAR as usize };
    |                                 "pointer-to-integer cast" needs an rfc before being allowed inside constants
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-55878.stderr
+++ b/src/test/ui/consts/issue-55878.stderr
@@ -16,6 +16,8 @@ LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -26,6 +26,8 @@ const U8_MUT2: &u8 = { //~ NOTE
     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
     //~^ WARN [const_err]
     //~| NOTE constant accesses static
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    //~| NOTE
 };
 #[warn(const_err)] //~ NOTE
 const U8_MUT3: &u8 = { //~ NOTE
@@ -33,6 +35,8 @@ const U8_MUT3: &u8 = { //~ NOTE
     //~^ WARN [const_err]
     //~| NOTE constant accesses static
     //~| NOTE in this expansion of panic!
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    //~| NOTE
 };
 
 pub fn test(x: &[u8; 1]) -> bool {

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.stderr
@@ -11,7 +11,7 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:44:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
@@ -29,7 +29,7 @@ LL | | };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:53:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
@@ -42,6 +42,8 @@ LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    | |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant accesses static
 LL | |
 LL | |
+LL | |
+LL | |
 LL | | };
    | |__-
    |
@@ -50,57 +52,62 @@ note: the lint level is defined here
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:64:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:34:51
    |
 LL | / const U8_MUT3: &u8 = {
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    | |                                                   ^^^^^^^^^^^ constant accesses static
 LL | |
 LL | |
+...  |
 LL | |
 LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:30:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:72:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:44:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:53:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:64:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:72:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
@@ -138,27 +145,27 @@ help: skipping check that does not even have a feature gate
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:34:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:34:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:34:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_panic` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:77
+  --> $DIR/const_refers_to_static_cross_crate.rs:34:77
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                                                                             ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:34:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -20,6 +20,8 @@ LL | | };
    | |__-
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -38,6 +40,9 @@ LL | |
 LL | |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
 LL | | };
    | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -59,6 +64,9 @@ LL | |     let field_ptr = &data[1] as *const u8 as *const u16;
 LL | |     unsafe { field_ptr.offset_from(base_ptr as *const u16) }
 LL | | };
    | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -78,6 +86,9 @@ LL | |     let ptr = 0 as *const u8;
 LL | |     unsafe { ptr.offset_from(ptr) }
 LL | | };
    | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -98,6 +109,9 @@ LL | |     let ptr2 = 16 as *const u8;
 LL | |     unsafe { ptr2.offset_from(ptr1) }
 LL | | };
    | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/offset_ub.stderr
+++ b/src/test/ui/consts/offset_ub.stderr
@@ -14,6 +14,8 @@ LL | pub const BEFORE_START: *const u8 = unsafe { (&0u8 as *const u8).offset(-1)
    | ------------------------------------------------------------------------------
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -29,6 +31,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const AFTER_END: *const u8 = unsafe { (&0u8 as *const u8).offset(2) };
    | --------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -44,6 +49,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const AFTER_ARRAY: *const u8 = unsafe { [0u8; 100].as_ptr().offset(101) };
    | ------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -59,6 +67,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const OVERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MAX) };
    | ----------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -74,6 +85,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const UNDERFLOW: *const u16 = unsafe { [0u16; 1].as_ptr().offset(isize::MIN) };
    | -----------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -89,6 +103,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const OVERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (usize::MAX as *const u8).offset(2) };
    | ---------------------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -104,6 +121,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const UNDERFLOW_ADDRESS_SPACE: *const u8 = unsafe { (1 as *const u8).offset(-2) };
    | --------------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -119,6 +139,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const ZERO_SIZED_ALLOC: *const u8 = unsafe { [0u8; 0].as_ptr().offset(1) };
    | -------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/mut_ptr.rs:LL:COL
@@ -134,6 +157,9 @@ LL |         unsafe { intrinsics::offset(self, count) as *mut T }
    |
 LL | pub const DANGLING: *const u8 = unsafe { ptr::NonNull::<u8>::dangling().as_ptr().offset(4) };
    | ---------------------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -149,6 +175,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const NULL_OFFSET_ZERO: *const u8 = unsafe { ptr::null::<u8>().offset(0) };
    | -------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -164,6 +193,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
 LL | pub const UNDERFLOW_ABS: *const u8 = unsafe { (usize::MAX as *const u8).offset(isize::MIN) };
    | ---------------------------------------------------------------------------------------------
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -66,13 +66,19 @@ const _: *const u8 =
     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
 //~^ ERROR any use of this value will cause an error
 //~| NOTE
+//~| WARN this was previously accepted by the compiler but is being phased out
+//~| NOTE
 
 const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
 //~^ ERROR any use of this value will cause an error
 //~| NOTE "pointer-to-integer cast" needs an rfc
 //~| NOTE
+//~| WARN this was previously accepted by the compiler but is being phased out
+//~| NOTE
 
 const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
 //~^ ERROR any use of this value will cause an error
 //~| NOTE "pointer-to-integer cast" needs an rfc
+//~| NOTE
+//~| WARN this was previously accepted by the compiler but is being phased out
 //~| NOTE

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -14,6 +14,8 @@ LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
    | -------------------------------------------------------------------
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
   --> $DIR/ptr_comparisons.rs:66:33
@@ -24,22 +26,31 @@ LL | |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 100
    | |_________________________________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^___-
    |                                   |
    |                                   memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size $WORD
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:70:27
+  --> $DIR/ptr_comparisons.rs:72:27
    |
 LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                           |
    |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:75:27
+  --> $DIR/ptr_comparisons.rs:79:27
    |
 LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                           |
    |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/transmute-size-mismatch-before-typeck.rs
+++ b/src/test/ui/consts/transmute-size-mismatch-before-typeck.rs
@@ -15,6 +15,7 @@ fn main() {
 const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
 //~^ ERROR any use of this value will cause an error
 //~| ERROR cannot transmute between types of different sizes
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 // Once the `any use of this value will cause an error` disappears in this test, make sure to
 // remove the `TransmuteSizeDiff` error variant and make its emitter site an assertion again.

--- a/src/test/ui/consts/transmute-size-mismatch-before-typeck.stderr
+++ b/src/test/ui/consts/transmute-size-mismatch-before-typeck.stderr
@@ -7,6 +7,8 @@ LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    |                             transmuting `usize` to `&[u8]` is not possible, because these types do not have the same size
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
   --> $DIR/transmute-size-mismatch-before-typeck.rs:10:9

--- a/src/test/ui/consts/uninhabited-const-issue-61744.rs
+++ b/src/test/ui/consts/uninhabited-const-issue-61744.rs
@@ -2,6 +2,7 @@
 
 pub const unsafe fn fake_type<T>() -> T {
     hint_unreachable() //~ ERROR any use of this value will cause an error [const_err]
+    //~| WARN this was previously accepted by the compiler but is being phased out
 }
 
 pub const unsafe fn hint_unreachable() -> ! {

--- a/src/test/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/src/test/ui/consts/uninhabited-const-issue-61744.stderr
@@ -6,141 +6,143 @@ LL |     hint_unreachable()
    |     |
    |     reached the configured maximum number of stack frames
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<!>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:8:5
+   |     inside `hint_unreachable` at $DIR/uninhabited-const-issue-61744.rs:9:5
    |     inside `fake_type::<i32>` at $DIR/uninhabited-const-issue-61744.rs:4:5
-   |     inside `<i32 as Const>::CONSTANT` at $DIR/uninhabited-const-issue-61744.rs:12:36
+   |     inside `<i32 as Const>::CONSTANT` at $DIR/uninhabited-const-issue-61744.rs:13:36
 ...
 LL |     const CONSTANT: i32 = unsafe { fake_type() };
    |     ---------------------------------------------
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: erroneous constant used
-  --> $DIR/uninhabited-const-issue-61744.rs:18:10
+  --> $DIR/uninhabited-const-issue-61744.rs:19:10
    |
 LL |     dbg!(i32::CONSTANT);
    |          ^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/error-codes/E0396-fixed.rs
+++ b/src/test/ui/error-codes/E0396-fixed.rs
@@ -4,6 +4,7 @@ const REG_ADDR: *const u8 = 0x5f3759df as *const u8;
 
 const VALUE: u8 = unsafe { *REG_ADDR };
 //~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
 
 fn main() {
 }

--- a/src/test/ui/error-codes/E0396-fixed.stderr
+++ b/src/test/ui/error-codes/E0396-fixed.stderr
@@ -7,6 +7,8 @@ LL | const VALUE: u8 = unsafe { *REG_ADDR };
    |                            unable to turn bytes into a pointer
    |
    = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This is the first step for https://github.com/rust-lang/rust/issues/71800: make const_err a future-incompat lint. I also rewrote the const_err lint description as the old one seemed wrong.

This has the unfortunate side-effect of making const-eval error even more verbose by making the const_err message longer without fixing the redundancy caused by additionally emitting an error on each use site of the constant. We cannot fix that redundancy until const_err is a *hard* error (at that point the error-on-use-site can be turned into a `delay_span_bug!` for uses of monomorphic consts, and into a nicely rendered error for [lazily / post-monomorhization evaluated] associated consts).

~~The one annoying effect of this PR is that `let _x = &(1/(1-1));` now also shows the future-incompat warning, even though of course we will *not* make this a hard error. We'll instead (hopefully) stop promoting it -- see https://github.com/rust-lang/rfcs/pull/3027. The only way I see to avoid the future-incompat warning is to use a different lint for "failure to evaluate promoted".~~

Cc @rust-lang/wg-const-eval 