### PR TITLE
Fix search section position on small devices

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1570,7 +1570,10 @@ h4 > .notable-traits {
 		height: 73px;
 	}
 
-	#main {
+	/* This is to prevent the search bar from being underneath the <section>
+	 * element following it.
+	 */
+	#main, #search {
 		margin-top: 100px;
 	}
 


### PR DESCRIPTION
Fixes #79526.

This is exactly the same issue fixed in 9c36491538476dd3ff5ec834944aacdaceb12f30 (in https://github.com/rust-lang/rust/pull/79936) but applied to the search section. When the width becomes too small, the search input goes on its own line to get more space, making it go "under" the section following (so either "main" or "search"). The fix is to simply make the section go more under so that it doesn't go over the search input.

r? @jyn514 