### PR TITLE
Allow references to interior mutable data behind a feature gate

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0492.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0492.md
@@ -3,7 +3,6 @@ A borrow of a constant containing interior mutability was attempted.
 Erroneous code example:
 
 ```compile_fail,E0492
-#![feature(const_refs_to_cell)]
 use std::sync::atomic::AtomicUsize;
 
 const A: AtomicUsize = AtomicUsize::new(0);
@@ -31,7 +30,6 @@ static B: &'static AtomicUsize = &A; // ok!
 You can also have this error while using a cell type:
 
 ```compile_fail,E0492
-#![feature(const_refs_to_cell)]
 use std::cell::Cell;
 
 const A: Cell<usize> = Cell::new(1);

--- a/compiler/rustc_error_codes/src/error_codes/E0492.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0492.md
@@ -3,10 +3,11 @@ A borrow of a constant containing interior mutability was attempted.
 Erroneous code example:
 
 ```compile_fail,E0492
+#![feature(const_refs_to_cell)]
 use std::sync::atomic::AtomicUsize;
 
 const A: AtomicUsize = AtomicUsize::new(0);
-static B: &'static AtomicUsize = &A;
+const B: &'static AtomicUsize = &A;
 // error: cannot borrow a constant which may contain interior mutability,
 //        create a static instead
 ```
@@ -18,7 +19,7 @@ can't be changed via a shared `&` pointer, but interior mutability would allow
 it. That is, a constant value could be mutated. On the other hand, a `static` is
 explicitly a single memory location, which can be mutated at will.
 
-So, in order to solve this error, either use statics which are `Sync`:
+So, in order to solve this error, use statics which are `Sync`:
 
 ```
 use std::sync::atomic::AtomicUsize;
@@ -30,6 +31,7 @@ static B: &'static AtomicUsize = &A; // ok!
 You can also have this error while using a cell type:
 
 ```compile_fail,E0492
+#![feature(const_refs_to_cell)]
 use std::cell::Cell;
 
 const A: Cell<usize> = Cell::new(1);

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -626,6 +626,9 @@ declare_features! (
     /// Allows const generics to have default values (e.g. `struct Foo<const N: usize = 3>(...);`).
     (active, const_generics_defaults, "1.51.0", Some(44580), None),
 
+    /// Allows references to types with interior mutability within constants
+    (active, const_refs_to_cell, "1.51.0", Some(80384), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -227,6 +227,13 @@ impl NonConstOp for CellBorrowBehindRef {
 #[derive(Debug)]
 pub struct CellBorrow;
 impl NonConstOp for CellBorrow {
+    fn status_in_item(&self, ccx: &ConstCx<'_, '_>) -> Status {
+        match ccx.const_kind() {
+            // The borrow checker does a much better job at handling these than we do
+            hir::ConstContext::ConstFn => Status::Allowed,
+            _ => Status::Forbidden,
+        }
+    }
     fn importance(&self) -> DiagnosticImportance {
         // The problematic cases will already emit a `CellBorrowBehindRef`
         DiagnosticImportance::Secondary

--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -251,15 +251,15 @@ impl NonConstOp for CellBorrow {
         );
         if let hir::ConstContext::Static(_) = ccx.const_kind() {
             err.help(
-                "To fix this, the value can be extracted to separate \
-                `static` and then referenced.",
+                "to fix this, the value can be extracted to a separate \
+                `static` item and then referenced",
             );
         }
         if ccx.tcx.sess.teach(&err.get_code().unwrap()) {
             err.note(
                 "A constant containing interior mutable data behind a reference can allow you
                  to modify that data. This would make multiple uses of a constant to be able to
-                 see different values and allow one to escape the `Send` and `Sync` requirements
+                 see different values and allow circumventing the `Send` and `Sync` requirements
                  for shared mutable data, which is unsound.",
             );
         }

--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -242,8 +242,8 @@ impl NonConstOp for CellBorrow {
             ccx.tcx.sess,
             span,
             E0492,
-            "cannot borrow a constant which may contain \
-            interior mutability, create a static instead"
+            "this borrow to an interior mutable value may end up in the final value of this {}",
+            ccx.const_kind(),
         )
     }
 }

--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -232,7 +232,7 @@ impl NonConstOp for TransientCellBorrow {
 }
 
 #[derive(Debug)]
-/// A borrow of a type that contains an `UnsafeCell` somewhere. The borrow escapes to
+/// A borrow of a type that contains an `UnsafeCell` somewhere. The borrow might escape to
 /// the final value of the constant, and thus we cannot allow this (for now). We may allow
 /// it in the future for static items.
 pub struct CellBorrow;

--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -237,13 +237,6 @@ impl NonConstOp for TransientCellBorrow {
 /// it in the future for static items.
 pub struct CellBorrow;
 impl NonConstOp for CellBorrow {
-    fn status_in_item(&self, ccx: &ConstCx<'_, '_>) -> Status {
-        match ccx.const_kind() {
-            // The borrow checker does a much better job at handling these than we do.
-            hir::ConstContext::ConstFn => Status::Unstable(sym::const_refs_to_cell),
-            _ => Status::Forbidden,
-        }
-    }
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
         struct_span_err!(
             ccx.tcx.sess,

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -595,8 +595,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                             // Locals with StorageDead are definitely not part of the final constant value, and
                             // it is thus inherently safe to permit such locals to have their
                             // address taken as we can't end up with a reference to them in the
-                            // final value without creating a dangling pointer, which will cause
-                            // errors during validation.
+                            // final value.
                             // Note: This is only sound if every local that has a `StorageDead` has a
                             // `StorageDead` in every control flow path leading to a `return` terminator.
                             if self.local_has_storage_dead(place.local) {

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -587,7 +587,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                     // Note: This is only sound if every local that has a `StorageDead` has a
                     // `StorageDead` in every control flow path leading to a `return` terminator.
                     if self.local_has_storage_dead(place.local) {
-                        self.check_op(ops::CellBorrowBehindRef);
+                        self.check_op(ops::TransientCellBorrow);
                     } else {
                         self.check_op(ops::CellBorrow);
                     }

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -584,6 +584,8 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 if borrowed_place_has_mut_interior {
                     // Locals without StorageDead follow the "enclosing scope" rule, meaning
                     // they are essentially anonymous static items themselves.
+                    // Note: This is only sound if every local that has a `StorageDead` has a
+                    // `StorageDead` in every control flow path leading to a `return` terminator.
                     if self.local_has_storage_dead(place.local) {
                         self.check_op(ops::CellBorrowBehindRef);
                     } else {

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -582,7 +582,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 );
 
                 if borrowed_place_has_mut_interior {
-                    // Locals without StorageDead follow the "trailing expression" rule, meaning
+                    // Locals without StorageDead follow the "enclosing scope" rule, meaning
                     // they are essentially anonymous static items themselves.
                     if self.local_has_storage_dead(place.local) {
                         self.check_op(ops::CellBorrowBehindRef);

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -592,7 +592,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                         // to (interior) mutable memory.
                         hir::ConstContext::ConstFn => self.check_op(ops::TransientCellBorrow),
                         _ => {
-                            // Locals StorageDead are known to not leak to the final constant, and
+                            // Locals with StorageDead are definitely not part of the final constant value, and
                             // it is thus inherently safe to permit such locals to have their
                             // address taken as we can't end up with a reference to them in the
                             // final value without creating a dangling pointer, which will cause

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -381,6 +381,7 @@ symbols! {
         const_ptr,
         const_raw_ptr_deref,
         const_raw_ptr_to_usize_cast,
+        const_refs_to_cell,
         const_slice_ptr,
         const_trait_bound_opt_out,
         const_trait_impl,

--- a/src/test/ui/consts/const-address-of-interior-mut.stderr
+++ b/src/test/ui/consts/const-address-of-interior-mut.stderr
@@ -1,27 +1,39 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:5:39
    |
 LL | const A: () = { let x = Cell::new(2); &raw const x; };
    |                                       ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:7:40
    |
 LL | static B: () = { let x = Cell::new(2); &raw const x; };
    |                                        ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:9:44
    |
 LL | static mut C: () = { let x = Cell::new(2); &raw const x; };
    |                                            ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-address-of-interior-mut.rs:13:13
    |
 LL |     let y = &raw const x;
    |             ^^^^^^^^^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0492`.
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/const-multi-ref.rs
+++ b/src/test/ui/consts/const-multi-ref.rs
@@ -13,7 +13,7 @@ const _: i32 = {
 
 const _: std::cell::Cell<i32> = {
     let mut a = std::cell::Cell::new(5);
-    let p = &a; //~ ERROR cannot borrow a constant which may contain interior mutability
+    let p = &a; //~ ERROR borrowed element may contain interior mutability
 
     let reborrow = {p};
     let pp = &reborrow;

--- a/src/test/ui/consts/const-multi-ref.stderr
+++ b/src/test/ui/consts/const-multi-ref.stderr
@@ -4,13 +4,16 @@ error[E0764]: mutable references are not allowed in constants
 LL |     let p = &mut a;
    |             ^^^^^^ `&mut` is only allowed in `const fn`
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/const-multi-ref.rs:16:13
    |
 LL |     let p = &a;
    |             ^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0492, E0764.
-For more information about an error, try `rustc --explain E0492`.
+Some errors have detailed explanations: E0658, E0764.
+For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/consts/partial_qualif.rs
+++ b/src/test/ui/consts/partial_qualif.rs
@@ -1,3 +1,5 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::Cell;
 
 const FOO: &(Cell<usize>, bool) = {

--- a/src/test/ui/consts/partial_qualif.rs
+++ b/src/test/ui/consts/partial_qualif.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 const FOO: &(Cell<usize>, bool) = {
     let mut a = (Cell::new(0), false);
     a.1 = true; // sets `qualif(a)` to `qualif(a) | qualif(true)`
-    &{a} //~ ERROR cannot borrow a constant which may contain interior mutability
+    &{a} //~ ERROR borrow to an interior mutable value may end up in the final value
 };
 
 fn main() {}

--- a/src/test/ui/consts/partial_qualif.rs
+++ b/src/test/ui/consts/partial_qualif.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 const FOO: &(Cell<usize>, bool) = {
     let mut a = (Cell::new(0), false);
     a.1 = true; // sets `qualif(a)` to `qualif(a) | qualif(true)`
-    &{a} //~ ERROR borrow to an interior mutable value may end up in the final value
+    &{a} //~ ERROR cannot refer to interior mutable
 };
 
 fn main() {}

--- a/src/test/ui/consts/partial_qualif.rs
+++ b/src/test/ui/consts/partial_qualif.rs
@@ -1,5 +1,3 @@
-#![feature(const_refs_to_cell)]
-
 use std::cell::Cell;
 
 const FOO: &(Cell<usize>, bool) = {

--- a/src/test/ui/consts/partial_qualif.stderr
+++ b/src/test/ui/consts/partial_qualif.stderr
@@ -1,4 +1,4 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
   --> $DIR/partial_qualif.rs:6:5
    |
 LL |     &{a}

--- a/src/test/ui/consts/partial_qualif.stderr
+++ b/src/test/ui/consts/partial_qualif.stderr
@@ -1,8 +1,8 @@
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
+error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/partial_qualif.rs:6:5
    |
 LL |     &{a}
-   |     ^^^^
+   |     ^^^^ this borrow of an interior mutable value may end up in the final value
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/partial_qualif.stderr
+++ b/src/test/ui/consts/partial_qualif.stderr
@@ -1,5 +1,5 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/partial_qualif.rs:8:5
+  --> $DIR/partial_qualif.rs:6:5
    |
 LL |     &{a}
    |     ^^^^

--- a/src/test/ui/consts/partial_qualif.stderr
+++ b/src/test/ui/consts/partial_qualif.stderr
@@ -1,5 +1,5 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/partial_qualif.rs:6:5
+  --> $DIR/partial_qualif.rs:8:5
    |
 LL |     &{a}
    |     ^^^^

--- a/src/test/ui/consts/qualif_overwrite.rs
+++ b/src/test/ui/consts/qualif_overwrite.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 const FOO: &Option<Cell<usize>> = {
     let mut a = Some(Cell::new(0));
     a = None; // sets `qualif(a)` to `qualif(a) | qualif(None)`
-    &{a} //~ ERROR borrow to an interior mutable value may end up in the final value
+    &{a} //~ ERROR cannot refer to interior mutable
 };
 
 fn main() {}

--- a/src/test/ui/consts/qualif_overwrite.rs
+++ b/src/test/ui/consts/qualif_overwrite.rs
@@ -1,3 +1,5 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::Cell;
 
 // this is overly conservative. The reset to `None` should clear `a` of all qualifications
@@ -7,7 +9,7 @@ use std::cell::Cell;
 const FOO: &Option<Cell<usize>> = {
     let mut a = Some(Cell::new(0));
     a = None; // sets `qualif(a)` to `qualif(a) | qualif(None)`
-    &{a} //~ ERROR cannot borrow a constant which may contain interior mutability
+    &{a}//~ ERROR cannot borrow a constant which may contain interior mutability
 };
 
 fn main() {}

--- a/src/test/ui/consts/qualif_overwrite.rs
+++ b/src/test/ui/consts/qualif_overwrite.rs
@@ -1,5 +1,3 @@
-#![feature(const_refs_to_cell)]
-
 use std::cell::Cell;
 
 // this is overly conservative. The reset to `None` should clear `a` of all qualifications

--- a/src/test/ui/consts/qualif_overwrite.rs
+++ b/src/test/ui/consts/qualif_overwrite.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 const FOO: &Option<Cell<usize>> = {
     let mut a = Some(Cell::new(0));
     a = None; // sets `qualif(a)` to `qualif(a) | qualif(None)`
-    &{a}//~ ERROR cannot borrow a constant which may contain interior mutability
+    &{a} //~ ERROR borrow to an interior mutable value may end up in the final value
 };
 
 fn main() {}

--- a/src/test/ui/consts/qualif_overwrite.stderr
+++ b/src/test/ui/consts/qualif_overwrite.stderr
@@ -1,8 +1,8 @@
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
+error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/qualif_overwrite.rs:10:5
    |
 LL |     &{a}
-   |     ^^^^
+   |     ^^^^ this borrow of an interior mutable value may end up in the final value
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/qualif_overwrite.stderr
+++ b/src/test/ui/consts/qualif_overwrite.stderr
@@ -1,5 +1,5 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/qualif_overwrite.rs:10:5
+  --> $DIR/qualif_overwrite.rs:12:5
    |
 LL |     &{a}
    |     ^^^^

--- a/src/test/ui/consts/qualif_overwrite.stderr
+++ b/src/test/ui/consts/qualif_overwrite.stderr
@@ -1,5 +1,5 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/qualif_overwrite.rs:12:5
+  --> $DIR/qualif_overwrite.rs:10:5
    |
 LL |     &{a}
    |     ^^^^

--- a/src/test/ui/consts/qualif_overwrite.stderr
+++ b/src/test/ui/consts/qualif_overwrite.stderr
@@ -1,4 +1,4 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
   --> $DIR/qualif_overwrite.rs:10:5
    |
 LL |     &{a}

--- a/src/test/ui/consts/qualif_overwrite_2.rs
+++ b/src/test/ui/consts/qualif_overwrite_2.rs
@@ -5,7 +5,7 @@ use std::cell::Cell;
 const FOO: &Option<Cell<usize>> = {
     let mut a = (Some(Cell::new(0)),);
     a.0 = None; // sets `qualif(a)` to `qualif(a) | qualif(None)`
-    &{a.0} //~ ERROR borrow to an interior mutable value may end up in the final value
+    &{a.0} //~ ERROR cannot refer to interior mutable
 };
 
 fn main() {}

--- a/src/test/ui/consts/qualif_overwrite_2.rs
+++ b/src/test/ui/consts/qualif_overwrite_2.rs
@@ -1,3 +1,5 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::Cell;
 
 // const qualification is not smart enough to know about fields and always assumes that there might

--- a/src/test/ui/consts/qualif_overwrite_2.rs
+++ b/src/test/ui/consts/qualif_overwrite_2.rs
@@ -5,7 +5,7 @@ use std::cell::Cell;
 const FOO: &Option<Cell<usize>> = {
     let mut a = (Some(Cell::new(0)),);
     a.0 = None; // sets `qualif(a)` to `qualif(a) | qualif(None)`
-    &{a.0} //~ ERROR cannot borrow a constant which may contain interior mutability
+    &{a.0} //~ ERROR borrow to an interior mutable value may end up in the final value
 };
 
 fn main() {}

--- a/src/test/ui/consts/qualif_overwrite_2.rs
+++ b/src/test/ui/consts/qualif_overwrite_2.rs
@@ -1,5 +1,3 @@
-#![feature(const_refs_to_cell)]
-
 use std::cell::Cell;
 
 // const qualification is not smart enough to know about fields and always assumes that there might

--- a/src/test/ui/consts/qualif_overwrite_2.stderr
+++ b/src/test/ui/consts/qualif_overwrite_2.stderr
@@ -1,4 +1,4 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
   --> $DIR/qualif_overwrite_2.rs:8:5
    |
 LL |     &{a.0}

--- a/src/test/ui/consts/qualif_overwrite_2.stderr
+++ b/src/test/ui/consts/qualif_overwrite_2.stderr
@@ -1,5 +1,5 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/qualif_overwrite_2.rs:8:5
+  --> $DIR/qualif_overwrite_2.rs:10:5
    |
 LL |     &{a.0}
    |     ^^^^^^

--- a/src/test/ui/consts/qualif_overwrite_2.stderr
+++ b/src/test/ui/consts/qualif_overwrite_2.stderr
@@ -1,5 +1,5 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/qualif_overwrite_2.rs:10:5
+  --> $DIR/qualif_overwrite_2.rs:8:5
    |
 LL |     &{a.0}
    |     ^^^^^^

--- a/src/test/ui/consts/qualif_overwrite_2.stderr
+++ b/src/test/ui/consts/qualif_overwrite_2.stderr
@@ -1,8 +1,8 @@
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
+error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/qualif_overwrite_2.rs:8:5
    |
 LL |     &{a.0}
-   |     ^^^^^^
+   |     ^^^^^^ this borrow of an interior mutable value may end up in the final value
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/std/cell.rs
+++ b/src/test/ui/consts/std/cell.rs
@@ -1,24 +1,33 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::*;
 
 // not ok, because this would create a silent constant with interior mutability.
 // the rules could be relaxed in the future
 static FOO: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
-//~^ ERROR cannot borrow a constant which may contain interior mutability
+//~^ ERROR encountered dangling pointer
+const FOO_CONST: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
+//~^ ERROR encountered dangling pointer
 
 static FOO3: Wrap<Cell<u32>> = Wrap(Cell::new(42));
+const FOO3_CONST: Wrap<Cell<u32>> = Wrap(Cell::new(42));
+
 // ok
 static FOO4: Wrap<*mut u32> = Wrap(FOO3.0.as_ptr());
+const FOO4_CONST: Wrap<*mut u32> = Wrap(FOO3_CONST.0.as_ptr());
+//~^ ERROR encountered dangling pointer
 
 // not ok, because the `as_ptr` call takes a reference to a type with interior mutability
 // which is not allowed in constants
 const FOO2: *mut u32 = Cell::new(42).as_ptr();
-//~^ ERROR cannot borrow a constant which may contain interior mutability
+//~^ ERROR encountered dangling pointer
 
 struct IMSafeTrustMe(UnsafeCell<u32>);
 unsafe impl Send for IMSafeTrustMe {}
 unsafe impl Sync for IMSafeTrustMe {}
 
 static BAR: IMSafeTrustMe = IMSafeTrustMe(UnsafeCell::new(5));
+
 
 
 struct Wrap<T>(T);

--- a/src/test/ui/consts/std/cell.rs
+++ b/src/test/ui/consts/std/cell.rs
@@ -36,4 +36,6 @@ unsafe impl<T> Sync for Wrap<T> {}
 
 static BAR_PTR: Wrap<*mut u32> = Wrap(BAR.0.get());
 
+const fn fst_ref<T, U>(x: &(T, U)) -> &T { &x.0 }
+
 fn main() {}

--- a/src/test/ui/consts/std/cell.stderr
+++ b/src/test/ui/consts/std/cell.stderr
@@ -1,15 +1,26 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/cell.rs:5:35
+error: encountered dangling pointer in final constant
+  --> $DIR/cell.rs:7:1
    |
 LL | static FOO: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
-   |                                   ^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/cell.rs:14:24
+error: encountered dangling pointer in final constant
+  --> $DIR/cell.rs:9:1
+   |
+LL | const FOO_CONST: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: encountered dangling pointer in final constant
+  --> $DIR/cell.rs:17:1
+   |
+LL | const FOO4_CONST: Wrap<*mut u32> = Wrap(FOO3_CONST.0.as_ptr());
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: encountered dangling pointer in final constant
+  --> $DIR/cell.rs:22:1
    |
 LL | const FOO2: *mut u32 = Cell::new(42).as_ptr();
-   |                        ^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0492`.

--- a/src/test/ui/consts/std/cell.stderr
+++ b/src/test/ui/consts/std/cell.stderr
@@ -1,23 +1,23 @@
 error: encountered dangling pointer in final constant
-  --> $DIR/cell.rs:7:1
+  --> $DIR/cell.rs:6:1
    |
 LL | static FOO: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered dangling pointer in final constant
-  --> $DIR/cell.rs:9:1
+  --> $DIR/cell.rs:8:1
    |
 LL | const FOO_CONST: Wrap<*mut u32> = Wrap(Cell::new(42).as_ptr());
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered dangling pointer in final constant
-  --> $DIR/cell.rs:17:1
+  --> $DIR/cell.rs:22:1
    |
 LL | const FOO4_CONST: Wrap<*mut u32> = Wrap(FOO3_CONST.0.as_ptr());
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: encountered dangling pointer in final constant
-  --> $DIR/cell.rs:22:1
+  --> $DIR/cell.rs:27:1
    |
 LL | const FOO2: *mut u32 = Cell::new(42).as_ptr();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0492.rs
+++ b/src/test/ui/error-codes/E0492.rs
@@ -1,7 +1,12 @@
+#![feature(const_refs_to_cell)]
+
 use std::sync::atomic::AtomicUsize;
 
 const A: AtomicUsize = AtomicUsize::new(0);
-static B: &'static AtomicUsize = &A; //~ ERROR E0492
+const B: &'static AtomicUsize = &A; //~ ERROR E0492
+static C: &'static AtomicUsize = &A; //~ ERROR E0492
+
+const NONE: &'static Option<AtomicUsize> = &None;
 
 fn main() {
 }

--- a/src/test/ui/error-codes/E0492.rs
+++ b/src/test/ui/error-codes/E0492.rs
@@ -1,5 +1,3 @@
-#![feature(const_refs_to_cell)]
-
 use std::sync::atomic::AtomicUsize;
 
 const A: AtomicUsize = AtomicUsize::new(0);

--- a/src/test/ui/error-codes/E0492.stderr
+++ b/src/test/ui/error-codes/E0492.stderr
@@ -1,14 +1,16 @@
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
+error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/E0492.rs:4:33
    |
 LL | const B: &'static AtomicUsize = &A;
-   |                                 ^^
+   |                                 ^^ this borrow of an interior mutable value may end up in the final value
 
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this static
+error[E0492]: statics cannot refer to interior mutable data
   --> $DIR/E0492.rs:5:34
    |
 LL | static C: &'static AtomicUsize = &A;
-   |                                  ^^
+   |                                  ^^ this borrow of an interior mutable value may end up in the final value
+   |
+   = help: To fix this, the value can be extracted to separate `static` and then referenced.
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0492.stderr
+++ b/src/test/ui/error-codes/E0492.stderr
@@ -1,9 +1,15 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/E0492.rs:4:34
+  --> $DIR/E0492.rs:6:33
    |
-LL | static B: &'static AtomicUsize = &A;
+LL | const B: &'static AtomicUsize = &A;
+   |                                 ^^
+
+error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+  --> $DIR/E0492.rs:7:34
+   |
+LL | static C: &'static AtomicUsize = &A;
    |                                  ^^
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0492`.

--- a/src/test/ui/error-codes/E0492.stderr
+++ b/src/test/ui/error-codes/E0492.stderr
@@ -10,7 +10,7 @@ error[E0492]: statics cannot refer to interior mutable data
 LL | static C: &'static AtomicUsize = &A;
    |                                  ^^ this borrow of an interior mutable value may end up in the final value
    |
-   = help: To fix this, the value can be extracted to separate `static` and then referenced.
+   = help: to fix this, the value can be extracted to a separate `static` item and then referenced
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0492.stderr
+++ b/src/test/ui/error-codes/E0492.stderr
@@ -1,10 +1,10 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
   --> $DIR/E0492.rs:4:33
    |
 LL | const B: &'static AtomicUsize = &A;
    |                                 ^^
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this static
   --> $DIR/E0492.rs:5:34
    |
 LL | static C: &'static AtomicUsize = &A;

--- a/src/test/ui/error-codes/E0492.stderr
+++ b/src/test/ui/error-codes/E0492.stderr
@@ -1,11 +1,11 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/E0492.rs:6:33
+  --> $DIR/E0492.rs:4:33
    |
 LL | const B: &'static AtomicUsize = &A;
    |                                 ^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/E0492.rs:7:34
+  --> $DIR/E0492.rs:5:34
    |
 LL | static C: &'static AtomicUsize = &A;
    |                                  ^^

--- a/src/test/ui/feature-gate/feature-gate-const_refs_to_cell.rs
+++ b/src/test/ui/feature-gate/feature-gate-const_refs_to_cell.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![feature(const_refs_to_cell)]
+
+const FOO: () = {
+    let x = std::cell::Cell::new(42);
+    let y = &x;
+};
+
+fn main() {
+    FOO;
+}

--- a/src/test/ui/issues/issue-17718-const-borrow.rs
+++ b/src/test/ui/issues/issue-17718-const-borrow.rs
@@ -1,14 +1,16 @@
+#![feature(const_refs_to_cell)]
+
 use std::cell::UnsafeCell;
 
 const A: UnsafeCell<usize> = UnsafeCell::new(1);
 const B: &'static UnsafeCell<usize> = &A;
-//~^ ERROR: cannot borrow a constant which may contain interior mutability
+//~^ ERROR: may contain interior mutability
 
 struct C { a: UnsafeCell<usize> }
 const D: C = C { a: UnsafeCell::new(1) };
 const E: &'static UnsafeCell<usize> = &D.a;
-//~^ ERROR: cannot borrow a constant which may contain interior mutability
+//~^ ERROR: may contain interior mutability
 const F: &'static C = &D;
-//~^ ERROR: cannot borrow a constant which may contain interior mutability
+//~^ ERROR: may contain interior mutability
 
 fn main() {}

--- a/src/test/ui/issues/issue-17718-const-borrow.rs
+++ b/src/test/ui/issues/issue-17718-const-borrow.rs
@@ -2,13 +2,13 @@ use std::cell::UnsafeCell;
 
 const A: UnsafeCell<usize> = UnsafeCell::new(1);
 const B: &'static UnsafeCell<usize> = &A;
-//~^ ERROR: borrow to an interior mutable value
+//~^ ERROR: cannot refer to interior mutable
 
 struct C { a: UnsafeCell<usize> }
 const D: C = C { a: UnsafeCell::new(1) };
 const E: &'static UnsafeCell<usize> = &D.a;
-//~^ ERROR: borrow to an interior mutable value
+//~^ ERROR: cannot refer to interior mutable
 const F: &'static C = &D;
-//~^ ERROR: borrow to an interior mutable value
+//~^ ERROR: cannot refer to interior mutable
 
 fn main() {}

--- a/src/test/ui/issues/issue-17718-const-borrow.rs
+++ b/src/test/ui/issues/issue-17718-const-borrow.rs
@@ -1,5 +1,3 @@
-#![feature(const_refs_to_cell)]
-
 use std::cell::UnsafeCell;
 
 const A: UnsafeCell<usize> = UnsafeCell::new(1);

--- a/src/test/ui/issues/issue-17718-const-borrow.rs
+++ b/src/test/ui/issues/issue-17718-const-borrow.rs
@@ -2,13 +2,13 @@ use std::cell::UnsafeCell;
 
 const A: UnsafeCell<usize> = UnsafeCell::new(1);
 const B: &'static UnsafeCell<usize> = &A;
-//~^ ERROR: may contain interior mutability
+//~^ ERROR: borrow to an interior mutable value
 
 struct C { a: UnsafeCell<usize> }
 const D: C = C { a: UnsafeCell::new(1) };
 const E: &'static UnsafeCell<usize> = &D.a;
-//~^ ERROR: may contain interior mutability
+//~^ ERROR: borrow to an interior mutable value
 const F: &'static C = &D;
-//~^ ERROR: may contain interior mutability
+//~^ ERROR: borrow to an interior mutable value
 
 fn main() {}

--- a/src/test/ui/issues/issue-17718-const-borrow.stderr
+++ b/src/test/ui/issues/issue-17718-const-borrow.stderr
@@ -1,17 +1,17 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:6:39
+  --> $DIR/issue-17718-const-borrow.rs:4:39
    |
 LL | const B: &'static UnsafeCell<usize> = &A;
    |                                       ^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:11:39
+  --> $DIR/issue-17718-const-borrow.rs:9:39
    |
 LL | const E: &'static UnsafeCell<usize> = &D.a;
    |                                       ^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:13:23
+  --> $DIR/issue-17718-const-borrow.rs:11:23
    |
 LL | const F: &'static C = &D;
    |                       ^^

--- a/src/test/ui/issues/issue-17718-const-borrow.stderr
+++ b/src/test/ui/issues/issue-17718-const-borrow.stderr
@@ -1,17 +1,17 @@
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:4:39
+  --> $DIR/issue-17718-const-borrow.rs:6:39
    |
 LL | const B: &'static UnsafeCell<usize> = &A;
    |                                       ^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:9:39
+  --> $DIR/issue-17718-const-borrow.rs:11:39
    |
 LL | const E: &'static UnsafeCell<usize> = &D.a;
    |                                       ^^^^
 
 error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
-  --> $DIR/issue-17718-const-borrow.rs:11:23
+  --> $DIR/issue-17718-const-borrow.rs:13:23
    |
 LL | const F: &'static C = &D;
    |                       ^^

--- a/src/test/ui/issues/issue-17718-const-borrow.stderr
+++ b/src/test/ui/issues/issue-17718-const-borrow.stderr
@@ -1,20 +1,20 @@
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
+error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/issue-17718-const-borrow.rs:4:39
    |
 LL | const B: &'static UnsafeCell<usize> = &A;
-   |                                       ^^
+   |                                       ^^ this borrow of an interior mutable value may end up in the final value
 
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
+error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/issue-17718-const-borrow.rs:9:39
    |
 LL | const E: &'static UnsafeCell<usize> = &D.a;
-   |                                       ^^^^
+   |                                       ^^^^ this borrow of an interior mutable value may end up in the final value
 
-error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
+error[E0492]: constants cannot refer to interior mutable data
   --> $DIR/issue-17718-const-borrow.rs:11:23
    |
 LL | const F: &'static C = &D;
-   |                       ^^
+   |                       ^^ this borrow of an interior mutable value may end up in the final value
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-17718-const-borrow.stderr
+++ b/src/test/ui/issues/issue-17718-const-borrow.stderr
@@ -1,16 +1,16 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
   --> $DIR/issue-17718-const-borrow.rs:4:39
    |
 LL | const B: &'static UnsafeCell<usize> = &A;
    |                                       ^^
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
   --> $DIR/issue-17718-const-borrow.rs:9:39
    |
 LL | const E: &'static UnsafeCell<usize> = &D.a;
    |                                       ^^^^
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0492]: this borrow to an interior mutable value may end up in the final value of this constant
   --> $DIR/issue-17718-const-borrow.rs:11:23
    |
 LL | const F: &'static C = &D;

--- a/src/test/ui/panic-handler/weak-lang-item.stderr
+++ b/src/test/ui/panic-handler/weak-lang-item.stderr
@@ -10,9 +10,9 @@ help: you can use `as` to change the binding name of the import
 LL | extern crate core as other_core;
    |
 
-error: `#[panic_handler]` function required, but not found
-
 error: language item required, but not found: `eh_personality`
+
+error: `#[panic_handler]` function required, but not found
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/unsafe/ranged_ints3_const.rs
+++ b/src/test/ui/unsafe/ranged_ints3_const.rs
@@ -9,13 +9,13 @@ fn main() {}
 
 const fn foo() -> NonZero<Cell<u32>> {
     let mut x = unsafe { NonZero(Cell::new(1)) };
-    let y = &x.0; //~ ERROR cannot borrow a constant which may contain interior mutability
+    let y = &x.0; //~ ERROR the borrowed element may contain interior mutability
     //~^ ERROR borrow of layout constrained field with interior mutability
     unsafe { NonZero(Cell::new(1)) }
 }
 
 const fn bar() -> NonZero<Cell<u32>> {
     let mut x = unsafe { NonZero(Cell::new(1)) };
-    let y = unsafe { &x.0 }; //~ ERROR cannot borrow a constant which may contain interior mut
+    let y = unsafe { &x.0 }; //~ ERROR the borrowed element may contain interior mutability
     unsafe { NonZero(Cell::new(1)) }
 }

--- a/src/test/ui/unsafe/ranged_ints3_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints3_const.stderr
@@ -1,14 +1,20 @@
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/ranged_ints3_const.rs:12:13
    |
 LL |     let y = &x.0;
    |             ^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
-error[E0492]: cannot borrow a constant which may contain interior mutability, create a static instead
+error[E0658]: cannot borrow here, since the borrowed element may contain interior mutability
   --> $DIR/ranged_ints3_const.rs:19:22
    |
 LL |     let y = unsafe { &x.0 };
    |                      ^^^^
+   |
+   = note: see issue #80384 <https://github.com/rust-lang/rust/issues/80384> for more information
+   = help: add `#![feature(const_refs_to_cell)]` to the crate attributes to enable
 
 error[E0133]: borrow of layout constrained field with interior mutability is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints3_const.rs:12:13
@@ -20,5 +26,5 @@ LL |     let y = &x.0;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0133, E0492.
+Some errors have detailed explanations: E0133, E0658.
 For more information about an error, try `rustc --explain E0133`.


### PR DESCRIPTION
supercedes #80373 by simply not checking for interior mutability on borrows of locals that have `StorageDead` and thus can never be leaked to the final value of the constant

tracking issue: https://github.com/rust-lang/rust/issues/80384

r? @RalfJung 