### PR TITLE
Add regression test for mutual recursion in obligation forest

### DIFF
--- a/src/test/ui/traits/mutual-recursion-issue-75860.rs
+++ b/src/test/ui/traits/mutual-recursion-issue-75860.rs
@@ -1,0 +1,15 @@
+pub fn iso<A, B, F1, F2>(a: F1, b: F2) -> (Box<dyn Fn(A) -> B>, Box<dyn Fn(B) -> A>)
+    where
+        F1: (Fn(A) -> B) + 'static,
+        F2: (Fn(B) -> A) + 'static,
+{
+    (Box::new(a), Box::new(b))
+}
+pub fn iso_un_option<A, B>() -> (Box<dyn Fn(A) -> B>, Box<dyn Fn(B) -> A>) {
+   let left = |o_a: Option<_>| o_a.unwrap();
+    let right = |o_b: Option<_>| o_b.unwrap();
+    iso(left, right)
+    //~^ ERROR overflow
+}
+
+fn main() {}

--- a/src/test/ui/traits/mutual-recursion-issue-75860.stderr
+++ b/src/test/ui/traits/mutual-recursion-issue-75860.stderr
@@ -1,0 +1,16 @@
+error[E0275]: overflow evaluating the requirement `Option<_>: Sized`
+  --> $DIR/mutual-recursion-issue-75860.rs:11:5
+   |
+LL |     iso(left, right)
+   |     ^^^
+   | 
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL | pub enum Option<T> {
+   |                 - required by this bound in `Option`
+   |
+   = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`mutual_recursion_issue_75860`)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Add regression test for #75860 with a slightly smaller example.
I was looking at what caused the issue and was surprised when it errors out on nightly, so I just added a regression test which should effectively close the issue, altho it would be nice to find the fix for reference.

Also I found that 80066 is not fixed by whatever fixed 75860.