### PR TITLE
bootstrap: put the component name in the tarball temp dir path

### DIFF
--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -112,7 +112,7 @@ impl<'a> Tarball<'a> {
     fn new_inner(builder: &'a Builder<'a>, component: &str, target: Option<String>) -> Self {
         let pkgname = crate::dist::pkgname(builder, component);
 
-        let mut temp_dir = builder.out.join("tmp").join("tarball");
+        let mut temp_dir = builder.out.join("tmp").join("tarball").join(component);
         if let Some(target) = &target {
             temp_dir = temp_dir.join(target);
         }


### PR DESCRIPTION
This should not matter right now, but if we ever parallelize rustbuild this will avoid tarball contents being merged together.

r? @Mark-Simulacrum 