### PR TITLE
Mention Arc::make_mut and Rc::make_mut in the documentation of Cow

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -103,6 +103,11 @@ where
 /// is desired, `to_mut` will obtain a mutable reference to an owned
 /// value, cloning if necessary.
 ///
+/// If you need reference-counting pointers, note that
+/// [`Rc::make_mut`][crate::rc::Rc::make_mut] and
+/// [`Arc::make_mut`][crate::sync::Arc::make_mut] can provide clone-on-write
+/// functionality as well.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Following this discussion: https://users.rust-lang.org/t/should-the-cow-documentation-mention-arc/53341

_Rendered (the last paragraph is new):_

![Screenshot_20201228_171551](https://user-images.githubusercontent.com/3986214/103228135-5d72e200-4930-11eb-89e1-38b5c86b08c7.png)

@rustbot modify labels: T-doc, T-libs