### PR TITLE
Some Promotion Refactoring

### DIFF
--- a/compiler/rustc_mir/src/transform/promote_consts.rs
+++ b/compiler/rustc_mir/src/transform/promote_consts.rs
@@ -687,7 +687,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                 self.validate_place(place_simplified)?;
 
                 // Check that the reference is fine (using the original place!).
-                // (Needs to come after `validate_local` to avoid ICEs.)
+                // (Needs to come after `validate_place` to avoid ICEs.)
                 self.validate_ref(*kind, place)?;
             }
 


### PR DESCRIPTION
Clean up promotion a bit:
* factor out some common code
* more exhaustive matches

This *should* not break anything... the only potentially-breaking change is that `BorrowKind::Shallow | BorrowKind::Unique` are now rejected for internal references.

r? @oli-obk 