### PR TITLE
Add `to_boxed_slice()` to clone slice into boxed slice

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1229,13 +1229,9 @@ impl<T: Copy> From<&[T]> for Box<[T]> {
     ///
     /// println!("{:?}", boxed_slice);
     /// ```
+    #[inline]
     fn from(slice: &[T]) -> Box<[T]> {
-        let len = slice.len();
-        let buf = RawVec::with_capacity(len);
-        unsafe {
-            ptr::copy_nonoverlapping(slice.as_ptr(), buf.ptr(), len);
-            buf.into_box(slice.len()).assume_init()
-        }
+        slice.to_boxed_slice()
     }
 }
 
@@ -1578,7 +1574,7 @@ impl<I> FromIterator<I> for Box<[I]> {
 impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {
         let alloc = Box::allocator(self).clone();
-        self.to_vec_in(alloc).into_boxed_slice()
+        self.to_boxed_slice_in(alloc)
     }
 
     fn clone_from(&mut self, other: &Self) {

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -160,60 +160,22 @@ mod hack {
     }
 
     #[inline]
-    pub fn to_vec<T: ConvertVec, A: Allocator>(s: &[T], alloc: A) -> Vec<T, A> {
-        T::to_vec(s, alloc)
+    pub fn to_vec<T: ConvertBoxed, A: Allocator>(s: &[T], alloc: A) -> Vec<T, A> {
+        into_vec(to_boxed_slice(s, alloc))
     }
 
     #[inline]
-    pub fn to_boxed_slice<T: ConvertVec, A: Allocator>(s: &[T], alloc: A) -> Box<[T], A> {
+    pub fn to_boxed_slice<T: ConvertBoxed, A: Allocator>(s: &[T], alloc: A) -> Box<[T], A> {
         T::to_boxed_slice(s, alloc)
     }
 
-    pub trait ConvertVec {
-        fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A>
-        where
-            Self: Sized;
-
+    pub trait ConvertBoxed {
         fn to_boxed_slice<A: Allocator>(s: &[Self], alloc: A) -> Box<[Self], A>
         where
             Self: Sized;
     }
 
-    impl<T: Clone> ConvertVec for T {
-        #[inline]
-        default fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A> {
-            struct DropGuard<'a, T, A: Allocator> {
-                vec: &'a mut Vec<T, A>,
-                num_init: usize,
-            }
-            impl<'a, T, A: Allocator> Drop for DropGuard<'a, T, A> {
-                #[inline]
-                fn drop(&mut self) {
-                    // SAFETY:
-                    // items were marked initialized in the loop below
-                    unsafe {
-                        self.vec.set_len(self.num_init);
-                    }
-                }
-            }
-            let mut vec = Vec::with_capacity_in(s.len(), alloc);
-            let mut guard = DropGuard { vec: &mut vec, num_init: 0 };
-            let slots = guard.vec.spare_capacity_mut();
-            // .take(slots.len()) is necessary for LLVM to remove bounds checks
-            // and has better codegen than zip.
-            for (i, b) in s.iter().enumerate().take(slots.len()) {
-                guard.num_init = i;
-                slots[i].write(b.clone());
-            }
-            core::mem::forget(guard);
-            // SAFETY:
-            // the vec was allocated and initialized above to at least this length.
-            unsafe {
-                vec.set_len(s.len());
-            }
-            vec
-        }
-
+    impl<T: Clone> ConvertBoxed for T {
         #[inline]
         default fn to_boxed_slice<A: Allocator>(s: &[Self], alloc: A) -> Box<[Self], A> {
             struct DropGuard<T> {
@@ -244,20 +206,7 @@ mod hack {
         }
     }
 
-    impl<T: Copy> ConvertVec for T {
-        #[inline]
-        fn to_vec<A: Allocator>(s: &[Self], alloc: A) -> Vec<Self, A> {
-            let mut v = Vec::with_capacity_in(s.len(), alloc);
-            // SAFETY:
-            // allocated above with the capacity of `s`, and initialize to `s.len()` in
-            // ptr::copy_to_non_overlapping below.
-            unsafe {
-                s.as_ptr().copy_to_nonoverlapping(v.as_mut_ptr(), s.len());
-                v.set_len(s.len());
-            }
-            v
-        }
-
+    impl<T: Copy> ConvertBoxed for T {
         #[inline]
         fn to_boxed_slice<A: Allocator>(s: &[Self], alloc: A) -> Box<[Self], A> {
             let mut boxed = Box::new_uninit_slice_in(s.len(), alloc);

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -464,8 +464,7 @@ impl Iterator for ReadDir {
                 let ret = DirEntry {
                     entry: *entry_ptr,
                     name: slice::from_raw_parts(name as *const u8, namelen as usize)
-                        .to_owned()
-                        .into_boxed_slice(),
+                        .to_boxed_slice(),
                     dir: Arc::clone(&self.inner),
                 };
                 if ret.name_bytes() != b"." && ret.name_bytes() != b".." {


### PR DESCRIPTION
The current recommended approach seems to be to use `.to_vec().into_boxed_slice()`, but this misses some opportunities for optimization. A Godbolt comparison shows that `Vec::into_boxed_slice()` emits unnecessary calls to `realloc()` and `free()` and uses some extra registers for local variables: https://godbolt.org/z/eq7Pc7. I was able to remove 3 calls to `Vec::into_boxed_slice()` from the standard library.
If this addition looks reasonable, I can create a tracking issue for the `slice_to_boxed` feature.