### PR TITLE
Fix small typo in time comment

### DIFF
--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -237,7 +237,7 @@ mod inner {
         // `denom` field.
         //
         // Encoding this as a single `AtomicU64` allows us to use `Relaxed`
-        // operations, as we are only interested in in the effects on a single
+        // operations, as we are only interested in the effects on a single
         // memory location.
         static INFO_BITS: AtomicU64 = AtomicU64::new(0);
 


### PR DESCRIPTION
I was reading through [this PR](https://github.com/rust-lang/rust/pull/77727/files) and noticed a [small typo](https://github.com/rust-lang/rust/pull/77727/files#diff-3183738c82f747fd92bb573712073aa384b16e14d154bf2df18f41077edc31cbR240) smuggled though. This just fixes that.