### PR TITLE
Stabilize by-value `[T; N]` iterator `core::array::IntoIter`

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -11,11 +11,9 @@
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     test(no_crate_inject, attr(deny(warnings)))
 )]
-#![feature(array_value_iter_slice)]
 #![feature(dropck_eyepatch)]
 #![feature(new_uninit)]
 #![feature(maybe_uninit_slice)]
-#![feature(array_value_iter)]
 #![cfg_attr(bootstrap, feature(min_const_generics))]
 #![feature(min_specialization)]
 #![cfg_attr(test, feature(test))]

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -30,7 +30,6 @@
 //! get confused if the spans from leaf AST nodes occur in multiple places
 //! in the HIR, especially for multiple identifiers.
 
-#![feature(array_value_iter)]
 #![feature(crate_visibility_modifier)]
 #![feature(or_patterns)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
-#![feature(array_value_iter)]
 #![feature(crate_visibility_modifier)]
 #![feature(const_fn)] // For the unsizing cast on `&[]`
 #![feature(const_panic)]

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -11,7 +11,6 @@
 //! This API is completely unstable and subject to change.
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(array_value_iter)]
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(drain_filter)]

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -56,7 +56,6 @@ This API is completely unstable and subject to change.
 */
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(array_value_iter)]
 #![feature(bool_to_option)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -79,7 +79,6 @@
 #![feature(allocator_api)]
 #![feature(array_chunks)]
 #![feature(array_methods)]
-#![feature(array_value_iter)]
 #![feature(array_windows)]
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -11,7 +11,7 @@ use crate::{
 /// A by-value [array] iterator.
 ///
 /// [array]: ../../std/primitive.array.html
-#[unstable(feature = "array_value_iter", issue = "65798")]
+#[stable(feature = "array_value_iter", since = "1.51.0")]
 pub struct IntoIter<T, const N: usize> {
     /// This is the array we are iterating over.
     ///
@@ -38,10 +38,11 @@ pub struct IntoIter<T, const N: usize> {
 impl<T, const N: usize> IntoIter<T, N> {
     /// Creates a new iterator over the given `array`.
     ///
-    /// *Note*: this method might never get stabilized and/or removed in the
-    /// future as there will likely be another, preferred way of obtaining this
-    /// iterator (either via `IntoIterator` for arrays or via another way).
-    #[unstable(feature = "array_value_iter", issue = "65798")]
+    /// *Note*: this method might be deprecated in the future,
+    /// after [`IntoIterator` is implemented for arrays][array-into-iter].
+    ///
+    /// [array-into-iter]: https://github.com/rust-lang/rust/pull/65819
+    #[stable(feature = "array_value_iter", since = "1.51.0")]
     pub fn new(array: [T; N]) -> Self {
         // SAFETY: The transmute here is actually safe. The docs of `MaybeUninit`
         // promise:
@@ -69,7 +70,7 @@ impl<T, const N: usize> IntoIter<T, N> {
 
     /// Returns an immutable slice of all elements that have not been yielded
     /// yet.
-    #[unstable(feature = "array_value_iter_slice", issue = "65798")]
+    #[stable(feature = "array_value_iter", since = "1.51.0")]
     pub fn as_slice(&self) -> &[T] {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {
@@ -79,7 +80,7 @@ impl<T, const N: usize> IntoIter<T, N> {
     }
 
     /// Returns a mutable slice of all elements that have not been yielded yet.
-    #[unstable(feature = "array_value_iter_slice", issue = "65798")]
+    #[stable(feature = "array_value_iter", since = "1.51.0")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         // SAFETY: We know that all elements within `alive` are properly initialized.
         unsafe {

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -41,6 +41,16 @@ impl<T, const N: usize> IntoIter<T, N> {
     /// *Note*: this method might be deprecated in the future,
     /// after [`IntoIterator` is implemented for arrays][array-into-iter].
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::array;
+    ///
+    /// for value in array::IntoIter::new([1, 2, 3, 4, 5]) {
+    ///     // The type of `value` is a `i32` here, instead of `&i32`
+    ///     let _: i32 = value;
+    /// }
+    /// ```
     /// [array-into-iter]: https://github.com/rust-lang/rust/pull/65819
     #[stable(feature = "array_value_iter", since = "1.51.0")]
     pub fn new(array: [T; N]) -> Self {

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -17,7 +17,7 @@ use crate::slice::{Iter, IterMut};
 
 mod iter;
 
-#[unstable(feature = "array_value_iter", issue = "65798")]
+#[stable(feature = "array_value_iter", since = "1.51.0")]
 pub use iter::IntoIter;
 
 /// Converts a reference to `T` into a reference to an array of length 1 (without copying).

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -45,7 +45,6 @@
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
 #![feature(int_error_matching)]
-#![feature(array_value_iter)]
 #![feature(iter_advance_by)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_is_partitioned)]

--- a/src/test/ui/const-generics/array-impls/into-iter-impls-length-32.rs
+++ b/src/test/ui/const-generics/array-impls/into-iter-impls-length-32.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(array_value_iter)]
 #![feature(trusted_len)]
 
 use std::{

--- a/src/test/ui/const-generics/array-impls/into-iter-impls-length-33.rs
+++ b/src/test/ui/const-generics/array-impls/into-iter-impls-length-33.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(array_value_iter)]
 #![feature(trusted_len)]
 
 use std::{


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/65798

This is unblocked now that `min_const_generics` has been stabilized in https://github.com/rust-lang/rust/pull/79135.

This PR does *not* include the corresponding `IntoIterator` impl, which is https://github.com/rust-lang/rust/pull/65819. Instead, an iterator can be constructed through the `new` method.

`new` would become unnecessary when `IntoIterator` is implemented and might be deprecated then, although it will stay stable.