### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -397,10 +397,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         match i.kind {
             ast::ForeignItemKind::Fn(..) | ast::ForeignItemKind::Static(..) => {
                 let link_name = self.sess.first_attr_value_str_by_name(&i.attrs, sym::link_name);
-                let links_to_llvm = match link_name {
-                    Some(val) => val.as_str().starts_with("llvm."),
-                    _ => false,
-                };
+                let links_to_llvm =
+                    link_name.map_or(false, |val| val.as_str().starts_with("llvm."));
                 if links_to_llvm {
                     gate_feature_post!(
                         &self,

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -75,7 +75,7 @@
 //! breaking inconsistently to become
 //!
 //! ```
-//! foo(hello, there
+//! foo(hello, there,
 //!     good, friends);
 //! ```
 //!
@@ -83,7 +83,7 @@
 //!
 //! ```
 //! foo(hello,
-//!     there
+//!     there,
 //!     good,
 //!     friends);
 //! ```

--- a/compiler/rustc_lint/src/redundant_semicolon.rs
+++ b/compiler/rustc_lint/src/redundant_semicolon.rs
@@ -28,37 +28,23 @@ declare_lint_pass!(RedundantSemicolons => [REDUNDANT_SEMICOLONS]);
 
 impl EarlyLintPass for RedundantSemicolons {
     fn check_block(&mut self, cx: &EarlyContext<'_>, block: &Block) {
-        let mut after_item_stmt = false;
         let mut seq = None;
         for stmt in block.stmts.iter() {
             match (&stmt.kind, &mut seq) {
                 (StmtKind::Empty, None) => seq = Some((stmt.span, false)),
                 (StmtKind::Empty, Some(seq)) => *seq = (seq.0.to(stmt.span), true),
-                (_, seq) => {
-                    maybe_lint_redundant_semis(cx, seq, after_item_stmt);
-                    after_item_stmt = matches!(stmt.kind, StmtKind::Item(_));
-                }
+                (_, seq) => maybe_lint_redundant_semis(cx, seq),
             }
         }
-        maybe_lint_redundant_semis(cx, &mut seq, after_item_stmt);
+        maybe_lint_redundant_semis(cx, &mut seq);
     }
 }
 
-fn maybe_lint_redundant_semis(
-    cx: &EarlyContext<'_>,
-    seq: &mut Option<(Span, bool)>,
-    after_item_stmt: bool,
-) {
+fn maybe_lint_redundant_semis(cx: &EarlyContext<'_>, seq: &mut Option<(Span, bool)>) {
     if let Some((span, multiple)) = seq.take() {
         // FIXME: Find a better way of ignoring the trailing
         // semicolon from macro expansion
         if span == rustc_span::DUMMY_SP {
-            return;
-        }
-
-        // FIXME: Lint on semicolons after item statements
-        // once doing so doesn't break bootstrapping
-        if after_item_stmt {
             return;
         }
 

--- a/compiler/rustc_span/src/edition.rs
+++ b/compiler/rustc_span/src/edition.rs
@@ -4,24 +4,25 @@ use std::str::FromStr;
 
 use rustc_macros::HashStable_Generic;
 
-/// The edition of the compiler (RFC 2052)
+/// The edition of the compiler. (See [RFC 2052](https://github.com/rust-lang/rfcs/blob/master/text/2052-epochs.md).)
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Debug, Encodable, Decodable, Eq)]
 #[derive(HashStable_Generic)]
 pub enum Edition {
-    // editions must be kept in order, oldest to newest
+    // When adding new editions, be sure to do the following:
+    //
+    // - update the `ALL_EDITIONS` const
+    // - update the `EDITION_NAME_LIST` const
+    // - add a `rust_####()` function to the session
+    // - update the enum in Cargo's sources as well
+    //
+    // Editions *must* be kept in order, oldest to newest.
     /// The 2015 edition
     Edition2015,
     /// The 2018 edition
     Edition2018,
-    // when adding new editions, be sure to update:
-    //
-    // - Update the `ALL_EDITIONS` const
-    // - Update the EDITION_NAME_LIST const
-    // - add a `rust_####()` function to the session
-    // - update the enum in Cargo's sources as well
 }
 
-// must be in order from oldest to newest
+// Must be in order from oldest to newest.
 pub const ALL_EDITIONS: &[Edition] = &[Edition::Edition2015, Edition::Edition2018];
 
 pub const EDITION_NAME_LIST: &str = "2015|2018";

--- a/compiler/rustc_span/src/lev_distance.rs
+++ b/compiler/rustc_span/src/lev_distance.rs
@@ -1,10 +1,16 @@
+//! Levenshtein distances.
+//!
+//! The [Levenshtein distance] is a metric for measuring the difference between two strings.
+//!
+//! [Levenshtein distance]: https://en.wikipedia.org/wiki/Levenshtein_distance
+
 use crate::symbol::Symbol;
 use std::cmp;
 
 #[cfg(test)]
 mod tests;
 
-/// Finds the Levenshtein distance between two strings
+/// Finds the Levenshtein distance between two strings.
 pub fn lev_distance(a: &str, b: &str) -> usize {
     // cases which don't require further computation
     if a.is_empty() {
@@ -35,14 +41,14 @@ pub fn lev_distance(a: &str, b: &str) -> usize {
     dcol[t_last + 1]
 }
 
-/// Finds the best match for a given word in the given iterator
+/// Finds the best match for a given word in the given iterator.
 ///
 /// As a loose rule to avoid the obviously incorrect suggestions, it takes
 /// an optional limit for the maximum allowable edit distance, which defaults
 /// to one-third of the given word.
 ///
-/// Besides Levenshtein, we use case insensitive comparison to improve accuracy on an edge case with
-/// a lower(upper)case letters mismatch.
+/// Besides Levenshtein, we use case insensitive comparison to improve accuracy
+/// on an edge case with a lower(upper)case letters mismatch.
 #[cold]
 pub fn find_best_match_for_name(
     name_vec: &[Symbol],
@@ -98,7 +104,7 @@ fn find_match_by_sorted_words(iter_names: &[Symbol], lookup: &str) -> Option<Sym
 
 fn sort_by_words(name: &str) -> String {
     let mut split_words: Vec<&str> = name.split('_').collect();
-    // We are sorting primitive &strs and can use unstable sort here
+    // We are sorting primitive &strs and can use unstable sort here.
     split_words.sort_unstable();
     split_words.join("_")
 }

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -1,9 +1,11 @@
-//! The `SourceMap` tracks all the source code used within a single crate, mapping
+//! Types for tracking pieces of source code within a crate.
+//!
+//! The [`SourceMap`] tracks all the source code used within a single crate, mapping
 //! from integer byte positions to the original source code location. Each bit
 //! of source parsed during crate parsing (typically files, in-memory strings,
 //! or various bits of macro expansion) cover a continuous range of bytes in the
-//! `SourceMap` and are represented by `SourceFile`s. Byte positions are stored in
-//! `Span` and used pervasively in the compiler. They are absolute positions
+//! `SourceMap` and are represented by [`SourceFile`]s. Byte positions are stored in
+//! [`Span`] and used pervasively in the compiler. They are absolute positions
 //! within the `SourceMap`, which upon request can be converted to line and column
 //! information, source code snippets, etc.
 

--- a/compiler/rustc_span/src/span_encoding.rs
+++ b/compiler/rustc_span/src/span_encoding.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::fx::FxIndexSet;
 
 /// A compressed span.
 ///
-/// `SpanData` is 12 bytes, which is a bit too big to stick everywhere. `Span`
+/// Whereas [`SpanData`] is 12 bytes, which is a bit too big to stick everywhere, `Span`
 /// is a form that only takes up 8 bytes, with less space for the length and
 /// context. The vast majority (99.9%+) of `SpanData` instances will fit within
 /// those 8 bytes; any `SpanData` whose fields don't fit into a `Span` are
@@ -42,13 +42,11 @@ use rustc_data_structures::fx::FxIndexSet;
 /// - `base` is 32 bits in both `Span` and `SpanData`, which means that `base`
 ///   values never cause interning. The number of bits needed for `base`
 ///   depends on the crate size. 32 bits allows up to 4 GiB of code in a crate.
-///   `script-servo` is the largest crate in `rustc-perf`, requiring 26 bits
-///   for some spans.
 /// - `len` is 15 bits in `Span` (a u16, minus 1 bit for the tag) and 32 bits
 ///   in `SpanData`, which means that large `len` values will cause interning.
 ///   The number of bits needed for `len` does not depend on the crate size.
-///   The most common number of bits for `len` are 0--7, with a peak usually at
-///   3 or 4, and then it drops off quickly from 8 onwards. 15 bits is enough
+///   The most common numbers of bits for `len` are from 0 to 7, with a peak usually
+///   at 3 or 4, and then it drops off quickly from 8 onwards. 15 bits is enough
 ///   for 99.99%+ of cases, but larger values (sometimes 20+ bits) might occur
 ///   dozens of times in a typical crate.
 /// - `ctxt` is 16 bits in `Span` and 32 bits in `SpanData`, which means that

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -237,7 +237,7 @@ mod inner {
         // `denom` field.
         //
         // Encoding this as a single `AtomicU64` allows us to use `Relaxed`
-        // operations, as we are only interested in in the effects on a single
+        // operations, as we are only interested in the effects on a single
         // memory location.
         static INFO_BITS: AtomicU64 = AtomicU64::new(0);
 

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to bootstrap will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Non-breaking changes since the last major version]
+
+## [Changes since the last major version]
+
+- `llvm-libunwind` now accepts `in-tree` (formerly true), `system` or `no` (formerly false) [#77703](https://github.com/rust-lang/rust/pull/77703)
+
+### Non-breaking changes
 
 - `x.py check` needs opt-in to check tests (--all-targets) [#77473](https://github.com/rust-lang/rust/pull/77473)
 - The default bootstrap profiles are now located at `bootstrap/defaults/config.$PROFILE.toml` (previously they were located at `bootstrap/defaults/config.toml.$PROFILE`) [#77558](https://github.com/rust-lang/rust/pull/77558)

--- a/src/doc/unstable-book/src/language-features/ffi-pure.md
+++ b/src/doc/unstable-book/src/language-features/ffi-pure.md
@@ -31,7 +31,7 @@ parameters (e.g. pointers), globals, etc. `#[ffi_pure]` functions are not
 referentially-transparent, and are therefore more relaxed than `#[ffi_const]`
 functions.
 
-However, accesing global memory through volatile or atomic reads can violate the
+However, accessing global memory through volatile or atomic reads can violate the
 requirement that two consecutive function calls shall return the same value.
 
 A `pure` function that returns unit has no effect on the abstract machine's

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -558,12 +558,12 @@ crate fn make_test(
                     "fn main() {{ {}fn {}() -> Result<(), impl core::fmt::Debug> {{\n",
                     inner_attr, inner_fn_name
                 ),
-                format!("\n}}; {}().unwrap() }}", inner_fn_name),
+                format!("\n}} {}().unwrap() }}", inner_fn_name),
             )
         } else if test_id.is_some() {
             (
                 format!("fn main() {{ {}fn {}() {{\n", inner_attr, inner_fn_name),
-                format!("\n}}; {}() }}", inner_fn_name),
+                format!("\n}} {}() }}", inner_fn_name),
             )
         } else {
             ("fn main() {\n".into(), "\n}".into())

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -292,7 +292,7 @@ use std::io;
 let mut input = String::new();
 io::stdin().read_line(&mut input)?;
 Ok::<(), io:Error>(())
-}; _inner().unwrap() }"
+} _inner().unwrap() }"
         .to_string();
     let (output, len, _) = make_test(input, None, false, &opts, DEFAULT_EDITION, None);
     assert_eq!((output, len), (expected, 2));
@@ -306,7 +306,7 @@ fn make_test_named_wrapper() {
     let expected = "#![allow(unused)]
 fn main() { #[allow(non_snake_case)] fn _doctest_main__some_unique_name() {
 assert_eq!(2+2, 4);
-}; _doctest_main__some_unique_name() }"
+} _doctest_main__some_unique_name() }"
         .to_string();
     let (output, len, _) =
         make_test(input, None, false, &opts, DEFAULT_EDITION, Some("_some_unique_name"));

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1027,7 +1027,7 @@ fn markdown_summary_with_limit(md: &str, length_limit: usize) -> (String, bool) 
     fn push(s: &mut String, text_length: &mut usize, text: &str) {
         s.push_str(text);
         *text_length += text.len();
-    };
+    }
 
     'outer: for event in Parser::new_ext(md, summary_opts()) {
         match &event {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -122,7 +122,9 @@ h3.impl, h3.method, h3.type {
 h1, h2, h3, h4,
 .sidebar, a.source, .search-input, .content table td:first-child > a,
 .collapse-toggle, div.item-list .out-of-band,
-#source-sidebar, #sidebar-toggle {
+#source-sidebar, #sidebar-toggle,
+/* This selector is for the items listed in the "all items" page. */
+#main > ul.docblock > li > a {
 	font-family: "Fira Sans", sans-serif;
 }
 

--- a/src/test/ui/lint/redundant-semicolon/item-stmt-semi.rs
+++ b/src/test/ui/lint/redundant-semicolon/item-stmt-semi.rs
@@ -1,10 +1,6 @@
-// check-pass
-// This test should stop compiling
-// we decide to enable this lint for item statements.
-
 #![deny(redundant_semicolons)]
 
 fn main() {
-    fn inner() {};
-    struct Bar {};
+    fn inner() {}; //~ ERROR unnecessary
+    struct Bar {}; //~ ERROR unnecessary
 }

--- a/src/test/ui/lint/redundant-semicolon/item-stmt-semi.stderr
+++ b/src/test/ui/lint/redundant-semicolon/item-stmt-semi.stderr
@@ -1,0 +1,20 @@
+error: unnecessary trailing semicolon
+  --> $DIR/item-stmt-semi.rs:4:18
+   |
+LL |     fn inner() {};
+   |                  ^ help: remove this semicolon
+   |
+note: the lint level is defined here
+  --> $DIR/item-stmt-semi.rs:1:9
+   |
+LL | #![deny(redundant_semicolons)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: unnecessary trailing semicolon
+  --> $DIR/item-stmt-semi.rs:5:18
+   |
+LL |     struct Bar {};
+   |                  ^ help: remove this semicolon
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #79812 (Lint on redundant trailing semicolon after item)
 - #80358 (Edit rustc_span documentation)
 - #80457 (Add missing commas to `rustc_ast_pretty::pp` docs)
 - #80461 (Add llvm-libunwind change to bootstrap CHANGELOG)
 - #80464 (Use Option::map_or instead of open coding it)
 - #80465 (Fix typo in ffi-pure.md)
 - #80469 (Fix small typo in time comment)
 - #80472 (Use sans-serif font for the "all items" page links)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=79812,80358,80457,80461,80464,80465,80469,80472)
<!-- homu-ignore:end -->