### PR TITLE
New mir-opt pass to simplify gotos with const values (reopening #77486)

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1518,7 +1518,14 @@ pub enum StatementKind<'tcx> {
 }
 
 impl<'tcx> StatementKind<'tcx> {
-    pub fn as_assign_mut(&mut self) -> Option<&mut Box<(Place<'tcx>, Rvalue<'tcx>)>> {
+    pub fn as_assign_mut(&mut self) -> Option<&mut (Place<'tcx>, Rvalue<'tcx>)> {
+        match self {
+            StatementKind::Assign(x) => Some(x),
+            _ => None,
+        }
+    }
+
+    pub fn as_assign(&self) -> Option<&(Place<'tcx>, Rvalue<'tcx>)> {
         match self {
             StatementKind::Assign(x) => Some(x),
             _ => None,

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -407,6 +407,22 @@ impl<'tcx> TerminatorKind<'tcx> {
             | TerminatorKind::FalseUnwind { ref mut unwind, .. } => Some(unwind),
         }
     }
+
+    pub fn as_switch(&self) -> Option<(&Operand<'tcx>, Ty<'tcx>, &SwitchTargets)> {
+        match self {
+            TerminatorKind::SwitchInt { discr, switch_ty, targets } => {
+                Some((discr, switch_ty, targets))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn as_goto(&self) -> Option<BasicBlock> {
+        match self {
+            TerminatorKind::Goto { target } => Some(*target),
+            _ => None,
+        }
+    }
 }
 
 impl<'tcx> Debug for TerminatorKind<'tcx> {

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -514,6 +514,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// Evaluate the operand, returning a place where you can then find the data.
     /// If you already know the layout, you can save two table lookups
     /// by passing it in here.
+    #[inline]
     pub fn eval_operand(
         &self,
         mir_op: &mir::Operand<'tcx>,

--- a/compiler/rustc_mir/src/transform/const_goto.rs
+++ b/compiler/rustc_mir/src/transform/const_goto.rs
@@ -1,0 +1,122 @@
+//! This pass optimizes the following sequence
+//! ```rust,ignore (example)
+//! bb2: {
+//!     _2 = const true;
+//!     goto -> bb3;
+//! }
+//!
+//! bb3: {
+//!     switchInt(_2) -> [false: bb4, otherwise: bb5];
+//! }
+//! ```
+//! into
+//! ```rust,ignore (example)
+//! bb2: {
+//!     _2 = const true;
+//!     goto -> bb5;
+//! }
+//! ```
+
+use crate::transform::MirPass;
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use rustc_middle::{mir::visit::Visitor, ty::ParamEnv};
+
+use super::simplify::{simplify_cfg, simplify_locals};
+
+pub struct ConstGoto;
+
+impl<'tcx> MirPass<'tcx> for ConstGoto {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        if tcx.sess.opts.debugging_opts.mir_opt_level < 3 {
+            return;
+        }
+        trace!("Running ConstGoto on {:?}", body.source);
+        let param_env = tcx.param_env_reveal_all_normalized(body.source.def_id());
+        let mut opt_finder =
+            ConstGotoOptimizationFinder { tcx, body, optimizations: vec![], param_env };
+        opt_finder.visit_body(body);
+        let should_simplify = !opt_finder.optimizations.is_empty();
+        for opt in opt_finder.optimizations {
+            let terminator = body.basic_blocks_mut()[opt.bb_with_goto].terminator_mut();
+            let new_goto = TerminatorKind::Goto { target: opt.target_to_use_in_goto };
+            debug!("SUCCESS: replacing `{:?}` with `{:?}`", terminator.kind, new_goto);
+            terminator.kind = new_goto;
+        }
+
+        // if we applied optimizations, we potentially have some cfg to cleanup to
+        // make it easier for further passes
+        if should_simplify {
+            simplify_cfg(body);
+            simplify_locals(body, tcx);
+        }
+    }
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for ConstGotoOptimizationFinder<'a, 'tcx> {
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
+        let _: Option<_> = try {
+            let target = terminator.kind.as_goto()?;
+            // We only apply this optimization if the last statement is a const assignment
+            let last_statement = self.body.basic_blocks()[location.block].statements.last()?;
+
+            if let (place, Rvalue::Use(Operand::Constant(_const))) =
+                last_statement.kind.as_assign()?
+            {
+                // We found a constant being assigned to `place`.
+                // Now check that the target of this Goto switches on this place.
+                let target_bb = &self.body.basic_blocks()[target];
+
+                // FIXME(simonvandel): We are conservative here when we don't allow
+                // any statements in the target basic block.
+                // This could probably be relaxed to allow `StorageDead`s which could be
+                // copied to the predecessor of this block.
+                if !target_bb.statements.is_empty() {
+                    None?
+                }
+
+                let target_bb_terminator = target_bb.terminator();
+                let (discr, switch_ty, targets) = target_bb_terminator.kind.as_switch()?;
+                if discr.place() == Some(*place) {
+                    // We now know that the Switch matches on the const place, and it is statementless
+                    // Now find which value in the Switch matches the const value.
+                    let const_value =
+                        _const.literal.try_eval_bits(self.tcx, self.param_env, switch_ty)?;
+                    let found_value_idx_option = targets
+                        .iter()
+                        .enumerate()
+                        .find(|(_, (value, _))| const_value == *value)
+                        .map(|(idx, _)| idx);
+
+                    let target_to_use_in_goto =
+                        if let Some(found_value_idx) = found_value_idx_option {
+                            targets.iter().nth(found_value_idx).unwrap().1
+                        } else {
+                            // If we did not find the const value in values, it must be the otherwise case
+                            targets.otherwise()
+                        };
+
+                    self.optimizations.push(OptimizationToApply {
+                        bb_with_goto: location.block,
+                        target_to_use_in_goto,
+                    });
+                }
+            }
+            Some(())
+        };
+
+        self.super_terminator(terminator, location);
+    }
+}
+
+struct OptimizationToApply {
+    bb_with_goto: BasicBlock,
+    target_to_use_in_goto: BasicBlock,
+}
+
+pub struct ConstGotoOptimizationFinder<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'a Body<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    optimizations: Vec<OptimizationToApply>,
+}

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -22,6 +22,7 @@ pub mod check_packed_ref;
 pub mod check_unsafety;
 pub mod cleanup_post_borrowck;
 pub mod const_debuginfo;
+pub mod const_goto;
 pub mod const_prop;
 pub mod coverage;
 pub mod deaggregator;
@@ -492,6 +493,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
 
     // The main optimizations that we do on MIR.
     let optimizations: &[&dyn MirPass<'tcx>] = &[
+        &const_goto::ConstGoto,
         &remove_unneeded_drops::RemoveUnneededDrops,
         &match_branches::MatchBranchSimplification,
         // inst combine is after MatchBranchSimplification to clean up Ne(_1, false)

--- a/compiler/rustc_mir/src/transform/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir/src/transform/simplify_comparison_integral.rs
@@ -80,7 +80,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyComparisonIntegral {
                 // we convert the move in the comparison statement to a copy.
 
                 // unwrap is safe as we know this statement is an assign
-                let box (_, rhs) = bb.statements[opt.bin_op_stmt_idx].kind.as_assign_mut().unwrap();
+                let (_, rhs) = bb.statements[opt.bin_op_stmt_idx].kind.as_assign_mut().unwrap();
 
                 use Operand::*;
                 match rhs {

--- a/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto.issue_77355_opt.ConstGoto.diff
@@ -1,0 +1,52 @@
+- // MIR for `issue_77355_opt` before ConstGoto
++ // MIR for `issue_77355_opt` after ConstGoto
+  
+  fn issue_77355_opt(_1: Foo) -> u64 {
+      debug num => _1;                     // in scope 0 at $DIR/const_goto.rs:11:20: 11:23
+      let mut _0: u64;                     // return place in scope 0 at $DIR/const_goto.rs:11:33: 11:36
+-     let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-     let mut _3: isize;                   // in scope 0 at $DIR/const_goto.rs:12:22: 12:28
++     let mut _2: isize;                   // in scope 0 at $DIR/const_goto.rs:12:22: 12:28
+  
+      bb0: {
+-         StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         _3 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:22: 12:28
+-         switchInt(move _3) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto.rs:12:22: 12:28
++         _2 = discriminant(_1);           // scope 0 at $DIR/const_goto.rs:12:22: 12:28
++         switchInt(move _2) -> [1_isize: bb2, 2_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto.rs:12:22: 12:28
+      }
+  
+      bb1: {
+-         _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
++         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:12:53: 12:55
++         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
+      }
+  
+      bb2: {
+-         _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+-     }
+- 
+-     bb3: {
+-         switchInt(move _2) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto.rs:12:5: 12:57
+-     }
+- 
+-     bb4: {
+          _0 = const 23_u64;               // scope 0 at $DIR/const_goto.rs:12:41: 12:43
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
++         goto -> bb3;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
+      }
+  
+-     bb5: {
+-         _0 = const 42_u64;               // scope 0 at $DIR/const_goto.rs:12:53: 12:55
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto.rs:12:5: 12:57
+-     }
+- 
+-     bb6: {
+-         StorageDead(_2);                 // scope 0 at $DIR/const_goto.rs:12:56: 12:57
++     bb3: {
+          return;                          // scope 0 at $DIR/const_goto.rs:13:2: 13:2
+      }
+  }
+  

--- a/src/test/mir-opt/const_goto.rs
+++ b/src/test/mir-opt/const_goto.rs
@@ -1,0 +1,16 @@
+pub enum Foo {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+}
+
+// EMIT_MIR const_goto.issue_77355_opt.ConstGoto.diff
+fn issue_77355_opt(num: Foo) -> u64 {
+    if matches!(num, Foo::B | Foo::C) { 23 } else { 42 }
+}
+fn main() {
+    issue_77355_opt(Foo::A);
+}

--- a/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto_const_eval_fail.f.ConstGoto.diff
@@ -1,0 +1,51 @@
+- // MIR for `f` before ConstGoto
++ // MIR for `f` after ConstGoto
+  
+  fn f() -> u64 {
+      let mut _0: u64;                     // return place in scope 0 at $DIR/const_goto_const_eval_fail.rs:6:44: 6:47
+      let mut _1: bool;                    // in scope 0 at $DIR/const_goto_const_eval_fail.rs:7:11: 12:6
+      let mut _2: i32;                     // in scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:11: 12:6
+          StorageLive(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
+          _2 = const A;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:15: 8:16
+          switchInt(_2) -> [1_i32: bb2, 2_i32: bb2, 3_i32: bb2, otherwise: bb1]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:13: 9:14
+      }
+  
+      bb1: {
+          _1 = const true;                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:10:18: 10:22
+          goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:9: 11:10
+      }
+  
+      bb2: {
+          _1 = const B;                    // scope 0 at $DIR/const_goto_const_eval_fail.rs:9:26: 9:27
+-         goto -> bb3;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:8:9: 11:10
++         switchInt(_1) -> [false: bb4, otherwise: bb3]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:9: 13:14
+      }
+  
+      bb3: {
+-         switchInt(_1) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:9: 13:14
+-     }
+- 
+-     bb4: {
+          _0 = const 2_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:14:17: 14:18
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
++         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
+      }
+  
+-     bb5: {
++     bb4: {
+          _0 = const 1_u64;                // scope 0 at $DIR/const_goto_const_eval_fail.rs:13:18: 13:19
+-         goto -> bb6;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
++         goto -> bb5;                     // scope 0 at $DIR/const_goto_const_eval_fail.rs:7:5: 15:6
+      }
+  
+-     bb6: {
++     bb5: {
+          StorageDead(_2);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:1: 16:2
+          StorageDead(_1);                 // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:1: 16:2
+          return;                          // scope 0 at $DIR/const_goto_const_eval_fail.rs:16:2: 16:2
+      }
+  }
+  

--- a/src/test/mir-opt/const_goto_const_eval_fail.rs
+++ b/src/test/mir-opt/const_goto_const_eval_fail.rs
@@ -1,0 +1,16 @@
+#![feature(min_const_generics)]
+#![crate_type = "lib"]
+
+// If const eval fails, then don't crash
+// EMIT_MIR const_goto_const_eval_fail.f.ConstGoto.diff
+pub fn f<const A: i32, const B: bool>() -> u64 {
+    match {
+        match A {
+            1 | 2 | 3 => B,
+            _ => true,
+        }
+    } {
+        false => 1,
+        true => 2,
+    }
+}

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
@@ -2,84 +2,84 @@
 + // MIR for `bar` after MatchBranchSimplification
   
   fn bar(_1: i32) -> (bool, bool, bool, bool) {
-      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:12:8: 12:9
-      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:12:19: 12:43
-      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:18:5: 33:6
-      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:6: 35:7
-      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:9: 35:10
-      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:12: 35:13
-      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:35:15: 35:16
-+     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:19:9: 19:10
+      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:13:8: 13:9
+      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:13:19: 13:43
+      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:6: 36:7
+      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:9: 36:10
+      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:12: 36:13
+      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:36:15: 36:16
++     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:20:9: 20:10
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
           scope 2 {
-              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
               scope 3 {
-                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
                   scope 4 {
-                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:17:9: 17:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
-          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
+          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
 -     }
 - 
 -     bb1: {
--         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:27:13: 27:21
--         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:22
--         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
--         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+-         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:21
+-         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
+-         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
+-         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
 -     }
 - 
 -     bb2: {
--         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
--         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
-+         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
-+         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
-+         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
-+         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+-         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
+-         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
++         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
++         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
 -     }
 - 
 -     bb3: {
-+         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
-          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:33:6: 33:7
-          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
-          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
-          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
-          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
-          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
-          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
-          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
-          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:36:2: 36:2
++         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
+          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
+          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
+          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
+          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
+          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
+          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
+          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
+          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
+          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
+          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:37:2: 37:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
@@ -2,84 +2,84 @@
 + // MIR for `bar` after MatchBranchSimplification
   
   fn bar(_1: i32) -> (bool, bool, bool, bool) {
-      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:12:8: 12:9
-      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:12:19: 12:43
-      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:18:5: 33:6
-      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:6: 35:7
-      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:9: 35:10
-      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:35:12: 35:13
-      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:35:15: 35:16
-+     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:19:9: 19:10
+      debug i => _1;                       // in scope 0 at $DIR/matches_reduce_branches.rs:13:8: 13:9
+      let mut _0: (bool, bool, bool, bool); // return place in scope 0 at $DIR/matches_reduce_branches.rs:13:19: 13:43
+      let _2: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+      let _6: ();                          // in scope 0 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+      let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:6: 36:7
+      let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:9: 36:10
+      let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:36:12: 36:13
+      let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:36:15: 36:16
++     let mut _11: i32;                    // in scope 0 at $DIR/matches_reduce_branches.rs:20:9: 20:10
       scope 1 {
-          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          debug a => _2;                   // in scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          let _3: bool;                    // in scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
           scope 2 {
-              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+              debug b => _3;               // in scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+              let _4: bool;                // in scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
               scope 3 {
-                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+                  debug c => _4;           // in scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+                  let _5: bool;            // in scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
                   scope 4 {
-                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+                      debug d => _5;       // in scope 4 at $DIR/matches_reduce_branches.rs:17:9: 17:10
                   }
               }
           }
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:13:9: 13:10
-          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:14:9: 14:10
-          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:15:9: 15:10
-          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:16:9: 16:10
-          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
--         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:14:9: 14:10
+          StorageLive(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:15:9: 15:10
+          StorageLive(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:16:9: 16:10
+          StorageLive(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:17:9: 17:10
+          StorageLive(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
+-         switchInt(_1) -> [7_i32: bb2, otherwise: bb1]; // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
 -     }
 - 
 -     bb1: {
--         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:27:13: 27:21
--         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:22
--         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
--         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+-         _2 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:28:13: 28:21
+-         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
+-         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
+-         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
 -     }
 - 
 -     bb2: {
--         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
--         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
-+         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
-+         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
-+         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:20:13: 20:22
-+         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:21
-          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:22
-          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:21
--         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:18:5: 33:6
+-         _2 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
+-         _3 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
++         StorageLive(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         _11 = _1;                        // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
++         _2 = Ne(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:21:13: 21:22
++         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
+          _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
+          _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
+-         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:19:5: 34:6
 -     }
 - 
 -     bb3: {
-+         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:19:9: 19:10
-          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:33:6: 33:7
-          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
-          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:6: 35:7
-          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
-          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:9: 35:10
-          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
-          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:35:12: 35:13
-          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
-          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:35:15: 35:16
-          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:35:5: 35:17
-          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:35:16: 35:17
-          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:36:1: 36:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:36:2: 36:2
++         StorageDead(_11);                // scope 4 at $DIR/matches_reduce_branches.rs:20:9: 20:10
+          StorageDead(_6);                 // scope 4 at $DIR/matches_reduce_branches.rs:34:6: 34:7
+          StorageLive(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
+          _7 = _2;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:6: 36:7
+          StorageLive(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
+          _8 = _3;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:9: 36:10
+          StorageLive(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
+          _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
+          StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
+          _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
+          (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          (_0.3: bool) = move _10;         // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
+          StorageDead(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_9);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_8);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_7);                 // scope 4 at $DIR/matches_reduce_branches.rs:36:16: 36:17
+          StorageDead(_5);                 // scope 3 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          StorageDead(_4);                 // scope 2 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          StorageDead(_3);                 // scope 1 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:37:1: 37:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:37:2: 37:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.32bit.diff
@@ -2,47 +2,26 @@
 + // MIR for `foo` after MatchBranchSimplification
   
   fn foo(_1: Option<()>) -> () {
-      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:6:8: 6:11
-      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:6:25: 6:25
-      let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+     let mut _4: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
+      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
--         switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         _4 = move _3;                    // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         _2 = Eq(_4, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         switchInt(move _2) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
       }
   
       bb1: {
--         _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--     }
-- 
--     bb2: {
--         _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--     }
-- 
--     bb3: {
--         switchInt(move _2) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
--     }
-- 
--     bb4: {
-          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:9:6: 9:6
--         goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
-+         goto -> bb2;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
+          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:10:6: 10:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:8:5: 10:6
       }
   
--     bb5: {
-+     bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:9:5: 9:6
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:10:2: 10:2
+      bb2: {
+          goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb3: {
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.foo.MatchBranchSimplification.64bit.diff
@@ -2,47 +2,26 @@
 + // MIR for `foo` after MatchBranchSimplification
   
   fn foo(_1: Option<()>) -> () {
-      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:6:8: 6:11
-      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:6:25: 6:25
-      let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _3: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+     let mut _4: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
+      debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
+      let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
+      let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _3 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
--         switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         _4 = move _3;                    // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         _2 = Eq(_4, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-+         StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:7:22: 7:26
-+         switchInt(move _2) -> [false: bb1, otherwise: bb2]; // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
+          _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
       }
   
       bb1: {
--         _2 = const false;                // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--     }
-- 
--     bb2: {
--         _2 = const true;                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--         goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
--     }
-- 
--     bb3: {
--         switchInt(move _2) -> [false: bb4, otherwise: bb5]; // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
--     }
-- 
--     bb4: {
-          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:9:6: 9:6
--         goto -> bb5;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
-+         goto -> bb2;                     // scope 0 at $DIR/matches_reduce_branches.rs:7:5: 9:6
+          _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:10:6: 10:6
+          goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:8:5: 10:6
       }
   
--     bb5: {
-+     bb2: {
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:9:5: 9:6
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:10:2: 10:2
+      bb2: {
+          goto -> bb3;                     // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb3: {
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:11:2: 11:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.32bit.mir
+++ b/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.32bit.mir
@@ -1,0 +1,21 @@
+// MIR for `foo` before PreCodegen
+
+fn foo(_1: Option<()>) -> () {
+    debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
+    let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
+    let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+
+    bb0: {
+        _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+        switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+    }
+
+    bb1: {
+        _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:10:6: 10:6
+        return;                          // scope 0 at $DIR/matches_reduce_branches.rs:8:5: 10:6
+    }
+
+    bb2: {
+        return;                          // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    }
+}

--- a/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.64bit.mir
+++ b/src/test/mir-opt/matches_reduce_branches.foo.PreCodegen.before.64bit.mir
@@ -1,0 +1,21 @@
+// MIR for `foo` before PreCodegen
+
+fn foo(_1: Option<()>) -> () {
+    debug bar => _1;                     // in scope 0 at $DIR/matches_reduce_branches.rs:7:8: 7:11
+    let mut _0: ();                      // return place in scope 0 at $DIR/matches_reduce_branches.rs:7:25: 7:25
+    let mut _2: isize;                   // in scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+
+    bb0: {
+        _2 = discriminant(_1);           // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+        switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:8:22: 8:26
+    }
+
+    bb1: {
+        _0 = const ();                   // scope 0 at $DIR/matches_reduce_branches.rs:10:6: 10:6
+        return;                          // scope 0 at $DIR/matches_reduce_branches.rs:8:5: 10:6
+    }
+
+    bb2: {
+        return;                          // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+    }
+}

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.32bit.diff
@@ -2,110 +2,110 @@
 + // MIR for `match_nested_if` after MatchBranchSimplification
   
   fn match_nested_if() -> bool {
-      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:38:25: 38:29
-      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:39:9: 39:12
-      let mut _2: ();                      // in scope 0 at $DIR/matches_reduce_branches.rs:39:21: 39:23
-      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-      let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-      let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:24: 40:28
-+     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-+     let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-+     let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+     let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
+      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:39:25: 39:29
+      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
+      let mut _2: ();                      // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
+      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+      let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+      let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++     let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++     let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++     let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
       scope 1 {
-          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:39:9: 39:12
+          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:39:9: 39:12
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:39:21: 39:23
-          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-          StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-          StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:24: 40:28
-          _6 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:24: 40:28
--         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
+          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
+          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          _6 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+-         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb1: {
--         _5 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:30: 40:34
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
+-         _5 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb2: {
--         _5 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:40:42: 40:47
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
+-         _5 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb3: {
-+         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-+         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-+         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:40:42: 40:47
-+         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:47: 40:48
--         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
++         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
++         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
+-         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb4: {
--         _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:50: 40:54
--         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
+-         _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
+-         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb5: {
--         _4 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:40:62: 40:67
--         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
+-         _4 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
+-         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb6: {
-+         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-+         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-+         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:40:62: 40:67
-+         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:67: 40:68
--         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
++         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
++         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:75: 41:76
+-         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb7: {
--         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:70: 40:74
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
+-         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:42:13: 42:17
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb8: {
--         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:40:82: 40:87
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
+-         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb9: {
-+         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:40:82: 40:87
-+         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:87: 40:88
--         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
++         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
++         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
+-         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb10: {
-+         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:95: 40:96
--         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:92: 40:96
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:39:15: 42:6
++         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
+-         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
 -     }
 - 
 -     bb11: {
--         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:95: 40:96
--         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:14: 41:19
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:39:15: 42:6
+-         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
+-         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
 -     }
 - 
 -     bb12: {
-+         _1 = Ne(_10, const false);       // scope 0 at $DIR/matches_reduce_branches.rs:41:14: 41:19
-+         StorageDead(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:42:6: 42:7
-          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:43:5: 43:8
-          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:44:1: 44:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:44:2: 44:2
++         _1 = Ne(_10, const false);       // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
++         StorageDead(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:50:6: 50:7
+          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8
+          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:52:1: 52:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:52:2: 52:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.match_nested_if.MatchBranchSimplification.64bit.diff
@@ -2,110 +2,110 @@
 + // MIR for `match_nested_if` after MatchBranchSimplification
   
   fn match_nested_if() -> bool {
-      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:38:25: 38:29
-      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:39:9: 39:12
-      let mut _2: ();                      // in scope 0 at $DIR/matches_reduce_branches.rs:39:21: 39:23
-      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-      let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-      let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:24: 40:28
-+     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-+     let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-+     let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+     let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
+      let mut _0: bool;                    // return place in scope 0 at $DIR/matches_reduce_branches.rs:39:25: 39:29
+      let _1: bool;                        // in scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
+      let mut _2: ();                      // in scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
+      let mut _3: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+      let mut _4: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+      let mut _5: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+      let mut _6: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
++     let mut _7: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++     let mut _8: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++     let mut _9: bool;                    // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++     let mut _10: bool;                   // in scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
       scope 1 {
-          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:39:9: 39:12
+          debug val => _1;                 // in scope 1 at $DIR/matches_reduce_branches.rs:40:9: 40:12
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:39:9: 39:12
-          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:39:21: 39:23
-          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-          StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-          StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:24: 40:28
-          _6 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:24: 40:28
--         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
+          StorageLive(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:9: 40:12
+          StorageLive(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:23
+          StorageLive(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageLive(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageLive(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageLive(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+          _6 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:24: 41:28
+-         switchInt(move _6) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb1: {
--         _5 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:30: 40:34
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
+-         _5 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:31: 41:35
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb2: {
--         _5 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:40:42: 40:47
--         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
+-         _5 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
+-         goto -> bb3;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
 -     }
 - 
 -     bb3: {
-+         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-+         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-+         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:40:42: 40:47
-+         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:21: 40:48
-          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:47: 40:48
--         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
++         StorageLive(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _7 = move _6;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
++         _5 = Ne(_7, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:45: 41:50
++         StorageDead(_7);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:21: 41:52
+          StorageDead(_6);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:51: 41:52
+-         switchInt(move _5) -> [false: bb5, otherwise: bb4]; // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb4: {
--         _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:50: 40:54
--         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
+-         _4 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:41:55: 41:59
+-         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb5: {
--         _4 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:40:62: 40:67
--         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
+-         _4 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
+-         goto -> bb6;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
 -     }
 - 
 -     bb6: {
-+         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-+         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-+         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:40:62: 40:67
-+         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:18: 40:68
-          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:67: 40:68
--         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
++         StorageLive(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         _8 = move _5;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
++         _4 = Ne(_8, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:41:69: 41:74
++         StorageDead(_8);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:18: 41:76
+          StorageDead(_5);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:75: 41:76
+-         switchInt(move _4) -> [false: bb8, otherwise: bb7]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb7: {
--         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:70: 40:74
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
+-         _3 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:42:13: 42:17
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb8: {
--         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:40:82: 40:87
--         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
+-         _3 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
+-         goto -> bb9;                     // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb9: {
-+         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:40:82: 40:87
-+         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:87: 40:88
--         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
++         StorageLive(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         _9 = move _4;                    // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         _3 = Ne(_9, const false);        // scope 0 at $DIR/matches_reduce_branches.rs:44:13: 44:18
++         StorageDead(_9);                 // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageDead(_4);                 // scope 0 at $DIR/matches_reduce_branches.rs:45:9: 45:10
+-         switchInt(move _3) -> [false: bb11, otherwise: bb10]; // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
 -     }
 - 
 -     bb10: {
-+         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-+         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:95: 40:96
--         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:40:92: 40:96
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:39:15: 42:6
++         StorageLive(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
++         _10 = move _3;                   // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
+-         _1 = const true;                 // scope 0 at $DIR/matches_reduce_branches.rs:47:13: 47:17
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
 -     }
 - 
 -     bb11: {
--         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:40:95: 40:96
--         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:41:14: 41:19
--         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:39:15: 42:6
+-         StorageDead(_3);                 // scope 0 at $DIR/matches_reduce_branches.rs:48:9: 48:10
+-         _1 = const false;                // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
+-         goto -> bb12;                    // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 50:6
 -     }
 - 
 -     bb12: {
-+         _1 = Ne(_10, const false);       // scope 0 at $DIR/matches_reduce_branches.rs:41:14: 41:19
-+         StorageDead(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:40:15: 40:88
-          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:42:6: 42:7
-          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:43:5: 43:8
-          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:44:1: 44:2
-          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:44:2: 44:2
++         _1 = Ne(_10, const false);       // scope 0 at $DIR/matches_reduce_branches.rs:49:14: 49:19
++         StorageDead(_10);                // scope 0 at $DIR/matches_reduce_branches.rs:41:15: 45:10
+          StorageDead(_2);                 // scope 0 at $DIR/matches_reduce_branches.rs:50:6: 50:7
+          _0 = _1;                         // scope 1 at $DIR/matches_reduce_branches.rs:51:5: 51:8
+          StorageDead(_1);                 // scope 0 at $DIR/matches_reduce_branches.rs:52:1: 52:2
+          return;                          // scope 0 at $DIR/matches_reduce_branches.rs:52:2: 52:2
       }
   }
   

--- a/src/test/mir-opt/matches_reduce_branches.rs
+++ b/src/test/mir-opt/matches_reduce_branches.rs
@@ -1,11 +1,12 @@
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 // EMIT_MIR matches_reduce_branches.foo.MatchBranchSimplification.diff
+// EMIT_MIR matches_reduce_branches.foo.PreCodegen.before.mir
 // EMIT_MIR matches_reduce_branches.bar.MatchBranchSimplification.diff
 // EMIT_MIR matches_reduce_branches.match_nested_if.MatchBranchSimplification.diff
 
 fn foo(bar: Option<()>) {
     if matches!(bar, None) {
-      ()
+        ()
     }
 }
 
@@ -37,15 +38,22 @@ fn bar(i: i32) -> (bool, bool, bool, bool) {
 
 fn match_nested_if() -> bool {
     let val = match () {
-        () if if if if true {true} else {false} {true} else {false} {true} else {false} => true,
+        () if if if if true { true } else { false } { true } else { false } {
+            true
+        } else {
+            false
+        } =>
+        {
+            true
+        }
         _ => false,
     };
     val
 }
 
 fn main() {
-  let _ = foo(None);
-  let _ = foo(Some(()));
-  let _ = bar(0);
-  let _ = match_nested_if();
+    let _ = foo(None);
+    let _ = foo(Some(()));
+    let _ = bar(0);
+    let _ = match_nested_if();
 }

--- a/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
+++ b/src/test/mir-opt/not_equal_false.opt.InstCombine.diff
@@ -1,50 +1,34 @@
 - // MIR for `opt` before InstCombine
 + // MIR for `opt` after InstCombine
   
-  fn opt(_1: Option<()>) -> bool {
+  fn opt(_1: bool) -> u32 {
       debug x => _1;                       // in scope 0 at $DIR/not_equal_false.rs:3:8: 3:9
-      let mut _0: bool;                    // return place in scope 0 at $DIR/not_equal_false.rs:3:26: 3:30
-      let mut _2: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _3: isize;                   // in scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
-      let mut _4: bool;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _5: isize;                   // in scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
-      let mut _6: isize;                   // in scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
-      let mut _7: isize;                   // in scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
-      let mut _8: bool;                    // in scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+      let mut _0: u32;                     // return place in scope 0 at $DIR/not_equal_false.rs:3:20: 3:23
+      let mut _2: bool;                    // in scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
+      let mut _3: bool;                    // in scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _3 = discriminant(_1);           // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
-          StorageLive(_6);                 // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
-          _6 = move _3;                    // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
-          _2 = Eq(_6, const 0_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_6);                 // scope 0 at $DIR/not_equal_false.rs:4:17: 4:21
-          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          StorageLive(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
+          StorageLive(_3);                 // scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
+          _3 = _1;                         // scope 0 at $DIR/not_equal_false.rs:4:8: 4:9
+-         _2 = Ne(move _3, const false);   // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
++         _2 = move _3;                    // scope 0 at $DIR/not_equal_false.rs:4:8: 4:18
+          StorageDead(_3);                 // scope 0 at $DIR/not_equal_false.rs:4:17: 4:18
+          switchInt(move _2) -> [false: bb2, otherwise: bb1]; // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
       }
   
       bb1: {
-          _0 = const true;                 // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          _0 = const 0_u32;                // scope 0 at $DIR/not_equal_false.rs:4:21: 4:22
+          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _5 = discriminant(_1);           // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
-          StorageLive(_7);                 // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
-          _7 = move _5;                    // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
-          _4 = Eq(_7, const 1_isize);      // scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_7);                 // scope 0 at $DIR/not_equal_false.rs:4:38: 4:45
-          StorageLive(_8);                 // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-          _8 = move _4;                    // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
--         _0 = Ne(_8, const false);        // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-+         _0 = _8;                         // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-          StorageDead(_8);                 // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
-          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:46
+          _0 = const 1_u32;                // scope 0 at $DIR/not_equal_false.rs:4:32: 4:33
+          goto -> bb3;                     // scope 0 at $DIR/not_equal_false.rs:4:5: 4:35
       }
   
       bb3: {
-          StorageDead(_4);                 // scope 0 at $DIR/not_equal_false.rs:4:45: 4:46
-          StorageDead(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:45: 4:46
+          StorageDead(_2);                 // scope 0 at $DIR/not_equal_false.rs:4:34: 4:35
           return;                          // scope 0 at $DIR/not_equal_false.rs:5:2: 5:2
       }
   }

--- a/src/test/mir-opt/not_equal_false.rs
+++ b/src/test/mir-opt/not_equal_false.rs
@@ -1,9 +1,9 @@
 // EMIT_MIR not_equal_false.opt.InstCombine.diff
 
-fn opt(x: Option<()>) -> bool {
-    matches!(x, None) || matches!(x, Some(_))
+fn opt(x: bool) -> u32 {
+    if x != false { 0 } else { 1 }
 }
 
 fn main() {
-    opt(None);
+    opt(false);
 }


### PR DESCRIPTION
Reopening PR #77486

Fixes #77355

This pass optimizes the following sequence
```rust
bb2: {
    _2 = const true;
    goto -> bb3;
}

bb3: {
    switchInt(_2) -> [false: bb4, otherwise: bb5];
}
```
into
```rust
bb2: {
    _2 = const true;
    goto -> bb5;
}
```