### PR TITLE
Miri: make size/align_of_val work for dangling raw ptrs

### DIFF
--- a/compiler/rustc_mir/src/interpret/intrinsics.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics.rs
@@ -141,9 +141,11 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             sym::min_align_of_val | sym::size_of_val => {
-                let place = self.deref_operand(args[0])?;
+                // Avoid `deref_operand` -- this is not a deref, the ptr does not have to be
+                // dereferencable!
+                let place = self.ref_to_mplace(self.read_immediate(args[0])?)?;
                 let (size, align) = self
-                    .size_and_align_of(place.meta, place.layout)?
+                    .size_and_align_of_mplace(place)?
                     .ok_or_else(|| err_unsup_format!("`extern type` does not have known layout"))?;
 
                 let result = match intrinsic_name {

--- a/compiler/rustc_mir/src/interpret/validity.rs
+++ b/compiler/rustc_mir/src/interpret/validity.rs
@@ -391,7 +391,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, '
         }
         // Make sure this is dereferenceable and all.
         let size_and_align = try_validation!(
-            self.ecx.size_and_align_of(place.meta, place.layout),
+            self.ecx.size_and_align_of_mplace(place),
             self.path,
             err_ub!(InvalidMeta(msg)) => { "invalid {} metadata: {}", kind, msg },
         );

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -374,7 +374,8 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 /// ```
 #[inline]
 #[unstable(feature = "layout_for_ptr", issue = "69835")]
-pub unsafe fn size_of_val_raw<T: ?Sized>(val: *const T) -> usize {
+#[rustc_const_unstable(feature = "const_size_of_val_raw", issue = "46571")]
+pub const unsafe fn size_of_val_raw<T: ?Sized>(val: *const T) -> usize {
     intrinsics::size_of_val(val)
 }
 
@@ -505,7 +506,8 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 /// ```
 #[inline]
 #[unstable(feature = "layout_for_ptr", issue = "69835")]
-pub unsafe fn align_of_val_raw<T: ?Sized>(val: *const T) -> usize {
+#[rustc_const_unstable(feature = "const_align_of_val_raw", issue = "46571")]
+pub const unsafe fn align_of_val_raw<T: ?Sized>(val: *const T) -> usize {
     intrinsics::min_align_of_val(val)
 }
 

--- a/src/test/ui/consts/const-size_of_val-align_of_val.rs
+++ b/src/test/ui/consts/const-size_of_val-align_of_val.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(const_size_of_val, const_align_of_val)]
+#![feature(const_size_of_val_raw, const_align_of_val_raw, layout_for_ptr)]
 
 use std::mem;
 
@@ -32,6 +33,9 @@ const ALIGN_OF_UGH: usize = mem::align_of_val(&UGH);
 
 const SIZE_OF_SLICE: usize = mem::size_of_val("foobar".as_bytes());
 
+const SIZE_OF_DANGLING: usize = unsafe { mem::size_of_val_raw(0x100 as *const i32) };
+const ALIGN_OF_DANGLING: usize = unsafe { mem::align_of_val_raw(0x100 as *const i16) };
+
 fn main() {
     assert_eq!(SIZE_OF_FOO, mem::size_of::<Foo>());
     assert_eq!(SIZE_OF_BAR, mem::size_of::<Bar>());
@@ -40,6 +44,9 @@ fn main() {
     assert_eq!(ALIGN_OF_FOO, mem::align_of::<Foo>());
     assert_eq!(ALIGN_OF_BAR, mem::align_of::<Bar>());
     assert_eq!(ALIGN_OF_UGH, mem::align_of::<Ugh>());
+
+    assert_eq!(SIZE_OF_DANGLING, mem::size_of::<i32>());
+    assert_eq!(ALIGN_OF_DANGLING, mem::align_of::<i16>());
 
     assert_eq!(SIZE_OF_SLICE, "foobar".len());
 }


### PR DESCRIPTION
This is needed for https://github.com/rust-lang/rust/issues/80365#issuecomment-752128105.

r? @oli-obk 