### PR TITLE
Consider Scalar to be a bool only if its unsigned

### DIFF
--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -103,7 +103,12 @@ impl ArgAttributes {
     }
 
     pub fn ext(&mut self, ext: ArgExtension) -> &mut Self {
-        assert!(self.arg_ext == ArgExtension::None || self.arg_ext == ext);
+        assert!(
+            self.arg_ext == ArgExtension::None || self.arg_ext == ext,
+            "cannot set {:?} when {:?} is already set",
+            ext,
+            self.arg_ext
+        );
         self.arg_ext = ext;
         self
     }

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -682,7 +682,7 @@ pub struct Scalar {
 
 impl Scalar {
     pub fn is_bool(&self) -> bool {
-        if let Int(I8, _) = self.value { self.valid_range == (0..=1) } else { false }
+        matches!(self.value, Int(I8, false)) && self.valid_range == (0..=1)
     }
 
     /// Returns the valid range as a `x..y` range.

--- a/src/test/codegen/abi-repr-ext.rs
+++ b/src/test/codegen/abi-repr-ext.rs
@@ -1,0 +1,13 @@
+#![crate_type="lib"]
+
+#[repr(i8)]
+pub enum Type {
+    Type1 = 0,
+    Type2 = 1
+}
+
+// CHECK: define signext i8 @test()
+#[no_mangle]
+pub extern "C" fn test() -> Type {
+    Type::Type1
+}


### PR DESCRIPTION
This seems right, given that conceptually bools are unsigned, but the
implications of this change may have more action at distance that I'm
not sure how to exhaustively consider.

For instance there are a number of cases where code attaches range
metadata if `scalar.is_bool()` holds. Supposedly it would no longer be
attached to the `repr(i8)` enums? Though I'm not sure why booleans are
being special-cased here in the first place...

Fixes #80556

cc @eddyb 