### PR TITLE
resolve/expand: Improve attribute expansion on macro definitions and calls

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1543,13 +1543,8 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
     }
 
     fn visit_item_kind(&mut self, item: &mut ast::ItemKind) {
-        match item {
-            ast::ItemKind::MacroDef(..) => {}
-            _ => {
-                self.cfg.configure_item_kind(item);
-                noop_visit_item_kind(item, self);
-            }
-        }
+        self.cfg.configure_item_kind(item);
+        noop_visit_item_kind(item, self);
     }
 
     fn flat_map_generic_param(

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -258,12 +258,9 @@ impl<'a, 'b> MutVisitor for PlaceholderExpander<'a, 'b> {
 
     fn flat_map_item(&mut self, item: P<ast::Item>) -> SmallVec<[P<ast::Item>; 1]> {
         match item.kind {
-            ast::ItemKind::MacCall(_) => return self.remove(item.id).make_items(),
-            ast::ItemKind::MacroDef(_) => return smallvec![item],
-            _ => {}
+            ast::ItemKind::MacCall(_) => self.remove(item.id).make_items(),
+            _ => noop_flat_map_item(item, self),
         }
-
-        noop_flat_map_item(item, self)
     }
 
     fn flat_map_trait_item(&mut self, item: P<ast::AssocItem>) -> SmallVec<[P<ast::AssocItem>; 1]> {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -91,7 +91,10 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
                 DefPathData::ValueNs(i.ident.name)
             }
             ItemKind::MacroDef(..) => DefPathData::MacroNs(i.ident.name),
-            ItemKind::MacCall(..) => return self.visit_macro_invoc(i.id),
+            ItemKind::MacCall(..) => {
+                visit::walk_item(self, i);
+                return self.visit_macro_invoc(i.id);
+            }
             ItemKind::GlobalAsm(..) => DefPathData::Misc,
             ItemKind::Use(..) => {
                 return visit::walk_item(self, i);

--- a/src/test/ui/attributes/key-value-expansion-on-mac.rs
+++ b/src/test/ui/attributes/key-value-expansion-on-mac.rs
@@ -1,0 +1,15 @@
+#![feature(extended_key_value_attributes)]
+#![feature(rustc_attrs)]
+
+#[rustc_dummy = stringify!(a)] // OK
+macro_rules! bar {
+    () => {};
+}
+
+// FIXME?: `bar` here expands before `stringify` has a chance to expand.
+// `#[rustc_dummy = ...]` is validated and dropped during expansion of `bar`,
+// the "unexpected token" errors comes from the validation.
+#[rustc_dummy = stringify!(b)] //~ ERROR unexpected token: `stringify!(b)`
+bar!();
+
+fn main() {}

--- a/src/test/ui/attributes/key-value-expansion-on-mac.stderr
+++ b/src/test/ui/attributes/key-value-expansion-on-mac.stderr
@@ -1,0 +1,8 @@
+error: unexpected token: `stringify!(b)`
+  --> $DIR/key-value-expansion-on-mac.rs:12:17
+   |
+LL | #[rustc_dummy = stringify!(b)]
+   |                 ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -173,18 +173,18 @@ LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
 warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:438:1
-   |
-LL | #[macro_escape]
-   | ^^^^^^^^^^^^^^^
-
-warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:441:17
    |
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
    |
    = help: try an outer attribute: `#[macro_use]`
+
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:438:1
+   |
+LL | #[macro_escape]
+   | ^^^^^^^^^^^^^^^
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:228:17

--- a/src/test/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-macro_use.stderr
@@ -1,8 +1,8 @@
 error: arguments to `macro_use` are not allowed here
-  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
+  --> $DIR/issue-43106-gating-of-macro_use.rs:12:17
    |
-LL | #![macro_use(my_macro)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
+LL |     mod inner { #![macro_use(my_macro)] }
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: arguments to `macro_use` are not allowed here
   --> $DIR/issue-43106-gating-of-macro_use.rs:9:1
@@ -11,10 +11,10 @@ LL | #[macro_use(my_macro)]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: arguments to `macro_use` are not allowed here
-  --> $DIR/issue-43106-gating-of-macro_use.rs:12:17
+  --> $DIR/issue-43106-gating-of-macro_use.rs:6:1
    |
-LL |     mod inner { #![macro_use(my_macro)] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+LL | #![macro_use(my_macro)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: malformed `macro_use` attribute input
   --> $DIR/issue-43106-gating-of-macro_use.rs:15:5


### PR DESCRIPTION
- Do not forget to visit attributes on macro definitions and calls in couple of places.
- Remove some weird special treatment of macro definition items, which is probably left from old times when macro definitions were treated more like macro calls.

Fixes https://github.com/rust-lang/rust/issues/80540