### PR TITLE
Fix tests that incorrectly used `!@has` instead of `@!has`

### DIFF
--- a/src/test/rustdoc/inline_local/trait-vis.rs
+++ b/src/test/rustdoc/inline_local/trait-vis.rs
@@ -14,5 +14,5 @@ mod asdf {
 
 // @has trait_vis/struct.SomeStruct.html
 // @has - '//code' 'impl ThisTrait for SomeStruct'
-// !@has - '//code' 'impl PrivateTrait for SomeStruct'
+// @!has - '//code' 'impl PrivateTrait for SomeStruct'
 pub use asdf::SomeStruct;

--- a/src/test/rustdoc/issue-74083.rs
+++ b/src/test/rustdoc/issue-74083.rs
@@ -7,7 +7,7 @@ impl Foo {
 }
 
 // @has issue_74083/struct.Bar.html
-// !@has - '//div[@class="sidebar-links"]/a[@href="#method.foo"]' 'foo'
+// @!has - '//div[@class="sidebar-links"]/a[@href="#method.foo"]' 'foo'
 pub struct Bar {
     foo: Foo,
 }

--- a/src/test/rustdoc/remove-url-from-headings.rs
+++ b/src/test/rustdoc/remove-url-from-headings.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
 // @has foo/fn.foo.html
-// !@has - '//a[@href="http://a.a"]'
+// @!has - '//a[@href="http://a.a"]'
 // @has - '//a[@href="#implementing-stuff-somewhere"]' 'Implementing stuff somewhere'
 // @has - '//a[@href="#another-one-urg"]' 'Another one urg'
 


### PR DESCRIPTION
The command is `@!has`, not `!@has`. I don't think these checks were
doing anything before! Ideally we would accept `!@has` as well, or at
least fail tests that use `!@has`. The current behavior seems to be
silently ignoring the check, which is very confusing.

r? @GuillaumeGomez
