### PR TITLE
Use Array.prototype.filter instead of open-coding

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -667,13 +667,7 @@ function defocusSearchBar() {
                 results = {}, results_in_args = {}, results_returned = {},
                 split = valLower.split("::");
 
-            var length = split.length;
-            for (var z = 0; z < length; ++z) {
-                if (split[z] === "") {
-                    split.splice(z, 1);
-                    z -= 1;
-                }
-            }
+            split = split.filter(function(segment) { return segment !== ""; });
 
             function transformResults(results, isType) {
                 var out = [];


### PR DESCRIPTION
Part of #79052, originally suggested in https://github.com/rust-lang/rust/pull/79052#discussion_r523468743 by @jyn514

Besides making main.js smaller (always a plus), this also performs better by using the optimized filter implementation in your browser's JavaScript engine (according to @GuillaumeGomez, an 84% performance improvement).