### PR TITLE
Give a better error for download-ci-llvm if .xz is not supported

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -487,7 +487,12 @@ class RustBuild(object):
         url = "https://ci-artifacts.rust-lang.org/rustc-builds/{}".format(llvm_sha)
         if llvm_assertions:
             url = url.replace('rustc-builds', 'rustc-builds-alt')
-        tarball_suffix = '.tar.xz' if support_xz() else '.tar.gz'
+        # ci-artifacts are only stored as .xz, not .gz
+        if not support_xz():
+            print("error: XZ support is required to download LLVM")
+            print("help: consider disabling `download-ci-llvm` or using python3")
+            exit(1)
+        tarball_suffix = '.tar.xz'
         filename = "rust-dev-nightly-" + self.build + tarball_suffix
         tarball = os.path.join(rustc_cache, filename)
         if not os.path.exists(tarball):


### PR DESCRIPTION
Previously:

```
curl: (22) The requested URL returned error: 404
failed to run: curl -# -y 30 -Y 10 --connect-timeout 30 --retry 3 -Sf -o /tmp/tmp6ptXJV https://ci-artifacts.rust-lang.org/rustc-builds/99ad5a1a2824fea1ecf60068fd3636beae7ea2da/rust-dev-nightly-x86_64-unknown-linux-gnu.tar.gz
```

Now:

```
error: XZ support is required to download LLVM
help: consider disabling `download-ci-llvm` or using a different version of python
Build completed unsuccessfully in 0:00:00
```

Follow-up to https://github.com/rust-lang/rust/pull/80435.

r? @Mark-Simulacrum 