### PR TITLE
Choose an appropriate python version for x.py at runtime

### DIFF
--- a/x.py
+++ b/x.py
@@ -1,4 +1,18 @@
-#!/usr/bin/env python
+# The beginning of this script is both valid shell and valid python, such that
+# the script starts with the shell and is reexecuted with the right python.
+# This works because shells only execute a line at a time.
+# Thanks to `./mach` from servo for the idea!
+''':' && {
+exists() { command -v "$1" >/dev/null 2>&1; }
+if exists python3; then
+    exec python3 "$0" "$@"
+elif exists python; then
+    exec python "$0" "$@"
+else
+    exec python2 "$0" "$@"
+fi
+}
+'''
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 


### PR DESCRIPTION
*Or, how I learned to stop worrying and love the shell.*

![image](https://user-images.githubusercontent.com/23638587/103443004-e045b680-4c28-11eb-89d0-86ee96b68ff0.png)


- Start `x.py` as a shell script and re-execute the program with the right python interpreter
- Default to python3 -> python -> python2

Closes https://github.com/rust-lang/rust/issues/71818.

r? @Mark-Simulacrum 