### PR TITLE
Suggest renaming or escaping when fixing non-snake-case identifiers which would conflict with keywords

### DIFF
--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -283,6 +283,7 @@ impl NonSnakeCase {
                             if sc_ident.name.can_be_raw() {
                                 ("rename the identifier or convert it to a snake case raw identifier", sc_ident.to_string())
                             } else {
+                                err.note(&format!("`{}` cannot be used as a raw identifier", sc));
                                 ("rename the identifier", String::new())
                             }
                         } else {

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -275,10 +275,24 @@ impl NonSnakeCase {
                     // We have a valid span in almost all cases, but we don't have one when linting a crate
                     // name provided via the command line.
                     if !ident.span.is_dummy() {
+                        let sc_ident = Ident::from_str_and_span(&sc, ident.span);
+                        let (message, suggestion) = if sc_ident.is_reserved() {
+                            // We shouldn't suggest a reserved identifier to fix non-snake-case identifiers.
+                            // Instead, recommend renaming the identifier entirely or, if permitted,
+                            // escaping it to create a raw identifier.
+                            if sc_ident.name.can_be_raw() {
+                                ("rename the identifier or convert it to a snake case raw identifier", sc_ident.to_string())
+                            } else {
+                                ("rename the identifier", String::new())
+                            }
+                        } else {
+                            ("convert the identifier to snake case", sc)
+                        };
+
                         err.span_suggestion(
                             ident.span,
-                            "convert the identifier to snake case",
-                            sc,
+                            message,
+                            suggestion,
                             Applicability::MaybeIncorrect,
                         );
                     } else {

--- a/src/test/ui/lint/lint-non-snake-case-identifiers-suggestion-reserved.rs
+++ b/src/test/ui/lint/lint-non-snake-case-identifiers-suggestion-reserved.rs
@@ -1,0 +1,19 @@
+#![warn(unused)]
+#![allow(dead_code)]
+#![deny(non_snake_case)]
+
+mod Impl {}
+//~^ ERROR module `Impl` should have a snake case name
+
+fn While() {}
+//~^ ERROR function `While` should have a snake case name
+
+fn main() {
+    let Mod: usize = 0;
+    //~^ ERROR variable `Mod` should have a snake case name
+    //~^^ WARN unused variable: `Mod`
+
+    let Super: usize = 0;
+    //~^ ERROR variable `Super` should have a snake case name
+    //~^^ WARN unused variable: `Super`
+}

--- a/src/test/ui/lint/lint-non-snake-case-identifiers-suggestion-reserved.stderr
+++ b/src/test/ui/lint/lint-non-snake-case-identifiers-suggestion-reserved.stderr
@@ -60,6 +60,8 @@ error: variable `Super` should have a snake case name
    |
 LL |     let Super: usize = 0;
    |         ^^^^^ help: rename the identifier
+   |
+   = note: `super` cannot be used as a raw identifier
 
 error: aborting due to 4 previous errors; 2 warnings emitted
 

--- a/src/test/ui/lint/lint-non-snake-case-identifiers-suggestion-reserved.stderr
+++ b/src/test/ui/lint/lint-non-snake-case-identifiers-suggestion-reserved.stderr
@@ -1,0 +1,65 @@
+warning: unused variable: `Mod`
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:12:9
+   |
+LL |     let Mod: usize = 0;
+   |         ^^^ help: if this is intentional, prefix it with an underscore: `_Mod`
+   |
+note: the lint level is defined here
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:1:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+
+warning: unused variable: `Super`
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:16:9
+   |
+LL |     let Super: usize = 0;
+   |         ^^^^^ help: if this is intentional, prefix it with an underscore: `_Super`
+
+error: module `Impl` should have a snake case name
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:5:5
+   |
+LL | mod Impl {}
+   |     ^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:3:9
+   |
+LL | #![deny(non_snake_case)]
+   |         ^^^^^^^^^^^^^^
+help: rename the identifier or convert it to a snake case raw identifier
+   |
+LL | mod r#impl {}
+   |     ^^^^^^
+
+error: function `While` should have a snake case name
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:8:4
+   |
+LL | fn While() {}
+   |    ^^^^^
+   |
+help: rename the identifier or convert it to a snake case raw identifier
+   |
+LL | fn r#while() {}
+   |    ^^^^^^^
+
+error: variable `Mod` should have a snake case name
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:12:9
+   |
+LL |     let Mod: usize = 0;
+   |         ^^^
+   |
+help: rename the identifier or convert it to a snake case raw identifier
+   |
+LL |     let r#mod: usize = 0;
+   |         ^^^^^
+
+error: variable `Super` should have a snake case name
+  --> $DIR/lint-non-snake-case-identifiers-suggestion-reserved.rs:16:9
+   |
+LL |     let Super: usize = 0;
+   |         ^^^^^ help: rename the identifier
+
+error: aborting due to 4 previous errors; 2 warnings emitted
+


### PR DESCRIPTION
Fixes #80575