### PR TITLE
`impl PartialEq<Punct> for char`; symmetry for #78636

### DIFF
--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -842,10 +842,17 @@ impl fmt::Debug for Punct {
     }
 }
 
-#[stable(feature = "proc_macro_punct_eq", since = "1.49.0")]
+#[stable(feature = "proc_macro_punct_eq", since = "1.50.0")]
 impl PartialEq<char> for Punct {
     fn eq(&self, rhs: &char) -> bool {
         self.as_char() == *rhs
+    }
+}
+
+#[stable(feature = "proc_macro_punct_eq_flipped", since = "1.52.0")]
+impl PartialEq<Punct> for char {
+    fn eq(&self, rhs: &Punct) -> bool {
+        *self == rhs.as_char()
     }
 }
 


### PR DESCRIPTION
Also fixes the "since" version of the original.

Pinging @dtolnay and @petrochenkov.