### PR TITLE
`const_generics_defaults`: don't ICE in the unimplemented parts

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2677,7 +2677,6 @@ impl<'a> State<'a> {
                     s.print_type_bounds(":", &param.bounds);
                     if let Some(ref _default) = default {
                         // FIXME(const_generics_defaults): print the `default` value here
-                        todo!();
                     }
                 }
             }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2210,7 +2210,6 @@ impl<'a> State<'a> {
                 self.print_type(ty);
                 if let Some(ref _default) = default {
                     // FIXME(const_generics_defaults): print the `default` value here
-                    todo!();
                 }
             }
         }

--- a/compiler/rustc_save_analysis/src/sig.rs
+++ b/compiler/rustc_save_analysis/src/sig.rs
@@ -619,7 +619,6 @@ impl<'hir> Sig for hir::Generics<'hir> {
                 param_text.push_str(&ty_to_string(&ty));
                 if let Some(ref _default) = default {
                     // FIXME(const_generics_defaults): push the `default` value here
-                    todo!();
                 }
             }
             if !param.bounds.is_empty() {


### PR DESCRIPTION
The thought was that we could use `todo!`s to ensure we wouldn't forget to implement parts of the experimental gate. 

However, that can also lead to a suboptimal experience for users as shown in #80589 having both the error/warning about the experimental feature, and the ICE.

Fixes #80589

r? @varkor 