### PR TITLE
Add `MaybeUninit` method `array_assume_init`

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -840,7 +840,7 @@ impl<T> MaybeUninit<T> {
         // And thus the conversion is safe
         unsafe {
             intrinsics::assert_inhabited::<T>();
-            (&array as *const _ as *const T).read()
+            (&array as *const _ as *const [T; N]).read()
         }
     }
 

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -804,12 +804,12 @@ impl<T> MaybeUninit<T> {
         }
     }
 
-    /// Extracts the values from an array of `MaybeUninit` containers. 
-    /// 
+    /// Extracts the values from an array of `MaybeUninit` containers.
+    ///
     /// # Safety
-    /// 
+    ///
     /// It is up to the caller to guarantee that all elements of the array are
-    /// in an initialized state. 
+    /// in an initialized state.
     ///
     /// # Examples
     ///
@@ -817,17 +817,17 @@ impl<T> MaybeUninit<T> {
     /// #![feature(maybe_uninit_uninit_array)]
     /// #![feature(maybe_uninit_array_assume_init)]
     /// use std::mem::MaybeUninit;
-    /// 
+    ///
     /// let mut array: [MaybeUninit<i32>; 3] = MaybeUninit::uninit_array();
     /// array[0] = MaybeUninit::new(0);
     /// array[1] = MaybeUninit::new(1);
     /// array[2] = MaybeUninit::new(2);
-    /// 
+    ///
     /// // SAFETY: Now safe as we initialised all elements
     /// let array = unsafe {
     ///     MaybeUninit::array_assume_init(array)
     /// };
-    /// 
+    ///
     /// assert_eq!(array, [0, 1, 2]);
     /// ```
     #[unstable(feature = "maybe_uninit_array_assume_init", issue = "none")]
@@ -846,9 +846,7 @@ impl<T> MaybeUninit<T> {
         unsafe {
             intrinsics::assert_inhabited::<T>();
 
-            let array = ArrayInit {
-                maybe_uninit: ManuallyDrop::new(array),
-            };
+            let array = ArrayInit { maybe_uninit: ManuallyDrop::new(array) };
             ManuallyDrop::into_inner(array.init)
         }
     }

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -830,7 +830,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// assert_eq!(array, [0, 1, 2]);
     /// ```
-    #[unstable(feature = "maybe_uninit_array_assume_init", issue = "none")]
+    #[unstable(feature = "maybe_uninit_array_assume_init", issue = "80908")]
     #[inline(always)]
     pub unsafe fn array_assume_init<const N: usize>(array: [Self; N]) -> [T; N] {
         // Convert using a union because mem::transmute does not support const_generics

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -36,6 +36,8 @@
 #![feature(raw)]
 #![feature(sort_internals)]
 #![feature(slice_partition_at_index)]
+#![feature(maybe_uninit_uninit_array)]
+#![feature(maybe_uninit_array_assume_init)]
 #![feature(maybe_uninit_extra)]
 #![feature(maybe_uninit_write_slice)]
 #![feature(min_specialization)]

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -149,10 +149,8 @@ fn uninit_array_assume_init() {
     array[3].write(1);
     array[4].write(5);
 
-    let array = unsafe {
-        MaybeUninit::array_assume_init(array)
-    };
-    
+    let array = unsafe { MaybeUninit::array_assume_init(array) };
+
     assert_eq!(array, [3, 1, 4, 1, 5]);
 }
 

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -141,6 +141,22 @@ fn assume_init_good() {
 }
 
 #[test]
+fn uninit_array_assume_init() {
+    let mut array: [MaybeUninit<i16>; 5] = MaybeUninit::uninit_array();
+    array[0].write(3);
+    array[1].write(1);
+    array[2].write(4);
+    array[3].write(1);
+    array[4].write(5);
+
+    let array = unsafe {
+        MaybeUninit::array_assume_init(array)
+    };
+    
+    assert_eq!(array, [3, 1, 4, 1, 5]);
+}
+
+#[test]
 fn uninit_write_slice() {
     let mut dst = [MaybeUninit::new(255); 64];
     let src = [0; 64];


### PR DESCRIPTION
When initialising an array element-by-element, the conversion to the initialised array is done through `mem::transmute`, which is both ugly and does not work with const generics (see #61956). This PR proposes the associated method `array_assume_init`, matching the style of `slice_assume_init_*`:

```rust
unsafe fn array_assume_init<T, const N: usize>(array: [MaybeUninit<T>; N]) -> [T; N];
```

Example:
```rust
let mut array: [MaybeUninit<i32>; 3] = MaybeUninit::uninit_array();
array[0].write(0);
array[1].write(1);
array[2].write(2);

// SAFETY: Now safe as we initialised all elements
let array: [i32; 3] = unsafe {
     MaybeUninit::array_assume_init(array)
};
```

Things I'm unsure about:
* Should this be a method of array instead?
* Should the function be const?