### PR TITLE
Improve grammar in documentation of format strings

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -282,21 +282,22 @@
 //! `%`. The actual grammar for the formatting syntax is:
 //!
 //! ```text
-//! format_string := <text> [ maybe-format <text> ] *
-//! maybe-format := '{' '{' | '}' '}' | <format>
+//! format_string := text [ maybe_format text ] *
+//! maybe_format := '{' '{' | '}' '}' | format
 //! format := '{' [ argument ] [ ':' format_spec ] '}'
 //! argument := integer | identifier
 //!
-//! format_spec := [[fill]align][sign]['#']['0'][width]['.' precision][type]
+//! format_spec := [[fill]align][sign]['#']['0'][width]['.' precision]type
 //! fill := character
 //! align := '<' | '^' | '>'
 //! sign := '+' | '-'
 //! width := count
 //! precision := count | '*'
-//! type := identifier | '?' | ''
+//! type := '' | '?' | 'x?' | 'X?' | identifier
 //! count := parameter | integer
 //! parameter := argument '$'
 //! ```
+//! In the above grammar, `text` may not contain any `'{'` or `'}'` characters.
 //!
 //! # Formatting traits
 //!


### PR DESCRIPTION
The docs previously were
* using some weird `<` and `>` around some nonterminals 
  * _correct me if these **did** have any meaning_
* using of a (not explicitly defined) `text` nonterminal that didn’t explicitly disallow productions containing `'{'` or `'}'`
* incorrect in not allowing for `x?` and `X?` productions of `type`
* unnecessarily ambiguous, both
  * allowing `type` to be `''`, and
  * using an optional `[type]`
* using inconsistent underscore/hyphenation style between `format_string` and `format_spec` vs `maybe-format`

_Rendered:_
![Screenshot_20210101_230901](https://user-images.githubusercontent.com/3986214/103447038-69d7a180-4c86-11eb-8fa0-0a6160a7ff7a.png)
_(current docs: https://doc.rust-lang.org/nightly/std/fmt/#syntax)_

@rustbot modify labels: T-doc