### PR TITLE
Implement `From<Box<T>>` for `NonNull<T>`.

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1176,7 +1176,7 @@ impl<T: ?Sized, A: Allocator> From<Box<T, A>> for NonNull<T> {
     /// releasing the memory previously managed by the `Box` (for example, via
     /// [`Box::from_raw`]).
     #[inline]
-    #[must_use]
+    #[must_use = "this will leak memory if unused"]
     fn from(b: Box<T, A>) -> Self {
         // Safety: Box's pointer is guaranteed to be nonnull, so we can use
         // new_unchecked.

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -148,7 +148,7 @@ use core::ops::{
     CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Generator, GeneratorState, Receiver,
 };
 use core::pin::Pin;
-use core::ptr::{self, Unique};
+use core::ptr::{self, Unique, NonNull};
 use core::task::{Context, Poll};
 
 use crate::alloc::{handle_alloc_error, AllocError, Allocator, Global, Layout};
@@ -1165,6 +1165,21 @@ impl<T> From<T> for Box<T> {
     /// ```
     fn from(t: T) -> Self {
         Box::new(t)
+    }
+}
+
+#[stable(feature = "nonnull_from_box", since = "1.51.0")]
+impl<T: ?Sized> From<Box<T>> for NonNull<T> {
+    /// Convert a `Box<T>` into a [`NonNull<T>`](core::ptr::NonNull).
+    ///
+    /// After calling this function, the caller is responsible for eventually
+    /// releasing the memory previously managed by the `Box` (for example, via
+    /// [`Box::from_raw`]).
+    #[inline]
+    fn from(b: Box<T>) -> Self {
+        // Safety: Box's pointer is guaranteed to be nonnull, so we can use
+        // new_unchecked.
+        unsafe { NonNull::new_unchecked(Box::into_raw(b)) }
     }
 }
 

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -148,7 +148,7 @@ use core::ops::{
     CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Generator, GeneratorState, Receiver,
 };
 use core::pin::Pin;
-use core::ptr::{self, Unique, NonNull};
+use core::ptr::{self, NonNull, Unique};
 use core::task::{Context, Poll};
 
 use crate::alloc::{handle_alloc_error, AllocError, Allocator, Global, Layout};
@@ -1169,14 +1169,15 @@ impl<T> From<T> for Box<T> {
 }
 
 #[stable(feature = "nonnull_from_box", since = "1.51.0")]
-impl<T: ?Sized> From<Box<T>> for NonNull<T> {
+impl<T: ?Sized, A: Allocator> From<Box<T, A>> for NonNull<T> {
     /// Convert a `Box<T>` into a [`NonNull<T>`](core::ptr::NonNull).
     ///
     /// After calling this function, the caller is responsible for eventually
     /// releasing the memory previously managed by the `Box` (for example, via
     /// [`Box::from_raw`]).
     #[inline]
-    fn from(b: Box<T>) -> Self {
+    #[must_use]
+    fn from(b: Box<T, A>) -> Self {
         // Safety: Box's pointer is guaranteed to be nonnull, so we can use
         // new_unchecked.
         unsafe { NonNull::new_unchecked(Box::into_raw(b)) }

--- a/library/alloc/tests/boxed.rs
+++ b/library/alloc/tests/boxed.rs
@@ -57,3 +57,19 @@ fn box_deref_lval() {
     x.set(1000);
     assert_eq!(x.get(), 1000);
 }
+
+#[test]
+fn nonnull_from_box() {
+    let x = Box::new(5);
+    let p = NonNull::from(x);
+    assert_eq!(unsafe { *p.as_ref() }, 5);
+    let _ = unsafe { Box::from_raw(p.as_ptr()) };
+}
+
+#[test]
+fn nonnull_from_box_dynsized() {
+    let s: Box<str> = "foo".into();
+    let ps = NonNull::from(s);
+    let s_again = unsafe { Box::from_raw(ps.as_ptr()) };
+    assert_eq!(&*s_again, "foo");
+}


### PR DESCRIPTION
This provides an implementation of `From<Box<T>>` for `NonNull<T>`.

It's a pretty small conceptual addition, but is good because but avoids a case where the operation is obviously sound, but you'd otherwise need unsafe to do it directly (at least, without an unwrap).

It also can be a bit subtle to implement this correctly (for example, my understanding is that using `NonNull::from` on a reference derived from the Box would have the wrong provenance), so it's good to provide a guaranteed-correct implementation.

The biggest downside is that this operation leaks (err, it transfers responsibility for cleanup to the caller), but that seems like the point of this operation. This has been noted in the documentation, however, and is in a must_use message.

I didn't do this for the other smart pointer types (`Rc<T>` and `Arc<T>`) since it seemed less useful, and is semantically a bit hairier, I think. I'm happy to change that though, if desirable.

~~I didn't make this generic over the Allocator parameter, mostly because the other From impls largely aren't (only a couple are). It's also not clear to me how that interacts with stability, although it's probably fine. Anyway, happy to change that as well.~~ Actually I was wrong, most of the similar impls are generic over the allocator, so this is too.

This is a trait implementation, so IIUC it's automatically stable (and thus needs to go through an FCP, I believe), and thus is marked as stable. I'm happy to change it to unstable if this wasn't correct information.