### PR TITLE
Explain why borrows can't be held across yield point in async blocks

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0373.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0373.md
@@ -54,34 +54,17 @@ about safety.
 This error may also be encountered while using `async` blocks:
 
 ```compile_fail,E0373,edition2018
-use std::{sync::Arc, future::Future, pin::Pin, task::{Context, Poll}};
+use std::future::Future;
 
 async fn f() {
-    let v = Arc::new(Vec::new());
-
-    let handle = spawn(async { //~ ERROR E0373
-        g(Arc::clone(&v))
+    let v = vec![1, 2, 3i32];
+    spawn(async { //~ ERROR E0373
+        println!("{:?}", v)
     });
-    handle.await;
 }
 
-fn g(v: Arc<Vec<usize>>) {}
-
-fn spawn<F>(future: F) -> JoinHandle
-where
-    F: Future + Send + 'static,
-    F::Output: Send + 'static,
-{
+fn spawn<F: Future + Send + 'static>(future: F) {
     unimplemented!()
-}
-
-struct JoinHandle;
-
-impl Future for JoinHandle {
-    type Output = ();
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        unimplemented!()
-    }
 }
 ```
 

--- a/compiler/rustc_error_codes/src/error_codes/E0373.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0373.md
@@ -50,3 +50,25 @@ fn foo() -> Box<Fn(u32) -> u32> {
 
 Now that the closure has its own copy of the data, there's no need to worry
 about safety.
+
+This error may also be encountered while using `async` blocks:
+
+```compile_fail,E0373
+use std::sync::Arc;
+use tokio::runtime::Runtime; // 0.3.1
+
+async fn f() {
+    let room_ref = Arc::new(Vec::new());
+
+    let gameloop_handle = Runtime::new().unwrap().spawn(async {
+        game_loop(Arc::clone(&room_ref))
+    });
+    gameloop_handle.await;
+}
+
+fn game_loop(v: Arc<Vec<usize>>) {}
+```
+
+Similarly to closures, `async` blocks are not executed immediately and may
+capture closed-over data by reference. For more information, see 
+https://rust-lang.github.io/async-book/03_async_await/01_chapter.html.

--- a/compiler/rustc_error_codes/src/error_codes/E0373.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0373.md
@@ -53,7 +53,7 @@ about safety.
 
 This error may also be encountered while using `async` blocks:
 
-```compile_fail,E0373
+```compile_fail,E0373,edition2018
 use std::{sync::Arc, future::Future, pin::Pin, task::{Context, Poll}};
 
 async fn f() {

--- a/compiler/rustc_error_codes/src/error_codes/E0373.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0373.md
@@ -70,5 +70,5 @@ fn game_loop(v: Arc<Vec<usize>>) {}
 ```
 
 Similarly to closures, `async` blocks are not executed immediately and may
-capture closed-over data by reference. For more information, see 
+capture closed-over data by reference. For more information, see
 https://rust-lang.github.io/async-book/03_async_await/01_chapter.html.

--- a/compiler/rustc_error_codes/src/error_codes/E0373.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0373.md
@@ -54,19 +54,35 @@ about safety.
 This error may also be encountered while using `async` blocks:
 
 ```compile_fail,E0373
-use std::sync::Arc;
-use tokio::runtime::Runtime; // 0.3.1
+use std::{sync::Arc, future::Future, pin::Pin, task::{Context, Poll}};
 
 async fn f() {
-    let room_ref = Arc::new(Vec::new());
+    let v = Arc::new(Vec::new());
 
-    let gameloop_handle = Runtime::new().unwrap().spawn(async {
-        game_loop(Arc::clone(&room_ref))
+    let handle = spawn(async { //~ ERROR E0373
+        g(Arc::clone(&v))
     });
-    gameloop_handle.await;
+    handle.await;
 }
 
-fn game_loop(v: Arc<Vec<usize>>) {}
+fn g(v: Arc<Vec<usize>>) {}
+
+fn spawn<F>(future: F) -> JoinHandle
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    unimplemented!()
+}
+
+struct JoinHandle;
+
+impl Future for JoinHandle {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        unimplemented!()
+    }
+}
 ```
 
 Similarly to closures, `async` blocks are not executed immediately and may

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -1335,11 +1335,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     if matches!(generator_kind, GeneratorKind::Async(_)))
                 {
                     err.note(
-                        "async blocks are not executed immediately and either must take a \
+                        "async blocks are not executed immediately and must either take a \
                     reference or ownership of outside variables they use",
                     );
-                    err.help("see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor \
-                        for more information");
                 } else {
                     let msg = format!("function requires argument type to outlive `{}`", fr_name);
                     err.span_note(constraint_span, &msg);

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -1331,9 +1331,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
             ConstraintCategory::CallArgument => {
                 fr_name.highlight_region_name(&mut err);
-                if matches!(use_span.generator_kind(), Some(generator_kind)
-                    if matches!(generator_kind, GeneratorKind::Async(_)))
-                {
+                if matches!(use_span.generator_kind(), Some(GeneratorKind::Async(_))) {
                     err.note(
                         "async blocks are not executed immediately and must either take a \
                     reference or ownership of outside variables they use",

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -1331,11 +1331,13 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
             ConstraintCategory::CallArgument => {
                 fr_name.highlight_region_name(&mut err);
-                if matches!(use_span.generator_kind(), Some(generator_kind) 
+                if matches!(use_span.generator_kind(), Some(generator_kind)
                     if matches!(generator_kind, GeneratorKind::Async(_)))
                 {
-                    err.note("async blocks are not executed immediately and either must take a \
-                    reference or ownership of outside variables they use");
+                    err.note(
+                        "async blocks are not executed immediately and either must take a \
+                    reference or ownership of outside variables they use",
+                    );
                     err.help("see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor \
                         for more information");
                 } else {

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -1323,6 +1323,16 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             suggestion,
             Applicability::MachineApplicable,
         );
+        if let Some(generator_kind) = use_span.generator_kind() {
+            if let GeneratorKind::Async(_) = generator_kind {
+                err.note(
+            "borrows cannot be held across a yield point, because the stack space of the current \
+            function is not preserved",
+        );
+                err.help("see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor \
+        for more information");
+            }
+        }
 
         let msg = match category {
             ConstraintCategory::Return(_) | ConstraintCategory::OpaqueType => {

--- a/src/test/ui/async-await/issues/issue-78938-async-block.rs
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.rs
@@ -16,7 +16,7 @@ fn game_loop(v: Arc<Vec<usize>>) {}
 fn spawn<F>(future: F) -> JoinHandle
 where
     F: Future + Send + 'static,
-    F::Output: Send + 'static,  
+    F::Output: Send + 'static,
 {
     loop {}
 }
@@ -26,7 +26,7 @@ struct JoinHandle;
 impl Future for JoinHandle {
     type Output = ();
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        loop {}
+       loop {}
     }
 }
 

--- a/src/test/ui/async-await/issues/issue-78938-async-block.rs
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-use std::{sync::Arc, future::Future, pin::Pin, task::{Context,Poll}};
+use std::{sync::Arc, future::Future, pin::Pin, task::{Context, Poll}};
 
 async fn f() {
     let room_ref = Arc::new(Vec::new());

--- a/src/test/ui/async-await/issues/issue-78938-async-block.rs
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.rs
@@ -26,7 +26,7 @@ struct JoinHandle;
 impl Future for JoinHandle {
     type Output = ();
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-       loop {}
+        loop {}
     }
 }
 

--- a/src/test/ui/async-await/issues/issue-78938-async-block.rs
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.rs
@@ -1,0 +1,33 @@
+// edition:2018
+
+use std::{sync::Arc, future::Future, pin::Pin, task::{Context,Poll}};
+
+async fn f() {
+    let room_ref = Arc::new(Vec::new());
+
+    let gameloop_handle = spawn(async { //~ ERROR E0373
+        game_loop(Arc::clone(&room_ref))
+    });
+    gameloop_handle.await;
+}
+
+fn game_loop(v: Arc<Vec<usize>>) {}
+
+fn spawn<F>(future: F) -> JoinHandle
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,  
+{
+    loop {}
+}
+
+struct JoinHandle;
+
+impl Future for JoinHandle {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issues/issue-78938-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.stderr
@@ -8,7 +8,7 @@ LL | |         game_loop(Arc::clone(&room_ref))
 LL | |     });
    | |_____^ may outlive borrowed value `room_ref`
    |
-   = note: async blocks are not executed immediately and either must take a reference or ownership of outside variables they use
+   = note: async blocks are not executed immediately and must either take a reference or ownership of outside variables they use
    = help: see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor for more information
 help: to force the async block to take ownership of `room_ref` (and any other referenced variables), use the `move` keyword
    |

--- a/src/test/ui/async-await/issues/issue-78938-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.stderr
@@ -8,15 +8,7 @@ LL | |         game_loop(Arc::clone(&room_ref))
 LL | |     });
    | |_____^ may outlive borrowed value `room_ref`
    |
-note: function requires argument type to outlive `'static`
-  --> $DIR/issue-78938-async-block.rs:8:33
-   |
-LL |       let gameloop_handle = spawn(async {
-   |  _________________________________^
-LL | |         game_loop(Arc::clone(&room_ref))
-LL | |     });
-   | |_____^
-   = note: borrows cannot be held across a yield point, because the stack space of the current function is not preserved
+   = note: async blocks are not executed immediately and either must take a reference or ownership of outside variables they use
    = help: see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor for more information
 help: to force the async block to take ownership of `room_ref` (and any other referenced variables), use the `move` keyword
    |

--- a/src/test/ui/async-await/issues/issue-78938-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.stderr
@@ -1,0 +1,30 @@
+error[E0373]: async block may outlive the current function, but it borrows `room_ref`, which is owned by the current function
+  --> $DIR/issue-78938-async-block.rs:8:39
+   |
+LL |       let gameloop_handle = spawn(async {
+   |  _______________________________________^
+LL | |         game_loop(Arc::clone(&room_ref))
+   | |                               -------- `room_ref` is borrowed here
+LL | |     });
+   | |_____^ may outlive borrowed value `room_ref`
+   |
+   = note: borrows cannot be held across a yield point, because the stack space of the current function is not preserved
+   = help: see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor for more information
+note: function requires argument type to outlive `'static`
+  --> $DIR/issue-78938-async-block.rs:8:33
+   |
+LL |       let gameloop_handle = spawn(async {
+   |  _________________________________^
+LL | |         game_loop(Arc::clone(&room_ref))
+LL | |     });
+   | |_____^
+help: to force the async block to take ownership of `room_ref` (and any other referenced variables), use the `move` keyword
+   |
+LL |     let gameloop_handle = spawn(async move {
+LL |         game_loop(Arc::clone(&room_ref))
+LL |     });
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0373`.

--- a/src/test/ui/async-await/issues/issue-78938-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.stderr
@@ -8,8 +8,6 @@ LL | |         game_loop(Arc::clone(&room_ref))
 LL | |     });
    | |_____^ may outlive borrowed value `room_ref`
    |
-   = note: borrows cannot be held across a yield point, because the stack space of the current function is not preserved
-   = help: see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor for more information
 note: function requires argument type to outlive `'static`
   --> $DIR/issue-78938-async-block.rs:8:33
    |
@@ -18,6 +16,8 @@ LL |       let gameloop_handle = spawn(async {
 LL | |         game_loop(Arc::clone(&room_ref))
 LL | |     });
    | |_____^
+   = note: borrows cannot be held across a yield point, because the stack space of the current function is not preserved
+   = help: see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor for more information
 help: to force the async block to take ownership of `room_ref` (and any other referenced variables), use the `move` keyword
    |
 LL |     let gameloop_handle = spawn(async move {

--- a/src/test/ui/async-await/issues/issue-78938-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-78938-async-block.stderr
@@ -9,7 +9,6 @@ LL | |     });
    | |_____^ may outlive borrowed value `room_ref`
    |
    = note: async blocks are not executed immediately and must either take a reference or ownership of outside variables they use
-   = help: see https://rust-lang.github.io/async-book/03_async_await/01_chapter.html#awaiting-on-a-multithreaded-executor for more information
 help: to force the async block to take ownership of `room_ref` (and any other referenced variables), use the `move` keyword
    |
 LL |     let gameloop_handle = spawn(async move {


### PR DESCRIPTION
For https://github.com/rust-lang/rust/issues/78938.