### PR TITLE
Detect invalid rustdoc test commands

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -218,7 +218,7 @@ def concat_multi_lines(f):
 
 
 LINE_PATTERN = re.compile(r'''
-    (?<=(?<!\S)@)(?P<negated>!?)
+    (?<=(?<!\S))(?P<invalid>!?)@(?P<negated>!?)
     (?P<cmd>[A-Za-z]+(?:-[A-Za-z]+)*)
     (?P<args>.*)$
 ''', re.X | re.UNICODE)
@@ -233,6 +233,16 @@ def get_commands(template):
 
             negated = (m.group('negated') == '!')
             cmd = m.group('cmd')
+            if m.group('invalid') == '!':
+                print_err(
+                    lineno,
+                    line,
+                    'Invalid command: `!@{0}{1}`, (help: try with `@!{1}`)'.format(
+                        '!' if negated else '',
+                        cmd,
+                    ),
+                )
+                continue
             args = m.group('args')
             if args and not args[:1].isspace():
                 print_err(lineno, line, 'Invalid template syntax')


### PR DESCRIPTION
Fixes #80570.

There are now errors displayed in case of bad command syntax:

```
---- [rustdoc] rustdoc/remove-url-from-headings.rs stdout ----

error: htmldocck failed!
status: exit code: 1
command: "/usr/bin/python" "/home/imperio/rust/rust/src/etc/htmldocck.py" "/home/imperio/rust/rust/build/x86_64-unknown-linux-gnu/test/rustdoc/remove-url-from-headings" "/home/imperio/rust/rust/src/test/rustdoc/remove-url-from-headings.rs"
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------
3: Invalid command: `!@has`, (try with `@!has`)
	// !@has - '//a[@href="http://a.a"]'

Encountered 1 errors
```

r? @camelid 