### PR TITLE
Choose the version of python at runtime (portable version)

### DIFF
--- a/x.py
+++ b/x.py
@@ -4,6 +4,22 @@
 
 import os
 import sys
+
+# If this is python2, check if python3 is available and re-execute with that
+# interpreter.
+if sys.version_info.major < 3:
+    try:
+        # On Windows, `py -3` sometimes works.
+        # Try this first, because 'python3' sometimes tries to launch the app
+        # store on Windows
+        os.execvp("py", ["py", "-3"] + sys.argv)
+    except OSError:
+        try:
+            os.execvp("python3", ["python3"] + sys.argv)
+        except OSError:
+            # Python 3 isn't available, fall back to python 2
+            pass
+
 rust_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(rust_dir, "src", "bootstrap"))
 


### PR DESCRIPTION
r? @Mark-Simulacrum

Fixed version of https://github.com/rust-lang/rust/pull/80585. The goal is to avoid giving 'error: python3 required' when downloading LLVM from CI and instead default to python3 where possible.

This has some minor overhead when you have `python` as python2, but almost nothing compared to actually running the build.