### PR TITLE
Fix non-working untestable doc code example

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1051,7 +1051,7 @@ pub(crate) mod builtin {
     /// ```ignore (cannot-doctest-external-file-dependency)
     /// fn main() {
     ///     let bytes = include_bytes!("spanish.in");
-    ///     assert_eq!(bytes, b"adi\xc3\xb3s\n");
+    ///     assert_eq!(bytes, b"adi\xc3\xb3s");
     ///     print!("{}", String::from_utf8_lossy(bytes));
     /// }
     /// ```


### PR DESCRIPTION
The `include_bytes!` macro's doc example doesn't actually compile if an end-user copies and pastes the example as is. To fix this, I removed the newline character in the assertion as the example file given, `spanish.in` does not have a newline character.

r? @steveklabnik