### PR TITLE
Add note to non-exhaustive match on reference to empty

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -503,6 +503,11 @@ fn non_exhaustive_match<'p, 'tcx>(
             ));
         }
     }
+    if let ty::Ref(_, sub_ty, _) = scrut_ty.kind() {
+        if cx.tcx.is_ty_uninhabited_from(cx.module, sub_ty, cx.param_env) {
+            err.note("references are always considered inhabited");
+        }
+    }
     err.emit();
 }
 

--- a/src/test/ui/pattern/usefulness/always-inhabited-union-ref.stderr
+++ b/src/test/ui/pattern/usefulness/always-inhabited-union-ref.stderr
@@ -6,6 +6,7 @@ LL |     match uninhab_ref() {
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&!`
+   = note: references are always considered inhabited
 
 error[E0004]: non-exhaustive patterns: type `Foo` is non-empty
   --> $DIR/always-inhabited-union-ref.rs:27:11

--- a/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.rs
+++ b/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.rs
@@ -1,7 +1,11 @@
 enum A {}
+    //~^ NOTE `A` defined here
 
 fn f(a: &A) {
-    match a {} //~ ERROR non-exhaustive patterns: type `&A` is non-empty
+    match a {}
+    //~^ ERROR non-exhaustive patterns: type `&A` is non-empty
+    //~| NOTE the matched value is of type `&A`
+    //~| NOTE references are always considered inhabited
 }
 
 fn main() {}

--- a/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.rs
+++ b/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.rs
@@ -1,0 +1,7 @@
+enum A {}
+
+fn f(a: &A) {
+    match a {} //~ ERROR non-exhaustive patterns: type `&A` is non-empty
+}
+
+fn main() {}

--- a/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.stderr
+++ b/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: type `&A` is non-empty
-  --> $DIR/issue-78123-non-exhaustive-reference.rs:4:11
+  --> $DIR/issue-78123-non-exhaustive-reference.rs:5:11
    |
 LL | enum A {}
    | --------- `A` defined here

--- a/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.stderr
+++ b/src/test/ui/pattern/usefulness/issue-78123-non-exhaustive-reference.stderr
@@ -1,0 +1,16 @@
+error[E0004]: non-exhaustive patterns: type `&A` is non-empty
+  --> $DIR/issue-78123-non-exhaustive-reference.rs:4:11
+   |
+LL | enum A {}
+   | --------- `A` defined here
+...
+LL |     match a {}
+   |           ^
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `&A`
+   = note: references are always considered inhabited
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
+++ b/src/test/ui/uninhabited/uninhabited-matches-feature-gated.stderr
@@ -23,6 +23,7 @@ LL |     let _ = match x {};
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
    = note: the matched value is of type `&Void`
+   = note: references are always considered inhabited
 
 error[E0004]: non-exhaustive patterns: type `(Void,)` is non-empty
   --> $DIR/uninhabited-matches-feature-gated.rs:18:19


### PR DESCRIPTION
Rust prints "type `&A` is non-empty" even is A is empty.
This is the intended behavior, but can be confusing.
This commit adds a note to non-exhaustive pattern errors if they are a
reference to something uninhabited.

I did not add tests to check that the note is not shown for
non-references or inhabited references, because this is already done
in other tests.

Maybe the added test is superfluous, because
`always-inhabited-union-ref` already checks for this case.

This does not handle &&Void or &&&void etc. I could add those as special
cases as well and ignore people who need quadruple
references.

Fixes #78123