### PR TITLE
Properly handle `SyntaxContext` of dummy spans in incr comp

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1899,8 +1899,9 @@ where
             return;
         }
 
-        if *self == DUMMY_SP {
+        if self.is_dummy() {
             Hash::hash(&TAG_INVALID_SPAN, hasher);
+            self.ctxt().hash_stable(ctx, hasher);
             return;
         }
 

--- a/src/test/incremental/issue-80336-invalid-span.rs
+++ b/src/test/incremental/issue-80336-invalid-span.rs
@@ -1,0 +1,10 @@
+// Regression test for issue #80336
+// Test that we properly handle encoding, decoding, and hashing
+// of spans with an invalid location and non-root `SyntaxContext`
+
+// revisions:rpass1 rpass2
+// only-x86_64
+
+pub fn main() {
+    let _ = is_x86_feature_detected!("avx2");
+}


### PR DESCRIPTION
Fixes #80336

Due to macro expansion, we may end up with spans with an invalid
location and non-root `SyntaxContext`. This commits preserves the
`SyntaxContext` of such spans in the incremental cache, and ensures
that we always hash the `SyntaxContext` when computing the `Fingerprint`
of a `Span`

Previously, we would discard the `SyntaxContext` during serialization to
the incremental cache, causing the span's `Fingerprint` to change across
compilation sessions.