### PR TITLE
Added support for i386-unknown-linux-gnu and i486-unknown-linux-gnu

### DIFF
--- a/compiler/rustc_target/src/spec/i386_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i386_unknown_linux_gnu.rs
@@ -1,0 +1,8 @@
+use crate::spec::Target;
+
+pub fn target() -> Target {
+    let mut base = super::i686_unknown_linux_gnu::target();
+    base.cpu = "i386".to_string();
+    base.llvm_target = "i386-unknown-linux-gnu".to_string();
+    base
+}

--- a/compiler/rustc_target/src/spec/i486_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/i486_unknown_linux_gnu.rs
@@ -1,0 +1,8 @@
+use crate::spec::Target;
+
+pub fn target() -> Target {
+    let mut base = super::i686_unknown_linux_gnu::target();
+    base.cpu = "i486".to_string();
+    base.llvm_target = "i486-unknown-linux-gnu".to_string();
+    base
+}


### PR DESCRIPTION
Support for both can be useful when creating new firmware, boot loaders,
or embedded operating systems.