### PR TITLE
Fix missing link for "fully qualified syntax"

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -238,6 +238,7 @@
 //! [downgrade]: Rc::downgrade
 //! [upgrade]: Weak::upgrade
 //! [mutability]: core::cell#introducing-mutability-inside-of-something-immutable
+//! [fully qualified syntax]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name
 
 #![stable(feature = "rust1", since = "1.0.0")]
 


### PR DESCRIPTION
This issue can currently be seen at https://doc.rust-lang.org/stable/std/rc/index.html#toggle-all-docs:~:text=%5B-,fully%20qualified%20syntax

It originates from #76138, where the link was added to `library/alloc/src/sync.rs`, but not `library/alloc/src/rc.rs`.