### PR TITLE
./x.py clippy: allow the most noisy lints

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -21,6 +21,16 @@ fn args(builder: &Builder<'_>) -> Vec<String> {
     }
 
     if let Subcommand::Clippy { fix, .. } = builder.config.cmd {
+        // disable the most spammy clippy lints
+        let ignored_lints = vec![
+            "many_single_char_names", // there are a lot in stdarch
+            "collapsible_if",
+            "type_complexity",
+            "missing_safety_doc", // almost 3K warnings
+            "too_many_arguments",
+            "needless_lifetimes", // people want to keep the lifetimes
+            "wrong_self_convention",
+        ];
         let mut args = vec![];
         if fix {
             #[rustfmt::skip]
@@ -33,6 +43,7 @@ fn args(builder: &Builder<'_>) -> Vec<String> {
             ]));
         }
         args.extend(strings(&["--", "--cap-lints", "warn"]));
+        args.extend(ignored_lints.iter().map(|lint| format!("-Aclippy::{}", lint)));
         args
     } else {
         vec![]


### PR DESCRIPTION
This silences the following clippy lints in ./x.py clippy:

many_single_char_names (there are a lot of warnings caused by stdarch)
collapsible_if (can reduce readability)
type_complexity
missing_safety_doc (there are almost 3K warnings issued)
too_many_arguments
needless_lifetimes (people want 'tcx lifetimes etc)
wrong_self_convention (warns about from_..(), to_..(), into_..().. fns that do or do not take self by reference.

Just for clarification; this only changes the output of `x.py clippy` inside the rustc repo and does not change anything about clippy or how `cargo clippy` is run on peoples crates. 