### PR TITLE
query: QueryModifiers: Box syn::Type

### DIFF
--- a/compiler/rustc_macros/src/query.rs
+++ b/compiler/rustc_macros/src/query.rs
@@ -33,7 +33,7 @@ enum QueryModifier {
     Desc(Option<Ident>, Punctuated<Expr, Token![,]>),
 
     /// Use this type for the in-memory cache.
-    Storage(Type),
+    Storage(Box<Type>),
 
     /// Cache the query to disk if the `Expr` returns true.
     Cache(Option<(IdentOrWild, IdentOrWild)>, Block),
@@ -213,7 +213,7 @@ struct QueryModifiers {
     desc: (Option<Ident>, Punctuated<Expr, Token![,]>),
 
     /// Use this type for the in-memory cache.
-    storage: Option<Type>,
+    storage: Option<Box<Type>>,
 
     /// Cache the query to disk if the `Block` returns true.
     cache: Option<(Option<(IdentOrWild, IdentOrWild)>, Block)>,


### PR DESCRIPTION
according to clippy:
````
warning: large size difference between variants
  --> compiler/rustc_macros/src/query.rs:36:5
   |
36 |     Storage(Type),
   |     ^^^^^^^^^^^^^ this variant is 304 bytes
   |
   = note: `#[warn(clippy::large_enum_variant)]` on by default
note: and the second-largest variant is 72 bytes:
  --> compiler/rustc_macros/src/query.rs:33:5
   |
33 |     Desc(Option<Ident>, Punctuated<Expr, Token![,]>),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
   |
36 |     Storage(Box<Type>),
   |             ^^^^^^^^^
````
Reduces the QueryModifier  enum size from 312 bytes to 120 bytes if I measured correctly.
Wondering if this has positive perf impact.