### PR TITLE
Error when #[doc(alias)] has same name as the item

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -310,7 +310,7 @@ impl CheckAttrVisitor<'tcx> {
                 .sess
                 .struct_span_err(
                     meta.name_value_literal_span().unwrap_or_else(|| meta.span()),
-                    &format!("{:?} character isn't allowed in `#[doc(alias = \"...\")]`", c,),
+                    &format!("{:?} character isn't allowed in `#[doc(alias = \"...\")]`", c),
                 )
                 .emit();
             return false;
@@ -354,6 +354,17 @@ impl CheckAttrVisitor<'tcx> {
                 .struct_span_err(
                     meta.span(),
                     &format!("`#[doc(alias = \"...\")]` isn't allowed on {}", err),
+                )
+                .emit();
+            return false;
+        }
+        let item_name = self.tcx.hir().name(hir_id);
+        if item_name.to_string() == doc_alias {
+            self.tcx
+                .sess
+                .struct_span_err(
+                    meta.span(),
+                    &format!("`#[doc(alias = \"...\")]` is the same as the item's name"),
                 )
                 .emit();
             return false;

--- a/src/test/rustdoc-ui/doc-alias-same-name.rs
+++ b/src/test/rustdoc-ui/doc-alias-same-name.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+#[doc(alias = "Foo")] //~ ERROR
+pub struct Foo;

--- a/src/test/rustdoc-ui/doc-alias-same-name.stderr
+++ b/src/test/rustdoc-ui/doc-alias-same-name.stderr
@@ -1,0 +1,8 @@
+error: `#[doc(alias = "...")]` is the same as the item's name
+  --> $DIR/doc-alias-same-name.rs:3:7
+   |
+LL | #[doc(alias = "Foo")]
+   |       ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/doc-alias-same-name.rs
+++ b/src/test/ui/doc-alias-same-name.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+#[doc(alias = "Foo")] //~ ERROR
+pub struct Foo;

--- a/src/test/ui/doc-alias-same-name.stderr
+++ b/src/test/ui/doc-alias-same-name.stderr
@@ -1,0 +1,8 @@
+error: `#[doc(alias = "...")]` is the same as the item's name
+  --> $DIR/doc-alias-same-name.rs:3:7
+   |
+LL | #[doc(alias = "Foo")]
+   |       ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Something I came across when reviewing some doc alias PRs.

r? @jyn514 