### PR TITLE
make sure that promoteds which fail to evaluate in dead const code behave correctly

### DIFF
--- a/src/test/ui/consts/promotion.rs
+++ b/src/test/ui/consts/promotion.rs
@@ -4,12 +4,23 @@
 
 fn foo(_: &'static [&'static str]) {}
 fn bar(_: &'static [&'static str; 3]) {}
-fn baz_i32(_: &'static i32) {}
-fn baz_u32(_: &'static u32) {}
+const fn baz_i32(_: &'static i32) {}
+const fn baz_u32(_: &'static u32) {}
+
+const fn fail() -> i32 { 1/0 }
+const C: i32 = {
+    // Promoted that fails to evaluate in dead code -- this must work
+    // (for backwards compatibility reasons).
+    if false {
+        baz_i32(&fail());
+    }
+    42
+};
 
 fn main() {
     foo(&["a", "b", "c"]);
     bar(&["d", "e", "f"]);
+    assert_eq!(C, 42);
 
     // make sure that these do not cause trouble despite overflowing
     baz_u32(&(0-1));


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/80243 showed that we'll have to live with these kinds of failing promoteds for a while, so let's make sure we have a test that covers them.