### PR TITLE
disable type inference fallback in inline consts

### DIFF
--- a/src/test/ui/inline-const/const-expr-array-init.rs
+++ b/src/test/ui/inline-const/const-expr-array-init.rs
@@ -6,5 +6,5 @@
 use std::cell::Cell;
 
 fn main() {
-    let _x = [const { Cell::new(0) }; 20];
+    let _x = [const { Cell::new(0i32) }; 20];
 }

--- a/src/test/ui/inline-const/const-expr-basic.rs
+++ b/src/test/ui/inline-const/const-expr-basic.rs
@@ -2,9 +2,9 @@
 
 #![allow(incomplete_features)]
 #![feature(inline_const)]
-fn foo() -> i32 {
+fn foo() -> u32 {
     const {
-        let x = 5 + 10;
+        let x = 5u32 + 10;
         x / 3
     }
 }

--- a/src/test/ui/inline-const/const-expr-macro.rs
+++ b/src/test/ui/inline-const/const-expr-macro.rs
@@ -7,6 +7,6 @@ macro_rules! do_const_block{
 }
 
 fn main() {
-    let s = do_const_block!({ 22 });
+    let s = do_const_block!({ 22u64 });
     assert_eq!(s, 22);
 }

--- a/src/test/ui/inline-const/const-expr-reference.rs
+++ b/src/test/ui/inline-const/const-expr-reference.rs
@@ -5,7 +5,7 @@
 
 const fn bar() -> i32 {
     const {
-        2 + 3
+        2i32 + 3
     }
 }
 

--- a/src/test/ui/inline-const/const-match-pat.rs
+++ b/src/test/ui/inline-const/const-match-pat.rs
@@ -8,8 +8,8 @@ const MMIO_BIT2: u8 = 5;
 fn main() {
     let s = match read_mmio() {
         0 => "FOO",
-        const { 1 << MMIO_BIT1 } => "BAR",
-        const { 1 << MMIO_BIT2 } => "BAZ",
+        const { 1i32 << MMIO_BIT1 } => "BAR",
+        const { 1i32 << MMIO_BIT2 } => "BAZ",
         _ => unreachable!(),
     };
 

--- a/src/test/ui/inline-const/no-fallback.rs
+++ b/src/test/ui/inline-const/no-fallback.rs
@@ -1,0 +1,9 @@
+// test for #78132, see the comment in `fn typeck` for why this
+// is supposed to fail.
+#![feature(inline_const)]
+#![allow(incomplete_features)]
+
+fn main() {
+    let _: usize = const { 0 };
+    //~^ ERROR type annotations needed
+}

--- a/src/test/ui/inline-const/no-fallback.stderr
+++ b/src/test/ui/inline-const/no-fallback.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/no-fallback.rs:7:26
+   |
+LL |     let _: usize = const { 0 };
+   |                          ^^^^^ cannot infer type for type `{integer}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Ideally we would `typeck` inline consts together with their parent body. This would however mean that we can't execute the inline const during its parents `typeck` as that would case inline cycles. We do need this however for `feature(const_evaluatable_checked)`, see https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/inline.20consts for more details about this.

When typechecking inline consts and their containing body there are two possible ways to do so, either by first typechecking the inline consts and using the resulting type while typechecking their parent, allowing `2 + const { 1u32 }` to compile. Or trying to first typecheck the outer body and using the result in the inline const, allowing `[u8; const { 2 } + 1]`.

imo the second possibility is preferable but it is also more difficult to implement as we have to somehow supply the type of the inline const node to the inline const during typeck, requiring us to pretty much also use `WithOptConstParam` but storing the type directly instead of the param `DefId`. How exactly this should work is fairly difficult as we must not call `typeck` for the inline const with different types.

The idea of this PR is to implement a restricted version of the first possibility which allows us to switch later. This is not yet the case as inline consts are still used in the type inference of their containing body. Meaning that switching to the second option will break the following:
```rust
fn main() {
    let mut x = const { 1u32 };
    x = 7;
}
```

*Closing cause I don't know how to deal with "This is not yet the case as inline consts are still used in the type inference of their containing body." and I also think that this restriction makes using const blocks really annoying. idk*

r? @nikomatsakis probably