### PR TITLE
Consistently avoid constructing optimized MIR when not doing codegen

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -796,7 +796,6 @@ impl EncodeContext<'a, 'tcx> {
         if opt_mir {
             self.encode_optimized_mir(def_id.expect_local());
         }
-        self.encode_promoted_mir(def_id.expect_local());
         self.encode_mir_for_ctfe(def_id.expect_local());
     }
 
@@ -908,7 +907,6 @@ impl EncodeContext<'a, 'tcx> {
             self.encode_optimized_mir(def_id.expect_local());
         }
         self.encode_mir_for_ctfe(def_id.expect_local());
-        self.encode_promoted_mir(def_id.expect_local());
     }
 
     fn encode_generics(&mut self, def_id: DefId) {


### PR DESCRIPTION
The optimized MIR for closures is being encoded unconditionally, while
being unnecessary for cargo check. This turns out to be especially
costly with MIR inlining enabled, since it triggers computation of
optimized MIR for all callees that are being examined for inlining
purposes https://github.com/rust-lang/rust/pull/77307#issuecomment-751915450.

Skip encoding of optimized MIR for closures, enum constructors, struct
constructors, and trait fns when not doing codegen, like it is already
done for other items since 49433.