### PR TITLE
Remove useless doc_alias feature gate

### DIFF
--- a/src/test/rustdoc-ui/doc-alias-crate-level.rs
+++ b/src/test/rustdoc-ui/doc-alias-crate-level.rs
@@ -1,5 +1,3 @@
-#![feature(doc_alias)]
-
 #![doc(alias = "crate-level-not-working")] //~ ERROR
 
 #[doc(alias = "shouldn't work!")] //~ ERROR

--- a/src/test/rustdoc-ui/doc-alias-crate-level.stderr
+++ b/src/test/rustdoc-ui/doc-alias-crate-level.stderr
@@ -1,11 +1,11 @@
 error: '\'' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/doc-alias-crate-level.rs:5:15
+  --> $DIR/doc-alias-crate-level.rs:3:15
    |
 LL | #[doc(alias = "shouldn't work!")]
    |               ^^^^^^^^^^^^^^^^^
 
 error: `#![doc(alias = "...")]` isn't allowed as a crate level attribute
-  --> $DIR/doc-alias-crate-level.rs:3:8
+  --> $DIR/doc-alias-crate-level.rs:1:8
    |
 LL | #![doc(alias = "crate-level-not-working")]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/check-doc-alias-attr-location.rs
+++ b/src/test/ui/check-doc-alias-attr-location.rs
@@ -1,5 +1,4 @@
 #![crate_type="lib"]
-#![feature(doc_alias)]
 
 pub struct Bar;
 pub trait Foo {

--- a/src/test/ui/check-doc-alias-attr-location.stderr
+++ b/src/test/ui/check-doc-alias-attr-location.stderr
@@ -1,23 +1,23 @@
 error: `#[doc(alias = "...")]` isn't allowed on extern block
-  --> $DIR/check-doc-alias-attr-location.rs:10:7
+  --> $DIR/check-doc-alias-attr-location.rs:9:7
    |
 LL | #[doc(alias = "foo")]
    |       ^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:13:7
+  --> $DIR/check-doc-alias-attr-location.rs:12:7
    |
 LL | #[doc(alias = "bar")]
    |       ^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:19:7
+  --> $DIR/check-doc-alias-attr-location.rs:18:7
    |
 LL | #[doc(alias = "foobar")]
    |       ^^^^^^^^^^^^^^^^
 
 error: `#[doc(alias = "...")]` isn't allowed on type alias in implementation block
-  --> $DIR/check-doc-alias-attr-location.rs:21:11
+  --> $DIR/check-doc-alias-attr-location.rs:20:11
    |
 LL |     #[doc(alias = "assoc")]
    |           ^^^^^^^^^^^^^^^

--- a/src/test/ui/check-doc-alias-attr.rs
+++ b/src/test/ui/check-doc-alias-attr.rs
@@ -1,5 +1,4 @@
 #![crate_type = "lib"]
-#![feature(doc_alias)]
 
 #[doc(alias = "foo")] // ok!
 pub struct Bar;

--- a/src/test/ui/check-doc-alias-attr.stderr
+++ b/src/test/ui/check-doc-alias-attr.stderr
@@ -1,35 +1,35 @@
 error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:7:7
+  --> $DIR/check-doc-alias-attr.rs:6:7
    |
 LL | #[doc(alias)]
    |       ^^^^^
 
 error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:8:7
+  --> $DIR/check-doc-alias-attr.rs:7:7
    |
 LL | #[doc(alias = 0)]
    |       ^^^^^^^^^
 
 error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:9:7
+  --> $DIR/check-doc-alias-attr.rs:8:7
    |
 LL | #[doc(alias("bar"))]
    |       ^^^^^^^^^^^^
 
 error: '\"' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:10:15
+  --> $DIR/check-doc-alias-attr.rs:9:15
    |
 LL | #[doc(alias = "\"")]
    |               ^^^^
 
 error: '\n' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:11:15
+  --> $DIR/check-doc-alias-attr.rs:10:15
    |
 LL | #[doc(alias = "\n")]
    |               ^^^^
 
 error: '\n' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:12:15
+  --> $DIR/check-doc-alias-attr.rs:11:15
    |
 LL |   #[doc(alias = "
    |  _______________^
@@ -37,19 +37,19 @@ LL | | ")]
    | |_^
 
 error: '\t' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/check-doc-alias-attr.rs:14:15
+  --> $DIR/check-doc-alias-attr.rs:13:15
    |
 LL | #[doc(alias = "\t")]
    |               ^^^^
 
 error: `#[doc(alias = "...")]` cannot start or end with ' '
-  --> $DIR/check-doc-alias-attr.rs:15:15
+  --> $DIR/check-doc-alias-attr.rs:14:15
    |
 LL | #[doc(alias = " hello")]
    |               ^^^^^^^^
 
 error: `#[doc(alias = "...")]` cannot start or end with ' '
-  --> $DIR/check-doc-alias-attr.rs:16:15
+  --> $DIR/check-doc-alias-attr.rs:15:15
    |
 LL | #[doc(alias = "hello ")]
    |               ^^^^^^^^

--- a/src/test/ui/doc-alias-crate-level.rs
+++ b/src/test/ui/doc-alias-crate-level.rs
@@ -1,7 +1,5 @@
 // compile-flags: -Zdeduplicate-diagnostics=no
 
-#![feature(doc_alias)]
-
 #![crate_type = "lib"]
 
 #![doc(alias = "not working!")] //~ ERROR

--- a/src/test/ui/doc-alias-crate-level.stderr
+++ b/src/test/ui/doc-alias-crate-level.stderr
@@ -1,11 +1,11 @@
 error: '\'' character isn't allowed in `#[doc(alias = "...")]`
-  --> $DIR/doc-alias-crate-level.rs:9:15
+  --> $DIR/doc-alias-crate-level.rs:7:15
    |
 LL | #[doc(alias = "shouldn't work!")]
    |               ^^^^^^^^^^^^^^^^^
 
 error: `#![doc(alias = "...")]` isn't allowed as a crate level attribute
-  --> $DIR/doc-alias-crate-level.rs:7:8
+  --> $DIR/doc-alias-crate-level.rs:5:8
    |
 LL | #![doc(alias = "not working!")]
    |        ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
As @jyn514  rightfully noted in https://github.com/rust-lang/rust/pull/80686 , this feature is no more. Therefore, cleanup time!

r? @jyn514 