### PR TITLE
Revert "Rollup merge of #80637 - LingMan:filter, r=oli-obk"

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -43,18 +43,22 @@ impl<'a, 'tcx> FindHirNodeVisitor<'a, 'tcx> {
     }
 
     fn node_ty_contains_target(&mut self, hir_id: HirId) -> Option<Ty<'tcx>> {
-        self.infcx
+        let ty_opt = self
+            .infcx
             .in_progress_typeck_results
-            .and_then(|typeck_results| typeck_results.borrow().node_type_opt(hir_id))
-            .map(|ty| self.infcx.resolve_vars_if_possible(ty))
-            .filter(|ty| {
-                ty.walk().any(|inner| {
+            .and_then(|typeck_results| typeck_results.borrow().node_type_opt(hir_id));
+        match ty_opt {
+            Some(ty) => {
+                let ty = self.infcx.resolve_vars_if_possible(ty);
+                if ty.walk().any(|inner| {
                     inner == self.target
                         || match (inner.unpack(), self.target.unpack()) {
                             (GenericArgKind::Type(inner_ty), GenericArgKind::Type(target_ty)) => {
-                                use ty::{Infer, TyVar};
                                 match (inner_ty.kind(), target_ty.kind()) {
-                                    (&Infer(TyVar(a_vid)), &Infer(TyVar(b_vid))) => self
+                                    (
+                                        &ty::Infer(ty::TyVar(a_vid)),
+                                        &ty::Infer(ty::TyVar(b_vid)),
+                                    ) => self
                                         .infcx
                                         .inner
                                         .borrow_mut()
@@ -65,8 +69,14 @@ impl<'a, 'tcx> FindHirNodeVisitor<'a, 'tcx> {
                             }
                             _ => false,
                         }
-                })
-            })
+                }) {
+                    Some(ty)
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
     }
 }
 


### PR DESCRIPTION
Reverts #80637 to test for possible performance regressions.

In the latest [perf triage](https://github.com/rust-lang/rustc-perf/pull/820), the [rollup](https://github.com/rust-lang/rust/pull/80708) that the reverted PR was a part of featured a [performance regression](https://perf.rust-lang.org/compare.html?start=9919ad6e9ed113557c68c430de2e0f434e4f5b6e&end=f412fb56b8d11c168e7ee49ee74e79c4ab2e5637&stat=instructions:u). We are testing whether the reverted PR was indeed (at least partially) responsible. 

This reverts commit faf8beddef859bbb387a24c536505d833c3821a5, reversing
changes made to 1c6593c473f2cd67a1199dac89fb0e6a811d26ab.

r? @ghost 

cc @LingMan @oli-obk 