### PR TITLE
Improve links in inline code in `core::pin`.

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -129,7 +129,7 @@
 //!
 //! To make this work, every element has pointers to its predecessor and successor in
 //! the list. Elements can only be added when they are pinned, because moving the elements
-//! around would invalidate the pointers. Moreover, the [`Drop`] implementation of a linked
+//! around would invalidate the pointers. Moreover, the [`Drop`][Drop] implementation of a linked
 //! list element will patch the pointers of its predecessor and successor to remove itself
 //! from the list.
 //!
@@ -165,18 +165,18 @@
 //! # `Drop` implementation
 //!
 //! If your type uses pinning (such as the two examples above), you have to be careful
-//! when implementing [`Drop`]. The [`drop`] function takes <code>[&mut] self</code>, but this
+//! when implementing [`Drop`][Drop]. The [`drop`] function takes <code>[&mut] self</code>, but this
 //! is called *even if your type was previously pinned*! It is as if the
 //! compiler automatically called [`Pin::get_unchecked_mut`].
 //!
 //! This can never cause a problem in safe code because implementing a type that
 //! relies on pinning requires unsafe code, but be aware that deciding to make
 //! use of pinning in your type (for example by implementing some operation on
-//! <code>[Pin]<[&]Self></code> or <code>[Pin]<[&mut] Self></code>) has consequences for your [`Drop`]
+//! <code>[Pin]<[&]Self></code> or <code>[Pin]<[&mut] Self></code>) has consequences for your [`Drop`][Drop]
 //! implementation as well: if an element of your type could have been pinned,
-//! you must treat [`Drop`] as implicitly taking <code>[Pin]<[&mut] Self></code>.
+//! you must treat [`Drop`][Drop] as implicitly taking <code>[Pin]<[&mut] Self></code>.
 //!
-//! For example, you could implement [`Drop`] as follows:
+//! For example, you could implement [`Drop`][Drop] as follows:
 //!
 //! ```rust,no_run
 //! # use std::pin::Pin;
@@ -284,7 +284,7 @@
 //! 2.  The destructor of the struct must not move structural fields out of its argument. This
 //!     is the exact point that was raised in the [previous section][drop-impl]: [`drop`] takes
 //!     <code>[&mut] self</code>, but the struct (and hence its fields) might have been pinned before.
-//!     You have to guarantee that you do not move a field inside your [`Drop`] implementation.
+//!     You have to guarantee that you do not move a field inside your [`Drop`][Drop] implementation.
 //!     In particular, as explained previously, this means that your struct must *not*
 //!     be `#[repr(packed)]`.
 //!     See that section for how to write [`drop`] in a way that the compiler can help you
@@ -294,7 +294,7 @@
 //!     content is not overwritten or deallocated without calling the content's destructors.
 //!     This can be tricky, as witnessed by <code>[VecDeque]\<T></code>: the destructor of <code>[VecDeque]\<T></code>
 //!     can fail to call [`drop`] on all elements if one of the destructors panics. This violates
-//!     the [`Drop`] guarantee, because it can lead to elements being deallocated without
+//!     the [`Drop`][Drop] guarantee, because it can lead to elements being deallocated without
 //!     their destructor being called. (<code>[VecDeque]\<T></code> has no pinning projections, so this
 //!     does not cause unsoundness.)
 //! 4.  You must not offer any other operations that could lead to data being moved out of

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -349,29 +349,29 @@
 //! mutable reference even when you just have <code>[Pin]<[&mut] Self></code> (such as in your own
 //! [`poll`] implementation).
 //!
-//! [Deref]: crate::ops::Deref
-//! [`Deref`]: crate::ops::Deref
-//! [Target]: crate::ops::Deref::Target
-//! [`DerefMut`]: crate::ops::DerefMut
-//! [`mem::swap`]: crate::mem::swap
-//! [`mem::forget`]: crate::mem::forget
-//! [Vec]: ../../std/vec/struct.Vec.html
-//! [`Vec::set_len`]: ../../std/vec/struct.Vec.html#method.set_len
-//! [Box]: ../../std/boxed/struct.Box.html
-//! [Vec::pop]: ../../std/vec/struct.Vec.html#method.pop
-//! [Vec::push]: ../../std/vec/struct.Vec.html#method.push
-//! [Rc]: ../../std/rc/struct.Rc.html
-//! [RefCell]: crate::cell::RefCell
-//! [`drop`]: Drop::drop
-//! [VecDeque]: ../../std/collections/struct.VecDeque.html
-//! [`ptr::write`]: crate::ptr::write
-//! [`Future`]: crate::future::Future
+//! [Deref]: crate::ops::Deref "ops::Deref"
+//! [`Deref`]: crate::ops::Deref "ops::Deref"
+//! [Target]: crate::ops::Deref::Target "ops::Deref::Target"
+//! [`DerefMut`]: crate::ops::DerefMut "ops::DerefMut"
+//! [`mem::swap`]: crate::mem::swap "mem::swap"
+//! [`mem::forget`]: crate::mem::forget "mem::forget"
+//! [Vec]: ../../std/vec/struct.Vec.html "Vec"
+//! [`Vec::set_len`]: ../../std/vec/struct.Vec.html#method.set_len "Vec::set_len"
+//! [Box]: ../../std/boxed/struct.Box.html "Box"
+//! [Vec::pop]: ../../std/vec/struct.Vec.html#method.pop "Vec::pop"
+//! [Vec::push]: ../../std/vec/struct.Vec.html#method.push "Vec::push"
+//! [Rc]: ../../std/rc/struct.Rc.html "rc::Rc"
+//! [RefCell]: crate::cell::RefCell "cell::RefCell"
+//! [`drop`]: Drop::drop "Drop::drop"
+//! [VecDeque]: ../../std/collections/struct.VecDeque.html "collections::VecDeque"
+//! [`ptr::write`]: crate::ptr::write "ptr::write"
+//! [`Future`]: crate::future::Future "future::Future"
 //! [drop-impl]: #drop-implementation
 //! [drop-guarantee]: #drop-guarantee
-//! [`poll`]: crate::future::Future::poll
-//! [&]: ../../std/primitive.reference.html
-//! [&mut]: ../../std/primitive.reference.html
-//! [`unsafe`]: ../../std/keyword.unsafe.html
+//! [`poll`]: crate::future::Future::poll "future::Future::poll"
+//! [&]: ../../std/primitive.reference.html "shared reference"
+//! [&mut]: ../../std/primitive.reference.html "mutable reference"
+//! [`unsafe`]: ../../std/keyword.unsafe.html "keyword unsafe"
 
 #![stable(feature = "pin", since = "1.33.0")]
 

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -14,13 +14,15 @@
 //! for more details.
 //!
 //! By default, all types in Rust are movable. Rust allows passing all types by-value,
-//! and common smart-pointer types such as <code>[Box]\<T></code> and <code>[&mut] T</code> allow replacing and
-//! moving the values they contain: you can move out of a <code>[Box]\<T></code>, or you can use [`mem::swap`].
-//! <code>[Pin]\<P></code> wraps a pointer type `P`, so <code>[Pin]<[Box]\<T>></code> functions much like a regular
-//! <code>[Box]\<T></code>: when a <code>[Pin]<[Box]\<T>></code> gets dropped, so do its contents, and the memory gets
-//! deallocated. Similarly, <code>[Pin]<[&mut] T></code> is a lot like <code>[&mut] T</code>. However, <code>[Pin]\<P></code> does
-//! not let clients actually obtain a <code>[Box]\<T></code> or <code>[&mut] T</code> to pinned data, which implies that you
-//! cannot use operations such as [`mem::swap`]:
+//! and common smart-pointer types such as <code>[Box]\<T></code> and <code>[&mut] T</code> allow
+//! replacing and moving the values they contain: you can move out of a <code>[Box]\<T></code>,
+//! or you can use [`mem::swap`]. <code>[Pin]\<P></code> wraps a pointer type `P`, so
+//! <code>[Pin]<[Box]\<T>></code> functions much like a regular <code>[Box]\<T></code>:
+//! when a <code>[Pin]<[Box]\<T>></code> gets dropped, so do its contents, and the memory gets
+//! deallocated. Similarly, <code>[Pin]<[&mut] T></code> is a lot like <code>[&mut] T</code>.
+//! However, <code>[Pin]\<P></code> does not let clients actually obtain a <code>[Box]\<T></code>
+//! or <code>[&mut] T</code> to pinned data, which implies that you cannot use operations such
+//! as [`mem::swap`]:
 //!
 //! ```
 //! use std::pin::Pin;
@@ -32,17 +34,17 @@
 //! }
 //! ```
 //!
-//! It is worth reiterating that <code>[Pin]\<P></code> does *not* change the fact that a Rust compiler
-//! considers all types movable. [`mem::swap`] remains callable for any `T`. Instead, <code>[Pin]\<P></code>
-//! prevents certain *values* (pointed to by pointers wrapped in <code>[Pin]\<P></code>) from being
-//! moved by making it impossible to call methods that require <code>[&mut] T</code> on them
-//! (like [`mem::swap`]).
+//! It is worth reiterating that <code>[Pin]\<P></code> does *not* change the fact that a Rust
+//! compiler considers all types movable. [`mem::swap`] remains callable for any `T`. Instead,
+//! <code>[Pin]\<P></code> prevents certain *values* (pointed to by pointers wrapped in
+//! <code>[Pin]\<P></code>) from being moved by making it impossible to call methods that require
+//! <code>[&mut] T</code> on them (like [`mem::swap`]).
 //!
 //! <code>[Pin]\<P></code> can be used to wrap any pointer type `P`, and as such it interacts with
-//! [`Deref`] and [`DerefMut`]. A <code>[Pin]\<P></code> where <code>P: [Deref]</code> should be considered
-//! as a "`P`-style pointer" to a pinned <code>P::[Target]</code> – so, a <code>[Pin]<[Box]\<T>></code> is
-//! an owned pointer to a pinned `T`, and a <code>[Pin]<[Rc]\<T>></code> is a reference-counted
-//! pointer to a pinned `T`.
+//! [`Deref`] and [`DerefMut`]. A <code>[Pin]\<P></code> where <code>P: [Deref]</code> should be
+//! considered as a "`P`-style pointer" to a pinned <code>P::[Target]</code> – so, a
+//! <code>[Pin]<[Box]\<T>></code> is an owned pointer to a pinned `T`, and a
+//! <code>[Pin]<[Rc]\<T>></code> is a reference-counted pointer to a pinned `T`.
 //! For correctness, <code>[Pin]\<P></code> relies on the implementations of [`Deref`] and
 //! [`DerefMut`] not to move out of their `self` parameter, and only ever to
 //! return a pointer to pinned data when they are called on a pinned pointer.
@@ -54,13 +56,13 @@
 //! [`bool`], [`i32`], and references) as well as types consisting solely of these
 //! types. Types that do not care about pinning implement the [`Unpin`]
 //! auto-trait, which cancels the effect of <code>[Pin]\<P></code>. For <code>T: [Unpin]</code>,
-//! <code>[Pin]<[Box]\<T>></code> and <code>[Box]\<T></code> function identically, as do <code>[Pin]<[&mut] T></code> and
-//! <code>[&mut] T</code>.
+//! <code>[Pin]<[Box]\<T>></code> and <code>[Box]\<T></code> function identically, as do
+//! <code>[Pin]<[&mut] T></code> and <code>[&mut] T</code>.
 //!
-//! Note that pinning and [`Unpin`] only affect the pointed-to type <code>P::[Target]</code>, not the pointer
-//! type `P` itself that got wrapped in <code>[Pin]\<P></code>. For example, whether or not <code>[Box]\<T></code> is
-//! [`Unpin`] has no effect on the behavior of <code>[Pin]<[Box]\<T>></code> (here, `T` is the
-//! pointed-to type).
+//! Note that pinning and [`Unpin`] only affect the pointed-to type <code>P::[Target]</code>,
+//! not the pointer type `P` itself that got wrapped in <code>[Pin]\<P></code>. For example,
+//! whether or not <code>[Box]\<T></code> is [`Unpin`] has no effect on the behavior of
+//! <code>[Pin]<[Box]\<T>></code> (here, `T` is the pointed-to type).
 //!
 //! # Example: self-referential struct
 //!
@@ -149,8 +151,8 @@
 //! when [`drop`] is called*.  Only once [`drop`] returns or panics, the memory may be reused.
 //!
 //! Memory can be "invalidated" by deallocation, but also by
-//! replacing a <code>[Some]\(v)</code> by [`None`], or calling [`Vec::set_len`] to "kill" some elements
-//! off of a vector. It can be repurposed by using [`ptr::write`] to overwrite it without
+//! replacing a <code>[Some]\(v)</code> by [`None`], or calling [`Vec::set_len`] to "kill" some
+//! elements off of a vector. It can be repurposed by using [`ptr::write`] to overwrite it without
 //! calling the destructor first. None of this is allowed for pinned data without calling [`drop`].
 //!
 //! This is exactly the kind of guarantee that the intrusive linked list from the previous
@@ -172,8 +174,8 @@
 //! This can never cause a problem in safe code because implementing a type that
 //! relies on pinning requires unsafe code, but be aware that deciding to make
 //! use of pinning in your type (for example by implementing some operation on
-//! <code>[Pin]<[&]Self></code> or <code>[Pin]<[&mut] Self></code>) has consequences for your [`Drop`][Drop]
-//! implementation as well: if an element of your type could have been pinned,
+//! <code>[Pin]<[&]Self></code> or <code>[Pin]<[&mut] Self></code>) has consequences for your
+//! [`Drop`][Drop]implementation as well: if an element of your type could have been pinned,
 //! you must treat [`Drop`][Drop] as implicitly taking <code>[Pin]<[&mut] Self></code>.
 //!
 //! For example, you could implement [`Drop`][Drop] as follows:
@@ -206,16 +208,16 @@
 //! When working with pinned structs, the question arises how one can access the
 //! fields of that struct in a method that takes just <code>[Pin]<[&mut] Struct></code>.
 //! The usual approach is to write helper methods (so called *projections*)
-//! that turn <code>[Pin]<[&mut] Struct></code> into a reference to the field, but what
-//! type should that reference have? Is it <code>[Pin]<[&mut] Field></code> or <code>[&mut] Field</code>?
+//! that turn <code>[Pin]<[&mut] Struct></code> into a reference to the field, but what type should
+//! that reference have? Is it <code>[Pin]<[&mut] Field></code> or <code>[&mut] Field</code>?
 //! The same question arises with the fields of an `enum`, and also when considering
-//! container/wrapper types such as <code>[Vec]\<T></code>, <code>[Box]\<T></code>, or <code>[RefCell]\<T></code>.
-//! (This question applies to both mutable and shared references, we just
-//! use the more common case of mutable references here for illustration.)
+//! container/wrapper types such as <code>[Vec]\<T></code>, <code>[Box]\<T></code>,
+//! or <code>[RefCell]\<T></code>. (This question applies to both mutable and shared references,
+//! we just use the more common case of mutable references here for illustration.)
 //!
-//! It turns out that it is actually up to the author of the data structure
-//! to decide whether the pinned projection for a particular field turns
-//! <code>[Pin]<[&mut] Struct></code> into <code>[Pin]<[&mut] Field></code> or <code>[&mut] Field</code>. There are some
+//! It turns out that it is actually up to the author of the data structure to decide whether
+//! the pinned projection for a particular field turns <code>[Pin]<[&mut] Struct></code>
+//! into <code>[Pin]<[&mut] Field></code> or <code>[&mut] Field</code>. There are some
 //! constraints though, and the most important constraint is *consistency*:
 //! every field can be *either* projected to a pinned reference, *or* have
 //! pinning removed as part of the projection. If both are done for the same field,
@@ -283,19 +285,20 @@
 //!     the principle that you only have to worry about any of this if you use [`unsafe`].)
 //! 2.  The destructor of the struct must not move structural fields out of its argument. This
 //!     is the exact point that was raised in the [previous section][drop-impl]: [`drop`] takes
-//!     <code>[&mut] self</code>, but the struct (and hence its fields) might have been pinned before.
-//!     You have to guarantee that you do not move a field inside your [`Drop`][Drop] implementation.
-//!     In particular, as explained previously, this means that your struct must *not*
-//!     be `#[repr(packed)]`.
+//!     <code>[&mut] self</code>, but the struct (and hence its fields) might have been pinned
+//!     before. You have to guarantee that you do not move a field inside your [`Drop`][Drop]
+//!     implementation. In particular, as explained previously, this means that your struct
+//!     must *not* be `#[repr(packed)]`.
 //!     See that section for how to write [`drop`] in a way that the compiler can help you
 //!     not accidentally break pinning.
 //! 3.  You must make sure that you uphold the [`Drop` guarantee][drop-guarantee]:
 //!     once your struct is pinned, the memory that contains the
 //!     content is not overwritten or deallocated without calling the content's destructors.
-//!     This can be tricky, as witnessed by <code>[VecDeque]\<T></code>: the destructor of <code>[VecDeque]\<T></code>
-//!     can fail to call [`drop`] on all elements if one of the destructors panics. This violates
-//!     the [`Drop`][Drop] guarantee, because it can lead to elements being deallocated without
-//!     their destructor being called. (<code>[VecDeque]\<T></code> has no pinning projections, so this
+//!     This can be tricky, as witnessed by <code>[VecDeque]\<T></code>: the destructor of
+//!     <code>[VecDeque]\<T></code> can fail to call [`drop`] on all elements if one of the
+//!     destructors panics. This violates the [`Drop`][Drop] guarantee, because it can lead to
+//!     elements being deallocated without their destructor being called.
+//!     (<code>[VecDeque]\<T></code> has no pinning projections, so this
 //!     does not cause unsoundness.)
 //! 4.  You must not offer any other operations that could lead to data being moved out of
 //!     the structural fields when your type is pinned. For example, if the struct contains an
@@ -304,8 +307,9 @@
 //!     that operation can be used to move a `T` out of a pinned `Struct<T>` – which means
 //!     pinning cannot be structural for the field holding this data.
 //!
-//!     For a more complex example of moving data out of a pinned type, imagine if <code>[RefCell]\<T></code>
-//!     had a method <code>fn get_pin_mut(self: [Pin]<[&mut] Self>) -> [Pin]<[&mut] T></code>.
+//!     For a more complex example of moving data out of a pinned type,
+//!     imagine if <code>[RefCell]\<T></code> had a method
+//!     <code>fn get_pin_mut(self: [Pin]<[&mut] Self>) -> [Pin]<[&mut] T></code>.
 //!     Then we could do the following:
 //!     ```compile_fail
 //!     fn exploit_ref_cell<T>(rc: Pin<&mut RefCell<T>>) {
@@ -315,31 +319,33 @@
 //!         let content = &mut *b; // And here we have `&mut T` to the same data.
 //!     }
 //!     ```
-//!     This is catastrophic, it means we can first pin the content of the <code>[RefCell]\<T></code>
-//!     (using <code>[RefCell]::get_pin_mut</code>) and then move that content using the mutable
-//!     reference we got later.
+//!     This is catastrophic, it means we can first pin the content of the
+//!     <code>[RefCell]\<T></code> (using <code>[RefCell]::get_pin_mut</code>) and then move that
+//!     content using the mutable reference we got later.
 //!
 //! ## Examples
 //!
-//! For a type like <code>[Vec]\<T></code>, both possibilities (structural pinning or not) make sense.
-//! A <code>[Vec]\<T></code> with structural pinning could have `get_pin`/`get_pin_mut` methods to get
-//! pinned references to elements. However, it could *not* allow calling
-//! [`pop`][Vec::pop] on a pinned <code>[Vec]\<T></code> because that would move the (structurally pinned)
-//! contents! Nor could it allow [`push`][Vec::push], which might reallocate and thus also move the
-//! contents.
+//! For a type like <code>[Vec]\<T></code>, both possibilities (structural pinning or not) make
+//! sense. A <code>[Vec]\<T></code> with structural pinning could have `get_pin`/`get_pin_mut`
+//! methods to get pinned references to elements. However, it could *not* allow calling
+//! [`pop`][Vec::pop] on a pinned <code>[Vec]\<T></code> because that would move the (structurally
+//! pinned) contents! Nor could it allow [`push`][Vec::push], which might reallocate and thus also
+//! move the contents.
 //!
-//! A <code>[Vec]\<T></code> without structural pinning could <code>impl\<T> [Unpin] for [Vec]\<T></code>, because the contents
-//! are never pinned and the <code>[Vec]\<T></code> itself is fine with being moved as well.
+//! A <code>[Vec]\<T></code> without structural pinning could
+//! <code>impl\<T> [Unpin] for [Vec]\<T></code>, because the contents are never pinned
+//! and the <code>[Vec]\<T></code> itself is fine with being moved as well.
 //! At that point pinning just has no effect on the vector at all.
 //!
 //! In the standard library, pointer types generally do not have structural pinning,
-//! and thus they do not offer pinning projections. This is why <code>[Box]\<T>: [Unpin]</code> holds for all `T`.
-//! It makes sense to do this for pointer types, because moving the <code>[Box]\<T></code>
-//! does not actually move the `T`: the <code>[Box]\<T></code> can be freely movable (aka [`Unpin`]) even if
-//! the `T` is not. In fact, even <code>[Pin]<[Box]\<T>></code> and <code>[Pin]<[&mut] T></code> are always
-//! [`Unpin`] themselves, for the same reason: their contents (the `T`) are pinned, but the
-//! pointers themselves can be moved without moving the pinned data. For both <code>[Box]\<T></code> and
-//! <code>[Pin]<[Box]\<T>></code>, whether the content is pinned is entirely independent of whether the
+//! and thus they do not offer pinning projections. This is why <code>[Box]\<T>: [Unpin]</code>
+//! holds for all `T`. It makes sense to do this for pointer types, because moving the
+//! <code>[Box]\<T></code> does not actually move the `T`: the <code>[Box]\<T></code> can be freely
+//! movable (aka [`Unpin`]) even if the `T` is not. In fact, even <code>[Pin]<[Box]\<T>></code> and
+//! <code>[Pin]<[&mut] T></code> are always [`Unpin`] themselves, for the same reason:
+//! their contents (the `T`) are pinned, but the pointers themselves can be moved without moving
+//! the pinned data. For both <code>[Box]\<T></code> and <code>[Pin]<[Box]\<T>></code>,
+//! whether the content is pinned is entirely independent of whether the
 //! pointer is pinned, meaning pinning is *not* structural.
 //!
 //! When implementing a [`Future`] combinator, you will usually need structural pinning

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -6,7 +6,7 @@
 //! as moving an object with pointers to itself will invalidate them, which could cause undefined
 //! behavior.
 //!
-//! At a high level, a [`Pin<P>`] ensures that the pointee of any pointer type
+//! At a high level, a <code>[Pin]\<P></code> ensures that the pointee of any pointer type
 //! `P` has a stable location in memory, meaning it cannot be moved elsewhere
 //! and its memory cannot be deallocated until it gets dropped. We say that the
 //! pointee is "pinned". Things get more subtle when discussing types that
@@ -14,12 +14,12 @@
 //! for more details.
 //!
 //! By default, all types in Rust are movable. Rust allows passing all types by-value,
-//! and common smart-pointer types such as [`Box<T>`] and `&mut T` allow replacing and
-//! moving the values they contain: you can move out of a [`Box<T>`], or you can use [`mem::swap`].
-//! [`Pin<P>`] wraps a pointer type `P`, so <code>[Pin]<[Box]\<T>></code> functions much like a regular
-//! [`Box<T>`]: when a <code>[Pin]<[Box]\<T>></code> gets dropped, so do its contents, and the memory gets
-//! deallocated. Similarly, <code>[Pin]<&mut T></code> is a lot like `&mut T`. However, [`Pin<P>`] does
-//! not let clients actually obtain a [`Box<T>`] or `&mut T` to pinned data, which implies that you
+//! and common smart-pointer types such as <code>[Box]\<T></code> and `&mut T` allow replacing and
+//! moving the values they contain: you can move out of a <code>[Box]\<T></code>, or you can use [`mem::swap`].
+//! <code>[Pin]\<P></code> wraps a pointer type `P`, so <code>[Pin]<[Box]\<T>></code> functions much like a regular
+//! <code>[Box]\<T></code>: when a <code>[Pin]<[Box]\<T>></code> gets dropped, so do its contents, and the memory gets
+//! deallocated. Similarly, <code>[Pin]<&mut T></code> is a lot like `&mut T`. However, <code>[Pin]\<P></code> does
+//! not let clients actually obtain a <code>[Box]\<T></code> or `&mut T` to pinned data, which implies that you
 //! cannot use operations such as [`mem::swap`]:
 //!
 //! ```
@@ -32,18 +32,18 @@
 //! }
 //! ```
 //!
-//! It is worth reiterating that [`Pin<P>`] does *not* change the fact that a Rust compiler
-//! considers all types movable. [`mem::swap`] remains callable for any `T`. Instead, [`Pin<P>`]
-//! prevents certain *values* (pointed to by pointers wrapped in [`Pin<P>`]) from being
+//! It is worth reiterating that <code>[Pin]\<P></code> does *not* change the fact that a Rust compiler
+//! considers all types movable. [`mem::swap`] remains callable for any `T`. Instead, <code>[Pin]\<P></code>
+//! prevents certain *values* (pointed to by pointers wrapped in <code>[Pin]\<P></code>) from being
 //! moved by making it impossible to call methods that require `&mut T` on them
 //! (like [`mem::swap`]).
 //!
-//! [`Pin<P>`] can be used to wrap any pointer type `P`, and as such it interacts with
-//! [`Deref`] and [`DerefMut`]. A [`Pin<P>`] where `P: Deref` should be considered
+//! <code>[Pin]\<P></code> can be used to wrap any pointer type `P`, and as such it interacts with
+//! [`Deref`] and [`DerefMut`]. A <code>[Pin]\<P></code> where `P: Deref` should be considered
 //! as a "`P`-style pointer" to a pinned `P::Target` -- so, a <code>[Pin]<[Box]\<T>></code> is
 //! an owned pointer to a pinned `T`, and a <code>[Pin]<[Rc]\<T>></code> is a reference-counted
 //! pointer to a pinned `T`.
-//! For correctness, [`Pin<P>`] relies on the implementations of [`Deref`] and
+//! For correctness, <code>[Pin]\<P></code> relies on the implementations of [`Deref`] and
 //! [`DerefMut`] not to move out of their `self` parameter, and only ever to
 //! return a pointer to pinned data when they are called on a pinned pointer.
 //!
@@ -53,12 +53,12 @@
 //! rely on having a stable address. This includes all the basic types (like
 //! [`bool`], [`i32`], and references) as well as types consisting solely of these
 //! types. Types that do not care about pinning implement the [`Unpin`]
-//! auto-trait, which cancels the effect of [`Pin<P>`]. For `T: Unpin`,
-//! <code>[Pin]<[Box]\<T>></code> and [`Box<T>`] function identically, as do <code>[Pin]<&mut T></code> and
+//! auto-trait, which cancels the effect of <code>[Pin]\<P></code>. For `T: Unpin`,
+//! <code>[Pin]<[Box]\<T>></code> and <code>[Box]\<T></code> function identically, as do <code>[Pin]<&mut T></code> and
 //! `&mut T`.
 //!
 //! Note that pinning and [`Unpin`] only affect the pointed-to type `P::Target`, not the pointer
-//! type `P` itself that got wrapped in [`Pin<P>`]. For example, whether or not [`Box<T>`] is
+//! type `P` itself that got wrapped in <code>[Pin]\<P></code>. For example, whether or not <code>[Box]\<T></code> is
 //! [`Unpin`] has no effect on the behavior of <code>[Pin]<[Box]\<T>></code> (here, `T` is the
 //! pointed-to type).
 //!
@@ -149,7 +149,7 @@
 //! when [`drop`] is called*.  Only once [`drop`] returns or panics, the memory may be reused.
 //!
 //! Memory can be "invalidated" by deallocation, but also by
-//! replacing a [`Some(v)`] by [`None`], or calling [`Vec::set_len`] to "kill" some elements
+//! replacing a <code>[Some]\(v)</code> by [`None`], or calling [`Vec::set_len`] to "kill" some elements
 //! off of a vector. It can be repurposed by using [`ptr::write`] to overwrite it without
 //! calling the destructor first. None of this is allowed for pinned data without calling [`drop`].
 //!
@@ -209,7 +209,7 @@
 //! that turn <code>[Pin]<&mut Struct></code> into a reference to the field, but what
 //! type should that reference have? Is it <code>[Pin]<&mut Field></code> or `&mut Field`?
 //! The same question arises with the fields of an `enum`, and also when considering
-//! container/wrapper types such as [`Vec<T>`], [`Box<T>`], or [`RefCell<T>`].
+//! container/wrapper types such as <code>[Vec]\<T></code>, <code>[Box]\<T></code>, or <code>[RefCell]\<T></code>.
 //! (This question applies to both mutable and shared references, we just
 //! use the more common case of mutable references here for illustration.)
 //!
@@ -292,19 +292,19 @@
 //! 3.  You must make sure that you uphold the [`Drop` guarantee][drop-guarantee]:
 //!     once your struct is pinned, the memory that contains the
 //!     content is not overwritten or deallocated without calling the content's destructors.
-//!     This can be tricky, as witnessed by [`VecDeque<T>`]: the destructor of [`VecDeque<T>`]
+//!     This can be tricky, as witnessed by <code>[VecDeque]\<T></code>: the destructor of <code>[VecDeque]\<T></code>
 //!     can fail to call [`drop`] on all elements if one of the destructors panics. This violates
 //!     the [`Drop`] guarantee, because it can lead to elements being deallocated without
-//!     their destructor being called. ([`VecDeque<T>`] has no pinning projections, so this
+//!     their destructor being called. (<code>[VecDeque]\<T></code> has no pinning projections, so this
 //!     does not cause unsoundness.)
 //! 4.  You must not offer any other operations that could lead to data being moved out of
 //!     the structural fields when your type is pinned. For example, if the struct contains an
-//!     [`Option<T>`] and there is a `take`-like operation with type
+//!     <code>[Option]\<T></code> and there is a `take`-like operation with type
 //!     `fn(Pin<&mut Struct<T>>) -> Option<T>`,
 //!     that operation can be used to move a `T` out of a pinned `Struct<T>` -- which means
 //!     pinning cannot be structural for the field holding this data.
 //!
-//!     For a more complex example of moving data out of a pinned type, imagine if [`RefCell<T>`]
+//!     For a more complex example of moving data out of a pinned type, imagine if <code>[RefCell]\<T></code>
 //!     had a method `fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T>`.
 //!     Then we could do the following:
 //!     ```compile_fail
@@ -315,30 +315,30 @@
 //!         let content = &mut *b; // And here we have `&mut T` to the same data.
 //!     }
 //!     ```
-//!     This is catastrophic, it means we can first pin the content of the [`RefCell<T>`]
+//!     This is catastrophic, it means we can first pin the content of the <code>[RefCell]\<T></code>
 //!     (using `RefCell::get_pin_mut`) and then move that content using the mutable
 //!     reference we got later.
 //!
 //! ## Examples
 //!
-//! For a type like [`Vec<T>`], both possibilities (structural pinning or not) make sense.
-//! A [`Vec<T>`] with structural pinning could have `get_pin`/`get_pin_mut` methods to get
+//! For a type like <code>[Vec]\<T></code>, both possibilities (structural pinning or not) make sense.
+//! A <code>[Vec]\<T></code> with structural pinning could have `get_pin`/`get_pin_mut` methods to get
 //! pinned references to elements. However, it could *not* allow calling
-//! [`pop`][Vec::pop] on a pinned [`Vec<T>`] because that would move the (structurally pinned)
+//! [`pop`][Vec::pop] on a pinned <code>[Vec]\<T></code> because that would move the (structurally pinned)
 //! contents! Nor could it allow [`push`][Vec::push], which might reallocate and thus also move the
 //! contents.
 //!
-//! A [`Vec<T>`] without structural pinning could `impl<T> Unpin for Vec<T>`, because the contents
-//! are never pinned and the [`Vec<T>`] itself is fine with being moved as well.
+//! A <code>[Vec]\<T></code> without structural pinning could `impl<T> Unpin for Vec<T>`, because the contents
+//! are never pinned and the <code>[Vec]\<T></code> itself is fine with being moved as well.
 //! At that point pinning just has no effect on the vector at all.
 //!
 //! In the standard library, pointer types generally do not have structural pinning,
 //! and thus they do not offer pinning projections. This is why `Box<T>: Unpin` holds for all `T`.
 //! It makes sense to do this for pointer types, because moving the `Box<T>`
-//! does not actually move the `T`: the [`Box<T>`] can be freely movable (aka `Unpin`) even if
+//! does not actually move the `T`: the <code>[Box]\<T></code> can be freely movable (aka `Unpin`) even if
 //! the `T` is not. In fact, even <code>[Pin]<[Box]\<T>></code> and <code>[Pin]<&mut T></code> are always
 //! [`Unpin`] themselves, for the same reason: their contents (the `T`) are pinned, but the
-//! pointers themselves can be moved without moving the pinned data. For both [`Box<T>`] and
+//! pointers themselves can be moved without moving the pinned data. For both <code>[Box]\<T></code> and
 //! <code>[Pin]<[Box]\<T>></code>, whether the content is pinned is entirely independent of whether the
 //! pointer is pinned, meaning pinning is *not* structural.
 //!
@@ -353,17 +353,15 @@
 //! [`DerefMut`]: crate::ops::DerefMut
 //! [`mem::swap`]: crate::mem::swap
 //! [`mem::forget`]: crate::mem::forget
-//! [`Box<T>`]: ../../std/boxed/struct.Box.html
-//! [`Vec<T>`]: ../../std/vec/struct.Vec.html
+//! [Vec]: ../../std/vec/struct.Vec.html
 //! [`Vec::set_len`]: ../../std/vec/struct.Vec.html#method.set_len
 //! [Box]: ../../std/boxed/struct.Box.html
 //! [Vec::pop]: ../../std/vec/struct.Vec.html#method.pop
 //! [Vec::push]: ../../std/vec/struct.Vec.html#method.push
 //! [Rc]: ../../std/rc/struct.Rc.html
-//! [`RefCell<T>`]: crate::cell::RefCell
+//! [RefCell]: crate::cell::RefCell
 //! [`drop`]: Drop::drop
-//! [`VecDeque<T>`]: ../../std/collections/struct.VecDeque.html
-//! [`Some(v)`]: Some
+//! [VecDeque]: ../../std/collections/struct.VecDeque.html
 //! [`ptr::write`]: crate::ptr::write
 //! [`Future`]: crate::future::Future
 //! [drop-impl]: #drop-implementation

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -16,9 +16,9 @@
 //! By default, all types in Rust are movable. Rust allows passing all types by-value,
 //! and common smart-pointer types such as [`Box<T>`] and `&mut T` allow replacing and
 //! moving the values they contain: you can move out of a [`Box<T>`], or you can use [`mem::swap`].
-//! [`Pin<P>`] wraps a pointer type `P`, so [`Pin`]`<`[`Box`]`<T>>` functions much like a regular
-//! [`Box<T>`]: when a [`Pin`]`<`[`Box`]`<T>>` gets dropped, so do its contents, and the memory gets
-//! deallocated. Similarly, [`Pin`]`<&mut T>` is a lot like `&mut T`. However, [`Pin<P>`] does
+//! [`Pin<P>`] wraps a pointer type `P`, so <code>[Pin]<[Box]\<T>></code> functions much like a regular
+//! [`Box<T>`]: when a <code>[Pin]<[Box]\<T>></code> gets dropped, so do its contents, and the memory gets
+//! deallocated. Similarly, <code>[Pin]<&mut T></code> is a lot like `&mut T`. However, [`Pin<P>`] does
 //! not let clients actually obtain a [`Box<T>`] or `&mut T` to pinned data, which implies that you
 //! cannot use operations such as [`mem::swap`]:
 //!
@@ -40,8 +40,8 @@
 //!
 //! [`Pin<P>`] can be used to wrap any pointer type `P`, and as such it interacts with
 //! [`Deref`] and [`DerefMut`]. A [`Pin<P>`] where `P: Deref` should be considered
-//! as a "`P`-style pointer" to a pinned `P::Target` -- so, a [`Pin`]`<`[`Box`]`<T>>` is
-//! an owned pointer to a pinned `T`, and a [`Pin`]`<`[`Rc`]`<T>>` is a reference-counted
+//! as a "`P`-style pointer" to a pinned `P::Target` -- so, a <code>[Pin]<[Box]\<T>></code> is
+//! an owned pointer to a pinned `T`, and a <code>[Pin]<[Rc]\<T>></code> is a reference-counted
 //! pointer to a pinned `T`.
 //! For correctness, [`Pin<P>`] relies on the implementations of [`Deref`] and
 //! [`DerefMut`] not to move out of their `self` parameter, and only ever to
@@ -54,12 +54,12 @@
 //! [`bool`], [`i32`], and references) as well as types consisting solely of these
 //! types. Types that do not care about pinning implement the [`Unpin`]
 //! auto-trait, which cancels the effect of [`Pin<P>`]. For `T: Unpin`,
-//! [`Pin`]`<`[`Box`]`<T>>` and [`Box<T>`] function identically, as do [`Pin`]`<&mut T>` and
+//! <code>[Pin]<[Box]\<T>></code> and [`Box<T>`] function identically, as do <code>[Pin]<&mut T></code> and
 //! `&mut T`.
 //!
 //! Note that pinning and [`Unpin`] only affect the pointed-to type `P::Target`, not the pointer
 //! type `P` itself that got wrapped in [`Pin<P>`]. For example, whether or not [`Box<T>`] is
-//! [`Unpin`] has no effect on the behavior of [`Pin`]`<`[`Box`]`<T>>` (here, `T` is the
+//! [`Unpin`] has no effect on the behavior of <code>[Pin]<[Box]\<T>></code> (here, `T` is the
 //! pointed-to type).
 //!
 //! # Example: self-referential struct
@@ -158,7 +158,7 @@
 //!
 //! Notice that this guarantee does *not* mean that memory does not leak! It is still
 //! completely okay not ever to call [`drop`] on a pinned element (e.g., you can still
-//! call [`mem::forget`] on a [`Pin`]`<`[`Box`]`<T>>`). In the example of the doubly-linked
+//! call [`mem::forget`] on a <code>[Pin]<[Box]\<T>></code>). In the example of the doubly-linked
 //! list, that element would just stay in the list. However you may not free or reuse the storage
 //! *without calling [`drop`]*.
 //!
@@ -172,9 +172,9 @@
 //! This can never cause a problem in safe code because implementing a type that
 //! relies on pinning requires unsafe code, but be aware that deciding to make
 //! use of pinning in your type (for example by implementing some operation on
-//! [`Pin`]`<&Self>` or [`Pin`]`<&mut Self>`) has consequences for your [`Drop`]
+//! <code>[Pin]<&Self></code> or <code>[Pin]<&mut Self></code>) has consequences for your [`Drop`]
 //! implementation as well: if an element of your type could have been pinned,
-//! you must treat [`Drop`] as implicitly taking [`Pin`]`<&mut Self>`.
+//! you must treat [`Drop`] as implicitly taking <code>[Pin]<&mut Self></code>.
 //!
 //! For example, you could implement `Drop` as follows:
 //!
@@ -204,10 +204,10 @@
 //! # Projections and Structural Pinning
 //!
 //! When working with pinned structs, the question arises how one can access the
-//! fields of that struct in a method that takes just [`Pin`]`<&mut Struct>`.
+//! fields of that struct in a method that takes just <code>[Pin]<&mut Struct></code>.
 //! The usual approach is to write helper methods (so called *projections*)
-//! that turn [`Pin`]`<&mut Struct>` into a reference to the field, but what
-//! type should that reference have? Is it [`Pin`]`<&mut Field>` or `&mut Field`?
+//! that turn <code>[Pin]<&mut Struct></code> into a reference to the field, but what
+//! type should that reference have? Is it <code>[Pin]<&mut Field></code> or `&mut Field`?
 //! The same question arises with the fields of an `enum`, and also when considering
 //! container/wrapper types such as [`Vec<T>`], [`Box<T>`], or [`RefCell<T>`].
 //! (This question applies to both mutable and shared references, we just
@@ -215,7 +215,7 @@
 //!
 //! It turns out that it is actually up to the author of the data structure
 //! to decide whether the pinned projection for a particular field turns
-//! [`Pin`]`<&mut Struct>` into [`Pin`]`<&mut Field>` or `&mut Field`. There are some
+//! <code>[Pin]<&mut Struct></code> into <code>[Pin]<&mut Field></code> or `&mut Field`. There are some
 //! constraints though, and the most important constraint is *consistency*:
 //! every field can be *either* projected to a pinned reference, *or* have
 //! pinning removed as part of the projection. If both are done for the same field,
@@ -230,12 +230,12 @@
 //! ## Pinning *is not* structural for `field`
 //!
 //! It may seem counter-intuitive that the field of a pinned struct might not be pinned,
-//! but that is actually the easiest choice: if a [`Pin`]`<&mut Field>` is never created,
+//! but that is actually the easiest choice: if a <code>[Pin]<&mut Field></code> is never created,
 //! nothing can go wrong! So, if you decide that some field does not have structural pinning,
 //! all you have to ensure is that you never create a pinned reference to that field.
 //!
 //! Fields without structural pinning may have a projection method that turns
-//! [`Pin`]`<&mut Struct>` into `&mut Field`:
+//! <code>[Pin]<&mut Struct></code> into `&mut Field`:
 //!
 //! ```rust,no_run
 //! # use std::pin::Pin;
@@ -251,14 +251,14 @@
 //!
 //! You may also `impl Unpin for Struct` *even if* the type of `field`
 //! is not [`Unpin`]. What that type thinks about pinning is not relevant
-//! when no [`Pin`]`<&mut Field>` is ever created.
+//! when no <code>[Pin]<&mut Field></code> is ever created.
 //!
 //! ## Pinning *is* structural for `field`
 //!
 //! The other option is to decide that pinning is "structural" for `field`,
 //! meaning that if the struct is pinned then so is the field.
 //!
-//! This allows writing a projection that creates a [`Pin`]`<&mut Field>`, thus
+//! This allows writing a projection that creates a <code>[Pin]<&mut Field></code>, thus
 //! witnessing that the field is pinned:
 //!
 //! ```rust,no_run
@@ -336,17 +336,17 @@
 //! and thus they do not offer pinning projections. This is why `Box<T>: Unpin` holds for all `T`.
 //! It makes sense to do this for pointer types, because moving the `Box<T>`
 //! does not actually move the `T`: the [`Box<T>`] can be freely movable (aka `Unpin`) even if
-//! the `T` is not. In fact, even [`Pin`]`<`[`Box`]`<T>>` and [`Pin`]`<&mut T>` are always
+//! the `T` is not. In fact, even <code>[Pin]<[Box]\<T>></code> and <code>[Pin]<&mut T></code> are always
 //! [`Unpin`] themselves, for the same reason: their contents (the `T`) are pinned, but the
 //! pointers themselves can be moved without moving the pinned data. For both [`Box<T>`] and
-//! [`Pin`]`<`[`Box`]`<T>>`, whether the content is pinned is entirely independent of whether the
+//! <code>[Pin]<[Box]\<T>></code>, whether the content is pinned is entirely independent of whether the
 //! pointer is pinned, meaning pinning is *not* structural.
 //!
 //! When implementing a [`Future`] combinator, you will usually need structural pinning
 //! for the nested futures, as you need to get pinned references to them to call [`poll`].
 //! But if your combinator contains any other data that does not need to be pinned,
 //! you can make those fields not structural and hence freely access them with a
-//! mutable reference even when you just have [`Pin`]`<&mut Self>` (such as in your own
+//! mutable reference even when you just have <code>[Pin]<&mut Self></code> (such as in your own
 //! [`poll`] implementation).
 //!
 //! [`Deref`]: crate::ops::Deref
@@ -356,10 +356,10 @@
 //! [`Box<T>`]: ../../std/boxed/struct.Box.html
 //! [`Vec<T>`]: ../../std/vec/struct.Vec.html
 //! [`Vec::set_len`]: ../../std/vec/struct.Vec.html#method.set_len
-//! [`Box`]: ../../std/boxed/struct.Box.html
+//! [Box]: ../../std/boxed/struct.Box.html
 //! [Vec::pop]: ../../std/vec/struct.Vec.html#method.pop
 //! [Vec::push]: ../../std/vec/struct.Vec.html#method.push
-//! [`Rc`]: ../../std/rc/struct.Rc.html
+//! [Rc]: ../../std/rc/struct.Rc.html
 //! [`RefCell<T>`]: crate::cell::RefCell
 //! [`drop`]: Drop::drop
 //! [`VecDeque<T>`]: ../../std/collections/struct.VecDeque.html


### PR DESCRIPTION
## Context

So I recently opened #80720. That PR uses HTML-based `<code>foo</code>` syntax in place of `` `foo` `` for some inline code. It looks like usage of `<code>` tags in doc comments is without precedent in the standard library, but the HTML-based syntax has an important advantage:

You can write something like
```
<code>[Box]<[Option]\<T>></code>
```
which becomes: <code>[Box]<[Option]\<T>></code>, whereas with ordinary backtick syntax, you cannot create links for a substring of an inline code block.

## Problem
I recalled (from my own experience) that a way to partially work around this limitation is to do something like
```
[`Box`]`<`[`Option`]`<T>>`
```
which looks like this: [`Box`]`<`[`Option`]`<T>>` _(admitted, it looks even worse on GitHub than in `rustdoc`’s CSS)_.

[Box]: https://doc.rust-lang.org/std/boxed/struct.Box.html "Box"
[`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html "Box"
[Option]: https://doc.rust-lang.org/std/option/enum.Option.html "Option"
[`Option`]: https://doc.rust-lang.org/std/option/enum.Option.html "Option"
[Pin]: https://doc.rust-lang.org/std/pin/struct.Pin.html "Pin"
[&mut]: https://doc.rust-lang.org/std/primitive.reference.html "mutable reference"

So I searched the standard library and found that e.g. the [std::pin](https://doc.rust-lang.org/std/pin/index.html) module documentation uses this hack/workaround quite a bit, with types like <code>[Pin]<[Box]\<T>></code> or <code>[Pin]<[&mut] T>></code>. Although the way they look like in this sentence is what I would like them to look like, not what they currently look.

### Status Quo

Here’s a screenshot of what it currently looks like:
![Screenshot_20210105_202751](https://user-images.githubusercontent.com/3986214/103692608-4a978780-4f98-11eb-9451-e13622b2e3c0.png)

With a few HTML-style code blocks, we can fix all the spacing issues in the above screenshot that are due usage of this hack/workaround of putting multiple code blocks right next to each other being used.

### after d3915c555ee016b11ce288e107e46dbab9f78c4f:
![Screenshot_20210105_202932](https://user-images.githubusercontent.com/3986214/103692688-6f8bfa80-4f98-11eb-9be5-9b370eaef644.png)

There’s still a problem of inconsistency. Especially in a sentence such as
> A [`Pin<P>`][Pin] where `P: Deref` should be considered as a "`P`-style pointer" to _[...]_

looks weird with the variable `P` having different colors (and `Deref` has a different color from before where it was a link, too). Or compare the difference of <code>[Pin]<[Box]\<T>></code> vs [`Box<T>`][Box] where one time the variable is part of the link and the other time it isn’t.

_Note: Color differences show even **more strongly** when the ayu theme is used, while they are a bit less prominent in the light theme than they are in the dark theme, which is the one used for these screenshots._

This is why I’ve added the next commit
### after ceaeb249a3813a78bd81fa3890e27e8843a58262
![Screenshot_20210105_203113](https://user-images.githubusercontent.com/3986214/103693496-ab738f80-4f99-11eb-942d-29dace459734.png)
pulling all the type parameters out of their links, and also the last commit with clearly visible changes
### after 87ac118ba3d0c8268e043fadbd63b51e06904795
![Screenshot_20210105_203252](https://user-images.githubusercontent.com/3986214/103693625-e5dd2c80-4f99-11eb-91b7-470c37934e7e.png)
where more links are added, removing e.g. the inconsistency with `Deref`’s color in e.g. `P: Deref` that I already mentioned above.

## Discussion

I am aware that this PR may very well be overkill. If for now only the first commit (plus the fix for the `Drop` link in e65385fbfa72995b27ec64aa54f330cf503dfc03, the link titles 684edf7a70d2e90466ae74e7a321670259bf3fd9 as far as they apply, and a few of the line-break changes) are wanted, I can reduce this PR to just those changes. I personally find the rendered result with all these changes very nice though. On the other hand, all these `<code>` tags are not very nice in the source code, I’ll admit.

Perhaps alternative solutions could be preferred, such as `rustdoc` support for merging subsequent inline code blocks so that all the cases that currently use workarounds rendered as [`Box`]`<`[`Option`]`<T>>` automatically become <code>[Box]<[Option]\<T>></code> without any need for further changes. Even in this case, having a properly formatted, better looking example in the standard library docs could help motivate such a change to `rustdoc` by prodiving an example of the expected results and also the already existing alternative (i.e. using `<code>`). On the other hand, `` [`Box`]`<`[`Option`]`<T>>` `` isn’t particularly nice-looking source code either. I’m not even sure if I wouldn’t actually find the version `<code>[Box]<[Option]\<T>></code>` cleaner to read.

@rustbot modify labels: T-doc, T-rustdoc