### PR TITLE
Remove bottom margin from crate version when the docs sidebar is collapsed

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1412,6 +1412,7 @@ h4 > .notable-traits {
 	.sidebar > .block.version {
 		border-bottom: none;
 		margin-top: 12px;
+		margin-bottom: 0;
 	}
 
 	nav.sub {


### PR DESCRIPTION
This fixes a mobile UI bug where a vertical scrollbar would always be
rendered on the sidebar nav when the menu was closed.  When opened, the overflow would be handled by the opened sidebar, causing the scrollbar to disappear, and the contents to shift to the right.

## Firefox
**Before**
![before-ff](https://user-images.githubusercontent.com/139487/103713599-c2f74c00-4f8a-11eb-88c0-d5c6c088f8a0.png)
![before](https://user-images.githubusercontent.com/139487/103713793-2bdec400-4f8b-11eb-8223-94b77cc05f71.gif)


**After**
![after-ff](https://user-images.githubusercontent.com/139487/103713605-c8ed2d00-4f8a-11eb-9ee8-f86cafaa8775.png)
![after](https://user-images.githubusercontent.com/139487/103713805-31d4a500-4f8b-11eb-9e5b-4156402ca43e.gif)


## Chrome
**Before**
![localhost_8000_unicode_xid_ (1)](https://user-images.githubusercontent.com/139487/103713626-d60a1c00-4f8a-11eb-8605-cc98e04e9ad0.png)

**After**
![localhost_8000_unicode_xid_](https://user-images.githubusercontent.com/139487/103713622-d1456800-4f8a-11eb-8c66-7d19f81614ca.png)
