### PR TITLE
Deprecate std::path::Path's aliases of `std::fs` functions.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -496,11 +496,8 @@ fn thin_lto(
             // If the previous file was deleted, or we get an IO error
             // reading the file, then we'll just use `None` as the
             // prev_key_map, which will force the code to be recompiled.
-            let prev = if fs::metadata(&path).is_ok() {
-                ThinLTOKeysMap::load_from_file(&path).ok()
-            } else {
-                None
-            };
+            let prev =
+                if fs::exists(&path) { ThinLTOKeysMap::load_from_file(&path).ok() } else { None };
             let curr = ThinLTOKeysMap::from_thin_lto_modules(&data, &thin_modules, &module_names);
             (Some(path), prev, curr)
         } else {

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -22,7 +22,7 @@ use rustc_session::config::{self, CrateType, Lto};
 use tracing::{debug, info};
 
 use std::ffi::{CStr, CString};
-use std::fs::File;
+use std::fs::{self, File};
 use std::io;
 use std::path::Path;
 use std::ptr;
@@ -496,8 +496,11 @@ fn thin_lto(
             // If the previous file was deleted, or we get an IO error
             // reading the file, then we'll just use `None` as the
             // prev_key_map, which will force the code to be recompiled.
-            let prev =
-                if path.exists() { ThinLTOKeysMap::load_from_file(&path).ok() } else { None };
+            let prev = if fs::metadata(&path).is_ok() {
+                ThinLTOKeysMap::load_from_file(&path).ok()
+            } else {
+                None
+            };
             let curr = ThinLTOKeysMap::from_thin_lto_modules(&data, &thin_modules, &module_names);
             (Some(path), prev, curr)
         } else {

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -15,12 +15,12 @@ pub fn find_library(name: Symbol, search_paths: &[PathBuf], sess: &Session) -> P
     for path in search_paths {
         debug!("looking for {} inside {:?}", name, path);
         let test = path.join(&oslibname);
-        if fs::metadata(&test).is_ok() {
+        if fs::exists(&test) {
             return test;
         }
         if oslibname != unixlibname {
             let test = path.join(&unixlibname);
-            if fs::metadata(&test).is_ok() {
+            if fs::exists(&test) {
                 return test;
             }
         }

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -1,6 +1,7 @@
 use rustc_session::Session;
 use rustc_span::symbol::Symbol;
 
+use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -14,12 +15,12 @@ pub fn find_library(name: Symbol, search_paths: &[PathBuf], sess: &Session) -> P
     for path in search_paths {
         debug!("looking for {} inside {:?}", name, path);
         let test = path.join(&oslibname);
-        if test.exists() {
+        if fs::metadata(&test).is_ok() {
             return test;
         }
         if oslibname != unixlibname {
             let test = path.join(&unixlibname);
-            if test.exists() {
+            if fs::metadata(&test).is_ok() {
                 return test;
             }
         }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1110,19 +1110,19 @@ fn print_native_static_libs(sess: &Session, all_native_libs: &[NativeLib]) {
 fn get_object_file_path(sess: &Session, name: &str, self_contained: bool) -> PathBuf {
     let fs = sess.target_filesearch(PathKind::Native);
     let file_path = fs.get_lib_path().join(name);
-    if fs::metadata(&file_path).is_ok() {
+    if fs::exists(&file_path) {
         return file_path;
     }
     // Special directory with objects used only in self-contained linkage mode
     if self_contained {
         let file_path = fs.get_self_contained_lib_path().join(name);
-        if fs::metadata(&file_path).is_ok() {
+        if fs::exists(&file_path) {
             return file_path;
         }
     }
     for search_path in fs.search_paths() {
         let file_path = search_path.dir.join(name);
-        if fs::metadata(&file_path).is_ok() {
+        if fs::exists(&file_path) {
             return file_path;
         }
     }
@@ -1312,9 +1312,7 @@ fn detect_self_contained_mingw(sess: &Session) -> bool {
     for dir in env::split_paths(&env::var_os("PATH").unwrap_or_default()) {
         let full_path = dir.join(&linker_with_extension);
         // If linker comes from sysroot assume self-contained mode
-        if fs::metadata(&full_path).map(|m| m.is_file()).unwrap_or(false)
-            && !full_path.starts_with(&sess.sysroot)
-        {
+        if fs::is_file(&full_path) && !full_path.starts_with(&sess.sysroot) {
             return false;
         }
     }
@@ -2230,7 +2228,7 @@ fn get_apple_sdk_root(sdk_name: &str) -> Result<String, String> {
                 if sdkroot.contains("iPhoneOS.platform")
                     || sdkroot.contains("iPhoneSimulator.platform") => {}
             // Ignore `SDKROOT` if it's not a valid path.
-            _ if !p.is_absolute() || p == Path::new("/") || fs::metadata(p).is_err() => {}
+            _ if !p.is_absolute() || p == Path::new("/") || !fs::exists(p) => {}
             _ => return Ok(sdkroot),
         }
     }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -695,7 +695,7 @@ impl<'a> Linker for MsvcLinker<'a> {
         // check to see if the file is there and just omit linking to it if it's
         // not present.
         let name = format!("{}.dll.lib", lib);
-        if fs::metadata(&path.join(&name)).is_ok() {
+        if fs::exists(&path.join(&name)) {
             self.cmd.arg(name);
         }
     }

--- a/compiler/rustc_fs_util/src/lib.rs
+++ b/compiler/rustc_fs_util/src/lib.rs
@@ -62,8 +62,10 @@ pub enum LinkOrCopy {
 pub fn link_or_copy<P: AsRef<Path>, Q: AsRef<Path>>(p: P, q: Q) -> io::Result<LinkOrCopy> {
     let p = p.as_ref();
     let q = q.as_ref();
-    if q.exists() {
-        fs::remove_file(&q)?;
+    match fs::remove_file(&q) {
+        Ok(()) => (),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => (),
+        Err(err) => return Err(err),
     }
 
     match fs::hard_link(p, q) {

--- a/compiler/rustc_incremental/src/persist/file_format.rs
+++ b/compiler/rustc_incremental/src/persist/file_format.rs
@@ -52,11 +52,11 @@ pub fn read_file(
     path: &Path,
     nightly_build: bool,
 ) -> io::Result<Option<(Vec<u8>, usize)>> {
-    if !path.exists() {
-        return Ok(None);
-    }
-
-    let data = fs::read(path)?;
+    let data = match fs::read(path) {
+        Ok(data) => data,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
 
     let mut file = io::Cursor::new(data);
 

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -8,6 +8,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_serialize::opaque::Decoder;
 use rustc_serialize::Decodable as RustcDecodable;
 use rustc_session::Session;
+use std::fs;
 use std::path::Path;
 
 use super::data::*;
@@ -142,7 +143,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
                 let mut all_files_exist = true;
                 if let Some(ref file_name) = swp.work_product.saved_file {
                     let path = in_incr_comp_dir_sess(sess, file_name);
-                    if !path.exists() {
+                    if fs::metadata(&path).is_err() {
                         all_files_exist = false;
 
                         if sess.opts.debugging_opts.incremental_info {

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -143,7 +143,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
                 let mut all_files_exist = true;
                 if let Some(ref file_name) = swp.work_product.saved_file {
                     let path = in_incr_comp_dir_sess(sess, file_name);
-                    if fs::metadata(&path).is_err() {
+                    if !fs::exists(&path) {
                         all_files_exist = false;
 
                         if sess.opts.debugging_opts.incremental_info {

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -74,7 +74,7 @@ pub fn save_work_product_index(
         if !new_work_products.contains_key(id) {
             work_product::delete_workproduct_files(sess, wp);
             debug_assert!(wp.saved_file.as_ref().map_or(true, |file_name| {
-                fs::metadata(in_incr_comp_dir_sess(sess, &file_name)).is_err()
+                !fs::exists(in_incr_comp_dir_sess(sess, &file_name))
             }));
         }
     }
@@ -85,7 +85,7 @@ pub fn save_work_product_index(
             .iter()
             .flat_map(|(_, wp)| wp.saved_file.iter())
             .map(|name| in_incr_comp_dir_sess(sess, name))
-            .all(|path| fs::metadata(path).is_ok())
+            .all(|path| fs::exists(path))
     });
 }
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -517,9 +517,7 @@ fn output_contains_path(output_paths: &[PathBuf], input_path: &PathBuf) -> bool 
 }
 
 fn output_conflicts_with_dir(output_paths: &[PathBuf]) -> Option<PathBuf> {
-    let check = |output_path: &PathBuf| {
-        fs::metadata(output_path).map(|m| m.is_dir()).unwrap_or(false).then(|| output_path.clone())
-    };
+    let check = |output_path: &PathBuf| fs::is_dir(output_path).then(|| output_path.clone());
     check_output(output_paths, check)
 }
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -506,18 +506,20 @@ where
 }
 
 fn output_contains_path(output_paths: &[PathBuf], input_path: &PathBuf) -> bool {
-    let input_path = input_path.canonicalize().ok();
+    let input_path = fs::canonicalize(input_path).ok();
     if input_path.is_none() {
         return false;
     }
     let check = |output_path: &PathBuf| {
-        if output_path.canonicalize().ok() == input_path { Some(()) } else { None }
+        if fs::canonicalize(output_path).ok() == input_path { Some(()) } else { None }
     };
     check_output(output_paths, check).is_some()
 }
 
 fn output_conflicts_with_dir(output_paths: &[PathBuf]) -> Option<PathBuf> {
-    let check = |output_path: &PathBuf| output_path.is_dir().then(|| output_path.clone());
+    let check = |output_path: &PathBuf| {
+        fs::metadata(output_path).map(|m| m.is_dir()).unwrap_or(false).then(|| output_path.clone())
+    };
     check_output(output_paths, check)
 }
 

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -270,7 +270,7 @@ fn get_rustc_path_inner(bin_path: &str) -> Option<PathBuf> {
         } else {
             "rustc"
         });
-        fs::metadata(&candidate).is_ok().then_some(candidate)
+        fs::exists(&candidate).then_some(candidate)
     })
 }
 
@@ -398,7 +398,7 @@ pub fn get_codegen_sysroot(backend_name: &str) -> fn() -> Box<dyn CodegenBackend
         })
         .find(|f| {
             info!("codegen backend candidate: {}", f.display());
-            fs::metadata(f).is_ok()
+            fs::exists(f)
         });
     let sysroot = sysroot.unwrap_or_else(|| {
         let candidates = sysroot_candidates

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -205,7 +206,7 @@ fn main() {
             stripped
         } else if let Some(stripped) = lib.strip_prefix('-') {
             stripped
-        } else if Path::new(lib).exists() {
+        } else if fs::metadata(Path::new(lib)).is_ok() {
             // On MSVC llvm-config will print the full name to libraries, but
             // we're only interested in the name part
             let name = Path::new(lib).file_name().unwrap().to_str().unwrap();

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -206,7 +206,7 @@ fn main() {
             stripped
         } else if let Some(stripped) = lib.strip_prefix('-') {
             stripped
-        } else if fs::metadata(Path::new(lib)).is_ok() {
+        } else if fs::exists(Path::new(lib)) {
             // On MSVC llvm-config will print the full name to libraries, but
             // we're only interested in the name part
             let name = Path::new(lib).file_name().unwrap().to_str().unwrap();

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -591,7 +591,7 @@ impl<'a> CrateLocator<'a> {
             // as well.
             if let Some((prev, _)) = &ret {
                 let sysroot = &self.sess.sysroot;
-                let sysroot = sysroot.canonicalize().unwrap_or_else(|_| sysroot.to_path_buf());
+                let sysroot = fs::canonicalize(sysroot).unwrap_or_else(|_| sysroot.to_path_buf());
                 if prev.starts_with(&sysroot) {
                     continue;
                 }
@@ -664,7 +664,7 @@ impl<'a> CrateLocator<'a> {
         let mut rmetas = FxHashMap::default();
         let mut dylibs = FxHashMap::default();
         for loc in &self.exact_paths {
-            if !loc.exists() {
+            if fs::metadata(loc).is_err() {
                 return Err(CrateError::ExternLocationNotExist(self.crate_name, loc.clone()));
             }
             let file = match loc.file_name().and_then(|s| s.to_str()) {
@@ -738,7 +738,7 @@ fn get_metadata_section(
     filename: &Path,
     loader: &dyn MetadataLoader,
 ) -> Result<MetadataBlob, String> {
-    if !filename.exists() {
+    if fs::metadata(filename).is_err() {
         return Err(format!("no such file: '{}'", filename.display()));
     }
     let raw_bytes: MetadataRef = match flavor {

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -664,7 +664,7 @@ impl<'a> CrateLocator<'a> {
         let mut rmetas = FxHashMap::default();
         let mut dylibs = FxHashMap::default();
         for loc in &self.exact_paths {
-            if fs::metadata(loc).is_err() {
+            if !fs::exists(loc) {
                 return Err(CrateError::ExternLocationNotExist(self.crate_name, loc.clone()));
             }
             let file = match loc.file_name().and_then(|s| s.to_str()) {
@@ -738,7 +738,7 @@ fn get_metadata_section(
     filename: &Path,
     loader: &dyn MetadataLoader,
 ) -> Result<MetadataBlob, String> {
-    if fs::metadata(filename).is_err() {
+    if !fs::exists(filename) {
         return Err(format!("no such file: '{}'", filename.display()));
     }
     let raw_bytes: MetadataRef = match flavor {

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -154,7 +154,7 @@ fn find_libdir(sysroot: &Path) -> Cow<'static, str> {
 
     match option_env!("CFG_LIBDIR_RELATIVE") {
         None | Some("lib") => {
-            if sysroot.join(PRIMARY_LIB_DIR).join(RUST_LIB_DIR).exists() {
+            if fs::metadata(sysroot.join(PRIMARY_LIB_DIR).join(RUST_LIB_DIR)).is_ok() {
                 PRIMARY_LIB_DIR.into()
             } else {
                 SECONDARY_LIB_DIR.into()

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -154,7 +154,7 @@ fn find_libdir(sysroot: &Path) -> Cow<'static, str> {
 
     match option_env!("CFG_LIBDIR_RELATIVE") {
         None | Some("lib") => {
-            if fs::metadata(sysroot.join(PRIMARY_LIB_DIR).join(RUST_LIB_DIR)).is_ok() {
+            if fs::exists(sysroot.join(PRIMARY_LIB_DIR).join(RUST_LIB_DIR)) {
                 PRIMARY_LIB_DIR.into()
             } else {
                 SECONDARY_LIB_DIR.into()

--- a/compiler/rustc_session/src/output.rs
+++ b/compiler/rustc_session/src/output.rs
@@ -4,6 +4,7 @@ use crate::Session;
 use rustc_ast as ast;
 use rustc_span::symbol::sym;
 use rustc_span::Span;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 pub fn out_filename(
@@ -39,7 +40,7 @@ pub fn check_file_is_writeable(file: &Path, sess: &Session) {
 }
 
 fn is_writeable(p: &Path) -> bool {
-    match p.metadata() {
+    match fs::metadata(p) {
         Err(..) => true,
         Ok(m) => !m.permissions().readonly(),
     }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1485,7 +1485,7 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
     // Make sure that any given profiling data actually exists so LLVM can't
     // decide to silently skip PGO.
     if let Some(ref path) = sess.opts.cg.profile_use {
-        if fs::metadata(path).is_err() {
+        if !fs::exists(path) {
             sess.err(&format!(
                 "File `{}` passed to `-C profile-use` does not exist.",
                 path.display()

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -109,7 +109,7 @@ pub struct RealFileLoader;
 
 impl FileLoader for RealFileLoader {
     fn file_exists(&self, path: &Path) -> bool {
-        fs::metadata(path).is_ok()
+        fs::exists(path)
     }
 
     fn read_file(&self, path: &Path) -> io::Result<String> {

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1600,14 +1600,14 @@ impl Target {
 
                 for dir in env::split_paths(&target_path) {
                     let p = dir.join(&path);
-                    if p.is_file() {
+                    if fs::metadata(&p).map(|m| m.is_file()).unwrap_or(false) {
                         return load_file(&p);
                     }
                 }
                 Err(format!("Could not find specification for target {:?}", target_triple))
             }
             TargetTriple::TargetPath(ref target_path) => {
-                if target_path.is_file() {
+                if fs::metadata(target_path).map(|m| m.is_file()).unwrap_or(false) {
                     return load_file(&target_path);
                 }
                 Err(format!("Target path {:?} is not a valid file", target_path))
@@ -1796,7 +1796,7 @@ impl TargetTriple {
 
     /// Creates a target triple from the passed target path.
     pub fn from_path(path: &Path) -> Result<Self, io::Error> {
-        let canonicalized_path = path.canonicalize()?;
+        let canonicalized_path = std::fs::canonicalize(path)?;
         Ok(TargetTriple::TargetPath(canonicalized_path))
     }
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1600,14 +1600,14 @@ impl Target {
 
                 for dir in env::split_paths(&target_path) {
                     let p = dir.join(&path);
-                    if fs::metadata(&p).map(|m| m.is_file()).unwrap_or(false) {
+                    if fs::is_file(&p) {
                         return load_file(&p);
                     }
                 }
                 Err(format!("Could not find specification for target {:?}", target_triple))
             }
             TargetTriple::TargetPath(ref target_path) => {
-                if fs::metadata(target_path).map(|m| m.is_file()).unwrap_or(false) {
+                if fs::is_file(target_path) {
                     return load_file(&target_path);
                 }
                 Err(format!("Target path {:?} is not a valid file", target_path))

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2179,7 +2179,7 @@ impl DirBuilder {
         match self.inner.mkdir(path) {
             Ok(()) => return Ok(()),
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
-            Err(_) if path.is_dir() => return Ok(()),
+            Err(_) if metadata(path).map(|m| m.is_dir()).unwrap_or(false) => return Ok(()),
             Err(e) => return Err(e),
         }
         match path.parent() {
@@ -2190,7 +2190,7 @@ impl DirBuilder {
         }
         match self.inner.mkdir(path) {
             Ok(()) => Ok(()),
-            Err(_) if path.is_dir() => Ok(()),
+            Err(_) if metadata(path).map(|m| m.is_dir()).unwrap_or(false) => Ok(()),
             Err(e) => Err(e),
         }
     }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2419,6 +2419,8 @@ impl Path {
     /// If you cannot access the directory containing the file, e.g., because of a
     /// permission error, this will return `false`.
     ///
+    /// This is an alias to [`fs::exists`].
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -2434,10 +2436,10 @@ impl Path {
     #[rustc_deprecated(
         since = "1.51.0",
         reason = "other processes may remove or rename files at any time",
-        suggestion = "use `std::fs::metadata`"
+        suggestion = "use `std::fs::exists`"
     )]
     pub fn exists(&self) -> bool {
-        fs::metadata(self).is_ok()
+        fs::exists(self)
     }
 
     /// Returns `true` if the path exists on disk and is pointing at a regular file.
@@ -2456,6 +2458,8 @@ impl Path {
     /// assert_eq!(Path::new("a_file.txt").is_file(), true);
     /// ```
     ///
+    /// This is an alias to [`fs::is_file`].
+    ///
     /// # See Also
     ///
     /// This is a convenience function that coerces errors to false. If you want to
@@ -2471,10 +2475,10 @@ impl Path {
     #[rustc_deprecated(
         since = "1.51.0",
         reason = "other processes may remove, rename, or replace files at any time",
-        suggestion = "use `std::fs::File::open` or `std::fs::metadata`"
+        suggestion = "use `std::fs::File::open` or `std::fs::is_file`"
     )]
     pub fn is_file(&self) -> bool {
-        fs::metadata(self).map(|m| m.is_file()).unwrap_or(false)
+        fs::is_file(self)
     }
 
     /// Returns `true` if the path exists on disk and is pointing at a directory.
@@ -2484,6 +2488,8 @@ impl Path {
     ///
     /// If you cannot access the directory containing the file, e.g., because of a
     /// permission error, this will return `false`.
+    ///
+    /// This is an alias to [`fs::is_dir`].
     ///
     /// # Examples
     ///
@@ -2506,10 +2512,10 @@ impl Path {
     #[rustc_deprecated(
         since = "1.51.0",
         reason = "other processes may remove, rename, or replace directories at any time",
-        suggestion = "use `std::fs::read_dir` or `std::fs::metadata`"
+        suggestion = "use `std::fs::read_dir` or `std::fs::is_dir`"
     )]
     pub fn is_dir(&self) -> bool {
-        fs::metadata(self).map(|m| m.is_dir()).unwrap_or(false)
+        fs::is_dir(self)
     }
 
     /// Converts a [`Box<Path>`](Box) into a [`PathBuf`] without copying or

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2307,7 +2307,7 @@ impl Path {
     #[stable(feature = "path_ext", since = "1.5.0")]
     #[rustc_deprecated(
         since = "1.51.0",
-        reason = "the `std::fs::metadata` function is now preferred",
+        reason = "use `std::fs::metadata` instead",
         suggestion = "std::fs::metadata"
     )]
     pub fn metadata(&self) -> io::Result<fs::Metadata> {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2330,7 +2330,7 @@ impl Path {
     #[stable(feature = "path_ext", since = "1.5.0")]
     #[rustc_deprecated(
         since = "1.51.0",
-        reason = "the `std::fs::symlink_metadata` function is now preferred",
+        reason = "use `std::fs::symlink_metadata` instead",
         suggestion = "std::fs::symlink_metadata"
     )]
     pub fn symlink_metadata(&self) -> io::Result<fs::Metadata> {
@@ -2353,7 +2353,7 @@ impl Path {
     #[stable(feature = "path_ext", since = "1.5.0")]
     #[rustc_deprecated(
         since = "1.51.0",
-        reason = "the `std::fs::canonicalize` function is now preferred",
+        reason = "use `std::fs::canonicalize` instead",
         suggestion = "std::fs::canonicalize"
     )]
     pub fn canonicalize(&self) -> io::Result<PathBuf> {
@@ -2375,7 +2375,7 @@ impl Path {
     #[stable(feature = "path_ext", since = "1.5.0")]
     #[rustc_deprecated(
         since = "1.51.0",
-        reason = "the `std::fs::read_link` function is now preferred",
+        reason = "use `std::fs::read_link` instead",
         suggestion = "std::fs::read_link"
     )]
     pub fn read_link(&self) -> io::Result<PathBuf> {
@@ -2404,7 +2404,7 @@ impl Path {
     #[stable(feature = "path_ext", since = "1.5.0")]
     #[rustc_deprecated(
         since = "1.51.0",
-        reason = "the `std::fs::read_dir` function is now preferred",
+        reason = "use `std::fs::read_dir` instead",
         suggestion = "std::fs::read_dir"
     )]
     pub fn read_dir(&self) -> io::Result<fs::ReadDir> {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2305,6 +2305,11 @@ impl Path {
     /// println!("{:?}", metadata.file_type());
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "the `std::fs::metadata` function is now preferred",
+        suggestion = "std::fs::metadata"
+    )]
     pub fn metadata(&self) -> io::Result<fs::Metadata> {
         fs::metadata(self)
     }
@@ -2323,6 +2328,11 @@ impl Path {
     /// println!("{:?}", metadata.file_type());
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "the `std::fs::symlink_metadata` function is now preferred",
+        suggestion = "std::fs::symlink_metadata"
+    )]
     pub fn symlink_metadata(&self) -> io::Result<fs::Metadata> {
         fs::symlink_metadata(self)
     }
@@ -2341,6 +2351,11 @@ impl Path {
     /// assert_eq!(path.canonicalize().unwrap(), PathBuf::from("/foo/test/bar.rs"));
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "the `std::fs::canonicalize` function is now preferred",
+        suggestion = "std::fs::canonicalize"
+    )]
     pub fn canonicalize(&self) -> io::Result<PathBuf> {
         fs::canonicalize(self)
     }
@@ -2358,6 +2373,11 @@ impl Path {
     /// let path_link = path.read_link().expect("read_link call failed");
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "the `std::fs::read_link` function is now preferred",
+        suggestion = "std::fs::read_link"
+    )]
     pub fn read_link(&self) -> io::Result<PathBuf> {
         fs::read_link(self)
     }
@@ -2382,6 +2402,11 @@ impl Path {
     /// }
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "the `std::fs::read_dir` function is now preferred",
+        suggestion = "std::fs::read_dir"
+    )]
     pub fn read_dir(&self) -> io::Result<fs::ReadDir> {
         fs::read_dir(self)
     }
@@ -2406,6 +2431,11 @@ impl Path {
     /// This is a convenience function that coerces errors to false. If you want to
     /// check errors, call [`fs::metadata`].
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "other processes may remove or rename files at any time",
+        suggestion = "use `std::fs::metadata`"
+    )]
     pub fn exists(&self) -> bool {
         fs::metadata(self).is_ok()
     }
@@ -2438,6 +2468,11 @@ impl Path {
     /// a Unix-like system for example. See [`fs::File::open`] or
     /// [`fs::OpenOptions::open`] for more information.
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "other processes may remove, rename, or replace files at any time",
+        suggestion = "use `std::fs::File::open` or `std::fs::metadata`"
+    )]
     pub fn is_file(&self) -> bool {
         fs::metadata(self).map(|m| m.is_file()).unwrap_or(false)
     }
@@ -2463,7 +2498,16 @@ impl Path {
     /// This is a convenience function that coerces errors to false. If you want to
     /// check errors, call [`fs::metadata`] and handle its [`Result`]. Then call
     /// [`fs::Metadata::is_dir`] if it was [`Ok`].
+    ///
+    /// When the goal is simply to read from the source, the most reliable way to
+    /// test the source can be read is to open it. See [`fs::read_dir`] for more
+    /// information.
     #[stable(feature = "path_ext", since = "1.5.0")]
+    #[rustc_deprecated(
+        since = "1.51.0",
+        reason = "other processes may remove, rename, or replace directories at any time",
+        suggestion = "use `std::fs::read_dir` or `std::fs::metadata`"
+    )]
     pub fn is_dir(&self) -> bool {
         fs::metadata(self).map(|m| m.is_dir()).unwrap_or(false)
     }

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -168,7 +168,7 @@ impl Command {
                     let path = path
                         .join(self.program.to_str().unwrap())
                         .with_extension(env::consts::EXE_EXTENSION);
-                    if fs::metadata(&path).is_ok() {
+                    if fs::exists(&path) {
                         return Some(path.into_os_string());
                     }
                 }

--- a/library/std/src/sys_common/fs.rs
+++ b/library/std/src/sys_common/fs.rs
@@ -19,7 +19,7 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     let perm = reader.metadata()?.permissions();
 
     let ret = io::copy(&mut reader, &mut writer)?;
-    fs::set_permissions(to, perm)?;
+    writer.set_permissions(perm)?;
     Ok(ret)
 }
 

--- a/library/std/src/sys_common/fs.rs
+++ b/library/std/src/sys_common/fs.rs
@@ -5,14 +5,16 @@ use crate::io::{self, Error, ErrorKind};
 use crate::path::Path;
 
 pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
-    if !from.is_file() {
+    let mut reader = fs::File::open(from)?;
+    let metadata = reader.metadata()?;
+
+    if !metadata.is_file() {
         return Err(Error::new(
             ErrorKind::InvalidInput,
             "the source path is not an existing regular file",
         ));
     }
 
-    let mut reader = fs::File::open(from)?;
     let mut writer = fs::File::create(to)?;
     let perm = reader.metadata()?.permissions();
 

--- a/library/term/src/terminfo/searcher.rs
+++ b/library/term/src/terminfo/searcher.rs
@@ -47,10 +47,10 @@ pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
 
     // Look for the terminal in all of the search directories
     for mut p in dirs_to_search {
-        if fs::metadata(&p).is_ok() {
+        if fs::exists(&p) {
             p.push(&first_char.to_string());
             p.push(&term);
-            if fs::metadata(&p).is_ok() {
+            if fs::exists(&p) {
                 return Some(p);
             }
             p.pop();
@@ -60,7 +60,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
             // (e.g., macOS)
             p.push(&format!("{:x}", first_char as usize));
             p.push(term);
-            if fs::metadata(&p).is_ok() {
+            if fs::exists(&p) {
                 return Some(p);
             }
         }

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -171,10 +171,11 @@ pub fn mtime(path: &Path) -> SystemTime {
 ///
 /// Uses last-modified time checks to verify this.
 pub fn up_to_date(src: &Path, dst: &Path) -> bool {
-    if fs::metadata(dst).is_err() {
-        return false;
-    }
-    let threshold = mtime(dst);
+    let dst_meta = match fs::metadata(dst) {
+        Ok(meta) => meta,
+        Err(_) => return false,
+    };
+    let threshold = dst_meta.modified().unwrap_or(UNIX_EPOCH);
     let meta = match fs::metadata(src) {
         Ok(meta) => meta,
         Err(e) => panic!("source {:?} failed to get metadata: {}", src, e),

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -146,8 +146,7 @@ pub fn output(cmd: &mut Command) -> String {
 }
 
 pub fn rerun_if_changed_anything_in_dir(dir: &Path) {
-    let mut stack = dir
-        .read_dir()
+    let mut stack = fs::read_dir(dir)
         .unwrap()
         .map(|e| e.unwrap())
         .filter(|e| &*e.file_name() != ".git")
@@ -155,7 +154,7 @@ pub fn rerun_if_changed_anything_in_dir(dir: &Path) {
     while let Some(entry) = stack.pop() {
         let path = entry.path();
         if entry.file_type().unwrap().is_dir() {
-            stack.extend(path.read_dir().unwrap().map(|e| e.unwrap()));
+            stack.extend(fs::read_dir(path).unwrap().map(|e| e.unwrap()));
         } else {
             println!("cargo:rerun-if-changed={}", path.display());
         }
@@ -172,7 +171,7 @@ pub fn mtime(path: &Path) -> SystemTime {
 ///
 /// Uses last-modified time checks to verify this.
 pub fn up_to_date(src: &Path, dst: &Path) -> bool {
-    if !dst.exists() {
+    if fs::metadata(dst).is_err() {
         return false;
     }
     let threshold = mtime(dst);

--- a/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
+++ b/src/test/ui-fulldeps/mod_dir_path_canonicalized.rs
@@ -13,6 +13,7 @@ extern crate rustc_span;
 use rustc_parse::new_parser_from_file;
 use rustc_session::parse::ParseSess;
 use rustc_span::source_map::FilePathMapping;
+use std::fs;
 use std::path::Path;
 
 #[path = "mod_dir_simple/test.rs"]
@@ -28,7 +29,7 @@ fn parse() {
     let parse_session = ParseSess::new(FilePathMapping::empty());
 
     let path = Path::new(file!());
-    let path = path.canonicalize().unwrap();
+    let path = fs::canonicalize(path).unwrap();
     let mut parser = new_parser_from_file(&parse_session, &path, None);
     let _ = parser.parse_crate_mod();
 }

--- a/src/test/ui-fulldeps/rename-directory.rs
+++ b/src/test/ui-fulldeps/rename-directory.rs
@@ -23,8 +23,8 @@ fn rename_directory() {
     let new_path = tmpdir.join("quux/blat");
     fs::create_dir_all(&new_path).unwrap();
     fs::rename(&old_path, &new_path.join("newdir"));
-    assert!(new_path.join("newdir").is_dir());
-    assert!(new_path.join("newdir/temp.txt").exists());
+    assert!(fs::metadata(new_path.join("newdir")).map(|m| m.is_dir()).unwrap_or(false));
+    assert!(fs::metadata(new_path.join("newdir/temp.txt")).is_ok());
 }
 
 pub fn main() { rename_directory() }

--- a/src/test/ui-fulldeps/rename-directory.rs
+++ b/src/test/ui-fulldeps/rename-directory.rs
@@ -23,8 +23,8 @@ fn rename_directory() {
     let new_path = tmpdir.join("quux/blat");
     fs::create_dir_all(&new_path).unwrap();
     fs::rename(&old_path, &new_path.join("newdir"));
-    assert!(fs::metadata(new_path.join("newdir")).map(|m| m.is_dir()).unwrap_or(false));
-    assert!(fs::metadata(new_path.join("newdir/temp.txt")).is_ok());
+    assert!(fs::is_dir(new_path.join("newdir")));
+    assert!(fs::exists(new_path.join("newdir/temp.txt")));
 }
 
 pub fn main() { rename_directory() }


### PR DESCRIPTION
`std::path::Path` has several functions which are trivial aliases for `std::fs`
functions (eg. [`metadata`]) and a few which are minor convenience wrappers for
`std::fs` functions (eg. [`is_file`]).

[`metadata`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.metadata
[`is_file`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.is_file

This PR deprecates these functions, so that `std` only has one preferred name
for these operations. And it clarifies the role of the `std::path` module, which
otherwise just has pure data structures and algorithms.

~~The convenience wrappers, `is_file`, `is_dir`, and `exists`, are operations for
which seemingly obvious uses are prone to TOCTTOU errors. So while it would be
straightforward to add corresponding similar convenience functions to `std::fs`,
this PR does not propose doing so.~~

This PR also adds convenience functions `exists`, `is_file`, `is_dir`, to `std::fs`,
in a dedicated commit.

Specifically, this PR deprecates the 5 functions in `std::path::Path` which are
trivial aliases of functions in `std::fs`:
 - [`metadata`](https://doc.rust-lang.org/std/path/struct.Path.html#method.metadata)
 - [`symlink_metadata`](https://doc.rust-lang.org/std/path/struct.Path.html#method.symlink_metadata)
 - [`canonicalize`](https://doc.rust-lang.org/std/path/struct.Path.html#method.canonicalize)
 - [`read_link`](https://doc.rust-lang.org/std/path/struct.Path.html#method.read_link)
 - [`read_dir`](https://doc.rust-lang.org/std/path/struct.Path.html#method.read_dir)

and the 3 which are convenience wrappers around `std::fs::metadata`:
 - [`is_file`](https://doc.rust-lang.org/std/path/struct.Path.html#method.is_file)
 - [`is_dir`](https://doc.rust-lang.org/std/path/struct.Path.html#method.is_dir)
 - [`exists`](https://doc.rust-lang.org/std/path/struct.Path.html#method.exists)