### PR TITLE
Make target-cpu=native detect individual features

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -164,7 +164,8 @@ pub fn target_machine_factory(
 
     let code_model = to_llvm_code_model(sess.code_model());
 
-    let features = attributes::llvm_target_features(sess).collect::<Vec<_>>();
+    let mut features = llvm_util::handle_native_features(sess);
+    features.extend(attributes::llvm_target_features(sess).map(|s| s.to_owned()));
     let mut singlethread = sess.target.singlethread;
 
     // On the wasm target once the `atomics` feature is enabled that means that

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -12,7 +12,6 @@
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
 #![feature(or_patterns)]
-#![feature(stdsimd)]
 #![recursion_limit = "256"]
 
 use back::write::{create_informational_target_machine, create_target_machine};

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(in_band_lifetimes)]
 #![feature(nll)]
 #![feature(or_patterns)]
+#![feature(stdsimd)]
 #![recursion_limit = "256"]
 
 use back::write::{create_informational_target_machine, create_target_machine};

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1708,6 +1708,10 @@ extern "C" {
         PM: &PassManager<'_>,
     );
 
+    pub fn LLVMGetHostCPUFeatures() -> *mut c_char;
+
+    pub fn LLVMDisposeMessage(message: *mut c_char);
+
     // Stuff that's in llvm-wrapper/ because it's not upstream yet.
 
     /// Opens an object file.

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -8,9 +8,8 @@ use rustc_session::config::PrintRequest;
 use rustc_session::Session;
 use rustc_span::symbol::Symbol;
 use rustc_target::spec::{MergeFunctions, PanicStrategy};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 
-use std::detect;
 use std::slice;
 use std::str;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -223,19 +222,20 @@ pub fn target_cpu(sess: &Session) -> &str {
 }
 
 pub fn handle_native_features(sess: &Session) -> Vec<String> {
-    const LLVM_NOT_RECOGNIZED: &[&str] = &["tsc"];
-
     match sess.opts.cg.target_cpu {
         Some(ref s) => {
             if s != "native" {
                 return vec![];
             }
 
-            detect::features()
-                .map(|(feature, support)| (to_llvm_feature(sess, feature), support))
-                .filter(|(feature, _)| !LLVM_NOT_RECOGNIZED.contains(feature))
-                .map(|(feature, support)| (if support { "+" } else { "-" }).to_owned() + feature)
-                .collect()
+            let ptr = unsafe { llvm::LLVMGetHostCPUFeatures() };
+            let str = unsafe { CStr::from_ptr(ptr).to_string_lossy() };
+
+            let features = str.split(",").map(|s| s.to_owned()).collect();
+
+            unsafe { llvm::LLVMDisposeMessage(ptr) };
+
+            features
         }
         None => vec![],
     }


### PR DESCRIPTION
This PR makes target-cpu=native check for and enable/disable individual features instead of detecting and targeting a CPU by name. This brings the flag's behavior more in line with clang and gcc and ensures that the host actually supports each feature that we are compiling for. 

This should resolve issues with miscompilations on e.g. "Haswell" Pentiums and Celerons that lack support for AVX, and also enable support for `aes` on Broadwell processors that support it. It should also resolve issues with failing to detect feature support in newer CPUs that aren't yet known by LLVM (see: #80633).

Fixes #54688 
Fixes #48464
Fixes #38218