### PR TITLE
Simplify `up_to_date` to call `metadata` once.

### DIFF
--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -172,10 +172,11 @@ pub fn mtime(path: &Path) -> SystemTime {
 ///
 /// Uses last-modified time checks to verify this.
 pub fn up_to_date(src: &Path, dst: &Path) -> bool {
-    if !dst.exists() {
-        return false;
-    }
-    let threshold = mtime(dst);
+    let dst_meta = match fs::metadata(dst) {
+        Ok(meta) => meta,
+        Err(_) => return false,
+    };
+    let threshold = dst_meta.modified().unwrap_or(UNIX_EPOCH);
     let meta = match fs::metadata(src) {
         Ok(meta) => meta,
         Err(e) => panic!("source {:?} failed to get metadata: {}", src, e),


### PR DESCRIPTION
This also eliminates a use of a `Path` convenience function, in support
of #80741, refactoring `std::path` to focus on pure data structures and
algorithms.