### PR TITLE
resolve: Cleanup visibility resolution for enum variants and trait items

### DIFF
--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1398,10 +1398,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
             let parent = self.parent_scope.module;
             let expansion = self.parent_scope.expansion;
             let res = Res::Def(def_kind, def_id);
-            // FIXME: For historical reasons the binding visibility is set to public,
-            // use actual visibility here instead, using enum variants as an example.
-            let vis_hack = ty::Visibility::Public;
-            self.r.define(parent, item.ident, ns, (res, vis_hack, item.span, expansion));
+            self.r.define(parent, item.ident, ns, (res, vis, item.span, expansion));
         }
 
         visit::walk_assoc_item(self, item, ctxt);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -258,16 +258,16 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 Ok(ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX)))
             }
             ast::VisibilityKind::Inherited => {
-                if matches!(self.parent_scope.module.kind, ModuleKind::Def(DefKind::Enum, _, _)) {
-                    // Any inherited visibility resolved directly inside an enum
-                    // (e.g. variants or fields) inherits from the visibility of the enum.
-                    let parent_enum = self.parent_scope.module.def_id().unwrap().expect_local();
-                    Ok(self.r.visibilities[&parent_enum])
-                } else {
-                    // If it's not in an enum, its visibility is restricted to the `mod` item
-                    // that it's defined in.
-                    Ok(ty::Visibility::Restricted(self.parent_scope.module.nearest_parent_mod))
-                }
+                Ok(match self.parent_scope.module.kind {
+                    // Any inherited visibility resolved directly inside an enum or trait
+                    // (i.e. variants, fields, and trait items) inherits from the visibility
+                    // of the enum or trait.
+                    ModuleKind::Def(DefKind::Enum | DefKind::Trait, def_id, _) => {
+                        self.r.visibilities[&def_id.expect_local()]
+                    }
+                    // Otherwise, the visibility is restricted to the nearest parent `mod` item.
+                    _ => ty::Visibility::Restricted(self.parent_scope.module.nearest_parent_mod),
+                })
             }
             ast::VisibilityKind::Restricted { ref path, id, .. } => {
                 // For visibilities we are not ready to provide correct implementation of "uniform
@@ -1365,58 +1365,43 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
             return;
         }
 
+        let vis = self.resolve_visibility(&item.vis);
         let local_def_id = self.r.local_def_id(item.id);
         let def_id = local_def_id.to_def_id();
-        let vis = match ctxt {
-            AssocCtxt::Trait => {
-                let (def_kind, ns) = match item.kind {
-                    AssocItemKind::Const(..) => (DefKind::AssocConst, ValueNS),
-                    AssocItemKind::Fn(box FnKind(_, ref sig, _, _)) => {
-                        if sig.decl.has_self() {
-                            self.r.has_self.insert(def_id);
-                        }
-                        (DefKind::AssocFn, ValueNS)
-                    }
-                    AssocItemKind::TyAlias(..) => (DefKind::AssocTy, TypeNS),
-                    AssocItemKind::MacCall(_) => bug!(), // handled above
-                };
 
-                let parent = self.parent_scope.module;
-                let expansion = self.parent_scope.expansion;
-                let res = Res::Def(def_kind, def_id);
-                // Trait item visibility is inherited from its trait when not specified explicitly.
-                let vis = match &item.vis.kind {
-                    ast::VisibilityKind::Inherited => {
-                        self.r.visibilities[&parent.def_id().unwrap().expect_local()]
-                    }
-                    _ => self.resolve_visibility(&item.vis),
-                };
-                // FIXME: For historical reasons the binding visibility is set to public,
-                // use actual visibility here instead, using enum variants as an example.
-                let vis_hack = ty::Visibility::Public;
-                self.r.define(parent, item.ident, ns, (res, vis_hack, item.span, expansion));
-                Some(vis)
-            }
-            AssocCtxt::Impl => {
-                // Trait impl item visibility is inherited from its trait when not specified
-                // explicitly. In that case we cannot determine it here in early resolve,
-                // so we leave a hole in the visibility table to be filled later.
-                // Inherent impl item visibility is never inherited from other items.
-                if matches!(item.vis.kind, ast::VisibilityKind::Inherited)
-                    && self
-                        .r
-                        .trait_impl_items
-                        .contains(&ty::DefIdTree::parent(&*self.r, def_id).unwrap().expect_local())
-                {
-                    None
-                } else {
-                    Some(self.resolve_visibility(&item.vis))
-                }
-            }
-        };
-
-        if let Some(vis) = vis {
+        if !(ctxt == AssocCtxt::Impl
+            && matches!(item.vis.kind, ast::VisibilityKind::Inherited)
+            && self
+                .r
+                .trait_impl_items
+                .contains(&ty::DefIdTree::parent(&*self.r, def_id).unwrap().expect_local()))
+        {
+            // Trait impl item visibility is inherited from its trait when not specified
+            // explicitly. In that case we cannot determine it here in early resolve,
+            // so we leave a hole in the visibility table to be filled later.
             self.r.visibilities.insert(local_def_id, vis);
+        }
+
+        if ctxt == AssocCtxt::Trait {
+            let (def_kind, ns) = match item.kind {
+                AssocItemKind::Const(..) => (DefKind::AssocConst, ValueNS),
+                AssocItemKind::Fn(box FnKind(_, ref sig, _, _)) => {
+                    if sig.decl.has_self() {
+                        self.r.has_self.insert(def_id);
+                    }
+                    (DefKind::AssocFn, ValueNS)
+                }
+                AssocItemKind::TyAlias(..) => (DefKind::AssocTy, TypeNS),
+                AssocItemKind::MacCall(_) => bug!(), // handled above
+            };
+
+            let parent = self.parent_scope.module;
+            let expansion = self.parent_scope.expansion;
+            let res = Res::Def(def_kind, def_id);
+            // FIXME: For historical reasons the binding visibility is set to public,
+            // use actual visibility here instead, using enum variants as an example.
+            let vis_hack = ty::Visibility::Public;
+            self.r.define(parent, item.ident, ns, (res, vis_hack, item.span, expansion));
         }
 
         visit::walk_assoc_item(self, item, ctxt);
@@ -1490,19 +1475,13 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
         }
 
         let parent = self.parent_scope.module;
-        let vis = match variant.vis.kind {
-            // Variant visibility is inherited from its enum when not specified explicitly.
-            ast::VisibilityKind::Inherited => {
-                self.r.visibilities[&parent.def_id().unwrap().expect_local()]
-            }
-            _ => self.resolve_visibility(&variant.vis),
-        };
         let expn_id = self.parent_scope.expansion;
         let ident = variant.ident;
 
         // Define a name in the type namespace.
         let def_id = self.r.local_def_id(variant.id);
         let res = Res::Def(DefKind::Variant, def_id.to_def_id());
+        let vis = self.resolve_visibility(&variant.vis);
         self.r.define(parent, ident, TypeNS, (res, vis, variant.span, expn_id));
         self.r.visibilities.insert(def_id, vis);
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -750,27 +750,12 @@ impl<'a> NameBinding<'a> {
     fn is_possibly_imported_variant(&self) -> bool {
         match self.kind {
             NameBindingKind::Import { binding, .. } => binding.is_possibly_imported_variant(),
-            _ => self.is_variant(),
-        }
-    }
-
-    // We sometimes need to treat variants as `pub` for backwards compatibility.
-    fn pseudo_vis(&self) -> ty::Visibility {
-        if self.is_variant() && self.res().def_id().is_local() {
-            ty::Visibility::Public
-        } else {
-            self.vis
-        }
-    }
-
-    fn is_variant(&self) -> bool {
-        matches!(
-            self.kind,
             NameBindingKind::Res(
                 Res::Def(DefKind::Variant | DefKind::Ctor(CtorOf::Variant, ..), _),
                 _,
-            )
-        )
+            ) => true,
+            NameBindingKind::Res(..) | NameBindingKind::Module(..) => false,
+        }
     }
 
     fn is_extern_crate(&self) -> bool {

--- a/src/test/ui/privacy/issue-46209-private-enum-variant-reexport.rs
+++ b/src/test/ui/privacy/issue-46209-private-enum-variant-reexport.rs
@@ -1,15 +1,16 @@
 #![feature(crate_visibility_modifier)]
 
+#[deny(unused_imports)]
 mod rank {
     pub use self::Professor::*;
-    //~^ ERROR enum is private and its variants cannot be re-exported
+    //~^ ERROR glob import doesn't reexport anything
     pub use self::Lieutenant::{JuniorGrade, Full};
-    //~^ ERROR variant `JuniorGrade` is private and cannot be re-exported
-    //~| ERROR variant `Full` is private and cannot be re-exported
+    //~^ ERROR `JuniorGrade` is private, and cannot be re-exported
+    //~| ERROR `Full` is private, and cannot be re-exported
     pub use self::PettyOfficer::*;
-    //~^ ERROR enum is private and its variants cannot be re-exported
+    //~^ ERROR glob import doesn't reexport anything
     pub use self::Crewman::*;
-    //~^ ERROR enum is private and its variants cannot be re-exported
+    //~^ ERROR glob import doesn't reexport anything
 
     enum Professor {
         Adjunct,

--- a/src/test/ui/privacy/issue-46209-private-enum-variant-reexport.stderr
+++ b/src/test/ui/privacy/issue-46209-private-enum-variant-reexport.stderr
@@ -1,44 +1,51 @@
-error: variant `JuniorGrade` is private and cannot be re-exported
-  --> $DIR/issue-46209-private-enum-variant-reexport.rs:6:32
+error[E0364]: `JuniorGrade` is private, and cannot be re-exported
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:7:32
    |
 LL |     pub use self::Lieutenant::{JuniorGrade, Full};
    |                                ^^^^^^^^^^^
-...
-LL |     enum Lieutenant {
-   |     --------------- help: consider making the enum public: `pub enum Lieutenant`
+   |
+note: consider marking `JuniorGrade` as `pub` in the imported module
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:7:32
+   |
+LL |     pub use self::Lieutenant::{JuniorGrade, Full};
+   |                                ^^^^^^^^^^^
 
-error: variant `Full` is private and cannot be re-exported
-  --> $DIR/issue-46209-private-enum-variant-reexport.rs:6:45
+error[E0364]: `Full` is private, and cannot be re-exported
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:7:45
+   |
+LL |     pub use self::Lieutenant::{JuniorGrade, Full};
+   |                                             ^^^^
+   |
+note: consider marking `Full` as `pub` in the imported module
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:7:45
    |
 LL |     pub use self::Lieutenant::{JuniorGrade, Full};
    |                                             ^^^^
 
-error: enum is private and its variants cannot be re-exported
-  --> $DIR/issue-46209-private-enum-variant-reexport.rs:4:13
+error: glob import doesn't reexport anything because no candidate is public enough
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:5:13
    |
 LL |     pub use self::Professor::*;
    |             ^^^^^^^^^^^^^^^^^^
-...
-LL |     enum Professor {
-   |     -------------- help: consider making the enum public: `pub enum Professor`
+   |
+note: the lint level is defined here
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:3:8
+   |
+LL | #[deny(unused_imports)]
+   |        ^^^^^^^^^^^^^^
 
-error: enum is private and its variants cannot be re-exported
-  --> $DIR/issue-46209-private-enum-variant-reexport.rs:9:13
+error: glob import doesn't reexport anything because no candidate is public enough
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:10:13
    |
 LL |     pub use self::PettyOfficer::*;
    |             ^^^^^^^^^^^^^^^^^^^^^
-...
-LL |     pub(in rank) enum PettyOfficer {
-   |     ------------------------------ help: consider making the enum public: `pub enum PettyOfficer`
 
-error: enum is private and its variants cannot be re-exported
-  --> $DIR/issue-46209-private-enum-variant-reexport.rs:11:13
+error: glob import doesn't reexport anything because no candidate is public enough
+  --> $DIR/issue-46209-private-enum-variant-reexport.rs:12:13
    |
 LL |     pub use self::Crewman::*;
    |             ^^^^^^^^^^^^^^^^
-...
-LL |     crate enum Crewman {
-   |     ------------------ help: consider making the enum public: `pub enum Crewman`
 
 error: aborting due to 5 previous errors
 
+For more information about this error, try `rustc --explain E0364`.

--- a/src/test/ui/privacy/private-variant-reexport.rs
+++ b/src/test/ui/privacy/private-variant-reexport.rs
@@ -1,17 +1,18 @@
 mod m1 {
-    pub use ::E::V; //~ ERROR variant `V` is private and cannot be re-exported
+    pub use ::E::V; //~ ERROR `V` is private, and cannot be re-exported
 }
 
 mod m2 {
-    pub use ::E::{V}; //~ ERROR variant `V` is private and cannot be re-exported
+    pub use ::E::{V}; //~ ERROR `V` is private, and cannot be re-exported
 }
 
 mod m3 {
-    pub use ::E::V::{self}; //~ ERROR variant `V` is private and cannot be re-exported
+    pub use ::E::V::{self}; //~ ERROR `V` is private, and cannot be re-exported
 }
 
+#[deny(unused_imports)]
 mod m4 {
-    pub use ::E::*; //~ ERROR enum is private and its variants cannot be re-exported
+    pub use ::E::*; //~ ERROR glob import doesn't reexport anything
 }
 
 enum E { V }

--- a/src/test/ui/privacy/private-variant-reexport.stderr
+++ b/src/test/ui/privacy/private-variant-reexport.stderr
@@ -1,29 +1,48 @@
-error: variant `V` is private and cannot be re-exported
+error[E0364]: `V` is private, and cannot be re-exported
   --> $DIR/private-variant-reexport.rs:2:13
    |
 LL |     pub use ::E::V;
    |             ^^^^^^
-...
-LL | enum E { V }
-   | ------ help: consider making the enum public: `pub enum E`
+   |
+note: consider marking `V` as `pub` in the imported module
+  --> $DIR/private-variant-reexport.rs:2:13
+   |
+LL |     pub use ::E::V;
+   |             ^^^^^^
 
-error: variant `V` is private and cannot be re-exported
+error[E0364]: `V` is private, and cannot be re-exported
+  --> $DIR/private-variant-reexport.rs:6:19
+   |
+LL |     pub use ::E::{V};
+   |                   ^
+   |
+note: consider marking `V` as `pub` in the imported module
   --> $DIR/private-variant-reexport.rs:6:19
    |
 LL |     pub use ::E::{V};
    |                   ^
 
-error: variant `V` is private and cannot be re-exported
+error[E0365]: `V` is private, and cannot be re-exported
   --> $DIR/private-variant-reexport.rs:10:22
    |
 LL |     pub use ::E::V::{self};
-   |                      ^^^^
+   |                      ^^^^ re-export of private `V`
+   |
+   = note: consider declaring type or module `V` with `pub`
 
-error: enum is private and its variants cannot be re-exported
-  --> $DIR/private-variant-reexport.rs:14:13
+error: glob import doesn't reexport anything because no candidate is public enough
+  --> $DIR/private-variant-reexport.rs:15:13
    |
 LL |     pub use ::E::*;
    |             ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/private-variant-reexport.rs:13:8
+   |
+LL | #[deny(unused_imports)]
+   |        ^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 
+Some errors have detailed explanations: E0364, E0365.
+For more information about an error, try `rustc --explain E0364`.

--- a/src/test/ui/variants/variant-namespacing.rs
+++ b/src/test/ui/variants/variant-namespacing.rs
@@ -1,6 +1,6 @@
 // aux-build:variant-namespacing.rs
 
-enum E {
+pub enum E {
     Struct { a: u8 },
     Tuple(u8),
     Unit,


### PR DESCRIPTION
by always delegating it to `fn resolve_visibility`.

Also remove some special treatment of visibility on enum variants and trait items remaining from pre-`pub(restricted)` times.