### PR TITLE
Re-stabilize Weak::as_ptr and friends for unsized T

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -120,6 +120,7 @@
 #![feature(receiver_trait)]
 #![cfg_attr(bootstrap, feature(min_const_generics))]
 #![feature(min_specialization)]
+#![feature(set_ptr_value)]
 #![feature(slice_ptr_get)]
 #![feature(slice_ptr_len)]
 #![feature(staged_api)]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2314,10 +2314,12 @@ impl<T: ?Sized> Unpin for Rc<T> {}
 /// The pointer must point to (and have valid metadata for) a previously
 /// valid instance of T, but the T is allowed to be dropped.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
-    // Align the unsized value to the end of the `RcBox`.
-    // Because it is ?Sized, it will always be the last field in memory.
-    // Note: This is a detail of the current implementation of the compiler,
-    // and is not a guaranteed language detail. Do not rely on it outside of std.
+    // Align the unsized value to the end of the RcBox.
+    // Because RcBox is repr(C), it will always be the last field in memory.
+    // SAFETY: since the only unsized types possible are slices, trait objects,
+    // and extern types, the input safety requirement is currently enough to
+    // satisfy the requirements of align_of_val_raw; this is an implementation
+    // detail of the language that may not be relied upon outside of std.
     unsafe { data_offset_align(align_of_val_raw(ptr)) }
 }
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1881,7 +1881,7 @@ impl<T: ?Sized> Weak<T> {
 
         if is_dangling(ptr) {
             // If the pointer is dangling, we return the sentinel directly. This cannot be
-            // a valid payload address, as it is at least as aligned as RcBox (usize).
+            // a valid payload address, as the payload is at least as aligned as RcBox (usize).
             ptr as *const T
         } else {
             // SAFETY: if is_dangling returns false, then the pointer is dereferencable.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1899,7 +1899,7 @@ impl<T: ?Sized> Weak<T> {
             // a valid pointer, so that `from_raw` can reverse this transformation.
             (ptr as *mut T).set_ptr_value(ptr::null_mut())
         } else {
-            // SAFETY: If the pointer is not dangling, it references a valid allocation.
+            // SAFETY: if is_dangling returns false, then the pointer is dereferencable.
             // The payload may be dropped at this point, and we have to maintain provenance,
             // so use raw pointer manipulation.
             unsafe { &raw mut (*ptr).value }
@@ -1991,7 +1991,7 @@ impl<T: ?Sized> Weak<T> {
             // SAFETY: this is the same sentinel as used in Weak::new and is_dangling
             (ptr as *mut RcBox<T>).set_ptr_value(usize::MAX as *mut _)
         } else {
-            // Otherwise, this references a real allocation.
+            // Otherwise, we're guaranteed the pointer came from a nondangling Weak.
             // SAFETY: data_offset is safe to call, as ptr references a real (potentially dropped) T.
             let offset = unsafe { data_offset(ptr) };
             // Thus, we reverse the offset to get the whole RcBox.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2325,11 +2325,8 @@ impl<T: ?Sized> Unpin for Rc<T> {}
 ///
 /// # Safety
 ///
-/// This has the same safety requirements as `align_of_val_raw`. In effect:
-///
-/// - This function is safe for any argument if `T` is sized, and
-/// - if `T` is unsized, the pointer must have appropriate pointer metadata
-///   acquired from the real instance that you are getting this offset for.
+/// The pointer must point to (and have valid metadata for) a previously
+/// valid instance of T, but the T is allowed to be dropped.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Align the unsized value to the end of the `RcBox`.
     // Because it is ?Sized, it will always be the last field in memory.

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1862,7 +1862,7 @@ struct WeakInner<'a> {
     strong: &'a Cell<usize>,
 }
 
-impl<T> Weak<T> {
+impl<T: ?Sized> Weak<T> {
     /// Returns a raw pointer to the object `T` pointed to by this `Weak<T>`.
     ///
     /// The pointer is valid only if there are some strong references. The pointer may be dangling,
@@ -1892,15 +1892,17 @@ impl<T> Weak<T> {
     pub fn as_ptr(&self) -> *const T {
         let ptr: *mut RcBox<T> = NonNull::as_ptr(self.ptr);
 
-        // SAFETY: we must offset the pointer manually, and said pointer may be
-        // a dangling weak (usize::MAX) if T is sized. data_offset is safe to call,
-        // because we know that a pointer to unsized T was derived from a real
-        // unsized T, as dangling weaks are only created for sized T. wrapping_offset
-        // is used so that we can use the same code path for the non-dangling
-        // unsized case and the potentially dangling sized case.
-        unsafe {
-            let offset = data_offset(ptr as *mut T);
-            set_data_ptr(ptr as *mut T, (ptr as *mut u8).wrapping_offset(offset))
+        if is_dangling(self.ptr) {
+            // If the pointer is dangling, we return a null pointer as the dangling sentinel.
+            // We can't return the usize::MAX sentinel, as that could valid if T is ZST.
+            // SAFETY: we have to return a known sentinel here that cannot be produced for
+            // a valid pointer, so that `from_raw` can reverse this transformation.
+            (ptr as *mut T).set_ptr_value(ptr::null_mut())
+        } else {
+            // SAFETY: If the pointer is not dangling, it describes to a valid allocation.
+            // The payload may be dropped at this point, and we have to maintain provenance,
+            // so use raw pointer manipulation.
+            unsafe { &raw mut (*ptr).value }
         }
     }
 
@@ -1982,22 +1984,25 @@ impl<T> Weak<T> {
     /// [`new`]: Weak::new
     #[stable(feature = "weak_into_raw", since = "1.45.0")]
     pub unsafe fn from_raw(ptr: *const T) -> Self {
-        // SAFETY: data_offset is safe to call, because this pointer originates from a Weak.
         // See Weak::as_ptr for context on how the input pointer is derived.
-        let offset = unsafe { data_offset(ptr) };
 
-        // Reverse the offset to find the original RcBox.
-        // SAFETY: we use wrapping_offset here because the pointer may be dangling (but only if T: Sized).
-        let ptr = unsafe {
-            set_data_ptr(ptr as *mut RcBox<T>, (ptr as *mut u8).wrapping_offset(-offset))
+        let ptr = if ptr.is_null() {
+            // If we get a null pointer, this is a dangling weak.
+            // SAFETY: this is the same sentinel as used in Weak::new and is_dangling
+            (ptr as *mut RcBox<T>).set_ptr_value(usize::MAX as *mut _)
+        } else {
+            // Otherwise, this describes a real allocation.
+            // SAFETY: data_offset is safe to call, as ptr describes a real allocation.
+            let offset = unsafe { data_offset(ptr) };
+            // Thus, we reverse the offset to get the whole RcBox.
+            // SAFETY: the pointer originated from a Weak, so this offset is safe.
+            unsafe { (ptr as *mut RcBox<T>).set_ptr_value((ptr as *mut u8).offset(-offset)) }
         };
 
         // SAFETY: we now have recovered the original Weak pointer, so can create the Weak.
         Weak { ptr: unsafe { NonNull::new_unchecked(ptr) } }
     }
-}
 
-impl<T: ?Sized> Weak<T> {
     /// Attempts to upgrade the `Weak` pointer to an [`Rc`], delaying
     /// dropping of the inner value if successful.
     ///

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1899,7 +1899,7 @@ impl<T: ?Sized> Weak<T> {
             // a valid pointer, so that `from_raw` can reverse this transformation.
             (ptr as *mut T).set_ptr_value(ptr::null_mut())
         } else {
-            // SAFETY: If the pointer is not dangling, it describes to a valid allocation.
+            // SAFETY: If the pointer is not dangling, it references a valid allocation.
             // The payload may be dropped at this point, and we have to maintain provenance,
             // so use raw pointer manipulation.
             unsafe { &raw mut (*ptr).value }
@@ -1991,8 +1991,8 @@ impl<T: ?Sized> Weak<T> {
             // SAFETY: this is the same sentinel as used in Weak::new and is_dangling
             (ptr as *mut RcBox<T>).set_ptr_value(usize::MAX as *mut _)
         } else {
-            // Otherwise, this describes a real allocation.
-            // SAFETY: data_offset is safe to call, as ptr describes a real allocation.
+            // Otherwise, this references a real allocation.
+            // SAFETY: data_offset is safe to call, as ptr references a real (potentially dropped) T.
             let offset = unsafe { data_offset(ptr) };
             // Thus, we reverse the offset to get the whole RcBox.
             // SAFETY: the pointer originated from a Weak, so this offset is safe.
@@ -2320,8 +2320,7 @@ impl<T: ?Sized> AsRef<T> for Rc<T> {
 #[stable(feature = "pin", since = "1.33.0")]
 impl<T: ?Sized> Unpin for Rc<T> {}
 
-/// Get the offset within an `RcBox` for
-/// a payload of type described by a pointer.
+/// Get the offset within an `RcBox` for the payload behind a pointer.
 ///
 /// # Safety
 ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1685,7 +1685,7 @@ impl<T: ?Sized> Weak<T> {
             // a valid pointer, so that `from_raw` can reverse this transformation.
             (ptr as *mut T).set_ptr_value(ptr::null_mut())
         } else {
-            // SAFETY: If the pointer is not dangling, it describes to a valid allocation.
+            // SAFETY: If the pointer is not dangling, it references a valid allocation.
             // The payload may be dropped at this point, and we have to maintain provenance,
             // so use raw pointer manipulation.
             unsafe { &raw mut (*ptr).data }
@@ -1777,8 +1777,8 @@ impl<T: ?Sized> Weak<T> {
             // SAFETY: this is the same sentinel as used in Weak::new and is_dangling
             (ptr as *mut ArcInner<T>).set_ptr_value(usize::MAX as *mut _)
         } else {
-            // Otherwise, this describes a real allocation.
-            // SAFETY: data_offset is safe to call, as ptr describes a real allocation.
+            // Otherwise, this references a real allocation.
+            // SAFETY: data_offset is safe to call, as ptr references a real (potentially dropped) T.
             let offset = unsafe { data_offset(ptr) };
             // Thus, we reverse the offset to get the whole RcBox.
             // SAFETY: the pointer originated from a Weak, so this offset is safe.
@@ -2471,8 +2471,7 @@ impl<T: ?Sized> AsRef<T> for Arc<T> {
 #[stable(feature = "pin", since = "1.33.0")]
 impl<T: ?Sized> Unpin for Arc<T> {}
 
-/// Get the offset within an `ArcInner` for
-/// a payload of type described by a pointer.
+/// Get the offset within an `ArcInner` for the payload behind a pointer.
 ///
 /// # Safety
 ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1685,7 +1685,7 @@ impl<T: ?Sized> Weak<T> {
             // a valid pointer, so that `from_raw` can reverse this transformation.
             (ptr as *mut T).set_ptr_value(ptr::null_mut())
         } else {
-            // SAFETY: If the pointer is not dangling, it references a valid allocation.
+            // SAFETY: if is_dangling returns false, then the pointer is dereferencable.
             // The payload may be dropped at this point, and we have to maintain provenance,
             // so use raw pointer manipulation.
             unsafe { &raw mut (*ptr).data }
@@ -1777,7 +1777,7 @@ impl<T: ?Sized> Weak<T> {
             // SAFETY: this is the same sentinel as used in Weak::new and is_dangling
             (ptr as *mut ArcInner<T>).set_ptr_value(usize::MAX as *mut _)
         } else {
-            // Otherwise, this references a real allocation.
+            // Otherwise, we're guaranteed the pointer came from a nondangling Weak.
             // SAFETY: data_offset is safe to call, as ptr references a real (potentially dropped) T.
             let offset = unsafe { data_offset(ptr) };
             // Thus, we reverse the offset to get the whole RcBox.

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2476,11 +2476,8 @@ impl<T: ?Sized> Unpin for Arc<T> {}
 ///
 /// # Safety
 ///
-/// This has the same safety requirements as `align_of_val_raw`. In effect:
-///
-/// - This function is safe for any argument if `T` is sized, and
-/// - if `T` is unsized, the pointer must have appropriate pointer metadata
-///   acquired from the real instance that you are getting this offset for.
+/// The pointer must point to (and have valid metadata for) a previously
+/// valid instance of T, but the T is allowed to be dropped.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
     // Align the unsized value to the end of the `ArcInner`.
     // Because it is `?Sized`, it will always be the last field in memory.

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2464,10 +2464,12 @@ impl<T: ?Sized> Unpin for Arc<T> {}
 /// The pointer must point to (and have valid metadata for) a previously
 /// valid instance of T, but the T is allowed to be dropped.
 unsafe fn data_offset<T: ?Sized>(ptr: *const T) -> isize {
-    // Align the unsized value to the end of the `ArcInner`.
-    // Because it is `?Sized`, it will always be the last field in memory.
-    // Note: This is a detail of the current implementation of the compiler,
-    // and is not a guaranteed language detail. Do not rely on it outside of std.
+    // Align the unsized value to the end of the ArcInner.
+    // Because RcBox is repr(C), it will always be the last field in memory.
+    // SAFETY: since the only unsized types possible are slices, trait objects,
+    // and extern types, the input safety requirement is currently enough to
+    // satisfy the requirements of align_of_val_raw; this is an implementation
+    // detail of the language that may not be relied upon outside of std.
     unsafe { data_offset_align(align_of_val_raw(ptr)) }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1666,7 +1666,7 @@ impl<T: ?Sized> Weak<T> {
 
         if is_dangling(ptr) {
             // If the pointer is dangling, we return the sentinel directly. This cannot be
-            // a valid payload address, as it is at least as aligned as ArcInner (usize).
+            // a valid payload address, as the payload is at least as aligned as ArcInner (usize).
             ptr as *const T
         } else {
             // SAFETY: if is_dangling returns false, then the pointer is dereferencable.

--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -159,6 +159,30 @@ fn into_from_weak_raw() {
 }
 
 #[test]
+fn test_into_from_weak_raw_unsized() {
+    use std::fmt::Display;
+    use std::string::ToString;
+
+    let arc: Arc<str> = Arc::from("foo");
+    let weak: Weak<str> = Arc::downgrade(&arc);
+
+    let ptr = Weak::into_raw(weak.clone());
+    let weak2 = unsafe { Weak::from_raw(ptr) };
+
+    assert_eq!(unsafe { &*ptr }, "foo");
+    assert!(weak.ptr_eq(&weak2));
+
+    let arc: Arc<dyn Display> = Arc::new(123);
+    let weak: Weak<dyn Display> = Arc::downgrade(&arc);
+
+    let ptr = Weak::into_raw(weak.clone());
+    let weak2 = unsafe { Weak::from_raw(ptr) };
+
+    assert_eq!(unsafe { &*ptr }.to_string(), "123");
+    assert!(weak.ptr_eq(&weak2));
+}
+
+#[test]
 fn test_cowarc_clone_make_mut() {
     let mut cow0 = Arc::new(75);
     let mut cow1 = cow0.clone();
@@ -327,6 +351,23 @@ fn test_unsized() {
     let y = Arc::downgrade(&x.clone());
     drop(x);
     assert!(y.upgrade().is_none());
+}
+
+#[test]
+fn test_maybe_thin_unsized() {
+    // If/when custom thin DSTs exist, this test should be updated to use one
+    use std::ffi::{CStr, CString};
+
+    let x: Arc<CStr> = Arc::from(CString::new("swordfish").unwrap().into_boxed_c_str());
+    assert_eq!(format!("{:?}", x), "\"swordfish\"");
+    let y: Weak<CStr> = Arc::downgrade(&x);
+    drop(x);
+
+    // At this point, the weak points to a dropped DST
+    assert!(y.upgrade().is_none());
+    // But we still need to be able to get the alloc layout to drop.
+    // CStr has no drop glue, but custom DSTs might, and need to work.
+    drop(y);
 }
 
 #[test]


### PR DESCRIPTION
As per [T-lang consensus](https://hackmd.io/7r3_is6uTz-163fsOV8Vfg), this uses a branch to handle the dangling case. The discussed optimization of only doing the branch in the T: ?Sized case is left for a followup patch, as doing so is not trivial (as it requires specialization) and not _obviously_ better (as it requires using `wrapping_offset` rather than `offset` more).

<details><summary>Basically said optimization</summary>

Specialize on `T: Sized`:

```rust
fn as_ptr(&self) -> *const T {
    if [ T is Sized ] || !is_dangling(ptr) {
        (ptr as *mut T).set_ptr_value( (ptr as *mut u8).wrapping_offset(data_offset) )
    } else {
        ptr::null()
    }
}

fn from_raw(*const T) -> Self {
    if [ T is Sized ] || !ptr.is_null() {
        let ptr = (ptr as *mut RcBox).set_ptr_value( (ptr as *mut u8).wrapping_offset(-data_offset) );
        Weak { ptr }
    } else {
        Weak::new()
    }
}
```

(but with more `set_ptr_value` to avoid `Sized` restrictions and maintain metadata.)

Written in this fashion, this is not a correctness-critical specialization (i.e. so long as `[ T is Sized ]` is false for unsized `T`, it can be `rand()` for sized `T` without breaking correctness), but it's still touchy, so I'd rather do it in another PR with separate review.

---
</details>

This effectively reverts #80422 and re-establishes #74160. T-libs [previously signed off](https://github.com/rust-lang/rust/pull/74160#issuecomment-660539373) on this stable API change in #74160.