### PR TITLE
Improve wording of parse doc

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2175,7 +2175,7 @@ impl str {
     /// helps the inference algorithm understand specifically which type
     /// you're trying to parse into.
     ///
-    /// `parse` can parse any type that implements the [`FromStr`] trait.
+    /// `parse` can parse into any type that implements the [`FromStr`] trait.
 
     ///
     /// # Errors


### PR DESCRIPTION
Change:
```
`parse` can parse any type that...
```
to:
```
`parse` can parse into any type that...
```
Word `into` added to be more precise and in coherence with other parts of the doc.