### PR TITLE
collaps if x {} else { if .. } conditions

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -205,22 +205,20 @@ fn parse_args<'a>(
                 err.emit();
             }
             args.named_args.insert(name, slot);
-        } else {
-            if !args.named_args.is_empty() || !args.reg_args.is_empty() {
-                let mut err = ecx.struct_span_err(
-                    span,
-                    "positional arguments cannot follow named arguments \
+        } else if !args.named_args.is_empty() || !args.reg_args.is_empty() {
+            let mut err = ecx.struct_span_err(
+                span,
+                "positional arguments cannot follow named arguments \
                      or explicit register arguments",
-                );
-                err.span_label(span, "positional argument");
-                for pos in args.named_args.values() {
-                    err.span_label(args.operands[*pos].1, "named argument");
-                }
-                for pos in &args.reg_args {
-                    err.span_label(args.operands[*pos].1, "explicit register argument");
-                }
-                err.emit();
+            );
+            err.span_label(span, "positional argument");
+            for pos in args.named_args.values() {
+                err.span_label(args.operands[*pos].1, "named argument");
             }
+            for pos in &args.reg_args {
+                err.span_label(args.operands[*pos].1, "explicit register argument");
+            }
+            err.emit();
         }
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1431,10 +1431,8 @@ fn add_late_link_args(
         if let Some(args) = sess.target.late_link_args_dynamic.get(&flavor) {
             cmd.args(args);
         }
-    } else {
-        if let Some(args) = sess.target.late_link_args_static.get(&flavor) {
-            cmd.args(args);
-        }
+    } else if let Some(args) = sess.target.late_link_args_static.get(&flavor) {
+        cmd.args(args);
     }
     if let Some(args) = sess.target.late_link_args.get(&flavor) {
         cmd.args(args);

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -371,11 +371,9 @@ impl<'tcx, Tag: Copy, Extra: AllocationExtra<Tag>> Allocation<Tag, Extra> {
         if size != cx.data_layout().pointer_size {
             // *Now*, we better make sure that the inside is free of relocations too.
             self.check_relocations(cx, ptr, size)?;
-        } else {
-            if let Some(&(tag, alloc_id)) = self.relocations.get(&ptr.offset) {
-                let ptr = Pointer::new_with_tag(alloc_id, Size::from_bytes(bits), tag);
-                return Ok(ScalarMaybeUninit::Scalar(ptr.into()));
-            }
+        } else if let Some(&(tag, alloc_id)) = self.relocations.get(&ptr.offset) {
+            let ptr = Pointer::new_with_tag(alloc_id, Size::from_bytes(bits), tag);
+            return Ok(ScalarMaybeUninit::Scalar(ptr.into()));
         }
         // We don't. Just return the bits.
         Ok(ScalarMaybeUninit::Scalar(Scalar::from_uint(bits, size)))

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -518,13 +518,11 @@ impl<'a, 'tcx> TypeFolder<'tcx> for BoundVarReplacer<'a, 'tcx> {
             } else {
                 ct
             }
+        } else if !ct.has_vars_bound_at_or_above(self.current_index) {
+            // Nothing more to substitute.
+            ct
         } else {
-            if !ct.has_vars_bound_at_or_above(self.current_index) {
-                // Nothing more to substitute.
-                ct
-            } else {
-                ct.super_fold_with(self)
-            }
+            ct.super_fold_with(self)
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2532,31 +2532,29 @@ fn fn_can_unwind(
     } else if codegen_fn_attr_flags.contains(CodegenFnAttrFlags::RUSTC_ALLOCATOR_NOUNWIND) {
         // Special attribute for allocator functions, which can't unwind.
         false
+    } else if call_conv == Conv::Rust {
+        // Any Rust method (or `extern "Rust" fn` or `extern
+        // "rust-call" fn`) is explicitly allowed to unwind
+        // (unless it has no-unwind attribute, handled above).
+        true
     } else {
-        if call_conv == Conv::Rust {
-            // Any Rust method (or `extern "Rust" fn` or `extern
-            // "rust-call" fn`) is explicitly allowed to unwind
-            // (unless it has no-unwind attribute, handled above).
-            true
-        } else {
-            // Anything else is either:
-            //
-            //  1. A foreign item using a non-Rust ABI (like `extern "C" { fn foo(); }`), or
-            //
-            //  2. A Rust item using a non-Rust ABI (like `extern "C" fn foo() { ... }`).
-            //
-            // Foreign items (case 1) are assumed to not unwind; it is
-            // UB otherwise. (At least for now; see also
-            // rust-lang/rust#63909 and Rust RFC 2753.)
-            //
-            // Items defined in Rust with non-Rust ABIs (case 2) are also
-            // not supposed to unwind. Whether this should be enforced
-            // (versus stating it is UB) and *how* it would be enforced
-            // is currently under discussion; see rust-lang/rust#58794.
-            //
-            // In either case, we mark item as explicitly nounwind.
-            false
-        }
+        // Anything else is either:
+        //
+        //  1. A foreign item using a non-Rust ABI (like `extern "C" { fn foo(); }`), or
+        //
+        //  2. A Rust item using a non-Rust ABI (like `extern "C" fn foo() { ... }`).
+        //
+        // Foreign items (case 1) are assumed to not unwind; it is
+        // UB otherwise. (At least for now; see also
+        // rust-lang/rust#63909 and Rust RFC 2753.)
+        //
+        // Items defined in Rust with non-Rust ABIs (case 2) are also
+        // not supposed to unwind. Whether this should be enforced
+        // (versus stating it is UB) and *how* it would be enforced
+        // is currently under discussion; see rust-lang/rust#58794.
+        //
+        // In either case, we mark item as explicitly nounwind.
+        false
     }
 }
 

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -168,87 +168,82 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             partially_str, move_msg
                         ),
                     );
-                } else {
-                    if let UseSpans::FnSelfUse { var_span, fn_call_span, fn_span, kind } =
-                        move_spans
-                    {
-                        let place_name = self
-                            .describe_place(moved_place.as_ref())
-                            .map(|n| format!("`{}`", n))
-                            .unwrap_or_else(|| "value".to_owned());
-                        match kind {
-                            FnSelfUseKind::FnOnceCall => {
-                                err.span_label(
-                                    fn_call_span,
-                                    &format!(
-                                        "{} {}moved due to this call",
-                                        place_name, partially_str
-                                    ),
-                                );
-                                err.span_note(
+                } else if let UseSpans::FnSelfUse { var_span, fn_call_span, fn_span, kind } =
+                    move_spans
+                {
+                    let place_name = self
+                        .describe_place(moved_place.as_ref())
+                        .map(|n| format!("`{}`", n))
+                        .unwrap_or_else(|| "value".to_owned());
+                    match kind {
+                        FnSelfUseKind::FnOnceCall => {
+                            err.span_label(
+                                fn_call_span,
+                                &format!("{} {}moved due to this call", place_name, partially_str),
+                            );
+                            err.span_note(
                                     var_span,
                                     "this value implements `FnOnce`, which causes it to be moved when called",
                                 );
+                        }
+                        FnSelfUseKind::Operator { self_arg } => {
+                            err.span_label(
+                                fn_call_span,
+                                &format!(
+                                    "{} {}moved due to usage in operator",
+                                    place_name, partially_str
+                                ),
+                            );
+                            if self.fn_self_span_reported.insert(fn_span) {
+                                err.span_note(
+                                    self_arg.span,
+                                    "calling this operator moves the left-hand side",
+                                );
                             }
-                            FnSelfUseKind::Operator { self_arg } => {
+                        }
+                        FnSelfUseKind::Normal { self_arg, implicit_into_iter } => {
+                            if implicit_into_iter {
                                 err.span_label(
                                     fn_call_span,
                                     &format!(
-                                        "{} {}moved due to usage in operator",
+                                        "{} {}moved due to this implicit call to `.into_iter()`",
                                         place_name, partially_str
                                     ),
                                 );
-                                if self.fn_self_span_reported.insert(fn_span) {
-                                    err.span_note(
-                                        self_arg.span,
-                                        "calling this operator moves the left-hand side",
-                                    );
-                                }
+                            } else {
+                                err.span_label(
+                                    fn_call_span,
+                                    &format!(
+                                        "{} {}moved due to this method call",
+                                        place_name, partially_str
+                                    ),
+                                );
                             }
-                            FnSelfUseKind::Normal { self_arg, implicit_into_iter } => {
-                                if implicit_into_iter {
-                                    err.span_label(
-                                        fn_call_span,
-                                        &format!(
-                                            "{} {}moved due to this implicit call to `.into_iter()`",
-                                            place_name, partially_str
-                                        ),
-                                    );
-                                } else {
-                                    err.span_label(
-                                        fn_call_span,
-                                        &format!(
-                                            "{} {}moved due to this method call",
-                                            place_name, partially_str
-                                        ),
-                                    );
-                                }
-                                // Avoid pointing to the same function in multiple different
-                                // error messages
-                                if self.fn_self_span_reported.insert(self_arg.span) {
-                                    err.span_note(
+                            // Avoid pointing to the same function in multiple different
+                            // error messages
+                            if self.fn_self_span_reported.insert(self_arg.span) {
+                                err.span_note(
                                         self_arg.span,
                                         &format!("this function consumes the receiver `self` by taking ownership of it, which moves {}", place_name)
                                     );
-                                }
                             }
-                            // Deref::deref takes &self, which cannot cause a move
-                            FnSelfUseKind::DerefCoercion { .. } => unreachable!(),
                         }
-                    } else {
-                        err.span_label(
-                            move_span,
-                            format!("value {}moved{} here", partially_str, move_msg),
-                        );
-                        move_spans.var_span_label(
-                            &mut err,
-                            format!(
-                                "variable {}moved due to use{}",
-                                partially_str,
-                                move_spans.describe()
-                            ),
-                        );
+                        // Deref::deref takes &self, which cannot cause a move
+                        FnSelfUseKind::DerefCoercion { .. } => unreachable!(),
                     }
+                } else {
+                    err.span_label(
+                        move_span,
+                        format!("value {}moved{} here", partially_str, move_msg),
+                    );
+                    move_spans.var_span_label(
+                        &mut err,
+                        format!(
+                            "variable {}moved due to use{}",
+                            partially_str,
+                            move_spans.describe()
+                        ),
+                    );
                 }
                 if let UseSpans::PatUse(span) = move_spans {
                     err.span_suggestion_verbose(

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
@@ -225,24 +225,22 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 buf.push('*');
                                 buf.push_str(&name);
                             }
+                        } else if autoderef {
+                            // FIXME turn this recursion into iteration
+                            self.append_place_to_string(
+                                PlaceRef { local, projection: proj_base },
+                                buf,
+                                autoderef,
+                                &including_downcast,
+                            )?;
                         } else {
-                            if autoderef {
-                                // FIXME turn this recursion into iteration
-                                self.append_place_to_string(
-                                    PlaceRef { local, projection: proj_base },
-                                    buf,
-                                    autoderef,
-                                    &including_downcast,
-                                )?;
-                            } else {
-                                buf.push('*');
-                                self.append_place_to_string(
-                                    PlaceRef { local, projection: proj_base },
-                                    buf,
-                                    autoderef,
-                                    &including_downcast,
-                                )?;
-                            }
+                            buf.push('*');
+                            self.append_place_to_string(
+                                PlaceRef { local, projection: proj_base },
+                                buf,
+                                autoderef,
+                                &including_downcast,
+                            )?;
                         }
                     }
                     ProjectionElem::Downcast(..) => {

--- a/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
@@ -345,24 +345,16 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
                         let promoted_ty = promoted_body.return_ty();
                         check_err(self, promoted_body, ty, promoted_ty);
                     }
-                } else {
-                    if let Err(terr) = self.cx.fully_perform_op(
-                        location.to_locations(),
-                        ConstraintCategory::Boring,
-                        self.cx.param_env.and(type_op::ascribe_user_type::AscribeUserType::new(
-                            constant.literal.ty,
-                            def.did,
-                            UserSubsts { substs, user_self_ty: None },
-                        )),
-                    ) {
-                        span_mirbug!(
-                            self,
-                            constant,
-                            "bad constant type {:?} ({:?})",
-                            constant,
-                            terr
-                        );
-                    }
+                } else if let Err(terr) = self.cx.fully_perform_op(
+                    location.to_locations(),
+                    ConstraintCategory::Boring,
+                    self.cx.param_env.and(type_op::ascribe_user_type::AscribeUserType::new(
+                        constant.literal.ty,
+                        def.did,
+                        UserSubsts { substs, user_self_ty: None },
+                    )),
+                ) {
+                    span_mirbug!(self, constant, "bad constant type {:?} ({:?})", constant, terr);
                 }
             } else if let Some(static_def_id) = constant.check_static_ptr(tcx) {
                 let unnormalized_ty = tcx.type_of(static_def_id);

--- a/compiler/rustc_mir/src/transform/const_prop.rs
+++ b/compiler/rustc_mir/src/transform/const_prop.rs
@@ -1220,15 +1220,13 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
                                 msg,
                             );
                         }
-                    } else {
-                        if self.should_const_prop(value) {
-                            if let ScalarMaybeUninit::Scalar(scalar) = value_const {
-                                *cond = self.operand_from_scalar(
-                                    scalar,
-                                    self.tcx.types.bool,
-                                    source_info.span,
-                                );
-                            }
+                    } else if self.should_const_prop(value) {
+                        if let ScalarMaybeUninit::Scalar(scalar) = value_const {
+                            *cond = self.operand_from_scalar(
+                                scalar,
+                                self.tcx.types.bool,
+                                source_info.span,
+                            );
                         }
                     }
                 }

--- a/compiler/rustc_mir/src/transform/inline.rs
+++ b/compiler/rustc_mir/src/transform/inline.rs
@@ -382,14 +382,12 @@ impl Inliner<'tcx> {
         if let attr::InlineAttr::Always = codegen_fn_attrs.inline {
             debug!("INLINING {:?} because inline(always) [cost={}]", callsite, cost);
             true
+        } else if cost <= threshold {
+            debug!("INLINING {:?} [cost={} <= threshold={}]", callsite, cost, threshold);
+            true
         } else {
-            if cost <= threshold {
-                debug!("INLINING {:?} [cost={} <= threshold={}]", callsite, cost, threshold);
-                true
-            } else {
-                debug!("NOT inlining {:?} [cost={} > threshold={}]", callsite, cost, threshold);
-                false
-            }
+            debug!("NOT inlining {:?} [cost={} > threshold={}]", callsite, cost, threshold);
+            false
         }
     }
 

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1588,22 +1588,20 @@ impl<'a> Parser<'a> {
                 )
                 .emit();
             (Vec::new(), Some(self.mk_block_err(span)))
-        } else {
-            if let Err(mut err) =
-                self.expected_one_of_not_found(&[], &[token::Semi, token::OpenDelim(token::Brace)])
-            {
-                if self.token.kind == token::CloseDelim(token::Brace) {
-                    // The enclosing `mod`, `trait` or `impl` is being closed, so keep the `fn` in
-                    // the AST for typechecking.
-                    err.span_label(ident.span, "while parsing this `fn`");
-                    err.emit();
-                    (Vec::new(), None)
-                } else {
-                    return Err(err);
-                }
+        } else if let Err(mut err) =
+            self.expected_one_of_not_found(&[], &[token::Semi, token::OpenDelim(token::Brace)])
+        {
+            if self.token.kind == token::CloseDelim(token::Brace) {
+                // The enclosing `mod`, `trait` or `impl` is being closed, so keep the `fn` in
+                // the AST for typechecking.
+                err.span_label(ident.span, "while parsing this `fn`");
+                err.emit();
+                (Vec::new(), None)
             } else {
-                unreachable!()
+                return Err(err);
             }
+        } else {
+            unreachable!()
         };
         attrs.extend(inner_attrs);
         Ok(body)

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -1426,19 +1426,17 @@ impl<'tcx> Liveness<'_, 'tcx> {
                         );
                     }
                 }
-            } else {
-                if let Some(name) = self.should_warn(var) {
-                    self.ir.tcx.struct_span_lint_hir(
-                        lint::builtin::UNUSED_VARIABLES,
-                        var_hir_id,
-                        vec![upvar.span],
-                        |lint| {
-                            lint.build(&format!("unused variable: `{}`", name))
-                                .help("did you mean to capture by reference instead?")
-                                .emit();
-                        },
-                    );
-                }
+            } else if let Some(name) = self.should_warn(var) {
+                self.ir.tcx.struct_span_lint_hir(
+                    lint::builtin::UNUSED_VARIABLES,
+                    var_hir_id,
+                    vec![upvar.span],
+                    |lint| {
+                        lint.build(&format!("unused variable: `{}`", name))
+                            .help("did you mean to capture by reference instead?")
+                            .emit();
+                    },
+                );
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2016,17 +2016,14 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 // then the tuple must be the one containing capture types.
                 let is_upvar_tys_infer_tuple = if !matches!(ty.kind(), ty::Tuple(..)) {
                     false
+                } else if let ObligationCauseCode::BuiltinDerivedObligation(ref data) =
+                    *data.parent_code
+                {
+                    let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_ref);
+                    let ty = parent_trait_ref.skip_binder().self_ty();
+                    matches!(ty.kind(), ty::Generator(..)) || matches!(ty.kind(), ty::Closure(..))
                 } else {
-                    if let ObligationCauseCode::BuiltinDerivedObligation(ref data) =
-                        *data.parent_code
-                    {
-                        let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_ref);
-                        let ty = parent_trait_ref.skip_binder().self_ty();
-                        matches!(ty.kind(), ty::Generator(..))
-                            || matches!(ty.kind(), ty::Closure(..))
-                    } else {
-                        false
-                    }
+                    false
                 };
 
                 // Don't print the tuple of capture types

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -224,12 +224,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             {
                                 let max_len = receiver.rfind('.').unwrap();
                                 format!("{}{}", &receiver[..max_len], method_call)
+                            } else if expr.precedence().order() < ExprPrecedence::MethodCall.order()
+                            {
+                                format!("({}){}", receiver, method_call)
                             } else {
-                                if expr.precedence().order() < ExprPrecedence::MethodCall.order() {
-                                    format!("({}){}", receiver, method_call)
-                                } else {
-                                    format!("{}{}", receiver, method_call)
-                                }
+                                format!("{}{}", receiver, method_call)
                             };
                             Some(if is_struct_pat_shorthand_field {
                                 format!("{}: {}", receiver, sugg)

--- a/compiler/rustc_typeck/src/check/gather_locals.rs
+++ b/compiler/rustc_typeck/src/check/gather_locals.rs
@@ -109,10 +109,8 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                         traits::SizedArgumentType(Some(p.span)),
                     );
                 }
-            } else {
-                if !self.fcx.tcx.features().unsized_locals {
-                    self.fcx.require_type_is_sized(var_ty, p.span, traits::VariableType(p.hir_id));
-                }
+            } else if !self.fcx.tcx.features().unsized_locals {
+                self.fcx.require_type_is_sized(var_ty, p.span, traits::VariableType(p.hir_id));
             }
 
             debug!(

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -1085,26 +1085,24 @@ fn check_method_receiver<'fcx, 'tcx>(
             // Report error; `arbitrary_self_types` was enabled.
             e0307(fcx, span, receiver_ty);
         }
-    } else {
-        if !receiver_is_valid(fcx, span, receiver_ty, self_ty, false) {
-            if receiver_is_valid(fcx, span, receiver_ty, self_ty, true) {
-                // Report error; would have worked with `arbitrary_self_types`.
-                feature_err(
-                    &fcx.tcx.sess.parse_sess,
-                    sym::arbitrary_self_types,
-                    span,
-                    &format!(
-                        "`{}` cannot be used as the type of `self` without \
+    } else if !receiver_is_valid(fcx, span, receiver_ty, self_ty, false) {
+        if receiver_is_valid(fcx, span, receiver_ty, self_ty, true) {
+            // Report error; would have worked with `arbitrary_self_types`.
+            feature_err(
+                &fcx.tcx.sess.parse_sess,
+                sym::arbitrary_self_types,
+                span,
+                &format!(
+                    "`{}` cannot be used as the type of `self` without \
                          the `arbitrary_self_types` feature",
-                        receiver_ty,
-                    ),
-                )
-                .help(HELP_FOR_SELF_TYPE)
-                .emit();
-            } else {
-                // Report error; would not have worked with `arbitrary_self_types`.
-                e0307(fcx, span, receiver_ty);
-            }
+                    receiver_ty,
+                ),
+            )
+            .help(HELP_FOR_SELF_TYPE)
+            .emit();
+        } else {
+            // Report error; would not have worked with `arbitrary_self_types`.
+            e0307(fcx, span, receiver_ty);
         }
     }
 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -256,10 +256,8 @@ crate fn get_all_types(
         let args = get_real_types(generics, &arg.type_, cx, 0);
         if !args.is_empty() {
             all_types.extend(args);
-        } else {
-            if let Some(kind) = arg.type_.def_id().map(|did| cx.tcx.def_kind(did).clean(cx)) {
-                all_types.insert((arg.type_.clone(), kind));
-            }
+        } else if let Some(kind) = arg.type_.def_id().map(|did| cx.tcx.def_kind(did).clean(cx)) {
+            all_types.insert((arg.type_.clone(), kind));
         }
     }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -230,12 +230,10 @@ impl<'a> fmt::Display for WhereClause<'a> {
         let mut clause = String::new();
         if f.alternate() {
             clause.push_str(" where");
+        } else if end_newline {
+            clause.push_str(" <span class=\"where fmt-newline\">where");
         } else {
-            if end_newline {
-                clause.push_str(" <span class=\"where fmt-newline\">where");
-            } else {
-                clause.push_str(" <span class=\"where\">where");
-            }
+            clause.push_str(" <span class=\"where\">where");
         }
         for (i, pred) in gens.where_predicates.iter().enumerate() {
             if f.alternate() {
@@ -806,12 +804,10 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter<'_>, use_absolute: bool) -> 
                 } else {
                     write!(f, "{:#}::", self_type.print())?
                 }
+            } else if should_show_cast {
+                write!(f, "&lt;{} as {}&gt;::", self_type.print(), trait_.print())?
             } else {
-                if should_show_cast {
-                    write!(f, "&lt;{} as {}&gt;::", self_type.print(), trait_.print())?
-                } else {
-                    write!(f, "{}::", self_type.print())?
-                }
+                write!(f, "{}::", self_type.print())?
             };
             match *trait_ {
                 // It's pretty unsightly to look at `<A as B>::C` in output, and

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2947,14 +2947,12 @@ fn render_stability_since_raw(
                     v
                 );
             }
-        } else {
-            if ver != containing_ver {
-                write!(
-                    w,
-                    "<span class=\"since\" title=\"Stable since Rust version {0}\">{0}</span>",
-                    v
-                );
-            }
+        } else if ver != containing_ver {
+            write!(
+                w,
+                "<span class=\"since\" title=\"Stable since Rust version {0}\">{0}</span>",
+                v
+            );
         }
     }
 }
@@ -3632,11 +3630,9 @@ fn render_deref_methods(
         AssocItemRender::DerefFor { trait_: deref_type, type_: real_target, deref_mut_: deref_mut };
     if let Some(did) = target.def_id() {
         render_assoc_items(w, cx, container_item, did, what, cache);
-    } else {
-        if let Some(prim) = target.primitive_type() {
-            if let Some(&did) = cache.primitive_locations.get(&prim) {
-                render_assoc_items(w, cx, container_item, did, what, cache);
-            }
+    } else if let Some(prim) = target.primitive_type() {
+        if let Some(&did) = cache.primitive_locations.get(&prim) {
+            render_assoc_items(w, cx, container_item, did, what, cache);
         }
     }
 }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2166,12 +2166,10 @@ fn strip_generics_from_path_segment(
                     MalformedGenerics::HasFullyQualifiedSyntax,
                 ));
             }
+        } else if param_depth == 0 {
+            stripped_segment.push(c);
         } else {
-            if param_depth == 0 {
-                stripped_segment.push(c);
-            } else {
-                latest_generics_chunk.push(c);
-            }
+            latest_generics_chunk.push(c);
         }
     }
 

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -51,11 +51,10 @@ impl<'a> DocFolder for Stripper<'a> {
                 }
                 _ => return None,
             }
-        } else {
-            if self.update_retained {
-                self.retained.insert(i.def_id);
-            }
+        } else if self.update_retained {
+            self.retained.insert(i.def_id);
         }
+
         Some(self.fold_item_recur(i))
     }
 }


### PR DESCRIPTION
Fixes clippy::collapsible_else_if

reduces nesting of
````
if x {
 A
} else {
 if y {
  B
 } else {
  C
 }
}
````
to
````
if x {
 A
} else if y {
 B
} else {
 C
}
````