### PR TITLE
Improve `Iterator::by_ref` example

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1549,34 +1549,6 @@ pub trait Iterator {
     /// let of_rust: Vec<_> = words.collect();
     /// assert_eq!(of_rust, vec!["of", "Rust"]);
     /// ```
-    ///
-    /// This demonstrates a use case that needs `by_ref`:
-    ///
-    /// ```compile_fail,E0382
-    /// let a = [1, 2, 3, 4, 5];
-    /// let mut iter = a.iter();
-    ///
-    /// let sum: i32 = iter.take(3).fold(0, |acc, i| acc + i);
-    /// assert_eq!(sum, 6);
-    ///
-    /// // Error! We can't use `iter` again because it was moved
-    /// // by `take`.
-    /// assert_eq!(iter.next(), Some(&4));
-    /// ```
-    ///
-    /// Now, let's use `by_ref` to make this work:
-    ///
-    /// ```
-    /// let a = [1, 2, 3, 4, 5];
-    /// let mut iter = a.iter();
-    ///
-    /// // We add in a call to `by_ref` here so `iter` isn't moved.
-    /// let sum: i32 = iter.by_ref().take(3).fold(0, |acc, i| acc + i);
-    /// assert_eq!(sum, 6);
-    ///
-    /// // And now we can use `iter` again because we still own it.
-    /// assert_eq!(iter.next(), Some(&4));
-    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn by_ref(&mut self) -> &mut Self
     where

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1535,34 +1535,32 @@ pub trait Iterator {
     ///
     /// # Examples
     ///
-    /// Basic usage:
+    /// This demonstrates a use case that needs `by_ref`:
     ///
-    /// ```
-    /// let a = [1, 2, 3];
-    ///
-    /// let iter = a.iter();
-    ///
-    /// let sum: i32 = iter.take(5).fold(0, |acc, i| acc + i);
+    /// ```compile_fail,E0382
+    /// let a = [1, 2, 3, 4, 5];
+    /// let mut iter = a.iter();
+    /// let sum: i32 = iter.take(3).fold(0, |acc, i| acc + i);
     ///
     /// assert_eq!(sum, 6);
     ///
-    /// // if we try to use iter again, it won't work. The following line
-    /// // gives "error: use of moved value: `iter`
-    /// // assert_eq!(iter.next(), None);
+    /// // Error! We can't use `iter` again because it was moved
+    /// // by `take`.
+    /// assert_eq!(iter.next(), Some(&4));
+    /// ```
     ///
-    /// // let's try that again
-    /// let a = [1, 2, 3];
+    /// Now, let's use `by_ref` to make this work:
     ///
+    /// ```
+    /// let a = [1, 2, 3, 4, 5];
     /// let mut iter = a.iter();
+    /// // We add in a call to `by_ref` here so `iter` isn't moved.
+    /// let sum: i32 = iter.by_ref().take(3).fold(0, |acc, i| acc + i);
     ///
-    /// // instead, we add in a .by_ref()
-    /// let sum: i32 = iter.by_ref().take(2).fold(0, |acc, i| acc + i);
+    /// assert_eq!(sum, 6);
     ///
-    /// assert_eq!(sum, 3);
-    ///
-    /// // now this is just fine:
-    /// assert_eq!(iter.next(), Some(&3));
-    /// assert_eq!(iter.next(), None);
+    /// // And now we can use `iter` again because we still own it.
+    /// assert_eq!(iter.next(), Some(&4));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     fn by_ref(&mut self) -> &mut Self

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1535,6 +1535,21 @@ pub trait Iterator {
     ///
     /// # Examples
     ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let mut words = vec!["hello", "world", "of", "Rust"].into_iter();
+    ///
+    /// // Take the first two words.
+    /// let hello_world: Vec<_> = words.by_ref().take(2).collect();
+    /// assert_eq!(hello_world, vec!["hello", "world"]);
+    ///
+    /// // Collect the rest of the words.
+    /// // We can only do this because we used `by_ref` earlier.
+    /// let of_rust: Vec<_> = words.collect();
+    /// assert_eq!(of_rust, vec!["of", "Rust"]);
+    /// ```
+    ///
     /// This demonstrates a use case that needs `by_ref`:
     ///
     /// ```compile_fail,E0382

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1540,8 +1540,8 @@ pub trait Iterator {
     /// ```compile_fail,E0382
     /// let a = [1, 2, 3, 4, 5];
     /// let mut iter = a.iter();
-    /// let sum: i32 = iter.take(3).fold(0, |acc, i| acc + i);
     ///
+    /// let sum: i32 = iter.take(3).fold(0, |acc, i| acc + i);
     /// assert_eq!(sum, 6);
     ///
     /// // Error! We can't use `iter` again because it was moved
@@ -1554,9 +1554,9 @@ pub trait Iterator {
     /// ```
     /// let a = [1, 2, 3, 4, 5];
     /// let mut iter = a.iter();
+    ///
     /// // We add in a call to `by_ref` here so `iter` isn't moved.
     /// let sum: i32 = iter.by_ref().take(3).fold(0, |acc, i| acc + i);
-    ///
     /// assert_eq!(sum, 6);
     ///
     /// // And now we can use `iter` again because we still own it.


### PR DESCRIPTION
I split the example into two: one that fails to compile, and one that
works. I also made them identical except for the addition of `by_ref`
so we don't confuse readers with random differences.

cc @steveklabnik, who is the one that added the previous version of this example
