### PR TITLE
Use standard formatting for "rust-call" ABI message

### DIFF
--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -113,7 +113,7 @@ pub(super) fn check_fn<'a, 'tcx>(
             };
 
             if let Some(header) = item {
-                tcx.sess.span_err(header.span, "A function with the \"rust-call\" ABI must take a single non-self argument that is a tuple")
+                tcx.sess.span_err(header.span, "functions with the \"rust-call\" ABI must take a single non-self argument that is a tuple")
             }
         };
 

--- a/src/test/ui/abi/issues/issue-22565-rust-call.rs
+++ b/src/test/ui/abi/issues/issue-22565-rust-call.rs
@@ -1,25 +1,25 @@
 #![feature(unboxed_closures)]
 
 extern "rust-call" fn b(_i: i32) {}
-//~^ ERROR A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+//~^ ERROR functions with the "rust-call" ABI must take a single non-self argument that is a tuple
 
 trait Tr {
     extern "rust-call" fn a();
 
     extern "rust-call" fn b() {}
-    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self argument
 }
 
 struct Foo;
 
 impl Foo {
     extern "rust-call" fn bar() {}
-    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self argument
 }
 
 impl Tr for Foo {
     extern "rust-call" fn a() {}
-    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self argument
 }
 
 fn main () {

--- a/src/test/ui/abi/issues/issue-22565-rust-call.stderr
+++ b/src/test/ui/abi/issues/issue-22565-rust-call.stderr
@@ -1,22 +1,22 @@
-error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+error: functions with the "rust-call" ABI must take a single non-self argument that is a tuple
   --> $DIR/issue-22565-rust-call.rs:3:1
    |
 LL | extern "rust-call" fn b(_i: i32) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+error: functions with the "rust-call" ABI must take a single non-self argument that is a tuple
   --> $DIR/issue-22565-rust-call.rs:9:5
    |
 LL |     extern "rust-call" fn b() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+error: functions with the "rust-call" ABI must take a single non-self argument that is a tuple
   --> $DIR/issue-22565-rust-call.rs:16:5
    |
 LL |     extern "rust-call" fn bar() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+error: functions with the "rust-call" ABI must take a single non-self argument that is a tuple
   --> $DIR/issue-22565-rust-call.rs:21:5
    |
 LL |     extern "rust-call" fn a() {}

--- a/src/test/ui/overloaded-calls-nontuple.rs
+++ b/src/test/ui/overloaded-calls-nontuple.rs
@@ -11,13 +11,13 @@ impl FnMut<isize> for S {
     extern "rust-call" fn call_mut(&mut self, z: isize) -> isize {
         self.x + self.y + z
     }
-    //~^^^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+    //~^^^ ERROR functions with the "rust-call" ABI must take a single non-self argument
 }
 
 impl FnOnce<isize> for S {
     type Output = isize;
     extern "rust-call" fn call_once(mut self, z: isize) -> isize { self.call_mut(z) }
-    //~^ ERROR A function with the "rust-call" ABI must take a single non-self argument
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self argument
 }
 
 fn main() {

--- a/src/test/ui/overloaded-calls-nontuple.stderr
+++ b/src/test/ui/overloaded-calls-nontuple.stderr
@@ -1,10 +1,10 @@
-error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+error: functions with the "rust-call" ABI must take a single non-self argument that is a tuple
   --> $DIR/overloaded-calls-nontuple.rs:11:5
    |
 LL |     extern "rust-call" fn call_mut(&mut self, z: isize) -> isize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: A function with the "rust-call" ABI must take a single non-self argument that is a tuple
+error: functions with the "rust-call" ABI must take a single non-self argument that is a tuple
   --> $DIR/overloaded-calls-nontuple.rs:19:5
    |
 LL |     extern "rust-call" fn call_once(mut self, z: isize) -> isize { self.call_mut(z) }


### PR DESCRIPTION
Nearly all error messages start with a lowercase letter and don't use
articles - instead they refer to the plural case.
