### PR TITLE
Don't mark `force_query_with_job` as `inline(always)`

### DIFF
--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -566,7 +566,6 @@ fn incremental_verify_ich<CTX, K, V>(
     assert!(new_hash == old_hash, "found unstable fingerprints for {:?}", dep_node,);
 }
 
-#[inline(always)]
 fn force_query_with_job<C, CTX>(
     tcx: CTX,
     key: C::Key,


### PR DESCRIPTION
It's rather large, and using `inline(always)` forces it to be recompiled
in each calling crate. Hopefully this change will help with #65031. I intentionally only removed inline from `force_query_with_job` because the other functions are tiny and I wanted to measure this change on its own.

This may conflict with https://github.com/rust-lang/rust/issues/78780. I am not sure if it will hurt or help.

cc @cjgillot 