### PR TITLE
Riscv64linux Test fixes

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -122,7 +122,21 @@ impl Step for Linkcheck {
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
-        run.path("src/tools/linkchecker").default_condition(builder.config.docs)
+        let run = run.path("src/tools/linkchecker");
+        let hosts = &builder.hosts;
+        let targets = &builder.targets;
+
+        // if we have different hosts and targets, some things may be built for
+        // the host (e.g. rustc) and others for the target (e.g. std). The
+        // documentation built for each will contain broken links to
+        // docs built for the other platform (e.g. rustc linking to cargo)
+        if (hosts != targets) && !hosts.is_empty() && !targets.is_empty() {
+            panic!(
+                "Linkcheck currently does not support builds with different hosts and targets.
+You can skip linkcheck with --exclude src/tools/linkchecker"
+            );
+        }
+        run.default_condition(builder.config.docs)
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/Dockerfile
@@ -98,6 +98,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --qemu-riscv64-rootfs=/tmp/rootfs
-ENV SCRIPT python3 ../x.py --stage 2 test --target riscv64gc-unknown-linux-gnu
+ENV SCRIPT python3 ../x.py --stage 2 test --host='' --target riscv64gc-unknown-linux-gnu
 
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-10/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-10/Dockerfile
@@ -46,6 +46,7 @@ ENV SCRIPT python2.7 ../x.py --stage 2 test --exclude src/tools/tidy && \
            # This is intended to make sure that both `--pass=check` continues to
            # work.
            #
-           python2.7 ../x.py --stage 2 test src/test/ui --pass=check --target=i686-unknown-linux-gnu && \
+           python2.7 ../x.py --stage 2 test src/test/ui --pass=check \
+                             --host='' --target=i686-unknown-linux-gnu && \
            # Run tidy at the very end, after all the other tests.
            python2.7 ../x.py --stage 2 test src/tools/tidy

--- a/src/test/run-make/incr-prev-body-beyond-eof/Makefile
+++ b/src/test/run-make/incr-prev-body-beyond-eof/Makefile
@@ -1,3 +1,5 @@
+# ignore-none no-std is not supported
+
 include ../../run-make-fulldeps/tools.mk
 
 # Tests that we don't ICE during incremental compilation after modifying a

--- a/src/test/run-make/incr-prev-body-beyond-eof/Makefile
+++ b/src/test/run-make/incr-prev-body-beyond-eof/Makefile
@@ -1,8 +1,5 @@
 include ../../run-make-fulldeps/tools.mk
 
-# FIXME https://github.com/rust-lang/rust/issues/78911
-# ignore-32bit wrong/no cross compiler and sometimes we pass wrong gcc args (-m64)
-
 # Tests that we don't ICE during incremental compilation after modifying a
 # function span such that its previous end line exceeds the number of lines
 # in the new file, but its start line/column and length remain the same.
@@ -14,6 +11,6 @@ all:
 	mkdir $(SRC)
 	mkdir $(INCR)
 	cp a.rs $(SRC)/main.rs
-	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs
+	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs --target $(TARGET)
 	cp b.rs $(SRC)/main.rs
-	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs
+	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs --target $(TARGET)

--- a/src/test/run-make/incr-prev-body-beyond-eof/Makefile
+++ b/src/test/run-make/incr-prev-body-beyond-eof/Makefile
@@ -1,4 +1,5 @@
 # ignore-none no-std is not supported
+# ignore-nvptx64-nvidia-cuda FIXME: can't find crate for `std`
 
 include ../../run-make-fulldeps/tools.mk
 

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,6 +1,7 @@
 # ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
 #                              so it won't work with remote-test-server
 # ignore-arm Another build using remote-test-server
+# ignore-none no-std is not supported
 
 include ../../run-make-fulldeps/tools.mk
 

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,3 +1,7 @@
+# ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
+#                              so it won't work with remote-test-server
+# ignore-arm Another build using remote-test-server
+
 include ../../run-make-fulldeps/tools.mk
 
 all: foo

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -2,6 +2,11 @@
 #                              so it won't work with remote-test-server
 # ignore-arm Another build using remote-test-server
 # ignore-none no-std is not supported
+# ignore-wasm32 FIXME: don't attempt to compile C++ to WASM
+# ignore-wasm64 FIXME: don't attempt to compile C++ to WASM
+# ignore-nvptx64-nvidia-cuda FIXME: can't find crate for `std`
+# ignore-musl FIXME: this makefile needs teaching how to use a musl toolchain
+#                    (see dist-i586-gnu-i586-i686-musl Dockerfile)
 
 include ../../run-make-fulldeps/tools.mk
 

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,13 +1,10 @@
 include ../../run-make-fulldeps/tools.mk
 
-# FIXME https://github.com/rust-lang/rust/issues/78911
-# ignore-32bit wrong/no cross compiler and sometimes we pass wrong gcc args (-m64)
-
 all: foo
 	$(call RUN,foo)
 
 foo: foo.rs $(call NATIVE_STATICLIB,foo)
-	$(RUSTC) $< -lfoo $(EXTRARSCXXFLAGS)
+	$(RUSTC) $< -lfoo $(EXTRARSCXXFLAGS) --target $(TARGET)
 
 $(TMPDIR)/libfoo.o: foo.cpp
 	$(call COMPILE_OBJ_CXX,$@,$<)

--- a/src/test/run-make/issue-83112-incr-test-moved-file/Makefile
+++ b/src/test/run-make/issue-83112-incr-test-moved-file/Makefile
@@ -1,6 +1,7 @@
 include ../../run-make-fulldeps/tools.mk
 
 # ignore-none no-std is not supported
+# ignore-nvptx64-nvidia-cuda FIXME: can't find crate for 'std'
 
 # Regression test for issue #83112
 # The generated test harness code contains spans with a dummy location,

--- a/src/test/run-make/issue-83112-incr-test-moved-file/Makefile
+++ b/src/test/run-make/issue-83112-incr-test-moved-file/Makefile
@@ -1,5 +1,7 @@
 include ../../run-make-fulldeps/tools.mk
 
+# ignore-none no-std is not supported
+
 # Regression test for issue #83112
 # The generated test harness code contains spans with a dummy location,
 # but a non-dummy SyntaxContext. Previously, the incremental cache was encoding

--- a/src/test/run-make/issue-83112-incr-test-moved-file/Makefile
+++ b/src/test/run-make/issue-83112-incr-test-moved-file/Makefile
@@ -1,8 +1,5 @@
 include ../../run-make-fulldeps/tools.mk
 
-# FIXME https://github.com/rust-lang/rust/issues/78911
-# ignore-32bit wrong/no cross compiler and sometimes we pass wrong gcc args (-m64)
-
 # Regression test for issue #83112
 # The generated test harness code contains spans with a dummy location,
 # but a non-dummy SyntaxContext. Previously, the incremental cache was encoding
@@ -20,6 +17,6 @@ all:
 	mkdir $(SRC)/mydir
 	mkdir $(INCR)
 	cp main.rs $(SRC)/main.rs
-	$(RUSTC) --test -C incremental=$(INCR) $(SRC)/main.rs
+	$(RUSTC) --test -C incremental=$(INCR) $(SRC)/main.rs --target $(TARGET)
 	mv $(SRC)/main.rs $(SRC)/mydir/main.rs
-	$(RUSTC) --test -C incremental=$(INCR) $(SRC)/mydir/main.rs
+	$(RUSTC) --test -C incremental=$(INCR) $(SRC)/mydir/main.rs --target $(TARGET)


### PR DESCRIPTION
Get tests passing again using the riscv64gc-unknown-linux-gnu docker image.

Test with
```
src/ci/docker/run.sh riscv64gc-linux
```

## linkcheck
Linkcheck tests that interdocument links in the documentation are correct. Some interdocument links go between rustc and tools (such as rustdoc and cargo). When cross compiling, rustc is built for the host while some tools are built for the target. This goes for the documentation too. Because of this, links in the rustc documentation reffering to cargo or rustdoc documentation look broken.

This issue is worked around by disabling linkcheck for cross compilation builds.

## run-make tests

#78911 seems to happen because `--target` was not passed to `rustc`, but the target linker was specified, causing the target linker to be called with options intended for the host.

Resolves #78911 

In a separate issue, `issue-36710` was trying to run a binary built for the target on the host system. This will not work for any platform using `remote-test-server`/`client` (such as riscv64). I don't know of a way of skipping those platforms specifically, so I set this test to skip only on riscv64 for now.