### PR TITLE
Add `OsStr::display` as a counterpart to `Path::display`

### DIFF
--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -150,6 +150,8 @@ pub use self::c_str::FromVecWithNulError;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::c_str::{CStr, CString, IntoStringError, NulError};
 
+#[stable(feature = "os_str_display", since = "1.51.0")]
+pub use self::os_str::Display;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::os_str::{OsStr, OsString};
 

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1068,8 +1068,31 @@ impl fmt::Debug for OsStr {
 }
 
 impl OsStr {
-    pub(crate) fn display(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.inner, formatter)
+    #[stable(feature = "os_str_display", since = "1.51.0")]
+    /// Returns an object that implements [`Display`] for safely printing strings that may contain
+    /// non-Unicode data.
+    ///
+    /// See also [`Path::display()`].
+    ///
+    /// [`Display`]: fmt::Display
+    /// [`Path::display()`]: crate::path::Path::display
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ffi::OsStr;
+    ///
+    /// let os_str = OsStr::new("foo.txt");
+    /// println!("{}", os_str.display());
+    /// ```
+    ///
+    /// ```
+    /// let path = std::path::Path::new("foo.txt");
+    /// let os_str = path.as_os_str();
+    /// println!("{}", os_str.display());
+    /// ```
+    pub fn display(&self) -> impl fmt::Display + '_ {
+        &self.inner
     }
 }
 

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1089,7 +1089,7 @@ impl OsStr {
     /// ```
     /// let path = std::path::Path::new("foo.txt");
     /// let os_str = path.as_os_str();
-    /// println!("{}", os_str.display());
+    /// assert_eq!(path.display().to_string(), os_str.display().to_string());
     /// ```
     pub fn display(&self) -> impl fmt::Display + '_ {
         &self.inner

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2525,7 +2525,7 @@ impl fmt::Debug for Display<'_> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for Display<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.path.inner.display(f)
+        self.path.inner.display().fmt(f)
     }
 }
 

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2285,7 +2285,7 @@ impl Path {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn display(&self) -> Display<'_> {
-        Display { path: self }
+        Display { path: self.as_os_str() }
     }
 
     /// Queries the file system to get information about a file, directory, etc.
@@ -2492,42 +2492,8 @@ impl fmt::Debug for Path {
     }
 }
 
-/// Helper struct for safely printing paths with [`format!`] and `{}`.
-///
-/// A [`Path`] might contain non-Unicode data. This `struct` implements the
-/// [`Display`] trait in a way that mitigates that. It is created by the
-/// [`display`](Path::display) method on [`Path`].
-///
-/// # Examples
-///
-/// ```
-/// use std::path::Path;
-///
-/// let path = Path::new("/tmp/foo.rs");
-///
-/// println!("{}", path.display());
-/// ```
-///
-/// [`Display`]: fmt::Display
-/// [`format!`]: crate::format
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Display<'a> {
-    path: &'a Path,
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl fmt::Debug for Display<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.path, f)
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl fmt::Display for Display<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.path.inner.display().fmt(f)
-    }
-}
+pub use crate::ffi::Display;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl cmp::PartialEq for Path {


### PR DESCRIPTION
Displaying the string could already be done with `Path::new(os_str).display()`; this just removes the middleman.

I marked this as insta-stable, but I'm happy to change it to unstable if you think it's better to get feedback on nightly.