### PR TITLE
Expand core::panic!() to always include `{ .. }`.

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -7,15 +7,15 @@ macro_rules! panic {
     () => (
         $crate::panic!("explicit panic")
     );
-    ($msg:literal $(,)?) => (
+    ($msg:literal $(,)?) => ({
         $crate::panicking::panic($msg)
-    );
-    ($msg:expr $(,)?) => (
+    });
+    ($msg:expr $(,)?) => ({
         $crate::panicking::panic_str($msg)
-    );
-    ($fmt:expr, $($arg:tt)+) => (
+    });
+    ($fmt:expr, $($arg:tt)+) => ({
         $crate::panicking::panic_fmt($crate::format_args!($fmt, $($arg)+))
-    );
+    });
 }
 
 /// Asserts that two expressions are equal to each other (using [`PartialEq`]).

--- a/src/test/ui/issues/issue-5500-1.rs
+++ b/src/test/ui/issues/issue-5500-1.rs
@@ -11,5 +11,6 @@ struct TrieMapIterator<'a> {
 fn main() {
     let a = 5;
     let _iter = TrieMapIterator{node: &a};
-    _iter.node = &panic!()
+    _iter.node = &panic!();
+    _iter.node = &core::panic!()
 }


### PR DESCRIPTION
`std::panic!()` always expanded to a `{..}` block, but `core::panic!()` did not. Because of this subtle difference, the `issue-5500-1` test passed for `std::panic!()`, but not for `core::panic!()`.

This makes them behave the same, and extends that test to also check core::panic!().

This fixes https://github.com/rust-lang/rust/issues/80846.

This is part of the effort to make `std::panic!()` and `core::panic!()` identical, as tracked in https://github.com/rust-lang/rust/issues/80162.