### PR TITLE
Expand assert!(expr, args..) to include $crate for hygiene on 2021.

### DIFF
--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -12,25 +12,23 @@ use rustc_span::{Span, DUMMY_SP};
 
 pub fn expand_assert<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
-    sp: Span,
+    span: Span,
     tts: TokenStream,
 ) -> Box<dyn MacResult + 'cx> {
-    let Assert { cond_expr, custom_message } = match parse_assert(cx, sp, tts) {
+    let Assert { cond_expr, custom_message } = match parse_assert(cx, span, tts) {
         Ok(assert) => assert,
         Err(mut err) => {
             err.emit();
-            return DummyResult::any(sp);
+            return DummyResult::any(span);
         }
     };
 
-    let is_2021 = sp.rust_2021();
-
     // `core::panic` and `std::panic` are different macros, so we use call-site
     // context to pick up whichever is currently in scope.
-    let sp = cx.with_call_site_ctxt(sp);
+    let sp = cx.with_call_site_ctxt(span);
 
     let panic_call = if let Some(tokens) = custom_message {
-        let path = if is_2021 {
+        let path = if span.rust_2021() {
             // On edition 2021, we always call `$crate::panic!()`.
             Path {
                 span: sp,

--- a/src/test/ui/hygiene/no_implicit_prelude-2021.rs
+++ b/src/test/ui/hygiene/no_implicit_prelude-2021.rs
@@ -1,0 +1,9 @@
+// check-pass
+// edition:2021
+
+#![no_implicit_prelude]
+
+fn main() {
+    assert!(true, "hoi");
+    assert!(false, "hoi {}", 123);
+}


### PR DESCRIPTION
This makes `assert!(expr, args..)` properly hygienic in Rust 2021.

This is part of rust-lang/rfcs#3007, see #80162.

Before edition 2021, this was a breaking change, as `std::panic` and `core::panic` are different. In edition 2021 they will be identical, making it possible to apply proper hygiene here.