### PR TITLE
Add comment to `Vec::truncate` explaining `>` vs `>=`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -990,6 +990,9 @@ impl<T, A: Allocator> Vec<T, A> {
         //   such that no value will be dropped twice in case `drop_in_place`
         //   were to panic once (if it panics twice, the program aborts).
         unsafe {
+            // Note: It's intentional that this is `>` and not `>=`.
+            //       Changing it to `>=` has negative performance
+            //       implications in some cases. See #78884 for more.
             if len > self.len {
                 return;
             }


### PR DESCRIPTION
Hopefully this will prevent people from continuing to ask about this
over and over again :)

See [this Zulip discussion][1] for more.

[1]: https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Vec.3A.3Atruncate.20implementation

r? @scottmcm