### PR TITLE
Print failure message on all tests that should panic, but don't

### DIFF
--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -63,7 +63,7 @@ pub fn calc_result<'a>(
                 ))
             }
         }
-        (&ShouldPanic::Yes, Ok(())) => {
+        (&ShouldPanic::Yes, Ok(())) | (&ShouldPanic::YesWithMessage(_), Ok(())) => {
             TestResult::TrFailedMsg("test did not panic as expected".to_string())
         }
         _ if desc.allow_fail => TestResult::TrAllowedFail,


### PR DESCRIPTION
Fixes #80861. Tests with the `#[should_panic]` attribute should always print a failure message if no panic occurs, regardless of whether or not an `expected` panic message is specified.