### PR TITLE
Fix typo in source-based-code-coverage.md

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/source-based-code-coverage.md
+++ b/src/doc/unstable-book/src/compiler-flags/source-based-code-coverage.md
@@ -123,7 +123,7 @@ The `rustup` option is guaranteed to install a compatible version of the LLVM to
 ```shell
 $ rustup component add llvm-tools-preview
 $ cargo install cargo-binutils
-$ cargo profdata -- --help  # note the additional "--" preceeding the tool-specific arguments
+$ cargo profdata -- --help  # note the additional "--" preceding the tool-specific arguments
 ```
 
 ## Creating coverage reports


### PR DESCRIPTION
preceeding -> preceding