### PR TITLE
Update intra-doc link documentation to match the implementation

### DIFF
--- a/src/doc/rustdoc/src/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/linking-to-items-by-name.md
@@ -24,6 +24,9 @@ pub struct Foo4;
 pub struct Bar;
 ```
 
+Unlike normal markdown, `[bar][Bar]` syntax is also supported without needing a
+`[Bar]: ...` reference link, and links are case-sensitive.
+
 Backticks around the link will be stripped, so ``[`Option`]`` will correctly
 link to `Option`.
 

--- a/src/doc/rustdoc/src/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/linking-to-items-by-name.md
@@ -135,7 +135,7 @@ when the item is re-exported. If a link from another crate fails to resolve, no
 warning is given.
 
 When re-exporting an item, rustdoc allows adding additional documentation to it.
-That additional documentation will be resolved in scope of the re-export, not
+That additional documentation will be resolved in the scope of the re-export, not
 the original, allowing you to link to items in the new crate. The new links
 will still give a warning if they fail to resolve.
 

--- a/src/doc/rustdoc/src/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/linking-to-items-by-name.md
@@ -37,14 +37,14 @@ You can refer to anything in scope, and use paths, including `Self`, `self`, `su
 trait implementations][#79682]. Rustdoc also supports linking to the following primitives, which
 have no path and cannot be imported:
 
-- [`slice`](../../std/primitive.slice.html)
-- [`array`](../../std/primitive.array.html)
-- [`tuple`](../../std/primitive.tuple.html)
-- [`unit`](../../std/primitive.unit.html)
-- [`fn`](../../std/primitive.fn.html)
-- [`pointer`](../../std/primitive.pointer.html), `*`, `*const`, or `*mut`
-- [`reference`](../../std/primitive.reference.html), `&`, or `&mut`
-- [`never`](../../std/primitive.never.html) or `!`
+- [`slice`](../std/primitive.slice.html)
+- [`array`](../std/primitive.array.html)
+- [`tuple`](../std/primitive.tuple.html)
+- [`unit`](../std/primitive.unit.html)
+- [`fn`](../std/primitive.fn.html)
+- [`pointer`](../std/primitive.pointer.html), `*`, `*const`, or `*mut`
+- [`reference`](../std/primitive.reference.html), `&`, or `&mut`
+- [`never`](../std/primitive.never.html) or `!`
 
 [#79682]: https://github.com/rust-lang/rust/pull/79682
 

--- a/src/doc/rustdoc/src/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/linking-to-items-by-name.md
@@ -24,7 +24,7 @@ pub struct Foo4;
 pub struct Bar;
 ```
 
-Unlike normal markdown, `[bar][Bar]` syntax is also supported without needing a
+Unlike normal Markdown, `[bar][Bar]` syntax is also supported without needing a
 `[Bar]: ...` reference link, and links are case-sensitive.
 
 Backticks around the link will be stripped, so ``[`Option`]`` will correctly
@@ -37,14 +37,14 @@ You can refer to anything in scope, and use paths, including `Self`, `self`, `su
 trait implementations][#79682]. Rustdoc also supports linking to the following primitives, which
 have no path and cannot be imported:
 
-- [`slice`](https://doc.rust-lang.org/std/primitive.slice.html)
-- [`array`](https://doc.rust-lang.org/std/primitive.array.html)
-- [`tuple`](https://doc.rust-lang.org/std/primitive.tuple.html)
-- [`unit`](https://doc.rust-lang.org/std/primitive.unit.html)
-- [`fn`](https://doc.rust-lang.org/std/primitive.fn.html)
-- [`pointer`](https://doc.rust-lang.org/std/primitive.pointer.html), `*`, `*const`, or `*mut`
-- [`reference`](https://doc.rust-lang.org/std/primitive.reference.html), `&`, or `&mut`
-- [`never`](https://doc.rust-lang.org/std/primitive.never.html) or `!`
+- [`slice`](../../std/primitive.slice.html)
+- [`array`](../../std/primitive.array.html)
+- [`tuple`](../../std/primitive.tuple.html)
+- [`unit`](../../std/primitive.unit.html)
+- [`fn`](../../std/primitive.fn.html)
+- [`pointer`](../../std/primitive.pointer.html), `*`, `*const`, or `*mut`
+- [`reference`](../../std/primitive.reference.html), `&`, or `&mut`
+- [`never`](../../std/primitive.never.html) or `!`
 
 [#79682]: https://github.com/rust-lang/rust/pull/79682
 
@@ -83,10 +83,8 @@ struct MySpecialFormatter;
 ## Namespaces and Disambiguators
 
 Paths in Rust have three namespaces: type, value, and macro. Item names must be unique within
-their namespace, but can overlap with items outside of their namespace. In case of ambiguity,
-rustdoc will warn about the ambiguity and ask you to disambiguate, which can be done by using a
-prefix like `struct@`, `enum@`, `type@`, `trait@`, `union@`, `const@`, `static@`, `value@`,
-`fn@`, `function@`, `mod@`, `module@`, `method@`, `prim@`, `primitive@`, `macro@`, or `derive@`:
+their namespace, but can overlap with items in other namespaces. In case of ambiguity,
+rustdoc will warn about the ambiguity and ask you to disambiguate.
 
 ```rust
 /// See also: [`Foo`](struct@Foo)
@@ -98,6 +96,22 @@ struct Foo {}
 fn Foo() {}
 ```
 
+The following prefixes can be used:
+
+- `struct@`
+- `enum@`
+- `type@`
+- `trait@`
+- `union@`
+- `const@`
+- `static@`
+- `value@`
+- `fn@` / `function@` / `method@`
+- `mod@` / `module@`
+- `prim@` / `primitive@`
+- `macro@`
+- `derive@`
+
 These prefixes will be stripped when displayed in the documentation, so `[struct@Foo]`
 will be rendered as `Foo`.
 
@@ -105,23 +119,25 @@ You can also disambiguate for functions by adding `()` after the function name,
 or for macros by adding `!` after the macro name:
 
 ```rust
-/// See also: [`Foo`](struct@Foo)
-struct Bar;
+/// This is different from [`foo!`]
+fn foo() {}
 
-/// This is different from [`Foo()`]
-struct Foo {}
-
-fn Foo() {}
+/// This is different from [`foo()`]
+macro_rules! foo {
+  () => {}
+}
 ```
 
 ## Warnings, re-exports, and scoping
 
-Links are resolved in the current module scope, even when re-exported. If a link from another
-crate fails to resolve, no warning is given.
+Links are resolved in the scope of the module where the item is defined, even
+when the item is re-exported. If a link from another crate fails to resolve, no
+warning is given.
 
-When re-exporting an item, rustdoc allows additional documentation to it. That documentation will
-be resolved in the new scope, not the original, allowing you to link to items in the current
-crate. The new links will still give a warning if they fail to resolve.
+When re-exporting an item, rustdoc allows adding additional documentation to it.
+That additional documentation will be resolved in scope of the re-export, not
+the original, allowing you to link to items in the new crate. The new links
+will still give a warning if they fail to resolve.
 
 ```rust
 /// See also [foo()]
@@ -130,7 +146,7 @@ pub use std::process::Command;
 pub fn foo() {}
 ```
 
-This is especially useful for proc-macros, which must always be in their own dedicated crate.
+This is especially useful for proc-macros, which must always be defined in their own dedicated crate.
 
 Note: Because of how `macro_rules!` macros are scoped in Rust, the intra-doc links of a
 `macro_rules!` macro will be resolved [relative to the crate root][#72243], as opposed to the

--- a/src/doc/rustdoc/src/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/linking-to-items-by-name.md
@@ -25,7 +25,7 @@ pub struct Bar;
 ```
 
 Unlike normal Markdown, `[bar][Bar]` syntax is also supported without needing a
-`[Bar]: ...` reference link, and links are case-sensitive.
+`[Bar]: ...` reference link.
 
 Backticks around the link will be stripped, so ``[`Option`]`` will correctly
 link to `Option`.
@@ -34,17 +34,8 @@ link to `Option`.
 
 You can refer to anything in scope, and use paths, including `Self`, `self`, `super`, and
 `crate`. Associated items (functions, types, and constants) are supported, but [not for blanket
-trait implementations][#79682]. Rustdoc also supports linking to the following primitives, which
-have no path and cannot be imported:
-
-- [`slice`](../std/primitive.slice.html)
-- [`array`](../std/primitive.array.html)
-- [`tuple`](../std/primitive.tuple.html)
-- [`unit`](../std/primitive.unit.html)
-- [`fn`](../std/primitive.fn.html)
-- [`pointer`](../std/primitive.pointer.html), `*`, `*const`, or `*mut`
-- [`reference`](../std/primitive.reference.html), `&`, or `&mut`
-- [`never`](../std/primitive.never.html) or `!`
+trait implementations][#79682]. Rustdoc also supports linking to all primitives listed in
+[the standard library documentation](../std/index.html#primitives).
 
 [#79682]: https://github.com/rust-lang/rust/pull/79682
 
@@ -84,7 +75,7 @@ struct MySpecialFormatter;
 
 Paths in Rust have three namespaces: type, value, and macro. Item names must be unique within
 their namespace, but can overlap with items in other namespaces. In case of ambiguity,
-rustdoc will warn about the ambiguity and ask you to disambiguate.
+rustdoc will warn about the ambiguity and suggest a disambiguator.
 
 ```rust
 /// See also: [`Foo`](struct@Foo)
@@ -96,24 +87,8 @@ struct Foo {}
 fn Foo() {}
 ```
 
-The following prefixes can be used:
-
-- `struct@`
-- `enum@`
-- `type@`
-- `trait@`
-- `union@`
-- `const@`
-- `static@`
-- `value@`
-- `fn@` / `function@` / `method@`
-- `mod@` / `module@`
-- `prim@` / `primitive@`
-- `macro@`
-- `derive@`
-
-These prefixes will be stripped when displayed in the documentation, so `[struct@Foo]`
-will be rendered as `Foo`.
+These prefixes will be stripped when displayed in the documentation, so `[struct@Foo]` will be
+rendered as `Foo`.
 
 You can also disambiguate for functions by adding `()` after the function name,
 or for macros by adding `!` after the macro name:
@@ -133,6 +108,15 @@ macro_rules! foo {
 Links are resolved in the scope of the module where the item is defined, even
 when the item is re-exported. If a link from another crate fails to resolve, no
 warning is given.
+
+```rust
+mod inner {
+    /// Link to [f()]
+    pub struct S;
+    pub fn f() {}
+}
+pub use inner::S; // the link to `f` will still resolve correctly
+```
 
 When re-exporting an item, rustdoc allows adding additional documentation to it.
 That additional documentation will be resolved in the scope of the re-export, not
@@ -154,8 +138,6 @@ module it is defined in.
 
 If links do not look 'sufficiently like' an intra-doc link, they will be ignored and no warning
 will be given, even if the link fails to resolve. For example, any link containing `/` or `[]`
-characters will be ignored. You can see the full criteria for 'sufficiently like' in [the source
-code].
+characters will be ignored.
 
 [#72243]: https://github.com/rust-lang/rust/issues/72243
-[the source code]: https://github.com/rust-lang/rust/blob/34628e5b533d35840b61c5db0665cf7633ed3c5a/src/librustdoc/passes/collect_intra_doc_links.rs#L982

--- a/src/doc/rustdoc/src/linking-to-items-by-name.md
+++ b/src/doc/rustdoc/src/linking-to-items-by-name.md
@@ -109,7 +109,7 @@ Links are resolved in the scope of the module where the item is defined, even
 when the item is re-exported. If a link from another crate fails to resolve, no
 warning is given.
 
-```rust
+```rust,edition2018
 mod inner {
     /// Link to [f()]
     pub struct S;


### PR DESCRIPTION
r? @Manishearth 
cc @camelid @m-ou-se

Relevant PRs:
- https://github.com/rust-lang/rust/pull/74489
- https://github.com/rust-lang/rust/pull/80181
- https://github.com/rust-lang/rust/pull/76078
- https://github.com/rust-lang/rust/pull/77519
- https://github.com/rust-lang/rust/pull/73101

Relevant issues:
- https://github.com/rust-lang/rust/issues/78800
- https://github.com/rust-lang/rust/issues/77200
- https://github.com/rust-lang/rust/issues/77199 / https://github.com/rust-lang/rust/issues/54191/

I haven't documented things that I consider 'just bugs', like https://github.com/rust-lang/rust/issues/77732, but I have documented features that aren't implemented, like https://github.com/rust-lang/rust/issues/78800.