### PR TITLE
Add `unwrap_unchecked()` methods for `Option` and `Result`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -428,6 +428,37 @@ impl<T> Option<T> {
         }
     }
 
+    /// Returns the contained [`Some`] value, consuming the `self` value,
+    /// without checking that the value is not [`None`].
+    ///
+    /// # Safety
+    ///
+    /// Undefined behavior if the value is [`None`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_result_unwrap_unchecked)]
+    /// let x = Some("air");
+    /// assert_eq!(unsafe { x.unwrap_unchecked() }, "air");
+    /// ```
+    ///
+    /// ```no_run
+    /// #![feature(option_result_unwrap_unchecked)]
+    /// let x: Option<&str> = None;
+    /// assert_eq!(unsafe { x.unwrap_unchecked() }, "air"); // Undefined behavior!
+    /// ```
+    #[inline]
+    #[track_caller]
+    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "none")]
+    pub unsafe fn unwrap_unchecked(self) -> T {
+        debug_assert!(self.is_some());
+        match self {
+            Some(val) => val,
+            None => unsafe { hint::unreachable_unchecked() },
+        }
+    }
+
     /////////////////////////////////////////////////////////////////////////
     // Transforming contained values
     /////////////////////////////////////////////////////////////////////////

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -455,6 +455,7 @@ impl<T> Option<T> {
         debug_assert!(self.is_some());
         match self {
             Some(val) => val,
+            // SAFETY: the safety contract must be upheld by the caller.
             None => unsafe { hint::unreachable_unchecked() },
         }
     }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -452,7 +452,7 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[track_caller]
-    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "none")]
+    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "81383")]
     pub unsafe fn unwrap_unchecked(self) -> T {
         debug_assert!(self.is_some());
         match self {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -433,7 +433,9 @@ impl<T> Option<T> {
     ///
     /// # Safety
     ///
-    /// Undefined behavior if the value is [`None`].
+    /// Calling this method on [`None`] is *[undefined behavior]*.
+    ///
+    /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     ///
     /// # Examples
     ///

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -849,6 +849,7 @@ impl<T, E> Result<T, E> {
         debug_assert!(self.is_ok());
         match self {
             Ok(t) => t,
+            // SAFETY: the safety contract must be upheld by the caller.
             Err(_) => unsafe { hint::unreachable_unchecked() },
         }
     }
@@ -879,6 +880,7 @@ impl<T, E> Result<T, E> {
     pub unsafe fn unwrap_err_unchecked(self) -> E {
         debug_assert!(self.is_err());
         match self {
+            // SAFETY: the safety contract must be upheld by the caller.
             Ok(_) => unsafe { hint::unreachable_unchecked() },
             Err(e) => e,
         }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -229,7 +229,7 @@
 
 use crate::iter::{self, FromIterator, FusedIterator, TrustedLen};
 use crate::ops::{self, Deref, DerefMut};
-use crate::{convert, fmt};
+use crate::{convert, fmt, hint};
 
 /// `Result` is a type that represents either success ([`Ok`]) or failure ([`Err`]).
 ///
@@ -819,6 +819,68 @@ impl<T, E> Result<T, E> {
         match self {
             Ok(t) => t,
             Err(e) => op(e),
+        }
+    }
+
+    /// Returns the contained [`Ok`] value, consuming the `self` value,
+    /// without checking that the value is not an [`Err`].
+    ///
+    /// # Safety
+    ///
+    /// Undefined behavior if the value is an [`Err`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_result_unwrap_unchecked)]
+    /// let x: Result<u32, &str> = Ok(2);
+    /// assert_eq!(unsafe { x.unwrap_unchecked() }, 2);
+    /// ```
+    ///
+    /// ```no_run
+    /// #![feature(option_result_unwrap_unchecked)]
+    /// let x: Result<u32, &str> = Err("emergency failure");
+    /// unsafe { x.unwrap_unchecked(); } // Undefined behavior!
+    /// ```
+    #[inline]
+    #[track_caller]
+    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "none")]
+    pub unsafe fn unwrap_unchecked(self) -> T {
+        debug_assert!(self.is_ok());
+        match self {
+            Ok(t) => t,
+            Err(_) => unsafe { hint::unreachable_unchecked() },
+        }
+    }
+
+    /// Returns the contained [`Err`] value, consuming the `self` value,
+    /// without checking that the value is not an [`Ok`].
+    ///
+    /// # Safety
+    ///
+    /// Undefined behavior if the value is an [`Ok`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// #![feature(option_result_unwrap_unchecked)]
+    /// let x: Result<u32, &str> = Ok(2);
+    /// unsafe { x.unwrap_err_unchecked() }; // Undefined behavior!
+    /// ```
+    ///
+    /// ```
+    /// #![feature(option_result_unwrap_unchecked)]
+    /// let x: Result<u32, &str> = Err("emergency failure");
+    /// assert_eq!(unsafe { x.unwrap_err_unchecked() }, "emergency failure");
+    /// ```
+    #[inline]
+    #[track_caller]
+    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "none")]
+    pub unsafe fn unwrap_err_unchecked(self) -> E {
+        debug_assert!(self.is_err());
+        match self {
+            Ok(_) => unsafe { hint::unreachable_unchecked() },
+            Err(e) => e,
         }
     }
 }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -846,7 +846,7 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[track_caller]
-    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "none")]
+    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "81383")]
     pub unsafe fn unwrap_unchecked(self) -> T {
         debug_assert!(self.is_ok());
         match self {
@@ -880,7 +880,7 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[track_caller]
-    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "none")]
+    #[unstable(feature = "option_result_unwrap_unchecked", reason = "newly added", issue = "81383")]
     pub unsafe fn unwrap_err_unchecked(self) -> E {
         debug_assert!(self.is_err());
         match self {

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -827,7 +827,9 @@ impl<T, E> Result<T, E> {
     ///
     /// # Safety
     ///
-    /// Undefined behavior if the value is an [`Err`].
+    /// Calling this method on an [`Err`] is *[undefined behavior]*.
+    ///
+    /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     ///
     /// # Examples
     ///
@@ -859,7 +861,9 @@ impl<T, E> Result<T, E> {
     ///
     /// # Safety
     ///
-    /// Undefined behavior if the value is an [`Ok`].
+    /// Calling this method on an [`Ok`] is *[undefined behavior]*.
+    ///
+    /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     ///
     /// # Examples
     ///

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -62,6 +62,7 @@
 #![feature(const_raw_ptr_deref)]
 #![feature(never_type)]
 #![feature(unwrap_infallible)]
+#![feature(option_result_unwrap_unchecked)]
 #![feature(option_unwrap_none)]
 #![feature(peekable_next_if)]
 #![feature(peekable_peek_mut)]

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -161,6 +161,13 @@ fn test_unwrap_or_else() {
 }
 
 #[test]
+fn test_unwrap_unchecked() {
+    assert_eq!(unsafe { Some(1).unwrap_unchecked() }, 1);
+    let s = unsafe { Some("hello".to_string()).unwrap_unchecked() };
+    assert_eq!(s, "hello");
+}
+
+#[test]
 fn test_iter() {
     let val = 5;
 

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -120,6 +120,18 @@ pub fn test_unwrap_or_else_panic() {
 }
 
 #[test]
+fn test_unwrap_unchecked() {
+    let ok: Result<isize, &'static str> = Ok(100);
+    assert_eq!(unsafe { ok.unwrap_unchecked() }, 100);
+}
+
+#[test]
+fn test_unwrap_err_unchecked() {
+    let ok_err: Result<isize, &'static str> = Err("Err");
+    assert_eq!(unsafe { ok_err.unwrap_err_unchecked() }, "Err");
+}
+
+#[test]
 pub fn test_expect_ok() {
     let ok: Result<isize, &'static str> = Ok(100);
     assert_eq!(ok.expect("Unexpected error"), 100);


### PR DESCRIPTION
In particular:
  - `unwrap_unchecked()` for `Option`.
  - `unwrap_unchecked()` and `unwrap_err_unchecked()` for `Result`.

These complement other `*_unchecked()` methods in `core` etc.

Currently there are a couple of places it may be used inside rustc (`LinkedList`, `BTree`). It is also easy to find other repositories with similar functionality.

Fixes #48278.