### PR TITLE
Remove some function fields

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -217,13 +217,10 @@ fn build_external_function(cx: &DocContext<'_>, did: DefId) -> clean::Function {
     let (generics, decl) = clean::enter_impl_trait(cx, || {
         ((cx.tcx.generics_of(did), predicates).clean(cx), (did, sig).clean(cx))
     });
-    let (all_types, ret_types) = clean::get_all_types(&generics, &decl, cx);
     clean::Function {
         decl,
         generics,
         header: hir::FnHeader { unsafety: sig.unsafety(), abi: sig.abi(), constness, asyncness },
-        all_types,
-        ret_types,
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -928,8 +928,7 @@ impl<'a> Clean<Function> for (&'a hir::FnSig<'a>, &'a hir::Generics<'a>, hir::Bo
     fn clean(&self, cx: &DocContext<'_>) -> Function {
         let (generics, decl) =
             enter_impl_trait(cx, || (self.1.clean(cx), (&*self.0.decl, self.2).clean(cx)));
-        let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
-        Function { decl, generics, header: self.0.header, all_types, ret_types }
+        Function { decl, generics, header: self.0.header }
     }
 }
 
@@ -1043,21 +1042,7 @@ impl Clean<PolyTrait> for hir::PolyTraitRef<'_> {
 
 impl Clean<TypeKind> for hir::def::DefKind {
     fn clean(&self, _: &DocContext<'_>) -> TypeKind {
-        match *self {
-            hir::def::DefKind::Mod => TypeKind::Module,
-            hir::def::DefKind::Struct => TypeKind::Struct,
-            hir::def::DefKind::Union => TypeKind::Union,
-            hir::def::DefKind::Enum => TypeKind::Enum,
-            hir::def::DefKind::Trait => TypeKind::Trait,
-            hir::def::DefKind::TyAlias => TypeKind::Typedef,
-            hir::def::DefKind::ForeignTy => TypeKind::Foreign,
-            hir::def::DefKind::TraitAlias => TypeKind::TraitAlias,
-            hir::def::DefKind::Fn => TypeKind::Function,
-            hir::def::DefKind::Const => TypeKind::Const,
-            hir::def::DefKind::Static => TypeKind::Static,
-            hir::def::DefKind::Macro(_) => TypeKind::Macro,
-            _ => TypeKind::Foreign,
-        }
+        self.into()
     }
 }
 
@@ -1082,9 +1067,7 @@ impl Clean<Item> for hir::TraitItem<'_> {
                     let (generics, decl) = enter_impl_trait(cx, || {
                         (self.generics.clean(cx), (&*sig.decl, &names[..]).clean(cx))
                     });
-                    let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
-                    let mut t =
-                        Function { header: sig.header, decl, generics, all_types, ret_types };
+                    let mut t = Function { header: sig.header, decl, generics };
                     if t.header.constness == hir::Constness::Const
                         && is_unstable_const_fn(cx.tcx, local_did).is_some()
                     {
@@ -1196,7 +1179,6 @@ impl Clean<Item> for ty::AssocItem {
                     ty::ImplContainer(_) => true,
                     ty::TraitContainer(_) => self.defaultness.has_value(),
                 };
-                let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
                 if provided {
                     let constness = if is_min_const_fn(cx.tcx, self.def_id) {
                         hir::Constness::Const
@@ -1218,8 +1200,6 @@ impl Clean<Item> for ty::AssocItem {
                                 constness,
                                 asyncness,
                             },
-                            all_types,
-                            ret_types,
                         },
                         defaultness,
                     )
@@ -1233,8 +1213,6 @@ impl Clean<Item> for ty::AssocItem {
                             constness: hir::Constness::NotConst,
                             asyncness: hir::IsAsync::NotAsync,
                         },
-                        all_types,
-                        ret_types,
                     })
                 }
             }
@@ -2274,7 +2252,6 @@ impl Clean<Item> for (&hir::ForeignItem<'_>, Option<Symbol>) {
                     let (generics, decl) = enter_impl_trait(cx, || {
                         (generics.clean(cx), (&**decl, &names[..]).clean(cx))
                     });
-                    let (all_types, ret_types) = get_all_types(&generics, &decl, cx);
                     ForeignFunctionItem(Function {
                         decl,
                         generics,
@@ -2284,8 +2261,6 @@ impl Clean<Item> for (&hir::ForeignItem<'_>, Option<Symbol>) {
                             constness: hir::Constness::NotConst,
                             asyncness: hir::IsAsync::NotAsync,
                         },
-                        all_types,
-                        ret_types,
                     })
                 }
                 hir::ForeignItemKind::Static(ref ty, mutability) => ForeignStaticItem(Static {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1042,7 +1042,7 @@ impl Clean<PolyTrait> for hir::PolyTraitRef<'_> {
 
 impl Clean<TypeKind> for hir::def::DefKind {
     fn clean(&self, _: &DocContext<'_>) -> TypeKind {
-        self.into()
+        (*self).into()
     }
 }
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1408,14 +1408,14 @@ impl Type {
         }
     }
 
-    crate fn generics(&self) -> Option<Vec<Type>> {
+    crate fn generics(&self) -> Option<Vec<&Type>> {
         match *self {
             ResolvedPath { ref path, .. } => path.segments.last().and_then(|seg| {
                 if let GenericArgs::AngleBracketed { ref args, .. } = seg.args {
                     Some(
                         args.iter()
                             .filter_map(|arg| match arg {
-                                GenericArg::Type(ty) => Some(ty.clone()),
+                                GenericArg::Type(ty) => Some(ty),
                                 _ => None,
                             })
                             .collect(),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1320,10 +1320,10 @@ impl From<hir::def::DefKind> for TypeKind {
             hir::def::DefKind::Union => Self::Union,
             hir::def::DefKind::Trait => Self::Trait,
             hir::def::DefKind::TyAlias => Self::Typedef,
-            hir::def::DefKind::ForeignTy => Self::Foreign,
             hir::def::DefKind::TraitAlias => Self::TraitAlias,
             hir::def::DefKind::Macro(_) => Self::Macro,
-            hir::def::DefKind::Variant
+            hir::def::DefKind::ForeignTy
+            | hir::def::DefKind::Variant
             | hir::def::DefKind::AssocTy
             | hir::def::DefKind::TyParam
             | hir::def::DefKind::ConstParam

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1302,12 +1302,6 @@ crate enum TypeKind {
     Primitive,
 }
 
-impl<'a> From<&'a hir::def::DefKind> for TypeKind {
-    fn from(other: &hir::def::DefKind) -> Self {
-        Self::from(*other)
-    }
-}
-
 impl From<hir::def::DefKind> for TypeKind {
     fn from(other: hir::def::DefKind) -> Self {
         match other {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1304,6 +1304,49 @@ crate enum TypeKind {
     Primitive,
 }
 
+impl<'a> From<&'a hir::def::DefKind> for TypeKind {
+    fn from(other: &hir::def::DefKind) -> Self {
+        Self::from(*other)
+    }
+}
+
+impl From<hir::def::DefKind> for TypeKind {
+    fn from(other: hir::def::DefKind) -> Self {
+        match other {
+            hir::def::DefKind::Enum => Self::Enum,
+            hir::def::DefKind::Fn => Self::Function,
+            hir::def::DefKind::Mod => Self::Module,
+            hir::def::DefKind::Const => Self::Const,
+            hir::def::DefKind::Static => Self::Static,
+            hir::def::DefKind::Struct => Self::Struct,
+            hir::def::DefKind::Union => Self::Union,
+            hir::def::DefKind::Trait => Self::Trait,
+            hir::def::DefKind::TyAlias => Self::Typedef,
+            hir::def::DefKind::ForeignTy => Self::Foreign,
+            hir::def::DefKind::TraitAlias => Self::TraitAlias,
+            hir::def::DefKind::Macro(_) => Self::Macro,
+            hir::def::DefKind::Variant
+            | hir::def::DefKind::AssocTy
+            | hir::def::DefKind::TyParam
+            | hir::def::DefKind::ConstParam
+            | hir::def::DefKind::Ctor(..)
+            | hir::def::DefKind::AssocFn
+            | hir::def::DefKind::AssocConst
+            | hir::def::DefKind::ExternCrate
+            | hir::def::DefKind::Use
+            | hir::def::DefKind::ForeignMod
+            | hir::def::DefKind::AnonConst
+            | hir::def::DefKind::OpaqueTy
+            | hir::def::DefKind::Field
+            | hir::def::DefKind::LifetimeParam
+            | hir::def::DefKind::GlobalAsm
+            | hir::def::DefKind::Impl
+            | hir::def::DefKind::Closure
+            | hir::def::DefKind::Generator => Self::Foreign,
+        }
+    }
+}
+
 crate trait GetDefId {
     /// Use this method to get the [`DefId`] of a [`clean`] AST node.
     /// This will return [`None`] when called on a primitive [`clean::Type`].

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1087,8 +1087,6 @@ crate struct Function {
     crate decl: FnDecl,
     crate generics: Generics,
     crate header: hir::FnHeader,
-    crate all_types: Vec<(Type, TypeKind)>,
-    crate ret_types: Vec<(Type, TypeKind)>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -1,10 +1,9 @@
 use crate::clean::auto_trait::AutoTraitFinder;
 use crate::clean::blanket_impl::BlanketImplFinder;
 use crate::clean::{
-    inline, Clean, Crate, ExternalCrate, FnDecl, FnRetTy, Generic, GenericArg, GenericArgs,
-    GenericBound, Generics, GetDefId, ImportSource, Item, ItemKind, Lifetime, MacroKind, Path,
-    PathSegment, Primitive, PrimitiveType, ResolvedPath, Type, TypeBinding, TypeKind,
-    WherePredicate,
+    inline, Clean, Crate, ExternalCrate, Generic, GenericArg, GenericArgs, ImportSource, Item,
+    ItemKind, Lifetime, MacroKind, Path, PathSegment, Primitive, PrimitiveType, ResolvedPath, Type,
+    TypeBinding, TypeKind,
 };
 use crate::core::DocContext;
 
@@ -158,125 +157,6 @@ pub(super) fn external_path(
             args: external_generic_args(cx, trait_did, has_self, bindings, substs),
         }],
     }
-}
-
-/// The point of this function is to replace bounds with types.
-///
-/// i.e. `[T, U]` when you have the following bounds: `T: Display, U: Option<T>` will return
-/// `[Display, Option]` (we just returns the list of the types, we don't care about the
-/// wrapped types in here).
-crate fn get_real_types(
-    generics: &Generics,
-    arg: &Type,
-    cx: &DocContext<'_>,
-    recurse: i32,
-) -> FxHashSet<(Type, TypeKind)> {
-    fn insert(res: &mut FxHashSet<(Type, TypeKind)>, cx: &DocContext<'_>, ty: Type) {
-        if let Some(kind) = ty.def_id().map(|did| cx.tcx.def_kind(did).clean(cx)) {
-            res.insert((ty, kind));
-        } else if ty.is_primitive() {
-            // This is a primitive, let's store it as such.
-            res.insert((ty, TypeKind::Primitive));
-        }
-    }
-    let mut res = FxHashSet::default();
-    if recurse >= 10 {
-        // FIXME: remove this whole recurse thing when the recursion bug is fixed
-        return res;
-    }
-
-    if arg.is_full_generic() {
-        let arg_s = Symbol::intern(&arg.print(&cx.cache).to_string());
-        if let Some(where_pred) = generics.where_predicates.iter().find(|g| match g {
-            WherePredicate::BoundPredicate { ty, .. } => ty.def_id() == arg.def_id(),
-            _ => false,
-        }) {
-            let bounds = where_pred.get_bounds().unwrap_or_else(|| &[]);
-            for bound in bounds.iter() {
-                if let GenericBound::TraitBound(poly_trait, _) = bound {
-                    for x in poly_trait.generic_params.iter() {
-                        if !x.is_type() {
-                            continue;
-                        }
-                        if let Some(ty) = x.get_type() {
-                            let adds = get_real_types(generics, &ty, cx, recurse + 1);
-                            if !adds.is_empty() {
-                                res.extend(adds);
-                            } else if !ty.is_full_generic() {
-                                insert(&mut res, cx, ty);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if let Some(bound) = generics.params.iter().find(|g| g.is_type() && g.name == arg_s) {
-            for bound in bound.get_bounds().unwrap_or_else(|| &[]) {
-                if let Some(ty) = bound.get_trait_type() {
-                    let adds = get_real_types(generics, &ty, cx, recurse + 1);
-                    if !adds.is_empty() {
-                        res.extend(adds);
-                    } else if !ty.is_full_generic() {
-                        insert(&mut res, cx, ty);
-                    }
-                }
-            }
-        }
-    } else {
-        insert(&mut res, cx, arg.clone());
-        if let Some(gens) = arg.generics() {
-            for gen in gens.iter() {
-                if gen.is_full_generic() {
-                    let adds = get_real_types(generics, gen, cx, recurse + 1);
-                    if !adds.is_empty() {
-                        res.extend(adds);
-                    }
-                } else {
-                    insert(&mut res, cx, gen.clone());
-                }
-            }
-        }
-    }
-    res
-}
-
-/// Return the full list of types when bounds have been resolved.
-///
-/// i.e. `fn foo<A: Display, B: Option<A>>(x: u32, y: B)` will return
-/// `[u32, Display, Option]`.
-crate fn get_all_types(
-    generics: &Generics,
-    decl: &FnDecl,
-    cx: &DocContext<'_>,
-) -> (Vec<(Type, TypeKind)>, Vec<(Type, TypeKind)>) {
-    let mut all_types = FxHashSet::default();
-    for arg in decl.inputs.values.iter() {
-        if arg.type_.is_self_type() {
-            continue;
-        }
-        let args = get_real_types(generics, &arg.type_, cx, 0);
-        if !args.is_empty() {
-            all_types.extend(args);
-        } else {
-            if let Some(kind) = arg.type_.def_id().map(|did| cx.tcx.def_kind(did).clean(cx)) {
-                all_types.insert((arg.type_.clone(), kind));
-            }
-        }
-    }
-
-    let ret_types = match decl.output {
-        FnRetTy::Return(ref return_type) => {
-            let mut ret = get_real_types(generics, &return_type, cx, 0);
-            if ret.is_empty() {
-                if let Some(kind) = return_type.def_id().map(|did| cx.tcx.def_kind(did).clean(cx)) {
-                    ret.insert((return_type.clone(), kind));
-                }
-            }
-            ret.into_iter().collect()
-        }
-        _ => Vec::new(),
-    };
-    (all_types.into_iter().collect(), ret_types)
 }
 
 crate fn strip_type(ty: Type) -> Type {

--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -61,6 +61,7 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
             &options.extern_html_root_urls,
             &options.output,
             krate,
+            tcx,
         )
     });
     let prof = &tcx.sess.prof;

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -304,7 +304,7 @@ crate fn get_real_types<'tcx>(
             }
         }
         if let Some(bound) = generics.params.iter().find(|g| g.is_type() && g.name == arg_s) {
-            for bound in bound.get_bounds().unwrap_or_else(|| &[]) {
+            for bound in bound.get_bounds().unwrap_or(&[]) {
                 if let Some(ty) = bound.get_trait_type() {
                     let adds = get_real_types(generics, &ty, tcx, recurse + 1, cache, res);
                     nb_added += adds;

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -70,8 +70,6 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
     let mut crate_items = Vec::with_capacity(cache.search_index.len());
     let mut crate_paths = vec![];
 
-    // For now we don't get the primitive types in the search index.
-    let empty_cache = Cache::default();
     // Attach all orphan items to the type's definition if the type
     // has since been learned.
     for &(did, ref item) in &cache.orphan_impl_items {
@@ -83,7 +81,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
                 desc: item.doc_value().map_or_else(String::new, |s| short_markdown_summary(&s)),
                 parent: Some(did),
                 parent_idx: None,
-                search_type: get_index_search_type(&item, cache),
+                search_type: get_index_search_type(&item, cache, tcx),
             });
             for alias in item.attrs.get_doc_aliases() {
                 cache
@@ -247,4 +245,128 @@ fn get_generics(clean_type: &clean::Type, cache: &Cache) -> Option<Vec<Generic>>
             .collect::<Vec<_>>();
         if r.is_empty() { None } else { Some(r) }
     })
+}
+
+/// The point of this function is to replace bounds with types.
+///
+/// i.e. `[T, U]` when you have the following bounds: `T: Display, U: Option<T>` will return
+/// `[Display, Option]` (we just returns the list of the types, we don't care about the
+/// wrapped types in here).
+crate fn get_real_types<'tcx>(
+    generics: &Generics,
+    arg: &Type,
+    tcx: TyCtxt<'tcx>,
+    recurse: i32,
+    cache: &Cache,
+    res: &mut FxHashSet<(Type, TypeKind)>,
+) -> usize {
+    fn insert(res: &mut FxHashSet<(Type, TypeKind)>, tcx: TyCtxt<'_>, ty: Type) -> usize {
+        if let Some(kind) = ty.def_id().map(|did| tcx.def_kind(did).into()) {
+            res.insert((ty, kind));
+            1
+        } else if ty.is_primitive() {
+            // This is a primitive, let's store it as such.
+            res.insert((ty, TypeKind::Primitive));
+            1
+        } else {
+            0
+        }
+    }
+
+    if recurse >= 10 {
+        // FIXME: remove this whole recurse thing when the recursion bug is fixed
+        return 0;
+    }
+    let mut nb_added = 0;
+
+    if arg.is_full_generic() {
+        let arg_s = Symbol::intern(&arg.print(cache).to_string());
+        if let Some(where_pred) = generics.where_predicates.iter().find(|g| match g {
+            WherePredicate::BoundPredicate { ty, .. } => ty.def_id() == arg.def_id(),
+            _ => false,
+        }) {
+            let bounds = where_pred.get_bounds().unwrap_or_else(|| &[]);
+            for bound in bounds.iter() {
+                if let GenericBound::TraitBound(poly_trait, _) = bound {
+                    for x in poly_trait.generic_params.iter() {
+                        if !x.is_type() {
+                            continue;
+                        }
+                        if let Some(ty) = x.get_type() {
+                            let adds = get_real_types(generics, &ty, tcx, recurse + 1, cache, res);
+                            nb_added += adds;
+                            if adds == 0 && !ty.is_full_generic() {
+                                nb_added += insert(res, tcx, ty);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(bound) = generics.params.iter().find(|g| g.is_type() && g.name == arg_s) {
+            for bound in bound.get_bounds().unwrap_or_else(|| &[]) {
+                if let Some(ty) = bound.get_trait_type() {
+                    let adds = get_real_types(generics, &ty, tcx, recurse + 1, cache, res);
+                    nb_added += adds;
+                    if adds == 0 && !ty.is_full_generic() {
+                        nb_added += insert(res, tcx, ty);
+                    }
+                }
+            }
+        }
+    } else {
+        nb_added += insert(res, tcx, arg.clone());
+        if let Some(gens) = arg.generics() {
+            for gen in gens.iter() {
+                if gen.is_full_generic() {
+                    nb_added += get_real_types(generics, gen, tcx, recurse + 1, cache, res);
+                } else {
+                    nb_added += insert(res, tcx, (*gen).clone());
+                }
+            }
+        }
+    }
+    nb_added
+}
+
+/// Return the full list of types when bounds have been resolved.
+///
+/// i.e. `fn foo<A: Display, B: Option<A>>(x: u32, y: B)` will return
+/// `[u32, Display, Option]`.
+crate fn get_all_types<'tcx>(
+    generics: &Generics,
+    decl: &FnDecl,
+    tcx: TyCtxt<'tcx>,
+    cache: &Cache,
+) -> (Vec<(Type, TypeKind)>, Vec<(Type, TypeKind)>) {
+    let mut all_types = FxHashSet::default();
+    for arg in decl.inputs.values.iter() {
+        if arg.type_.is_self_type() {
+            continue;
+        }
+        let mut args = FxHashSet::default();
+        get_real_types(generics, &arg.type_, tcx, 0, cache, &mut args);
+        if !args.is_empty() {
+            all_types.extend(args);
+        } else {
+            if let Some(kind) = arg.type_.def_id().map(|did| tcx.def_kind(did).into()) {
+                all_types.insert((arg.type_.clone(), kind));
+            }
+        }
+    }
+
+    let ret_types = match decl.output {
+        FnRetTy::Return(ref return_type) => {
+            let mut ret = FxHashSet::default();
+            get_real_types(generics, &return_type, tcx, 0, cache, &mut ret);
+            if ret.is_empty() {
+                if let Some(kind) = return_type.def_id().map(|did| tcx.def_kind(did).into()) {
+                    ret.insert((return_type.clone(), kind));
+                }
+            }
+            ret.into_iter().collect()
+        }
+        _ => Vec::new(),
+    };
+    (all_types.into_iter().collect(), ret_types)
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -499,7 +499,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         krate = sources::render(&dst, &mut scx, krate)?;
 
         // Build our search index
-        let index = build_index(&krate, &mut cache);
+        let index = build_index(&krate, &mut cache, tcx);
 
         let mut cx = Context {
             current: Vec::new(),

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -238,7 +238,7 @@ fn stringify_header(header: &rustc_hir::FnHeader) -> String {
 
 impl From<clean::Function> for Function {
     fn from(function: clean::Function) -> Self {
-        let clean::Function { decl, generics, header, all_types: _, ret_types: _ } = function;
+        let clean::Function { decl, generics, header } = function;
         Function {
             decl: decl.into(),
             generics: generics.into(),
@@ -435,7 +435,7 @@ impl From<clean::Impl> for Impl {
 }
 
 crate fn from_function_method(function: clean::Function, has_body: bool) -> Method {
-    let clean::Function { header, decl, generics, all_types: _, ret_types: _ } = function;
+    let clean::Function { header, decl, generics } = function;
     Method {
         decl: decl.into(),
         generics: generics.into(),


### PR DESCRIPTION
Same kind as #80845.

This PR removes the `all_types` and `ret_types` from the `clean::Function` type.

Another change that I had to do was implementing the `From` trait to be able to convert `hir::def::DefKind` into `clean::TypeKind` without requiring `DocContext` (and so I updated the `clean` method so that it's taken into account).

The last two commits improve a bit the `get_real_types` function and the `Type::generics` method.

r? @jyn514 