### PR TITLE
rustdoc: Resolve `&str` as `str`

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2086,7 +2086,7 @@ fn resolve_primitive(path_str: &str, ns: Namespace) -> Option<Res> {
         "f64" => F64,
         "char" => Char,
         "bool" | "true" | "false" => Bool,
-        "str" => Str,
+        "str" | "&str" => Str,
         // See #80181 for why these don't have symbols associated.
         "slice" => Slice,
         "array" => Array,

--- a/src/test/rustdoc/intra-doc/non-path-primitives.rs
+++ b/src/test/rustdoc/intra-doc/non-path-primitives.rs
@@ -8,6 +8,15 @@
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.array.html#method.map"]' 'array::map'
 //! [array::map]
 
+// @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.str.html"]' 'owned str'
+// @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.str.html"]' 'str ref'
+// @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.str.html#method.is_empty"]' 'str::is_empty'
+// @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.str.html#method.len"]' '&str::len'
+//! [owned str][str]
+//! [str ref][&str]
+//! [str::is_empty]
+//! [&str::len]
+
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.is_null"]' 'pointer::is_null'
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.is_null"]' '*const::is_null'
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.is_null"]' '*mut::is_null'


### PR DESCRIPTION
People almost always are referring to `&str`, not `str`, so this will
save a manual link resolve in many cases.

Note that we already accept `&` (resolves to `reference`) in intra-doc
links, so this shouldn't cause breakage.

r? @jyn514
