### PR TITLE
Stabilize raw ref macros

### DIFF
--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -543,8 +543,8 @@ impl<'a, K, V, Type> NodeRef<marker::ValMut<'a>, K, V, Type> {
         // to avoid aliasing with outstanding references to other elements,
         // in particular, those returned to the caller in earlier iterations.
         let leaf = Self::as_leaf_ptr(&mut self);
-        let keys = unsafe { &raw const (*leaf).keys };
-        let vals = unsafe { &raw mut (*leaf).vals };
+        let keys = unsafe { ptr::addr_of!((*leaf).keys) };
+        let vals = unsafe { ptr::addr_of_mut!((*leaf).vals) };
         // We must coerce to unsized array pointers because of Rust issue #74679.
         let keys: *const [_] = keys;
         let vals: *mut [_] = vals;

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -115,7 +115,6 @@
 #![feature(pattern)]
 #![feature(ptr_internals)]
 #![feature(range_bounds_assert_len)]
-#![feature(raw_ref_op)]
 #![feature(rustc_attrs)]
 #![feature(receiver_trait)]
 #![cfg_attr(bootstrap, feature(min_const_generics))]

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -398,7 +398,7 @@ impl<T> Rc<T> {
 
         unsafe {
             let inner = init_ptr.as_ptr();
-            ptr::write(&raw mut (*inner).value, data);
+            ptr::write(ptr::addr_of_mut!((*inner).value), data);
 
             let prev_value = (*inner).strong.get();
             debug_assert_eq!(prev_value, 0, "No prior strong references should exist");
@@ -804,7 +804,7 @@ impl<T: ?Sized> Rc<T> {
         // SAFETY: This cannot go through Deref::deref or Rc::inner because
         // this is required to retain raw/mut provenance such that e.g. `get_mut` can
         // write through the pointer after the Rc is recovered through `from_raw`.
-        unsafe { &raw const (*ptr).value }
+        unsafe { ptr::addr_of_mut!((*ptr).value) }
     }
 
     /// Constructs an `Rc<T>` from a raw pointer.
@@ -1917,7 +1917,7 @@ impl<T: ?Sized> Weak<T> {
             // SAFETY: if is_dangling returns false, then the pointer is dereferencable.
             // The payload may be dropped at this point, and we have to maintain provenance,
             // so use raw pointer manipulation.
-            unsafe { &raw const (*ptr).value }
+            unsafe { ptr::addr_of_mut!((*ptr).value) }
         }
     }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -384,7 +384,7 @@ impl<T> Arc<T> {
         // reference into a strong reference.
         unsafe {
             let inner = init_ptr.as_ptr();
-            ptr::write(&raw mut (*inner).data, data);
+            ptr::write(ptr::addr_of_mut!((*inner).data), data);
 
             // The above write to the data field must be visible to any threads which
             // observe a non-zero strong count. Therefore we need at least "Release" ordering
@@ -800,7 +800,7 @@ impl<T: ?Sized> Arc<T> {
         // SAFETY: This cannot go through Deref::deref or RcBoxPtr::inner because
         // this is required to retain raw/mut provenance such that e.g. `get_mut` can
         // write through the pointer after the Rc is recovered through `from_raw`.
-        unsafe { &raw const (*ptr).data }
+        unsafe { ptr::addr_of_mut!((*ptr).data) }
     }
 
     /// Constructs an `Arc<T>` from a raw pointer.
@@ -1677,7 +1677,7 @@ impl<T: ?Sized> Weak<T> {
             // SAFETY: if is_dangling returns false, then the pointer is dereferencable.
             // The payload may be dropped at this point, and we have to maintain provenance,
             // so use raw pointer manipulation.
-            unsafe { &raw mut (*ptr).data }
+            unsafe { ptr::addr_of_mut!((*ptr).data) }
         }
     }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -126,7 +126,6 @@
 #![feature(auto_traits)]
 #![feature(or_patterns)]
 #![feature(prelude_import)]
-#![feature(raw_ref_macros)]
 #![feature(repr_simd, platform_intrinsics)]
 #![feature(rustc_attrs)]
 #![feature(simd_ffi)]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1501,7 +1501,6 @@ fnptr_impls_args! { A, B, C, D, E, F, G, H, I, J, K, L }
 /// # Example
 ///
 /// ```
-/// #![feature(raw_ref_macros)]
 /// use std::ptr;
 ///
 /// #[repr(packed)]
@@ -1512,14 +1511,14 @@ fnptr_impls_args! { A, B, C, D, E, F, G, H, I, J, K, L }
 ///
 /// let packed = Packed { f1: 1, f2: 2 };
 /// // `&packed.f2` would create an unaligned reference, and thus be Undefined Behavior!
-/// let raw_f2 = ptr::raw_const!(packed.f2);
+/// let raw_f2 = ptr::addr_of!(packed.f2);
 /// assert_eq!(unsafe { raw_f2.read_unaligned() }, 2);
 /// ```
-#[unstable(feature = "raw_ref_macros", issue = "73394")]
+#[stable(feature = "raw_ref_macros", since = "1.51.0")]
 #[rustc_macro_transparency = "semitransparent"]
 #[allow_internal_unstable(raw_ref_op)]
-pub macro raw_const($e:expr) {
-    &raw const $e
+pub macro addr_of($place:expr) {
+    &raw const $place
 }
 
 /// Create a `mut` raw pointer to a place, without creating an intermediate reference.
@@ -1534,7 +1533,6 @@ pub macro raw_const($e:expr) {
 /// # Example
 ///
 /// ```
-/// #![feature(raw_ref_macros)]
 /// use std::ptr;
 ///
 /// #[repr(packed)]
@@ -1545,13 +1543,13 @@ pub macro raw_const($e:expr) {
 ///
 /// let mut packed = Packed { f1: 1, f2: 2 };
 /// // `&mut packed.f2` would create an unaligned reference, and thus be Undefined Behavior!
-/// let raw_f2 = ptr::raw_mut!(packed.f2);
+/// let raw_f2 = ptr::addr_of_mut!(packed.f2);
 /// unsafe { raw_f2.write_unaligned(42); }
 /// assert_eq!({packed.f2}, 42); // `{...}` forces copying the field instead of creating a reference.
 /// ```
-#[unstable(feature = "raw_ref_macros", issue = "73394")]
+#[stable(feature = "raw_ref_macros", since = "1.51.0")]
 #[rustc_macro_transparency = "semitransparent"]
 #[allow_internal_unstable(raw_ref_op)]
-pub macro raw_mut($e:expr) {
-    &raw mut $e
+pub macro addr_of_mut($place:expr) {
+    &raw mut $place
 }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -543,8 +543,8 @@ impl<T> [T] {
     #[inline]
     pub fn swap(&mut self, a: usize, b: usize) {
         // Can't take two mutable loans from one vector, so instead use raw pointers.
-        let pa = ptr::raw_mut!(self[a]);
-        let pb = ptr::raw_mut!(self[b]);
+        let pa = ptr::addr_of_mut!(self[a]);
+        let pb = ptr::addr_of_mut!(self[b]);
         // SAFETY: `pa` and `pb` have been created from safe mutable references and refer
         // to elements in the slice and therefore are guaranteed to be valid and aligned.
         // Note that accessing the elements behind `a` and `b` is checked and will

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -298,7 +298,6 @@
 #![feature(prelude_import)]
 #![feature(ptr_internals)]
 #![feature(raw)]
-#![feature(raw_ref_macros)]
 #![feature(ready_macro)]
 #![feature(rustc_attrs)]
 #![feature(rustc_private)]

--- a/src/test/ui/consts/min_const_fn/allow_raw_ptr_dereference_const_fn.rs
+++ b/src/test/ui/consts/min_const_fn/allow_raw_ptr_dereference_const_fn.rs
@@ -1,11 +1,10 @@
 // check-pass
 #![feature(const_raw_ptr_deref)]
-#![feature(raw_ref_macros)]
 
 use std::ptr;
 
 const fn test_fn(x: *const i32) {
-    let x2 = unsafe { ptr::raw_const!(*x) };
+    let x2 = unsafe { ptr::addr_of!(*x) };
 }
 
 fn main() {}

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -9,8 +9,7 @@
     core_intrinsics,
     const_raw_ptr_comparison,
     const_ptr_offset,
-    const_raw_ptr_deref,
-    raw_ref_macros
+    const_raw_ptr_deref
 )]
 
 const FOO: &usize = &42;
@@ -64,7 +63,7 @@ const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
 
 const _: *const u8 =
 //~^ NOTE
-    unsafe { std::ptr::raw_const!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
+    unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
 //~^ ERROR any use of this value will cause an error
 //~| NOTE
 

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -6,9 +6,9 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |                  |
    |                  inbounds test failed: pointer must be in-bounds at offset $TWO_WORDS, but is outside bounds of alloc2 which has size $WORD
    |                  inside `ptr::const_ptr::<impl *const usize>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
-   |                  inside `_` at $DIR/ptr_comparisons.rs:62:34
+   |                  inside `_` at $DIR/ptr_comparisons.rs:61:34
    | 
-  ::: $DIR/ptr_comparisons.rs:62:1
+  ::: $DIR/ptr_comparisons.rs:61:1
    |
 LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
    | -------------------------------------------------------------------
@@ -16,17 +16,17 @@ LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
    = note: `#[deny(const_err)]` on by default
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:67:35
+  --> $DIR/ptr_comparisons.rs:66:33
    |
 LL | / const _: *const u8 =
 LL | |
-LL | |     unsafe { std::ptr::raw_const!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
-   | |___________________________________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^___-
-   |                                     |
-   |                                     memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size $WORD
+LL | |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
+   | |_________________________________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^___-
+   |                                   |
+   |                                   memory access failed: pointer must be in-bounds at offset 1000, but is outside bounds of alloc2 which has size $WORD
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:71:27
+  --> $DIR/ptr_comparisons.rs:70:27
    |
 LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -34,7 +34,7 @@ LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) +
    |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:76:27
+  --> $DIR/ptr_comparisons.rs:75:27
    |
 LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---


### PR DESCRIPTION
This stabilizes `raw_ref_macros` (https://github.com/rust-lang/rust/issues/73394), which is possible now that https://github.com/rust-lang/rust/issues/74355 is fixed.

However, as I already said in https://github.com/rust-lang/rust/issues/73394#issuecomment-751342185, I am not particularly happy with the current names of the macros. So I propose we also change them, which means I am proposing to stabilize the following in `core::ptr`:
```rust
pub macro const_addr_of($e:expr) {
    &raw const $e
}

pub macro mut_addr_of($e:expr) {
    &raw mut $e
}
```

The macro name change means we need another round of FCP. Cc @rust-lang/libs
Fixes #73394