### PR TITLE
Make the `Query` enum a simple struct.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,6 +4203,7 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_serialize",
+ "rustc_session",
  "rustc_span",
  "smallvec 1.6.1",
  "tracing",

--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -2,6 +2,7 @@ use crate::ich::StableHashingContext;
 use crate::ty::{self, TyCtxt};
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sync::Lock;
+use rustc_session::Session;
 
 #[macro_use]
 mod dep_node;
@@ -101,20 +102,18 @@ impl<'tcx> DepContext for TyCtxt<'tcx> {
         TyCtxt::create_stable_hashing_context(*self)
     }
 
-    fn debug_dep_tasks(&self) -> bool {
-        self.sess.opts.debugging_opts.dep_tasks
-    }
-    fn debug_dep_node(&self) -> bool {
-        self.sess.opts.debugging_opts.incremental_info
-            || self.sess.opts.debugging_opts.query_dep_graph
-    }
-
     #[inline]
     fn dep_graph(&self) -> &DepGraph {
         &self.dep_graph
     }
 
+    #[inline(always)]
     fn profiler(&self) -> &SelfProfilerRef {
         &self.prof
+    }
+
+    #[inline(always)]
+    fn sess(&self) -> &Session {
+        self.sess
     }
 }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -18,7 +18,7 @@ extern crate tracing;
 
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_errors::{Diagnostic, Handler, Level};
+use rustc_errors::{Diagnostic, DiagnosticBuilder, Handler, Level};
 use rustc_hir::def_id::CrateNum;
 use rustc_index::vec::IndexVec;
 use rustc_middle::dep_graph;

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -17,7 +17,6 @@ extern crate rustc_middle;
 extern crate tracing;
 
 use rustc_data_structures::fingerprint::Fingerprint;
-use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_errors::{Diagnostic, Handler, Level};
 use rustc_hir::def_id::CrateNum;

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -26,10 +26,9 @@ use rustc_middle::dep_graph;
 use rustc_middle::ich::StableHashingContext;
 use rustc_middle::ty::query::{query_keys, query_storage, query_stored, query_values};
 use rustc_middle::ty::query::{Providers, QueryEngine};
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_serialize::opaque;
 use rustc_span::{Span, DUMMY_SP};
-use std::mem;
 
 #[macro_use]
 mod plumbing;

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -18,7 +18,7 @@ extern crate tracing;
 
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
-use rustc_errors::{Diagnostic, DiagnosticBuilder, Handler, Level};
+use rustc_errors::{DiagnosticBuilder, Handler};
 use rustc_hir::def_id::CrateNum;
 use rustc_index::vec::IndexVec;
 use rustc_middle::dep_graph;

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -339,12 +339,12 @@ macro_rules! define_queries {
                 } else {
                     Some(key.default_span(*tcx))
                 };
-                let hash = {
+                let hash = || {
                     let mut hcx = tcx.create_stable_hashing_context();
                     let mut hasher = StableHasher::new();
                     std::mem::discriminant(&kind).hash_stable(&mut hcx, &mut hasher);
                     key.hash_stable(&mut hcx, &mut hasher);
-                    hasher.finish()
+                    hasher.finish::<u64>()
                 };
 
                 QueryStackFrame::new(name, description, span, hash)

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -47,13 +47,6 @@ impl HasDepContext for QueryCtxt<'tcx> {
 impl QueryContext for QueryCtxt<'tcx> {
     type Query = Query<'tcx>;
 
-    fn incremental_verify_ich(&self) -> bool {
-        self.sess.opts.debugging_opts.incremental_verify_ich
-    }
-    fn verbose(&self) -> bool {
-        self.sess.verbose()
-    }
-
     fn def_path_str(&self, def_id: DefId) -> String {
         self.tcx.def_path_str(def_id)
     }
@@ -130,14 +123,6 @@ impl QueryContext for QueryCtxt<'tcx> {
 
         let cb = &super::QUERY_CALLBACKS[dep_node.kind as usize];
         (cb.force_from_dep_node)(*self, dep_node)
-    }
-
-    fn has_errors_or_delayed_span_bugs(&self) -> bool {
-        self.sess.has_errors_or_delayed_span_bugs()
-    }
-
-    fn diagnostic(&self) -> &rustc_errors::Handler {
-        self.sess.diagnostic()
     }
 
     // Interactions with on_disk_cache

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -16,6 +16,7 @@ rustc_errors = { path = "../rustc_errors" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_index = { path = "../rustc_index" }
 rustc_serialize = { path = "../rustc_serialize" }
+rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 parking_lot = "0.11"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -87,7 +87,10 @@ impl<K: DepKind> DepNode<K> {
 
         #[cfg(debug_assertions)]
         {
-            if !kind.can_reconstruct_query_key() && tcx.debug_dep_node() {
+            if !kind.can_reconstruct_query_key()
+                && (tcx.sess().opts.debugging_opts.incremental_info
+                    || tcx.sess().opts.debugging_opts.query_dep_graph)
+            {
                 tcx.dep_graph().register_dep_node_debug_str(dep_node, || arg.to_debug_str(tcx));
             }
         }

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -280,7 +280,7 @@ impl<K: DepKind> DepGraph<K> {
             let mut hcx = dcx.create_stable_hashing_context();
             let current_fingerprint = hash_result(&mut hcx, &result);
 
-            let print_status = cfg!(debug_assertions) && dcx.debug_dep_tasks();
+            let print_status = cfg!(debug_assertions) && dcx.sess().opts.debugging_opts.dep_tasks;
 
             // Intern the new `DepNode`.
             let dep_node_index = if let Some(prev_index) = data.previous.node_to_index_opt(&key) {
@@ -731,7 +731,7 @@ impl<K: DepKind> DepGraph<K> {
                                 return None;
                             }
                             None => {
-                                if !tcx.has_errors_or_delayed_span_bugs() {
+                                if !tcx.dep_context().sess().has_errors_or_delayed_span_bugs() {
                                     panic!(
                                         "try_mark_previous_green() - Forcing the DepNode \
                                           should have set its color"
@@ -835,7 +835,7 @@ impl<K: DepKind> DepGraph<K> {
             // Promote the previous diagnostics to the current session.
             tcx.store_diagnostics(dep_node_index, diagnostics.clone().into());
 
-            let handle = tcx.diagnostic();
+            let handle = tcx.dep_context().sess().diagnostic();
 
             for diagnostic in diagnostics {
                 handle.emit_diagnostic(&diagnostic);

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -13,6 +13,7 @@ pub use serialized::{SerializedDepGraph, SerializedDepNodeIndex};
 
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sync::Lock;
+use rustc_session::Session;
 
 use std::fmt;
 use std::hash::Hash;
@@ -24,9 +25,6 @@ pub trait DepContext: Copy {
     /// Create a hashing context for hashing new results.
     fn create_stable_hashing_context(&self) -> Self::StableHashingContext;
 
-    fn debug_dep_tasks(&self) -> bool;
-    fn debug_dep_node(&self) -> bool;
-
     /// Access the DepGraph.
     fn dep_graph(&self) -> &DepGraph<Self::DepKind>;
 
@@ -34,6 +32,9 @@ pub trait DepContext: Copy {
 
     /// Access the profiler.
     fn profiler(&self) -> &SelfProfilerRef;
+
+    /// Access the compiler session.
+    fn sess(&self) -> &Session;
 }
 
 pub trait HasDepContext: Copy {

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -27,7 +27,7 @@ pub(crate) struct QueryVtable<CTX: QueryContext, K, V> {
     pub compute: fn(CTX, K) -> V,
 
     pub hash_result: fn(&mut CTX::StableHashingContext, &V) -> Option<Fingerprint>,
-    pub handle_cycle_error: fn(CTX, CycleError<CTX::Query>) -> V,
+    pub handle_cycle_error: fn(CTX, CycleError) -> V,
     pub cache_on_disk: fn(CTX, &K, Option<&V>) -> bool,
     pub try_load_from_disk: fn(CTX, SerializedDepNodeIndex) -> Option<V>,
 }
@@ -52,7 +52,7 @@ impl<CTX: QueryContext, K, V> QueryVtable<CTX, K, V> {
         (self.hash_result)(hcx, value)
     }
 
-    pub(crate) fn handle_cycle_error(&self, tcx: CTX, error: CycleError<CTX::Query>) -> V {
+    pub(crate) fn handle_cycle_error(&self, tcx: CTX, error: CycleError) -> V {
         (self.handle_cycle_error)(tcx, error)
     }
 
@@ -73,7 +73,7 @@ pub trait QueryAccessors<CTX: QueryContext>: QueryConfig {
     type Cache: QueryCache<Key = Self::Key, Stored = Self::Stored, Value = Self::Value>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(tcx: CTX) -> &'a QueryState<CTX::DepKind, CTX::Query, Self::Key>
+    fn query_state<'a>(tcx: CTX) -> &'a QueryState<CTX::DepKind, Self::Key>
     where
         CTX: 'a;
 
@@ -90,7 +90,7 @@ pub trait QueryAccessors<CTX: QueryContext>: QueryConfig {
         result: &Self::Value,
     ) -> Option<Fingerprint>;
 
-    fn handle_cycle_error(tcx: CTX, error: CycleError<CTX::Query>) -> Self::Value;
+    fn handle_cycle_error(tcx: CTX, error: CycleError) -> Self::Value;
 }
 
 pub trait QueryDescription<CTX: QueryContext>: QueryAccessors<CTX> {

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -3,10 +3,10 @@
 use crate::dep_graph::DepNode;
 use crate::dep_graph::SerializedDepNodeIndex;
 use crate::query::caches::QueryCache;
-use crate::query::plumbing::CycleError;
 use crate::query::{QueryCacheStore, QueryContext, QueryState};
 
 use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_errors::DiagnosticBuilder;
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -27,7 +27,7 @@ pub(crate) struct QueryVtable<CTX: QueryContext, K, V> {
     pub compute: fn(CTX, K) -> V,
 
     pub hash_result: fn(&mut CTX::StableHashingContext, &V) -> Option<Fingerprint>,
-    pub handle_cycle_error: fn(CTX, CycleError) -> V,
+    pub handle_cycle_error: fn(CTX, DiagnosticBuilder<'_>) -> V,
     pub cache_on_disk: fn(CTX, &K, Option<&V>) -> bool,
     pub try_load_from_disk: fn(CTX, SerializedDepNodeIndex) -> Option<V>,
 }
@@ -52,8 +52,8 @@ impl<CTX: QueryContext, K, V> QueryVtable<CTX, K, V> {
         (self.hash_result)(hcx, value)
     }
 
-    pub(crate) fn handle_cycle_error(&self, tcx: CTX, error: CycleError) -> V {
-        (self.handle_cycle_error)(tcx, error)
+    pub(crate) fn handle_cycle_error(&self, tcx: CTX, diag: DiagnosticBuilder<'_>) -> V {
+        (self.handle_cycle_error)(tcx, diag)
     }
 
     pub(crate) fn cache_on_disk(&self, tcx: CTX, key: &K, value: Option<&V>) -> bool {
@@ -90,7 +90,7 @@ pub trait QueryAccessors<CTX: QueryContext>: QueryConfig {
         result: &Self::Value,
     ) -> Option<Fingerprint>;
 
-    fn handle_cycle_error(tcx: CTX, error: CycleError) -> Self::Value;
+    fn handle_cycle_error(tcx: CTX, diag: DiagnosticBuilder<'_>) -> Self::Value;
 }
 
 pub trait QueryDescription<CTX: QueryContext>: QueryAccessors<CTX> {

--- a/compiler/rustc_query_system/src/query/config.rs
+++ b/compiler/rustc_query_system/src/query/config.rs
@@ -73,7 +73,9 @@ pub trait QueryAccessors<CTX: QueryContext>: QueryConfig {
     type Cache: QueryCache<Key = Self::Key, Stored = Self::Stored, Value = Self::Value>;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
-    fn query_state<'a>(tcx: CTX) -> &'a QueryState<CTX::DepKind, CTX::Query, Self::Key>;
+    fn query_state<'a>(tcx: CTX) -> &'a QueryState<CTX::DepKind, CTX::Query, Self::Key>
+    where
+        CTX: 'a;
 
     // Don't use this method to access query results, instead use the methods on TyCtxt
     fn query_cache<'a>(tcx: CTX) -> &'a QueryCacheStore<Self::Cache>

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -4,7 +4,7 @@ pub use self::plumbing::*;
 mod job;
 #[cfg(parallel_compiler)]
 pub use self::job::deadlock;
-pub use self::job::{QueryInfo, QueryJob, QueryJobId, QueryJobInfo};
+pub use self::job::{QueryInfo, QueryJob, QueryJobId, QueryJobInfo, QueryMap};
 
 mod caches;
 pub use self::caches::{
@@ -15,24 +15,63 @@ mod config;
 pub use self::config::{QueryAccessors, QueryConfig, QueryDescription};
 
 use crate::dep_graph::{DepNode, DepNodeIndex, HasDepContext, SerializedDepNodeIndex};
-use crate::query::job::QueryMap;
 
-use rustc_data_structures::stable_hasher::HashStable;
+use rustc_data_structures::fingerprint::Fingerprint;
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lock;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::Diagnostic;
 use rustc_span::def_id::DefId;
+use rustc_span::Span;
+
+/// Description of a frame in the query stack.
+///
+/// This is mostly used in case of cycles for error reporting.
+#[derive(Clone, Debug)]
+pub struct QueryStackFrame {
+    pub name: &'static str,
+    pub description: String,
+    span: Option<Span>,
+    /// This hash is used to deterministically pick
+    /// a query to remove cycles in the parallel compiler.
+    hash: Fingerprint,
+}
+
+impl QueryStackFrame {
+    #[inline]
+    pub fn new(
+        name: &'static str,
+        description: String,
+        span: Option<Span>,
+        hash: Fingerprint,
+    ) -> Self {
+        Self { name, hash, description, span }
+    }
+
+    // FIXME(eddyb) Get more valid `Span`s on queries.
+    #[inline]
+    pub fn default_span(&self, span: Span) -> Span {
+        if !span.is_dummy() {
+            return span;
+        }
+        self.span.unwrap_or(span)
+    }
+}
+
+impl<CTX> HashStable<CTX> for QueryStackFrame {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+        self.hash.hash_stable(hcx, hasher)
+    }
+}
 
 pub trait QueryContext: HasDepContext {
-    type Query: Clone + HashStable<Self::StableHashingContext>;
-
     /// Get string representation from DefPath.
     fn def_path_str(&self, def_id: DefId) -> String;
 
     /// Get the query information from the TLS context.
     fn current_query_job(&self) -> Option<QueryJobId<Self::DepKind>>;
 
-    fn try_collect_active_jobs(&self) -> Option<QueryMap<Self::DepKind, Self::Query>>;
+    fn try_collect_active_jobs(&self) -> Option<QueryMap<Self::DepKind>>;
 
     /// Load data from the on-disk cache.
     fn try_load_from_on_disk_cache(&self, dep_node: &DepNode<Self::DepKind>);

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -4,7 +4,7 @@ pub use self::plumbing::*;
 mod job;
 #[cfg(parallel_compiler)]
 pub use self::job::deadlock;
-pub use self::job::{QueryInfo, QueryJob, QueryJobId, QueryJobInfo, QueryMap};
+pub use self::job::{print_query_stack, QueryInfo, QueryJob, QueryJobId, QueryJobInfo, QueryMap};
 
 mod caches;
 pub use self::caches::{

--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -26,9 +26,6 @@ use rustc_span::def_id::DefId;
 pub trait QueryContext: HasDepContext {
     type Query: Clone + HashStable<Self::StableHashingContext>;
 
-    fn incremental_verify_ich(&self) -> bool;
-    fn verbose(&self) -> bool;
-
     /// Get string representation from DefPath.
     fn def_path_str(&self, def_id: DefId) -> String;
 
@@ -42,12 +39,6 @@ pub trait QueryContext: HasDepContext {
 
     /// Try to force a dep node to execute and see if it's green.
     fn try_force_from_dep_node(&self, dep_node: &DepNode<Self::DepKind>) -> bool;
-
-    /// Return whether the current session is tainted by errors.
-    fn has_errors_or_delayed_span_bugs(&self) -> bool;
-
-    /// Return the diagnostic handler.
-    fn diagnostic(&self) -> &rustc_errors::Handler;
 
     /// Load diagnostics associated to the node in the previous session.
     fn load_diagnostics(&self, prev_dep_node_index: SerializedDepNodeIndex) -> Vec<Diagnostic>;

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -119,10 +119,11 @@ where
         shards.iter().all(|shard| shard.active.is_empty())
     }
 
-    pub fn try_collect_active_jobs(
+    pub fn try_collect_active_jobs<CTX: Copy>(
         &self,
+        tcx: CTX,
         kind: D,
-        make_query: fn(K) -> Q,
+        make_query: fn(CTX, K) -> Q,
         jobs: &mut QueryMap<D, Q>,
     ) -> Option<()> {
         // We use try_lock_shards here since we are called from the
@@ -133,7 +134,7 @@ where
             shard.active.iter().filter_map(move |(k, v)| {
                 if let QueryResult::Started(ref job) = *v {
                     let id = QueryJobId::new(job.id, shard_id, kind);
-                    let info = QueryInfo { span: job.span, query: make_query(k.clone()) };
+                    let info = QueryInfo { span: job.span, query: make_query(tcx, k.clone()) };
                     Some((id, QueryJobInfo { info, job: job.clone() }))
                 } else {
                     None

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -550,7 +550,7 @@ where
 
     // If `-Zincremental-verify-ich` is specified, re-hash results from
     // the cache and make sure that they have the expected fingerprint.
-    if unlikely!(tcx.incremental_verify_ich()) {
+    if unlikely!(tcx.dep_context().sess().opts.debugging_opts.incremental_verify_ich) {
         incremental_verify_ich(*tcx.dep_context(), &result, dep_node, dep_node_index, query);
     }
 

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -7,7 +7,7 @@ use crate::dep_graph::{DepNodeIndex, SerializedDepNodeIndex};
 use crate::query::caches::QueryCache;
 use crate::query::config::{QueryDescription, QueryVtable, QueryVtableExt};
 use crate::query::job::{QueryInfo, QueryJob, QueryJobId, QueryJobInfo, QueryShardJobId};
-use crate::query::{QueryContext, QueryMap};
+use crate::query::{QueryContext, QueryMap, QueryStackFrame};
 
 #[cfg(not(parallel_compiler))]
 use rustc_data_structures::cold_path;
@@ -81,37 +81,36 @@ impl<C: QueryCache> QueryCacheStore<C> {
     }
 }
 
-struct QueryStateShard<D, Q, K> {
-    active: FxHashMap<K, QueryResult<D, Q>>,
+struct QueryStateShard<D, K> {
+    active: FxHashMap<K, QueryResult<D>>,
 
     /// Used to generate unique ids for active jobs.
     jobs: u32,
 }
 
-impl<D, Q, K> Default for QueryStateShard<D, Q, K> {
-    fn default() -> QueryStateShard<D, Q, K> {
+impl<D, K> Default for QueryStateShard<D, K> {
+    fn default() -> QueryStateShard<D, K> {
         QueryStateShard { active: Default::default(), jobs: 0 }
     }
 }
 
-pub struct QueryState<D, Q, K> {
-    shards: Sharded<QueryStateShard<D, Q, K>>,
+pub struct QueryState<D, K> {
+    shards: Sharded<QueryStateShard<D, K>>,
 }
 
 /// Indicates the state of a query for a given key in a query map.
-enum QueryResult<D, Q> {
+enum QueryResult<D> {
     /// An already executing query. The query job can be used to await for its completion.
-    Started(QueryJob<D, Q>),
+    Started(QueryJob<D>),
 
     /// The query panicked. Queries trying to wait on this will raise a fatal error which will
     /// silently panic.
     Poisoned,
 }
 
-impl<D, Q, K> QueryState<D, Q, K>
+impl<D, K> QueryState<D, K>
 where
     D: Copy + Clone + Eq + Hash,
-    Q: Clone,
     K: Eq + Hash + Clone + Debug,
 {
     pub fn all_inactive(&self) -> bool {
@@ -123,8 +122,8 @@ where
         &self,
         tcx: CTX,
         kind: D,
-        make_query: fn(CTX, K) -> Q,
-        jobs: &mut QueryMap<D, Q>,
+        make_query: fn(CTX, K) -> QueryStackFrame,
+        jobs: &mut QueryMap<D>,
     ) -> Option<()> {
         // We use try_lock_shards here since we are called from the
         // deadlock handler, and this shouldn't be locked.
@@ -146,30 +145,28 @@ where
     }
 }
 
-impl<D, Q, K> Default for QueryState<D, Q, K> {
-    fn default() -> QueryState<D, Q, K> {
+impl<D, K> Default for QueryState<D, K> {
+    fn default() -> QueryState<D, K> {
         QueryState { shards: Default::default() }
     }
 }
 
 /// A type representing the responsibility to execute the job in the `job` field.
 /// This will poison the relevant query if dropped.
-struct JobOwner<'tcx, D, Q, C>
+struct JobOwner<'tcx, D, C>
 where
     D: Copy + Clone + Eq + Hash,
-    Q: Clone,
     C: QueryCache,
 {
-    state: &'tcx QueryState<D, Q, C::Key>,
+    state: &'tcx QueryState<D, C::Key>,
     cache: &'tcx QueryCacheStore<C>,
     key: C::Key,
     id: QueryJobId<D>,
 }
 
-impl<'tcx, D, Q, C> JobOwner<'tcx, D, Q, C>
+impl<'tcx, D, C> JobOwner<'tcx, D, C>
 where
     D: Copy + Clone + Eq + Hash,
-    Q: Clone,
     C: QueryCache,
 {
     /// Either gets a `JobOwner` corresponding the query, allowing us to
@@ -183,13 +180,13 @@ where
     #[inline(always)]
     fn try_start<'b, CTX>(
         tcx: CTX,
-        state: &'b QueryState<CTX::DepKind, CTX::Query, C::Key>,
+        state: &'b QueryState<CTX::DepKind, C::Key>,
         cache: &'b QueryCacheStore<C>,
         span: Span,
         key: &C::Key,
         lookup: QueryLookup,
         query: &QueryVtable<CTX, C::Key, C::Value>,
-    ) -> TryGetJob<'b, CTX::DepKind, CTX::Query, C>
+    ) -> TryGetJob<'b, CTX::DepKind, C>
     where
         CTX: QueryContext,
     {
@@ -243,7 +240,7 @@ where
         // so we just return the error.
         #[cfg(not(parallel_compiler))]
         return TryGetJob::Cycle(cold_path(|| {
-            let error: CycleError<CTX::Query> = latch.find_cycle_in_stack(
+            let error: CycleError = latch.find_cycle_in_stack(
                 tcx.try_collect_active_jobs().unwrap(),
                 &tcx.current_query_job(),
                 span,
@@ -328,10 +325,9 @@ where
     (result, diagnostics.into_inner())
 }
 
-impl<'tcx, D, Q, C> Drop for JobOwner<'tcx, D, Q, C>
+impl<'tcx, D, C> Drop for JobOwner<'tcx, D, C>
 where
     D: Copy + Clone + Eq + Hash,
-    Q: Clone,
     C: QueryCache,
 {
     #[inline(never)]
@@ -356,21 +352,20 @@ where
 }
 
 #[derive(Clone)]
-pub struct CycleError<Q> {
+pub struct CycleError {
     /// The query and related span that uses the cycle.
-    pub usage: Option<(Span, Q)>,
-    pub cycle: Vec<QueryInfo<Q>>,
+    pub usage: Option<(Span, QueryStackFrame)>,
+    pub cycle: Vec<QueryInfo>,
 }
 
 /// The result of `try_start`.
-enum TryGetJob<'tcx, D, Q, C>
+enum TryGetJob<'tcx, D, C>
 where
     D: Copy + Clone + Eq + Hash,
-    Q: Clone,
     C: QueryCache,
 {
     /// The query is not yet started. Contains a guard to the cache eventually used to start it.
-    NotYetStarted(JobOwner<'tcx, D, Q, C>),
+    NotYetStarted(JobOwner<'tcx, D, C>),
 
     /// The query was already completed.
     /// Returns the result of the query and its dep-node index
@@ -414,7 +409,7 @@ where
 
 fn try_execute_query<CTX, C>(
     tcx: CTX,
-    state: &QueryState<CTX::DepKind, CTX::Query, C::Key>,
+    state: &QueryState<CTX::DepKind, C::Key>,
     cache: &QueryCacheStore<C>,
     span: Span,
     key: C::Key,
@@ -426,7 +421,7 @@ where
     C::Key: crate::dep_graph::DepNodeParams<CTX::DepContext>,
     CTX: QueryContext,
 {
-    let job = match JobOwner::<'_, CTX::DepKind, CTX::Query, C>::try_start(
+    let job = match JobOwner::<'_, CTX::DepKind, C>::try_start(
         tcx, state, cache, span, &key, lookup, query,
     ) {
         TryGetJob::NotYetStarted(job) => job,
@@ -590,7 +585,7 @@ fn incremental_verify_ich<CTX, K, V: Debug>(
 fn force_query_with_job<C, CTX>(
     tcx: CTX,
     key: C::Key,
-    job: JobOwner<'_, CTX::DepKind, CTX::Query, C>,
+    job: JobOwner<'_, CTX::DepKind, C>,
     dep_node: DepNode<CTX::DepKind>,
     query: &QueryVtable<CTX, C::Key, C::Value>,
 ) -> (C::Stored, DepNodeIndex)
@@ -650,7 +645,7 @@ where
 #[inline(never)]
 fn get_query_impl<CTX, C>(
     tcx: CTX,
-    state: &QueryState<CTX::DepKind, CTX::Query, C::Key>,
+    state: &QueryState<CTX::DepKind, C::Key>,
     cache: &QueryCacheStore<C>,
     span: Span,
     key: C::Key,
@@ -708,7 +703,7 @@ where
 #[inline(never)]
 fn force_query_impl<CTX, C>(
     tcx: CTX,
-    state: &QueryState<CTX::DepKind, CTX::Query, C::Key>,
+    state: &QueryState<CTX::DepKind, C::Key>,
     cache: &QueryCacheStore<C>,
     key: C::Key,
     span: Span,
@@ -736,7 +731,7 @@ fn force_query_impl<CTX, C>(
         Err(lookup) => lookup,
     };
 
-    let job = match JobOwner::<'_, CTX::DepKind, CTX::Query, C>::try_start(
+    let job = match JobOwner::<'_, CTX::DepKind, C>::try_start(
         tcx, state, cache, span, &key, lookup, query,
     ) {
         TryGetJob::NotYetStarted(job) => job,


### PR DESCRIPTION
A lot of code in `rustc_query_system` is generic over it, only to encode an exceptional error case: query cycles.
The delayed computations are now done at cycle detection.