### PR TITLE
rustdoc: Remove `*` intra-doc alias for `pointer`

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2092,7 +2092,7 @@ fn resolve_primitive(path_str: &str, ns: Namespace) -> Option<Res> {
         "array" => Array,
         "tuple" => Tuple,
         "unit" => Unit,
-        "pointer" | "*" | "*const" | "*mut" => RawPointer,
+        "pointer" | "*const" | "*mut" => RawPointer,
         "reference" | "&" | "&mut" => Reference,
         "fn" => Fn,
         "never" | "!" => Never,

--- a/src/test/rustdoc/intra-doc/non-path-primitives.rs
+++ b/src/test/rustdoc/intra-doc/non-path-primitives.rs
@@ -11,11 +11,9 @@
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.is_null"]' 'pointer::is_null'
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.is_null"]' '*const::is_null'
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.is_null"]' '*mut::is_null'
-// @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.is_null"]' '*::is_null'
 //! [pointer::is_null]
 //! [*const::is_null]
 //! [*mut::is_null]
-//! [*::is_null]
 
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/std/primitive.unit.html"]' 'unit'
 //! [unit]


### PR DESCRIPTION
It's not valid Rust code and it can easily be confused with a wildcard
glob pattern or something else. People can always use `pointer` instead,
so it's just removing an alias.

It hasn't hit stable yet (I think it's still on nightly), so it's okay
to remove it. (We can always add it back later if we change our mind
too.)

r? @jyn514
cc https://github.com/rust-lang/rust/pull/80885#discussion_r554622737
