### PR TITLE
Fix handling of malicious Readers in read_to_end

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -388,10 +388,9 @@ where
         match r.read(buf) {
             Ok(0) => return Ok(g.len - start_len),
             Ok(n) => {
-                // We can't let g.len overflow which would result in the vec shrinking when the function returns. In
-                // particular, that could break read_to_string if the shortened buffer doesn't end on a UTF-8 boundary.
-                // The minimal check would just be a checked_add, but this assert is a bit more precise and should be
-                // just about the same cost.
+                // We can't allow bogus values from read. If it is too large, the returned vec could have its length
+                // set past its capacity, or if it overflows the vec could be shortened which could create an invalid
+                // string if this is called via read_to_string.
                 assert!(n <= buf.len());
                 g.len += n;
             }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -384,14 +384,15 @@ where
             }
         }
 
-        match r.read(&mut g.buf[g.len..]) {
+        let buf = &mut g.buf[g.len..];
+        match r.read(buf) {
             Ok(0) => return Ok(g.len - start_len),
             Ok(n) => {
                 // We can't let g.len overflow which would result in the vec shrinking when the function returns. In
                 // particular, that could break read_to_string if the shortened buffer doesn't end on a UTF-8 boundary.
                 // The minimal check would just be a checked_add, but this assert is a bit more precise and should be
                 // just about the same cost.
-                assert!(n <= g.buf.len() - g.len);
+                assert!(n <= buf.len());
                 g.len += n;
             }
             Err(ref e) if e.kind() == ErrorKind::Interrupted => {}


### PR DESCRIPTION
A malicious `Read` impl could return overly large values from `read`, which would result in the guard's drop impl setting the buffer's length to greater than its capacity! ~~To fix this, the drop impl now uses the safe `truncate` function instead of `set_len` which ensures that this will not happen. The result of calling the function will be nonsensical, but that's fine given the contract violation of the `Read` impl.~~

~~The `Guard` type is also used by `append_to_string` which does not pass untrusted values into the length field, so I've copied the guard type into each function and only modified the one used by `read_to_end`. We could just keep a single one and modify it, but it seems a bit cleaner to keep the guard code close to the functions and related specifically to them.~~

To fix this, we now assert that the returned length is not larger than the buffer passed to the method.

For reference, this bug has been present for ~2.5 years since 1.20: https://github.com/rust-lang/rust/commit/ecbb896b9eb2acadefde57be493e4298c1aa04a3.

Closes #80894.