### PR TITLE
Add a regression test for #76281

### DIFF
--- a/src/test/ui/wasm/wasm-hang-issue-76281.rs
+++ b/src/test/ui/wasm/wasm-hang-issue-76281.rs
@@ -1,0 +1,12 @@
+// only-wasm32
+// compile-flags: -C opt-level=2
+// build-pass
+
+// Regression test for #76281.
+// This seems like an issue related to LLVM rather than
+// libs-impl so place here.
+
+fn main() {
+    let mut v: Vec<&()> = Vec::new();
+    v.sort_by_key(|&r| r as *const ());
+}


### PR DESCRIPTION
This has been fixed between 1.47.0-nightly (663d2f5cd 2020-08-22) and 1.47.0-nightly (5180f3da5 2020-08-23). Maybe fixed by #73526?

Created `wasm` dir, it currently has only one test but I'll move some wasm-related tests there as a follow-up.

Closes #76281