### PR TITLE
Remove is_spotlight field from `Trait`

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -195,14 +195,12 @@ crate fn build_external_trait(cx: &mut DocContext<'_>, did: DefId) -> clean::Tra
     let generics = (cx.tcx.generics_of(did), predicates).clean(cx);
     let generics = filter_non_trait_generics(did, generics);
     let (generics, supertrait_bounds) = separate_supertrait_bounds(generics);
-    let is_spotlight = load_attrs(cx, did).clean(cx).has_doc_flag(sym::spotlight);
     let is_auto = cx.tcx.trait_is_auto(did);
     clean::Trait {
         unsafety: cx.tcx.trait_def(did).unsafety,
         generics,
         items: trait_items,
         bounds: supertrait_bounds,
-        is_spotlight,
         is_auto,
     }
 }
@@ -626,6 +624,8 @@ crate fn record_extern_trait(cx: &mut DocContext<'_>, did: DefId) {
     debug!("record_extern_trait: {:?}", did);
     let trait_ = build_external_trait(cx, did);
 
-    cx.external_traits.borrow_mut().insert(did, trait_);
+    cx.external_traits
+        .borrow_mut()
+        .insert(did, (trait_, clean::utils::has_doc_flag(cx.tcx.get_attrs(did), sym::spotlight)));
     cx.active_extern_traits.remove(&did);
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -624,12 +624,10 @@ crate fn record_extern_trait(cx: &mut DocContext<'_>, did: DefId) {
     debug!("record_extern_trait: {:?}", did);
     let trait_ = build_external_trait(cx, did);
 
-    cx.external_traits.borrow_mut().insert(
-        did,
-        clean::TraitWithExtraInfo {
-            trait_,
-            is_spotlight: clean::utils::has_doc_flag(cx.tcx.get_attrs(did), sym::spotlight),
-        },
-    );
+    let trait_ = clean::TraitWithExtraInfo {
+        trait_,
+        is_spotlight: clean::utils::has_doc_flag(cx.tcx.get_attrs(did), sym::spotlight),
+    };
+    cx.external_traits.borrow_mut().insert(did, trait_);
     cx.active_extern_traits.remove(&did);
 }

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -624,8 +624,12 @@ crate fn record_extern_trait(cx: &mut DocContext<'_>, did: DefId) {
     debug!("record_extern_trait: {:?}", did);
     let trait_ = build_external_trait(cx, did);
 
-    cx.external_traits
-        .borrow_mut()
-        .insert(did, (trait_, clean::utils::has_doc_flag(cx.tcx.get_attrs(did), sym::spotlight)));
+    cx.external_traits.borrow_mut().insert(
+        did,
+        clean::TraitWithExtraInfo {
+            trait_,
+            is_spotlight: clean::utils::has_doc_flag(cx.tcx.get_attrs(did), sym::spotlight),
+        },
+    );
     cx.active_extern_traits.remove(&did);
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2003,14 +2003,11 @@ impl Clean<Vec<Item>> for (&hir::Item<'_>, Option<Symbol>) {
                         .iter()
                         .map(|ti| cx.tcx.hir().trait_item(ti.id).clean(cx))
                         .collect();
-                    let attrs = item.attrs.clean(cx);
-                    let is_spotlight = attrs.has_doc_flag(sym::spotlight);
                     TraitItem(Trait {
                         unsafety,
                         items,
                         generics: generics.clean(cx),
                         bounds: bounds.clean(cx),
-                        is_spotlight,
                         is_auto: is_auto.clean(cx),
                     })
                 }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -57,9 +57,16 @@ crate struct Crate {
     crate primitives: Vec<(DefId, PrimitiveType)>,
     // These are later on moved into `CACHEKEY`, leaving the map empty.
     // Only here so that they can be filtered through the rustdoc passes.
-    crate external_traits: Rc<RefCell<FxHashMap<DefId, (Trait, bool)>>>,
+    crate external_traits: Rc<RefCell<FxHashMap<DefId, TraitWithExtraInfo>>>,
     crate masked_crates: FxHashSet<CrateNum>,
     crate collapsed: bool,
+}
+
+/// This struct is used to wrap additional information added by rustdoc on a `trait` item.
+#[derive(Clone, Debug)]
+crate struct TraitWithExtraInfo {
+    crate trait_: Trait,
+    crate is_spotlight: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -57,7 +57,7 @@ crate struct Crate {
     crate primitives: Vec<(DefId, PrimitiveType)>,
     // These are later on moved into `CACHEKEY`, leaving the map empty.
     // Only here so that they can be filtered through the rustdoc passes.
-    crate external_traits: Rc<RefCell<FxHashMap<DefId, Trait>>>,
+    crate external_traits: Rc<RefCell<FxHashMap<DefId, (Trait, bool)>>>,
     crate masked_crates: FxHashSet<CrateNum>,
     crate collapsed: bool,
 }
@@ -1185,7 +1185,6 @@ crate struct Trait {
     crate items: Vec<Item>,
     crate generics: Generics,
     crate bounds: Vec<GenericBound>,
-    crate is_spotlight: bool,
     crate is_auto: bool,
 }
 

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -521,14 +521,15 @@ crate fn find_nearest_parent_module(tcx: TyCtxt<'_>, def_id: DefId) -> Option<De
     }
 }
 
-/// Checks that one attribute is `doc`. For example:
+/// Checks for the existence of `hidden` in the attribute below if `flag` is `sym::hidden`:
 ///
-/// ```text
-/// #[doc(spotlight)]
+/// ```
+/// #[doc(hidden)]
+/// pub fn foo() {}
 /// ```
 ///
-/// This function has to exists because it runs on `hir::Attributes` whereas the other runs on
-/// `clean::Attributes`.
+/// This function exists because it runs on `hir::Attributes` whereas the other is a
+/// `clean::Attributes` method.
 crate fn has_doc_flag(attrs: Attributes<'_>, flag: Symbol) -> bool {
     attrs.iter().any(|attr| {
         attr.has_name(sym::doc)

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -7,7 +7,6 @@ use crate::clean::{
 };
 use crate::core::DocContext;
 
-use rustc_attr::list_contains_name;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
@@ -533,6 +532,6 @@ crate fn find_nearest_parent_module(tcx: TyCtxt<'_>, def_id: DefId) -> Option<De
 crate fn has_doc_flag(attrs: Attributes<'_>, flag: Symbol) -> bool {
     attrs.iter().any(|attr| {
         attr.has_name(sym::doc)
-            && attr.meta_item_list().map_or(false, |l| list_contains_name(&l, flag))
+            && attr.meta_item_list().map_or(false, |l| rustc_attr::list_contains_name(&l, flag))
     })
 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -7,13 +7,14 @@ use crate::clean::{
 };
 use crate::core::DocContext;
 
+use rustc_attr::list_contains_name;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::interpret::ConstValue;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
-use rustc_middle::ty::{self, DefIdTree, Ty, TyCtxt};
+use rustc_middle::ty::{self, Attributes, DefIdTree, Ty, TyCtxt};
 use rustc_span::symbol::{kw, sym, Symbol};
 use std::mem;
 
@@ -519,4 +520,19 @@ crate fn find_nearest_parent_module(tcx: TyCtxt<'_>, def_id: DefId) -> Option<De
         }
         None
     }
+}
+
+/// Checks that one attribute is `doc`. For example:
+///
+/// ```text
+/// #[doc(spotlight)]
+/// ```
+///
+/// This function has to exists because it runs on `hir::Attributes` whereas the other runs on
+/// `clean::Attributes`.
+crate fn has_doc_flag(attrs: Attributes<'_>, flag: Symbol) -> bool {
+    attrs.iter().any(|attr| {
+        attr.has_name(sym::doc)
+            && attr.meta_item_list().map_or(false, |l| list_contains_name(&l, flag))
+    })
 }

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -13,7 +13,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::interpret::ConstValue;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
-use rustc_middle::ty::{self, Attributes, DefIdTree, Ty, TyCtxt};
+use rustc_middle::ty::{self, DefIdTree, Ty, TyCtxt};
 use rustc_span::symbol::{kw, sym, Symbol};
 use std::mem;
 
@@ -530,7 +530,7 @@ crate fn find_nearest_parent_module(tcx: TyCtxt<'_>, def_id: DefId) -> Option<De
 ///
 /// This function exists because it runs on `hir::Attributes` whereas the other is a
 /// `clean::Attributes` method.
-crate fn has_doc_flag(attrs: Attributes<'_>, flag: Symbol) -> bool {
+crate fn has_doc_flag(attrs: ty::Attributes<'_>, flag: Symbol) -> bool {
     attrs.iter().any(|attr| {
         attr.has_name(sym::doc)
             && attr.meta_item_list().map_or(false, |l| rustc_attr::list_contains_name(&l, flag))

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -30,7 +30,7 @@ use std::{cell::RefCell, collections::hash_map::Entry};
 
 use crate::clean;
 use crate::clean::inline::build_external_trait;
-use crate::clean::{AttributesExt, MAX_DEF_IDX};
+use crate::clean::{AttributesExt, TraitWithExtraInfo, MAX_DEF_IDX};
 use crate::config::{Options as RustdocOptions, RenderOptions};
 use crate::config::{OutputFormat, RenderInfo};
 use crate::formats::cache::Cache;
@@ -538,7 +538,10 @@ crate fn run_global_ctxt(
     if let Some(sized_trait_did) = ctxt.tcx.lang_items().sized_trait() {
         let mut sized_trait = build_external_trait(&mut ctxt, sized_trait_did);
         sized_trait.is_auto = true;
-        ctxt.external_traits.borrow_mut().insert(sized_trait_did, sized_trait);
+        ctxt.external_traits.borrow_mut().insert(
+            sized_trait_did,
+            TraitWithExtraInfo { trait_: sized_trait, is_spotlight: false },
+        );
     }
 
     debug!("crate: {:?}", tcx.hir().krate());

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -55,7 +55,7 @@ crate struct DocContext<'tcx> {
     /// Later on moved into `cache`
     crate renderinfo: RenderInfo,
     /// Later on moved through `clean::Crate` into `cache`
-    crate external_traits: Rc<RefCell<FxHashMap<DefId, (clean::Trait, bool)>>>,
+    crate external_traits: Rc<RefCell<FxHashMap<DefId, clean::TraitWithExtraInfo>>>,
     /// Used while populating `external_traits` to ensure we don't process the same trait twice at
     /// the same time.
     crate active_extern_traits: FxHashSet<DefId>,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -55,7 +55,7 @@ crate struct DocContext<'tcx> {
     /// Later on moved into `cache`
     crate renderinfo: RenderInfo,
     /// Later on moved through `clean::Crate` into `cache`
-    crate external_traits: Rc<RefCell<FxHashMap<DefId, clean::Trait>>>,
+    crate external_traits: Rc<RefCell<FxHashMap<DefId, (clean::Trait, bool)>>>,
     /// Used while populating `external_traits` to ensure we don't process the same trait twice at
     /// the same time.
     crate active_extern_traits: FxHashSet<DefId>,

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -91,9 +91,9 @@ crate trait DocFolder: Sized {
 
         {
             let external_traits = { std::mem::take(&mut *c.external_traits.borrow_mut()) };
-            for (k, mut v) in external_traits {
+            for (k, (mut v, is_spotlight)) in external_traits {
                 v.items = v.items.into_iter().filter_map(|i| self.fold_item(i)).collect();
-                c.external_traits.borrow_mut().insert(k, v);
+                c.external_traits.borrow_mut().insert(k, (v, is_spotlight));
             }
         }
         c

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -91,9 +91,10 @@ crate trait DocFolder: Sized {
 
         {
             let external_traits = { std::mem::take(&mut *c.external_traits.borrow_mut()) };
-            for (k, (mut v, is_spotlight)) in external_traits {
-                v.items = v.items.into_iter().filter_map(|i| self.fold_item(i)).collect();
-                c.external_traits.borrow_mut().insert(k, (v, is_spotlight));
+            for (k, mut v) in external_traits {
+                v.trait_.items =
+                    v.trait_.items.into_iter().filter_map(|i| self.fold_item(i)).collect();
+                c.external_traits.borrow_mut().insert(k, v);
             }
         }
         c

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -245,16 +245,12 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
             }
         }
 
-        let tcx = self.tcx;
         // Propagate a trait method's documentation to all implementors of the
         // trait.
         if let clean::TraitItem(ref t) = *item.kind {
             self.cache.traits.entry(item.def_id).or_insert_with(|| clean::TraitWithExtraInfo {
                 trait_: t.clone(),
-                is_spotlight: clean::utils::has_doc_flag(
-                    tcx.get_attrs(item.def_id),
-                    sym::spotlight,
-                ),
+                is_spotlight: item.attrs.has_doc_flag(sym::spotlight),
             });
         }
 

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -7,6 +7,7 @@ use rustc_hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX};
 use rustc_middle::middle::privacy::AccessLevels;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::source_map::FileName;
+use rustc_span::symbol::sym;
 use rustc_span::Symbol;
 
 use crate::clean::{self, GetDefId};
@@ -64,7 +65,9 @@ crate struct Cache {
     /// Implementations of a crate should inherit the documentation of the
     /// parent trait if no extra documentation is specified, and default methods
     /// should show up in documentation about trait implementations.
-    crate traits: FxHashMap<DefId, clean::Trait>,
+    ///
+    /// The `bool` parameter is about if the trait is `spotlight`.
+    crate traits: FxHashMap<DefId, (clean::Trait, bool)>,
 
     /// When rendering traits, it's often useful to be able to list all
     /// implementors of the trait, and this mapping is exactly, that: a mapping
@@ -244,10 +247,13 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
             }
         }
 
+        let tcx = self.tcx;
         // Propagate a trait method's documentation to all implementors of the
         // trait.
         if let clean::TraitItem(ref t) = *item.kind {
-            self.cache.traits.entry(item.def_id).or_insert_with(|| t.clone());
+            self.cache.traits.entry(item.def_id).or_insert_with(|| {
+                (t.clone(), clean::utils::has_doc_flag(tcx.get_attrs(item.def_id), sym::spotlight))
+            });
         }
 
         // Collect all the implementors of traits.

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -65,9 +65,7 @@ crate struct Cache {
     /// Implementations of a crate should inherit the documentation of the
     /// parent trait if no extra documentation is specified, and default methods
     /// should show up in documentation about trait implementations.
-    ///
-    /// The `bool` parameter is about if the trait is `spotlight`.
-    crate traits: FxHashMap<DefId, (clean::Trait, bool)>,
+    crate traits: FxHashMap<DefId, clean::TraitWithExtraInfo>,
 
     /// When rendering traits, it's often useful to be able to list all
     /// implementors of the trait, and this mapping is exactly, that: a mapping
@@ -251,8 +249,12 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
         // Propagate a trait method's documentation to all implementors of the
         // trait.
         if let clean::TraitItem(ref t) = *item.kind {
-            self.cache.traits.entry(item.def_id).or_insert_with(|| {
-                (t.clone(), clean::utils::has_doc_flag(tcx.get_attrs(item.def_id), sym::spotlight))
+            self.cache.traits.entry(item.def_id).or_insert_with(|| clean::TraitWithExtraInfo {
+                trait_: t.clone(),
+                is_spotlight: clean::utils::has_doc_flag(
+                    tcx.get_attrs(item.def_id),
+                    sym::spotlight,
+                ),
             });
         }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3687,8 +3687,9 @@ fn spotlight_decl(decl: &clean::FnDecl, cache: &Cache) -> String {
         if let Some(impls) = cache.impls.get(&did) {
             for i in impls {
                 let impl_ = i.inner_impl();
-                if impl_.trait_.def_id_full(cache).map_or(false, |d| cache.traits[&d].is_spotlight)
-                {
+                if impl_.trait_.def_id().map_or(false, |d| {
+                    cache.traits.get(&d).map(|(_, is_spotlight)| *is_spotlight).unwrap_or(false)
+                }) {
                     if out.is_empty() {
                         write!(
                             &mut out,
@@ -3979,7 +3980,7 @@ fn render_impl(
             false,
             outer_version,
             outer_const_version,
-            trait_,
+            trait_.map(|(t, _)| t),
             show_def_docs,
         );
     }
@@ -4024,7 +4025,7 @@ fn render_impl(
     // We don't emit documentation for default items if they appear in the
     // Implementations on Foreign Types or Implementors sections.
     if show_default_items {
-        if let Some(t) = trait_ {
+        if let Some((t, _)) = trait_ {
             render_default_items(
                 w,
                 cx,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3688,7 +3688,7 @@ fn spotlight_decl(decl: &clean::FnDecl, cache: &Cache) -> String {
             for i in impls {
                 let impl_ = i.inner_impl();
                 if impl_.trait_.def_id().map_or(false, |d| {
-                    cache.traits.get(&d).map(|(_, is_spotlight)| *is_spotlight).unwrap_or(false)
+                    cache.traits.get(&d).map(|t| t.is_spotlight).unwrap_or(false)
                 }) {
                     if out.is_empty() {
                         write!(
@@ -3980,7 +3980,7 @@ fn render_impl(
             false,
             outer_version,
             outer_const_version,
-            trait_.map(|(t, _)| t),
+            trait_.map(|t| &t.trait_),
             show_def_docs,
         );
     }
@@ -4025,11 +4025,11 @@ fn render_impl(
     // We don't emit documentation for default items if they appear in the
     // Implementations on Foreign Types or Implementors sections.
     if show_default_items {
-        if let Some((t, _)) = trait_ {
+        if let Some(t) = trait_ {
             render_default_items(
                 w,
                 cx,
-                t,
+                &t.trait_,
                 &i.inner_impl(),
                 &i.impl_item,
                 render_mode,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -408,7 +408,7 @@ impl From<clean::FnDecl> for FnDecl {
 
 impl From<clean::Trait> for Trait {
     fn from(trait_: clean::Trait) -> Self {
-        let clean::Trait { unsafety, items, generics, bounds, is_spotlight: _, is_auto } = trait_;
+        let clean::Trait { unsafety, items, generics, bounds, is_auto } = trait_;
         Trait {
             is_auto,
             is_unsafe: unsafety == rustc_hir::Unsafety::Unsafe,

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -84,9 +84,10 @@ impl JsonRenderer<'tcx> {
         Rc::clone(&self.cache)
             .traits
             .iter()
-            .filter_map(|(&id, (trait_item, _))| {
+            .filter_map(|(&id, trait_item)| {
                 // only need to synthesize items for external traits
                 if !id.is_local() {
+                    let trait_item = &trait_item.trait_;
                     trait_item.items.clone().into_iter().for_each(|i| self.item(i).unwrap());
                     Some((
                         from_def_id(id),

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -84,7 +84,7 @@ impl JsonRenderer<'tcx> {
         Rc::clone(&self.cache)
             .traits
             .iter()
-            .filter_map(|(&id, trait_item)| {
+            .filter_map(|(&id, (trait_item, _))| {
                 // only need to synthesize items for external traits
                 if !id.is_local() {
                     trait_item.items.clone().into_iter().for_each(|i| self.item(i).unwrap());

--- a/src/test/rustdoc/spotlight-from-dependency.rs
+++ b/src/test/rustdoc/spotlight-from-dependency.rs
@@ -1,0 +1,24 @@
+#![crate_name = "foo"]
+
+use std::iter::Iterator;
+
+// @has foo/struct.Odd.html
+// @has - '//h4[@id="method.new"]//span[@class="notable-traits"]//code/span' 'impl Iterator for Odd'
+pub struct Odd {
+    current: usize,
+}
+
+impl Odd {
+    pub fn new() -> Odd {
+        Odd { current: 1 }
+    }
+}
+
+impl Iterator for Odd {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.current += 2;
+        Some(self.current - 2)
+    }
+}


### PR DESCRIPTION
Small PR, only the last commit is relevant here. The rest is coming from #80883 because I need the `TyCtxt` stored inside `Cache`.

The point is to make ItemKind looks as close as possible to the compiler type so that it makes the switch simpler (which is why I make all these "small" PRs).

r? @jyn514 