### PR TITLE
core/slice: remove doc comment about scoped borrow

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1357,14 +1357,11 @@ impl<T> [T] {
     ///
     /// ```
     /// let mut v = [1, 0, 3, 0, 5, 6];
-    /// // scoped to restrict the lifetime of the borrows
-    /// {
-    ///     let (left, right) = v.split_at_mut(2);
-    ///     assert_eq!(left, [1, 0]);
-    ///     assert_eq!(right, [3, 0, 5, 6]);
-    ///     left[1] = 2;
-    ///     right[1] = 4;
-    /// }
+    /// let (left, right) = v.split_at_mut(2);
+    /// assert_eq!(left, [1, 0]);
+    /// assert_eq!(right, [3, 0, 5, 6]);
+    /// left[1] = 2;
+    /// right[1] = 4;
     /// assert_eq!(v, [1, 2, 3, 4, 5, 6]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
There's no need to scope the borrow in the doc example due to NLL.

[Playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20main()%20%7B%0A%20%20%20%20let%20mut%20v%20%3D%20%5B1%2C%200%2C%203%2C%200%2C%205%2C%206%5D%3B%0A%0A%20%20%20%20let%20(left%2C%20right)%20%3D%20v.split_at_mut(2)%3B%0A%20%20%20%20assert_eq!(left%2C%20%5B1%2C%200%5D)%3B%0A%20%20%20%20assert_eq!(right%2C%20%5B3%2C%200%2C%205%2C%206%5D)%3B%0A%20%20%20%20left%5B1%5D%20%3D%202%3B%0A%20%20%20%20right%5B1%5D%20%3D%204%3B%0A%0A%20%20%20%20assert_eq!(v%2C%20%5B1%2C%202%2C%203%2C%204%2C%205%2C%206%5D)%3B%0A%7D%0A) where changed code compiles
