### PR TITLE
Revert "Auto merge of #76896 - spastorino:codegen-inline-fns2

### DIFF
--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -1,6 +1,7 @@
 use crate::dep_graph::{dep_constructor, DepNode, WorkProduct, WorkProductId};
 use crate::ich::{NodeIdHashingMode, StableHashingContext};
 use crate::ty::{subst::InternalSubsts, Instance, InstanceDef, SymbolName, TyCtxt};
+use rustc_attr::InlineAttr;
 use rustc_data_structures::base_n;
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::FxHashMap;
@@ -78,6 +79,14 @@ impl<'tcx> MonoItem<'tcx> {
     }
 
     pub fn instantiation_mode(&self, tcx: TyCtxt<'tcx>) -> InstantiationMode {
+        let generate_cgu_internal_copies = tcx
+            .sess
+            .opts
+            .debugging_opts
+            .inline_in_all_cgus
+            .unwrap_or_else(|| tcx.sess.opts.optimize != OptLevel::No)
+            && !tcx.sess.link_dead_code();
+
         match *self {
             MonoItem::Fn(ref instance) => {
                 let entry_def_id = tcx.entry_fn(LOCAL_CRATE).map(|(id, _)| id);
@@ -90,26 +99,21 @@ impl<'tcx> MonoItem<'tcx> {
                     return InstantiationMode::GloballyShared { may_conflict: false };
                 }
 
-                let generate_cgu_internal_copies = tcx
-                    .sess
-                    .opts
-                    .debugging_opts
-                    .inline_in_all_cgus
-                    .unwrap_or_else(|| tcx.sess.opts.optimize != OptLevel::No)
-                    && !tcx.sess.link_dead_code();
-
                 // At this point we don't have explicit linkage and we're an
-                // inlined function. If we should generate local copies for each CGU,
-                // then return `LocalCopy`, otherwise we'll just generate one copy
-                // and share it with all CGUs in this crate.
+                // inlined function. If we're inlining into all CGUs then we'll
+                // be creating a local copy per CGU.
                 if generate_cgu_internal_copies {
-                    InstantiationMode::LocalCopy
-                } else {
-                    // Finally, if we've reached this point, then we should optimize for
-                    // compilation speed. In that regard, we will ignore any `#[inline]`
-                    // annotations on the function and simply codegen it as usual. This could
-                    // conflict with upstream crates as it could be an exported symbol.
-                    InstantiationMode::GloballyShared { may_conflict: true }
+                    return InstantiationMode::LocalCopy;
+                }
+
+                // Finally, if this is `#[inline(always)]` we're sure to respect
+                // that with an inline copy per CGU, but otherwise we'll be
+                // creating one copy of this `#[inline]` function which may
+                // conflict with upstream crates as it could be an exported
+                // symbol.
+                match tcx.codegen_fn_attrs(instance.def_id()).inline {
+                    InlineAttr::Always => InstantiationMode::LocalCopy,
+                    _ => InstantiationMode::GloballyShared { may_conflict: true },
                 }
             }
             MonoItem::Static(..) | MonoItem::GlobalAsm(..) => {

--- a/src/test/incremental/hygiene/load_cached_hygiene.rs
+++ b/src/test/incremental/hygiene/load_cached_hygiene.rs
@@ -1,5 +1,5 @@
 // revisions:rpass1 rpass2
-// compile-flags: -Z query-dep-graph -O
+// compile-flags: -Z query-dep-graph
 // aux-build:cached_hygiene.rs
 
 // This tests the folllowing scenario
@@ -19,12 +19,7 @@
 // the metadata. Specifically, we were not resetting `orig_id`
 // for an `EpxnData` generate in the current crate, which would cause
 // us to serialize the `ExpnId` pointing to a garbage location in
-// the metadata.o
-
-// NOTE: We're explicitly passing the `-O` optimization flag because if optimizations are not
-// enabled, then rustc will ignore the `#[inline(always)]` attribute which means we do not load
-// the optimized mir for the unmodified function to be loaded and so the CGU containing that
-// function will be reused.
+// the metadata.
 
 #![feature(rustc_attrs)]
 

--- a/src/test/incremental/remapped_paths_cc/main.rs
+++ b/src/test/incremental/remapped_paths_cc/main.rs
@@ -1,17 +1,10 @@
 // revisions:rpass1 rpass2 rpass3
-// compile-flags: -Z query-dep-graph -g -O
+// compile-flags: -Z query-dep-graph -g
 // aux-build:extern_crate.rs
 
 // ignore-asmjs wasm2js does not support source maps yet
-
 // This test case makes sure that we detect if paths emitted into debuginfo
 // are changed, even when the change happens in an external crate.
-
-// NOTE: We're explicitly passing the `-O` optimization flag because if no optimizations are
-// requested, rustc will ignore the `#[inline]` attribute. This is a performance optimization for
-// non-optimized builds which causes us to generate fewer copies of inlined functions when
-// runtime performance doesn't matter. Without this flag, the function will go into a different
-// CGU which can be reused by this crate.
 
 #![feature(rustc_attrs)]
 

--- a/src/test/run-make-fulldeps/inline-always-many-cgu/Makefile
+++ b/src/test/run-make-fulldeps/inline-always-many-cgu/Makefile
@@ -1,12 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) foo.rs --emit llvm-ir -C codegen-units=2 -C opt-level=0
-	if ![cat $(TMPDIR)/*.ll | $(CGREP) -e '\bcall\b']; then \
-		echo "not found call instruction when one was expected"; \
-		exit 1; \
-	fi
-	$(RUSTC) foo.rs --emit llvm-ir -C codegen-units=2 -C opt-level=1
+	$(RUSTC) foo.rs --emit llvm-ir -C codegen-units=2
 	if cat $(TMPDIR)/*.ll | $(CGREP) -e '\bcall\b'; then \
 		echo "found call instruction when one wasn't expected"; \
 		exit 1; \


### PR DESCRIPTION
This reverts commit ddf2cc7f8eb34f1a63b491d6a52e3e8208393c09 (part of PR #76896), reversing
changes made to 937f629535f38c655267f1ed21ce6830f592f5df.

As @alexcrichton pointed out in https://github.com/rust-lang/rust/issues/80916 there's a problem with the taken approach.