### PR TITLE
Fix rustdoc --test-builder argument parsing

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -412,10 +412,11 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         unstable("test-builder", |o| {
-            o.optflag(
+            o.optopt(
                 "",
                 "test-builder",
-                "specified the rustc-like binary to use as the test builder",
+                "specifies the rustc-like binary to use as the test builder",
+                "PATH",
             )
         }),
         unstable("check", |o| o.optflag("", "check", "Run rustdoc checks")),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -412,12 +412,7 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         unstable("test-builder", |o| {
-            o.optopt(
-                "",
-                "test-builder",
-                "specifies the rustc-like binary to use as the test builder",
-                "PATH",
-            )
+            o.optopt("", "test-builder", "The rustc-like binary to use as the test builder", "PATH")
         }),
         unstable("check", |o| o.optflag("", "check", "Run rustdoc checks")),
     ]

--- a/src/test/rustdoc/issue-80893.rs
+++ b/src/test/rustdoc/issue-80893.rs
@@ -1,0 +1,7 @@
+// compile-flags: --test -Z unstable-options --test-builder true --runtool true
+
+/// ```
+/// This does not compile, but specifying a custom --test-builder should let this pass anyway
+/// `true` does not generate an output file to run, so we also specify it as a runtool
+/// ```
+pub struct Foo;

--- a/src/test/rustdoc/issue-80893.rs
+++ b/src/test/rustdoc/issue-80893.rs
@@ -1,7 +1,6 @@
-// compile-flags: --test -Z unstable-options --test-builder true --runtool true
+// compile-flags: --test -Z unstable-options --test-builder true
 
-/// ```
-/// This does not compile, but specifying a custom --test-builder should let this pass anyway
-/// `true` does not generate an output file to run, so we also specify it as a runtool
+/// ```no_run
+/// This tests that `--test-builder` is accepted as a flag by rustdoc.
 /// ```
 pub struct Foo;


### PR DESCRIPTION
My suggested fix to issue #80893. I can actually hook Miri in there now.

I also fixed what I believe to be a typo in the option's help text.