### PR TITLE
don't gratuitously error on tests returning Result with lifetime

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -392,6 +392,12 @@ pub struct GenericParam {
     pub kind: GenericParamKind,
 }
 
+impl GenericParam {
+    pub fn is_lifetime(&self) -> bool {
+        matches!(self.kind, GenericParamKind::Lifetime)
+    }
+}
+
 /// Represents lifetime, type and const parameters attached to a declaration of
 /// a function, enum, trait, etc.
 #[derive(Clone, Encodable, Decodable, Debug)]

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -458,8 +458,8 @@ fn has_test_signature(cx: &ExtCtxt<'_>, i: &ast::Item) -> bool {
                 false
             }
             (true, false) => {
-                if !generics.params.is_empty() {
-                    sd.span_err(i.span, "functions used as tests must have signature fn() -> ()");
+                if !generics.params.iter().all(|p| p.is_lifetime()) {
+                    sd.span_err(i.span, "return value of functions used as tests must either be `()` or implement `Termination`, and cannot use generics");
                     false
                 } else {
                     true

--- a/src/test/ui/test-fn-with-lifetime.rs
+++ b/src/test/ui/test-fn-with-lifetime.rs
@@ -1,0 +1,47 @@
+// compile-flags: --test
+
+// Issue #55228
+
+#![feature(termination_trait_lib)]
+
+use std::process::Termination;
+
+#[test]
+fn unit_1() -> Result<(), &'static str> { // this is OK
+    Ok(())
+}
+
+#[test]
+fn unit_2<'a>() -> Result<(), &'a str> { // also OK
+    Ok(())
+}
+
+#[test]
+fn unit_3<T: Termination>() -> Result<(), T> { // nope (how would this get monomorphized?)
+    //~^ ERROR return value of functions used as tests must either be `()` or implement
+    Ok(())
+}
+
+
+struct Quux;
+
+trait Bar {
+    type Baz;
+
+    fn rah(&self) -> Self::Baz;
+}
+
+impl Bar for Quux {
+    type Baz = String;
+
+    fn rah(&self) -> Self::Baz {
+        "rah".to_owned()
+    }
+}
+
+#[test]
+fn unit_4<T: Bar<Baz = String>>() -> <T as Bar>::Baz { // also nope
+    //~^ ERROR return value of functions used as tests must either be `()` or implement
+    let q = Quux{};
+    <Quux as Bar>::rah(&q)
+}

--- a/src/test/ui/test-fn-with-lifetime.stderr
+++ b/src/test/ui/test-fn-with-lifetime.stderr
@@ -1,0 +1,21 @@
+error: return value of functions used as tests must either be `()` or implement `Termination`, and cannot use generics
+  --> $DIR/test-fn-with-lifetime.rs:20:1
+   |
+LL | / fn unit_3<T: Termination>() -> Result<(), T> { // nope (how would this get monomorphized?)
+LL | |
+LL | |     Ok(())
+LL | | }
+   | |_^
+
+error: return value of functions used as tests must either be `()` or implement `Termination`, and cannot use generics
+  --> $DIR/test-fn-with-lifetime.rs:43:1
+   |
+LL | / fn unit_4<T: Bar<Baz = String>>() -> <T as Bar>::Baz { // also nope
+LL | |
+LL | |     let q = Quux{};
+LL | |     <Quux as Bar>::rah(&q)
+LL | | }
+   | |_^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
(Personal note: I'm not dead; I just didn't have time for Rust for, um, seventeen months, because I had to fight a religious war over the philosophy of language in my local apocalyptic robot cult. I won, sort of. Um, I think according to the letter of [RFC 2689](https://rust-lang.github.io/rfcs/2689-compiler-team-contributors.html), I was supposed to be demoted from compiler team contributors to alumni status on inactivity grounds, but it doesn't look like anyone noticed??)

-----

Sander Maijers reports that #[test] functions that return a `Result` with a named lifetime fail to compile with a "functions used as tests must have signature fn() -> ()" error message—but that can't really be right, because #[test] functions that return a `Result` with a static lifetime are accepted!

It turns out that this error message dates all the way back to April 2013's 5f1a90ebe ("Issue 4391: rustc should not silently skip tests with erroneous signature."). But after RFC 1937, we actually do accept non-unit return types in tests. ~~So the check to which this 2013 error message has survived attached, looking to see if the generic params are empty, can be deleted: non-empty generic params aren't necessarily an error anymore. Having been deleted, the match expression simplifies down to a conditional.~~

This resolves #55228, and is of historical interest to #4391.

r? @estebank 