### PR TITLE
Revert of #79968 to test perf regression in #80867

### DIFF
--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -56,15 +56,7 @@ pub(super) fn mangle(
     let hash = get_symbol_hash(tcx, instance, instance_ty, instantiating_crate);
 
     let mut printer = SymbolPrinter { tcx, path: SymbolPath::new(), keep_within_component: false }
-        .print_def_path(
-            def_id,
-            if let ty::InstanceDef::DropGlue(_, _) = instance.def {
-                // Add the name of the dropped type to the symbol name
-                &*instance.substs
-            } else {
-                &[]
-            },
-        )
+        .print_def_path(def_id, &[])
         .unwrap();
 
     if let ty::InstanceDef::VtableShim(..) = instance.def {


### PR DESCRIPTION
*DO NOT MERGE*

Revert "Rollup merge of #79968 - bjorn3:better_drop_glue_debuginfo, r=matthewjasper"

This is a revert of #79968  to test whether it was responsible for [performance regressions](https://perf.rust-lang.org/compare.html?start=7a193921a024e910262ff90bfb028074fddf20d0&end=34628e5b533d35840b61c5db0665cf7633ed3c5a&stat=instructions:u) in the rollup #80867. 

This reverts commit f90c7f0f42dbebbb85d9699b5826b0b103b0fbde, reversing
changes made to 5c0f5b69c2b11a16f34ff25da69be831336f3596.

r? @ghost 