### PR TITLE
Deprecate-in-future the constants superceded by RFC 2700

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -460,7 +460,6 @@ pub trait TryInto<T>: Sized {
 /// assert!(try_successful_smaller_number.is_ok());
 /// ```
 ///
-/// [`i32::MAX`]: crate::i32::MAX
 /// [`try_from`]: TryFrom::try_from
 /// [`!`]: ../../std/primitive.never.html
 #[stable(feature = "try_from", since = "1.34.0")]

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -1,5 +1,5 @@
 use crate::iter::{DoubleEndedIterator, FusedIterator, Iterator, TrustedLen};
-use crate::{ops::Try, usize};
+use crate::ops::Try;
 
 /// An iterator that links two iterators together, in a chain.
 ///

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -225,8 +225,6 @@ pub trait Iterator {
     /// This function might panic if the iterator has more than [`usize::MAX`]
     /// elements.
     ///
-    /// [`usize::MAX`]: crate::usize::MAX
-    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -871,7 +869,6 @@ pub trait Iterator {
     /// overflow a [`usize`].
     ///
     /// [`usize`]: type@usize
-    /// [`usize::MAX`]: crate::usize::MAX
     /// [`zip`]: Iterator::zip
     ///
     /// # Examples
@@ -2383,7 +2380,6 @@ pub trait Iterator {
     /// non-matching elements.
     ///
     /// [`Some(index)`]: Some
-    /// [`usize::MAX`]: crate::usize::MAX
     ///
     /// # Examples
     ///

--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -33,8 +33,6 @@ impl<I: FusedIterator + ?Sized> FusedIterator for &mut I {}
 ///
 /// This trait must only be implemented when the contract is upheld. Consumers
 /// of this trait must inspect [`Iterator::size_hint()`]’s upper bound.
-///
-/// [`usize::MAX`]: crate::usize::MAX
 #[unstable(feature = "trusted_len", issue = "37572")]
 #[rustc_unsafe_specialization_marker]
 pub unsafe trait TrustedLen: Iterator {}

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f32` floating point data type.
+//! Constants specific to the `f32` single-precision floating point type.
 //!
 //! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f32` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -23,12 +24,14 @@ use crate::num::FpCategory;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let r = std::f32::RADIX;
 ///
 /// // intended way
 /// let r = f32::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `RADIX` associated constant on `f32`")]
 pub const RADIX: u32 = f32::RADIX;
 
 /// Number of significant digits in base 2.
@@ -38,12 +41,17 @@ pub const RADIX: u32 = f32::RADIX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f32::MANTISSA_DIGITS;
 ///
 /// // intended way
 /// let d = f32::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f32`"
+)]
 pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -53,12 +61,14 @@ pub const MANTISSA_DIGITS: u32 = f32::MANTISSA_DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f32::DIGITS;
 ///
 /// // intended way
 /// let d = f32::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `DIGITS` associated constant on `f32`")]
 pub const DIGITS: u32 = f32::DIGITS;
 
 /// [Machine epsilon] value for `f32`.
@@ -72,12 +82,17 @@ pub const DIGITS: u32 = f32::DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let e = std::f32::EPSILON;
 ///
 /// // intended way
 /// let e = f32::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `EPSILON` associated constant on `f32`"
+)]
 pub const EPSILON: f32 = f32::EPSILON;
 
 /// Smallest finite `f32` value.
@@ -87,12 +102,14 @@ pub const EPSILON: f32 = f32::EPSILON;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN;
 ///
 /// // intended way
 /// let min = f32::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `MIN` associated constant on `f32`")]
 pub const MIN: f32 = f32::MIN;
 
 /// Smallest positive normal `f32` value.
@@ -102,12 +119,17 @@ pub const MIN: f32 = f32::MIN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN_POSITIVE;
 ///
 /// // intended way
 /// let min = f32::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MIN_POSITIVE` associated constant on `f32`"
+)]
 pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 
 /// Largest finite `f32` value.
@@ -117,12 +139,14 @@ pub const MIN_POSITIVE: f32 = f32::MIN_POSITIVE;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f32::MAX;
 ///
 /// // intended way
 /// let max = f32::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `MAX` associated constant on `f32`")]
 pub const MAX: f32 = f32::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -132,12 +156,17 @@ pub const MAX: f32 = f32::MAX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN_EXP;
 ///
 /// // intended way
 /// let min = f32::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MIN_EXP` associated constant on `f32`"
+)]
 pub const MIN_EXP: i32 = f32::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -147,12 +176,17 @@ pub const MIN_EXP: i32 = f32::MIN_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f32::MAX_EXP;
 ///
 /// // intended way
 /// let max = f32::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MAX_EXP` associated constant on `f32`"
+)]
 pub const MAX_EXP: i32 = f32::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -162,12 +196,17 @@ pub const MAX_EXP: i32 = f32::MAX_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f32::MIN_10_EXP;
 ///
 /// // intended way
 /// let min = f32::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MIN_10_EXP` associated constant on `f32`"
+)]
 pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -177,12 +216,17 @@ pub const MIN_10_EXP: i32 = f32::MIN_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f32::MAX_10_EXP;
 ///
 /// // intended way
 /// let max = f32::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MAX_10_EXP` associated constant on `f32`"
+)]
 pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -192,12 +236,14 @@ pub const MAX_10_EXP: i32 = f32::MAX_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let nan = std::f32::NAN;
 ///
 /// // intended way
 /// let nan = f32::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `NAN` associated constant on `f32`")]
 pub const NAN: f32 = f32::NAN;
 
 /// Infinity (∞).
@@ -207,12 +253,17 @@ pub const NAN: f32 = f32::NAN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let inf = std::f32::INFINITY;
 ///
 /// // intended way
 /// let inf = f32::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `INFINITY` associated constant on `f32`"
+)]
 pub const INFINITY: f32 = f32::INFINITY;
 
 /// Negative infinity (−∞).
@@ -222,12 +273,17 @@ pub const INFINITY: f32 = f32::INFINITY;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let ninf = std::f32::NEG_INFINITY;
 ///
 /// // intended way
 /// let ninf = f32::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `NEG_INFINITY` associated constant on `f32`"
+)]
 pub const NEG_INFINITY: f32 = f32::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f64` floating point data type.
+//! Constants specific to the `f64` double-precision floating point type.
 //!
 //! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f64` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -23,12 +24,14 @@ use crate::num::FpCategory;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let r = std::f64::RADIX;
 ///
 /// // intended way
 /// let r = f64::RADIX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `RADIX` associated constant on `f64`")]
 pub const RADIX: u32 = f64::RADIX;
 
 /// Number of significant digits in base 2.
@@ -38,12 +41,17 @@ pub const RADIX: u32 = f64::RADIX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f64::MANTISSA_DIGITS;
 ///
 /// // intended way
 /// let d = f64::MANTISSA_DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MANTISSA_DIGITS` associated constant on `f64`"
+)]
 pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 
 /// Approximate number of significant digits in base 10.
@@ -53,12 +61,14 @@ pub const MANTISSA_DIGITS: u32 = f64::MANTISSA_DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let d = std::f64::DIGITS;
 ///
 /// // intended way
 /// let d = f64::DIGITS;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `DIGITS` associated constant on `f64`")]
 pub const DIGITS: u32 = f64::DIGITS;
 
 /// [Machine epsilon] value for `f64`.
@@ -72,12 +82,17 @@ pub const DIGITS: u32 = f64::DIGITS;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let e = std::f64::EPSILON;
 ///
 /// // intended way
 /// let e = f64::EPSILON;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `EPSILON` associated constant on `f64`"
+)]
 pub const EPSILON: f64 = f64::EPSILON;
 
 /// Smallest finite `f64` value.
@@ -87,12 +102,14 @@ pub const EPSILON: f64 = f64::EPSILON;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN;
 ///
 /// // intended way
 /// let min = f64::MIN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `MIN` associated constant on `f64`")]
 pub const MIN: f64 = f64::MIN;
 
 /// Smallest positive normal `f64` value.
@@ -102,12 +119,17 @@ pub const MIN: f64 = f64::MIN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN_POSITIVE;
 ///
 /// // intended way
 /// let min = f64::MIN_POSITIVE;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MIN_POSITIVE` associated constant on `f64`"
+)]
 pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 
 /// Largest finite `f64` value.
@@ -117,12 +139,14 @@ pub const MIN_POSITIVE: f64 = f64::MIN_POSITIVE;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f64::MAX;
 ///
 /// // intended way
 /// let max = f64::MAX;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `MAX` associated constant on `f64`")]
 pub const MAX: f64 = f64::MAX;
 
 /// One greater than the minimum possible normal power of 2 exponent.
@@ -132,12 +156,17 @@ pub const MAX: f64 = f64::MAX;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN_EXP;
 ///
 /// // intended way
 /// let min = f64::MIN_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MIN_EXP` associated constant on `f64`"
+)]
 pub const MIN_EXP: i32 = f64::MIN_EXP;
 
 /// Maximum possible power of 2 exponent.
@@ -147,12 +176,17 @@ pub const MIN_EXP: i32 = f64::MIN_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f64::MAX_EXP;
 ///
 /// // intended way
 /// let max = f64::MAX_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MAX_EXP` associated constant on `f64`"
+)]
 pub const MAX_EXP: i32 = f64::MAX_EXP;
 
 /// Minimum possible normal power of 10 exponent.
@@ -162,12 +196,17 @@ pub const MAX_EXP: i32 = f64::MAX_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let min = std::f64::MIN_10_EXP;
 ///
 /// // intended way
 /// let min = f64::MIN_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MIN_10_EXP` associated constant on `f64`"
+)]
 pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 
 /// Maximum possible power of 10 exponent.
@@ -177,12 +216,17 @@ pub const MIN_10_EXP: i32 = f64::MIN_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let max = std::f64::MAX_10_EXP;
 ///
 /// // intended way
 /// let max = f64::MAX_10_EXP;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `MAX_10_EXP` associated constant on `f64`"
+)]
 pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 
 /// Not a Number (NaN).
@@ -192,12 +236,14 @@ pub const MAX_10_EXP: i32 = f64::MAX_10_EXP;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let nan = std::f64::NAN;
 ///
 /// // intended way
 /// let nan = f64::NAN;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "replaced by the `NAN` associated constant on `f64`")]
 pub const NAN: f64 = f64::NAN;
 
 /// Infinity (∞).
@@ -207,12 +253,17 @@ pub const NAN: f64 = f64::NAN;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let inf = std::f64::INFINITY;
 ///
 /// // intended way
 /// let inf = f64::INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `INFINITY` associated constant on `f64`"
+)]
 pub const INFINITY: f64 = f64::INFINITY;
 
 /// Negative infinity (−∞).
@@ -222,12 +273,17 @@ pub const INFINITY: f64 = f64::INFINITY;
 ///
 /// ```rust
 /// // deprecated way
+/// # #[allow(deprecated, deprecated_in_future)]
 /// let ninf = std::f64::NEG_INFINITY;
 ///
 /// // intended way
 /// let ninf = f64::NEG_INFINITY;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(
+    since = "TBD",
+    reason = "replaced by the `NEG_INFINITY` associated constant on `f64`"
+)]
 pub const NEG_INFINITY: f64 = f64::NEG_INFINITY;
 
 /// Basic mathematical constants.

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1975,32 +1975,28 @@ macro_rules! int_impl {
             unsafe { mem::transmute(bytes) }
         }
 
-        /// **This method is soft-deprecated.**
-        ///
-        /// Although using it won’t cause a compilation warning, new code should use
-        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN)")]
-        /// instead.
+        /// New code should prefer to use
+        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN).")]
         ///
         /// Returns the smallest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline(always)]
         #[rustc_promotable]
         #[rustc_const_stable(feature = "const_min_value", since = "1.32.0")]
+        #[rustc_deprecated(since = "TBD", reason = "replaced by the `MIN` associated constant on this type")]
         pub const fn min_value() -> Self {
             Self::MIN
         }
 
-        /// **This method is soft-deprecated.**
-        ///
-        /// Although using it won’t cause a compilation warning, new code should use
-        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX)")]
-        /// instead.
+        /// New code should prefer to use
+        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX).")]
         ///
         /// Returns the largest value that can be represented by this integer type.
         #[stable(feature = "rust1", since = "1.0.0")]
         #[inline(always)]
         #[rustc_promotable]
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
+        #[rustc_deprecated(since = "TBD", reason = "replaced by the `MAX` associated constant on this type")]
         pub const fn max_value() -> Self {
             Self::MAX
         }

--- a/library/core/src/num/shells/i128.rs
+++ b/library/core/src/num/shells/i128.rs
@@ -1,10 +1,13 @@
-//! The 128-bit signed integer type.
+//! Constants for the 128-bit signed integer type.
 //!
 //! *[See also the `i128` primitive type](../../std/primitive.i128.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "i128", since = "1.26.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `i128`"
+)]
 
 int_module! { i128, #[stable(feature = "i128", since="1.26.0")] }

--- a/library/core/src/num/shells/i16.rs
+++ b/library/core/src/num/shells/i16.rs
@@ -1,10 +1,13 @@
-//! The 16-bit signed integer type.
+//! Constants for the 16-bit signed integer type.
 //!
 //! *[See also the `i16` primitive type](../../std/primitive.i16.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `i16`"
+)]
 
 int_module! { i16 }

--- a/library/core/src/num/shells/i32.rs
+++ b/library/core/src/num/shells/i32.rs
@@ -1,10 +1,13 @@
-//! The 32-bit signed integer type.
+//! Constants for the 32-bit signed integer type.
 //!
 //! *[See also the `i32` primitive type](../../std/primitive.i32.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `i32`"
+)]
 
 int_module! { i32 }

--- a/library/core/src/num/shells/i64.rs
+++ b/library/core/src/num/shells/i64.rs
@@ -1,10 +1,13 @@
-//! The 64-bit signed integer type.
+//! Constants for the 64-bit signed integer type.
 //!
 //! *[See also the `i64` primitive type](../../std/primitive.i64.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `i64`"
+)]
 
 int_module! { i64 }

--- a/library/core/src/num/shells/i8.rs
+++ b/library/core/src/num/shells/i8.rs
@@ -1,10 +1,13 @@
-//! The 8-bit signed integer type.
+//! Constants for the 8-bit signed integer type.
 //!
 //! *[See also the `i8` primitive type](../../std/primitive.i8.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `i8`"
+)]
 
 int_module! { i8 }

--- a/library/core/src/num/shells/int_macros.rs
+++ b/library/core/src/num/shells/int_macros.rs
@@ -20,6 +20,7 @@ macro_rules! int_module {
         /// ```
         ///
         #[$attr]
+        #[rustc_deprecated(since = "TBD", reason = "replaced by the `MIN` associated constant on this type")]
         pub const MIN: $T = $T::MIN;
 
         #[doc = concat!(
@@ -39,6 +40,7 @@ macro_rules! int_module {
         /// ```
         ///
         #[$attr]
+        #[rustc_deprecated(since = "TBD", reason = "replaced by the `MAX` associated constant on this type")]
         pub const MAX: $T = $T::MAX;
     )
 }

--- a/library/core/src/num/shells/isize.rs
+++ b/library/core/src/num/shells/isize.rs
@@ -1,10 +1,13 @@
-//! The pointer-sized signed integer type.
+//! Constants for the pointer-sized signed integer type.
 //!
 //! *[See also the `isize` primitive type](../../std/primitive.isize.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `isize`"
+)]
 
 int_module! { isize }

--- a/library/core/src/num/shells/u128.rs
+++ b/library/core/src/num/shells/u128.rs
@@ -1,9 +1,13 @@
-//! The 128-bit unsigned integer type.
+//! Constants for the 128-bit unsigned integer type.
 //!
 //! *[See also the `u128` primitive type](../../std/primitive.u128.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "i128", since = "1.26.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `u128`"
+)]
+
 int_module! { u128, #[stable(feature = "i128", since="1.26.0")] }

--- a/library/core/src/num/shells/u16.rs
+++ b/library/core/src/num/shells/u16.rs
@@ -1,10 +1,13 @@
-//! The 16-bit unsigned integer type.
+//! Constants for the 16-bit unsigned integer type.
 //!
 //! *[See also the `u16` primitive type](../../std/primitive.u16.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `u16`"
+)]
 
 int_module! { u16 }

--- a/library/core/src/num/shells/u32.rs
+++ b/library/core/src/num/shells/u32.rs
@@ -1,10 +1,13 @@
-//! The 32-bit unsigned integer type.
+//! Constants for the 32-bit unsigned integer type.
 //!
 //! *[See also the `u32` primitive type](../../std/primitive.u32.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `u32`"
+)]
 
 int_module! { u32 }

--- a/library/core/src/num/shells/u64.rs
+++ b/library/core/src/num/shells/u64.rs
@@ -1,10 +1,13 @@
-//! The 64-bit unsigned integer type.
+//! Constants for the 64-bit unsigned integer type.
 //!
 //! *[See also the `u64` primitive type](../../std/primitive.u64.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `u64`"
+)]
 
 int_module! { u64 }

--- a/library/core/src/num/shells/u8.rs
+++ b/library/core/src/num/shells/u8.rs
@@ -1,10 +1,13 @@
-//! The 8-bit unsigned integer type.
+//! Constants for the 8-bit unsigned integer type.
 //!
 //! *[See also the `u8` primitive type](../../std/primitive.u8.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `u8`"
+)]
 
 int_module! { u8 }

--- a/library/core/src/num/shells/usize.rs
+++ b/library/core/src/num/shells/usize.rs
@@ -1,10 +1,13 @@
-//! The pointer-sized unsigned integer type.
+//! Constants for the pointer-sized unsigned integer type.
 //!
 //! *[See also the `usize` primitive type](../../std/primitive.usize.html).*
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! New code should use the associated constants directly on the primitive type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
+#![rustc_deprecated(
+    since = "TBD",
+    reason = "all constants in this module replaced by associated constants on `usize`"
+)]
 
 int_module! { usize }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1805,10 +1805,8 @@ macro_rules! uint_impl {
             unsafe { mem::transmute(bytes) }
         }
 
-        /// **This method is soft-deprecated.**
-        ///
-        /// Although using it won’t cause compilation warning, new code should use
-        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN)")]
+        /// New code should prefer to use
+        #[doc = concat!("[`", stringify!($SelfT), "::MIN", "`](#associatedconstant.MIN).")]
         /// instead.
         ///
         /// Returns the smallest value that can be represented by this integer type.
@@ -1816,12 +1814,11 @@ macro_rules! uint_impl {
         #[rustc_promotable]
         #[inline(always)]
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
+        #[rustc_deprecated(since = "TBD", reason = "replaced by the `MIN` associated constant on this type")]
         pub const fn min_value() -> Self { Self::MIN }
 
-        /// **This method is soft-deprecated.**
-        ///
-        /// Although using it won’t cause compilation warning, new code should use
-        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX)")]
+        /// New code should prefer to use
+        #[doc = concat!("[`", stringify!($SelfT), "::MAX", "`](#associatedconstant.MAX).")]
         /// instead.
         ///
         /// Returns the largest value that can be represented by this integer type.
@@ -1829,6 +1826,7 @@ macro_rules! uint_impl {
         #[rustc_promotable]
         #[inline(always)]
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
+        #[rustc_deprecated(since = "TBD", reason = "replaced by the `MAX` associated constant on this type")]
         pub const fn max_value() -> Self { Self::MAX }
     }
 }

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f32` floating point data type.
+//! Constants specific to the `f32` single-precision floating point type.
 //!
 //! *[See also the `f32` primitive type](primitive@f32).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f32` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
@@ -20,15 +21,11 @@ use crate::intrinsics;
 use crate::sys::cmath;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::consts;
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{DIGITS, EPSILON, MANTISSA_DIGITS, RADIX};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{INFINITY, MAX_10_EXP, NAN, NEG_INFINITY};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{MAX, MIN, MIN_POSITIVE};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f32::{MAX_EXP, MIN_10_EXP, MIN_EXP};
+#[allow(deprecated, deprecated_in_future)]
+pub use core::f32::{
+    consts, DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP,
+    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX,
+};
 
 #[cfg(not(test))]
 #[lang = "f32_runtime"]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -1,12 +1,13 @@
-//! This module provides constants which are specific to the implementation
-//! of the `f64` floating point data type.
+//! Constants specific to the `f64` double-precision floating point type.
 //!
 //! *[See also the `f64` primitive type](primitive@f64).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 //!
-//! Although using these constants won’t cause compilation warnings,
-//! new code should use the associated constants directly on the primitive type.
+//! For the constants defined directly in this module
+//! (as distinct from those defined in the `consts` sub-module),
+//! new code should instead use the associated constants
+//! defined directly on the `f64` type.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 #![allow(missing_docs)]
@@ -20,15 +21,11 @@ use crate::intrinsics;
 use crate::sys::cmath;
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::consts;
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{DIGITS, EPSILON, MANTISSA_DIGITS, RADIX};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{INFINITY, MAX_10_EXP, NAN, NEG_INFINITY};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{MAX, MIN, MIN_POSITIVE};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::f64::{MAX_EXP, MIN_10_EXP, MIN_EXP};
+#[allow(deprecated, deprecated_in_future)]
+pub use core::f64::{
+    consts, DIGITS, EPSILON, INFINITY, MANTISSA_DIGITS, MAX, MAX_10_EXP, MAX_EXP, MIN, MIN_10_EXP,
+    MIN_EXP, MIN_POSITIVE, NAN, NEG_INFINITY, RADIX,
+};
 
 #[cfg(not(test))]
 #[lang = "f64_runtime"]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -411,18 +411,24 @@ pub use core::hash;
 #[stable(feature = "core_hint", since = "1.27.0")]
 pub use core::hint;
 #[stable(feature = "i128", since = "1.26.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i128;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i16;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i32;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i64;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::i8;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::intrinsics;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::isize;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::iter;
@@ -443,16 +449,22 @@ pub use core::raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;
 #[stable(feature = "i128", since = "1.26.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u128;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u16;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u32;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u64;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::u8;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::usize;
 
 pub mod f32;

--- a/library/std/src/sys/unix/process/zircon.rs
+++ b/library/std/src/sys/unix/process/zircon.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types, unused)]
 
 use crate::convert::TryInto;
-use crate::i64;
 use crate::io;
 use crate::mem::MaybeUninit;
 use crate::os::raw::c_char;

--- a/src/test/rustdoc/reexport-check.rs
+++ b/src/test/rustdoc/reexport-check.rs
@@ -4,7 +4,7 @@
 extern crate reexport_check;
 
 // @!has 'foo/index.html' '//code' 'pub use self::i32;'
-// @has 'foo/index.html' '//tr[@class="module-item"]' 'i32'
+// @has 'foo/index.html' '//tr[@class="deprecated module-item"]' 'i32'
 // @has 'foo/i32/index.html'
 #[allow(deprecated, deprecated_in_future)]
 pub use std::i32;


### PR DESCRIPTION
Successor to #78335, re-opened after addressing the issues tracked in #68490.

This PR makes use of the new ability to explicitly annotate an item as triggering the deprecated-in-future lint (via `rustc_deprecated(since="TBD"`, see #78381). We might call this *soft deprecation*; unlike with deprecation, users will *not* receive warnings when compiling code that uses these items *unless* they opt-in via `#[warn(deprecated_in_future)]`. Like deprecation, soft deprecation causes documentation to formally acknowledge that an item is marked for eventual deprecation (at a non-specific point in the future).

With this new ability, we can sidestep all debate about when or on what timeframe something ought to be deprecated; as long as we can agree that something ought to be deprecated, we can receive much of the benefits of deprecation with none of the drawbacks. For these items specifically, the libs team has already agreed that they should be deprecated (see https://github.com/rust-lang/rust/issues/68490#issuecomment-747022696).