### PR TITLE
Deprecate atomic::spin_loop_hint in favour of hint::spin_loop

### DIFF
--- a/library/alloc/src/sync/tests.rs
+++ b/library/alloc/src/sync/tests.rs
@@ -370,7 +370,7 @@ fn test_weak_count_locked() {
         let n = Arc::weak_count(&a2);
         assert!(n < 2, "bad weak count: {}", n);
         #[cfg(miri)] // Miri's scheduler does not guarantee liveness, and thus needs this hint.
-        atomic::spin_loop_hint();
+        std::hint::spin_loop();
     }
     t.join().unwrap();
 }

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -120,21 +120,6 @@ use crate::intrinsics;
 
 use crate::hint::spin_loop;
 
-/// Signals the processor that it is inside a busy-wait spin-loop ("spin lock").
-///
-/// This function is expected to be deprecated in favor of
-/// [`hint::spin_loop`].
-///
-/// **Note**: On platforms that do not support receiving spin-loop hints this function does not
-/// do anything at all.
-///
-/// [`hint::spin_loop`]: crate::hint::spin_loop
-#[inline]
-#[stable(feature = "spin_loop_hint", since = "1.24.0")]
-pub fn spin_loop_hint() {
-    spin_loop()
-}
-
 /// A boolean type which can be safely shared between threads.
 ///
 /// This type has the same in-memory representation as a [`bool`].
@@ -2790,4 +2775,16 @@ impl<T> fmt::Pointer for AtomicPtr<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Pointer::fmt(&self.load(Ordering::SeqCst), f)
     }
+}
+
+/// Signals the processor that it is inside a busy-wait spin-loop ("spin lock").
+///
+/// This function is deprecated in favor of [`hint::spin_loop`].
+///
+/// [`hint::spin_loop`]: crate::hint::spin_loop
+#[inline]
+#[stable(feature = "spin_loop_hint", since = "1.24.0")]
+#[rustc_deprecated(since = "1.51.0", reason = "use hint::spin_loop instead")]
+pub fn spin_loop_hint() {
+    spin_loop()
 }

--- a/library/std/src/sys/hermit/mutex.rs
+++ b/library/std/src/sys/hermit/mutex.rs
@@ -1,9 +1,10 @@
 use crate::cell::UnsafeCell;
 use crate::collections::VecDeque;
 use crate::ffi::c_void;
+use crate::hint;
 use crate::ops::{Deref, DerefMut, Drop};
 use crate::ptr;
-use crate::sync::atomic::{spin_loop_hint, AtomicUsize, Ordering};
+use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sys::hermit::abi;
 
 /// This type provides a lock based on busy waiting to realize mutual exclusion
@@ -46,7 +47,7 @@ impl<T> Spinlock<T> {
     fn obtain_lock(&self) {
         let ticket = self.queue.fetch_add(1, Ordering::SeqCst) + 1;
         while self.dequeue.load(Ordering::SeqCst) != ticket {
-            spin_loop_hint();
+            hint::spin_loop();
         }
     }
 

--- a/library/std/src/sys/sgx/waitqueue/spin_mutex.rs
+++ b/library/std/src/sys/sgx/waitqueue/spin_mutex.rs
@@ -2,8 +2,9 @@
 mod tests;
 
 use crate::cell::UnsafeCell;
+use crate::hint;
 use crate::ops::{Deref, DerefMut};
-use crate::sync::atomic::{spin_loop_hint, AtomicBool, Ordering};
+use crate::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Default)]
 pub struct SpinMutex<T> {
@@ -32,7 +33,7 @@ impl<T> SpinMutex<T> {
             match self.try_lock() {
                 None => {
                     while self.lock.load(Ordering::Relaxed) {
-                        spin_loop_hint()
+                        hint::spin_loop()
                     }
                 }
                 Some(guard) => return guard,


### PR DESCRIPTION
For https://github.com/rust-lang/rust/issues/55002

We wanted to leave `atomic::spin_loop_hint` alone when stabilizing `hint::spin_loop` so folks had some time to migrate. This now deprecates `atomic_spin_loop_hint`.