### PR TITLE
Use better ICE message when no MIR is available

### DIFF
--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -823,7 +823,7 @@ fn should_codegen_locally<'tcx>(tcx: TyCtxt<'tcx>, instance: &Instance<'tcx>) ->
     }
 
     if !tcx.is_mir_available(def_id) {
-        bug!("cannot create local mono-item for {:?}", def_id)
+        bug!("no MIR available for {:?}", def_id);
     }
 
     true


### PR DESCRIPTION
The ICE message is somewhat confusing and overly specific - the issue is
that there's no MIR available.

This should make debugging these ICEs easier since the error tells you
what's actually wrong, not what it was trying to do when it failed.

cc https://github.com/rust-lang/rust/pull/80952#issuecomment-759198841
cc @jyn514
