### PR TITLE
Improved documentation of Path::exists

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2386,7 +2386,8 @@ impl Path {
         fs::read_dir(self)
     }
 
-    /// Returns `true` if the path points at an existing entity and syscall succeeds.
+    /// Returns `true` if the path points at an existing entity. False if it doesn't
+    /// **or** we can't tell.
     ///
     /// This function will traverse symbolic links to query information about the
     /// destination file. In case of broken symbolic links this will return `false`.
@@ -2423,11 +2424,13 @@ impl Path {
     /// ```no_run
     /// use std::path::Path;
     /// use std::io::ErrorKind;
-    /// use std::fs::metadata;
-    /// let exists = fs::metadata(Path::new("does_not_exist.txt"))
-    ///     .map(|_| true)
-    ///     .or_else(|error| if error.kind() == ErrorKind::NotFound { Ok(false) } else { Err(error) } )
-    ///     .expect("failed to check existence of a file");
+    /// use std::fs;
+    /// let exists = match fs::metadata(Path::new("does_not_exist.txt")) {
+    ///     Ok(_) => true,
+    ///     Err(err) if err.kind() == ErrorKind::NotFound => false,
+    ///     Err(err) => return Err(err),
+    /// };
+    ///
     /// assert!(!exists);
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2424,7 +2424,7 @@ impl Path {
     /// use std::path::Path;
     /// use std::io::ErrorKind;
     /// use std::fs::metadata;
-    /// let exists = metadata(Path::new("does_not_exist.txt"))
+    /// let exists = fs::metadata(Path::new("does_not_exist.txt"))
     ///     .map(|_| true)
     ///     .or_else(|error| if error.kind() == ErrorKind::NotFound { Ok(false) } else { Err(error) } )
     ///     .expect("failed to check existence of a file");

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2422,9 +2422,9 @@ impl Path {
     ///
     /// An example of proper error handling.
     /// ```no_run
-    /// use std::path::Path;
-    /// use std::io::{ self, ErrorKind};
     /// use std::fs;
+    /// use std::io::{self, ErrorKind};
+    /// use std::path::Path;
     ///
     /// fn main() -> io::Result<()> {
     ///     let exists = match fs::metadata(Path::new("does_not_exist.txt")) {

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2434,6 +2434,7 @@ impl Path {
     ///     };
     ///
     ///     assert!(!exists);
+    ///     Ok(())
     /// }
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2423,15 +2423,18 @@ impl Path {
     /// An example of proper error handling.
     /// ```no_run
     /// use std::path::Path;
-    /// use std::io::ErrorKind;
+    /// use std::io::{ self, ErrorKind};
     /// use std::fs;
-    /// let exists = match fs::metadata(Path::new("does_not_exist.txt")) {
-    ///     Ok(_) => true,
-    ///     Err(err) if err.kind() == ErrorKind::NotFound => false,
-    ///     Err(err) => return Err(err),
-    /// };
     ///
-    /// assert!(!exists);
+    /// fn main() -> io::Result<()> {
+    ///     let exists = match fs::metadata(Path::new("does_not_exist.txt")) {
+    ///         Ok(_) => true,
+    ///         Err(err) if err.kind() == ErrorKind::NotFound => false,
+    ///         Err(err) => return Err(err),
+    ///     };
+    ///
+    ///     assert!(!exists);
+    /// }
     /// ```
     #[stable(feature = "path_ext", since = "1.5.0")]
     pub fn exists(&self) -> bool {


### PR DESCRIPTION
This improves the documentation of `Path::exists` in several ways:

* Clarifies that the method only returns true if the syscall succeeds
* Doesn't make it look like there has to be something wrong with the
  directory for it to fail.
* Adds "Caveats" section to make possible dangers more visible
* Mentions race conditions which, while known by experienced programmers,
  is more welcoming towards newbies
* Mentions that `access()` may be sometimes more appropriate
* Adds an actual example of proper error handling so that users are not
  detracted from it by having to come up with complicated code.

I hope this makes sense. I'm non-native speaker, feel free to grammar nazi or suggest different wording. :)

I'm willing to file PRs for these further changes, but I expect that at least some of them require an RFC. Please let me know.

- [x] Add `fn try_exists(&self) -> io::Result<bool>;` - containing code from the latter example in this change.
- [ ] Add `accessible(&self) -> io::Result<()>;` that calls `access()` or `faccessat` on Unix (need to decide which is better) and whatever is appropriate on Windows (does anyone know?) Return value should be bikesheded (perhaps `io::Result<bool>`).
- [ ] Add `fn metadata_accessible(&self) -> bool` which does exactly what `exists` does today, just has a clearer name (feel free to suggest a better name). Probably should be accompanied by the next one
- [ ] Deprecate `Path::exists` in favor of one of the previous ones

See [internals thread](https://internals.rust-lang.org/t/the-api-of-path-exists-encourages-broken-code/13817) for more discussion about what's wrong with `Path::exists`.