### PR TITLE
Remove doctree::Variant

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1837,19 +1837,6 @@ impl Clean<VariantStruct> for rustc_hir::VariantData<'_> {
     }
 }
 
-impl Clean<Item> for doctree::Variant<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> Item {
-        let what_rustc_thinks = Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            VariantItem(Variant { kind: self.def.clean(cx) }),
-            cx,
-        );
-        // don't show `pub` for variants, which are always public
-        Item { visibility: Inherited, ..what_rustc_thinks }
-    }
-}
-
 impl Clean<Item> for ty::VariantDef {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
         let kind = match self.ctor_kind {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -48,12 +48,6 @@ crate enum StructType {
     Unit,
 }
 
-crate struct Variant<'hir> {
-    crate name: Symbol,
-    crate id: hir::HirId,
-    crate def: &'hir hir::VariantData<'hir>,
-}
-
 #[derive(Debug)]
 crate struct Import<'hir> {
     crate name: Symbol,


### PR DESCRIPTION
This was easy, probably was missed when whatever used it was removed