### PR TITLE
Remove useless `clean::Variant` struct

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1840,11 +1840,11 @@ impl Clean<VariantStruct> for rustc_hir::VariantData<'_> {
 impl Clean<Item> for ty::VariantDef {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
         let kind = match self.ctor_kind {
-            CtorKind::Const => VariantKind::CLike,
-            CtorKind::Fn => VariantKind::Tuple(
+            CtorKind::Const => Variant::CLike,
+            CtorKind::Fn => Variant::Tuple(
                 self.fields.iter().map(|f| cx.tcx.type_of(f.did).clean(cx)).collect(),
             ),
-            CtorKind::Fictive => VariantKind::Struct(VariantStruct {
+            CtorKind::Fictive => Variant::Struct(VariantStruct {
                 struct_type: doctree::Plain,
                 fields_stripped: false,
                 fields: self
@@ -1868,14 +1868,14 @@ impl Clean<Item> for ty::VariantDef {
     }
 }
 
-impl Clean<VariantKind> for hir::VariantData<'_> {
-    fn clean(&self, cx: &DocContext<'_>) -> VariantKind {
+impl Clean<Variant> for hir::VariantData<'_> {
+    fn clean(&self, cx: &DocContext<'_>) -> Variant {
         match self {
-            hir::VariantData::Struct(..) => VariantKind::Struct(self.clean(cx)),
+            hir::VariantData::Struct(..) => Variant::Struct(self.clean(cx)),
             hir::VariantData::Tuple(..) => {
-                VariantKind::Tuple(self.fields().iter().map(|x| x.ty.clean(cx)).collect())
+                Variant::Tuple(self.fields().iter().map(|x| x.ty.clean(cx)).collect())
             }
-            hir::VariantData::Unit(..) => VariantKind::CLike,
+            hir::VariantData::Unit(..) => Variant::CLike,
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1861,12 +1861,8 @@ impl Clean<Item> for ty::VariantDef {
                     .collect(),
             }),
         };
-        let what_rustc_thinks = Item::from_def_id_and_parts(
-            self.def_id,
-            Some(self.ident.name),
-            VariantItem(Variant { kind }),
-            cx,
-        );
+        let what_rustc_thinks =
+            Item::from_def_id_and_parts(self.def_id, Some(self.ident.name), VariantItem(kind), cx);
         // don't show `pub` for fields, which are always public
         Item { visibility: Inherited, ..what_rustc_thinks }
     }
@@ -2048,7 +2044,7 @@ impl Clean<Vec<Item>> for (&hir::Item<'_>, Option<Symbol>) {
 
 impl Clean<Item> for hir::Variant<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> Item {
-        let kind = VariantItem(Variant { kind: self.data.clean(cx) });
+        let kind = VariantItem(self.data.clean(cx));
         let what_rustc_thinks =
             Item::from_hir_id_and_parts(self.id, Some(self.ident.name), kind, cx);
         // don't show `pub` for variants, which are always public

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -237,7 +237,7 @@ impl Item {
         match *self.kind {
             StructItem(ref _struct) => Some(_struct.fields_stripped),
             UnionItem(ref union) => Some(union.fields_stripped),
-            VariantItem(VariantKind::Struct(ref vstruct)) => Some(vstruct.fields_stripped),
+            VariantItem(Variant::Struct(ref vstruct)) => Some(vstruct.fields_stripped),
             _ => None,
         }
     }
@@ -323,7 +323,7 @@ crate enum ItemKind {
     /// A method with a body.
     MethodItem(Function, Option<hir::Defaultness>),
     StructFieldItem(Type),
-    VariantItem(VariantKind),
+    VariantItem(Variant),
     /// `fn`s from an extern block
     ForeignFunctionItem(Function),
     /// `static`s from an extern block
@@ -351,7 +351,7 @@ impl ItemKind {
         match self {
             StructItem(s) => s.fields.iter(),
             UnionItem(u) => u.fields.iter(),
-            VariantItem(VariantKind::Struct(v)) => v.fields.iter(),
+            VariantItem(Variant::Struct(v)) => v.fields.iter(),
             EnumItem(e) => e.variants.iter(),
             TraitItem(t) => t.items.iter(),
             ImplItem(i) => i.items.iter(),
@@ -1717,7 +1717,7 @@ crate struct Enum {
 }
 
 #[derive(Clone, Debug)]
-crate enum VariantKind {
+crate enum Variant {
     CLike,
     Tuple(Vec<Type>),
     Struct(VariantStruct),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -237,9 +237,7 @@ impl Item {
         match *self.kind {
             StructItem(ref _struct) => Some(_struct.fields_stripped),
             UnionItem(ref union) => Some(union.fields_stripped),
-            VariantItem(Variant { kind: VariantKind::Struct(ref vstruct) }) => {
-                Some(vstruct.fields_stripped)
-            }
+            VariantItem(VariantKind::Struct(ref vstruct)) => Some(vstruct.fields_stripped),
             _ => None,
         }
     }
@@ -325,7 +323,7 @@ crate enum ItemKind {
     /// A method with a body.
     MethodItem(Function, Option<hir::Defaultness>),
     StructFieldItem(Type),
-    VariantItem(Variant),
+    VariantItem(VariantKind),
     /// `fn`s from an extern block
     ForeignFunctionItem(Function),
     /// `static`s from an extern block
@@ -353,7 +351,7 @@ impl ItemKind {
         match self {
             StructItem(s) => s.fields.iter(),
             UnionItem(u) => u.fields.iter(),
-            VariantItem(Variant { kind: VariantKind::Struct(v) }) => v.fields.iter(),
+            VariantItem(VariantKind::Struct(v)) => v.fields.iter(),
             EnumItem(e) => e.variants.iter(),
             TraitItem(t) => t.items.iter(),
             ImplItem(i) => i.items.iter(),
@@ -1716,11 +1714,6 @@ crate struct Enum {
     crate variants: IndexVec<VariantIdx, Item>,
     crate generics: Generics,
     crate variants_stripped: bool,
-}
-
-#[derive(Clone, Debug)]
-crate struct Variant {
-    crate kind: VariantKind,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -56,12 +56,12 @@ crate trait DocFolder: Sized {
             VariantItem(i) => {
                 let i2 = i.clone(); // this clone is small
                 match i {
-                    VariantKind::Struct(mut j) => {
+                    Variant::Struct(mut j) => {
                         let num_fields = j.fields.len();
                         j.fields = j.fields.into_iter().filter_map(|x| self.fold_item(x)).collect();
                         j.fields_stripped |= num_fields != j.fields.len()
                             || j.fields.iter().any(|f| f.is_stripped());
-                        VariantItem(VariantKind::Struct(j))
+                        VariantItem(Variant::Struct(j))
                     }
                     _ => VariantItem(i2),
                 }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -55,13 +55,13 @@ crate trait DocFolder: Sized {
             }
             VariantItem(i) => {
                 let i2 = i.clone(); // this clone is small
-                match i.kind {
+                match i {
                     VariantKind::Struct(mut j) => {
                         let num_fields = j.fields.len();
                         j.fields = j.fields.into_iter().filter_map(|x| self.fold_item(x)).collect();
                         j.fields_stripped |= num_fields != j.fields.len()
                             || j.fields.iter().any(|f| f.is_stripped());
-                        VariantItem(Variant { kind: VariantKind::Struct(j) })
+                        VariantItem(VariantKind::Struct(j))
                     }
                     _ => VariantItem(i2),
                 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3200,7 +3200,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                 write!(w, "    ");
                 let name = v.name.as_ref().unwrap();
                 match *v.kind {
-                    clean::VariantItem(ref var) => match var.kind {
+                    clean::VariantItem(ref var) => match var {
                         clean::VariantKind::CLike => write!(w, "{}", name),
                         clean::VariantKind::Tuple(ref tys) => {
                             write!(w, "{}(", name);
@@ -3249,25 +3249,22 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                 id = id,
                 name = variant.name.as_ref().unwrap()
             );
-            if let clean::VariantItem(ref var) = *variant.kind {
-                if let clean::VariantKind::Tuple(ref tys) = var.kind {
-                    write!(w, "(");
-                    for (i, ty) in tys.iter().enumerate() {
-                        if i > 0 {
-                            write!(w, ",&nbsp;");
-                        }
-                        write!(w, "{}", ty.print());
+            if let clean::VariantItem(clean::VariantKind::Tuple(ref tys)) = *variant.kind {
+                write!(w, "(");
+                for (i, ty) in tys.iter().enumerate() {
+                    if i > 0 {
+                        write!(w, ",&nbsp;");
                     }
-                    write!(w, ")");
+                    write!(w, "{}", ty.print());
                 }
+                write!(w, ")");
             }
             write!(w, "</code></div>");
             document(w, cx, variant, Some(it));
             document_non_exhaustive(w, variant);
 
-            use crate::clean::{Variant, VariantKind};
-            if let clean::VariantItem(Variant { kind: VariantKind::Struct(ref s) }) = *variant.kind
-            {
+            use crate::clean::VariantKind;
+            if let clean::VariantItem(VariantKind::Struct(ref s)) = *variant.kind {
                 let variant_id = cx.derive_id(format!(
                     "{}.{}.fields",
                     ItemType::Variant,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3201,8 +3201,8 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                 let name = v.name.as_ref().unwrap();
                 match *v.kind {
                     clean::VariantItem(ref var) => match var {
-                        clean::VariantKind::CLike => write!(w, "{}", name),
-                        clean::VariantKind::Tuple(ref tys) => {
+                        clean::Variant::CLike => write!(w, "{}", name),
+                        clean::Variant::Tuple(ref tys) => {
                             write!(w, "{}(", name);
                             for (i, ty) in tys.iter().enumerate() {
                                 if i > 0 {
@@ -3212,7 +3212,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                             }
                             write!(w, ")");
                         }
-                        clean::VariantKind::Struct(ref s) => {
+                        clean::Variant::Struct(ref s) => {
                             render_struct(w, v, None, s.struct_type, &s.fields, "    ", false, cx);
                         }
                     },
@@ -3249,7 +3249,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                 id = id,
                 name = variant.name.as_ref().unwrap()
             );
-            if let clean::VariantItem(clean::VariantKind::Tuple(ref tys)) = *variant.kind {
+            if let clean::VariantItem(clean::Variant::Tuple(ref tys)) = *variant.kind {
                 write!(w, "(");
                 for (i, ty) in tys.iter().enumerate() {
                     if i > 0 {
@@ -3263,8 +3263,8 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
             document(w, cx, variant, Some(it));
             document_non_exhaustive(w, variant);
 
-            use crate::clean::VariantKind;
-            if let clean::VariantItem(VariantKind::Struct(ref s)) = *variant.kind {
+            use crate::clean::Variant;
+            if let clean::VariantItem(Variant::Struct(ref s)) = *variant.kind {
                 let variant_id = cx.derive_id(format!(
                     "{}.{}.fields",
                     ItemType::Variant,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -480,9 +480,9 @@ impl From<clean::VariantStruct> for Struct {
     }
 }
 
-impl From<clean::VariantKind> for Variant {
-    fn from(variant: clean::VariantKind) -> Self {
-        use clean::VariantKind::*;
+impl From<clean::Variant> for Variant {
+    fn from(variant: clean::Variant) -> Self {
+        use clean::Variant::*;
         match variant {
             CLike => Variant::Plain,
             Tuple(t) => Variant::Tuple(t.into_iter().map(Into::into).collect()),

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -480,10 +480,10 @@ impl From<clean::VariantStruct> for Struct {
     }
 }
 
-impl From<clean::Variant> for Variant {
-    fn from(variant: clean::Variant) -> Self {
+impl From<clean::VariantKind> for Variant {
+    fn from(variant: clean::VariantKind) -> Self {
         use clean::VariantKind::*;
-        match variant.kind {
+        match variant {
             CLike => Variant::Plain,
             Tuple(t) => Variant::Tuple(t.into_iter().map(Into::into).collect()),
             Struct(s) => Variant::Struct(ids(s.fields)),

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -94,7 +94,7 @@ impl<'a> DocFolder for Stripper<'a> {
             // implementations of traits are always public.
             clean::ImplItem(ref imp) if imp.trait_.is_some() => true,
             // Struct variant fields have inherited visibility
-            clean::VariantItem(clean::Variant { kind: clean::VariantKind::Struct(..) }) => true,
+            clean::VariantItem(clean::VariantKind::Struct(..)) => true,
             _ => false,
         };
 

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -94,7 +94,7 @@ impl<'a> DocFolder for Stripper<'a> {
             // implementations of traits are always public.
             clean::ImplItem(ref imp) if imp.trait_.is_some() => true,
             // Struct variant fields have inherited visibility
-            clean::VariantItem(clean::VariantKind::Struct(..)) => true,
+            clean::VariantItem(clean::Variant::Struct(..)) => true,
             _ => false,
         };
 


### PR DESCRIPTION
It had exactly one field and no special behavior, so there was no point in having it.

r? @CraftSpider 