### PR TITLE
doctest: Reset errors before dropping the parse session

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -500,6 +500,12 @@ crate fn make_test(
                 }
             }
 
+            // Reset errors so that they won't be reported as compiler bugs when dropping the
+            // handler. Any errors in the tests will be reported when the test file is compiled,
+            // Note that we still need to cancel the errors above otherwise `DiagnosticBuilder`
+            // will panic on drop.
+            sess.span_diagnostic.reset_err_count();
+
             (found_main, found_extern_crate, found_macro)
         })
     });

--- a/src/test/rustdoc-ui/issue-80992.rs
+++ b/src/test/rustdoc-ui/issue-80992.rs
@@ -1,0 +1,11 @@
+// check-pass
+// compile-flags:--test
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+pub fn test() -> Result<(), ()> {
+    //! ```compile_fail
+    //! fn test() -> Result< {}
+    //! ```
+    Ok(())
+}

--- a/src/test/rustdoc-ui/issue-80992.stdout
+++ b/src/test/rustdoc-ui/issue-80992.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/issue-80992.rs - test (line 7) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
The first parse is to collect whether the code contains macros, has
`main`, and uses other crates. In that pass we ignore errors as those
will be reported when the test file is actually built.

For that we need to reset errors in the `Diagnostic` otherwise when
dropping it unhandled errors will be reported as compiler bugs.

Fixes #80992