### PR TITLE
Add test for #80981, print cranelift version

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -231,6 +231,10 @@ impl CodegenBackend for CraneliftCodegenBackend {
         }
     }
 
+    fn print_version(&self) {
+        println!("Cranelift version: {}", cranelift_codegen::VERSION);
+    }
+
     fn metadata_loader(&self) -> Box<dyn MetadataLoader + Sync> {
         Box::new(crate::metadata::CraneliftMetadataLoader)
     }

--- a/src/test/run-make/codegen-version/Makefile
+++ b/src/test/run-make/codegen-version/Makefile
@@ -1,0 +1,4 @@
+-include ../../run-make-fulldeps/tools.mk
+
+all:
+	$(RUSTC) -vV | grep -P "LLVM version|Cranelift version"


### PR DESCRIPTION
- Regression test added for #80981
- -vV now prints cranelift version when cranelift backend is used
