### PR TITLE
Add size hint for byte iterator over file

### DIFF
--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2464,7 +2464,9 @@ impl<R: Read> Iterator for Bytes<R> {
         }
     }
 
-    default fn size_hint(&self) -> (usize, Option<usize>) {}
+    default fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
+    }
 }
 
 impl Iterator for Bytes<fs::File> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2466,13 +2466,11 @@ impl<R: Read> Iterator for Bytes<R> {
 }
 
 impl Iterator for Bytes<fs::File> {
-    type Item = Result<u8>;
-
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.inner.metadata() {
             Ok(metadata) => {
                 let file_length = metadata.len() as usize;
-                (file_length, Some(file_length))
+                (0, Some(file_length))
             }
             Err(_) => (0, None),
         }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2463,6 +2463,8 @@ impl<R: Read> Iterator for Bytes<R> {
             };
         }
     }
+
+    default fn size_hint(&self) -> (usize, Option<usize>) {}
 }
 
 impl Iterator for Bytes<fs::File> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2469,6 +2469,7 @@ impl<R: Read> Iterator for Bytes<R> {
     }
 }
 
+#[unstable(feature = "file_size_hint", reason = "New implementation optimization")]
 impl Iterator for Bytes<fs::File> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.inner.metadata() {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2469,7 +2469,7 @@ impl<R: Read> Iterator for Bytes<R> {
     }
 }
 
-#[unstable(feature = "file_size_hint", reason = "New implementation optimization")]
+#[unstable]
 impl Iterator for Bytes<fs::File> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         match self.inner.metadata() {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -253,6 +253,7 @@ mod tests;
 
 use crate::cmp;
 use crate::fmt;
+use crate::fs;
 use crate::memchr;
 use crate::ops::{Deref, DerefMut};
 use crate::ptr;
@@ -2460,6 +2461,20 @@ impl<R: Read> Iterator for Bytes<R> {
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
                 Err(e) => Some(Err(e)),
             };
+        }
+    }
+}
+
+impl Iterator for Bytes<fs::File> {
+    type Item = Result<u8>;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self.inner.metadata() {
+            Ok(metadata) => {
+                let file_length = metadata.len() as usize;
+                (file_length, Some(file_length))
+            }
+            Err(_) => (0, None),
         }
     }
 }


### PR DESCRIPTION
I noticed that the `Bytes` iterator over the bytes of a `File` returned the default value when calling `size_hint`. Since files are one of the cases where the number of items to iterate over is fixed, I felt that it made sense to take advantage of the available information.

Now, the `Bytes` `Iterator` returned by calling `bytes()` on a `File` will provide more accurate bounds with its size_hint.