### PR TITLE
Improve unknown external crate error

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -244,6 +244,13 @@ impl<'a> PathSource<'a> {
                 // "function" here means "anything callable" rather than `DefKind::Fn`,
                 // this is not precise but usually more helpful than just "value".
                 Some(ExprKind::Call(call_expr, _)) => match &call_expr.kind {
+                    // the case of `::some_crate()`
+                    ExprKind::Path(_, path)
+                        if path.segments.len() == 2
+                            && path.segments[0].ident.name == kw::PathRoot =>
+                    {
+                        "external crate"
+                    }
                     ExprKind::Path(_, path) => {
                         let mut msg = "function";
                         if let Some(segment) = path.segments.iter().last() {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2458,8 +2458,14 @@ impl<'a> Resolver<'a> {
                             (format!("use of undeclared crate or module `{}`", ident), None)
                         }
                     } else {
-                        let mut msg =
-                            format!("could not find `{}` in `{}`", ident, path[i - 1].ident);
+                        let parent = path[i - 1].ident.name;
+                        let parent = if parent == kw::PathRoot {
+                            "crate root".to_owned()
+                        } else {
+                            format!("`{}`", parent)
+                        };
+
+                        let mut msg = format!("could not find `{}` in {}", ident, parent);
                         if ns == TypeNS || ns == ValueNS {
                             let ns_to_try = if ns == TypeNS { ValueNS } else { TypeNS };
                             if let FindBindingResult::Binding(Ok(binding)) =
@@ -2467,11 +2473,11 @@ impl<'a> Resolver<'a> {
                             {
                                 let mut found = |what| {
                                     msg = format!(
-                                        "expected {}, found {} `{}` in `{}`",
+                                        "expected {}, found {} `{}` in {}",
                                         ns.descr(),
                                         what,
                                         ident,
-                                        path[i - 1].ident
+                                        parent
                                     )
                                 };
                                 if binding.module().is_some() {

--- a/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
+++ b/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `E`
   --> $DIR/edition-imports-virtual-2015-gated.rs:8:5
    |
 LL |     gen_gated!();
-   |     ^^^^^^^^^^^^^ could not find `E` in `{{root}}`
+   |     ^^^^^^^^^^^^^ could not find `E` in crate root
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/resolve/crate-called-as-function.rs
+++ b/src/test/ui/resolve/crate-called-as-function.rs
@@ -1,0 +1,3 @@
+fn main() {
+    ::foo() //~ cannot find external crate `foo` in the crate root
+}

--- a/src/test/ui/resolve/crate-called-as-function.stderr
+++ b/src/test/ui/resolve/crate-called-as-function.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find external crate `foo` in the crate root
+  --> $DIR/crate-called-as-function.rs:2:7
+   |
+LL |     ::foo()
+   |       ^^^ not found in the crate root
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/resolve/missing-in-namespace.rs
+++ b/src/test/ui/resolve/missing-in-namespace.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _map = std::hahmap::HashMap::new();
+    //~^ ERROR failed to resolve: could not find `hahmap` in `std
+}

--- a/src/test/ui/resolve/missing-in-namespace.stderr
+++ b/src/test/ui/resolve/missing-in-namespace.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve: could not find `hahmap` in `std`
+  --> $DIR/missing-in-namespace.rs:2:29
+   |
+LL |     let _map = std::hahmap::HashMap::new();
+   |                             ^^^^^^^ not found in `std::hahmap`
+   |
+help: consider importing this struct
+   |
+LL | use std::collections::HashMap;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.rs
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let s = ::xcrate::S;
-    //~^ ERROR failed to resolve: could not find `xcrate` in `{{root}}`
+    //~^ ERROR failed to resolve: could not find `xcrate` in crate root
 }

--- a/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.stderr
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: could not find `xcrate` in `{{root}}`
+error[E0433]: failed to resolve: could not find `xcrate` in crate root
   --> $DIR/non-existent-2.rs:4:15
    |
 LL |     let s = ::xcrate::S;
-   |               ^^^^^^ could not find `xcrate` in `{{root}}`
+   |               ^^^^^^ could not find `xcrate` in crate root
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This improves error messages when unknown items in the crate root are encountered. 

Fixes #63799 

r? @estebank 