### PR TITLE
Implement size_hint for BufReader

### DIFF
--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -1,6 +1,8 @@
 use crate::cmp;
 use crate::fmt;
-use crate::io::{self, BufRead, Initializer, IoSliceMut, Read, Seek, SeekFrom, SizeHint, DEFAULT_BUF_SIZE};
+use crate::io::{
+    self, BufRead, Initializer, IoSliceMut, Read, Seek, SeekFrom, SizeHint, DEFAULT_BUF_SIZE,
+};
 
 /// The `BufReader<R>` struct adds buffering to any reader.
 ///
@@ -428,4 +430,3 @@ impl<T> SizeHint for BufReader<T> {
         self.buffer().len()
     }
 }
-

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -1,6 +1,6 @@
 use crate::cmp;
 use crate::fmt;
-use crate::io::{self, BufRead, Initializer, IoSliceMut, Read, Seek, SeekFrom, DEFAULT_BUF_SIZE};
+use crate::io::{self, BufRead, Initializer, IoSliceMut, Read, Seek, SeekFrom, SizeHint, DEFAULT_BUF_SIZE};
 
 /// The `BufReader<R>` struct adds buffering to any reader.
 ///
@@ -422,3 +422,10 @@ impl<R: Seek> Seek for BufReader<R> {
         })
     }
 }
+
+impl<T> SizeHint for BufReader<T> {
+    fn lower_bound(&self) -> usize {
+        self.buffer().len()
+    }
+}
+

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2478,7 +2478,7 @@ impl<R: Read + SizeHint> Iterator for Bytes<R> {
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 trait SizeHint {
-    fn lower_bound(&self) -> usize {
+    fn lower_bound(&self) -> usize;
 
     fn upper_bound(&self) -> Option<usize> {
         None

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2492,7 +2492,7 @@ trait SizeHint {
 }
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
-impl<T> SizeHint for T;
+impl<T> SizeHint for T {}
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 impl<T> SizeHint for BufReader<T> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2478,6 +2478,8 @@ impl<R: Read + SizeHint> Iterator for Bytes<R> {
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 trait SizeHint {
+    fn lower_bound(&self) -> usize {
+
     fn upper_bound(&self) -> Option<usize> {
         None
     }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2478,7 +2478,9 @@ impl<R: Read + SizeHint> Iterator for Bytes<R> {
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 trait SizeHint {
-    fn lower_bound(&self) -> usize;
+    fn lower_bound(&self) -> usize {
+        0
+    }
 
     fn upper_bound(&self) -> Option<usize> {
         None
@@ -2490,11 +2492,7 @@ trait SizeHint {
 }
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
-impl<T> SizeHint for T {
-    fn lower_bound(&self) -> usize {
-        0
-    }
-}
+impl<T> SizeHint for T;
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 impl<T> SizeHint for BufReader<T> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2213,7 +2213,11 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
 
     unsafe fn initializer(&self) -> Initializer {
         let initializer = self.first.initializer();
-        if initializer.should_initialize() { initializer } else { self.second.initializer() }
+        if initializer.should_initialize() {
+            initializer
+        } else {
+            self.second.initializer()
+        }
     }
 }
 
@@ -2232,7 +2236,11 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
     }
 
     fn consume(&mut self, amt: usize) {
-        if !self.done_first { self.first.consume(amt) } else { self.second.consume(amt) }
+        if !self.done_first {
+            self.first.consume(amt)
+        } else {
+            self.second.consume(amt)
+        }
     }
 }
 
@@ -2461,6 +2469,17 @@ impl<R: Read> Iterator for Bytes<R> {
                 Err(e) => Some(Err(e)),
             };
         }
+    }
+
+    default fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+
+#[stable(feature = "bufreader_size_hint", since = "1.51.0")]
+impl<T> Iterator for Bytes<BufReader<T>> {
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.inner.buffer().len(), None)
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2478,10 +2478,6 @@ impl<R: Read + SizeHint> Iterator for Bytes<R> {
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 trait SizeHint {
-    fn lower_bound(&self) -> usize {
-        0
-    }
-
     fn upper_bound(&self) -> Option<usize> {
         None
     }
@@ -2492,7 +2488,11 @@ trait SizeHint {
 }
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
-impl<T> SizeHint for T {}
+impl<T> SizeHint for T {
+    default fn lower_bound(&self) -> usize {
+        0
+    }
+}
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 impl<T> SizeHint for BufReader<T> {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2468,7 +2468,6 @@ impl<R: Read> Iterator for Bytes<R> {
     }
 }
 
-#[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 trait SizeHint {
     fn lower_bound(&self) -> usize;
 
@@ -2481,14 +2480,12 @@ trait SizeHint {
     }
 }
 
-#[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 impl<T> SizeHint for T {
     default fn lower_bound(&self) -> usize {
         0
     }
 }
 
-#[stable(feature = "bufreader_size_hint", since = "1.51.0")]
 impl<T> SizeHint for BufReader<T> {
     fn lower_bound(&self) -> usize {
         self.buffer().len()

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2236,6 +2236,20 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
     }
 }
 
+impl<T, U> SizeHint for Chain<T, U> {
+    fn lower_bound(&self) -> usize {
+        SizeHint::lower_bound(&self.first) + SizeHint::lower_bound(&self.second)
+    }
+
+    fn upper_bound(&self) -> Option<usize > {
+        match (SizeHint::upper_bound(&self.first), SizeHint::upper_bound(&self.second)) {
+            (Some(first), Some(second)) => Some(first + second),
+            _ => None,
+        }
+    }
+}
+
+
 /// Reader adaptor which limits the bytes read from an underlying reader.
 ///
 /// This struct is generally created by calling [`take`] on a reader.
@@ -2485,12 +2499,6 @@ impl<T> SizeHint for T {
 
     default fn upper_bound(&self) -> Option<usize> {
         None
-    }
-}
-
-impl<T> SizeHint for BufReader<T> {
-    fn lower_bound(&self) -> usize {
-        self.buffer().len()
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2456,7 +2456,7 @@ pub struct Bytes<R> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<R: Read + SizeHint> Iterator for Bytes<R> {
+impl<R: Read> Iterator for Bytes<R> {
     type Item = Result<u8>;
 
     fn next(&mut self) -> Option<Result<u8>> {
@@ -2472,7 +2472,7 @@ impl<R: Read + SizeHint> Iterator for Bytes<R> {
     }
 
     default fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        (&self.inner as &SizeHint).size_hint()
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2464,7 +2464,7 @@ impl<R: Read> Iterator for Bytes<R> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (&self.inner as &dyn SizeHint).size_hint()
+        SizeHint::size_hint(&self.inner)
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2490,7 +2490,7 @@ trait SizeHint {
 }
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
-impl SizeHint for T {
+impl<T> SizeHint for T {
     fn lower_bound(&self) -> usize {
         0
     }

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2241,14 +2241,13 @@ impl<T, U> SizeHint for Chain<T, U> {
         SizeHint::lower_bound(&self.first) + SizeHint::lower_bound(&self.second)
     }
 
-    fn upper_bound(&self) -> Option<usize > {
+    fn upper_bound(&self) -> Option<usize> {
         match (SizeHint::upper_bound(&self.first), SizeHint::upper_bound(&self.second)) {
             (Some(first), Some(second)) => Some(first + second),
             _ => None,
         }
     }
 }
-
 
 /// Reader adaptor which limits the bytes read from an underlying reader.
 ///

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2213,11 +2213,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
 
     unsafe fn initializer(&self) -> Initializer {
         let initializer = self.first.initializer();
-        if initializer.should_initialize() {
-            initializer
-        } else {
-            self.second.initializer()
-        }
+        if initializer.should_initialize() { initializer } else { self.second.initializer() }
     }
 }
 
@@ -2236,11 +2232,7 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
     }
 
     fn consume(&mut self, amt: usize) {
-        if !self.done_first {
-            self.first.consume(amt)
-        } else {
-            self.second.consume(amt)
-        }
+        if !self.done_first { self.first.consume(amt) } else { self.second.consume(amt) }
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2472,7 +2472,7 @@ impl<R: Read> Iterator for Bytes<R> {
     }
 
     default fn size_hint(&self) -> (usize, Option<usize>) {
-        (&self.inner as &SizeHint).size_hint()
+        (&self.inner as &dyn SizeHint).size_hint()
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2463,7 +2463,7 @@ impl<R: Read> Iterator for Bytes<R> {
         }
     }
 
-    default fn size_hint(&self) -> (usize, Option<usize>) {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         (&self.inner as &dyn SizeHint).size_hint()
     }
 }
@@ -2471,9 +2471,7 @@ impl<R: Read> Iterator for Bytes<R> {
 trait SizeHint {
     fn lower_bound(&self) -> usize;
 
-    fn upper_bound(&self) -> Option<usize> {
-        None
-    }
+    fn upper_bound(&self) -> Option<usize>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.lower_bound(), self.upper_bound())
@@ -2483,6 +2481,10 @@ trait SizeHint {
 impl<T> SizeHint for T {
     default fn lower_bound(&self) -> usize {
         0
+    }
+
+    default fn upper_bound(&self) -> Option<usize> {
+        None
     }
 }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2477,7 +2477,7 @@ impl<R: Read> Iterator for Bytes<R> {
 }
 
 #[stable(feature = "bufreader_size_hint", since = "1.51.0")]
-impl<T> Iterator for Bytes<BufReader<T>> {
+impl<R: Read> Iterator for Bytes<BufReader<R>> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.inner.buffer().len(), None)
     }

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -204,8 +204,8 @@ fn bufreader_size_hint() {
     let mut buf_reader = BufReader::new(&testdata[..]);
     assert_eq!(buf_reader.buffer().len(), 0);
 
-    let buffer = buf_reader.fill_buf().unwrap();
-    let buffer_length = buffer.len();
+    let buffer_length = testdata.len();
+    buf_reader.fill_buf().unwrap();
 
     // Check that size hint matches buffer contents
     let mut buffered_bytes = buf_reader.bytes();
@@ -216,6 +216,33 @@ fn bufreader_size_hint() {
     buffered_bytes.next().unwrap().unwrap();
     let (lower_bound, _upper_bound) = buffered_bytes.size_hint();
     assert_eq!(lower_bound, buffer_length - 1);
+}
+
+#[test]
+fn empty_size_hint() {
+    let size_hint = io::empty().bytes().size_hint();
+    assert_eq!(size_hint, (0, Some(0)));
+}
+
+#[test]
+fn chain_empty_size_hint() {
+    let chain = io::empty().chain(io::empty());
+    let size_hint = chain.bytes().size_hint();
+    assert_eq!(size_hint, (0, Some(0)));
+}
+
+#[test]
+fn chain_size_hint() {
+    let testdata = b"ABCDEFGHIJKL";
+    let mut buf_reader_1 = BufReader::new(&testdata[..6]);
+    let mut buf_reader_2 = BufReader::new(&testdata[6..]);
+
+    buf_reader_1.fill_buf().unwrap();
+    buf_reader_2.fill_buf().unwrap();
+
+    let chain = buf_reader_1.chain(buf_reader_2);
+    let size_hint = chain.bytes().size_hint();
+    assert_eq!(size_hint, (testdata.len(), None));
 }
 
 #[test]

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -67,7 +67,7 @@ impl fmt::Debug for Empty {
 
 impl SizeHint for Empty {
     fn upper_bound(&self) -> Option<usize> {
-       Some(0)
+        Some(0)
     }
 }
 

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -4,7 +4,7 @@
 mod tests;
 
 use crate::fmt;
-use crate::io::{self, BufRead, Initializer, IoSlice, IoSliceMut, Read, Write};
+use crate::io::{self, BufRead, Initializer, IoSlice, IoSliceMut, Read, SizeHint, Write};
 
 /// A reader which is always at EOF.
 ///
@@ -62,6 +62,12 @@ impl BufRead for Empty {
 impl fmt::Debug for Empty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Empty { .. }")
+    }
+}
+
+impl SizeHint for Empty {
+    fn upper_bound(&self) -> Option<usize> {
+       Some(0)
     }
 }
 


### PR DESCRIPTION
After trying to implement better `size_hint()` return values for `File` in [this PR](https://github.com/rust-lang/rust/pull/81044), it was recommended that I implement this instead. Due to buffering, the `Iterator` `Bytes` is guaranteed to produce at least as many `u8`s as are currently in the buffer. This allows the `size_hint()` to provide a tighter lower bound than the default of `0`.