### PR TITLE
Query-ify needs_gdb_debug_scripts_section

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -106,7 +106,7 @@ pub fn finalize(cx: &CodegenCx<'_, '_>) {
 
     debug!("finalize");
 
-    if gdb::needs_gdb_debug_scripts_section(cx) {
+    if cx.tcx.needs_gdb_debug_scripts_section(LOCAL_CRATE) {
         // Add a .debug_gdb_scripts section to this compile-unit. This will
         // cause GDB to try and load the gdb_load_rust_pretty_printers.py file,
         // which activates the Rust pretty printers for binary this section is

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -28,8 +28,9 @@ use rustc_middle::ty::layout::{FAT_PTR_ADDR, FAT_PTR_EXTRA};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_session::cgu_reuse_tracker::CguReuse;
-use rustc_session::config::{self, EntryFnType};
+use rustc_session::config::{self, DebugInfo, EntryFnType};
 use rustc_session::Session;
+use rustc_span::sym;
 use rustc_target::abi::{Align, LayoutOf, VariantIdx};
 
 use std::cmp;
@@ -827,6 +828,17 @@ pub fn provide(providers: &mut Providers) {
             }
         }
         tcx.sess.opts.optimize
+    };
+
+    providers.needs_gdb_debug_scripts_section = |tcx, cnum| {
+        assert_eq!(cnum, LOCAL_CRATE);
+
+        let omit_gdb_pretty_printer_section =
+            tcx.sess.contains_name(&tcx.hir().krate_attrs(), sym::omit_gdb_pretty_printer_section);
+
+        !omit_gdb_pretty_printer_section
+            && tcx.sess.opts.debuginfo != DebugInfo::None
+            && tcx.sess.target.emit_debug_gdb_scripts
     };
 }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1214,6 +1214,13 @@ rustc_queries! {
         desc { "looking up the paths for extern crates" }
     }
 
+    /// Determines if we need to emit a GDB debug script section
+    /// during codegen for the current crate. The CrateNum
+    /// should always be LOCAL_CRATE
+    query needs_gdb_debug_scripts_section(_: CrateNum) -> bool {
+        desc { "determine if the current crate needs a gdb debug scripts section" }
+    }
+
     /// Given a crate and a trait, look up all impls of that trait in the crate.
     /// Return `(impl_id, self_ty)`.
     query implementations_of_trait(_: (CrateNum, DefId))


### PR DESCRIPTION
This ensures that a codegen unit DepNode does not have a direct
dependency on the crate's attributes