### PR TITLE
Re-enable all num tests on WASM

### DIFF
--- a/library/core/tests/num/dec2flt/mod.rs
+++ b/library/core/tests/num/dec2flt/mod.rs
@@ -21,7 +21,6 @@ macro_rules! test_literal {
     }};
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn ordinary() {
     test_literal!(1.0);
@@ -38,7 +37,6 @@ fn ordinary() {
     test_literal!(2.2250738585072014e-308);
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn special_code_paths() {
     test_literal!(36893488147419103229.0); // 2^65 - 3, triggers half-to-even with even significand

--- a/library/core/tests/num/dec2flt/rawfp.rs
+++ b/library/core/tests/num/dec2flt/rawfp.rs
@@ -81,7 +81,6 @@ fn rounding_overflow() {
     assert_eq!(rounded.k, adjusted_k + 1);
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn prev_float_monotonic() {
     let mut x = 1.0;
@@ -117,7 +116,6 @@ fn next_float_inf() {
     assert_eq!(next_float(f64::INFINITY), f64::INFINITY);
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn next_prev_identity() {
     for &x in &SOME_FLOATS {
@@ -128,7 +126,6 @@ fn next_prev_identity() {
     }
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn next_float_monotonic() {
     let mut x = 0.49999999999999;

--- a/library/core/tests/num/flt2dec/strategy/dragon.rs
+++ b/library/core/tests/num/flt2dec/strategy/dragon.rs
@@ -13,7 +13,6 @@ fn test_mul_pow10() {
     }
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn shortest_sanity_test() {
     f64_shortest_sanity_test(format_shortest);

--- a/library/core/tests/num/flt2dec/strategy/grisu.rs
+++ b/library/core/tests/num/flt2dec/strategy/grisu.rs
@@ -33,7 +33,6 @@ fn test_max_pow10_no_more_than() {
     }
 }
 
-#[cfg_attr(all(target_arch = "wasm32", target_os = "emscripten"), ignore)] // issue 42630
 #[test]
 fn shortest_sanity_test() {
     f64_shortest_sanity_test(format_shortest);


### PR DESCRIPTION
This was partially done by #47365, but a few tests were missed in that PR.