### PR TITLE
rustc_parse_format: Fix character indices in find_skips

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -736,7 +736,7 @@ fn find_skips_from_snippet(
 
     fn find_skips(snippet: &str, is_raw: bool) -> Vec<usize> {
         let mut eat_ws = false;
-        let mut s = snippet.chars().enumerate().peekable();
+        let mut s = snippet.char_indices().peekable();
         let mut skips = vec![];
         while let Some((pos, c)) = s.next() {
             match (c, s.peek()) {

--- a/src/test/ui/macros/issue-81006.rs
+++ b/src/test/ui/macros/issue-81006.rs
@@ -1,0 +1,10 @@
+// check-fail
+
+// First format below would cause a panic, second would generate error with incorrect span
+
+fn main() {
+    let _ = format!("→{}→\n");
+    //~^ ERROR 1 positional argument in format string, but no arguments were given
+    let _ = format!("→{} \n");
+    //~^ ERROR 1 positional argument in format string, but no arguments were given
+}

--- a/src/test/ui/macros/issue-81006.stderr
+++ b/src/test/ui/macros/issue-81006.stderr
@@ -1,0 +1,14 @@
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/issue-81006.rs:6:23
+   |
+LL |     let _ = format!("→{}→\n");
+   |                       ^^
+
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/issue-81006.rs:8:23
+   |
+LL |     let _ = format!("→{} \n");
+   |                       ^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #81006