### PR TITLE
Allow overruling forbidden lints in derive macros

### DIFF
--- a/src/test/ui/lint/unused-qualification-in-derive.rs
+++ b/src/test/ui/lint/unused-qualification-in-derive.rs
@@ -1,0 +1,7 @@
+// check-pass
+#![forbid(unused_qualifications)]
+
+#[derive(Clone)]
+pub struct S;
+
+fn main() {}


### PR DESCRIPTION
Fixes #71898 by allowing derive expansions to override forbidden lints that are set outside the expansion.