### PR TITLE
don't suggest erroneous trailing comma after `..`

### DIFF
--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -32,11 +32,11 @@ LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |
 help: include the missing field in the pattern
    |
-LL |     Struct { a, b, _ } = Struct { a: 1, b: 2 };
+LL |     Struct { a, b _ } = Struct { a: 1, b: 2 };
    |               ^^^
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL |     Struct { a, .., _ } = Struct { a: 1, b: 2 };
+LL |     Struct { a, .. _ } = Struct { a: 1, b: 2 };
    |               ^^^^
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/error-codes/E0027.rs
+++ b/src/test/ui/error-codes/E0027.rs
@@ -3,11 +3,20 @@ struct Dog {
     age: u32,
 }
 
+
 fn main() {
     let d = Dog { name: "Rusty".to_string(), age: 8 };
 
     match d {
         Dog { age: x } => {} //~ ERROR pattern does not mention field `name`
+    }
+    match d {
+        // trailing comma
+        Dog { name: x, } => {} //~ ERROR pattern does not mention field `age`
+    }
+    match d {
+        // trailing comma with weird whitespace
+        Dog { name: x  , } => {} //~ ERROR pattern does not mention field `age`
     }
     match d {
         Dog {} => {} //~ ERROR pattern does not mention fields `name`, `age`

--- a/src/test/ui/error-codes/E0027.stderr
+++ b/src/test/ui/error-codes/E0027.stderr
@@ -1,5 +1,5 @@
 error[E0027]: pattern does not mention field `name`
-  --> $DIR/E0027.rs:10:9
+  --> $DIR/E0027.rs:11:9
    |
 LL |         Dog { age: x } => {}
    |         ^^^^^^^^^^^^^^ missing field `name`
@@ -13,8 +13,38 @@ help: if you don't care about this missing field, you can explicitly ignore it
 LL |         Dog { age: x, .. } => {}
    |                     ^^^^
 
+error[E0027]: pattern does not mention field `age`
+  --> $DIR/E0027.rs:15:9
+   |
+LL |         Dog { name: x, } => {}
+   |         ^^^^^^^^^^^^^^^^ missing field `age`
+   |
+help: include the missing field in the pattern
+   |
+LL |         Dog { name: x, age } => {}
+   |                      ^^^^^
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+LL |         Dog { name: x, .. } => {}
+   |                      ^^^^
+
+error[E0027]: pattern does not mention field `age`
+  --> $DIR/E0027.rs:19:9
+   |
+LL |         Dog { name: x  , } => {}
+   |         ^^^^^^^^^^^^^^^^^^ missing field `age`
+   |
+help: include the missing field in the pattern
+   |
+LL |         Dog { name: x, age } => {}
+   |                      ^^^^^
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+LL |         Dog { name: x, .. } => {}
+   |                      ^^^^
+
 error[E0027]: pattern does not mention fields `name`, `age`
-  --> $DIR/E0027.rs:13:9
+  --> $DIR/E0027.rs:22:9
    |
 LL |         Dog {} => {}
    |         ^^^^^^ missing fields `name`, `age`
@@ -28,6 +58,6 @@ help: if you don't care about these missing fields, you can explicitly ignore th
 LL |         Dog { .. } => {}
    |             ^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0027`.


### PR DESCRIPTION
In #76612, suggestions were added for missing fields in patterns. However, the suggestions are being inserted just at the end
of the last field in the pattern—before any trailing comma after the last field. This resulted in the "if you don't care about missing fields" suggestion to recommend code with a trailing comma after the field ellipsis (`..,`), which is actually not legal ("`..` must be at the end and cannot have a trailing comma")!

Incidentally, the doc-comment on `error_unmentioned_fields` was using `you_cant_use_this_field` as an example field name (presumably copy-paste inherited from the description of Issue #76077), but the present author found this confusing, because unmentioned fields aren't necessarily unusable.

The suggested code in the diff this commit introduces to `destructuring-assignment/struct_destructure_fail.stderr` doesn't work, but it didn't work beforehand, either (because of the "found reserved identifier `_`" thing), so you can't really call it a regression; it could be fixed in a separate PR.

Resolves #78511.

r? @davidtwco or @estebank 