### PR TITLE
Remove unused alloc::std::ops re-export.

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -183,11 +183,6 @@ pub mod task;
 mod tests;
 pub mod vec;
 
-#[cfg(not(test))]
-mod std {
-    pub use core::ops; // RangeFull
-}
-
 #[doc(hidden)]
 #[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
 pub mod __export {


### PR DESCRIPTION
Removes unused re-export in alloc/lib.rs.