### PR TITLE
Skip linking if it is not required

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -74,7 +74,7 @@ pub fn link_binary<'a, B: ArchiveBuilder<'a>>(
             }
         });
 
-        if outputs.outputs.should_codegen() {
+        if outputs.outputs.should_link() {
             let tmpdir = TempFileBuilder::new()
                 .prefix("rustc")
                 .tempdir()
@@ -123,9 +123,7 @@ pub fn link_binary<'a, B: ArchiveBuilder<'a>>(
                 }
             };
 
-            if sess.opts.output_types.should_codegen()
-                && !preserve_objects_for_their_debuginfo(sess)
-            {
+            if sess.opts.output_types.should_link() && !preserve_objects_for_their_debuginfo(sess) {
                 for module in &codegen_results.modules {
                     remove_temps_from_module(module);
                 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -403,6 +403,20 @@ impl OutputTypes {
             OutputType::Metadata | OutputType::DepInfo => false,
         })
     }
+
+    // Returns `true` if any of the output types require linking.
+    pub fn should_link(&self) -> bool {
+        self.0.keys().any(|k| match *k {
+            OutputType::Bitcode
+            | OutputType::Assembly
+            | OutputType::LlvmAssembly
+            | OutputType::Mir
+            | OutputType::Metadata
+            | OutputType::Object
+            | OutputType::DepInfo => false,
+            OutputType::Exe => true,
+        })
+    }
 }
 
 /// Use tree-based collections to cheaply get a deterministic `Hash` implementation.

--- a/src/test/ui/emit-metadata-obj.rs
+++ b/src/test/ui/emit-metadata-obj.rs
@@ -1,0 +1,7 @@
+// compile-flags:--emit=metadata,obj
+// build-pass
+
+// A test for the emission of metadata + obj and other metadata + non-link
+// combinations. See issue #81117.
+
+fn main() {}


### PR DESCRIPTION
This allows to use `--emit=metadata,obj` and other metadata + non-link combinations.

Fixes #81117.