### PR TITLE
Avoid describing a method as 'not found' when bounds are unsatisfied

### DIFF
--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -74,11 +74,10 @@ macro_rules! forward {
         });
     };
 
-    // Forward pattern for &mut self -> &mut Self, with S: Into<MultiSpan>
-    // type parameter. No obvious way to make this more generic.
+    // Forward pattern for &mut self -> &mut Self, with generic parameters.
     (
         $(#[$attrs:meta])*
-        pub fn $n:ident<S: Into<MultiSpan>>(
+        pub fn $n:ident<$($generic:ident: $bound:path),*>(
             &mut self,
             $($name:ident: $ty:ty),*
             $(,)?
@@ -86,7 +85,7 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         forward_inner_docs!(concat!("See [`Diagnostic::", stringify!($n), "()`].") =>
-        pub fn $n<S: Into<MultiSpan>>(&mut self, $($name: $ty),*) -> &mut Self {
+        pub fn $n<$($generic: $bound),*>(&mut self, $($name: $ty),*) -> &mut Self {
             self.0.diagnostic.$n($($name),*);
             self
         });
@@ -398,6 +397,7 @@ impl<'a> DiagnosticBuilder<'a> {
         self
     }
 
+    forward!(pub fn set_primary_message<M: Into<String>>(&mut self, msg: M) -> &mut Self);
     forward!(pub fn set_span<S: Into<MultiSpan>>(&mut self, sp: S) -> &mut Self);
     forward!(pub fn code(&mut self, s: DiagnosticId) -> &mut Self);
 

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -60,6 +60,7 @@ This API is completely unstable and subject to change.
 #![feature(bool_to_option)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
+#![feature(format_args_capture)]
 #![feature(in_band_lifetimes)]
 #![feature(is_sorted)]
 #![feature(nll)]

--- a/src/test/ui/associated-types/hr-associated-type-bound-2.rs
+++ b/src/test/ui/associated-types/hr-associated-type-bound-2.rs
@@ -17,5 +17,5 @@ where
 
 fn main() {
     1u32.f("abc");
-    //~^ ERROR no method named `f` found for type `u32` in the current scope
+    //~^ ERROR the method
 }

--- a/src/test/ui/associated-types/hr-associated-type-bound-2.stderr
+++ b/src/test/ui/associated-types/hr-associated-type-bound-2.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no method named `f` found for type `u32` in the current scope
+error[E0599]: the method `f` exists for type `u32`, but its trait bounds were not satisfied
   --> $DIR/hr-associated-type-bound-2.rs:19:10
    |
 LL |     1u32.f("abc");
-   |          ^ method not found in `u32`
+   |          ^ method cannot be called on `u32` due to unsatisfied trait bounds
    |
-   = note: the method `f` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `<u32 as X<'b>>::U: Clone`
            which is required by `u32: X`
 

--- a/src/test/ui/derives/derive-assoc-type-not-impl.stderr
+++ b/src/test/ui/derives/derive-assoc-type-not-impl.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `clone` found for struct `Bar<NotClone>` in the current scope
+error[E0599]: the method `clone` exists for struct `Bar<NotClone>`, but its trait bounds were not satisfied
   --> $DIR/derive-assoc-type-not-impl.rs:18:30
    |
 LL | struct Bar<T: Foo> {
@@ -11,7 +11,7 @@ LL | struct NotClone;
    | ---------------- doesn't satisfy `NotClone: Clone`
 ...
 LL |     Bar::<NotClone> { x: 1 }.clone();
-   |                              ^^^^^ method not found in `Bar<NotClone>`
+   |                              ^^^^^ method cannot be called on `Bar<NotClone>` due to unsatisfied trait bounds
    | 
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
@@ -21,7 +21,7 @@ LL |     fn clone(&self) -> Self;
    |        the method is available for `Arc<Bar<NotClone>>` here
    |        the method is available for `Rc<Bar<NotClone>>` here
    |
-   = note: the method `clone` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `NotClone: Clone`
            which is required by `Bar<NotClone>: Clone`
    = help: items from traits can only be used if the trait is implemented and in scope

--- a/src/test/ui/hrtb/issue-30786.migrate.stderr
+++ b/src/test/ui/hrtb/issue-30786.migrate.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `filterx` found for struct `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>` in the current scope
+error[E0599]: the method `filterx` exists for struct `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>`, but its trait bounds were not satisfied
   --> $DIR/issue-30786.rs:128:22
    |
 LL | pub struct Map<S, F> {
@@ -8,9 +8,9 @@ LL | pub struct Map<S, F> {
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let filter = map.filterx(|x: &_| true);
-   |                      ^^^^^^^ method not found in `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>`
+   |                      ^^^^^^^ method cannot be called on `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>` due to unsatisfied trait bounds
    |
-   = note: the method `filterx` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `&'a mut Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: Stream`
            which is required by `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: StreamExt`
            `&'a mut &Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: Stream`
@@ -18,7 +18,7 @@ LL |     let filter = map.filterx(|x: &_| true);
            `&'a mut &mut Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: Stream`
            which is required by `&mut Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: StreamExt`
 
-error[E0599]: no method named `countx` found for struct `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>` in the current scope
+error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>`, but its trait bounds were not satisfied
   --> $DIR/issue-30786.rs:141:24
    |
 LL | pub struct Filter<S, F> {
@@ -28,9 +28,9 @@ LL | pub struct Filter<S, F> {
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let count = filter.countx();
-   |                        ^^^^^^ method not found in `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>`
+   |                        ^^^^^^ method cannot be called on `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>` due to unsatisfied trait bounds
    |
-   = note: the method `countx` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `&'a mut Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>: Stream`
            which is required by `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>: StreamExt`
            `&'a mut &Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>: Stream`

--- a/src/test/ui/hrtb/issue-30786.nll.stderr
+++ b/src/test/ui/hrtb/issue-30786.nll.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `filterx` found for struct `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>` in the current scope
+error[E0599]: the method `filterx` exists for struct `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>`, but its trait bounds were not satisfied
   --> $DIR/issue-30786.rs:128:22
    |
 LL | pub struct Map<S, F> {
@@ -8,9 +8,9 @@ LL | pub struct Map<S, F> {
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let filter = map.filterx(|x: &_| true);
-   |                      ^^^^^^^ method not found in `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>`
+   |                      ^^^^^^^ method cannot be called on `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>` due to unsatisfied trait bounds
    |
-   = note: the method `filterx` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `&'a mut Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: Stream`
            which is required by `Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: StreamExt`
            `&'a mut &Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: Stream`
@@ -18,7 +18,7 @@ LL |     let filter = map.filterx(|x: &_| true);
            `&'a mut &mut Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: Stream`
            which is required by `&mut Map<Repeat, [closure@$DIR/issue-30786.rs:127:27: 127:36]>: StreamExt`
 
-error[E0599]: no method named `countx` found for struct `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>` in the current scope
+error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>`, but its trait bounds were not satisfied
   --> $DIR/issue-30786.rs:141:24
    |
 LL | pub struct Filter<S, F> {
@@ -28,9 +28,9 @@ LL | pub struct Filter<S, F> {
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let count = filter.countx();
-   |                        ^^^^^^ method not found in `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>`
+   |                        ^^^^^^ method cannot be called on `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>` due to unsatisfied trait bounds
    |
-   = note: the method `countx` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `&'a mut Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>: Stream`
            which is required by `Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>: StreamExt`
            `&'a mut &Filter<Map<Repeat, for<'r> fn(&'r u64) -> &'r u64 {identity::<u64>}>, [closure@$DIR/issue-30786.rs:140:30: 140:42]>: Stream`

--- a/src/test/ui/hrtb/issue-30786.rs
+++ b/src/test/ui/hrtb/issue-30786.rs
@@ -126,8 +126,8 @@ fn variant1() {
     // guess.
     let map = source.mapx(|x: &_| x);
     let filter = map.filterx(|x: &_| true);
-    //[migrate]~^ ERROR no method named `filterx`
-    //[nll]~^^ ERROR no method named `filterx`
+    //[migrate]~^ ERROR the method
+    //[nll]~^^ ERROR the method
 }
 
 fn variant2() {
@@ -139,8 +139,8 @@ fn variant2() {
     let map = source.mapx(identity);
     let filter = map.filterx(|x: &_| true);
     let count = filter.countx();
-    //[migrate]~^ ERROR no method named `countx`
-    //[nll]~^^ ERROR no method named `countx`
+    //[migrate]~^ ERROR the method
+    //[nll]~^^ ERROR the method
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-21596.stderr
+++ b/src/test/ui/issues/issue-21596.stderr
@@ -1,12 +1,12 @@
-error[E0599]: no method named `to_string` found for raw pointer `*const u8` in the current scope
+error[E0599]: the method `to_string` exists for raw pointer `*const u8`, but its trait bounds were not satisfied
   --> $DIR/issue-21596.rs:4:22
    |
 LL |     println!("{}", z.to_string());
-   |                      ^^^^^^^^^ method not found in `*const u8`
+   |                      ^^^^^^^^^ method cannot be called on `*const u8` due to unsatisfied trait bounds
    |
    = note: try using `<*const T>::as_ref()` to get a reference to the type behind the pointer: https://doc.rust-lang.org/std/primitive.pointer.html#method.as_ref
    = note: using `<*const T>::as_ref()` on a pointer which is unaligned or points to invalid or uninitialized memory is undefined behavior
-   = note: the method `to_string` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `*const u8: std::fmt::Display`
            which is required by `*const u8: ToString`
 

--- a/src/test/ui/issues/issue-31173.rs
+++ b/src/test/ui/issues/issue-31173.rs
@@ -11,7 +11,7 @@ pub fn get_tok(it: &mut IntoIter<u8>) {
         //~^ ERROR type mismatch resolving
         //~| expected type `u8`
         //~| found reference `&_`
-        .collect(); //~ ERROR no method named `collect`
+        .collect(); //~ ERROR the method
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-31173.stderr
+++ b/src/test/ui/issues/issue-31173.stderr
@@ -7,11 +7,11 @@ LL |         .cloned()
    = note:   expected type `u8`
            found reference `&_`
 
-error[E0599]: no method named `collect` found for struct `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]>>` in the current scope
+error[E0599]: the method `collect` exists for struct `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]>>`, but its trait bounds were not satisfied
   --> $DIR/issue-31173.rs:14:10
    |
 LL |         .collect();
-   |          ^^^^^^^ method not found in `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]>>`
+   |          ^^^^^^^ method cannot be called on `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]>>` due to unsatisfied trait bounds
    | 
   ::: $SRC_DIR/core/src/iter/adapters/cloned.rs:LL:COL
    |
@@ -23,7 +23,7 @@ LL | pub struct Cloned<I> {
 LL | pub struct TakeWhile<I, P> {
    | -------------------------- doesn't satisfy `<_ as Iterator>::Item = &_`
    |
-   = note: the method `collect` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]> as Iterator>::Item = &_`
            which is required by `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]>>: Iterator`
            `Cloned<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]>>: Iterator`

--- a/src/test/ui/issues/issue-35677.rs
+++ b/src/test/ui/issues/issue-35677.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 fn is_subset<T>(this: &HashSet<T>, other: &HashSet<T>) -> bool {
     this.is_subset(other)
-    //~^ ERROR no method named
+    //~^ ERROR the method
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-35677.stderr
+++ b/src/test/ui/issues/issue-35677.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no method named `is_subset` found for reference `&HashSet<T>` in the current scope
+error[E0599]: the method `is_subset` exists for reference `&HashSet<T>`, but its trait bounds were not satisfied
   --> $DIR/issue-35677.rs:4:10
    |
 LL |     this.is_subset(other)
-   |          ^^^^^^^^^ method not found in `&HashSet<T>`
+   |          ^^^^^^^^^ method cannot be called on `&HashSet<T>` due to unsatisfied trait bounds
    |
-   = note: the method `is_subset` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `T: Eq`
            `T: Hash`
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.rs
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _result = &Some(42).as_deref();
-//~^ ERROR no method named `as_deref` found for enum `Option<{integer}>`
+//~^ ERROR the method
 }

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no method named `as_deref` found for enum `Option<{integer}>` in the current scope
+error[E0599]: the method `as_deref` exists for enum `Option<{integer}>`, but its trait bounds were not satisfied
   --> $DIR/option-as_deref.rs:2:29
    |
 LL |     let _result = &Some(42).as_deref();
-   |                             ^^^^^^^^ help: there is an associated function with a similar name: `as_ref`
+   |                             ^^^^^^^^
    |
-   = note: the method `as_deref` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `{integer}: Deref`
            `<{integer} as Deref>::Target = _`
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref_mut.rs
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref_mut.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _result = &mut Some(42).as_deref_mut();
-//~^ ERROR no method named `as_deref_mut` found for enum `Option<{integer}>`
+//~^ ERROR the method
 }

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref_mut.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/option-as_deref_mut.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no method named `as_deref_mut` found for enum `Option<{integer}>` in the current scope
+error[E0599]: the method `as_deref_mut` exists for enum `Option<{integer}>`, but its trait bounds were not satisfied
   --> $DIR/option-as_deref_mut.rs:2:33
    |
 LL |     let _result = &mut Some(42).as_deref_mut();
-   |                                 ^^^^^^^^^^^^ method not found in `Option<{integer}>`
+   |                                 ^^^^^^^^^^^^ method cannot be called on `Option<{integer}>` due to unsatisfied trait bounds
    |
-   = note: the method `as_deref_mut` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `{integer}: DerefMut`
            `<{integer} as Deref>::Target = _`
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.rs
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _result = &Ok(42).as_deref();
-//~^ ERROR no method named `as_deref` found
+//~^ ERROR the method
 }

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no method named `as_deref` found for enum `std::result::Result<{integer}, _>` in the current scope
+error[E0599]: the method `as_deref` exists for enum `std::result::Result<{integer}, _>`, but its trait bounds were not satisfied
   --> $DIR/result-as_deref.rs:2:27
    |
 LL |     let _result = &Ok(42).as_deref();
-   |                           ^^^^^^^^ help: there is an associated function with a similar name: `as_ref`
+   |                           ^^^^^^^^
    |
-   = note: the method `as_deref` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `{integer}: Deref`
            `<{integer} as Deref>::Target = _`
 

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.rs
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _result = &mut Ok(42).as_deref_mut();
-//~^ ERROR no method named `as_deref_mut` found
+//~^ ERROR the method
 }

--- a/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.stderr
+++ b/src/test/ui/issues/issue-50264-inner-deref-trait/result-as_deref_mut.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no method named `as_deref_mut` found for enum `std::result::Result<{integer}, _>` in the current scope
+error[E0599]: the method `as_deref_mut` exists for enum `std::result::Result<{integer}, _>`, but its trait bounds were not satisfied
   --> $DIR/result-as_deref_mut.rs:2:31
    |
 LL |     let _result = &mut Ok(42).as_deref_mut();
-   |                               ^^^^^^^^^^^^ method not found in `std::result::Result<{integer}, _>`
+   |                               ^^^^^^^^^^^^ method cannot be called on `std::result::Result<{integer}, _>` due to unsatisfied trait bounds
    |
-   = note: the method `as_deref_mut` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `{integer}: DerefMut`
            `<{integer} as Deref>::Target = _`
 

--- a/src/test/ui/issues/issue-57362-2.rs
+++ b/src/test/ui/issues/issue-57362-2.rs
@@ -19,7 +19,7 @@ impl<'a> X for fn(&'a ()) {
 }
 
 fn g() {
-    let x = <fn (&())>::make_g(); //~ ERROR no function or associated item
+    let x = <fn (&())>::make_g(); //~ ERROR the function
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-57362-2.stderr
+++ b/src/test/ui/issues/issue-57362-2.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no function or associated item named `make_g` found for fn pointer `for<'r> fn(&'r ())` in the current scope
+error[E0599]: the function or associated item `make_g` exists for fn pointer `for<'r> fn(&'r ())`, but its trait bounds were not satisfied
   --> $DIR/issue-57362-2.rs:22:25
    |
 LL |     let x = <fn (&())>::make_g();
-   |                         ^^^^^^ function or associated item not found in `for<'r> fn(&'r ())`
+   |                         ^^^^^^ function or associated item cannot be called on `for<'r> fn(&'r ())` due to unsatisfied trait bounds
    |
-   = note: the method `make_g` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `for<'r> fn(&'r ()): X`
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `X` defines an item `make_g`, perhaps you need to implement it

--- a/src/test/ui/issues/issue-69725.rs
+++ b/src/test/ui/issues/issue-69725.rs
@@ -5,7 +5,7 @@ use issue_69725::Struct;
 
 fn crash<A>() {
     let _ = Struct::<A>::new().clone();
-    //~^ ERROR: no method named `clone` found
+    //~^ ERROR: the method
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-69725.stderr
+++ b/src/test/ui/issues/issue-69725.stderr
@@ -1,8 +1,8 @@
-error[E0599]: no method named `clone` found for struct `Struct<A>` in the current scope
+error[E0599]: the method `clone` exists for struct `Struct<A>`, but its trait bounds were not satisfied
   --> $DIR/issue-69725.rs:7:32
    |
 LL |     let _ = Struct::<A>::new().clone();
-   |                                ^^^^^ method not found in `Struct<A>`
+   |                                ^^^^^ method cannot be called on `Struct<A>` due to unsatisfied trait bounds
    | 
   ::: $DIR/auxiliary/issue-69725.rs:2:1
    |
@@ -17,7 +17,7 @@ LL |     fn clone(&self) -> Self;
    |        the method is available for `Arc<Struct<A>>` here
    |        the method is available for `Rc<Struct<A>>` here
    |
-   = note: the method `clone` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `A: Clone`
            which is required by `Struct<A>: Clone`
 

--- a/src/test/ui/methods/method-call-err-msg.rs
+++ b/src/test/ui/methods/method-call-err-msg.rs
@@ -16,7 +16,7 @@ fn main() {
 
     let y = Foo;
     y.zero()
-     .take()    //~ ERROR no method named `take` found
+     .take()    //~ ERROR the method
      .one(0);
     y.three::<usize>(); //~ ERROR this function takes 3 arguments but 0 arguments were supplied
 }

--- a/src/test/ui/methods/method-call-err-msg.stderr
+++ b/src/test/ui/methods/method-call-err-msg.stderr
@@ -40,7 +40,7 @@ note: associated function defined here
 LL |     fn two(self, _: isize, _: isize) -> Foo { self }
    |        ^^^ ----  --------  --------
 
-error[E0599]: no method named `take` found for struct `Foo` in the current scope
+error[E0599]: the method `take` exists for struct `Foo`, but its trait bounds were not satisfied
   --> $DIR/method-call-err-msg.rs:19:7
    |
 LL | pub struct Foo;
@@ -50,9 +50,9 @@ LL | pub struct Foo;
    | doesn't satisfy `Foo: Iterator`
 ...
 LL |      .take()
-   |       ^^^^ method not found in `Foo`
+   |       ^^^^ method cannot be called on `Foo` due to unsatisfied trait bounds
    |
-   = note: the method `take` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `Foo: Iterator`
            which is required by `&mut Foo: Iterator`
    = help: items from traits can only be used if the trait is implemented and in scope

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -12,7 +12,7 @@ LL |     intrinsics::size_of::<T>()
 LL |     [u8; size_of::<T>() + 1]: ,
    |          -------------- inside `Inline::<dyn Debug>::{constant#0}` at $DIR/issue-80742.rs:23:10
 
-error[E0599]: no function or associated item named `new` found for struct `Inline<dyn Debug>` in the current scope
+error[E0599]: the function or associated item `new` exists for struct `Inline<dyn Debug>`, but its trait bounds were not satisfied
   --> $DIR/issue-80742.rs:31:36
    |
 LL | / struct Inline<T>
@@ -25,14 +25,14 @@ LL | | }
    | |_- function or associated item `new` not found for this
 ...
 LL |       let dst = Inline::<dyn Debug>::new(0);
-   |                                      ^^^ function or associated item not found in `Inline<dyn Debug>`
+   |                                      ^^^ function or associated item cannot be called on `Inline<dyn Debug>` due to unsatisfied trait bounds
    | 
   ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
    |
 LL |   pub trait Debug {
    |   --------------- doesn't satisfy `dyn Debug: Sized`
    |
-   = note: the method `new` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `dyn Debug: Sized`
 
 error[E0080]: evaluation of constant value failed

--- a/src/test/ui/mismatched_types/issue-36053-2.rs
+++ b/src/test/ui/mismatched_types/issue-36053-2.rs
@@ -5,6 +5,6 @@
 use std::iter::once;
 fn main() {
     once::<&str>("str").fuse().filter(|a: &str| true).count();
-    //~^ ERROR no method named `count`
+    //~^ ERROR the method
     //~| ERROR type mismatch in closure arguments
 }

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -6,11 +6,11 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |                                |
    |                                expected signature of `for<'r> fn(&'r &str) -> _`
 
-error[E0599]: no method named `count` found for struct `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:53]>` in the current scope
+error[E0599]: the method `count` exists for struct `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:53]>`, but its trait bounds were not satisfied
   --> $DIR/issue-36053-2.rs:7:55
    |
 LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
-   |                                       --------------  ^^^^^ method not found in `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:53]>`
+   |                                       --------------  ^^^^^ method cannot be called on `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:53]>` due to unsatisfied trait bounds
    |                                       |
    |                                       doesn't satisfy `<_ as FnOnce<(&&str,)>>::Output = bool`
    |                                       doesn't satisfy `_: FnMut<(&&str,)>`
@@ -20,7 +20,7 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
 LL | pub struct Filter<I, P> {
    | ----------------------- doesn't satisfy `_: Iterator`
    |
-   = note: the method `count` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `<[closure@$DIR/issue-36053-2.rs:7:39: 7:53] as FnOnce<(&&str,)>>::Output = bool`
            which is required by `Filter<Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:53]>: Iterator`
            `[closure@$DIR/issue-36053-2.rs:7:39: 7:53]: FnMut<(&&str,)>`

--- a/src/test/ui/mismatched_types/method-help-unsatisfied-bound.rs
+++ b/src/test/ui/mismatched_types/method-help-unsatisfied-bound.rs
@@ -3,5 +3,5 @@ struct Foo;
 fn main() {
     let a: Result<(), Foo> = Ok(());
     a.unwrap();
-    //~^ ERROR no method named `unwrap` found
+    //~^ ERROR the method
 }

--- a/src/test/ui/mismatched_types/method-help-unsatisfied-bound.stderr
+++ b/src/test/ui/mismatched_types/method-help-unsatisfied-bound.stderr
@@ -1,13 +1,13 @@
-error[E0599]: no method named `unwrap` found for enum `std::result::Result<(), Foo>` in the current scope
+error[E0599]: the method `unwrap` exists for enum `std::result::Result<(), Foo>`, but its trait bounds were not satisfied
   --> $DIR/method-help-unsatisfied-bound.rs:5:7
    |
 LL | struct Foo;
    | ----------- doesn't satisfy `Foo: Debug`
 ...
 LL |     a.unwrap();
-   |       ^^^^^^ method not found in `std::result::Result<(), Foo>`
+   |       ^^^^^^ method cannot be called on `std::result::Result<(), Foo>` due to unsatisfied trait bounds
    |
-   = note: the method `unwrap` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `Foo: Debug`
 
 error: aborting due to previous error

--- a/src/test/ui/nll/issue-57642-higher-ranked-subtype.rs
+++ b/src/test/ui/nll/issue-57642-higher-ranked-subtype.rs
@@ -31,7 +31,7 @@ impl<T> Y for fn(T) {
 }
 
 fn higher_ranked_region_has_lost_its_binder() {
-    let x = <fn (&())>::make_g(); //~ ERROR no function
+    let x = <fn (&())>::make_g(); //~ ERROR the function
 }
 
 fn magical() {

--- a/src/test/ui/nll/issue-57642-higher-ranked-subtype.stderr
+++ b/src/test/ui/nll/issue-57642-higher-ranked-subtype.stderr
@@ -1,10 +1,10 @@
-error[E0599]: no function or associated item named `make_g` found for fn pointer `for<'r> fn(&'r ())` in the current scope
+error[E0599]: the function or associated item `make_g` exists for fn pointer `for<'r> fn(&'r ())`, but its trait bounds were not satisfied
   --> $DIR/issue-57642-higher-ranked-subtype.rs:34:25
    |
 LL |     let x = <fn (&())>::make_g();
-   |                         ^^^^^^ function or associated item not found in `for<'r> fn(&'r ())`
+   |                         ^^^^^^ function or associated item cannot be called on `for<'r> fn(&'r ())` due to unsatisfied trait bounds
    |
-   = note: the method `make_g` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `for<'r> fn(&'r ()): X`
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `X` defines an item `make_g`, perhaps you need to implement it

--- a/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.rs
+++ b/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.rs
@@ -20,5 +20,5 @@ default impl<T> Foo for T {
 
 fn main() {
     println!("{}", MyStruct.foo_one());
-    //~^ ERROR no method named `foo_one` found
+    //~^ ERROR the method
 }

--- a/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
@@ -8,7 +8,7 @@ LL | #![feature(specialization)]
    = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: consider using `min_specialization` instead, which is more stable and complete
 
-error[E0599]: no method named `foo_one` found for struct `MyStruct` in the current scope
+error[E0599]: the method `foo_one` exists for struct `MyStruct`, but its trait bounds were not satisfied
   --> $DIR/specialization-trait-not-implemented.rs:22:29
    |
 LL | struct MyStruct;
@@ -18,9 +18,9 @@ LL | struct MyStruct;
    | doesn't satisfy `MyStruct: Foo`
 ...
 LL |     println!("{}", MyStruct.foo_one());
-   |                             ^^^^^^^ method not found in `MyStruct`
+   |                             ^^^^^^^ method cannot be called on `MyStruct` due to unsatisfied trait bounds
    |
-   = note: the method `foo_one` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `MyStruct: Foo`
    = help: items from traits can only be used if the trait is implemented and in scope
 note: `Foo` defines an item `foo_one`, perhaps you need to implement it

--- a/src/test/ui/suggestions/missing-trait-bounds-for-method-call.rs
+++ b/src/test/ui/suggestions/missing-trait-bounds-for-method-call.rs
@@ -12,7 +12,7 @@ impl<T: Default + Bar> Bar for Foo<T> {}
 impl<T> Foo<T> {
     fn bar(&self) {
         self.foo();
-        //~^ ERROR no method named `foo` found for reference `&Foo<T>` in the current scope
+        //~^ ERROR the method
     }
 }
 
@@ -25,7 +25,7 @@ impl<T: Default + Bar> Bar for Fin<T> {}
 impl<T: Bar> Fin<T> {
     fn bar(&self) {
         self.foo();
-        //~^ ERROR no method named `foo` found for reference `&Fin<T>` in the current scope
+        //~^ ERROR the method
     }
 }
 fn main() {}

--- a/src/test/ui/suggestions/missing-trait-bounds-for-method-call.stderr
+++ b/src/test/ui/suggestions/missing-trait-bounds-for-method-call.stderr
@@ -1,13 +1,13 @@
-error[E0599]: no method named `foo` found for reference `&Foo<T>` in the current scope
+error[E0599]: the method `foo` exists for reference `&Foo<T>`, but its trait bounds were not satisfied
   --> $DIR/missing-trait-bounds-for-method-call.rs:14:14
    |
 LL | struct Foo<T> {
    | ------------- doesn't satisfy `Foo<T>: Bar`
 ...
 LL |         self.foo();
-   |              ^^^ method not found in `&Foo<T>`
+   |              ^^^ method cannot be called on `&Foo<T>` due to unsatisfied trait bounds
    |
-   = note: the method `foo` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `T: Bar`
            which is required by `Foo<T>: Bar`
            `T: Default`
@@ -17,16 +17,16 @@ help: consider restricting the type parameters to satisfy the trait bounds
 LL | struct Foo<T> where T: Bar, T: Default {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0599]: no method named `foo` found for reference `&Fin<T>` in the current scope
+error[E0599]: the method `foo` exists for reference `&Fin<T>`, but its trait bounds were not satisfied
   --> $DIR/missing-trait-bounds-for-method-call.rs:27:14
    |
 LL | struct Fin<T> where T: Bar {
    | -------------------------- doesn't satisfy `Fin<T>: Bar`
 ...
 LL |         self.foo();
-   |              ^^^ method not found in `&Fin<T>`
+   |              ^^^ method cannot be called on `&Fin<T>` due to unsatisfied trait bounds
    |
-   = note: the method `foo` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `T: Default`
            which is required by `Fin<T>: Bar`
 help: consider restricting the type parameter to satisfy the trait bound

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.rs
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.rs
@@ -19,5 +19,5 @@ fn main() {
     //~| ERROR the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
     //~| ERROR the trait bound `&dyn std::io::Write: std::io::Write` is not satisfied
 
-    writeln!(fp, "hello world").unwrap(); //~ ERROR no method named `write_fmt` found for struct
+    writeln!(fp, "hello world").unwrap(); //~ ERROR the method
 }

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -33,18 +33,18 @@ LL | pub struct BufWriter<W: Write> {
    |
    = note: `std::io::Write` is implemented for `&mut dyn std::io::Write`, but not for `&dyn std::io::Write`
 
-error[E0599]: no method named `write_fmt` found for struct `BufWriter<&dyn std::io::Write>` in the current scope
+error[E0599]: the method `write_fmt` exists for struct `BufWriter<&dyn std::io::Write>`, but its trait bounds were not satisfied
   --> $DIR/mut-borrow-needed-by-trait.rs:22:5
    |
 LL |     writeln!(fp, "hello world").unwrap();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `BufWriter<&dyn std::io::Write>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `BufWriter<&dyn std::io::Write>` due to unsatisfied trait bounds
    | 
   ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |
 LL | pub struct BufWriter<W: Write> {
    | ------------------------------ doesn't satisfy `BufWriter<&dyn std::io::Write>: std::io::Write`
    |
-   = note: the method `write_fmt` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `&dyn std::io::Write: std::io::Write`
            which is required by `BufWriter<&dyn std::io::Write>: std::io::Write`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/union/union-derive-clone.rs
+++ b/src/test/ui/union/union-derive-clone.rs
@@ -32,5 +32,5 @@ struct CloneNoCopy;
 
 fn main() {
     let u = U5 { a: ManuallyDrop::new(CloneNoCopy) };
-    let w = u.clone(); //~ ERROR no method named `clone` found for union `U5<CloneNoCopy>`
+    let w = u.clone(); //~ ERROR the method
 }

--- a/src/test/ui/union/union-derive-clone.stderr
+++ b/src/test/ui/union/union-derive-clone.stderr
@@ -11,7 +11,7 @@ LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0599]: no method named `clone` found for union `U5<CloneNoCopy>` in the current scope
+error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its trait bounds were not satisfied
   --> $DIR/union-derive-clone.rs:35:15
    |
 LL | union U5<T> {
@@ -24,7 +24,7 @@ LL | struct CloneNoCopy;
    | ------------------- doesn't satisfy `CloneNoCopy: Copy`
 ...
 LL |     let w = u.clone();
-   |               ^^^^^ method not found in `U5<CloneNoCopy>`
+   |               ^^^^^ method cannot be called on `U5<CloneNoCopy>` due to unsatisfied trait bounds
    | 
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
@@ -34,7 +34,7 @@ LL |     fn clone(&self) -> Self;
    |        the method is available for `Arc<U5<CloneNoCopy>>` here
    |        the method is available for `Rc<U5<CloneNoCopy>>` here
    |
-   = note: the method `clone` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `CloneNoCopy: Copy`
            which is required by `U5<CloneNoCopy>: Clone`
 

--- a/src/test/ui/unique-object-noncopyable.rs
+++ b/src/test/ui/unique-object-noncopyable.rs
@@ -21,5 +21,5 @@ impl Foo for Bar {
 fn main() {
     let x = box Bar { x: 10 };
     let y: Box<dyn Foo> = x as Box<dyn Foo>;
-    let _z = y.clone(); //~ ERROR no method named `clone` found
+    let _z = y.clone(); //~ ERROR the method
 }

--- a/src/test/ui/unique-object-noncopyable.stderr
+++ b/src/test/ui/unique-object-noncopyable.stderr
@@ -1,4 +1,4 @@
-error[E0599]: no method named `clone` found for struct `Box<dyn Foo>` in the current scope
+error[E0599]: the method `clone` exists for struct `Box<dyn Foo>`, but its trait bounds were not satisfied
   --> $DIR/unique-object-noncopyable.rs:24:16
    |
 LL |   trait Foo {
@@ -8,7 +8,7 @@ LL |   trait Foo {
    |   doesn't satisfy `dyn Foo: Sized`
 ...
 LL |       let _z = y.clone();
-   |                  ^^^^^ method not found in `Box<dyn Foo>`
+   |                  ^^^^^ method cannot be called on `Box<dyn Foo>` due to unsatisfied trait bounds
    | 
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
@@ -26,7 +26,7 @@ LL | |     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator 
 LL | | >(Unique<T>, A);
    | |________________- doesn't satisfy `Box<dyn Foo>: Clone`
    |
-   = note: the method `clone` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `dyn Foo: Sized`
            which is required by `Box<dyn Foo>: Clone`
            `dyn Foo: Clone`

--- a/src/test/ui/unique-pinned-nocopy.rs
+++ b/src/test/ui/unique-pinned-nocopy.rs
@@ -9,6 +9,6 @@ impl Drop for R {
 
 fn main() {
     let i = Box::new(R { b: true });
-    let _j = i.clone(); //~ ERROR no method named `clone` found
+    let _j = i.clone(); //~ ERROR the method
     println!("{:?}", i);
 }

--- a/src/test/ui/unique-pinned-nocopy.stderr
+++ b/src/test/ui/unique-pinned-nocopy.stderr
@@ -1,11 +1,11 @@
-error[E0599]: no method named `clone` found for struct `Box<R>` in the current scope
+error[E0599]: the method `clone` exists for struct `Box<R>`, but its trait bounds were not satisfied
   --> $DIR/unique-pinned-nocopy.rs:12:16
    |
 LL |   struct R {
    |   -------- doesn't satisfy `R: Clone`
 ...
 LL |       let _j = i.clone();
-   |                  ^^^^^ method not found in `Box<R>`
+   |                  ^^^^^ method cannot be called on `Box<R>` due to unsatisfied trait bounds
    | 
   ::: $SRC_DIR/core/src/clone.rs:LL:COL
    |
@@ -23,7 +23,7 @@ LL | |     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator 
 LL | | >(Unique<T>, A);
    | |________________- doesn't satisfy `Box<R>: Clone`
    |
-   = note: the method `clone` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `R: Clone`
            which is required by `Box<R>: Clone`
    = help: items from traits can only be used if the trait is implemented and in scope


### PR DESCRIPTION
Fixes #76267

When there is a single applicable method candidate, but its trait bounds
are not satisfied, we avoid saying that the method is "not found".
Insted, we update the error message to directly mention which bounds are
not satisfied, rather than mentioning them in a note.