### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -72,7 +72,7 @@ impl NonConstOp for FnCallIndirect {
 
 /// A function call where the callee is not marked as `const`.
 #[derive(Debug)]
-pub struct FnCallNonConst(pub DefId);
+pub struct FnCallNonConst;
 impl NonConstOp for FnCallNonConst {
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
         struct_span_err!(

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -929,7 +929,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 if callee_is_unstable_unmarked {
                     trace!("callee_is_unstable_unmarked");
                     // We do not use `const` modifiers for intrinsic "functions", as intrinsics are
-                    // `extern` funtions, and these have way to get marked `const`. So instead we
+                    // `extern` funtions, and these have no way to get marked `const`. So instead we
                     // use `rustc_const_(un)stable` attributes to mean that the intrinsic is `const`
                     if self.ccx.is_const_stable_const_fn() || is_intrinsic {
                         self.check_op(ops::FnCallUnstable(callee, None));

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -817,7 +817,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 // Attempting to call a trait method?
                 if let Some(trait_id) = tcx.trait_of_item(callee) {
                     if !self.tcx.features().const_trait_impl {
-                        self.check_op(ops::FnCallNonConst(callee));
+                        self.check_op(ops::FnCallNonConst);
                         return;
                     }
 
@@ -883,7 +883,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 }
 
                 if !tcx.is_const_fn_raw(callee) {
-                    self.check_op(ops::FnCallNonConst(callee));
+                    self.check_op(ops::FnCallNonConst);
                     return;
                 }
 

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -789,10 +789,10 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
         }
     }
 
+    #[instrument(skip(self))]
     fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
         use rustc_target::spec::abi::Abi::RustIntrinsic;
 
-        trace!("visit_terminator: terminator={:?} location={:?}", terminator, location);
         self.super_terminator(terminator, location);
 
         match &terminator.kind {
@@ -816,6 +816,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
 
                 // Attempting to call a trait method?
                 if let Some(trait_id) = tcx.trait_of_item(callee) {
+                    trace!("attempting to call a trait method");
                     if !self.tcx.features().const_trait_impl {
                         self.check_op(ops::FnCallNonConst);
                         return;
@@ -871,13 +872,13 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                     return;
                 }
 
+                let is_intrinsic = tcx.fn_sig(callee).abi() == RustIntrinsic;
+
                 // HACK: This is to "unstabilize" the `transmute` intrinsic
                 // within const fns. `transmute` is allowed in all other const contexts.
                 // This won't really scale to more intrinsics or functions. Let's allow const
                 // transmutes in const fn before we add more hacks to this.
-                if tcx.fn_sig(callee).abi() == RustIntrinsic
-                    && tcx.item_name(callee) == sym::transmute
-                {
+                if is_intrinsic && tcx.item_name(callee) == sym::transmute {
                     self.check_op(ops::Transmute);
                     return;
                 }
@@ -890,6 +891,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 // If the `const fn` we are trying to call is not const-stable, ensure that we have
                 // the proper feature gate enabled.
                 if let Some(gate) = is_unstable_const_fn(tcx, callee) {
+                    trace!(?gate, "calling unstable const fn");
                     if self.span.allows_unstable(gate) {
                         return;
                     }
@@ -904,12 +906,14 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                     // If this crate is not using stability attributes, or the caller is not claiming to be a
                     // stable `const fn`, that is all that is required.
                     if !self.ccx.is_const_stable_const_fn() {
+                        trace!("crate not using stability attributes or caller not stably const");
                         return;
                     }
 
                     // Otherwise, we are something const-stable calling a const-unstable fn.
 
                     if super::rustc_allow_const_fn_unstable(tcx, caller, gate) {
+                        trace!("rustc_allow_const_fn_unstable gate active");
                         return;
                     }
 
@@ -923,10 +927,16 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                 let callee_is_unstable_unmarked = tcx.lookup_const_stability(callee).is_none()
                     && tcx.lookup_stability(callee).map_or(false, |s| s.level.is_unstable());
                 if callee_is_unstable_unmarked {
-                    if self.ccx.is_const_stable_const_fn() {
+                    trace!("callee_is_unstable_unmarked");
+                    // We do not use `const` modifiers for intrinsic "functions", as intrinsics are
+                    // `extern` funtions, and these have way to get marked `const`. So instead we
+                    // use `rustc_const_(un)stable` attributes to mean that the intrinsic is `const`
+                    if self.ccx.is_const_stable_const_fn() || is_intrinsic {
                         self.check_op(ops::FnCallUnstable(callee, None));
+                        return;
                     }
                 }
+                trace!("permitting call");
             }
 
             // Forbid all `Drop` terminators unless the place being dropped is a local with no

--- a/compiler/rustc_mir/src/transform/check_unsafety.rs
+++ b/compiler/rustc_mir/src/transform/check_unsafety.rs
@@ -580,24 +580,23 @@ fn is_enclosed(
     tcx: TyCtxt<'_>,
     used_unsafe: &FxHashSet<hir::HirId>,
     id: hir::HirId,
-) -> Option<(String, hir::HirId)> {
+    unsafe_op_in_unsafe_fn_allowed: bool,
+) -> Option<(&'static str, hir::HirId)> {
     let parent_id = tcx.hir().get_parent_node(id);
     if parent_id != id {
         if used_unsafe.contains(&parent_id) {
-            Some(("block".to_string(), parent_id))
+            Some(("block", parent_id))
         } else if let Some(Node::Item(&hir::Item {
             kind: hir::ItemKind::Fn(ref sig, _, _), ..
         })) = tcx.hir().find(parent_id)
         {
-            if sig.header.unsafety == hir::Unsafety::Unsafe
-                && !tcx.features().unsafe_block_in_unsafe_fn
-            {
-                Some(("fn".to_string(), parent_id))
+            if sig.header.unsafety == hir::Unsafety::Unsafe && unsafe_op_in_unsafe_fn_allowed {
+                Some(("fn", parent_id))
             } else {
                 None
             }
         } else {
-            is_enclosed(tcx, used_unsafe, parent_id)
+            is_enclosed(tcx, used_unsafe, parent_id, unsafe_op_in_unsafe_fn_allowed)
         }
     } else {
         None
@@ -610,7 +609,9 @@ fn report_unused_unsafe(tcx: TyCtxt<'_>, used_unsafe: &FxHashSet<hir::HirId>, id
         let msg = "unnecessary `unsafe` block";
         let mut db = lint.build(msg);
         db.span_label(span, msg);
-        if let Some((kind, id)) = is_enclosed(tcx, used_unsafe, id) {
+        if let Some((kind, id)) =
+            is_enclosed(tcx, used_unsafe, id, unsafe_op_in_unsafe_fn_allowed(tcx, id))
+        {
             db.span_label(
                 tcx.sess.source_map().guess_head_span(tcx.hir().span(id)),
                 format!("because it's nested under this `unsafe` {}", kind),

--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -55,7 +55,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // * the bindings from the previous iteration of the loop is prepended to the bindings from
         // the current iteration (in the implementation this is done by mem::swap and extend)
         // * after all iterations, these new bindings are then appended to the bindings that were
-        // prexisting (i.e. `candidate.binding` when the function was called).
+        // preexisting (i.e. `candidate.binding` when the function was called).
         //
         // example:
         // candidate.bindings = [1, 2, 3]

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -55,6 +55,21 @@ impl InheritDeprecation {
     }
 }
 
+/// Whether to inherit const stability flags for nested items. In most cases, we do not want to
+/// inherit const stability: just because an enclosing `fn` is const-stable does not mean
+/// all `extern` imports declared in it should be const-stable! However, trait methods
+/// inherit const stability attributes from their parent and do not have their own.
+enum InheritConstStability {
+    Yes,
+    No,
+}
+
+impl InheritConstStability {
+    fn yes(&self) -> bool {
+        matches!(self, InheritConstStability::Yes)
+    }
+}
+
 // A private tree-walker for producing an Index.
 struct Annotator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -75,6 +90,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         item_sp: Span,
         kind: AnnotationKind,
         inherit_deprecation: InheritDeprecation,
+        inherit_const_stability: InheritConstStability,
         visit_children: F,
     ) where
         F: FnOnce(&mut Self),
@@ -140,6 +156,8 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             const_stab
         });
 
+        // `impl const Trait for Type` items forward their const stability to their
+        // immediate children.
         if const_stab.is_none() {
             debug!("annotate: const_stab not found, parent = {:?}", self.parent_const_stab);
             if let Some(parent) = self.parent_const_stab {
@@ -228,7 +246,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         self.recurse_with_stability_attrs(
             depr.map(|(d, _)| DeprecationEntry::local(d, hir_id)),
             stab,
-            const_stab,
+            if inherit_const_stability.yes() { const_stab } else { None },
             visit_children,
         );
     }
@@ -325,6 +343,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     fn visit_item(&mut self, i: &'tcx Item<'tcx>) {
         let orig_in_trait_impl = self.in_trait_impl;
         let mut kind = AnnotationKind::Required;
+        let mut const_stab_inherit = InheritConstStability::No;
         match i.kind {
             // Inherent impls and foreign modules serve only as containers for other items,
             // they don't have their own stability. They still can be annotated as unstable
@@ -338,6 +357,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             hir::ItemKind::Impl(hir::Impl { of_trait: Some(_), .. }) => {
                 self.in_trait_impl = true;
                 kind = AnnotationKind::DeprecationProhibited;
+                const_stab_inherit = InheritConstStability::Yes;
             }
             hir::ItemKind::Struct(ref sd, _) => {
                 if let Some(ctor_hir_id) = sd.ctor_hir_id() {
@@ -347,6 +367,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         i.span,
                         AnnotationKind::Required,
                         InheritDeprecation::Yes,
+                        InheritConstStability::No,
                         |_| {},
                     )
                 }
@@ -354,9 +375,15 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => {}
         }
 
-        self.annotate(i.hir_id, &i.attrs, i.span, kind, InheritDeprecation::Yes, |v| {
-            intravisit::walk_item(v, i)
-        });
+        self.annotate(
+            i.hir_id,
+            &i.attrs,
+            i.span,
+            kind,
+            InheritDeprecation::Yes,
+            const_stab_inherit,
+            |v| intravisit::walk_item(v, i),
+        );
         self.in_trait_impl = orig_in_trait_impl;
     }
 
@@ -367,6 +394,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             ti.span,
             AnnotationKind::Required,
             InheritDeprecation::Yes,
+            InheritConstStability::No,
             |v| {
                 intravisit::walk_trait_item(v, ti);
             },
@@ -376,9 +404,17 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
     fn visit_impl_item(&mut self, ii: &'tcx hir::ImplItem<'tcx>) {
         let kind =
             if self.in_trait_impl { AnnotationKind::Prohibited } else { AnnotationKind::Required };
-        self.annotate(ii.hir_id, &ii.attrs, ii.span, kind, InheritDeprecation::Yes, |v| {
-            intravisit::walk_impl_item(v, ii);
-        });
+        self.annotate(
+            ii.hir_id,
+            &ii.attrs,
+            ii.span,
+            kind,
+            InheritDeprecation::Yes,
+            InheritConstStability::No,
+            |v| {
+                intravisit::walk_impl_item(v, ii);
+            },
+        );
     }
 
     fn visit_variant(&mut self, var: &'tcx Variant<'tcx>, g: &'tcx Generics<'tcx>, item_id: HirId) {
@@ -388,6 +424,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             var.span,
             AnnotationKind::Required,
             InheritDeprecation::Yes,
+            InheritConstStability::No,
             |v| {
                 if let Some(ctor_hir_id) = var.data.ctor_hir_id() {
                     v.annotate(
@@ -396,6 +433,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
                         var.span,
                         AnnotationKind::Required,
                         InheritDeprecation::Yes,
+                        InheritConstStability::No,
                         |_| {},
                     );
                 }
@@ -412,6 +450,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             s.span,
             AnnotationKind::Required,
             InheritDeprecation::Yes,
+            InheritConstStability::No,
             |v| {
                 intravisit::walk_struct_field(v, s);
             },
@@ -425,6 +464,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             i.span,
             AnnotationKind::Required,
             InheritDeprecation::Yes,
+            InheritConstStability::No,
             |v| {
                 intravisit::walk_foreign_item(v, i);
             },
@@ -438,6 +478,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             md.span,
             AnnotationKind::Required,
             InheritDeprecation::Yes,
+            InheritConstStability::No,
             |_| {},
         );
     }
@@ -451,9 +492,17 @@ impl<'a, 'tcx> Visitor<'tcx> for Annotator<'a, 'tcx> {
             _ => AnnotationKind::Prohibited,
         };
 
-        self.annotate(p.hir_id, &p.attrs, p.span, kind, InheritDeprecation::No, |v| {
-            intravisit::walk_generic_param(v, p);
-        });
+        self.annotate(
+            p.hir_id,
+            &p.attrs,
+            p.span,
+            kind,
+            InheritDeprecation::No,
+            InheritConstStability::No,
+            |v| {
+                intravisit::walk_generic_param(v, p);
+            },
+        );
     }
 }
 
@@ -618,6 +667,7 @@ fn new_index(tcx: TyCtxt<'tcx>) -> Index<'tcx> {
             krate.item.span,
             AnnotationKind::Required,
             InheritDeprecation::Yes,
+            InheritConstStability::No,
             |v| intravisit::walk_crate(v, krate),
         );
     }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1163,7 +1163,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 debug!("instantiate_value_path: def_id={:?} container={:?}", def_id, container);
                 match container {
                     ty::TraitContainer(trait_did) => {
-                        callee::check_legal_trait_for_method_call(tcx, span, None, trait_did)
+                        callee::check_legal_trait_for_method_call(tcx, span, None, span, trait_did)
                     }
                     ty::ImplContainer(impl_def_id) => {
                         if segments.len() == 1 {

--- a/compiler/rustc_typeck/src/check/method/confirm.rs
+++ b/compiler/rustc_typeck/src/check/method/confirm.rs
@@ -507,6 +507,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 self.tcx,
                 self.span,
                 Some(self.self_expr.span),
+                self.call_expr.span,
                 trait_def_id,
             ),
             ty::ImplContainer(..) => {}

--- a/library/alloc/src/collections/btree/remove.rs
+++ b/library/alloc/src/collections/btree/remove.rs
@@ -121,25 +121,25 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::Mut<'a>, K, V, marker::Internal> {
         self,
     ) -> Option<NodeRef<marker::Mut<'a>, K, V, marker::Internal>> {
         match self.forget_type().choose_parent_kv() {
-            Ok(Left(left_parent_kv)) => {
+            Ok(Left(mut left_parent_kv)) => {
                 debug_assert_eq!(left_parent_kv.right_child_len(), MIN_LEN - 1);
                 if left_parent_kv.can_merge() {
                     let parent = left_parent_kv.merge_tracking_parent();
                     Some(parent)
                 } else {
                     debug_assert!(left_parent_kv.left_child_len() > MIN_LEN);
-                    left_parent_kv.steal_left(0);
+                    left_parent_kv.bulk_steal_left(1);
                     None
                 }
             }
-            Ok(Right(right_parent_kv)) => {
+            Ok(Right(mut right_parent_kv)) => {
                 debug_assert_eq!(right_parent_kv.left_child_len(), MIN_LEN - 1);
                 if right_parent_kv.can_merge() {
                     let parent = right_parent_kv.merge_tracking_parent();
                     Some(parent)
                 } else {
                     debug_assert!(right_parent_kv.right_child_len() > MIN_LEN);
-                    right_parent_kv.steal_right(0);
+                    right_parent_kv.bulk_steal_right(1);
                     None
                 }
             }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1842,6 +1842,7 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 #[inline]
 pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
+        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 
@@ -1926,6 +1927,7 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 #[inline]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
+        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
         fn copy<T>(src: *const T, dst: *mut T, count: usize);
     }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -126,6 +126,7 @@
 #![feature(auto_traits)]
 #![feature(or_patterns)]
 #![feature(prelude_import)]
+#![feature(raw_ref_macros)]
 #![feature(repr_simd, platform_intrinsics)]
 #![feature(rustc_attrs)]
 #![feature(simd_ffi)]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -633,7 +633,7 @@ impl<T: ?Sized> *const T {
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
-    /// (convenience for `.wrapping_offset((count as isize).wrapping_sub())`)
+    /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
     ///
     /// `count` is in units of T; e.g., a `count` of 3 represents a pointer
     /// offset of `3 * size_of::<T>()` bytes.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -687,7 +687,6 @@ pub unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_ptr_read", issue = "80377")]
 pub const unsafe fn read<T>(src: *const T) -> T {
-    // `copy_nonoverlapping` takes care of debug_assert.
     let mut tmp = MaybeUninit::<T>::uninit();
     // SAFETY: the caller must guarantee that `src` is valid for reads.
     // `src` cannot overlap `tmp` because `tmp` was just allocated on
@@ -787,7 +786,6 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
 #[rustc_const_unstable(feature = "const_ptr_read", issue = "80377")]
 pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
-    // `copy_nonoverlapping` takes care of debug_assert.
     let mut tmp = MaybeUninit::<T>::uninit();
     // SAFETY: the caller must guarantee that `src` is valid for reads.
     // `src` cannot overlap `tmp` because `tmp` was just allocated on
@@ -988,7 +986,6 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
     // `dst` cannot overlap `src` because the caller has mutable access
     // to `dst` while `src` is owned by this function.
     unsafe {
-        // `copy_nonoverlapping` takes care of debug_assert.
         copy_nonoverlapping(&src as *const T as *const u8, dst as *mut u8, mem::size_of::<T>());
     }
     mem::forget(src);

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -740,7 +740,7 @@ impl<T: ?Sized> *mut T {
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
-    /// (convenience for `.wrapping_offset((count as isize).wrapping_sub())`)
+    /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
     ///
     /// `count` is in units of T; e.g., a `count` of 3 represents a pointer
     /// offset of `3 * size_of::<T>()` bytes.

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -542,10 +542,9 @@ impl<T> [T] {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn swap(&mut self, a: usize, b: usize) {
-        // Can't take two mutable loans from one vector, so instead just cast
-        // them to their raw pointers to do the swap.
-        let pa: *mut T = &mut self[a];
-        let pb: *mut T = &mut self[b];
+        // Can't take two mutable loans from one vector, so instead use raw pointers.
+        let pa = ptr::raw_mut!(self[a]);
+        let pb = ptr::raw_mut!(self[b]);
         // SAFETY: `pa` and `pb` have been created from safe mutable references and refer
         // to elements in the slice and therefore are guaranteed to be valid and aligned.
         // Note that accessing the elements behind `a` and `b` is checked and will

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -111,10 +111,7 @@ crate fn render<T: Print, S: Print>(
     <section id=\"search\" class=\"content hidden\"></section>\
     <section class=\"footer\"></section>\
     {after_content}\
-    <script>\
-        window.rootPath = \"{root_path}\";\
-        window.currentCrate = \"{krate}\";\
-    </script>\
+    <div id=\"rustdoc-vars\" data-root-path=\"{root_path}\" data-current-crate=\"{krate}\"></div>
     <script src=\"{static_root_path}main{suffix}.js\"></script>\
     {static_extra_scripts}\
     {extra_scripts}\

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1313,6 +1313,8 @@ fn init_id_map() -> FxHashMap<String, usize> {
     map.insert("toggle-all-docs".to_owned(), 1);
     map.insert("all-types".to_owned(), 1);
     map.insert("default-settings".to_owned(), 1);
+    map.insert("rustdoc-vars".to_owned(), 1);
+    map.insert("sidebar-vars".to_owned(), 1);
     // This is the list of IDs used by rustdoc sections.
     map.insert("fields".to_owned(), 1);
     map.insert("variants".to_owned(), 1);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -4216,11 +4216,8 @@ fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer, cache:
     let relpath = if it.is_mod() { "../" } else { "" };
     write!(
         buffer,
-        "<script>window.sidebarCurrent = {{\
-                name: \"{name}\", \
-                ty: \"{ty}\", \
-                relpath: \"{path}\"\
-            }};</script>",
+        "<div id=\"sidebar-vars\" data-name=\"{name}\" data-ty=\"{ty}\" data-relpath=\"{path}\">\
+        </div>",
         name = it.name.unwrap_or(kw::Empty),
         ty = it.type_(),
         path = relpath

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1,5 +1,5 @@
 // From rust:
-/* global ALIASES, currentCrate, rootPath */
+/* global ALIASES */
 
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass */
@@ -40,6 +40,21 @@ if (!DOMTokenList.prototype.remove) {
     };
 }
 
+(function () {
+    var rustdocVars = document.getElementById("rustdoc-vars");
+    if (rustdocVars) {
+        window.rootPath = rustdocVars.attributes["data-root-path"].value;
+        window.currentCrate = rustdocVars.attributes["data-current-crate"].value;
+    }
+    var sidebarVars = document.getElementById("sidebar-vars");
+    if (sidebarVars) {
+        window.sidebarCurrent = {
+            name: sidebarVars.attributes["data-name"].value,
+            ty: sidebarVars.attributes["data-ty"].value,
+            relpath: sidebarVars.attributes["data-relpath"].value,
+        };
+    }
+}());
 
 // Gets the human-readable string for the virtual-key code of the
 // given KeyboardEvent, ev.
@@ -565,7 +580,7 @@ function defocusSearchBar() {
                 var i, match,
                     url = document.location.href,
                     stripped = "",
-                    len = rootPath.match(/\.\.\//g).length + 1;
+                    len = window.rootPath.match(/\.\.\//g).length + 1;
 
                 for (i = 0; i < len; ++i) {
                     match = url.match(/\/[^\/]*$/);
@@ -1504,15 +1519,15 @@ function defocusSearchBar() {
 
             if (type === "mod") {
                 displayPath = path + "::";
-                href = rootPath + path.replace(/::/g, "/") + "/" +
+                href = window.rootPath + path.replace(/::/g, "/") + "/" +
                        name + "/index.html";
             } else if (type === "primitive" || type === "keyword") {
                 displayPath = "";
-                href = rootPath + path.replace(/::/g, "/") +
+                href = window.rootPath + path.replace(/::/g, "/") +
                        "/" + type + "." + name + ".html";
             } else if (type === "externcrate") {
                 displayPath = "";
-                href = rootPath + name + "/index.html";
+                href = window.rootPath + name + "/index.html";
             } else if (item.parent !== undefined) {
                 var myparent = item.parent;
                 var anchor = "#" + type + "." + name;
@@ -1535,13 +1550,13 @@ function defocusSearchBar() {
                 } else {
                     displayPath = path + "::" + myparent.name + "::";
                 }
-                href = rootPath + path.replace(/::/g, "/") +
+                href = window.rootPath + path.replace(/::/g, "/") +
                        "/" + pageType +
                        "." + pageName +
                        ".html" + anchor;
             } else {
                 displayPath = item.path + "::";
-                href = rootPath + item.path.replace(/::/g, "/") +
+                href = window.rootPath + item.path.replace(/::/g, "/") +
                        "/" + type + "." + name + ".html";
             }
             return [displayPath, href];
@@ -1973,7 +1988,7 @@ function defocusSearchBar() {
         startSearch();
 
         // Draw a convenient sidebar of known crates if we have a listing
-        if (rootPath === "../" || rootPath === "./") {
+        if (window.rootPath === "../" || window.rootPath === "./") {
             var sidebar = document.getElementsByClassName("sidebar-elems")[0];
             if (sidebar) {
                 var div = document.createElement("div");
@@ -1992,11 +2007,11 @@ function defocusSearchBar() {
                 crates.sort();
                 for (var i = 0; i < crates.length; ++i) {
                     var klass = "crate";
-                    if (rootPath !== "./" && crates[i] === window.currentCrate) {
+                    if (window.rootPath !== "./" && crates[i] === window.currentCrate) {
                         klass += " current";
                     }
                     var link = document.createElement("a");
-                    link.href = rootPath + crates[i] + "/index.html";
+                    link.href = window.rootPath + crates[i] + "/index.html";
                     // The summary in the search index has HTML, so we need to
                     // dynamically render it as plaintext.
                     link.title = convertHTMLToPlaintext(rawSearchIndex[crates[i]].doc);
@@ -2118,7 +2133,7 @@ function defocusSearchBar() {
 
         var libs = Object.getOwnPropertyNames(imp);
         for (var i = 0, llength = libs.length; i < llength; ++i) {
-            if (libs[i] === currentCrate) { continue; }
+            if (libs[i] === window.currentCrate) { continue; }
             var structs = imp[libs[i]];
 
             struct_loop:
@@ -2143,7 +2158,7 @@ function defocusSearchBar() {
                     var href = elem.getAttribute("href");
 
                     if (href && href.indexOf("http") !== 0) {
-                        elem.setAttribute("href", rootPath + href);
+                        elem.setAttribute("href", window.rootPath + href);
                     }
                 });
 

--- a/src/test/ui/consts/intrinsic_without_const_stab.rs
+++ b/src/test/ui/consts/intrinsic_without_const_stab.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 #![feature(intrinsics, staged_api, const_intrinsic_copy)]
 #![stable(feature = "core", since = "1.6.0")]
 
@@ -7,14 +5,13 @@
 #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
 #[inline]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+    // Const stability attributes are not inherited from parent items.
     extern "rust-intrinsic" {
         fn copy<T>(src: *const T, dst: *mut T, count: usize);
     }
 
-    // Even though the `copy` intrinsic lacks stability attributes, this works, because it
-    // inherits its stability attributes from its parent. That includes `rustc_const_(un)stable`
-    // attributes.
     unsafe { copy(src, dst, count) }
+    //~^ ERROR calls in constant functions are limited to constant functions
 }
 
 fn main() {}

--- a/src/test/ui/consts/intrinsic_without_const_stab.rs
+++ b/src/test/ui/consts/intrinsic_without_const_stab.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+#![feature(intrinsics, staged_api, const_intrinsic_copy)]
+#![stable(feature = "core", since = "1.6.0")]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+#[inline]
+pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+    extern "rust-intrinsic" {
+        fn copy<T>(src: *const T, dst: *mut T, count: usize);
+    }
+
+    // Even though the `copy` intrinsic lacks stability attributes, this works, because it
+    // inherits its stability attributes from its parent. That includes `rustc_const_(un)stable`
+    // attributes.
+    unsafe { copy(src, dst, count) }
+}
+
+fn main() {}

--- a/src/test/ui/consts/intrinsic_without_const_stab.stderr
+++ b/src/test/ui/consts/intrinsic_without_const_stab.stderr
@@ -1,0 +1,9 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/intrinsic_without_const_stab.rs:13:14
+   |
+LL |     unsafe { copy(src, dst, count) }
+   |              ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/consts/intrinsic_without_const_stab_fail.rs
+++ b/src/test/ui/consts/intrinsic_without_const_stab_fail.rs
@@ -1,0 +1,15 @@
+#![feature(intrinsics, staged_api, const_intrinsic_copy)]
+#![stable(feature = "core", since = "1.6.0")]
+
+extern "rust-intrinsic" {
+    fn copy<T>(src: *const T, dst: *mut T, count: usize);
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+#[inline]
+pub const unsafe fn stuff<T>(src: *const T, dst: *mut T, count: usize) {
+    unsafe { copy(src, dst, count) } //~ ERROR calls in constant functions are limited
+}
+
+fn main() {}

--- a/src/test/ui/consts/intrinsic_without_const_stab_fail.stderr
+++ b/src/test/ui/consts/intrinsic_without_const_stab_fail.stderr
@@ -1,0 +1,9 @@
+error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/intrinsic_without_const_stab_fail.rs:12:14
+   |
+LL |     unsafe { copy(src, dst, count) }
+   |              ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -32,11 +32,11 @@ LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |
 help: include the missing field in the pattern
    |
-LL |     Struct { a, b, _ } = Struct { a: 1, b: 2 };
+LL |     Struct { a, b _ } = Struct { a: 1, b: 2 };
    |               ^^^
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL |     Struct { a, .., _ } = Struct { a: 1, b: 2 };
+LL |     Struct { a, .. _ } = Struct { a: 1, b: 2 };
    |               ^^^^
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/error-codes/E0027.rs
+++ b/src/test/ui/error-codes/E0027.rs
@@ -3,11 +3,20 @@ struct Dog {
     age: u32,
 }
 
+
 fn main() {
     let d = Dog { name: "Rusty".to_string(), age: 8 };
 
     match d {
         Dog { age: x } => {} //~ ERROR pattern does not mention field `name`
+    }
+    match d {
+        // trailing comma
+        Dog { name: x, } => {} //~ ERROR pattern does not mention field `age`
+    }
+    match d {
+        // trailing comma with weird whitespace
+        Dog { name: x  , } => {} //~ ERROR pattern does not mention field `age`
     }
     match d {
         Dog {} => {} //~ ERROR pattern does not mention fields `name`, `age`

--- a/src/test/ui/error-codes/E0027.stderr
+++ b/src/test/ui/error-codes/E0027.stderr
@@ -1,5 +1,5 @@
 error[E0027]: pattern does not mention field `name`
-  --> $DIR/E0027.rs:10:9
+  --> $DIR/E0027.rs:11:9
    |
 LL |         Dog { age: x } => {}
    |         ^^^^^^^^^^^^^^ missing field `name`
@@ -13,8 +13,38 @@ help: if you don't care about this missing field, you can explicitly ignore it
 LL |         Dog { age: x, .. } => {}
    |                     ^^^^
 
+error[E0027]: pattern does not mention field `age`
+  --> $DIR/E0027.rs:15:9
+   |
+LL |         Dog { name: x, } => {}
+   |         ^^^^^^^^^^^^^^^^ missing field `age`
+   |
+help: include the missing field in the pattern
+   |
+LL |         Dog { name: x, age } => {}
+   |                      ^^^^^
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+LL |         Dog { name: x, .. } => {}
+   |                      ^^^^
+
+error[E0027]: pattern does not mention field `age`
+  --> $DIR/E0027.rs:19:9
+   |
+LL |         Dog { name: x  , } => {}
+   |         ^^^^^^^^^^^^^^^^^^ missing field `age`
+   |
+help: include the missing field in the pattern
+   |
+LL |         Dog { name: x, age } => {}
+   |                      ^^^^^
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+LL |         Dog { name: x, .. } => {}
+   |                      ^^^^
+
 error[E0027]: pattern does not mention fields `name`, `age`
-  --> $DIR/E0027.rs:13:9
+  --> $DIR/E0027.rs:22:9
    |
 LL |         Dog {} => {}
    |         ^^^^^^ missing fields `name`, `age`
@@ -28,6 +58,6 @@ help: if you don't care about these missing fields, you can explicitly ignore th
 LL |         Dog { .. } => {}
    |             ^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0027`.

--- a/src/test/ui/error-codes/E0040.fixed
+++ b/src/test/ui/error-codes/E0040.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 struct Foo {
-    x: isize
+    x: i32,
 }
 
 impl Drop for Foo {
@@ -10,7 +10,9 @@ impl Drop for Foo {
 }
 
 fn main() {
-    let x = Foo { x: 3 };
+    let mut x = Foo { x: -7 };
+    x.x = 0;
     println!("{}", x.x);
-    x.drop();   //~ ERROR explicit use of destructor method
+    drop(x);
+    //~^ ERROR E0040
 }

--- a/src/test/ui/error-codes/E0040.rs
+++ b/src/test/ui/error-codes/E0040.rs
@@ -1,3 +1,4 @@
+// run-rustfix
 struct Foo {
     x: i32,
 }
@@ -10,6 +11,8 @@ impl Drop for Foo {
 
 fn main() {
     let mut x = Foo { x: -7 };
+    x.x = 0;
+    println!("{}", x.x);
     x.drop();
     //~^ ERROR E0040
 }

--- a/src/test/ui/error-codes/E0040.stderr
+++ b/src/test/ui/error-codes/E0040.stderr
@@ -1,11 +1,11 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/E0040.rs:13:7
+  --> $DIR/E0040.rs:16:7
    |
 LL |     x.drop();
-   |       ^^^^
-   |       |
-   |       explicit destructor calls not allowed
-   |       help: consider using `drop` function: `drop(x)`
+   |     --^^^^--
+   |     | |
+   |     | explicit destructor calls not allowed
+   |     help: consider using `drop` function: `drop(x)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/explicit/explicit-call-to-dtor.fixed
+++ b/src/test/ui/explicit/explicit-call-to-dtor.fixed
@@ -12,5 +12,5 @@ impl Drop for Foo {
 fn main() {
     let x = Foo { x: 3 };
     println!("{}", x.x);
-    x.drop();   //~ ERROR explicit use of destructor method
+    drop(x);   //~ ERROR explicit use of destructor method
 }

--- a/src/test/ui/explicit/explicit-call-to-dtor.stderr
+++ b/src/test/ui/explicit/explicit-call-to-dtor.stderr
@@ -1,11 +1,11 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/explicit-call-to-dtor.rs:13:7
+  --> $DIR/explicit-call-to-dtor.rs:15:7
    |
 LL |     x.drop();
-   |       ^^^^
-   |       |
-   |       explicit destructor calls not allowed
-   |       help: consider using `drop` function: `drop(x)`
+   |     --^^^^--
+   |     | |
+   |     | explicit destructor calls not allowed
+   |     help: consider using `drop` function: `drop(x)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/explicit/explicit-call-to-supertrait-dtor.fixed
+++ b/src/test/ui/explicit/explicit-call-to-supertrait-dtor.fixed
@@ -3,14 +3,24 @@ struct Foo {
     x: isize
 }
 
+#[allow(drop_bounds)]
+trait Bar: Drop {
+    fn blah(&self);
+}
+
 impl Drop for Foo {
     fn drop(&mut self) {
         println!("kaboom");
     }
 }
 
+impl Bar for Foo {
+    fn blah(&self) {
+        drop(self);    //~ ERROR explicit use of destructor method
+    }
+}
+
 fn main() {
     let x = Foo { x: 3 };
     println!("{}", x.x);
-    x.drop();   //~ ERROR explicit use of destructor method
 }

--- a/src/test/ui/explicit/explicit-call-to-supertrait-dtor.rs
+++ b/src/test/ui/explicit/explicit-call-to-supertrait-dtor.rs
@@ -1,8 +1,10 @@
+// run-rustfix
 struct Foo {
     x: isize
 }
 
-trait Bar : Drop {
+#[allow(drop_bounds)]
+trait Bar: Drop {
     fn blah(&self);
 }
 
@@ -20,4 +22,5 @@ impl Bar for Foo {
 
 fn main() {
     let x = Foo { x: 3 };
+    println!("{}", x.x);
 }

--- a/src/test/ui/explicit/explicit-call-to-supertrait-dtor.stderr
+++ b/src/test/ui/explicit/explicit-call-to-supertrait-dtor.stderr
@@ -1,11 +1,11 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/explicit-call-to-supertrait-dtor.rs:17:14
+  --> $DIR/explicit-call-to-supertrait-dtor.rs:19:14
    |
 LL |         self.drop();
-   |              ^^^^
-   |              |
-   |              explicit destructor calls not allowed
-   |              help: consider using `drop` function: `drop(self)`
+   |         -----^^^^--
+   |         |    |
+   |         |    explicit destructor calls not allowed
+   |         help: consider using `drop` function: `drop(self)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/illegal-ufcs-drop.fixed
+++ b/src/test/ui/illegal-ufcs-drop.fixed
@@ -6,5 +6,5 @@ impl Drop for Foo {
 }
 
 fn main() {
-    Drop::drop(&mut Foo) //~ ERROR explicit use of destructor method
+    drop(&mut Foo) //~ ERROR explicit use of destructor method
 }

--- a/src/test/ui/illegal-ufcs-drop.stderr
+++ b/src/test/ui/illegal-ufcs-drop.stderr
@@ -1,5 +1,5 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/illegal-ufcs-drop.rs:8:5
+  --> $DIR/illegal-ufcs-drop.rs:9:5
    |
 LL |     Drop::drop(&mut Foo)
    |     ^^^^^^^^^^

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.rs
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.rs
@@ -13,6 +13,9 @@ unsafe fn deny_level() {
     //~^ ERROR dereference of raw pointer is unsafe and requires unsafe block
     VOID = ();
     //~^ ERROR use of mutable static is unsafe and requires unsafe block
+
+    unsafe {}
+    //~^ ERROR unnecessary `unsafe` block
 }
 
 // Check that `unsafe_op_in_unsafe_fn` works starting from the `warn` level.
@@ -25,6 +28,8 @@ unsafe fn warning_level() {
     //~^ ERROR dereference of raw pointer is unsafe and requires unsafe block
     VOID = ();
     //~^ ERROR use of mutable static is unsafe and requires unsafe block
+    unsafe {}
+    //~^ ERROR unnecessary `unsafe` block
 }
 
 unsafe fn explicit_block() {

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.stderr
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.stderr
@@ -27,43 +27,11 @@ LL |     VOID = ();
    |
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
-error: call to unsafe function is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:22:5
-   |
-LL |     unsf();
-   |     ^^^^^^ call to unsafe function
-   |
-note: the lint level is defined here
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:20:8
-   |
-LL | #[deny(warnings)]
-   |        ^^^^^^^^
-   = note: `#[deny(unsafe_op_in_unsafe_fn)]` implied by `#[deny(warnings)]`
-   = note: consult the function's documentation for information on how to avoid undefined behavior
-
-error: dereference of raw pointer is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:24:5
-   |
-LL |     *PTR;
-   |     ^^^^ dereference of raw pointer
-   |
-   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
-
-error: use of mutable static is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:26:5
-   |
-LL |     VOID = ();
-   |     ^^^^^^^^^ use of mutable static
-   |
-   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
-
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:40:14
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:17:5
    |
-LL |     unsafe { unsafe { unsf() } }
-   |     ------   ^^^^^^ unnecessary `unsafe` block
-   |     |
-   |     because it's nested under this `unsafe` block
+LL |     unsafe {}
+   |     ^^^^^^ unnecessary `unsafe` block
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:3:9
@@ -71,20 +39,70 @@ note: the lint level is defined here
 LL | #![deny(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
-error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:51:5
+error: call to unsafe function is unsafe and requires unsafe block (error E0133)
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:25:5
    |
+LL |     unsf();
+   |     ^^^^^^ call to unsafe function
+   |
+note: the lint level is defined here
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:23:8
+   |
+LL | #[deny(warnings)]
+   |        ^^^^^^^^
+   = note: `#[deny(unsafe_op_in_unsafe_fn)]` implied by `#[deny(warnings)]`
+   = note: consult the function's documentation for information on how to avoid undefined behavior
+
+error: dereference of raw pointer is unsafe and requires unsafe block (error E0133)
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:27:5
+   |
+LL |     *PTR;
+   |     ^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: use of mutable static is unsafe and requires unsafe block (error E0133)
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:29:5
+   |
+LL |     VOID = ();
+   |     ^^^^^^^^^ use of mutable static
+   |
+   = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
+
+error: unnecessary `unsafe` block
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:31:5
+   |
+LL |     unsafe {}
+   |     ^^^^^^ unnecessary `unsafe` block
+
+error: unnecessary `unsafe` block
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:45:14
+   |
+LL |     unsafe { unsafe { unsf() } }
+   |     ------   ^^^^^^ unnecessary `unsafe` block
+   |     |
+   |     because it's nested under this `unsafe` block
+
+error: unnecessary `unsafe` block
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:56:5
+   |
+LL | unsafe fn allow_level() {
+   | ----------------------- because it's nested under this `unsafe` fn
+...
 LL |     unsafe { unsf() }
    |     ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:63:9
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:68:9
    |
+LL | unsafe fn nested_allow_level() {
+   | ------------------------------ because it's nested under this `unsafe` fn
+...
 LL |         unsafe { unsf() }
    |         ^^^^^^ unnecessary `unsafe` block
 
 error[E0133]: call to unsafe function is unsafe and requires unsafe block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:69:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:74:5
    |
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
@@ -92,13 +110,13 @@ LL |     unsf();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:73:9
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:78:9
    |
 LL |         unsf();
    |         ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error: aborting due to 11 previous errors
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0133`.

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -263,8 +263,7 @@ function loadMainJsAndIndex(mainJs, searchIndex, storageJs, crate) {
                            "handleAliases", "getQuery", "buildIndex", "execQuery", "execSearch"];
 
     ALIASES = {};
-    finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
-    finalJS += 'var rootPath = "../";\n';
+    finalJS += 'window = { "currentCrate": "' + crate + '", rootPath: "../" };\n';
     finalJS += loadThings(["hasOwnProperty", "onEach"], 'function', extractFunction, storageJs);
     finalJS += loadThings(arraysToLoad, 'array', extractArrayVariable, mainJs);
     finalJS += loadThings(variablesToLoad, 'variable', extractVariable, mainJs);


### PR DESCRIPTION
Successful merges:

 - #80707 (Stability oddity with const intrinsics)
 - #81103 (don't suggest erroneous trailing comma after `..`)
 - #81110 (Fix `unused_unsafe` label with `unsafe_block_in_unsafe_fn)
 - #81115 (BTreeMap: prefer bulk_steal functions over specialized ones)
 - #81147 (Fix structured suggestion for explicit `drop` call)
 - #81160 (use raw-ptr-addr-of for slice::swap)
 - #81161 (Remove inline script tags)
 - #81164 (Fix typo in simplify.rs)
 - #81166 (remove some outdated comments regarding  debug assertions)
 - #81168 (Fixes #81109 - Typo in pointer::wrapping_sub)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=80707,81103,81110,81115,81147,81160,81161,81164,81166,81168)
<!-- homu-ignore:end -->