### PR TITLE
Fix broken links with `--document-private-items` in the standard library

### DIFF
--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -1,13 +1,11 @@
 use core::iter::TrustedLen;
 use core::ptr::{self};
 
-#[allow(unused_imports)]
-use super::SpecFromIter;
 use super::{SpecExtend, Vec};
 
 /// Another specialization trait for Vec::from_iter
 /// necessary to manually prioritize overlapping specializations
-/// see [`SpecFromIter`] for details.
+/// see [`SpecFromIter`](super::SpecFromIter) for details.
 pub(super) trait SpecFromIterNested<T, I> {
     fn from_iter(iter: I) -> Self;
 }

--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -1,6 +1,8 @@
 use core::iter::TrustedLen;
 use core::ptr::{self};
 
+#[allow(unused_imports)]
+use super::SpecFromIter;
 use super::{SpecExtend, Vec};
 
 /// Another specialization trait for Vec::from_iter


### PR DESCRIPTION
As it was suggested in #81037 `SpecFromIter` is not
in the scope and therefore we get a warning when we try to
do document private intems in `rust/library/alloc/`.

This addresses #81037 by adding the trait in the scope as @jyn514 
suggested and also adding an `allow(unused_imports)` flag so that
the compiler does not complain, Since the trait is not used
per se in the code, it's just needed to have properly documented
docs.