### PR TITLE
Remove unnecessary `after_run` function

### DIFF
--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -38,10 +38,14 @@ crate trait FormatRenderer<'tcx>: Clone {
     fn mod_item_out(&mut self, item_name: &str) -> Result<(), Error>;
 
     /// Post processing hook for cleanup and dumping output to files.
-    fn after_krate(&mut self, krate: &clean::Crate, cache: &Cache) -> Result<(), Error>;
-
-    /// Called after everything else to write out errors.
-    fn after_run(&mut self, diag: &rustc_errors::Handler) -> Result<(), Error>;
+    ///
+    /// A handler is available if the renderer wants to report errors.
+    fn after_krate(
+        &mut self,
+        krate: &clean::Crate,
+        cache: &Cache,
+        diag: &rustc_errors::Handler,
+    ) -> Result<(), Error>;
 }
 
 /// Main method for rendering a crate.
@@ -104,6 +108,5 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
         }
     }
 
-    format_renderer.after_krate(&krate, &cache)?;
-    format_renderer.after_run(diag)
+    format_renderer.after_krate(&krate, &cache, diag)
 }

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -199,7 +199,12 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         Ok(())
     }
 
-    fn after_krate(&mut self, krate: &clean::Crate, cache: &Cache) -> Result<(), Error> {
+    fn after_krate(
+        &mut self,
+        krate: &clean::Crate,
+        cache: &Cache,
+        _diag: &rustc_errors::Handler,
+    ) -> Result<(), Error> {
         debug!("Done with crate");
         let mut index = (*self.index).clone().into_inner();
         index.extend(self.get_trait_items(cache));
@@ -243,10 +248,6 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         p.set_extension("json");
         let file = File::create(&p).map_err(|error| Error { error: error.to_string(), file: p })?;
         serde_json::ser::to_writer(&file, &output).unwrap();
-        Ok(())
-    }
-
-    fn after_run(&mut self, _diag: &rustc_errors::Handler) -> Result<(), Error> {
         Ok(())
     }
 }


### PR DESCRIPTION
It's called at the same time and in the same place as `after_krate`, so
they can be combined.