### PR TITLE
Fix ICE in mir when evaluating SizeOf on unsized type

### DIFF
--- a/src/test/ui/mir/issue-80742.rs
+++ b/src/test/ui/mir/issue-80742.rs
@@ -1,0 +1,33 @@
+// check-fail
+
+// This test used to cause an ICE in rustc_mir::interpret::step::eval_rvalue_into_place
+
+#![allow(incomplete_features)]
+#![feature(const_evaluatable_checked)]
+#![feature(const_generics)]
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::mem::size_of;
+
+struct Inline<T>
+where
+    [u8; size_of::<T>() + 1]: ,
+{
+    _phantom: PhantomData<T>,
+    buf: [u8; size_of::<T>() + 1],
+}
+
+impl<T> Inline<T>
+where
+    [u8; size_of::<T>() + 1]: ,
+{
+    pub fn new(val: T) -> Inline<T> {
+        todo!()
+    }
+}
+
+fn main() {
+    let dst = Inline::<dyn Debug>::new(0); //~ ERROR
+    //~^ ERROR
+}

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -1,0 +1,42 @@
+error[E0599]: no function or associated item named `new` found for struct `Inline<dyn Debug>` in the current scope
+  --> $DIR/issue-80742.rs:31:36
+   |
+LL | / struct Inline<T>
+LL | | where
+LL | |     [u8; size_of::<T>() + 1]: ,
+LL | | {
+LL | |     _phantom: PhantomData<T>,
+LL | |     buf: [u8; size_of::<T>() + 1],
+LL | | }
+   | |_- function or associated item `new` not found for this
+...
+LL |       let dst = Inline::<dyn Debug>::new(0);
+   |                                      ^^^ function or associated item not found in `Inline<dyn Debug>`
+   | 
+  ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+   |
+LL |   pub trait Debug {
+   |   --------------- doesn't satisfy `dyn Debug: Sized`
+   |
+   = note: the method `new` exists but the following trait bounds were not satisfied:
+           `dyn Debug: Sized`
+
+error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time
+  --> $DIR/issue-80742.rs:31:15
+   |
+LL | struct Inline<T>
+   |               - required by this bound in `Inline`
+...
+LL |     let dst = Inline::<dyn Debug>::new(0);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn Debug`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | struct Inline<T: ?Sized>
+   |                ^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Not quite ready yet. This tries to fix #80742 as discussed on [Zulip topic][1],
by using `delay_span_bug`.

I don't understand what `delay_span_bug` does. It seems like my error message
is never used. With this patch, in this program:

```rust
#![allow(incomplete_features)]
#![feature(const_evaluatable_checked)]
#![feature(const_generics)]

use std::fmt::Debug;
use std::marker::PhantomData;
use std::mem::size_of;

struct Inline<T>
where
    [u8; size_of::<T>() + 1]: ,
{
    _phantom: PhantomData<T>,
    buf: [u8; size_of::<T>() + 1],
}

impl<T> Inline<T>
where
    [u8; size_of::<T>() + 1]: ,
{
    pub fn new(val: T) -> Inline<T> {
        todo!()
    }
}

fn main() {
    let dst = Inline::<dyn Debug>::new(0); // line 27
}
```

these errors are printed, both for line 27 (annotated line above):

- "no function or associated item named `new` found for struct `Inline<dyn
  Debug>` in the current scope"
- "the size for values of type `dyn Debug` cannot be known at compilation time"

Second error makes sense, but I'm not sure about the first one and why it's
even printed.

Finally, I'm not sure about the span passing in `const_eval`.

[1]: https://rust-lang.zulipchat.com/#narrow/stream/269128-miri/topic/Help.20fixing.20.2380742
