### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -55,7 +55,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // * the bindings from the previous iteration of the loop is prepended to the bindings from
         // the current iteration (in the implementation this is done by mem::swap and extend)
         // * after all iterations, these new bindings are then appended to the bindings that were
-        // prexisting (i.e. `candidate.binding` when the function was called).
+        // preexisting (i.e. `candidate.binding` when the function was called).
         //
         // example:
         // candidate.bindings = [1, 2, 3]

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1163,7 +1163,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 debug!("instantiate_value_path: def_id={:?} container={:?}", def_id, container);
                 match container {
                     ty::TraitContainer(trait_did) => {
-                        callee::check_legal_trait_for_method_call(tcx, span, None, trait_did)
+                        callee::check_legal_trait_for_method_call(tcx, span, None, span, trait_did)
                     }
                     ty::ImplContainer(impl_def_id) => {
                         if segments.len() == 1 {

--- a/compiler/rustc_typeck/src/check/method/confirm.rs
+++ b/compiler/rustc_typeck/src/check/method/confirm.rs
@@ -507,6 +507,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 self.tcx,
                 self.span,
                 Some(self.self_expr.span),
+                self.call_expr.span,
                 trait_def_id,
             ),
             ty::ImplContainer(..) => {}

--- a/library/alloc/src/collections/btree/remove.rs
+++ b/library/alloc/src/collections/btree/remove.rs
@@ -121,25 +121,25 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::Mut<'a>, K, V, marker::Internal> {
         self,
     ) -> Option<NodeRef<marker::Mut<'a>, K, V, marker::Internal>> {
         match self.forget_type().choose_parent_kv() {
-            Ok(Left(left_parent_kv)) => {
+            Ok(Left(mut left_parent_kv)) => {
                 debug_assert_eq!(left_parent_kv.right_child_len(), MIN_LEN - 1);
                 if left_parent_kv.can_merge() {
                     let parent = left_parent_kv.merge_tracking_parent();
                     Some(parent)
                 } else {
                     debug_assert!(left_parent_kv.left_child_len() > MIN_LEN);
-                    left_parent_kv.steal_left(0);
+                    left_parent_kv.bulk_steal_left(1);
                     None
                 }
             }
-            Ok(Right(right_parent_kv)) => {
+            Ok(Right(mut right_parent_kv)) => {
                 debug_assert_eq!(right_parent_kv.left_child_len(), MIN_LEN - 1);
                 if right_parent_kv.can_merge() {
                     let parent = right_parent_kv.merge_tracking_parent();
                     Some(parent)
                 } else {
                     debug_assert!(right_parent_kv.right_child_len() > MIN_LEN);
-                    right_parent_kv.steal_right(0);
+                    right_parent_kv.bulk_steal_right(1);
                     None
                 }
             }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -183,11 +183,6 @@ pub mod task;
 mod tests;
 pub mod vec;
 
-#[cfg(not(test))]
-mod std {
-    pub use core::ops; // RangeFull
-}
-
 #[doc(hidden)]
 #[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
 pub mod __export {

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -633,7 +633,7 @@ impl<T: ?Sized> *const T {
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
-    /// (convenience for `.wrapping_offset((count as isize).wrapping_sub())`)
+    /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
     ///
     /// `count` is in units of T; e.g., a `count` of 3 represents a pointer
     /// offset of `3 * size_of::<T>()` bytes.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -687,7 +687,6 @@ pub unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_ptr_read", issue = "80377")]
 pub const unsafe fn read<T>(src: *const T) -> T {
-    // `copy_nonoverlapping` takes care of debug_assert.
     let mut tmp = MaybeUninit::<T>::uninit();
     // SAFETY: the caller must guarantee that `src` is valid for reads.
     // `src` cannot overlap `tmp` because `tmp` was just allocated on
@@ -787,7 +786,6 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 #[stable(feature = "ptr_unaligned", since = "1.17.0")]
 #[rustc_const_unstable(feature = "const_ptr_read", issue = "80377")]
 pub const unsafe fn read_unaligned<T>(src: *const T) -> T {
-    // `copy_nonoverlapping` takes care of debug_assert.
     let mut tmp = MaybeUninit::<T>::uninit();
     // SAFETY: the caller must guarantee that `src` is valid for reads.
     // `src` cannot overlap `tmp` because `tmp` was just allocated on
@@ -988,7 +986,6 @@ pub unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
     // `dst` cannot overlap `src` because the caller has mutable access
     // to `dst` while `src` is owned by this function.
     unsafe {
-        // `copy_nonoverlapping` takes care of debug_assert.
         copy_nonoverlapping(&src as *const T as *const u8, dst as *mut u8, mem::size_of::<T>());
     }
     mem::forget(src);

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -740,7 +740,7 @@ impl<T: ?Sized> *mut T {
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
-    /// (convenience for `.wrapping_offset((count as isize).wrapping_sub())`)
+    /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
     ///
     /// `count` is in units of T; e.g., a `count` of 3 represents a pointer
     /// offset of `3 * size_of::<T>()` bytes.

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -111,10 +111,7 @@ crate fn render<T: Print, S: Print>(
     <section id=\"search\" class=\"content hidden\"></section>\
     <section class=\"footer\"></section>\
     {after_content}\
-    <script>\
-        window.rootPath = \"{root_path}\";\
-        window.currentCrate = \"{krate}\";\
-    </script>\
+    <div id=\"rustdoc-vars\" data-root-path=\"{root_path}\" data-current-crate=\"{krate}\"></div>
     <script src=\"{static_root_path}main{suffix}.js\"></script>\
     {static_extra_scripts}\
     {extra_scripts}\

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1313,6 +1313,8 @@ fn init_id_map() -> FxHashMap<String, usize> {
     map.insert("toggle-all-docs".to_owned(), 1);
     map.insert("all-types".to_owned(), 1);
     map.insert("default-settings".to_owned(), 1);
+    map.insert("rustdoc-vars".to_owned(), 1);
+    map.insert("sidebar-vars".to_owned(), 1);
     // This is the list of IDs used by rustdoc sections.
     map.insert("fields".to_owned(), 1);
     map.insert("variants".to_owned(), 1);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -4216,11 +4216,8 @@ fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer, cache:
     let relpath = if it.is_mod() { "../" } else { "" };
     write!(
         buffer,
-        "<script>window.sidebarCurrent = {{\
-                name: \"{name}\", \
-                ty: \"{ty}\", \
-                relpath: \"{path}\"\
-            }};</script>",
+        "<div id=\"sidebar-vars\" data-name=\"{name}\" data-ty=\"{ty}\" data-relpath=\"{path}\">\
+        </div>",
         name = it.name.unwrap_or(kw::Empty),
         ty = it.type_(),
         path = relpath

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1664,6 +1664,21 @@ function defocusSearchBar() {
             var ret_in_args = addTab(results.in_args, query, false);
             var ret_returned = addTab(results.returned, query, false);
 
+            // Navigate to the relevant tab if the current tab is empty, like in case users search
+            // for "-> String". If they had selected another tab previously, they have to click on
+            // it again.
+            if ((currentTab === 0 && ret_others[1] === 0) ||
+                    (currentTab === 1 && ret_in_args[1] === 0) ||
+                    (currentTab === 2 && ret_returned[1] === 0)) {
+                if (ret_others[1] !== 0) {
+                    currentTab = 0;
+                } else if (ret_in_args[1] !== 0) {
+                    currentTab = 1;
+                } else if (ret_returned[1] !== 0) {
+                    currentTab = 2;
+                }
+            }
+
             var output = "<h1>Results for " + escape(query.query) +
                 (query.type ? " (type: " + escape(query.type) + ")" : "") + "</h1>" +
                 "<div id=\"titles\">" +

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1,5 +1,5 @@
 // From rust:
-/* global ALIASES, currentCrate, rootPath */
+/* global ALIASES */
 
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass */
@@ -40,6 +40,21 @@ if (!DOMTokenList.prototype.remove) {
     };
 }
 
+(function () {
+    var rustdocVars = document.getElementById("rustdoc-vars");
+    if (rustdocVars) {
+        window.rootPath = rustdocVars.attributes["data-root-path"].value;
+        window.currentCrate = rustdocVars.attributes["data-current-crate"].value;
+    }
+    var sidebarVars = document.getElementById("sidebar-vars");
+    if (sidebarVars) {
+        window.sidebarCurrent = {
+            name: sidebarVars.attributes["data-name"].value,
+            ty: sidebarVars.attributes["data-ty"].value,
+            relpath: sidebarVars.attributes["data-relpath"].value,
+        };
+    }
+}());
 
 // Gets the human-readable string for the virtual-key code of the
 // given KeyboardEvent, ev.
@@ -565,7 +580,7 @@ function defocusSearchBar() {
                 var i, match,
                     url = document.location.href,
                     stripped = "",
-                    len = rootPath.match(/\.\.\//g).length + 1;
+                    len = window.rootPath.match(/\.\.\//g).length + 1;
 
                 for (i = 0; i < len; ++i) {
                     match = url.match(/\/[^\/]*$/);
@@ -1504,15 +1519,15 @@ function defocusSearchBar() {
 
             if (type === "mod") {
                 displayPath = path + "::";
-                href = rootPath + path.replace(/::/g, "/") + "/" +
+                href = window.rootPath + path.replace(/::/g, "/") + "/" +
                        name + "/index.html";
             } else if (type === "primitive" || type === "keyword") {
                 displayPath = "";
-                href = rootPath + path.replace(/::/g, "/") +
+                href = window.rootPath + path.replace(/::/g, "/") +
                        "/" + type + "." + name + ".html";
             } else if (type === "externcrate") {
                 displayPath = "";
-                href = rootPath + name + "/index.html";
+                href = window.rootPath + name + "/index.html";
             } else if (item.parent !== undefined) {
                 var myparent = item.parent;
                 var anchor = "#" + type + "." + name;
@@ -1535,13 +1550,13 @@ function defocusSearchBar() {
                 } else {
                     displayPath = path + "::" + myparent.name + "::";
                 }
-                href = rootPath + path.replace(/::/g, "/") +
+                href = window.rootPath + path.replace(/::/g, "/") +
                        "/" + pageType +
                        "." + pageName +
                        ".html" + anchor;
             } else {
                 displayPath = item.path + "::";
-                href = rootPath + item.path.replace(/::/g, "/") +
+                href = window.rootPath + item.path.replace(/::/g, "/") +
                        "/" + type + "." + name + ".html";
             }
             return [displayPath, href];
@@ -1973,7 +1988,7 @@ function defocusSearchBar() {
         startSearch();
 
         // Draw a convenient sidebar of known crates if we have a listing
-        if (rootPath === "../" || rootPath === "./") {
+        if (window.rootPath === "../" || window.rootPath === "./") {
             var sidebar = document.getElementsByClassName("sidebar-elems")[0];
             if (sidebar) {
                 var div = document.createElement("div");
@@ -1992,11 +2007,11 @@ function defocusSearchBar() {
                 crates.sort();
                 for (var i = 0; i < crates.length; ++i) {
                     var klass = "crate";
-                    if (rootPath !== "./" && crates[i] === window.currentCrate) {
+                    if (window.rootPath !== "./" && crates[i] === window.currentCrate) {
                         klass += " current";
                     }
                     var link = document.createElement("a");
-                    link.href = rootPath + crates[i] + "/index.html";
+                    link.href = window.rootPath + crates[i] + "/index.html";
                     // The summary in the search index has HTML, so we need to
                     // dynamically render it as plaintext.
                     link.title = convertHTMLToPlaintext(rawSearchIndex[crates[i]].doc);
@@ -2118,7 +2133,7 @@ function defocusSearchBar() {
 
         var libs = Object.getOwnPropertyNames(imp);
         for (var i = 0, llength = libs.length; i < llength; ++i) {
-            if (libs[i] === currentCrate) { continue; }
+            if (libs[i] === window.currentCrate) { continue; }
             var structs = imp[libs[i]];
 
             struct_loop:
@@ -2143,7 +2158,7 @@ function defocusSearchBar() {
                     var href = elem.getAttribute("href");
 
                     if (href && href.indexOf("http") !== 0) {
-                        elem.setAttribute("href", rootPath + href);
+                        elem.setAttribute("href", window.rootPath + href);
                     }
                 });
 

--- a/src/test/ui/error-codes/E0040.fixed
+++ b/src/test/ui/error-codes/E0040.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 struct Foo {
-    x: isize
+    x: i32,
 }
 
 impl Drop for Foo {
@@ -10,7 +10,9 @@ impl Drop for Foo {
 }
 
 fn main() {
-    let x = Foo { x: 3 };
+    let mut x = Foo { x: -7 };
+    x.x = 0;
     println!("{}", x.x);
-    x.drop();   //~ ERROR explicit use of destructor method
+    drop(x);
+    //~^ ERROR E0040
 }

--- a/src/test/ui/error-codes/E0040.rs
+++ b/src/test/ui/error-codes/E0040.rs
@@ -1,3 +1,4 @@
+// run-rustfix
 struct Foo {
     x: i32,
 }
@@ -10,6 +11,8 @@ impl Drop for Foo {
 
 fn main() {
     let mut x = Foo { x: -7 };
+    x.x = 0;
+    println!("{}", x.x);
     x.drop();
     //~^ ERROR E0040
 }

--- a/src/test/ui/error-codes/E0040.stderr
+++ b/src/test/ui/error-codes/E0040.stderr
@@ -1,11 +1,11 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/E0040.rs:13:7
+  --> $DIR/E0040.rs:16:7
    |
 LL |     x.drop();
-   |       ^^^^
-   |       |
-   |       explicit destructor calls not allowed
-   |       help: consider using `drop` function: `drop(x)`
+   |     --^^^^--
+   |     | |
+   |     | explicit destructor calls not allowed
+   |     help: consider using `drop` function: `drop(x)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/explicit/explicit-call-to-dtor.fixed
+++ b/src/test/ui/explicit/explicit-call-to-dtor.fixed
@@ -12,5 +12,5 @@ impl Drop for Foo {
 fn main() {
     let x = Foo { x: 3 };
     println!("{}", x.x);
-    x.drop();   //~ ERROR explicit use of destructor method
+    drop(x);   //~ ERROR explicit use of destructor method
 }

--- a/src/test/ui/explicit/explicit-call-to-dtor.stderr
+++ b/src/test/ui/explicit/explicit-call-to-dtor.stderr
@@ -1,11 +1,11 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/explicit-call-to-dtor.rs:13:7
+  --> $DIR/explicit-call-to-dtor.rs:15:7
    |
 LL |     x.drop();
-   |       ^^^^
-   |       |
-   |       explicit destructor calls not allowed
-   |       help: consider using `drop` function: `drop(x)`
+   |     --^^^^--
+   |     | |
+   |     | explicit destructor calls not allowed
+   |     help: consider using `drop` function: `drop(x)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/explicit/explicit-call-to-supertrait-dtor.fixed
+++ b/src/test/ui/explicit/explicit-call-to-supertrait-dtor.fixed
@@ -3,14 +3,24 @@ struct Foo {
     x: isize
 }
 
+#[allow(drop_bounds)]
+trait Bar: Drop {
+    fn blah(&self);
+}
+
 impl Drop for Foo {
     fn drop(&mut self) {
         println!("kaboom");
     }
 }
 
+impl Bar for Foo {
+    fn blah(&self) {
+        drop(self);    //~ ERROR explicit use of destructor method
+    }
+}
+
 fn main() {
     let x = Foo { x: 3 };
     println!("{}", x.x);
-    x.drop();   //~ ERROR explicit use of destructor method
 }

--- a/src/test/ui/explicit/explicit-call-to-supertrait-dtor.rs
+++ b/src/test/ui/explicit/explicit-call-to-supertrait-dtor.rs
@@ -1,8 +1,10 @@
+// run-rustfix
 struct Foo {
     x: isize
 }
 
-trait Bar : Drop {
+#[allow(drop_bounds)]
+trait Bar: Drop {
     fn blah(&self);
 }
 
@@ -20,4 +22,5 @@ impl Bar for Foo {
 
 fn main() {
     let x = Foo { x: 3 };
+    println!("{}", x.x);
 }

--- a/src/test/ui/explicit/explicit-call-to-supertrait-dtor.stderr
+++ b/src/test/ui/explicit/explicit-call-to-supertrait-dtor.stderr
@@ -1,11 +1,11 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/explicit-call-to-supertrait-dtor.rs:17:14
+  --> $DIR/explicit-call-to-supertrait-dtor.rs:19:14
    |
 LL |         self.drop();
-   |              ^^^^
-   |              |
-   |              explicit destructor calls not allowed
-   |              help: consider using `drop` function: `drop(self)`
+   |         -----^^^^--
+   |         |    |
+   |         |    explicit destructor calls not allowed
+   |         help: consider using `drop` function: `drop(self)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/illegal-ufcs-drop.fixed
+++ b/src/test/ui/illegal-ufcs-drop.fixed
@@ -6,5 +6,5 @@ impl Drop for Foo {
 }
 
 fn main() {
-    Drop::drop(&mut Foo) //~ ERROR explicit use of destructor method
+    drop(&mut Foo) //~ ERROR explicit use of destructor method
 }

--- a/src/test/ui/illegal-ufcs-drop.stderr
+++ b/src/test/ui/illegal-ufcs-drop.stderr
@@ -1,5 +1,5 @@
 error[E0040]: explicit use of destructor method
-  --> $DIR/illegal-ufcs-drop.rs:8:5
+  --> $DIR/illegal-ufcs-drop.rs:9:5
    |
 LL |     Drop::drop(&mut Foo)
    |     ^^^^^^^^^^

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -263,8 +263,7 @@ function loadMainJsAndIndex(mainJs, searchIndex, storageJs, crate) {
                            "handleAliases", "getQuery", "buildIndex", "execQuery", "execSearch"];
 
     ALIASES = {};
-    finalJS += 'window = { "currentCrate": "' + crate + '" };\n';
-    finalJS += 'var rootPath = "../";\n';
+    finalJS += 'window = { "currentCrate": "' + crate + '", rootPath: "../" };\n';
     finalJS += loadThings(["hasOwnProperty", "onEach"], 'function', extractFunction, storageJs);
     finalJS += loadThings(arraysToLoad, 'array', extractArrayVariable, mainJs);
     finalJS += loadThings(variablesToLoad, 'variable', extractVariable, mainJs);


### PR DESCRIPTION
Successful merges:

 - #80382 (Improve search result tab handling)
 - #81112 (Remove unused alloc::std::ops re-export.)
 - #81115 (BTreeMap: prefer bulk_steal functions over specialized ones)
 - #81147 (Fix structured suggestion for explicit `drop` call)
 - #81161 (Remove inline script tags)
 - #81164 (Fix typo in simplify.rs)
 - #81166 (remove some outdated comments regarding  debug assertions)
 - #81168 (Fixes #81109 - Typo in pointer::wrapping_sub)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=80382,81112,81115,81147,81161,81164,81166,81168)
<!-- homu-ignore:end -->