### PR TITLE
Fix flaky test

### DIFF
--- a/src/test/run-make-fulldeps/rustdoc-test-builder/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-test-builder/Makefile
@@ -1,0 +1,10 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# How to manually run this
+# $ ./x.py test src/test/run-make/rustdoc-test-builder
+
+all:
+	# Rustc isn't available in UI tests because the only compiler available is the
+	# one built from source, which isn't in PATH.  This needs to be a run-make
+	# test so rustc is available.
+	$(RUSTDOC) --test -Z unstable-options --test-builder $(RUSTC_ORIGINAL) doctest.rs

--- a/src/test/run-make-fulldeps/rustdoc-test-builder/doctest.rs
+++ b/src/test/run-make-fulldeps/rustdoc-test-builder/doctest.rs
@@ -1,0 +1,4 @@
+/// ```no_run
+/// // This tests that `--test-builder` is accepted as a flag by rustdoc.
+/// ```
+pub struct Foo;

--- a/src/test/rustdoc/issue-80893.rs
+++ b/src/test/rustdoc/issue-80893.rs
@@ -1,6 +1,0 @@
-// compile-flags: --test -Z unstable-options --test-builder true
-
-/// ```no_run
-/// This tests that `--test-builder` is accepted as a flag by rustdoc.
-/// ```
-pub struct Foo;


### PR DESCRIPTION
Rustdoc writes to a pipe, and if the program on the other side has
exited, it will exit with SIGPIPE. To avoid that happening, call `rustc`
instead of `true`, which will wait to exit until it sees EOF on stdin.

cc https://github.com/rust-lang/rust/pull/79705#issuecomment-762950468, https://github.com/rust-lang/rust/pull/80924#discussion_r560328083

r? @ijackson