### PR TITLE
Don't prefix 0x for each segments in `dbg!(Ipv6)`

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1611,10 +1611,10 @@ impl fmt::Display for Ipv6Addr {
                 #[inline]
                 fn fmt_subslice(f: &mut fmt::Formatter<'_>, chunk: &[u16]) -> fmt::Result {
                     if let Some((first, tail)) = chunk.split_first() {
-                        fmt::LowerHex::fmt(first, f)?;
+                        write!(f, "{:x}", first)?;
                         for segment in tail {
                             f.write_char(':')?;
-                            fmt::LowerHex::fmt(segment, f)?;
+                            write!(f, "{:x}", segment)?;
                         }
                     }
                     Ok(())

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1610,9 +1610,9 @@ impl fmt::Display for Ipv6Addr {
                 /// Write a colon-separated part of the address
                 #[inline]
                 fn fmt_subslice(f: &mut fmt::Formatter<'_>, chunk: &[u16]) -> fmt::Result {
-                    if let Some(first) = chunk.first() {
+                    if let Some((first, tail)) = chunk.split_first() {
                         fmt::LowerHex::fmt(first, f)?;
-                        for segment in &chunk[1..] {
+                        for segment in tail {
                             f.write_char(':')?;
                             fmt::LowerHex::fmt(segment, f)?;
                         }

--- a/library/std/src/net/ip/tests.rs
+++ b/library/std/src/net/ip/tests.rs
@@ -166,6 +166,9 @@ fn ipv6_addr_to_string() {
 
     // two runs of zeros, equal length
     assert_eq!("1::4:5:0:0:8", Ipv6Addr::new(1, 0, 0, 4, 5, 0, 0, 8).to_string());
+
+    // don't prefix `0x` to each segment in `dbg!`.
+    assert_eq!("1::4:5:0:0:8", &format!("{:#?}", Ipv6Addr::new(1, 0, 0, 4, 5, 0, 0, 8)));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #81182

