### PR TITLE
Redirect to "main crate" when clicking Rust logo (or custom logo)

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::externalfiles::ExternalHtml;
 use crate::html::escape::Escape;
 use crate::html::format::{Buffer, Print};
-use crate::html::render::{ensure_trailing_slash, StylePath};
+use crate::html::render::StylePath;
 
 #[derive(Clone)]
 crate struct Layout {
@@ -134,22 +134,20 @@ crate fn render<T: Print, S: Print>(
         root_path = page.root_path,
         css_class = page.css_class,
         logo = {
-            let p = format!("{}{}", page.root_path, layout.krate);
-            let p = ensure_trailing_slash(&p);
             if layout.logo.is_empty() {
                 format!(
-                    "<a href='{path}index.html'>\
+                    "<a href='{path}logo-redirect.html'>\
                      <div class='logo-container rust-logo'>\
                      <img src='{static_root_path}rust-logo{suffix}.png' alt='logo'></div></a>",
-                    path = p,
+                    path = page.root_path,
                     static_root_path = static_root_path,
                     suffix = page.resource_suffix
                 )
             } else {
                 format!(
-                    "<a href='{}index.html'>\
+                    "<a href='{}logo-redirect.html'>\
                      <div class='logo-container'><img src='{}' alt='logo'></div></a>",
-                    p, layout.logo
+                    page.root_path, layout.logo
                 )
             }
         },

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -596,6 +596,21 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             &style_files,
         );
         self.shared.fs.write(&settings_file, v.as_bytes())?;
+
+        // HACK(ThePuzzlemaker, #81031): As suggested by jynelson, we create a
+        // redirect page in the parent directory (below the specific crate dir,
+        // i.e. target/doc or similar) redirecting to that crate's index. This
+        // way, the last crate compiled will be the one redirected to. Assuming
+        // you never document examples, and that if you document a binary, you
+        // want it to take precedence over a library present there, this works
+        // to have the logo redirect to the "main crate" (the one that would be
+        // opened by cargo doc --open), without having to add a new rustdoc
+        // flag and cargo integration.
+
+        let v =
+            layout::redirect(Path::new(&*krate.name.as_str()).join("index.html").to_str().unwrap());
+        self.shared.fs.write(&self.dst.join("logo-redirect.html"), v.as_bytes())?;
+
         Ok(())
     }
 

--- a/src/test/rustdoc/keyword.rs
+++ b/src/test/rustdoc/keyword.rs
@@ -8,7 +8,7 @@
 // @has foo/keyword.match.html '//a[@class="keyword"]' 'match'
 // @has foo/keyword.match.html '//span[@class="in-band"]' 'Keyword match'
 // @has foo/keyword.match.html '//section[@id="main"]//div[@class="docblock"]//p' 'this is a test!'
-// @has foo/index.html '//a/@href' '../foo/index.html'
+// @has foo/index.html '//a/@href' '../logo-redirect.html'
 // @!has foo/foo/index.html
 // @!has-dir foo/foo
 #[doc(keyword = "match")]


### PR DESCRIPTION
The "main crate" in this case would be the one that is opened by `cargo doc --open` by default. However, since doing this on cargo's end would require a lot more work, @jyn514 recommended a hacky solution that works. This solution is to create a redirect page (called
`logo-redirect.html`) in the documentation root directory when documenting a crate. Thus, the last crate documented (usually a binary or the main library) is the one redirected to by this file. This file is then pointed to by the logo.

Note that as jynelson noted:
> this assumes you never document examples, and that if you document a binary, you want it to take precedence over the library

I'm pretty sure this is probably the desired behaviour (and I don't think that examples are documented during `cargo doc`), so this hack should probably work for now. (And that's how programming works!)

This PR fixes part of #81031. (The other part is a larger project that I'm going to work on for a bit)

r? @jyn514