### PR TITLE
Seal all extension traits

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -76,6 +76,10 @@ pub struct OsString {
     inner: Buf,
 }
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for OsString {}
+
 /// Borrowed reference to an OS string (see [`OsString`]).
 ///
 /// This type represents a borrowed reference to a string in the operating system's preferred
@@ -99,6 +103,10 @@ pub struct OsString {
 pub struct OsStr {
     inner: Slice,
 }
+
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for OsStr {}
 
 impl OsString {
     /// Constructs a new empty `OsString`.

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -92,6 +92,10 @@ pub struct File {
     inner: fs_imp::File,
 }
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for File {}
+
 /// Metadata information about a file.
 ///
 /// This structure is returned from the [`metadata`] or
@@ -101,6 +105,10 @@ pub struct File {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone)]
 pub struct Metadata(fs_imp::FileAttr);
+
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for Metadata {}
 
 /// Iterator over the entries in a directory.
 ///
@@ -127,6 +135,10 @@ pub struct ReadDir(fs_imp::ReadDir);
 /// path or possibly other metadata through per-platform extension traits.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct DirEntry(fs_imp::DirEntry);
+
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for DirEntry {}
 
 /// Options and flags which can be used to configure how a file is opened.
 ///
@@ -167,6 +179,10 @@ pub struct DirEntry(fs_imp::DirEntry);
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct OpenOptions(fs_imp::OpenOptions);
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for OpenOptions {}
+
 /// Representation of the various permissions on a file.
 ///
 /// This module only currently provides one bit of information,
@@ -179,11 +195,19 @@ pub struct OpenOptions(fs_imp::OpenOptions);
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Permissions(fs_imp::FilePermissions);
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for Permissions {}
+
 /// A structure representing a type of file with accessors for each file type.
 /// It is returned by [`Metadata::file_type`] method.
 #[stable(feature = "file_type", since = "1.1.0")]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub struct FileType(fs_imp::FileType);
+
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for FileType {}
 
 /// A builder used to create directories in various manners.
 ///
@@ -194,6 +218,10 @@ pub struct DirBuilder {
     inner: fs_imp::DirBuilder,
     recursive: bool,
 }
+
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for DirBuilder {}
 
 /// Indicates how large a buffer to pre-allocate before reading the entire file.
 fn initial_buffer_size(file: &File) -> usize {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -579,3 +579,11 @@ include!("keyword_docs.rs");
 // is unconditional, so the unstable feature needs to be defined somewhere.
 #[unstable(feature = "restricted_std", issue = "none")]
 mod __restricted_std_workaround {}
+
+mod sealed {
+    /// This trait being unreachable from outside the crate
+    /// prevents outside implementations of our extension traits.
+    /// This allows adding more trait methods in the future.
+    #[unstable(feature = "sealed", issue = "none")]
+    pub trait Sealed {}
+}

--- a/library/std/src/os/android/fs.rs
+++ b/library/std/src/os/android/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::android::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/dragonfly/fs.rs
+++ b/library/std/src/os/dragonfly/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::dragonfly::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/emscripten/fs.rs
+++ b/library/std/src/os/emscripten/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::emscripten::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/freebsd/fs.rs
+++ b/library/std/src/os/freebsd/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::freebsd::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/fuchsia/fs.rs
+++ b/library/std/src/os/fuchsia/fs.rs
@@ -1,13 +1,14 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 /// OS-specific extensions to [`fs::Metadata`].
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]

--- a/library/std/src/os/haiku/fs.rs
+++ b/library/std/src/os/haiku/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::haiku::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/illumos/fs.rs
+++ b/library/std/src/os/illumos/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::illumos::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/ios/fs.rs
+++ b/library/std/src/os/ios/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::ios::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/linux/fs.rs
+++ b/library/std/src/os/linux/fs.rs
@@ -3,6 +3,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -12,7 +13,7 @@ use crate::os::linux::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/macos/fs.rs
+++ b/library/std/src/os/macos/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::macos::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/netbsd/fs.rs
+++ b/library/std/src/os/netbsd/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::netbsd::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/openbsd/fs.rs
+++ b/library/std/src/os/openbsd/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::openbsd::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/redox/fs.rs
+++ b/library/std/src/os/redox/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::redox::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/solaris/fs.rs
+++ b/library/std/src/os/solaris/fs.rs
@@ -1,6 +1,7 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 #[allow(deprecated)]
@@ -10,7 +11,7 @@ use crate::os::solaris::raw;
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Gain a reference to the underlying `stat` structure which contains
     /// the raw information returned by the OS.
     ///

--- a/library/std/src/os/vxworks/fs.rs
+++ b/library/std/src/os/vxworks/fs.rs
@@ -1,12 +1,13 @@
 #![stable(feature = "metadata_ext", since = "1.1.0")]
 
 use crate::fs::Metadata;
+use crate::sealed::Sealed;
 use crate::sys_common::AsInner;
 
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_dev(&self) -> u64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -498,6 +498,10 @@ pub struct Command {
     inner: imp::Command,
 }
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for Command {}
+
 impl Command {
     /// Constructs a new `Command` for launching the program at
     /// path `program`, with the following default configuration:

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1375,6 +1375,10 @@ impl From<fs::File> for Stdio {
 #[stable(feature = "process", since = "1.0.0")]
 pub struct ExitStatus(imp::ExitStatus);
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for ExitStatus {}
+
 impl ExitStatus {
     /// Was termination successful? Signal termination is not considered a
     /// success, and success is defined as a zero exit status.

--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -5,6 +5,7 @@
 use crate::fs::{self, OpenOptions, Permissions};
 use crate::io;
 use crate::path::Path;
+use crate::sealed::Sealed;
 use crate::sys;
 use crate::sys::platform::fs::MetadataExt as UnixMetadataExt;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
@@ -14,7 +15,7 @@ use io::{Read, Write};
 
 /// Unix-specific extensions to [`fs::File`].
 #[stable(feature = "file_offset", since = "1.15.0")]
-pub trait FileExt {
+pub trait FileExt: Sealed {
     /// Reads a number of bytes starting from a given offset.
     ///
     /// Returns the number of bytes read.
@@ -220,7 +221,7 @@ impl FileExt for fs::File {
 
 /// Unix-specific extensions to [`fs::Permissions`].
 #[stable(feature = "fs_ext", since = "1.1.0")]
-pub trait PermissionsExt {
+pub trait PermissionsExt: Sealed {
     /// Returns the underlying raw `st_mode` bits that contain the standard
     /// Unix permissions for this file.
     ///
@@ -297,7 +298,7 @@ impl PermissionsExt for Permissions {
 
 /// Unix-specific extensions to [`fs::OpenOptions`].
 #[stable(feature = "fs_ext", since = "1.1.0")]
-pub trait OpenOptionsExt {
+pub trait OpenOptionsExt: Sealed {
     /// Sets the mode bits that a new file will be created with.
     ///
     /// If a new file is created as part of an `OpenOptions::open` call then this
@@ -365,7 +366,7 @@ impl OpenOptionsExt for OpenOptions {
 
 /// Unix-specific extensions to [`fs::Metadata`].
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the ID of the device containing the file.
     ///
     /// # Examples
@@ -716,7 +717,7 @@ impl MetadataExt for fs::Metadata {
 /// Adds support for special Unix file types such as block/character devices,
 /// pipes, and sockets.
 #[stable(feature = "file_type_ext", since = "1.5.0")]
-pub trait FileTypeExt {
+pub trait FileTypeExt: Sealed {
     /// Returns `true` if this file type is a block device.
     ///
     /// # Examples
@@ -809,7 +810,7 @@ impl FileTypeExt for fs::FileType {
 
 /// Unix-specific extension methods for [`fs::DirEntry`].
 #[stable(feature = "dir_entry_ext", since = "1.1.0")]
-pub trait DirEntryExt {
+pub trait DirEntryExt: Sealed {
     /// Returns the underlying `d_ino` field in the contained `dirent`
     /// structure.
     ///
@@ -860,7 +861,7 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Resu
 
 /// Unix-specific extensions to [`fs::DirBuilder`].
 #[stable(feature = "dir_builder", since = "1.6.0")]
-pub trait DirBuilderExt {
+pub trait DirBuilderExt: Sealed {
     /// Sets the mode to create new directories with. This option defaults to
     /// 0o777.
     ///

--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -203,9 +203,6 @@ pub trait ExitStatusExt: Sealed {
     fn into_raw(self) -> i32;
 }
 
-#[unstable(feature = "sealed", issue = "none")]
-impl Sealed for process::ExitStatus {}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ExitStatusExt for process::ExitStatus {
     fn from_raw(raw: i32) -> Self {

--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -12,7 +12,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
 /// Unix-specific extensions to the [`process::Command`] builder.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait CommandExt {
+pub trait CommandExt: Sealed {
     /// Sets the child process's user ID. This translates to a
     /// `setuid` call in the child process. Failure in the `setuid`
     /// call will cause the spawn to fail.

--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -6,16 +6,9 @@ use crate::ffi::OsStr;
 use crate::io;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::process;
+use crate::sealed::Sealed;
 use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
-
-mod private {
-    /// This trait being unreachable from outside the crate
-    /// prevents other implementations of the `ExitStatusExt` trait,
-    /// which allows potentially adding more trait methods in the future.
-    #[stable(feature = "none", since = "1.51.0")]
-    pub trait Sealed {}
-}
 
 /// Unix-specific extensions to the [`process::Command`] builder.
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -175,7 +168,7 @@ impl CommandExt for process::Command {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait ExitStatusExt: private::Sealed {
+pub trait ExitStatusExt: Sealed {
     /// Creates a new `ExitStatus` from the raw underlying `i32` return value of
     /// a process.
     #[stable(feature = "exit_status_from", since = "1.12.0")]
@@ -210,8 +203,8 @@ pub trait ExitStatusExt: private::Sealed {
     fn into_raw(self) -> i32;
 }
 
-#[stable(feature = "none", since = "1.51.0")]
-impl private::Sealed for process::ExitStatus {}
+#[unstable(feature = "sealed", issue = "none")]
+impl Sealed for process::ExitStatus {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl ExitStatusExt for process::ExitStatus {

--- a/library/std/src/sys/wasi/ext/fs.rs
+++ b/library/std/src/sys/wasi/ext/fs.rs
@@ -6,11 +6,12 @@
 use crate::fs::{self, File, Metadata, OpenOptions};
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::path::{Path, PathBuf};
+use crate::sealed::Sealed;
 use crate::sys::fs::osstr2str;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 
 /// WASI-specific extensions to [`File`].
-pub trait FileExt {
+pub trait FileExt: Sealed {
     /// Reads a number of bytes starting from a given offset.
     ///
     /// Returns the number of bytes read.
@@ -275,7 +276,7 @@ impl FileExt for fs::File {
 }
 
 /// WASI-specific extensions to [`fs::OpenOptions`].
-pub trait OpenOptionsExt {
+pub trait OpenOptionsExt: Sealed {
     /// Pass custom `dirflags` argument to `path_open`.
     ///
     /// This option configures the `dirflags` argument to the
@@ -390,7 +391,7 @@ impl OpenOptionsExt for OpenOptions {
 }
 
 /// WASI-specific extensions to [`fs::Metadata`].
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the `st_dev` field of the internal `filestat_t`
     fn dev(&self) -> u64;
     /// Returns the `st_ino` field of the internal `filestat_t`
@@ -430,7 +431,7 @@ impl MetadataExt for fs::Metadata {
 ///
 /// Adds support for special WASI file types such as block/character devices,
 /// pipes, and sockets.
-pub trait FileTypeExt {
+pub trait FileTypeExt: Sealed {
     /// Returns `true` if this file type is a block device.
     fn is_block_device(&self) -> bool;
     /// Returns `true` if this file type is a character device.
@@ -457,7 +458,7 @@ impl FileTypeExt for fs::FileType {
 }
 
 /// WASI-specific extension methods for [`fs::DirEntry`].
-pub trait DirEntryExt {
+pub trait DirEntryExt: Sealed {
     /// Returns the underlying `d_ino` field of the `dirent_t`
     fn ino(&self) -> u64;
 }

--- a/library/std/src/sys/windows/ext/ffi.rs
+++ b/library/std/src/sys/windows/ext/ffi.rs
@@ -53,6 +53,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::ffi::{OsStr, OsString};
+use crate::sealed::Sealed;
 use crate::sys::os_str::Buf;
 use crate::sys_common::wtf8::Wtf8Buf;
 use crate::sys_common::{AsInner, FromInner};
@@ -62,7 +63,7 @@ pub use crate::sys_common::wtf8::EncodeWide;
 
 /// Windows-specific extensions to [`OsString`].
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStringExt {
+pub trait OsStringExt: Sealed {
     /// Creates an `OsString` from a potentially ill-formed UTF-16 slice of
     /// 16-bit code units.
     ///
@@ -93,7 +94,7 @@ impl OsStringExt for OsString {
 
 /// Windows-specific extensions to [`OsStr`].
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStrExt {
+pub trait OsStrExt: Sealed {
     /// Re-encodes an `OsStr` as a wide character sequence, i.e., potentially
     /// ill-formed UTF-16.
     ///

--- a/library/std/src/sys/windows/ext/fs.rs
+++ b/library/std/src/sys/windows/ext/fs.rs
@@ -5,12 +5,13 @@
 use crate::fs::{self, Metadata, OpenOptions};
 use crate::io;
 use crate::path::Path;
+use crate::sealed::Sealed;
 use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut};
 
 /// Windows-specific extensions to [`fs::File`].
 #[stable(feature = "file_offset", since = "1.15.0")]
-pub trait FileExt {
+pub trait FileExt: Sealed {
     /// Seeks to a given position and reads a number of bytes.
     ///
     /// Returns the number of bytes read.
@@ -93,7 +94,7 @@ impl FileExt for fs::File {
 
 /// Windows-specific extensions to [`fs::OpenOptions`].
 #[stable(feature = "open_options_ext", since = "1.10.0")]
-pub trait OpenOptionsExt {
+pub trait OpenOptionsExt: Sealed {
     /// Overrides the `dwDesiredAccess` argument to the call to [`CreateFile`]
     /// with the specified value.
     ///
@@ -294,7 +295,7 @@ impl OpenOptionsExt for OpenOptions {
 /// [`BY_HANDLE_FILE_INFORMATION`]:
 ///     https://docs.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information
 #[stable(feature = "metadata_ext", since = "1.1.0")]
-pub trait MetadataExt {
+pub trait MetadataExt: Sealed {
     /// Returns the value of the `dwFileAttributes` field of this metadata.
     ///
     /// This field contains the file system attribute information for a file
@@ -498,7 +499,7 @@ impl MetadataExt for Metadata {
 ///
 /// On Windows, a symbolic link knows whether it is a file or directory.
 #[unstable(feature = "windows_file_type_ext", issue = "none")]
-pub trait FileTypeExt {
+pub trait FileTypeExt: Sealed {
     /// Returns `true` if this file type is a symbolic link that is also a directory.
     #[unstable(feature = "windows_file_type_ext", issue = "none")]
     fn is_symlink_dir(&self) -> bool;

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -94,7 +94,7 @@ impl ExitStatusExt for process::ExitStatus {
 
 /// Windows-specific extensions to the [`process::Command`] builder.
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
-pub trait CommandExt {
+pub trait CommandExt: Sealed {
     /// Sets the [process creation flags][1] to be passed to `CreateProcess`.
     ///
     /// These will always be ORed with `CREATE_UNICODE_ENVIRONMENT`.

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -4,16 +4,9 @@
 
 use crate::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
 use crate::process;
+use crate::sealed::Sealed;
 use crate::sys;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
-
-mod private {
-    /// This trait being unreachable from outside the crate
-    /// prevents other implementations of the `ExitStatusExt` trait,
-    /// which allows potentially adding more trait methods in the future.
-    #[stable(feature = "none", since = "1.51.0")]
-    pub trait Sealed {}
-}
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl FromRawHandle for process::Stdio {
@@ -85,7 +78,7 @@ impl IntoRawHandle for process::ChildStderr {
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "exit_status_from", since = "1.12.0")]
-pub trait ExitStatusExt: private::Sealed {
+pub trait ExitStatusExt: Sealed {
     /// Creates a new `ExitStatus` from the raw underlying `u32` return value of
     /// a process.
     #[stable(feature = "exit_status_from", since = "1.12.0")]
@@ -99,8 +92,8 @@ impl ExitStatusExt for process::ExitStatus {
     }
 }
 
-#[stable(feature = "none", since = "1.51.0")]
-impl private::Sealed for process::ExitStatus {}
+#[unstable(feature = "sealed", issue = "none")]
+impl Sealed for process::ExitStatus {}
 
 /// Windows-specific extensions to the [`process::Command`] builder.
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -92,9 +92,6 @@ impl ExitStatusExt for process::ExitStatus {
     }
 }
 
-#[unstable(feature = "sealed", issue = "none")]
-impl Sealed for process::ExitStatus {}
-
 /// Windows-specific extensions to the [`process::Command`] builder.
 #[stable(feature = "windows_process_extensions", since = "1.16.0")]
 pub trait CommandExt {

--- a/library/std/src/sys_common/os_str_bytes.rs
+++ b/library/std/src/sys_common/os_str_bytes.rs
@@ -6,6 +6,7 @@ use crate::ffi::{OsStr, OsString};
 use crate::fmt;
 use crate::mem;
 use crate::rc::Rc;
+use crate::sealed::Sealed;
 use crate::str;
 use crate::sync::Arc;
 use crate::sys_common::bytestring::debug_fmt_bytestring;
@@ -233,7 +234,7 @@ impl Slice {
 
 /// Platform-specific extensions to [`OsString`].
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStringExt {
+pub trait OsStringExt: Sealed {
     /// Creates an [`OsString`] from a byte vector.
     ///
     /// See the module documentation for an example.
@@ -259,7 +260,7 @@ impl OsStringExt for OsString {
 
 /// Platform-specific extensions to [`OsStr`].
 #[stable(feature = "rust1", since = "1.0.0")]
-pub trait OsStrExt {
+pub trait OsStrExt: Sealed {
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Creates an [`OsStr`] from a byte slice.
     ///


### PR DESCRIPTION
This seals all extension traits, to make sure we can add new methods to them in the future without breaking anything.

(`ExitStatusExt` was already sealed a few days ago by https://github.com/rust-lang/rust/pull/79982.)

This needs a crater run. See #80634.

cc @SimonSapin @camelid