### PR TITLE
BTreeMap: bring back the key slice for immutable lookup

### DIFF
--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -29,17 +29,7 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::Immut<'a>, K, V, marker::LeafOrInternal> 
             navigate::Position::Leaf(leaf) => {
                 let depth = self.height();
                 let indent = "  ".repeat(depth);
-                result += &format!("\n{}", indent);
-                if leaf.len() == 0 {
-                    result += "(empty node)";
-                } else {
-                    for idx in 0..leaf.len() {
-                        if idx > 0 {
-                            result += ", ";
-                        }
-                        result += &format!("{:?}", unsafe { leaf.key_at(idx) });
-                    }
-                }
+                result += &format!("\n{}{:?}", indent, leaf.keys());
             }
             navigate::Position::Internal(_) => {}
             navigate::Position::InternalKV(kv) => {

--- a/library/alloc/src/collections/btree/search.rs
+++ b/library/alloc/src/collections/btree/search.rs
@@ -71,18 +71,15 @@ impl<BorrowType, K, V, Type> NodeRef<BorrowType, K, V, Type> {
         Q: Ord,
         K: Borrow<Q>,
     {
-        // This function is defined over all borrow types (immutable, mutable, owned).
-        // Using `keys_at()` is fine here even if BorrowType is mutable, as all we return
-        // is an index -- not a reference.
-        let len = self.len();
-        for i in 0..len {
-            let k = unsafe { self.reborrow().key_at(i) };
+        let node = self.reborrow();
+        let keys = node.keys();
+        for (i, k) in keys.iter().enumerate() {
             match key.cmp(k.borrow()) {
                 Ordering::Greater => {}
                 Ordering::Equal => return IndexResult::KV(i),
                 Ordering::Less => return IndexResult::Edge(i),
             }
         }
-        IndexResult::Edge(len)
+        IndexResult::Edge(keys.len())
     }
 }


### PR DESCRIPTION
Pave the way for binary search, by reverting a bit of #73971, which banned `keys` for misbehaving while it was defined for every `BorrowType`. Adding some `debug_assert`s along the way.

r? @Mark-Simulacrum 