### PR TITLE
Make 'docs' nullable in rustdoc-json output

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -27,7 +27,7 @@ impl JsonRenderer<'_> {
                 name: name.map(|sym| sym.to_string()),
                 source: self.convert_span(source),
                 visibility: self.convert_visibility(visibility),
-                docs: attrs.collapsed_doc_value().unwrap_or_default(),
+                docs: attrs.collapsed_doc_value(),
                 links: attrs
                     .links
                     .into_iter()

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -236,7 +236,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 1,
+            format_version: 2,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/librustdoc/json/types.rs
+++ b/src/librustdoc/json/types.rs
@@ -68,7 +68,8 @@ pub struct Item {
     /// By default all documented items are public, but you can tell rustdoc to output private items
     /// so this field is needed to differentiate.
     pub visibility: Visibility,
-    /// The full markdown docstring of this item.
+    /// The full markdown docstring of this item. Absent if there is no documentation at all,
+    /// Some("") if there is some documentation but it is empty (EG `#[doc = ""]`).
     pub docs: Option<String>,
     /// This mapping resolves [intra-doc links](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md) from the docstring to their IDs
     pub links: FxHashMap<String, Id>,

--- a/src/librustdoc/json/types.rs
+++ b/src/librustdoc/json/types.rs
@@ -69,7 +69,7 @@ pub struct Item {
     /// so this field is needed to differentiate.
     pub visibility: Visibility,
     /// The full markdown docstring of this item.
-    pub docs: String,
+    pub docs: Option<String>,
     /// This mapping resolves [intra-doc links](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md) from the docstring to their IDs
     pub links: FxHashMap<String, Id>,
     /// Stringified versions of the attributes on this item (e.g. `"#[inline]"`)


### PR DESCRIPTION
Matches the backing better, and makes it so there's a difference between 'empty docs' and 'no docs'.