### PR TITLE
Fix file descriptor ranges for fuchsia

### DIFF
--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -12,11 +12,11 @@ use crate::sys_common::AsInner;
 use libc::{c_int, c_void};
 
 #[derive(Debug)]
-#[rustc_layout_scalar_valid_range_start(0)]
+#[cfg_attr(not(target_os = "fuchsia"), rustc_layout_scalar_valid_range_start(0))]
 // libstd/os/raw/mod.rs assures me that every libstd-supported platform has a
 // 32-bit c_int. Below is -2, in two's complement, but that only works out
 // because c_int is 32 bits.
-#[rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE)]
+#[cfg_attr(not(target_os = "fuchsia"), rustc_layout_scalar_valid_range_end(0xFF_FF_FF_FE))]
 pub struct FileDesc {
     fd: c_int,
 }
@@ -68,7 +68,10 @@ const fn max_iov() -> usize {
 
 impl FileDesc {
     pub fn new(fd: c_int) -> FileDesc {
-        assert_ne!(fd, -1i32);
+        if cfg!(not(target_os = "fuchsia")) {
+            assert_ne!(fd, -1i32);
+        }
+
         // SAFETY: we just asserted that the value is in the valid range and isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
         unsafe { FileDesc { fd } }
     }

--- a/library/std/src/sys/unix/fd/tests.rs
+++ b/library/std/src/sys/unix/fd/tests.rs
@@ -3,7 +3,16 @@ use core::mem::ManuallyDrop;
 
 #[test]
 fn limit_vector_count() {
-    let stdout = ManuallyDrop::new(unsafe { FileDesc { fd: 1 } });
+    let stdout = ManuallyDrop::new(
+        #[cfg(not(target_os = "fuchsia"))]
+        {
+            unsafe { FileDesc { fd: 1 } }
+        },
+        #[cfg(target_os = "fuchsia")]
+        {
+            FileDesc { fd: 1 }
+        },
+    );
     let bufs = (0..1500).map(|_| IoSlice::new(&[])).collect::<Vec<_>>();
     assert!(stdout.write_vectored(&bufs).is_ok());
 }

--- a/library/std/src/sys/unix/fd/tests.rs
+++ b/library/std/src/sys/unix/fd/tests.rs
@@ -4,12 +4,8 @@ use core::mem::ManuallyDrop;
 #[test]
 fn limit_vector_count() {
     let stdout = ManuallyDrop::new(
-        #[cfg(not(target_os = "fuchsia"))]
-        {
-            unsafe { FileDesc { fd: 1 } }
-        },
-        #[cfg(target_os = "fuchsia")]
-        {
+        #[cfg_attr(target_os = "fuchsia", allow(unused_unsafe))]
+        unsafe {
             FileDesc { fd: 1 }
         },
     );


### PR DESCRIPTION
Fuchsia does not restrict the range of valid values for a file descriptor, so the previous change that marked -1 as an invalid file descriptor does not apply to fuchsia.