### PR TITLE
Remove doctree::StructType

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -15,9 +15,8 @@ use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
 
-use crate::clean::{self, Attributes, GetDefId, ToSource, TypeKind};
+use crate::clean::{self, Attributes, GetDefId, ToSource, TypeKind, StructType};
 use crate::core::DocContext;
-use crate::doctree;
 
 use super::Clean;
 
@@ -247,9 +246,9 @@ fn build_struct(cx: &DocContext<'_>, did: DefId) -> clean::Struct {
 
     clean::Struct {
         struct_type: match variant.ctor_kind {
-            CtorKind::Fictive => doctree::Plain,
-            CtorKind::Fn => doctree::Tuple,
-            CtorKind::Const => doctree::Unit,
+            CtorKind::Fictive => StructType::Plain,
+            CtorKind::Fn => StructType::Tuple,
+            CtorKind::Const => StructType::Unit,
         },
         generics: (cx.tcx.generics_of(did), predicates).clean(cx),
         fields: variant.fields.clean(cx),
@@ -262,7 +261,6 @@ fn build_union(cx: &DocContext<'_>, did: DefId) -> clean::Union {
     let variant = cx.tcx.adt_def(did).non_enum_variant();
 
     clean::Union {
-        struct_type: doctree::Plain,
         generics: (cx.tcx.generics_of(did), predicates).clean(cx),
         fields: variant.fields.clean(cx),
         fields_stripped: false,

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -5,7 +5,7 @@ use std::iter::once;
 use rustc_ast as ast;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
-use rustc_hir::def::{CtorKind, DefKind, Res};
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX};
 use rustc_hir::Mutability;
 use rustc_metadata::creader::LoadedMacro;
@@ -15,7 +15,7 @@ use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
 
-use crate::clean::{self, Attributes, GetDefId, ToSource, TypeKind, StructType};
+use crate::clean::{self, Attributes, GetDefId, ToSource, TypeKind};
 use crate::core::DocContext;
 
 use super::Clean;
@@ -245,11 +245,7 @@ fn build_struct(cx: &DocContext<'_>, did: DefId) -> clean::Struct {
     let variant = cx.tcx.adt_def(did).non_enum_variant();
 
     clean::Struct {
-        struct_type: match variant.ctor_kind {
-            CtorKind::Fictive => StructType::Plain,
-            CtorKind::Fn => StructType::Tuple,
-            CtorKind::Const => StructType::Unit,
-        },
+        struct_type: variant.ctor_kind,
         generics: (cx.tcx.generics_of(did), predicates).clean(cx),
         fields: variant.fields.clean(cx),
         fields_stripped: false,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1824,10 +1824,19 @@ impl Clean<Visibility> for ty::Visibility {
     }
 }
 
+crate fn struct_type_from_def(vdata: &hir::VariantData<'_>) -> StructType {
+    use StructType::*;
+    match *vdata {
+        hir::VariantData::Struct(..) => Plain,
+        hir::VariantData::Tuple(..) => Tuple,
+        hir::VariantData::Unit(..) => Unit,
+    }
+}
+
 impl Clean<VariantStruct> for rustc_hir::VariantData<'_> {
     fn clean(&self, cx: &DocContext<'_>) -> VariantStruct {
         VariantStruct {
-            struct_type: doctree::struct_type_from_def(self),
+            struct_type: struct_type_from_def(self),
             fields: self.fields().iter().map(|x| x.clean(cx)).collect(),
             fields_stripped: false,
         }
@@ -1842,7 +1851,7 @@ impl Clean<Item> for ty::VariantDef {
                 self.fields.iter().map(|f| cx.tcx.type_of(f.did).clean(cx)).collect(),
             ),
             CtorKind::Fictive => Variant::Struct(VariantStruct {
-                struct_type: doctree::Plain,
+                struct_type: StructType::Plain,
                 fields_stripped: false,
                 fields: self
                     .fields
@@ -1996,13 +2005,12 @@ impl Clean<Vec<Item>> for (&hir::Item<'_>, Option<Symbol>) {
                     bounds: bounds.clean(cx),
                 }),
                 ItemKind::Union(ref variant_data, ref generics) => UnionItem(Union {
-                    struct_type: doctree::struct_type_from_def(&variant_data),
                     generics: generics.clean(cx),
                     fields: variant_data.fields().clean(cx),
                     fields_stripped: false,
                 }),
                 ItemKind::Struct(ref variant_data, ref generics) => StructItem(Struct {
-                    struct_type: doctree::struct_type_from_def(&variant_data),
+                    struct_type: struct_type_from_def(&variant_data),
                     generics: generics.clean(cx),
                     fields: variant_data.fields().clean(cx),
                     fields_stripped: false,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -16,7 +16,7 @@ use rustc_attr::{ConstStability, Deprecation, Stability, StabilityLevel};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_feature::UnstableFeatures;
 use rustc_hir as hir;
-use rustc_hir::def::Res;
+use rustc_hir::def::{CtorKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::Mutability;
@@ -1682,19 +1682,9 @@ impl Visibility {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-crate enum StructType {
-    /// A braced struct
-    Plain,
-    /// A tuple struct
-    Tuple,
-    /// A unit struct
-    Unit,
-}
-
 #[derive(Clone, Debug)]
 crate struct Struct {
-    crate struct_type: StructType,
+    crate struct_type: CtorKind,
     crate generics: Generics,
     crate fields: Vec<Item>,
     crate fields_stripped: bool,
@@ -1712,7 +1702,7 @@ crate struct Union {
 /// only as a variant in an enum.
 #[derive(Clone, Debug)]
 crate struct VariantStruct {
-    crate struct_type: StructType,
+    crate struct_type: CtorKind,
     crate fields: Vec<Item>,
     crate fields_stripped: bool,
 }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -37,7 +37,6 @@ use crate::clean::inline;
 use crate::clean::types::Type::{QPath, ResolvedPath};
 use crate::clean::Clean;
 use crate::core::DocContext;
-use crate::doctree;
 use crate::formats::cache::cache;
 use crate::formats::item_type::ItemType;
 use crate::html::render::cache::ExternalLocation;
@@ -1683,9 +1682,19 @@ impl Visibility {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+crate enum StructType {
+    /// A braced struct
+    Plain,
+    /// A tuple struct
+    Tuple,
+    /// A unit struct
+    Unit,
+}
+
 #[derive(Clone, Debug)]
 crate struct Struct {
-    crate struct_type: doctree::StructType,
+    crate struct_type: StructType,
     crate generics: Generics,
     crate fields: Vec<Item>,
     crate fields_stripped: bool,
@@ -1693,7 +1702,6 @@ crate struct Struct {
 
 #[derive(Clone, Debug)]
 crate struct Union {
-    crate struct_type: doctree::StructType,
     crate generics: Generics,
     crate fields: Vec<Item>,
     crate fields_stripped: bool,
@@ -1704,7 +1712,7 @@ crate struct Union {
 /// only as a variant in an enum.
 #[derive(Clone, Debug)]
 crate struct VariantStruct {
-    crate struct_type: doctree::StructType,
+    crate struct_type: StructType,
     crate fields: Vec<Item>,
     crate fields_stripped: bool,
 }

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -1,7 +1,5 @@
 //! This module is used to store stuff from Rust's AST in a more convenient
 //! manner (and with prettier names) before cleaning.
-crate use self::StructType::*;
-
 use rustc_span::{self, Span, Symbol};
 
 use rustc_hir as hir;
@@ -32,23 +30,5 @@ impl Module<'hir> {
             macros: Vec::new(),
             is_crate: false,
         }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-crate enum StructType {
-    /// A braced struct
-    Plain,
-    /// A tuple struct
-    Tuple,
-    /// A unit struct
-    Unit,
-}
-
-crate fn struct_type_from_def(vdata: &hir::VariantData<'_>) -> StructType {
-    match *vdata {
-        hir::VariantData::Struct(..) => Plain,
-        hir::VariantData::Tuple(..) => Tuple,
-        hir::VariantData::Unit(..) => Unit,
     }
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -68,7 +68,6 @@ use serde::{Serialize, Serializer};
 use crate::clean::{self, AttributesExt, GetDefId, RenderedLink, SelfTy, TypeKind};
 use crate::config::{RenderInfo, RenderOptions};
 use crate::docfs::{DocFS, PathError};
-use crate::doctree;
 use crate::error::Error;
 use crate::formats::cache::{cache, Cache};
 use crate::formats::item_type::ItemType;
@@ -3101,7 +3100,7 @@ fn item_struct(
             _ => None,
         })
         .peekable();
-    if let doctree::Plain = s.struct_type {
+    if let clean::StructType::Plain = s.struct_type {
         if fields.peek().is_some() {
             write!(
                 w,
@@ -3351,7 +3350,7 @@ fn render_struct(
     w: &mut Buffer,
     it: &clean::Item,
     g: Option<&clean::Generics>,
-    ty: doctree::StructType,
+    ty: clean::StructType,
     fields: &[clean::Item],
     tab: &str,
     structhead: bool,
@@ -3368,7 +3367,7 @@ fn render_struct(
         write!(w, "{}", g.print())
     }
     match ty {
-        doctree::Plain => {
+        clean::StructType::Plain => {
             if let Some(g) = g {
                 write!(w, "{}", WhereClause { gens: g, indent: 0, end_newline: true })
             }
@@ -3400,7 +3399,7 @@ fn render_struct(
             }
             write!(w, "}}");
         }
-        doctree::Tuple => {
+        clean::StructType::Tuple => {
             write!(w, "(");
             for (i, field) in fields.iter().enumerate() {
                 if i > 0 {
@@ -3425,7 +3424,7 @@ fn render_struct(
             }
             write!(w, ";");
         }
-        doctree::Unit => {
+        clean::StructType::Unit => {
             // Needed for PhantomData.
             if let Some(g) = g {
                 write!(w, "{}", WhereClause { gens: g, indent: 0, end_newline: false })
@@ -4460,7 +4459,7 @@ fn sidebar_struct(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, s: &clea
     let fields = get_struct_fields_name(&s.fields);
 
     if !fields.is_empty() {
-        if let doctree::Plain = s.struct_type {
+        if let clean::StructType::Plain = s.struct_type {
             sidebar.push_str(&format!(
                 "<a class=\"sidebar-title\" href=\"#fields\">Fields</a>\
                  <div class=\"sidebar-links\">{}</div>",

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -52,6 +52,7 @@ use rustc_attr::{Deprecation, StabilityLevel};
 use rustc_data_structures::flock;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir as hir;
+use rustc_hir::def::CtorKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::Mutability;
 use rustc_middle::middle::stability;
@@ -3100,7 +3101,7 @@ fn item_struct(
             _ => None,
         })
         .peekable();
-    if let clean::StructType::Plain = s.struct_type {
+    if let CtorKind::Fictive = s.struct_type {
         if fields.peek().is_some() {
             write!(
                 w,
@@ -3350,7 +3351,7 @@ fn render_struct(
     w: &mut Buffer,
     it: &clean::Item,
     g: Option<&clean::Generics>,
-    ty: clean::StructType,
+    ty: CtorKind,
     fields: &[clean::Item],
     tab: &str,
     structhead: bool,
@@ -3367,7 +3368,7 @@ fn render_struct(
         write!(w, "{}", g.print())
     }
     match ty {
-        clean::StructType::Plain => {
+        CtorKind::Fictive => {
             if let Some(g) = g {
                 write!(w, "{}", WhereClause { gens: g, indent: 0, end_newline: true })
             }
@@ -3399,7 +3400,7 @@ fn render_struct(
             }
             write!(w, "}}");
         }
-        clean::StructType::Tuple => {
+        CtorKind::Fn => {
             write!(w, "(");
             for (i, field) in fields.iter().enumerate() {
                 if i > 0 {
@@ -3424,7 +3425,7 @@ fn render_struct(
             }
             write!(w, ";");
         }
-        clean::StructType::Unit => {
+        CtorKind::Const => {
             // Needed for PhantomData.
             if let Some(g) = g {
                 write!(w, "{}", WhereClause { gens: g, indent: 0, end_newline: false })
@@ -4459,7 +4460,7 @@ fn sidebar_struct(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, s: &clea
     let fields = get_struct_fields_name(&s.fields);
 
     if !fields.is_empty() {
-        if let clean::StructType::Plain = s.struct_type {
+        if let CtorKind::Fictive = s.struct_type {
             sidebar.push_str(&format!(
                 "<a class=\"sidebar-title\" href=\"#fields\">Fields</a>\
                  <div class=\"sidebar-links\">{}</div>",

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -9,7 +9,6 @@ use rustc_span::def_id::{DefId, CRATE_DEF_INDEX};
 use rustc_span::Pos;
 
 use crate::clean;
-use crate::doctree;
 use crate::formats::item_type::ItemType;
 use crate::json::types::*;
 use crate::json::JsonRenderer;
@@ -210,9 +209,9 @@ impl From<clean::Struct> for Struct {
 
 impl From<clean::Union> for Struct {
     fn from(struct_: clean::Union) -> Self {
-        let clean::Union { struct_type, generics, fields, fields_stripped } = struct_;
+        let clean::Union { generics, fields, fields_stripped } = struct_;
         Struct {
-            struct_type: struct_type.into(),
+            struct_type: StructType::Union,
             generics: generics.into(),
             fields_stripped,
             fields: ids(fields),
@@ -221,9 +220,9 @@ impl From<clean::Union> for Struct {
     }
 }
 
-impl From<doctree::StructType> for StructType {
-    fn from(struct_type: doctree::StructType) -> Self {
-        use doctree::StructType::*;
+impl From<clean::StructType> for StructType {
+    fn from(struct_type: clean::StructType) -> Self {
+        use clean::StructType::*;
         match struct_type {
             Plain => StructType::Plain,
             Tuple => StructType::Tuple,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -5,6 +5,7 @@
 use std::convert::From;
 
 use rustc_ast::ast;
+use rustc_hir::def::CtorKind;
 use rustc_span::def_id::{DefId, CRATE_DEF_INDEX};
 use rustc_span::Pos;
 
@@ -220,13 +221,12 @@ impl From<clean::Union> for Struct {
     }
 }
 
-impl From<clean::StructType> for StructType {
-    fn from(struct_type: clean::StructType) -> Self {
-        use clean::StructType::*;
+impl From<CtorKind> for StructType {
+    fn from(struct_type: CtorKind) -> Self {
         match struct_type {
-            Plain => StructType::Plain,
-            Tuple => StructType::Tuple,
-            Unit => StructType::Unit,
+            CtorKind::Fictive => StructType::Plain,
+            CtorKind::Fn => StructType::Tuple,
+            CtorKind::Const => StructType::Unit,
         }
     }
 }

--- a/src/librustdoc/json/types.rs
+++ b/src/librustdoc/json/types.rs
@@ -269,6 +269,7 @@ pub enum StructType {
     Plain,
     Tuple,
     Unit,
+    Union,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
Also removes it from the Union type, as unions can only ever be 'Plain'. Adds a new StructType to JSON, 'union', as the easiest way to encode the type of a union there. This leaves only one item in doctree, `Module`.

r? @jyn514 