### PR TITLE
Work around missing -dev packages in solaris docker image.

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
@@ -30,18 +30,26 @@ cd solaris
 dpkg --add-architecture $APT_ARCH
 apt-get update
 apt-get download $(apt-cache depends --recurse --no-replaces \
-  libc-dev:$APT_ARCH       \
+  libc:$APT_ARCH           \
   libm-dev:$APT_ARCH       \
-  libpthread-dev:$APT_ARCH \
-  libresolv-dev:$APT_ARCH  \
-  librt-dev:$APT_ARCH      \
-  libsocket-dev:$APT_ARCH  \
+  libpthread:$APT_ARCH     \
+  libresolv:$APT_ARCH      \
+  librt:$APT_ARCH          \
+  libsocket:$APT_ARCH      \
   system-crt:$APT_ARCH     \
   system-header:$APT_ARCH  \
   | grep "^\w")
 
 for deb in *$APT_ARCH.deb; do
   dpkg -x $deb .
+done
+
+# The -dev packages are not available from the apt repository we're using.
+# However, those packages are just symlinks from *.so to *.so.<version>.
+# This makes all those symlinks.
+for lib in $(find -name '*.so.*'); do
+  target=${lib%.so.*}.so
+  [ -e $target ] || ln -s ${lib##*/} $target
 done
 
 # Remove Solaris 11 functions that are optionally used by libbacktrace.


### PR DESCRIPTION
This should hopefully make the `dist-various-2` docker build work again on CI, which is now blocking everything from getting merged.

r? @pietroalbini