### PR TITLE
Document why not use concat! in dbg! macro

### DIFF
--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -282,6 +282,10 @@ macro_rules! eprintln {
 #[macro_export]
 #[stable(feature = "dbg_macro", since = "1.32.0")]
 macro_rules! dbg {
+    // NOTE: We cannot use `concat!` to make a static string as a format argument
+    // of `eprintln!` because `file!` could contain a `{` or
+    // `$val` expression could be a block (`{ .. }`), in which case the `eprintln!`
+    // will be malformed.
     () => {
         $crate::eprintln!("[{}:{}]", $crate::file!(), $crate::line!());
     };


### PR DESCRIPTION
Original title: Reduce code generated by `dbg!` macro
The expanded code before/after: <https://rust.godbolt.org/z/hE3j95>.

---

We cannot use `concat!` since `file!` could contains `{` or the expression is a block (`{ .. }`).
Using it will generated malformed format strings.
So let's document this reason why we don't use `concat!` macro at all.