### PR TITLE
Allow specifying alignment for functions

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -279,6 +279,9 @@ pub fn from_fn_attrs(cx: &CodegenCx<'ll, 'tcx>, llfn: &'ll Value, instance: ty::
     if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::CMSE_NONSECURE_ENTRY) {
         llvm::AddFunctionAttrString(llfn, Function, cstr!("cmse_nonsecure_entry"));
     }
+    if let Some(align) = codegen_fn_attrs.alignment {
+        llvm::set_alignment(llfn, align as usize);
+    }
     sanitize(cx, codegen_fn_attrs.no_sanitize, llfn);
 
     // Always annotate functions with the target-cpu they are compiled for.

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -645,6 +645,9 @@ declare_features! (
     /// Allows `extern "C-unwind" fn` to enable unwinding across ABI boundaries.
     (active, c_unwind, "1.52.0", Some(74990), None),
 
+    /// Allows using `#[repr(align(...))]` on function items
+    (active, fn_align, "1.53.0", Some(82232), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -38,6 +38,9 @@ pub struct CodegenFnAttrs {
     /// be generated against a specific instruction set. Only usable on architectures which allow
     /// switching between multiple instruction sets.
     pub instruction_set: Option<InstructionSetAttr>,
+    /// The `#[repr(align(...))]` attribute. Indicates the value of which the function should be
+    /// aligned to.
+    pub alignment: Option<u32>,
 }
 
 bitflags! {
@@ -103,6 +106,7 @@ impl CodegenFnAttrs {
             link_section: None,
             no_sanitize: SanitizerSet::empty(),
             instruction_set: None,
+            alignment: None,
         }
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -561,6 +561,7 @@ symbols! {
         fmt,
         fmt_internals,
         fmul_fast,
+        fn_align,
         fn_must_use,
         fn_mut,
         fn_once,

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -15,6 +15,8 @@
 //! At present, however, we do run collection across all items in the
 //! crate as a kind of pass. This should eventually be factored away.
 
+// ignore-tidy-filelength
+
 use crate::astconv::{AstConv, SizedByDefault};
 use crate::bounds::Bounds;
 use crate::check::intrinsic::intrinsic_operation_unsafety;
@@ -2883,6 +2885,36 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     .emit();
                     None
                 }
+            };
+        } else if tcx.sess.check_name(attr, sym::repr) {
+            codegen_fn_attrs.alignment = match attr.meta_item_list() {
+                Some(items) => match items.as_slice() {
+                    [item] => match item.name_value_literal() {
+                        Some((sym::align, literal)) => {
+                            let alignment = rustc_attr::parse_alignment(&literal.kind);
+
+                            match alignment {
+                                Ok(align) => Some(align),
+                                Err(msg) => {
+                                    struct_span_err!(
+                                        tcx.sess.diagnostic(),
+                                        attr.span,
+                                        E0589,
+                                        "invalid `repr(align)` attribute: {}",
+                                        msg
+                                    )
+                                    .emit();
+
+                                    None
+                                }
+                            }
+                        }
+                        _ => None,
+                    },
+                    [] => None,
+                    _ => None,
+                },
+                None => None,
             };
         }
     }

--- a/src/test/codegen/align-fn.rs
+++ b/src/test/codegen/align-fn.rs
@@ -1,0 +1,9 @@
+// compile-flags: -C no-prepopulate-passes -Z mir-opt-level=0
+
+#![crate_type = "lib"]
+#![feature(fn_align)]
+
+// CHECK: align 16
+#[no_mangle]
+#[repr(align(16))]
+pub fn fn_align() {}

--- a/src/test/ui/attributes/nonterminal-expansion.rs
+++ b/src/test/ui/attributes/nonterminal-expansion.rs
@@ -3,7 +3,6 @@
 macro_rules! pass_nonterminal {
     ($n:expr) => {
         #[repr(align($n))] //~ ERROR expected unsuffixed literal or identifier, found `n!()`
-                           //~| ERROR unrecognized representation hint
         struct S;
     };
 }

--- a/src/test/ui/attributes/nonterminal-expansion.stderr
+++ b/src/test/ui/attributes/nonterminal-expansion.stderr
@@ -9,17 +9,5 @@ LL | pass_nonterminal!(n!());
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0552]: unrecognized representation hint
-  --> $DIR/nonterminal-expansion.rs:5:16
-   |
-LL |         #[repr(align($n))]
-   |                ^^^^^^^^^
-...
-LL | pass_nonterminal!(n!());
-   | ------------------------ in this macro invocation
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0552`.

--- a/src/test/ui/error-codes/E0565.rs
+++ b/src/test/ui/error-codes/E0565.rs
@@ -1,6 +1,5 @@
 // repr currently doesn't support literals
 #[repr("C")] //~ ERROR E0565
-             //~| ERROR E0565
-struct A {  }
+struct A {}
 
-fn main() {  }
+fn main() {}

--- a/src/test/ui/error-codes/E0565.stderr
+++ b/src/test/ui/error-codes/E0565.stderr
@@ -4,12 +4,6 @@ error[E0565]: meta item in `repr` must be an identifier
 LL | #[repr("C")]
    |        ^^^
 
-error[E0565]: meta item in `repr` must be an identifier
-  --> $DIR/E0565.rs:2:8
-   |
-LL | #[repr("C")]
-   |        ^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0565`.

--- a/src/test/ui/feature-gates/feature-gate-fn_align.rs
+++ b/src/test/ui/feature-gates/feature-gate-fn_align.rs
@@ -1,0 +1,4 @@
+#![crate_type = "lib"]
+
+#[repr(align(16))] //~ ERROR `repr(align)` attributes on functions are unstable
+fn requires_alignment() {}

--- a/src/test/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/src/test/ui/feature-gates/feature-gate-fn_align.stderr
@@ -1,0 +1,12 @@
+error[E0658]: `repr(align)` attributes on functions are unstable
+  --> $DIR/feature-gate-fn_align.rs:3:8
+   |
+LL | #[repr(align(16))]
+   |        ^^^^^^^^^
+   |
+   = note: see issue #82232 <https://github.com/rust-lang/rust/issues/82232> for more information
+   = help: add `#![feature(fn_align)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/issues/issue-43988.rs
+++ b/src/test/ui/issues/issue-43988.rs
@@ -13,13 +13,13 @@ fn main() {
 
     #[repr(nothing)]
     let _x = 0;
-    //~^^ ERROR attribute should be applied to a struct, enum, or union
+    //~^^ ERROR E0552
 
     #[repr(something_not_real)]
     loop {
         ()
     };
-    //~^^^^ ERROR attribute should be applied to a struct, enum, or union
+    //~^^^^ ERROR E0552
 
     #[repr]
     let _y = "123";

--- a/src/test/ui/issues/issue-43988.stderr
+++ b/src/test/ui/issues/issue-43988.stderr
@@ -26,23 +26,17 @@ LL |     #[inline(XYZ)]
 LL |     let _b = 4;
    |     ----------- not a function or closure
 
-error[E0517]: attribute should be applied to a struct, enum, or union
+error[E0552]: unrecognized representation hint
   --> $DIR/issue-43988.rs:14:12
    |
 LL |     #[repr(nothing)]
    |            ^^^^^^^
-LL |     let _x = 0;
-   |     ----------- not a struct, enum, or union
 
-error[E0517]: attribute should be applied to a struct, enum, or union
+error[E0552]: unrecognized representation hint
   --> $DIR/issue-43988.rs:18:12
    |
-LL |       #[repr(something_not_real)]
-   |              ^^^^^^^^^^^^^^^^^^
-LL | /     loop {
-LL | |         ()
-LL | |     };
-   | |_____- not a struct, enum, or union
+LL |     #[repr(something_not_real)]
+   |            ^^^^^^^^^^^^^^^^^^
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/issue-43988.rs:30:5
@@ -54,5 +48,5 @@ LL |     foo();
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0517, E0518.
-For more information about an error, try `rustc --explain E0517`.
+Some errors have detailed explanations: E0518, E0552.
+For more information about an error, try `rustc --explain E0518`.

--- a/src/test/ui/repr/repr-disallow-on-variant.rs
+++ b/src/test/ui/repr/repr-disallow-on-variant.rs
@@ -2,7 +2,7 @@ struct Test;
 
 enum Foo {
     #[repr(u8)]
-    //~^ ERROR attribute should be applied to a struct, enum, or union
+    //~^ ERROR attribute should be applied to an enum
     Variant,
 }
 

--- a/src/test/ui/repr/repr-disallow-on-variant.stderr
+++ b/src/test/ui/repr/repr-disallow-on-variant.stderr
@@ -1,11 +1,11 @@
-error[E0517]: attribute should be applied to a struct, enum, or union
+error[E0517]: attribute should be applied to an enum
   --> $DIR/repr-disallow-on-variant.rs:4:12
    |
 LL |     #[repr(u8)]
    |            ^^
 LL |
 LL |     Variant,
-   |     ------- not a struct, enum, or union
+   |     ------- not an enum
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #75072

This allows the user to specify alignment for functions, which can be useful for low level work where functions need to necessarily be aligned to a specific value.

I believe the error cases not covered in the match are caught earlier based on my testing so I had them just return `None`.