### PR TITLE
Gracefully handle loop labels missing leading `'` in different positions

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1617,7 +1617,9 @@ pub enum ExprKind<'hir> {
     /// A conditionless loop (can be exited with `break`, `continue`, or `return`).
     ///
     /// I.e., `'label: loop { <block> }`.
-    Loop(&'hir Block<'hir>, Option<Label>, LoopSource),
+    ///
+    /// The `Span` is the loop header (`for x in y`/`while let pat = expr`).
+    Loop(&'hir Block<'hir>, Option<Label>, LoopSource, Span),
     /// A `match` block, with a source that indicates whether or not it is
     /// the result of a desugaring, and if so, which kind.
     Match(&'hir Expr<'hir>, &'hir [Arm<'hir>], MatchSource),

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1151,7 +1151,7 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
             visitor.visit_expr(then);
             walk_list!(visitor, visit_expr, else_opt);
         }
-        ExprKind::Loop(ref block, ref opt_label, _) => {
+        ExprKind::Loop(ref block, ref opt_label, _, _) => {
             walk_list!(visitor, visit_label, opt_label);
             visitor.visit_block(block);
         }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1396,7 +1396,7 @@ impl<'a> State<'a> {
             hir::ExprKind::If(ref test, ref blk, ref elseopt) => {
                 self.print_if(&test, &blk, elseopt.as_ref().map(|e| &**e));
             }
-            hir::ExprKind::Loop(ref blk, opt_label, _) => {
+            hir::ExprKind::Loop(ref blk, opt_label, _, _) => {
                 if let Some(label) = opt_label {
                     self.print_ident(label.ident);
                     self.word_space(":");

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -546,9 +546,7 @@ fn make_mirror_unadjusted<'a, 'tcx>(
             scrutinee: discr.to_ref(),
             arms: arms.iter().map(|a| convert_arm(cx, a)).collect(),
         },
-        hir::ExprKind::Loop(ref body, _, _) => {
-            ExprKind::Loop { body: block::to_expr_ref(cx, body) }
-        }
+        hir::ExprKind::Loop(ref body, ..) => ExprKind::Loop { body: block::to_expr_ref(cx, body) },
         hir::ExprKind::Field(ref source, ..) => ExprKind::Field {
             lhs: source.to_ref(),
             name: Field::new(cx.tcx.field_index(expr.hir_id, cx.typeck_results)),

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -199,7 +199,7 @@ impl<'tcx> Visitor<'tcx> for CheckConstVisitor<'tcx> {
             // Skip the following checks if we are not currently in a const context.
             _ if self.const_kind.is_none() => {}
 
-            hir::ExprKind::Loop(_, _, source) => {
+            hir::ExprKind::Loop(_, _, source, _) => {
                 self.const_check_violated(NonConstExpr::Loop(*source), e.span);
             }
 

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -844,7 +844,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
             // Note that labels have been resolved, so we don't need to look
             // at the label ident
-            hir::ExprKind::Loop(ref blk, _, _) => self.propagate_through_loop(expr, &blk, succ),
+            hir::ExprKind::Loop(ref blk, ..) => self.propagate_through_loop(expr, &blk, succ),
 
             hir::ExprKind::If(ref cond, ref then, ref else_opt) => {
                 //

--- a/compiler/rustc_passes/src/loops.rs
+++ b/compiler/rustc_passes/src/loops.rs
@@ -53,7 +53,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
 
     fn visit_expr(&mut self, e: &'hir hir::Expr<'hir>) {
         match e.kind {
-            hir::ExprKind::Loop(ref b, _, source) => {
+            hir::ExprKind::Loop(ref b, _, source, _) => {
                 self.with_context(Loop(source), |v| v.visit_block(&b));
             }
             hir::ExprKind::Closure(_, ref function_decl, b, span, movability) => {
@@ -89,8 +89,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
                     Err(hir::LoopIdError::UnresolvedLabel) => None,
                 };
 
-                if let Some(loop_id) = loop_id {
-                    if let Node::Block(_) = self.hir_map.find(loop_id).unwrap() {
+                if let Some(Node::Block(_)) = loop_id.and_then(|id| self.hir_map.find(id)) {
                         return;
                     }
                 }

--- a/compiler/rustc_passes/src/region.rs
+++ b/compiler/rustc_passes/src/region.rs
@@ -252,7 +252,7 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
                 terminating(then.hir_id.local_id);
             }
 
-            hir::ExprKind::Loop(ref body, _, _) => {
+            hir::ExprKind::Loop(ref body, _, _, _) => {
                 terminating(body.hir_id.local_id);
             }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2266,6 +2266,12 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 visit::walk_expr(self, expr);
             }
 
+            ExprKind::Break(None, Some(ref e)) => {
+                // We use this instead of `visit::walk_expr` to keep the parent expr around for
+                // better
+                self.resolve_expr(e, Some(&expr));
+            }
+
             ExprKind::Let(ref pat, ref scrutinee) => {
                 self.visit_expr(scrutinee);
                 self.resolve_pattern_top(pat, PatternSource::Let);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2268,7 +2268,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
 
             ExprKind::Break(None, Some(ref e)) => {
                 // We use this instead of `visit::walk_expr` to keep the parent expr around for
-                // better
+                // better diagnostics.
                 self.resolve_expr(e, Some(&expr));
             }
 

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -547,15 +547,19 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                 for label_rib in &self.label_ribs {
                     for (label_ident, _) in &label_rib.bindings {
                         if format!("'{}", ident) == label_ident.to_string() {
-                            let msg = "a label with a similar name exists";
-                            // FIXME: consider only emitting this suggestion if a label would be valid here
-                            // which is pretty much only the case for `break` expressions.
-                            err.span_suggestion(
-                                span,
-                                &msg,
-                                label_ident.name.to_string(),
-                                Applicability::MaybeIncorrect,
-                            );
+                            err.span_label(label_ident.span, "a label with a similar name exists");
+                            if let PathSource::Expr(Some(Expr {
+                                kind: ExprKind::Break(None, Some(_)),
+                                ..
+                            })) = source
+                            {
+                                err.span_suggestion(
+                                    span,
+                                    "use the similarly named label",
+                                    label_ident.name.to_string(),
+                                    Applicability::MaybeIncorrect,
+                                );
+                            }
                         }
                     }
                 }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -545,7 +545,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         if let Some(err_code) = &err.code {
             if err_code == &rustc_errors::error_code!(E0425) {
                 for label_rib in &self.label_ribs {
-                    for (label_ident, _) in &label_rib.bindings {
+                    for (label_ident, node_id) in &label_rib.bindings {
                         if format!("'{}", ident) == label_ident.to_string() {
                             err.span_label(label_ident.span, "a label with a similar name exists");
                             if let PathSource::Expr(Some(Expr {
@@ -559,6 +559,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                                     label_ident.name.to_string(),
                                     Applicability::MaybeIncorrect,
                                 );
+                                // Do not lint against unused label when we suggest them.
+                                self.diagnostic_metadata.unused_labels.remove(node_id);
                             }
                         }
                     }

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -1173,7 +1173,7 @@ fn extract_labels(ctxt: &mut LifetimeContext<'_, '_>, body: &hir::Body<'_>) {
     }
 
     fn expression_label(ex: &hir::Expr<'_>) -> Option<Ident> {
-        if let hir::ExprKind::Loop(_, Some(label), _) = ex.kind { Some(label.ident) } else { None }
+        if let hir::ExprKind::Loop(_, Some(label), ..) = ex.kind { Some(label.ident) } else { None }
     }
 
     fn check_if_label_shadows_lifetime(tcx: TyCtxt<'_>, mut scope: ScopeRef<'_>, label: Ident) {

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -266,7 +266,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
             ExprKind::Ret(ref expr_opt) => self.check_expr_return(expr_opt.as_deref(), expr),
-            ExprKind::Loop(ref body, _, source) => {
+            ExprKind::Loop(ref body, _, source, _) => {
                 self.check_expr_loop(body, source, expected, expr)
             }
             ExprKind::Match(ref discrim, ref arms, match_src) => {

--- a/compiler/rustc_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_typeck/src/expr_use_visitor.rs
@@ -289,7 +289,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
             | hir::ExprKind::ConstBlock(..)
             | hir::ExprKind::Err => {}
 
-            hir::ExprKind::Loop(ref blk, _, _) => {
+            hir::ExprKind::Loop(ref blk, ..) => {
                 self.walk_block(blk);
             }
 

--- a/src/test/ui/issues/issue-1962.fixed
+++ b/src/test/ui/issues/issue-1962.fixed
@@ -3,8 +3,8 @@
 
 fn main() {
     let mut i = 0;
-    loop { //~ ERROR denote infinite loops with `loop
+    'a: loop { //~ ERROR denote infinite loops with `loop
         i += 1;
-        if i == 5 { break; }
+        if i == 5 { break 'a; }
     }
 }

--- a/src/test/ui/issues/issue-1962.rs
+++ b/src/test/ui/issues/issue-1962.rs
@@ -3,8 +3,8 @@
 
 fn main() {
     let mut i = 0;
-    while true { //~ ERROR denote infinite loops with `loop
+    'a: while true { //~ ERROR denote infinite loops with `loop
         i += 1;
-        if i == 5 { break; }
+        if i == 5 { break 'a; }
     }
 }

--- a/src/test/ui/issues/issue-1962.stderr
+++ b/src/test/ui/issues/issue-1962.stderr
@@ -1,8 +1,8 @@
 error: denote infinite loops with `loop { ... }`
   --> $DIR/issue-1962.rs:6:5
    |
-LL |     while true {
-   |     ^^^^^^^^^^ help: use `loop`
+LL |     'a: while true {
+   |     ^^^^^^^^^^^^^^ help: use `loop`
    |
    = note: requested on the command line with `-D while-true`
 

--- a/src/test/ui/issues/issue-27042.stderr
+++ b/src/test/ui/issues/issue-27042.stderr
@@ -4,7 +4,7 @@ warning: denote infinite loops with `loop { ... }`
 LL | /         'b:
 LL | |
 LL | |         while true { break }; // but here we cite the whole loop
-   | |____________________________^ help: use `loop`
+   | |__________________^ help: use `loop`
    |
    = note: `#[warn(while_true)]` on by default
 

--- a/src/test/ui/label/label_misspelled.rs
+++ b/src/test/ui/label/label_misspelled.rs
@@ -1,17 +1,23 @@
+#![warn(unused_labels)]
+
 fn main() {
     'while_loop: while true { //~ WARN denote infinite loops with
+        //~^ WARN unused label
         while_loop;
         //~^ ERROR cannot find value `while_loop` in this scope
     };
     'while_let: while let Some(_) = Some(()) {
+        //~^ WARN unused label
         while_let;
         //~^ ERROR cannot find value `while_let` in this scope
     }
     'for_loop: for _ in 0..3 {
+        //~^ WARN unused label
         for_loop;
         //~^ ERROR cannot find value `for_loop` in this scope
     };
     'LOOP: loop {
+        //~^ WARN unused label
         LOOP;
         //~^ ERROR cannot find value `LOOP` in this scope
     };
@@ -19,18 +25,22 @@ fn main() {
 
 fn foo() {
     'LOOP: loop {
+        //~^ WARN unused label
         break LOOP;
         //~^ ERROR cannot find value `LOOP` in this scope
     };
     'while_loop: while true { //~ WARN denote infinite loops with
+        //~^ WARN unused label
         break while_loop;
         //~^ ERROR cannot find value `while_loop` in this scope
     };
     'while_let: while let Some(_) = Some(()) {
+        //~^ WARN unused label
         break while_let;
         //~^ ERROR cannot find value `while_let` in this scope
     }
     'for_loop: for _ in 0..3 {
+        //~^ WARN unused label
         break for_loop;
         //~^ ERROR cannot find value `for_loop` in this scope
     };
@@ -39,14 +49,17 @@ fn foo() {
 fn bar() {
     let foo = ();
     'while_loop: while true { //~ WARN denote infinite loops with
+        //~^ WARN unused label
         break foo;
         //~^ ERROR `break` with value from a `while` loop
     };
     'while_let: while let Some(_) = Some(()) {
+        //~^ WARN unused label
         break foo;
         //~^ ERROR `break` with value from a `while` loop
     }
     'for_loop: for _ in 0..3 {
+        //~^ WARN unused label
         break foo;
         //~^ ERROR `break` with value from a `for` loop
     };

--- a/src/test/ui/label/label_misspelled.rs
+++ b/src/test/ui/label/label_misspelled.rs
@@ -25,22 +25,18 @@ fn main() {
 
 fn foo() {
     'LOOP: loop {
-        //~^ WARN unused label
         break LOOP;
         //~^ ERROR cannot find value `LOOP` in this scope
     };
     'while_loop: while true { //~ WARN denote infinite loops with
-        //~^ WARN unused label
         break while_loop;
         //~^ ERROR cannot find value `while_loop` in this scope
     };
     'while_let: while let Some(_) = Some(()) {
-        //~^ WARN unused label
         break while_let;
         //~^ ERROR cannot find value `while_let` in this scope
     }
     'for_loop: for _ in 0..3 {
-        //~^ WARN unused label
         break for_loop;
         //~^ ERROR cannot find value `for_loop` in this scope
     };

--- a/src/test/ui/label/label_misspelled.rs
+++ b/src/test/ui/label/label_misspelled.rs
@@ -16,3 +16,25 @@ fn main() {
         //~^ ERROR cannot find value `for_loop` in this scope
     };
 }
+
+fn foo() {
+    'LOOP: loop {
+        break LOOP;
+        //~^ ERROR cannot find value `LOOP` in this scope
+    };
+    'while_loop: while true { //~ WARN denote infinite loops with
+        break while_loop;
+        //~^ ERROR cannot find value `while_loop` in this scope
+        //~| ERROR `break` with value from a `while` loop
+    };
+    'while_let: while let Some(_) = Some(()) {
+        break while_let;
+        //~^ ERROR cannot find value `while_let` in this scope
+        //~| ERROR `break` with value from a `while` loop
+    }
+    'for_loop: for _ in 0..3 {
+        break for_loop;
+        //~^ ERROR cannot find value `for_loop` in this scope
+        //~| ERROR `break` with value from a `for` loop
+    };
+}

--- a/src/test/ui/label/label_misspelled.rs
+++ b/src/test/ui/label/label_misspelled.rs
@@ -1,8 +1,4 @@
 fn main() {
-    'LOOP: loop {
-        LOOP;
-        //~^ ERROR cannot find value `LOOP` in this scope
-    };
     'while_loop: while true { //~ WARN denote infinite loops with
         while_loop;
         //~^ ERROR cannot find value `while_loop` in this scope
@@ -15,6 +11,10 @@ fn main() {
         for_loop;
         //~^ ERROR cannot find value `for_loop` in this scope
     };
+    'LOOP: loop {
+        LOOP;
+        //~^ ERROR cannot find value `LOOP` in this scope
+    };
 }
 
 fn foo() {
@@ -25,16 +25,29 @@ fn foo() {
     'while_loop: while true { //~ WARN denote infinite loops with
         break while_loop;
         //~^ ERROR cannot find value `while_loop` in this scope
-        //~| ERROR `break` with value from a `while` loop
     };
     'while_let: while let Some(_) = Some(()) {
         break while_let;
         //~^ ERROR cannot find value `while_let` in this scope
-        //~| ERROR `break` with value from a `while` loop
     }
     'for_loop: for _ in 0..3 {
         break for_loop;
         //~^ ERROR cannot find value `for_loop` in this scope
-        //~| ERROR `break` with value from a `for` loop
+    };
+}
+
+fn bar() {
+    let foo = ();
+    'while_loop: while true { //~ WARN denote infinite loops with
+        break foo;
+        //~^ ERROR `break` with value from a `while` loop
+    };
+    'while_let: while let Some(_) = Some(()) {
+        break foo;
+        //~^ ERROR `break` with value from a `while` loop
+    }
+    'for_loop: for _ in 0..3 {
+        break foo;
+        //~^ ERROR `break` with value from a `for` loop
     };
 }

--- a/src/test/ui/label/label_misspelled.stderr
+++ b/src/test/ui/label/label_misspelled.stderr
@@ -1,13 +1,5 @@
-error[E0425]: cannot find value `LOOP` in this scope
-  --> $DIR/label_misspelled.rs:3:9
-   |
-LL |     'LOOP: loop {
-   |     ----- a label with a similar name exists
-LL |         LOOP;
-   |         ^^^^ not found in this scope
-
 error[E0425]: cannot find value `while_loop` in this scope
-  --> $DIR/label_misspelled.rs:7:9
+  --> $DIR/label_misspelled.rs:3:9
    |
 LL |     'while_loop: while true {
    |     ----------- a label with a similar name exists
@@ -15,7 +7,7 @@ LL |         while_loop;
    |         ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `while_let` in this scope
-  --> $DIR/label_misspelled.rs:11:9
+  --> $DIR/label_misspelled.rs:7:9
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ---------- a label with a similar name exists
@@ -23,12 +15,20 @@ LL |         while_let;
    |         ^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `for_loop` in this scope
-  --> $DIR/label_misspelled.rs:15:9
+  --> $DIR/label_misspelled.rs:11:9
    |
 LL |     'for_loop: for _ in 0..3 {
    |     --------- a label with a similar name exists
 LL |         for_loop;
    |         ^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `LOOP` in this scope
+  --> $DIR/label_misspelled.rs:15:9
+   |
+LL |     'LOOP: loop {
+   |     ----- a label with a similar name exists
+LL |         LOOP;
+   |         ^^^^ not found in this scope
 
 error[E0425]: cannot find value `LOOP` in this scope
   --> $DIR/label_misspelled.rs:22:15
@@ -53,7 +53,7 @@ LL |         break while_loop;
    |               help: use the similarly named label: `'while_loop`
 
 error[E0425]: cannot find value `while_let` in this scope
-  --> $DIR/label_misspelled.rs:31:15
+  --> $DIR/label_misspelled.rs:30:15
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ---------- a label with a similar name exists
@@ -64,7 +64,7 @@ LL |         break while_let;
    |               help: use the similarly named label: `'while_let`
 
 error[E0425]: cannot find value `for_loop` in this scope
-  --> $DIR/label_misspelled.rs:36:15
+  --> $DIR/label_misspelled.rs:34:15
    |
 LL |     'for_loop: for _ in 0..3 {
    |     --------- a label with a similar name exists
@@ -75,7 +75,7 @@ LL |         break for_loop;
    |               help: use the similarly named label: `'for_loop`
 
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/label_misspelled.rs:6:5
+  --> $DIR/label_misspelled.rs:2:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
@@ -88,40 +88,64 @@ warning: denote infinite loops with `loop { ... }`
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
 
-error[E0571]: `break` with value from a `while` loop
-  --> $DIR/label_misspelled.rs:26:9
+warning: denote infinite loops with `loop { ... }`
+  --> $DIR/label_misspelled.rs:41:5
    |
-LL |         break while_loop;
-   |         ^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
-   |
-help: instead, use `break` on its own without a value inside this `while` loop
-   |
-LL |         break;
-   |         ^^^^^
+LL |     'while_loop: while true {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/label_misspelled.rs:31:9
+  --> $DIR/label_misspelled.rs:42:9
    |
-LL |         break while_let;
-   |         ^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+LL |     'while_loop: while true {
+   |     ----------------------- you can't `break` with a value in a `while` loop
+LL |         break foo;
+   |         ^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `while` loop
+help: use `break` on its own without a value inside this `while` loop
    |
 LL |         break;
    |         ^^^^^
+help: alternatively, you might have meant to use the available loop label
+   |
+LL |         break 'while_loop;
+   |               ^^^^^^^^^^^
+
+error[E0571]: `break` with value from a `while` loop
+  --> $DIR/label_misspelled.rs:46:9
+   |
+LL |     'while_let: while let Some(_) = Some(()) {
+   |     ---------------------------------------- you can't `break` with a value in a `while` loop
+LL |         break foo;
+   |         ^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
+help: use `break` on its own without a value inside this `while` loop
+   |
+LL |         break;
+   |         ^^^^^
+help: alternatively, you might have meant to use the available loop label
+   |
+LL |         break 'while_let;
+   |               ^^^^^^^^^^
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/label_misspelled.rs:36:9
+  --> $DIR/label_misspelled.rs:50:9
    |
-LL |         break for_loop;
-   |         ^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+LL |     'for_loop: for _ in 0..3 {
+   |     ------------------------ you can't `break` with a value in a `for` loop
+LL |         break foo;
+   |         ^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `for` loop
+help: use `break` on its own without a value inside this `for` loop
    |
 LL |         break;
    |         ^^^^^
+help: alternatively, you might have meant to use the available loop label
+   |
+LL |         break 'for_loop;
+   |               ^^^^^^^^^
 
-error: aborting due to 11 previous errors; 2 warnings emitted
+error: aborting due to 11 previous errors; 3 warnings emitted
 
 Some errors have detailed explanations: E0425, E0571.
 For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/label/label_misspelled.stderr
+++ b/src/test/ui/label/label_misspelled.stderr
@@ -34,6 +34,42 @@ LL |         for_loop;
    |         not found in this scope
    |         help: a label with a similar name exists: `'for_loop`
 
+error[E0425]: cannot find value `LOOP` in this scope
+  --> $DIR/label_misspelled.rs:22:15
+   |
+LL |         break LOOP;
+   |               ^^^^
+   |               |
+   |               not found in this scope
+   |               help: a label with a similar name exists: `'LOOP`
+
+error[E0425]: cannot find value `while_loop` in this scope
+  --> $DIR/label_misspelled.rs:26:15
+   |
+LL |         break while_loop;
+   |               ^^^^^^^^^^
+   |               |
+   |               not found in this scope
+   |               help: a label with a similar name exists: `'while_loop`
+
+error[E0425]: cannot find value `while_let` in this scope
+  --> $DIR/label_misspelled.rs:31:15
+   |
+LL |         break while_let;
+   |               ^^^^^^^^^
+   |               |
+   |               not found in this scope
+   |               help: a label with a similar name exists: `'while_let`
+
+error[E0425]: cannot find value `for_loop` in this scope
+  --> $DIR/label_misspelled.rs:36:15
+   |
+LL |         break for_loop;
+   |               ^^^^^^^^
+   |               |
+   |               not found in this scope
+   |               help: a label with a similar name exists: `'for_loop`
+
 warning: denote infinite loops with `loop { ... }`
   --> $DIR/label_misspelled.rs:6:5
    |
@@ -42,6 +78,46 @@ LL |     'while_loop: while true {
    |
    = note: `#[warn(while_true)]` on by default
 
-error: aborting due to 4 previous errors; 1 warning emitted
+warning: denote infinite loops with `loop { ... }`
+  --> $DIR/label_misspelled.rs:25:5
+   |
+LL |     'while_loop: while true {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
 
-For more information about this error, try `rustc --explain E0425`.
+error[E0571]: `break` with value from a `while` loop
+  --> $DIR/label_misspelled.rs:26:9
+   |
+LL |         break while_loop;
+   |         ^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
+help: instead, use `break` on its own without a value inside this `while` loop
+   |
+LL |         break;
+   |         ^^^^^
+
+error[E0571]: `break` with value from a `while` loop
+  --> $DIR/label_misspelled.rs:31:9
+   |
+LL |         break while_let;
+   |         ^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
+help: instead, use `break` on its own without a value inside this `while` loop
+   |
+LL |         break;
+   |         ^^^^^
+
+error[E0571]: `break` with value from a `for` loop
+  --> $DIR/label_misspelled.rs:36:9
+   |
+LL |         break for_loop;
+   |         ^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
+help: instead, use `break` on its own without a value inside this `for` loop
+   |
+LL |         break;
+   |         ^^^^^
+
+error: aborting due to 11 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0425, E0571.
+For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/label/label_misspelled.stderr
+++ b/src/test/ui/label/label_misspelled.stderr
@@ -1,40 +1,45 @@
 error[E0425]: cannot find value `while_loop` in this scope
-  --> $DIR/label_misspelled.rs:3:9
+  --> $DIR/label_misspelled.rs:6:9
    |
 LL |     'while_loop: while true {
    |     ----------- a label with a similar name exists
+LL |
 LL |         while_loop;
    |         ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `while_let` in this scope
-  --> $DIR/label_misspelled.rs:7:9
+  --> $DIR/label_misspelled.rs:11:9
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ---------- a label with a similar name exists
+LL |
 LL |         while_let;
    |         ^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `for_loop` in this scope
-  --> $DIR/label_misspelled.rs:11:9
+  --> $DIR/label_misspelled.rs:16:9
    |
 LL |     'for_loop: for _ in 0..3 {
    |     --------- a label with a similar name exists
+LL |
 LL |         for_loop;
    |         ^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `LOOP` in this scope
-  --> $DIR/label_misspelled.rs:15:9
+  --> $DIR/label_misspelled.rs:21:9
    |
 LL |     'LOOP: loop {
    |     ----- a label with a similar name exists
+LL |
 LL |         LOOP;
    |         ^^^^ not found in this scope
 
 error[E0425]: cannot find value `LOOP` in this scope
-  --> $DIR/label_misspelled.rs:22:15
+  --> $DIR/label_misspelled.rs:29:15
    |
 LL |     'LOOP: loop {
    |     ----- a label with a similar name exists
+LL |
 LL |         break LOOP;
    |               ^^^^
    |               |
@@ -42,10 +47,11 @@ LL |         break LOOP;
    |               help: use the similarly named label: `'LOOP`
 
 error[E0425]: cannot find value `while_loop` in this scope
-  --> $DIR/label_misspelled.rs:26:15
+  --> $DIR/label_misspelled.rs:34:15
    |
 LL |     'while_loop: while true {
    |     ----------- a label with a similar name exists
+LL |
 LL |         break while_loop;
    |               ^^^^^^^^^^
    |               |
@@ -53,10 +59,11 @@ LL |         break while_loop;
    |               help: use the similarly named label: `'while_loop`
 
 error[E0425]: cannot find value `while_let` in this scope
-  --> $DIR/label_misspelled.rs:30:15
+  --> $DIR/label_misspelled.rs:39:15
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ---------- a label with a similar name exists
+LL |
 LL |         break while_let;
    |               ^^^^^^^^^
    |               |
@@ -64,41 +71,115 @@ LL |         break while_let;
    |               help: use the similarly named label: `'while_let`
 
 error[E0425]: cannot find value `for_loop` in this scope
-  --> $DIR/label_misspelled.rs:34:15
+  --> $DIR/label_misspelled.rs:44:15
    |
 LL |     'for_loop: for _ in 0..3 {
    |     --------- a label with a similar name exists
+LL |
 LL |         break for_loop;
    |               ^^^^^^^^
    |               |
    |               not found in this scope
    |               help: use the similarly named label: `'for_loop`
 
+warning: unused label
+  --> $DIR/label_misspelled.rs:4:5
+   |
+LL |     'while_loop: while true {
+   |     ^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/label_misspelled.rs:1:9
+   |
+LL | #![warn(unused_labels)]
+   |         ^^^^^^^^^^^^^
+
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/label_misspelled.rs:2:5
+  --> $DIR/label_misspelled.rs:4:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
    |
    = note: `#[warn(while_true)]` on by default
 
+warning: unused label
+  --> $DIR/label_misspelled.rs:9:5
+   |
+LL |     'while_let: while let Some(_) = Some(()) {
+   |     ^^^^^^^^^^
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:14:5
+   |
+LL |     'for_loop: for _ in 0..3 {
+   |     ^^^^^^^^^
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:19:5
+   |
+LL |     'LOOP: loop {
+   |     ^^^^^
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:27:5
+   |
+LL |     'LOOP: loop {
+   |     ^^^^^
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:32:5
+   |
+LL |     'while_loop: while true {
+   |     ^^^^^^^^^^^
+
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/label_misspelled.rs:25:5
+  --> $DIR/label_misspelled.rs:32:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
 
+warning: unused label
+  --> $DIR/label_misspelled.rs:37:5
+   |
+LL |     'while_let: while let Some(_) = Some(()) {
+   |     ^^^^^^^^^^
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:42:5
+   |
+LL |     'for_loop: for _ in 0..3 {
+   |     ^^^^^^^^^
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:51:5
+   |
+LL |     'while_loop: while true {
+   |     ^^^^^^^^^^^
+
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/label_misspelled.rs:41:5
+  --> $DIR/label_misspelled.rs:51:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:56:5
+   |
+LL |     'while_let: while let Some(_) = Some(()) {
+   |     ^^^^^^^^^^
+
+warning: unused label
+  --> $DIR/label_misspelled.rs:61:5
+   |
+LL |     'for_loop: for _ in 0..3 {
+   |     ^^^^^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/label_misspelled.rs:42:9
+  --> $DIR/label_misspelled.rs:53:9
    |
 LL |     'while_loop: while true {
    |     ----------------------- you can't `break` with a value in a `while` loop
+LL |
 LL |         break foo;
    |         ^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
@@ -112,10 +193,11 @@ LL |         break 'while_loop;
    |               ^^^^^^^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/label_misspelled.rs:46:9
+  --> $DIR/label_misspelled.rs:58:9
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ---------------------------------------- you can't `break` with a value in a `while` loop
+LL |
 LL |         break foo;
    |         ^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
@@ -129,10 +211,11 @@ LL |         break 'while_let;
    |               ^^^^^^^^^^
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/label_misspelled.rs:50:9
+  --> $DIR/label_misspelled.rs:63:9
    |
 LL |     'for_loop: for _ in 0..3 {
    |     ------------------------ you can't `break` with a value in a `for` loop
+LL |
 LL |         break foo;
    |         ^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
@@ -145,7 +228,7 @@ help: alternatively, you might have meant to use the available loop label
 LL |         break 'for_loop;
    |               ^^^^^^^^^
 
-error: aborting due to 11 previous errors; 3 warnings emitted
+error: aborting due to 11 previous errors; 14 warnings emitted
 
 Some errors have detailed explanations: E0425, E0571.
 For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/label/label_misspelled.stderr
+++ b/src/test/ui/label/label_misspelled.stderr
@@ -35,11 +35,10 @@ LL |         LOOP;
    |         ^^^^ not found in this scope
 
 error[E0425]: cannot find value `LOOP` in this scope
-  --> $DIR/label_misspelled.rs:29:15
+  --> $DIR/label_misspelled.rs:28:15
    |
 LL |     'LOOP: loop {
    |     ----- a label with a similar name exists
-LL |
 LL |         break LOOP;
    |               ^^^^
    |               |
@@ -47,11 +46,10 @@ LL |         break LOOP;
    |               help: use the similarly named label: `'LOOP`
 
 error[E0425]: cannot find value `while_loop` in this scope
-  --> $DIR/label_misspelled.rs:34:15
+  --> $DIR/label_misspelled.rs:32:15
    |
 LL |     'while_loop: while true {
    |     ----------- a label with a similar name exists
-LL |
 LL |         break while_loop;
    |               ^^^^^^^^^^
    |               |
@@ -59,11 +57,10 @@ LL |         break while_loop;
    |               help: use the similarly named label: `'while_loop`
 
 error[E0425]: cannot find value `while_let` in this scope
-  --> $DIR/label_misspelled.rs:39:15
+  --> $DIR/label_misspelled.rs:36:15
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ---------- a label with a similar name exists
-LL |
 LL |         break while_let;
    |               ^^^^^^^^^
    |               |
@@ -71,11 +68,10 @@ LL |         break while_let;
    |               help: use the similarly named label: `'while_let`
 
 error[E0425]: cannot find value `for_loop` in this scope
-  --> $DIR/label_misspelled.rs:44:15
+  --> $DIR/label_misspelled.rs:40:15
    |
 LL |     'for_loop: for _ in 0..3 {
    |     --------- a label with a similar name exists
-LL |
 LL |         break for_loop;
    |               ^^^^^^^^
    |               |
@@ -120,62 +116,38 @@ warning: unused label
 LL |     'LOOP: loop {
    |     ^^^^^
 
-warning: unused label
-  --> $DIR/label_misspelled.rs:27:5
-   |
-LL |     'LOOP: loop {
-   |     ^^^^^
-
-warning: unused label
-  --> $DIR/label_misspelled.rs:32:5
-   |
-LL |     'while_loop: while true {
-   |     ^^^^^^^^^^^
-
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/label_misspelled.rs:32:5
+  --> $DIR/label_misspelled.rs:31:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
 
 warning: unused label
-  --> $DIR/label_misspelled.rs:37:5
-   |
-LL |     'while_let: while let Some(_) = Some(()) {
-   |     ^^^^^^^^^^
-
-warning: unused label
-  --> $DIR/label_misspelled.rs:42:5
-   |
-LL |     'for_loop: for _ in 0..3 {
-   |     ^^^^^^^^^
-
-warning: unused label
-  --> $DIR/label_misspelled.rs:51:5
+  --> $DIR/label_misspelled.rs:47:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^
 
 warning: denote infinite loops with `loop { ... }`
-  --> $DIR/label_misspelled.rs:51:5
+  --> $DIR/label_misspelled.rs:47:5
    |
 LL |     'while_loop: while true {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use `loop`
 
 warning: unused label
-  --> $DIR/label_misspelled.rs:56:5
+  --> $DIR/label_misspelled.rs:52:5
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ^^^^^^^^^^
 
 warning: unused label
-  --> $DIR/label_misspelled.rs:61:5
+  --> $DIR/label_misspelled.rs:57:5
    |
 LL |     'for_loop: for _ in 0..3 {
    |     ^^^^^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/label_misspelled.rs:53:9
+  --> $DIR/label_misspelled.rs:49:9
    |
 LL |     'while_loop: while true {
    |     ----------------------- you can't `break` with a value in a `while` loop
@@ -193,7 +165,7 @@ LL |         break 'while_loop;
    |               ^^^^^^^^^^^
 
 error[E0571]: `break` with value from a `while` loop
-  --> $DIR/label_misspelled.rs:58:9
+  --> $DIR/label_misspelled.rs:54:9
    |
 LL |     'while_let: while let Some(_) = Some(()) {
    |     ---------------------------------------- you can't `break` with a value in a `while` loop
@@ -211,7 +183,7 @@ LL |         break 'while_let;
    |               ^^^^^^^^^^
 
 error[E0571]: `break` with value from a `for` loop
-  --> $DIR/label_misspelled.rs:63:9
+  --> $DIR/label_misspelled.rs:59:9
    |
 LL |     'for_loop: for _ in 0..3 {
    |     ------------------------ you can't `break` with a value in a `for` loop
@@ -228,7 +200,7 @@ help: alternatively, you might have meant to use the available loop label
 LL |         break 'for_loop;
    |               ^^^^^^^^^
 
-error: aborting due to 11 previous errors; 14 warnings emitted
+error: aborting due to 11 previous errors; 10 warnings emitted
 
 Some errors have detailed explanations: E0425, E0571.
 For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/label/label_misspelled.stderr
+++ b/src/test/ui/label/label_misspelled.stderr
@@ -1,74 +1,78 @@
 error[E0425]: cannot find value `LOOP` in this scope
   --> $DIR/label_misspelled.rs:3:9
    |
+LL |     'LOOP: loop {
+   |     ----- a label with a similar name exists
 LL |         LOOP;
-   |         ^^^^
-   |         |
-   |         not found in this scope
-   |         help: a label with a similar name exists: `'LOOP`
+   |         ^^^^ not found in this scope
 
 error[E0425]: cannot find value `while_loop` in this scope
   --> $DIR/label_misspelled.rs:7:9
    |
+LL |     'while_loop: while true {
+   |     ----------- a label with a similar name exists
 LL |         while_loop;
-   |         ^^^^^^^^^^
-   |         |
-   |         not found in this scope
-   |         help: a label with a similar name exists: `'while_loop`
+   |         ^^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `while_let` in this scope
   --> $DIR/label_misspelled.rs:11:9
    |
+LL |     'while_let: while let Some(_) = Some(()) {
+   |     ---------- a label with a similar name exists
 LL |         while_let;
-   |         ^^^^^^^^^
-   |         |
-   |         not found in this scope
-   |         help: a label with a similar name exists: `'while_let`
+   |         ^^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `for_loop` in this scope
   --> $DIR/label_misspelled.rs:15:9
    |
+LL |     'for_loop: for _ in 0..3 {
+   |     --------- a label with a similar name exists
 LL |         for_loop;
-   |         ^^^^^^^^
-   |         |
-   |         not found in this scope
-   |         help: a label with a similar name exists: `'for_loop`
+   |         ^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `LOOP` in this scope
   --> $DIR/label_misspelled.rs:22:15
    |
+LL |     'LOOP: loop {
+   |     ----- a label with a similar name exists
 LL |         break LOOP;
    |               ^^^^
    |               |
    |               not found in this scope
-   |               help: a label with a similar name exists: `'LOOP`
+   |               help: use the similarly named label: `'LOOP`
 
 error[E0425]: cannot find value `while_loop` in this scope
   --> $DIR/label_misspelled.rs:26:15
    |
+LL |     'while_loop: while true {
+   |     ----------- a label with a similar name exists
 LL |         break while_loop;
    |               ^^^^^^^^^^
    |               |
    |               not found in this scope
-   |               help: a label with a similar name exists: `'while_loop`
+   |               help: use the similarly named label: `'while_loop`
 
 error[E0425]: cannot find value `while_let` in this scope
   --> $DIR/label_misspelled.rs:31:15
    |
+LL |     'while_let: while let Some(_) = Some(()) {
+   |     ---------- a label with a similar name exists
 LL |         break while_let;
    |               ^^^^^^^^^
    |               |
    |               not found in this scope
-   |               help: a label with a similar name exists: `'while_let`
+   |               help: use the similarly named label: `'while_let`
 
 error[E0425]: cannot find value `for_loop` in this scope
   --> $DIR/label_misspelled.rs:36:15
    |
+LL |     'for_loop: for _ in 0..3 {
+   |     --------- a label with a similar name exists
 LL |         break for_loop;
    |               ^^^^^^^^
    |               |
    |               not found in this scope
-   |               help: a label with a similar name exists: `'for_loop`
+   |               help: use the similarly named label: `'for_loop`
 
 warning: denote infinite loops with `loop { ... }`
   --> $DIR/label_misspelled.rs:6:5

--- a/src/test/ui/label/label_misspelled_2.rs
+++ b/src/test/ui/label/label_misspelled_2.rs
@@ -5,7 +5,6 @@ fn main() {
         break 'a;
     }
     'b: for _ in 0..1 {
-        //~^ WARN unused label
         break b; //~ ERROR cannot find value `b` in this scope
     }
     c: for _ in 0..1 { //~ ERROR expected identifier, found keyword `for`

--- a/src/test/ui/label/label_misspelled_2.rs
+++ b/src/test/ui/label/label_misspelled_2.rs
@@ -1,0 +1,18 @@
+#![warn(unused_labels)]
+
+fn main() {
+    'a: for _ in 0..1 {
+        break 'a;
+    }
+    'b: for _ in 0..1 {
+        //~^ WARN unused label
+        break b; //~ ERROR cannot find value `b` in this scope
+    }
+    c: for _ in 0..1 { //~ ERROR expected identifier, found keyword `for`
+        //~^ ERROR expected `<`, found reserved identifier `_`
+        break 'c;
+    }
+    d: for _ in 0..1 {
+        break ;
+    }
+}

--- a/src/test/ui/label/label_misspelled_2.rs
+++ b/src/test/ui/label/label_misspelled_2.rs
@@ -7,11 +7,10 @@ fn main() {
     'b: for _ in 0..1 {
         break b; //~ ERROR cannot find value `b` in this scope
     }
-    c: for _ in 0..1 { //~ ERROR expected identifier, found keyword `for`
-        //~^ ERROR expected `<`, found reserved identifier `_`
+    c: for _ in 0..1 { //~ ERROR malformed loop label
         break 'c;
     }
-    d: for _ in 0..1 {
-        break ;
+    d: for _ in 0..1 { //~ ERROR malformed loop label
+        break d; //~ ERROR cannot find value `d` in this scope
     }
 }

--- a/src/test/ui/label/label_misspelled_2.stderr
+++ b/src/test/ui/label/label_misspelled_2.stderr
@@ -1,0 +1,44 @@
+error: expected identifier, found keyword `for`
+  --> $DIR/label_misspelled_2.rs:11:8
+   |
+LL |     c: for _ in 0..1 {
+   |        ^^^ expected identifier, found keyword
+
+error: expected `<`, found reserved identifier `_`
+  --> $DIR/label_misspelled_2.rs:11:12
+   |
+LL |     c: for _ in 0..1 {
+   |      -     ^ expected `<`
+   |      |
+   |      tried to parse a type due to this type ascription
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
+
+error[E0425]: cannot find value `b` in this scope
+  --> $DIR/label_misspelled_2.rs:9:15
+   |
+LL |     'b: for _ in 0..1 {
+   |     -- a label with a similar name exists
+LL |
+LL |         break b;
+   |               ^
+   |               |
+   |               not found in this scope
+   |               help: use the similarly named label: `'b`
+
+warning: unused label
+  --> $DIR/label_misspelled_2.rs:7:5
+   |
+LL |     'b: for _ in 0..1 {
+   |     ^^
+   |
+note: the lint level is defined here
+  --> $DIR/label_misspelled_2.rs:1:9
+   |
+LL | #![warn(unused_labels)]
+   |         ^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/label/label_misspelled_2.stderr
+++ b/src/test/ui/label/label_misspelled_2.stderr
@@ -1,19 +1,14 @@
-error: expected identifier, found keyword `for`
-  --> $DIR/label_misspelled_2.rs:10:8
+error: malformed loop label
+  --> $DIR/label_misspelled_2.rs:10:5
    |
 LL |     c: for _ in 0..1 {
-   |        ^^^ expected identifier, found keyword
+   |     ^ help: use the correct loop label format: `'c`
 
-error: expected `<`, found reserved identifier `_`
-  --> $DIR/label_misspelled_2.rs:10:12
+error: malformed loop label
+  --> $DIR/label_misspelled_2.rs:13:5
    |
-LL |     c: for _ in 0..1 {
-   |      -     ^ expected `<`
-   |      |
-   |      tried to parse a type due to this type ascription
-   |
-   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
+LL |     d: for _ in 0..1 {
+   |     ^ help: use the correct loop label format: `'d`
 
 error[E0425]: cannot find value `b` in this scope
   --> $DIR/label_misspelled_2.rs:8:15
@@ -26,6 +21,17 @@ LL |         break b;
    |               not found in this scope
    |               help: use the similarly named label: `'b`
 
-error: aborting due to 3 previous errors
+error[E0425]: cannot find value `d` in this scope
+  --> $DIR/label_misspelled_2.rs:14:15
+   |
+LL |     d: for _ in 0..1 {
+   |     - a label with a similar name exists
+LL |         break d;
+   |               ^
+   |               |
+   |               not found in this scope
+   |               help: use the similarly named label: `'d`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/label/label_misspelled_2.stderr
+++ b/src/test/ui/label/label_misspelled_2.stderr
@@ -1,11 +1,11 @@
 error: expected identifier, found keyword `for`
-  --> $DIR/label_misspelled_2.rs:11:8
+  --> $DIR/label_misspelled_2.rs:10:8
    |
 LL |     c: for _ in 0..1 {
    |        ^^^ expected identifier, found keyword
 
 error: expected `<`, found reserved identifier `_`
-  --> $DIR/label_misspelled_2.rs:11:12
+  --> $DIR/label_misspelled_2.rs:10:12
    |
 LL |     c: for _ in 0..1 {
    |      -     ^ expected `<`
@@ -16,29 +16,16 @@ LL |     c: for _ in 0..1 {
    = note: see issue #23416 <https://github.com/rust-lang/rust/issues/23416> for more information
 
 error[E0425]: cannot find value `b` in this scope
-  --> $DIR/label_misspelled_2.rs:9:15
+  --> $DIR/label_misspelled_2.rs:8:15
    |
 LL |     'b: for _ in 0..1 {
    |     -- a label with a similar name exists
-LL |
 LL |         break b;
    |               ^
    |               |
    |               not found in this scope
    |               help: use the similarly named label: `'b`
 
-warning: unused label
-  --> $DIR/label_misspelled_2.rs:7:5
-   |
-LL |     'b: for _ in 0..1 {
-   |     ^^
-   |
-note: the lint level is defined here
-  --> $DIR/label_misspelled_2.rs:1:9
-   |
-LL | #![warn(unused_labels)]
-   |         ^^^^^^^^^^^^^
-
-error: aborting due to 3 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/loops/loop-break-value-no-repeat.stderr
+++ b/src/test/ui/loops/loop-break-value-no-repeat.stderr
@@ -1,10 +1,12 @@
 error[E0571]: `break` with value from a `for` loop
   --> $DIR/loop-break-value-no-repeat.rs:12:9
    |
+LL |     for _ in &[1,2,3] {
+   |     ----------------- you can't `break` with a value in a `for` loop
 LL |         break 22
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `for` loop
+help: use `break` on its own without a value inside this `for` loop
    |
 LL |         break
    |         ^^^^^

--- a/src/test/ui/loops/loop-break-value.rs
+++ b/src/test/ui/loops/loop-break-value.rs
@@ -94,6 +94,5 @@ fn main() {
     'LOOP: for _ in 0 .. 9 {
         break LOOP;
         //~^ ERROR cannot find value `LOOP` in this scope
-        //~| ERROR `break` with value from a `for` loop
     }
 }

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -20,32 +20,48 @@ LL |     'while_loop: while true {
 error[E0571]: `break` with value from a `while` loop
   --> $DIR/loop-break-value.rs:28:9
    |
+LL |     'while_loop: while true {
+   |     ----------------------- you can't `break` with a value in a `while` loop
+LL |         break;
 LL |         break ();
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `while` loop
+help: use `break` on its own without a value inside this `while` loop
    |
 LL |         break;
    |         ^^^^^
+help: alternatively, you might have meant to use the available loop label
+   |
+LL |         break 'while_loop;
+   |               ^^^^^^^^^^^
 
 error[E0571]: `break` with value from a `while` loop
   --> $DIR/loop-break-value.rs:30:13
    |
+LL |     'while_loop: while true {
+   |     ----------------------- you can't `break` with a value in a `while` loop
+...
 LL |             break 'while_loop 123;
    |             ^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `while` loop
+help: use `break` on its own without a value inside this `while` loop
    |
 LL |             break;
    |             ^^^^^
+help: alternatively, you might have meant to use the available loop label
+   |
+LL |             break 'while_loop 'while_loop;
+   |                               ^^^^^^^^^^^
 
 error[E0571]: `break` with value from a `while` loop
   --> $DIR/loop-break-value.rs:38:12
    |
+LL |     while let Some(_) = Some(()) {
+   |     ---------------------------- you can't `break` with a value in a `while` loop
 LL |         if break () {
    |            ^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `while` loop
+help: use `break` on its own without a value inside this `while` loop
    |
 LL |         if break {
    |            ^^^^^
@@ -53,10 +69,12 @@ LL |         if break {
 error[E0571]: `break` with value from a `while` loop
   --> $DIR/loop-break-value.rs:43:9
    |
+LL |     while let Some(_) = Some(()) {
+   |     ---------------------------- you can't `break` with a value in a `while` loop
 LL |         break None;
    |         ^^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `while` loop
+help: use `break` on its own without a value inside this `while` loop
    |
 LL |         break;
    |         ^^^^^
@@ -64,21 +82,30 @@ LL |         break;
 error[E0571]: `break` with value from a `while` loop
   --> $DIR/loop-break-value.rs:49:13
    |
+LL |     'while_let_loop: while let Some(_) = Some(()) {
+   |     --------------------------------------------- you can't `break` with a value in a `while` loop
+LL |         loop {
 LL |             break 'while_let_loop "nope";
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `while` loop
+help: use `break` on its own without a value inside this `while` loop
    |
 LL |             break;
    |             ^^^^^
+help: alternatively, you might have meant to use the available loop label
+   |
+LL |             break 'while_let_loop 'while_let_loop;
+   |                                   ^^^^^^^^^^^^^^^
 
 error[E0571]: `break` with value from a `for` loop
   --> $DIR/loop-break-value.rs:56:9
    |
+LL |     for _ in &[1,2,3] {
+   |     ----------------- you can't `break` with a value in a `for` loop
 LL |         break ();
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `for` loop
+help: use `break` on its own without a value inside this `for` loop
    |
 LL |         break;
    |         ^^^^^
@@ -86,10 +113,13 @@ LL |         break;
 error[E0571]: `break` with value from a `for` loop
   --> $DIR/loop-break-value.rs:57:9
    |
+LL |     for _ in &[1,2,3] {
+   |     ----------------- you can't `break` with a value in a `for` loop
+LL |         break ();
 LL |         break [()];
    |         ^^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `for` loop
+help: use `break` on its own without a value inside this `for` loop
    |
 LL |         break;
    |         ^^^^^
@@ -97,24 +127,20 @@ LL |         break;
 error[E0571]: `break` with value from a `for` loop
   --> $DIR/loop-break-value.rs:64:13
    |
+LL |     'for_loop: for _ in &[1,2,3] {
+   |     ---------------------------- you can't `break` with a value in a `for` loop
+...
 LL |             break 'for_loop Some(17);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
    |
-help: instead, use `break` on its own without a value inside this `for` loop
+help: use `break` on its own without a value inside this `for` loop
    |
 LL |             break;
    |             ^^^^^
-
-error[E0571]: `break` with value from a `for` loop
-  --> $DIR/loop-break-value.rs:95:9
+help: alternatively, you might have meant to use the available loop label
    |
-LL |         break LOOP;
-   |         ^^^^^^^^^^ can only break with a value inside `loop` or breakable block
-   |
-help: instead, use `break` on its own without a value inside this `for` loop
-   |
-LL |         break;
-   |         ^^^^^
+LL |             break 'for_loop 'for_loop;
+   |                             ^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
@@ -173,7 +199,7 @@ LL |         break;
    |         expected integer, found `()`
    |         help: give it a value of the expected type: `break value`
 
-error: aborting due to 18 previous errors; 1 warning emitted
+error: aborting due to 17 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0308, E0425, E0571.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -46,12 +46,8 @@ LL |             break 'while_loop 123;
    |
 help: use `break` on its own without a value inside this `while` loop
    |
-LL |             break;
-   |             ^^^^^
-help: alternatively, you might have meant to use the available loop label
-   |
-LL |             break 'while_loop 'while_loop;
-   |                               ^^^^^^^^^^^
+LL |             break 'while_loop;
+   |             ^^^^^^^^^^^^^^^^^
 
 error[E0571]: `break` with value from a `while` loop
   --> $DIR/loop-break-value.rs:38:12
@@ -90,12 +86,8 @@ LL |             break 'while_let_loop "nope";
    |
 help: use `break` on its own without a value inside this `while` loop
    |
-LL |             break;
-   |             ^^^^^
-help: alternatively, you might have meant to use the available loop label
-   |
-LL |             break 'while_let_loop 'while_let_loop;
-   |                                   ^^^^^^^^^^^^^^^
+LL |             break 'while_let_loop;
+   |             ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0571]: `break` with value from a `for` loop
   --> $DIR/loop-break-value.rs:56:9
@@ -135,12 +127,8 @@ LL |             break 'for_loop Some(17);
    |
 help: use `break` on its own without a value inside this `for` loop
    |
-LL |             break;
-   |             ^^^^^
-help: alternatively, you might have meant to use the available loop label
-   |
-LL |             break 'for_loop 'for_loop;
-   |                             ^^^^^^^^^
+LL |             break 'for_loop;
+   |             ^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -1,11 +1,13 @@
 error[E0425]: cannot find value `LOOP` in this scope
   --> $DIR/loop-break-value.rs:95:15
    |
+LL |     'LOOP: for _ in 0 .. 9 {
+   |     ----- a label with a similar name exists
 LL |         break LOOP;
    |               ^^^^
    |               |
    |               not found in this scope
-   |               help: a label with a similar name exists: `'LOOP`
+   |               help: use the similarly named label: `'LOOP`
 
 warning: denote infinite loops with `loop { ... }`
   --> $DIR/loop-break-value.rs:26:5

--- a/src/tools/clippy/clippy_lints/src/needless_continue.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_continue.rs
@@ -221,7 +221,7 @@ where
 {
     if let ast::ExprKind::While(_, loop_block, label)
     | ast::ExprKind::ForLoop(_, _, loop_block, label)
-    | ast::ExprKind::Loop(loop_block, label, _) = &expr.kind
+    | ast::ExprKind::Loop(loop_block, label, ..) = &expr.kind
     {
         func(loop_block, label.as_ref());
     }

--- a/src/tools/clippy/clippy_lints/src/needless_continue.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_continue.rs
@@ -221,7 +221,7 @@ where
 {
     if let ast::ExprKind::While(_, loop_block, label)
     | ast::ExprKind::ForLoop(_, _, loop_block, label)
-    | ast::ExprKind::Loop(loop_block, label) = &expr.kind
+    | ast::ExprKind::Loop(loop_block, label, _) = &expr.kind
     {
         func(loop_block, label.as_ref());
     }

--- a/src/tools/clippy/clippy_lints/src/shadow.rs
+++ b/src/tools/clippy/clippy_lints/src/shadow.rs
@@ -325,7 +325,7 @@ fn check_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, bindings: &mut
         | ExprKind::Field(ref e, _)
         | ExprKind::AddrOf(_, _, ref e)
         | ExprKind::Box(ref e) => check_expr(cx, e, bindings),
-        ExprKind::Block(ref block, _) | ExprKind::Loop(ref block, _, _) => check_block(cx, block, bindings),
+        ExprKind::Block(ref block, _) | ExprKind::Loop(ref block, ..) => check_block(cx, block, bindings),
         // ExprKind::Call
         // ExprKind::MethodCall
         ExprKind::Array(v) | ExprKind::Tup(v) => {

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -317,7 +317,7 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
                 self.current = cast_pat;
                 self.visit_expr(expr);
             },
-            ExprKind::Loop(ref body, _, desugaring) => {
+            ExprKind::Loop(ref body, _, desugaring, _) => {
                 let body_pat = self.next("body");
                 let des = loop_desugaring_name(desugaring);
                 let label_pat = self.next("label");

--- a/src/tools/clippy/clippy_lints/src/utils/higher.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/higher.rs
@@ -142,7 +142,7 @@ pub fn for_loop<'tcx>(
         if let hir::ExprKind::Match(ref iterexpr, ref arms, hir::MatchSource::ForLoopDesugar) = expr.kind;
         if let hir::ExprKind::Call(_, ref iterargs) = iterexpr.kind;
         if iterargs.len() == 1 && arms.len() == 1 && arms[0].guard.is_none();
-        if let hir::ExprKind::Loop(ref block, _, _) = arms[0].body.kind;
+        if let hir::ExprKind::Loop(ref block, ..) = arms[0].body.kind;
         if block.expr.is_none();
         if let [ _, _, ref let_stmt, ref body ] = *block.stmts;
         if let hir::StmtKind::Local(ref local) = let_stmt.kind;
@@ -158,7 +158,7 @@ pub fn for_loop<'tcx>(
 /// `while cond { body }` becomes `(cond, body)`.
 pub fn while_loop<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> Option<(&'tcx hir::Expr<'tcx>, &'tcx hir::Expr<'tcx>)> {
     if_chain! {
-        if let hir::ExprKind::Loop(block, _, hir::LoopSource::While) = &expr.kind;
+        if let hir::ExprKind::Loop(block, _, hir::LoopSource::While, _) = &expr.kind;
         if let hir::Block { expr: Some(expr), .. } = &**block;
         if let hir::ExprKind::Match(cond, arms, hir::MatchSource::WhileDesugar) = &expr.kind;
         if let hir::ExprKind::DropTemps(cond) = &cond.kind;

--- a/src/tools/clippy/clippy_lints/src/utils/hir_utils.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/hir_utils.rs
@@ -123,7 +123,7 @@ impl<'a, 'tcx> SpanlessEq<'a, 'tcx> {
                 self.eq_expr(lc, rc) && self.eq_expr(&**lt, &**rt) && both(le, re, |l, r| self.eq_expr(l, r))
             },
             (&ExprKind::Lit(ref l), &ExprKind::Lit(ref r)) => l.node == r.node,
-            (&ExprKind::Loop(ref lb, ref ll, ref lls), &ExprKind::Loop(ref rb, ref rl, ref rls)) => {
+            (&ExprKind::Loop(ref lb, ref ll, ref lls, _), &ExprKind::Loop(ref rb, ref rl, ref rls, _)) => {
                 lls == rls && self.eq_block(lb, rb) && both(ll, rl, |l, r| l.ident.name == r.ident.name)
             },
             (&ExprKind::Match(ref le, ref la, ref ls), &ExprKind::Match(ref re, ref ra, ref rs)) => {
@@ -560,7 +560,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
             ExprKind::Lit(ref l) => {
                 l.node.hash(&mut self.s);
             },
-            ExprKind::Loop(ref b, ref i, _) => {
+            ExprKind::Loop(ref b, ref i, ..) => {
                 self.hash_block(b);
                 if let Some(i) = *i {
                     self.hash_name(i.ident.name);


### PR DESCRIPTION
Fix #81192.

* Account for labels when suggesting `loop` instead of `while true`
* Suggest `'a` when given `a` only when appropriate
* Add loop head span to hir
* Tweak error for invalid `break expr`
* Add more misspelled label tests
* Avoid emitting redundant "unused label" lint
* Parse loop labels missing a leading `'`

Each commit can be reviewed in isolation.