### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_mir/src/shim.rs
+++ b/compiler/rustc_mir/src/shim.rs
@@ -81,7 +81,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> Body<'
         MirPhase::Const,
         &[&[
             &add_moves_for_packed_drops::AddMovesForPackedDrops,
-            &no_landing_pads::NoLandingPads::new(tcx),
+            &no_landing_pads::NoLandingPads,
             &remove_noop_landing_pads::RemoveNoopLandingPads,
             &simplify::SimplifyCfg::new("make_shim"),
             &add_call_guards::CriticalCallEdges,

--- a/compiler/rustc_mir/src/transform/coverage/counters.rs
+++ b/compiler/rustc_mir/src/transform/coverage/counters.rs
@@ -32,7 +32,7 @@ impl CoverageCounters {
     }
 
     /// Activate the `DebugCounters` data structures, to provide additional debug formatting
-    /// features when formating `CoverageKind` (counter) values.
+    /// features when formatting `CoverageKind` (counter) values.
     pub fn enable_debug(&mut self) {
         self.debug_counters.enable();
     }

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -433,7 +433,7 @@ fn run_post_borrowck_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tc
 
     let post_borrowck_cleanup: &[&dyn MirPass<'tcx>] = &[
         // Remove all things only needed by analysis
-        &no_landing_pads::NoLandingPads::new(tcx),
+        &no_landing_pads::NoLandingPads,
         &simplify_branches::SimplifyBranches::new("initial"),
         &remove_noop_landing_pads::RemoveNoopLandingPads,
         &cleanup_post_borrowck::CleanupNonCodegenStatements,
@@ -441,7 +441,7 @@ fn run_post_borrowck_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tc
         // These next passes must be executed together
         &add_call_guards::CriticalCallEdges,
         &elaborate_drops::ElaborateDrops,
-        &no_landing_pads::NoLandingPads::new(tcx),
+        &no_landing_pads::NoLandingPads,
         // AddMovesForPackedDrops needs to run after drop
         // elaboration.
         &add_moves_for_packed_drops::AddMovesForPackedDrops,

--- a/compiler/rustc_mir/src/transform/no_landing_pads.rs
+++ b/compiler/rustc_mir/src/transform/no_landing_pads.rs
@@ -2,42 +2,27 @@
 //! specified.
 
 use crate::transform::MirPass;
-use rustc_middle::mir::visit::MutVisitor;
 use rustc_middle::mir::*;
 use rustc_middle::ty::TyCtxt;
 use rustc_target::spec::PanicStrategy;
 
-pub struct NoLandingPads<'tcx> {
-    tcx: TyCtxt<'tcx>,
-}
+pub struct NoLandingPads;
 
-impl<'tcx> NoLandingPads<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
-        NoLandingPads { tcx }
-    }
-}
-
-impl<'tcx> MirPass<'tcx> for NoLandingPads<'tcx> {
+impl<'tcx> MirPass<'tcx> for NoLandingPads {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         no_landing_pads(tcx, body)
     }
 }
 
 pub fn no_landing_pads<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-    if tcx.sess.panic_strategy() == PanicStrategy::Abort {
-        NoLandingPads::new(tcx).visit_body(body);
-    }
-}
-
-impl<'tcx> MutVisitor<'tcx> for NoLandingPads<'tcx> {
-    fn tcx(&self) -> TyCtxt<'tcx> {
-        self.tcx
+    if tcx.sess.panic_strategy() != PanicStrategy::Abort {
+        return;
     }
 
-    fn visit_terminator(&mut self, terminator: &mut Terminator<'tcx>, location: Location) {
+    for block in body.basic_blocks_mut() {
+        let terminator = block.terminator_mut();
         if let Some(unwind) = terminator.kind.unwind_mut() {
             unwind.take();
         }
-        self.super_terminator(terminator, location);
     }
 }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -244,6 +244,13 @@ impl<'a> PathSource<'a> {
                 // "function" here means "anything callable" rather than `DefKind::Fn`,
                 // this is not precise but usually more helpful than just "value".
                 Some(ExprKind::Call(call_expr, _)) => match &call_expr.kind {
+                    // the case of `::some_crate()`
+                    ExprKind::Path(_, path)
+                        if path.segments.len() == 2
+                            && path.segments[0].ident.name == kw::PathRoot =>
+                    {
+                        "external crate"
+                    }
                     ExprKind::Path(_, path) => {
                         let mut msg = "function";
                         if let Some(segment) = path.segments.iter().last() {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -2458,8 +2458,14 @@ impl<'a> Resolver<'a> {
                             (format!("use of undeclared crate or module `{}`", ident), None)
                         }
                     } else {
-                        let mut msg =
-                            format!("could not find `{}` in `{}`", ident, path[i - 1].ident);
+                        let parent = path[i - 1].ident.name;
+                        let parent = if parent == kw::PathRoot {
+                            "crate root".to_owned()
+                        } else {
+                            format!("`{}`", parent)
+                        };
+
+                        let mut msg = format!("could not find `{}` in {}", ident, parent);
                         if ns == TypeNS || ns == ValueNS {
                             let ns_to_try = if ns == TypeNS { ValueNS } else { TypeNS };
                             if let FindBindingResult::Binding(Ok(binding)) =
@@ -2467,11 +2473,11 @@ impl<'a> Resolver<'a> {
                             {
                                 let mut found = |what| {
                                     msg = format!(
-                                        "expected {}, found {} `{}` in `{}`",
+                                        "expected {}, found {} `{}` in {}",
                                         ns.descr(),
                                         what,
                                         ident,
-                                        path[i - 1].ident
+                                        parent
                                     )
                                 };
                                 if binding.module().is_some() {

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -282,21 +282,22 @@
 //! `%`. The actual grammar for the formatting syntax is:
 //!
 //! ```text
-//! format_string := <text> [ maybe-format <text> ] *
-//! maybe-format := '{' '{' | '}' '}' | <format>
+//! format_string := text [ maybe_format text ] *
+//! maybe_format := '{' '{' | '}' '}' | format
 //! format := '{' [ argument ] [ ':' format_spec ] '}'
 //! argument := integer | identifier
 //!
-//! format_spec := [[fill]align][sign]['#']['0'][width]['.' precision][type]
+//! format_spec := [[fill]align][sign]['#']['0'][width]['.' precision]type
 //! fill := character
 //! align := '<' | '^' | '>'
 //! sign := '+' | '-'
 //! width := count
 //! precision := count | '*'
-//! type := identifier | '?' | ''
+//! type := '' | '?' | 'x?' | 'X?' | identifier
 //! count := parameter | integer
 //! parameter := argument '$'
 //! ```
+//! In the above grammar, `text` may not contain any `'{'` or `'}'` characters.
 //!
 //! # Formatting traits
 //!

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -253,26 +253,6 @@ mod spec_extend;
 /// can be slow. For this reason, it is recommended to use [`Vec::with_capacity`]
 /// whenever possible to specify how big the vector is expected to get.
 ///
-/// A vector containing the elements `'a'` and `'b'` with capacity 4 can be
-/// visualized as:
-///
-/// ```text
-/// Stack       ptr      len  capacity
-/// /Heap  +--------+--------+--------+
-///        | 0x0123 |      2 |      4 |
-///        +--------+--------+--------+
-///             |
-///             v
-/// Heap   +--------+--------+--------+--------+
-///        |    'a' |    'b' | uninit | uninit |
-///        +--------+--------+--------+--------+
-/// ```
-///
-/// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
-/// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory 
-///   layout (including the order of fields). See [the section about 
-///   guarantees](#guarantees).
-///
 /// # Guarantees
 ///
 /// Due to its incredibly fundamental nature, `Vec` makes a lot of guarantees
@@ -304,6 +284,28 @@ mod spec_extend;
 /// pointer points to [`len`] initialized, contiguous elements in order (what
 /// you would see if you coerced it to a slice), followed by [`capacity`]` -
 /// `[`len`] logically uninitialized, contiguous elements.
+///
+/// A vector containing the elements `'a'` and `'b'` with capacity 4 can be
+/// visualized as below. The top part is the `Vec` struct, it contains a
+/// pointer to the head of the allocation in the heap, length and capacity.
+/// The bottom part is the allocation on the heap, a contiguous memory block.
+///
+/// ```text
+///             ptr      len  capacity
+///        +--------+--------+--------+
+///        | 0x0123 |      2 |      4 |
+///        +--------+--------+--------+
+///             |
+///             v
+/// Heap   +--------+--------+--------+--------+
+///        |    'a' |    'b' | uninit | uninit |
+///        +--------+--------+--------+--------+
+/// ```
+///
+/// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
+/// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory
+///   layout (including the order of fields). See [the section about
+///   guarantees](#guarantees).
 ///
 /// `Vec` will never perform a "small optimization" where elements are actually
 /// stored on the stack for two reasons:

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -253,6 +253,26 @@ mod spec_extend;
 /// can be slow. For this reason, it is recommended to use [`Vec::with_capacity`]
 /// whenever possible to specify how big the vector is expected to get.
 ///
+/// A vector containing the elements `'a'` and `'b'` with capacity 4 can be
+/// visualized as:
+///
+/// ```text
+/// Stack       ptr      len  capacity
+/// /Heap  +--------+--------+--------+
+///        | 0x0123 |      2 |      4 |
+///        +--------+--------+--------+
+///             |
+///             v
+/// Heap   +--------+--------+--------+--------+
+///        |    'a' |    'b' | uninit | uninit |
+///        +--------+--------+--------+--------+
+/// ```
+///
+/// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
+/// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory 
+///   layout (including the order of fields). See [the section about 
+///   guarantees](#guarantees).
+///
 /// # Guarantees
 ///
 /// Due to its incredibly fundamental nature, `Vec` makes a lot of guarantees
@@ -345,6 +365,7 @@ mod spec_extend;
 /// [`push`]: Vec::push
 /// [`insert`]: Vec::insert
 /// [`reserve`]: Vec::reserve
+/// [`MaybeUninit`]: core::mem::MaybeUninit
 /// [owned slice]: Box
 /// [slice]: ../../std/primitive.slice.html
 /// [`&`]: ../../std/primitive.reference.html

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -304,8 +304,7 @@ mod spec_extend;
 ///
 /// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].
 /// - Note: the ABI is not stable and `Vec` makes no guarantees about its memory
-///   layout (including the order of fields). See [the section about
-///   guarantees](#guarantees).
+///   layout (including the order of fields).
 ///
 /// `Vec` will never perform a "small optimization" where elements are actually
 /// stored on the stack for two reasons:

--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -1,13 +1,11 @@
 use core::iter::TrustedLen;
 use core::ptr::{self};
 
-#[allow(unused_imports)]
-use super::SpecFromIter;
 use super::{SpecExtend, Vec};
 
 /// Another specialization trait for Vec::from_iter
 /// necessary to manually prioritize overlapping specializations
-/// see [`SpecFromIter`] for details.
+/// see [`SpecFromIter`](super::SpecFromIter) for details.
 pub(super) trait SpecFromIterNested<T, I> {
     fn from_iter(iter: I) -> Self;
 }

--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -1,6 +1,8 @@
 use core::iter::TrustedLen;
 use core::ptr::{self};
 
+#[allow(unused_imports)]
+use super::SpecFromIter;
 use super::{SpecExtend, Vec};
 
 /// Another specialization trait for Vec::from_iter

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -561,6 +561,13 @@ pub fn home_dir() -> Option<PathBuf> {
 
 /// Returns the path of a temporary directory.
 ///
+/// The temporary directory may be shared among users, or between processes
+/// with different privileges; thus, the creation of any files or directories
+/// in the temporary directory must use a secure method to create a uniquely
+/// named file. Creating a file or directory with a fixed or predictable name
+/// may result in "insecure temporary file" security vulnerabilities. Consider
+/// using a crate that securely creates temporary files or directories.
+///
 /// # Unix
 ///
 /// Returns the value of the `TMPDIR` environment variable if it is
@@ -580,14 +587,10 @@ pub fn home_dir() -> Option<PathBuf> {
 ///
 /// ```no_run
 /// use std::env;
-/// use std::fs::File;
 ///
-/// fn main() -> std::io::Result<()> {
+/// fn main() {
 ///     let mut dir = env::temp_dir();
-///     dir.push("foo.txt");
-///
-///     let f = File::create(dir)?;
-///     Ok(())
+///     println!("Temporary directory: {}", dir.display());
 /// }
 /// ```
 #[stable(feature = "env", since = "1.0.0")]

--- a/library/std/src/io/prelude.rs
+++ b/library/std/src/io/prelude.rs
@@ -1,4 +1,4 @@
-//! # The I/O Prelude
+//! The I/O Prelude.
 //!
 //! The purpose of this module is to alleviate imports of many common I/O traits
 //! by adding a glob import to the top of I/O heavy modules:

--- a/library/std/src/io/prelude.rs
+++ b/library/std/src/io/prelude.rs
@@ -1,4 +1,4 @@
-//! The I/O Prelude
+//! # The I/O Prelude
 //!
 //! The purpose of this module is to alleviate imports of many common I/O traits
 //! by adding a glob import to the top of I/O heavy modules:

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -1,4 +1,4 @@
-//! The Rust Prelude.
+//! # The Rust Prelude
 //!
 //! Rust comes with a variety of things in its standard library. However, if
 //! you had to manually import every single thing that you used, it would be

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -29,34 +29,34 @@
 //! [`std::prelude::v1`], and re-exports the following:
 //!
 //! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`], [`Unpin`]}:
-//!   Marker traits that indicate fundamental properties of types.
-//! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}: Various
+//!   marker traits that indicate fundamental properties of types.
+//! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}: various
 //!   operations for both destructors and overloading `()`.
-//! * [`std::mem`]::[`drop`][`mem::drop`]: A convenience function for explicitly
+//! * [`std::mem`]::[`drop`][`mem::drop`]: a convenience function for explicitly
 //!   dropping a value.
-//! * [`std::boxed`]::[`Box`]: A way to allocate values on the heap.
-//! * [`std::borrow`]::[`ToOwned`]: The conversion trait that defines
+//! * [`std::boxed`]::[`Box`]: a way to allocate values on the heap.
+//! * [`std::borrow`]::[`ToOwned`]: the conversion trait that defines
 //!   [`to_owned`], the generic method for creating an owned type from a
 //!   borrowed type.
-//! * [`std::clone`]::[`Clone`]: The ubiquitous trait that defines
+//! * [`std::clone`]::[`Clone`]: the ubiquitous trait that defines
 //!   [`clone`][`Clone::clone`], the method for producing a copy of a value.
-//! * [`std::cmp`]::{[`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]}: The
+//! * [`std::cmp`]::{[`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]}: the
 //!   comparison traits, which implement the comparison operators and are often
 //!   seen in trait bounds.
-//! * [`std::convert`]::{[`AsRef`], [`AsMut`], [`Into`], [`From`]}: Generic
+//! * [`std::convert`]::{[`AsRef`], [`AsMut`], [`Into`], [`From`]}: generic
 //!   conversions, used by savvy API authors to create overloaded methods.
 //! * [`std::default`]::[`Default`], types that have default values.
 //! * [`std::iter`]::{[`Iterator`], [`Extend`], [`IntoIterator`],
-//!   [`DoubleEndedIterator`], [`ExactSizeIterator`]}: Iterators of various
+//!   [`DoubleEndedIterator`], [`ExactSizeIterator`]}: iterators of various
 //!   kinds.
 //! * [`std::option`]::[`Option`]::{[`self`][`Option`], [`Some`], [`None`]}, a
 //!   type which expresses the presence or absence of a value. This type is so
 //!   commonly used, its variants are also exported.
-//! * [`std::result`]::[`Result`]::{[`self`][`Result`], [`Ok`], [`Err`]}: A type
+//! * [`std::result`]::[`Result`]::{[`self`][`Result`], [`Ok`], [`Err`]}: a type
 //!   for functions that may succeed or fail. Like [`Option`], its variants are
 //!   exported as well.
-//! * [`std::string`]::{[`String`], [`ToString`]}: Heap-allocated strings.
-//! * [`std::vec`]::[`Vec`]: A growable, heap-allocated vector.
+//! * [`std::string`]::{[`String`], [`ToString`]}: heap-allocated strings.
+//! * [`std::vec`]::[`Vec`]: a growable, heap-allocated vector.
 //!
 //! [`mem::drop`]: crate::mem::drop
 //! [`std::borrow`]: crate::borrow

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -28,35 +28,35 @@
 //! The current version of the prelude (version 1) lives in
 //! [`std::prelude::v1`], and re-exports the following:
 //!
-//! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`], [`Unpin`]},
-//!   marker traits that indicate fundamental properties of types.
-//! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}, various
+//! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`], [`Unpin`]}:
+//!   Marker traits that indicate fundamental properties of types.
+//! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}: Various
 //!   operations for both destructors and overloading `()`.
-//! * [`std::mem`]::[`drop`][`mem::drop`], a convenience function for explicitly
+//! * [`std::mem`]::[`drop`][`mem::drop`]: A convenience function for explicitly
 //!   dropping a value.
-//! * [`std::boxed`]::[`Box`], a way to allocate values on the heap.
-//! * [`std::borrow`]::[`ToOwned`], the conversion trait that defines
+//! * [`std::boxed`]::[`Box`]: A way to allocate values on the heap.
+//! * [`std::borrow`]::[`ToOwned`]: The conversion trait that defines
 //!   [`to_owned`], the generic method for creating an owned type from a
 //!   borrowed type.
-//! * [`std::clone`]::[`Clone`], the ubiquitous trait that defines
+//! * [`std::clone`]::[`Clone`]: The ubiquitous trait that defines
 //!   [`clone`][`Clone::clone`], the method for producing a copy of a value.
-//! * [`std::cmp`]::{[`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`] }, the
+//! * [`std::cmp`]::{[`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]}: The
 //!   comparison traits, which implement the comparison operators and are often
 //!   seen in trait bounds.
-//! * [`std::convert`]::{[`AsRef`], [`AsMut`], [`Into`], [`From`]}, generic
+//! * [`std::convert`]::{[`AsRef`], [`AsMut`], [`Into`], [`From`]}: Generic
 //!   conversions, used by savvy API authors to create overloaded methods.
 //! * [`std::default`]::[`Default`], types that have default values.
-//! * [`std::iter`]::{[`Iterator`], [`Extend`], [`IntoIterator`]
-//!   [`DoubleEndedIterator`], [`ExactSizeIterator`]}, iterators of various
+//! * [`std::iter`]::{[`Iterator`], [`Extend`], [`IntoIterator`],
+//!   [`DoubleEndedIterator`], [`ExactSizeIterator`]}: Iterators of various
 //!   kinds.
 //! * [`std::option`]::[`Option`]::{[`self`][`Option`], [`Some`], [`None`]}, a
 //!   type which expresses the presence or absence of a value. This type is so
 //!   commonly used, its variants are also exported.
-//! * [`std::result`]::[`Result`]::{[`self`][`Result`], [`Ok`], [`Err`]}, a type
+//! * [`std::result`]::[`Result`]::{[`self`][`Result`], [`Ok`], [`Err`]}: A type
 //!   for functions that may succeed or fail. Like [`Option`], its variants are
 //!   exported as well.
-//! * [`std::string`]::{[`String`], [`ToString`]}, heap allocated strings.
-//! * [`std::vec`]::[`Vec`], a growable, heap-allocated vector.
+//! * [`std::string`]::{[`String`], [`ToString`]}: Heap-allocated strings.
+//! * [`std::vec`]::[`Vec`]: A growable, heap-allocated vector.
 //!
 //! [`mem::drop`]: crate::mem::drop
 //! [`std::borrow`]: crate::borrow

--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -38,10 +38,14 @@ crate trait FormatRenderer<'tcx>: Clone {
     fn mod_item_out(&mut self, item_name: &str) -> Result<(), Error>;
 
     /// Post processing hook for cleanup and dumping output to files.
-    fn after_krate(&mut self, krate: &clean::Crate, cache: &Cache) -> Result<(), Error>;
-
-    /// Called after everything else to write out errors.
-    fn after_run(&mut self, diag: &rustc_errors::Handler) -> Result<(), Error>;
+    ///
+    /// A handler is available if the renderer wants to report errors.
+    fn after_krate(
+        &mut self,
+        krate: &clean::Crate,
+        cache: &Cache,
+        diag: &rustc_errors::Handler,
+    ) -> Result<(), Error>;
 }
 
 /// Main method for rendering a crate.
@@ -104,6 +108,5 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
         }
     }
 
-    format_renderer.after_krate(&krate, &cache)?;
-    format_renderer.after_run(diag)
+    format_renderer.after_krate(&krate, &cache, diag)
 }

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -199,7 +199,12 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         Ok(())
     }
 
-    fn after_krate(&mut self, krate: &clean::Crate, cache: &Cache) -> Result<(), Error> {
+    fn after_krate(
+        &mut self,
+        krate: &clean::Crate,
+        cache: &Cache,
+        _diag: &rustc_errors::Handler,
+    ) -> Result<(), Error> {
         debug!("Done with crate");
         let mut index = (*self.index).clone().into_inner();
         index.extend(self.get_trait_items(cache));
@@ -243,10 +248,6 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         p.set_extension("json");
         let file = File::create(&p).map_err(|error| Error { error: error.to_string(), file: p })?;
         serde_json::ser::to_writer(&file, &output).unwrap();
-        Ok(())
-    }
-
-    fn after_run(&mut self, _diag: &rustc_errors::Handler) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
+++ b/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `E`
   --> $DIR/edition-imports-virtual-2015-gated.rs:8:5
    |
 LL |     gen_gated!();
-   |     ^^^^^^^^^^^^^ could not find `E` in `{{root}}`
+   |     ^^^^^^^^^^^^^ could not find `E` in crate root
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/mir/issue-80742.rs
+++ b/src/test/ui/mir/issue-80742.rs
@@ -1,0 +1,33 @@
+// check-fail
+
+// This test used to cause an ICE in rustc_mir::interpret::step::eval_rvalue_into_place
+
+#![allow(incomplete_features)]
+#![feature(const_evaluatable_checked)]
+#![feature(const_generics)]
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::mem::size_of;
+
+struct Inline<T>
+where
+    [u8; size_of::<T>() + 1]: ,
+{
+    _phantom: PhantomData<T>,
+    buf: [u8; size_of::<T>() + 1],
+}
+
+impl<T> Inline<T>
+where
+    [u8; size_of::<T>() + 1]: ,
+{
+    pub fn new(val: T) -> Inline<T> {
+        todo!()
+    }
+}
+
+fn main() {
+    let dst = Inline::<dyn Debug>::new(0); //~ ERROR
+    //~^ ERROR
+}

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -1,0 +1,42 @@
+error[E0599]: no function or associated item named `new` found for struct `Inline<dyn Debug>` in the current scope
+  --> $DIR/issue-80742.rs:31:36
+   |
+LL | / struct Inline<T>
+LL | | where
+LL | |     [u8; size_of::<T>() + 1]: ,
+LL | | {
+LL | |     _phantom: PhantomData<T>,
+LL | |     buf: [u8; size_of::<T>() + 1],
+LL | | }
+   | |_- function or associated item `new` not found for this
+...
+LL |       let dst = Inline::<dyn Debug>::new(0);
+   |                                      ^^^ function or associated item not found in `Inline<dyn Debug>`
+   | 
+  ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+   |
+LL |   pub trait Debug {
+   |   --------------- doesn't satisfy `dyn Debug: Sized`
+   |
+   = note: the method `new` exists but the following trait bounds were not satisfied:
+           `dyn Debug: Sized`
+
+error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time
+  --> $DIR/issue-80742.rs:31:15
+   |
+LL | struct Inline<T>
+   |               - required by this bound in `Inline`
+...
+LL |     let dst = Inline::<dyn Debug>::new(0);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `dyn Debug`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | struct Inline<T: ?Sized>
+   |                ^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/resolve/crate-called-as-function.rs
+++ b/src/test/ui/resolve/crate-called-as-function.rs
@@ -1,0 +1,3 @@
+fn main() {
+    ::foo() //~ cannot find external crate `foo` in the crate root
+}

--- a/src/test/ui/resolve/crate-called-as-function.stderr
+++ b/src/test/ui/resolve/crate-called-as-function.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find external crate `foo` in the crate root
+  --> $DIR/crate-called-as-function.rs:2:7
+   |
+LL |     ::foo()
+   |       ^^^ not found in the crate root
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/resolve/missing-in-namespace.rs
+++ b/src/test/ui/resolve/missing-in-namespace.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _map = std::hahmap::HashMap::new();
+    //~^ ERROR failed to resolve: could not find `hahmap` in `std
+}

--- a/src/test/ui/resolve/missing-in-namespace.stderr
+++ b/src/test/ui/resolve/missing-in-namespace.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve: could not find `hahmap` in `std`
+  --> $DIR/missing-in-namespace.rs:2:29
+   |
+LL |     let _map = std::hahmap::HashMap::new();
+   |                             ^^^^^^^ not found in `std::hahmap`
+   |
+help: consider importing this struct
+   |
+LL | use std::collections::HashMap;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.rs
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let s = ::xcrate::S;
-    //~^ ERROR failed to resolve: could not find `xcrate` in `{{root}}`
+    //~^ ERROR failed to resolve: could not find `xcrate` in crate root
 }

--- a/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.stderr
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/non-existent-2.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: could not find `xcrate` in `{{root}}`
+error[E0433]: failed to resolve: could not find `xcrate` in crate root
   --> $DIR/non-existent-2.rs:4:15
    |
 LL |     let s = ::xcrate::S;
-   |               ^^^^^^ could not find `xcrate` in `{{root}}`
+   |               ^^^^^^ could not find `xcrate` in crate root
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/mutual-recursion-issue-75860.rs
+++ b/src/test/ui/traits/mutual-recursion-issue-75860.rs
@@ -1,0 +1,15 @@
+pub fn iso<A, B, F1, F2>(a: F1, b: F2) -> (Box<dyn Fn(A) -> B>, Box<dyn Fn(B) -> A>)
+    where
+        F1: (Fn(A) -> B) + 'static,
+        F2: (Fn(B) -> A) + 'static,
+{
+    (Box::new(a), Box::new(b))
+}
+pub fn iso_un_option<A, B>() -> (Box<dyn Fn(A) -> B>, Box<dyn Fn(B) -> A>) {
+   let left = |o_a: Option<_>| o_a.unwrap();
+    let right = |o_b: Option<_>| o_b.unwrap();
+    iso(left, right)
+    //~^ ERROR overflow
+}
+
+fn main() {}

--- a/src/test/ui/traits/mutual-recursion-issue-75860.stderr
+++ b/src/test/ui/traits/mutual-recursion-issue-75860.stderr
@@ -1,0 +1,16 @@
+error[E0275]: overflow evaluating the requirement `Option<_>: Sized`
+  --> $DIR/mutual-recursion-issue-75860.rs:11:5
+   |
+LL |     iso(left, right)
+   |     ^^^
+   | 
+  ::: $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL | pub enum Option<T> {
+   |                 - required by this bound in `Option`
+   |
+   = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`mutual_recursion_issue_75860`)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
Successful merges:

 - #79655 (Add Vec visualization to understand capacity)
 - #80172 (Use consistent punctuation for 'Prelude contents' docs)
 - #80429 (Add regression test for mutual recursion in obligation forest)
 - #80601 (Improve grammar in documentation of format strings)
 - #81046 (Improve unknown external crate error)
 - #81178 (Visit only terminators when removing landing pads)
 - #81179 (Fix broken links with `--document-private-items` in the standard library)
 - #81184 (Remove unnecessary `after_run` function)
 - #81185 (Fix ICE in mir when evaluating SizeOf on unsized type)
 - #81187 (Fix typo in counters.rs)
 - #81219 (Document security implications of std::env::temp_dir)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=79655,80172,80429,80601,81046,81178,81179,81184,81185,81187,81219)
<!-- homu-ignore:end -->