### PR TITLE
Turn alloc's force_expr macro into a regular macro_rules.

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -189,11 +189,4 @@ pub mod vec;
 #[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
 pub mod __export {
     pub use core::format_args;
-
-    /// Force AST node to an expression to improve diagnostics in pattern position.
-    #[rustc_macro_transparency = "semitransparent"]
-    #[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
-    pub macro force_expr($e:expr) {
-        $e
-    }
 }

--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -40,13 +40,13 @@
 #[allow_internal_unstable(box_syntax, liballoc_internals)]
 macro_rules! vec {
     () => (
-        $crate::__export::force_expr!($crate::vec::Vec::new())
+        $crate::force_expr!($crate::vec::Vec::new())
     );
     ($elem:expr; $n:expr) => (
-        $crate::__export::force_expr!($crate::vec::from_elem($elem, $n))
+        $crate::force_expr!($crate::vec::from_elem($elem, $n))
     );
     ($($x:expr),+ $(,)?) => (
-        $crate::__export::force_expr!(<[_]>::into_vec(box [$($x),+]))
+        $crate::force_expr!(<[_]>::into_vec(box [$($x),+]))
     );
 }
 
@@ -110,4 +110,14 @@ macro_rules! format {
         let res = $crate::fmt::format($crate::__export::format_args!($($arg)*));
         res
     }}
+}
+
+/// Force AST node to an expression to improve diagnostics in pattern position.
+#[doc(hidden)]
+#[macro_export]
+#[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
+macro_rules! force_expr {
+    ($e:expr) => {
+        $e
+    };
 }

--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -40,13 +40,13 @@
 #[allow_internal_unstable(box_syntax, liballoc_internals)]
 macro_rules! vec {
     () => (
-        $crate::force_expr!($crate::vec::Vec::new())
+        $crate::__rust_force_expr!($crate::vec::Vec::new())
     );
     ($elem:expr; $n:expr) => (
-        $crate::force_expr!($crate::vec::from_elem($elem, $n))
+        $crate::__rust_force_expr!($crate::vec::from_elem($elem, $n))
     );
     ($($x:expr),+ $(,)?) => (
-        $crate::force_expr!(<[_]>::into_vec(box [$($x),+]))
+        $crate::__rust_force_expr!(<[_]>::into_vec(box [$($x),+]))
     );
 }
 
@@ -116,7 +116,7 @@ macro_rules! format {
 #[doc(hidden)]
 #[macro_export]
 #[unstable(feature = "liballoc_internals", issue = "none", reason = "implementation detail")]
-macro_rules! force_expr {
+macro_rules! __rust_force_expr {
     ($e:expr) => {
         $e
     };


### PR DESCRIPTION
This turns `alloc`'s `force_expr` macro into a regular `macro_rules`.

Otherwise rust-analyzer doesn't understand `vec![]`. See https://github.com/rust-analyzer/rust-analyzer/issues/7349 and https://github.com/rust-lang/rust/pull/81080#issuecomment-764741721

Edit: See https://github.com/rust-lang/rust/pull/81241#issuecomment-764812660 for a discussion of alternatives.