### PR TITLE
Update BARE_TRAIT_OBJECTS lint to deny in 2021 edition

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1637,7 +1637,8 @@ declare_lint! {
     /// [`impl Trait`]: https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
     pub BARE_TRAIT_OBJECTS,
     Warn,
-    "suggest using `dyn Trait` for trait objects"
+    "suggest using `dyn Trait` for trait objects",
+    Edition::Edition2021 => Deny
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -426,6 +426,7 @@ macro_rules! declare_lint {
             edition_lint_opts: Some(($lint_edition, $crate::Level::$edition_level)),
             report_in_external_macro: false,
             is_plugin: false,
+            ..$crate::Lint::default_fields_for_macro()
         };
     );
 }

--- a/src/test/ui/dyn-keyword/dyn-2021-edition-error.rs
+++ b/src/test/ui/dyn-keyword/dyn-2021-edition-error.rs
@@ -1,0 +1,11 @@
+// edition:2021
+fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+    //~| ERROR trait objects without an explicit `dyn` are deprecated
+    let _x: &SomeTrait = todo!();
+    //~^ ERROR trait objects without an explicit `dyn` are deprecated
+}
+
+trait SomeTrait {}
+
+fn main() {}

--- a/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -1,0 +1,22 @@
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2021-edition-error.rs:2:17
+   |
+LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+   |                 ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+   |
+   = note: `#[deny(bare_trait_objects)]` on by default
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2021-edition-error.rs:2:35
+   |
+LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
+   |                                   ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+
+error: trait objects without an explicit `dyn` are deprecated
+  --> $DIR/dyn-2021-edition-error.rs:5:14
+   |
+LL |     let _x: &SomeTrait = todo!();
+   |              ^^^^^^^^^ help: use `dyn`: `dyn SomeTrait`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
As part of #80165 this upgrades the `BARE_TRAIT_OBJECTS` lint from `Warn` to `Deny` in the 2021 edition. In practice this doesn't change very much as the compiler is still compiled in 2018 edition. 

There is [active discussion](https://github.com/rust-lang/rust/issues/80165#issuecomment-763060628) on whether a deny by default lint is the right path or whether this should be handled in another part of the compiler as a hard error. This PR can be used to further that discussion. 

r? @nikomatsakis 