### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "remove_dir_all",
  "serde_json",
  "tar",
+ "toml",
  "url 2.1.1",
 ]
 


### PR DESCRIPTION
5 commits in a73e5b7d567c3036b296fc6b33ed52c5edcd882e..783bc43c660bf39c1e562c8c429b32078ad3099b
2021-01-12 23:45:39 +0000 to 2021-01-20 19:02:26 +0000
- Fix some issues with `cargo doc` and the new feature resolver. (rust-lang/cargo#9077)
- Implement support for rust-version field in project metadata (rust-lang/cargo#8037)
- Fix a bug in Cargo's cyclic dep graph detection (rust-lang/cargo#9075)
- Typo correction: artifcats -&gt; artifacts (rust-lang/cargo#9081)
- Remove stray backtick from doc (rust-lang/cargo#9079)