### PR TITLE
Add Clone impl for AssertUnwindSafe<T: Clone>

### DIFF
--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -314,7 +314,7 @@ impl<T> DerefMut for AssertUnwindSafe<T> {
     }
 }
 
-#[stable(feature = "catch_unwind", since = "1.49.0")]
+#[stable(feature = "assert_unwind_safe_clone", since = "1.51.0")]
 impl<T: Clone> Clone for AssertUnwindSafe<T> {
     fn clone(&self) -> Self {
         Self(self.0.clone())

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -314,6 +314,13 @@ impl<T> DerefMut for AssertUnwindSafe<T> {
     }
 }
 
+#[stable(feature = "catch_unwind", since = "1.49.0")]
+impl<T: Clone> Clone for AssertUnwindSafe<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<R, F: FnOnce() -> R> FnOnce<()> for AssertUnwindSafe<F> {
     type Output = R;


### PR DESCRIPTION
# Background

While building a web-server with gotham-rs, I ran into an edge-case while storing `Arc<Mutex<dyn Service + Send + Sync + RefUnwindSafe>>` as the "shared state" for the `gotham::router::Router` and sharing this data across an `.await`. 

gotham-rs bounds data used as shared state to be `RefUnwindSafe` _and_ `Clone`:

```rust
pub struct StateMiddleware<T>
where
    T: Clone + RefUnwindSafe + StateData + Sync,
{
    t: T,
}
```

Initially, the decision was on the choice of Mutex to use:

1. `std::sync::Mutex` is unwind safe, but the `MutexGuard` is not Send and cannot be used across an `.await`.
2. `parking_lot::Mutex` and `tokio::sync::Mutex` are both `Send`, but both are not unwind safe (`RefUnwindSafe`).

I chose `tokio::sync::Mutex` since it can be used across an `.await`, but had to solve the MutexGuard's lack of being unwind safe.

# Problem

After working with several folks from [the discord](), I came across the [`AssertUnwindSafe`](https://doc.rust-lang.org/beta/std/panic/struct.AssertUnwindSafe.html) struct and combined it with `tokio::sync::Mutex`. This works great, until you try to instantiate a `StateMiddleware` using an `AssertUnwindSafe<Arc<Mutex<dyn Service + Send + Sync + RefUnwindSafe>>>`:

```rust
error[E0277]: the trait bound `AssertUnwindSafe<Arc<tokio::sync::Mutex<(dyn project_users::users::read::ReadService + RefUnwindSafe + Sync + std::marker::Send + 'static)>>>: Clone` is not satisfied
  --> project-server/src/handlers/users.rs:32:5
   |
32 |     pub read: AssertUnwindSafe<Arc<Mutex<dyn users::read::ReadService + Sync + Send + RefUnwindSafe>>>,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `AssertUnwindSafe<Arc<tokio::sync::Mutex<(dyn project_users::users::read::ReadService + RefUnwindSafe + Sync + std::marker::Send + 'static)>>>`
```

If not for this damned `Clone` bounds on `StateMiddleware<T>`!

# Solution

newtype!

```rust
pub struct CloneableAssertUnsafeWind<T> {
    inner: AssertUnwindSafe<T>,
}

impl<T: Clone> Clone for CloneableAssertUnsafeWind<T> {
    fn clone(&self) -> Self {
        Self {
            inner: AssertUnwindSafe(self.inner.0.clone()),
        }
    }
}

impl<T> Deref for CloneableAssertUnsafeWind<T> {
    type Target = T;

    fn deref(&self) -> &Self::Target {
        &self.inner
    }
}
```

However, I don't see any reason why the real `AssertUnwindSafe` cannot be `Clone`, so this PR implements this :)


Signed-off-by: Sean Pianka <pianka@eml.cc>