### PR TITLE
Replace version_check dependency with own version parsing code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,6 @@ dependencies = [
  "rustc_serialize",
  "rustc_session",
  "rustc_span",
- "version_check",
 ]
 
 [[package]]

--- a/compiler/rustc_attr/Cargo.toml
+++ b/compiler/rustc_attr/Cargo.toml
@@ -18,4 +18,3 @@ rustc_lexer = { path = "../rustc_lexer" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_session = { path = "../rustc_session" }
 rustc_ast = { path = "../rustc_ast" }
-version_check = "0.9"

--- a/src/test/ui/feature-gates/feature-gate-cfg-version.rs
+++ b/src/test/ui/feature-gates/feature-gate-cfg-version.rs
@@ -1,3 +1,9 @@
+#[cfg(version(42))] //~ ERROR: expected a version literal
+//~^ ERROR `cfg(version)` is experimental and subject to change
+fn foo() {}
+#[cfg(version(1.20))] //~ ERROR: expected a version literal
+//~^ ERROR `cfg(version)` is experimental and subject to change
+fn foo() -> bool { true }
 #[cfg(version("1.44"))]
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn foo() -> bool { true }
@@ -11,30 +17,32 @@ fn bar() -> bool  { false }
 #[cfg(version(false))] //~ ERROR: expected a version literal
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn bar() -> bool  { false }
-#[cfg(version("foo"))] //~ ERROR: invalid version literal
+#[cfg(version("foo"))] //~ WARNING: unknown version literal format
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn bar() -> bool  { false }
-#[cfg(version("999"))]
+#[cfg(version("999"))] //~ WARNING: unknown version literal format
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn bar() -> bool  { false }
-#[cfg(version("-1"))] //~ ERROR: invalid version literal
+#[cfg(version("-1"))] //~ WARNING: unknown version literal format
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn bar() -> bool  { false }
-#[cfg(version("65536"))] //~ ERROR: invalid version literal
+#[cfg(version("65536"))] //~ WARNING: unknown version literal format
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn bar() -> bool  { false }
-#[cfg(version("0"))]
+#[cfg(version("0"))] //~ WARNING: unknown version literal format
 //~^ ERROR `cfg(version)` is experimental and subject to change
 fn bar() -> bool { true }
-
-#[cfg(version("1.65536.2"))]
+#[cfg(version("1.0"))]
 //~^ ERROR `cfg(version)` is experimental and subject to change
-fn version_check_bug() {}
+fn bar() -> bool { true }
+#[cfg(version("1.65536.2"))] //~ WARNING: unknown version literal format
+//~^ ERROR `cfg(version)` is experimental and subject to change
+fn bar() -> bool  { false }
+#[cfg(version("1.20.0-stable"))] //~ WARNING: unknown version literal format
+//~^ ERROR `cfg(version)` is experimental and subject to change
+fn bar() {}
 
 fn main() {
-    // This should fail but due to a bug in version_check `1.65536.2` is interpreted as `1.2`.
-    // See https://github.com/SergioBenitez/version_check/issues/11
-    version_check_bug();
     assert!(foo());
     assert!(bar());
     assert!(cfg!(version("1.42"))); //~ ERROR `cfg(version)` is experimental and subject to change

--- a/src/test/ui/feature-gates/feature-gate-cfg-version.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-version.stderr
@@ -1,6 +1,36 @@
 error[E0658]: `cfg(version)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-version.rs:1:7
    |
+LL | #[cfg(version(42))]
+   |       ^^^^^^^^^^^
+   |
+   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
+   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+
+error: expected a version literal
+  --> $DIR/feature-gate-cfg-version.rs:1:15
+   |
+LL | #[cfg(version(42))]
+   |               ^^
+
+error[E0658]: `cfg(version)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-version.rs:4:7
+   |
+LL | #[cfg(version(1.20))]
+   |       ^^^^^^^^^^^^^
+   |
+   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
+   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+
+error: expected a version literal
+  --> $DIR/feature-gate-cfg-version.rs:4:15
+   |
+LL | #[cfg(version(1.20))]
+   |               ^^^^
+
+error[E0658]: `cfg(version)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-version.rs:7:7
+   |
 LL | #[cfg(version("1.44"))]
    |       ^^^^^^^^^^^^^^^
    |
@@ -8,7 +38,7 @@ LL | #[cfg(version("1.44"))]
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:4:11
+  --> $DIR/feature-gate-cfg-version.rs:10:11
    |
 LL | #[cfg(not(version("1.44")))]
    |           ^^^^^^^^^^^^^^^
@@ -17,7 +47,7 @@ LL | #[cfg(not(version("1.44")))]
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:8:7
+  --> $DIR/feature-gate-cfg-version.rs:14:7
    |
 LL | #[cfg(version("1.43", "1.44", "1.45"))]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,13 +56,13 @@ LL | #[cfg(version("1.43", "1.44", "1.45"))]
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
 error: expected single version literal
-  --> $DIR/feature-gate-cfg-version.rs:8:7
+  --> $DIR/feature-gate-cfg-version.rs:14:7
    |
 LL | #[cfg(version("1.43", "1.44", "1.45"))]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:11:7
+  --> $DIR/feature-gate-cfg-version.rs:17:7
    |
 LL | #[cfg(version(false))]
    |       ^^^^^^^^^^^^^^
@@ -41,13 +71,13 @@ LL | #[cfg(version(false))]
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
 error: expected a version literal
-  --> $DIR/feature-gate-cfg-version.rs:11:15
+  --> $DIR/feature-gate-cfg-version.rs:17:15
    |
 LL | #[cfg(version(false))]
    |               ^^^^^
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:14:7
+  --> $DIR/feature-gate-cfg-version.rs:20:7
    |
 LL | #[cfg(version("foo"))]
    |       ^^^^^^^^^^^^^^
@@ -55,14 +85,14 @@ LL | #[cfg(version("foo"))]
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
-error: invalid version literal
-  --> $DIR/feature-gate-cfg-version.rs:14:15
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/feature-gate-cfg-version.rs:20:15
    |
 LL | #[cfg(version("foo"))]
    |               ^^^^^
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:17:7
+  --> $DIR/feature-gate-cfg-version.rs:23:7
    |
 LL | #[cfg(version("999"))]
    |       ^^^^^^^^^^^^^^
@@ -70,8 +100,14 @@ LL | #[cfg(version("999"))]
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/feature-gate-cfg-version.rs:23:15
+   |
+LL | #[cfg(version("999"))]
+   |               ^^^^^
+
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:20:7
+  --> $DIR/feature-gate-cfg-version.rs:26:7
    |
 LL | #[cfg(version("-1"))]
    |       ^^^^^^^^^^^^^
@@ -79,14 +115,14 @@ LL | #[cfg(version("-1"))]
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
-error: invalid version literal
-  --> $DIR/feature-gate-cfg-version.rs:20:15
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/feature-gate-cfg-version.rs:26:15
    |
 LL | #[cfg(version("-1"))]
    |               ^^^^
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:23:7
+  --> $DIR/feature-gate-cfg-version.rs:29:7
    |
 LL | #[cfg(version("65536"))]
    |       ^^^^^^^^^^^^^^^^
@@ -94,14 +130,14 @@ LL | #[cfg(version("65536"))]
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
-error: invalid version literal
-  --> $DIR/feature-gate-cfg-version.rs:23:15
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/feature-gate-cfg-version.rs:29:15
    |
 LL | #[cfg(version("65536"))]
    |               ^^^^^^^
 
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:26:7
+  --> $DIR/feature-gate-cfg-version.rs:32:7
    |
 LL | #[cfg(version("0"))]
    |       ^^^^^^^^^^^^
@@ -109,8 +145,23 @@ LL | #[cfg(version("0"))]
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/feature-gate-cfg-version.rs:32:15
+   |
+LL | #[cfg(version("0"))]
+   |               ^^^
+
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:30:7
+  --> $DIR/feature-gate-cfg-version.rs:35:7
+   |
+LL | #[cfg(version("1.0"))]
+   |       ^^^^^^^^^^^^^^
+   |
+   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
+   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+
+error[E0658]: `cfg(version)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-version.rs:38:7
    |
 LL | #[cfg(version("1.65536.2"))]
    |       ^^^^^^^^^^^^^^^^^^^^
@@ -118,8 +169,29 @@ LL | #[cfg(version("1.65536.2"))]
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/feature-gate-cfg-version.rs:38:15
+   |
+LL | #[cfg(version("1.65536.2"))]
+   |               ^^^^^^^^^^^
+
 error[E0658]: `cfg(version)` is experimental and subject to change
-  --> $DIR/feature-gate-cfg-version.rs:40:18
+  --> $DIR/feature-gate-cfg-version.rs:41:7
+   |
+LL | #[cfg(version("1.20.0-stable"))]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
+   = help: add `#![feature(cfg_version)]` to the crate attributes to enable
+
+warning: unknown version literal format, assuming it refers to a future version
+  --> $DIR/feature-gate-cfg-version.rs:41:15
+   |
+LL | #[cfg(version("1.20.0-stable"))]
+   |               ^^^^^^^^^^^^^^^
+
+error[E0658]: `cfg(version)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-version.rs:48:18
    |
 LL |     assert!(cfg!(version("1.42")));
    |                  ^^^^^^^^^^^^^^^
@@ -127,6 +199,6 @@ LL |     assert!(cfg!(version("1.42")));
    = note: see issue #64796 <https://github.com/rust-lang/rust/issues/64796> for more information
    = help: add `#![feature(cfg_version)]` to the crate attributes to enable
 
-error: aborting due to 16 previous errors
+error: aborting due to 19 previous errors; 7 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This gives compiler maintainers a better degree of control
over how the version gets parsed and is a good way to ensure
that there are no changes of behaviour in the future.

Also, issue a warning if the version is invalid instead of erroring
so that we stay forwards compatible with possible future changes
of the versioning scheme.

Last, this improves the present test a little.

Fixes #79436

r? @petrochenkov 