### PR TITLE
Fix <unknown> queries and add more timing info to render_html

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1017,13 +1017,6 @@ pub fn start_codegen<'tcx>(
     tcx.sess.time("assert_dep_graph", || rustc_incremental::assert_dep_graph(tcx));
     tcx.sess.time("serialize_dep_graph", || rustc_incremental::save_dep_graph(tcx));
 
-    // We assume that no queries are run past here. If there are new queries
-    // after this point, they'll show up as "<unknown>" in self-profiling data.
-    {
-        let _prof_timer = tcx.prof.generic_activity("self_profile_alloc_query_strings");
-        tcx.alloc_self_profile_query_strings();
-    }
-
     info!("Post-codegen\n{:?}", tcx.debug_stats());
 
     if tcx.sess.opts.output_types.contains_key(&OutputType::Mir) {

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -379,17 +379,9 @@ pub fn check_ast_crate<T: EarlyLintPass>(
     // All of the buffered lints should have been emitted at this point.
     // If not, that means that we somehow buffered a lint for a node id
     // that was not lint-checked (perhaps it doesn't exist?). This is a bug.
-    //
-    // Rustdoc runs everybody-loops before the early lints and removes
-    // function bodies, so it's totally possible for linted
-    // node ids to not exist (e.g., macros defined within functions for the
-    // unused_macro lint) anymore. So we only run this check
-    // when we're not in rustdoc mode. (see issue #47639)
-    if !sess.opts.actually_rustdoc {
-        for (_id, lints) in buffered.map {
-            for early_lint in lints {
-                sess.delay_span_bug(early_lint.span, "failed to process buffered lint here");
-            }
+    for (_id, lints) in buffered.map {
+        for early_lint in lints {
+            sess.delay_span_bug(early_lint.span, "failed to process buffered lint here");
         }
     }
 }

--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -12,6 +12,9 @@ use crate::formats::cache::{Cache, CACHE_KEY};
 /// backend renderer has hooks for initialization, documenting an item, entering and exiting a
 /// module, and cleanup/finalizing output.
 crate trait FormatRenderer<'tcx>: Clone {
+    /// Gives a description of the renderer. Used for performance profiling.
+    fn descr() -> &'static str;
+
     /// Sets up any state required for the renderer. When this is called the cache has already been
     /// populated.
     fn init(
@@ -57,16 +60,20 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
     edition: Edition,
     tcx: ty::TyCtxt<'tcx>,
 ) -> Result<(), Error> {
-    let (krate, mut cache) = Cache::from_krate(
-        render_info.clone(),
-        options.document_private,
-        &options.extern_html_root_urls,
-        &options.output,
-        krate,
-    );
+    let (krate, mut cache) = tcx.sess.time("create_format_cache", || {
+        Cache::from_krate(
+            render_info.clone(),
+            options.document_private,
+            &options.extern_html_root_urls,
+            &options.output,
+            krate,
+        )
+    });
+    let prof = &tcx.sess.prof;
 
-    let (mut format_renderer, mut krate) =
-        T::init(krate, options, render_info, edition, &mut cache, tcx)?;
+    let (mut format_renderer, mut krate) = prof
+        .extra_verbose_generic_activity("create_renderer", T::descr())
+        .run(|| T::init(krate, options, render_info, edition, &mut cache, tcx))?;
 
     let cache = Arc::new(cache);
     // Freeze the cache now that the index has been built. Put an Arc into TLS for future
@@ -83,6 +90,7 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
     // Render the crate documentation
     let mut work = vec![(format_renderer.clone(), item)];
 
+    let unknown = rustc_span::Symbol::intern("<unknown item>");
     while let Some((mut cx, item)) = work.pop() {
         if item.is_mod() {
             // modules are special because they add a namespace. We also need to
@@ -91,6 +99,7 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
             if name.is_empty() {
                 panic!("Unexpected module with empty name");
             }
+            let _timer = prof.generic_activity_with_arg("render_mod_item", name.as_str());
 
             cx.mod_item_in(&item, &name, &cache)?;
             let module = match *item.kind {
@@ -104,9 +113,10 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
 
             cx.mod_item_out(&name)?;
         } else if item.name.is_some() {
-            cx.item(item, &cache)?;
+            prof.generic_activity_with_arg("render_item", &*item.name.unwrap_or(unknown).as_str())
+                .run(|| cx.item(item, &cache))?;
         }
     }
-
-    format_renderer.after_krate(&krate, &cache, diag)
+    prof.extra_verbose_generic_activity("renderer_after_krate", T::descr())
+        .run(|| format_renderer.after_krate(&krate, &cache, diag))
 }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -384,6 +384,10 @@ crate fn initial_ids() -> Vec<String> {
 
 /// Generates the documentation for `crate` into the directory `dst`
 impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
+    fn descr() -> &'static str {
+        "html"
+    }
+
     fn init(
         mut krate: clean::Crate,
         options: RenderOptions,

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -125,6 +125,10 @@ impl JsonRenderer<'_> {
 }
 
 impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
+    fn descr() -> &'static str {
+        "json"
+    }
+
     fn init(
         krate: clean::Crate,
         options: RenderOptions,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -568,7 +568,7 @@ fn main_options(options: config::Options) -> MainResult {
                 info!("going to format");
                 let (error_format, edition, debugging_options) = diag_opts;
                 let diag = core::new_handler(error_format, None, &debugging_options);
-                match output_format {
+                let main_result = match output_format {
                     None | Some(config::OutputFormat::Html) => sess.time("render_html", || {
                         run_renderer::<html::render::Context<'_>>(
                             krate,
@@ -589,7 +589,10 @@ fn main_options(options: config::Options) -> MainResult {
                             tcx,
                         )
                     }),
-                }
+                };
+                // NOTE: this is normally called in codegen, but rustdoc never goes to codegen.
+                tcx.alloc_self_profile_query_strings();
+                main_result
             })
         })
     })

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -539,7 +539,7 @@ fn main_options(options: config::Options) -> MainResult {
                 sess.fatal("Compilation failed, aborting rustdoc");
             }
 
-            let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).take();
+            let mut global_ctxt = abort_on_err(queries.global_ctxt(), sess).peek_mut();
 
             global_ctxt.enter(|tcx| {
                 let (mut krate, render_info, render_opts) = sess.time("run_global_ctxt", || {
@@ -568,7 +568,7 @@ fn main_options(options: config::Options) -> MainResult {
                 info!("going to format");
                 let (error_format, edition, debugging_options) = diag_opts;
                 let diag = core::new_handler(error_format, None, &debugging_options);
-                let main_result = match output_format {
+                match output_format {
                     None | Some(config::OutputFormat::Html) => sess.time("render_html", || {
                         run_renderer::<html::render::Context<'_>>(
                             krate,
@@ -589,10 +589,7 @@ fn main_options(options: config::Options) -> MainResult {
                             tcx,
                         )
                     }),
-                };
-                // NOTE: this is normally called in codegen, but rustdoc never goes to codegen.
-                tcx.alloc_self_profile_query_strings();
-                main_result
+                }
             })
         })
     })


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/81251.

##  Fix `<unknown>` queries

This happened because `alloc_query_strings` was never called.

##  Add more timing info to render_html

This still has some issues I'm not sure how to work out:

- `create_renderer` and `renderer_after_krate` aren't shown by default.
  I want something like `verbose_generic_activity_with_arg`, but it doesn't exist.

I'm also not sure how to show activities that aren't on by default - I
tried `-Z self-profile -Z self-profile-args=all`, but it didn't show up.

r? @wesleywiser 