### PR TITLE
Do not mark unit variants as used when in path pattern

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -290,6 +290,7 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
     }
 
     fn visit_pat(&mut self, pat: &'tcx hir::Pat<'tcx>) {
+        self.in_pat = true;
         match pat.kind {
             PatKind::Struct(ref path, ref fields, _) => {
                 let res = self.typeck_results().qpath_res(path, pat.hir_id);
@@ -302,7 +303,6 @@ impl<'tcx> Visitor<'tcx> for MarkSymbolVisitor<'tcx> {
             _ => (),
         }
 
-        self.in_pat = true;
         intravisit::walk_pat(self, pat);
         self.in_pat = false;
     }

--- a/src/test/ui/lint/dead-code/const-and-self.rs
+++ b/src/test/ui/lint/dead-code/const-and-self.rs
@@ -1,6 +1,6 @@
 // check-pass
 
-#![deny(dead_code)]
+#![warn(dead_code)]
 
 const TLC: usize = 4;
 
@@ -28,8 +28,27 @@ impl Foo<Y> for X {
     }
 }
 
+enum E {
+    A,
+    B, //~ WARN variant is never constructed: `B`
+    C, //~ WARN variant is never constructed: `C`
+}
+
+type F = E;
+
+impl E {
+    fn check(&self) -> bool {
+        match self {
+            Self::A => true,
+            Self::B => false,
+            F::C => false,
+        }
+    }
+}
+
 fn main() {
     let s = [0,1,2,3];
     s.doit();
     X::foo();
+    E::A.check();
 }

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -1,0 +1,20 @@
+warning: variant is never constructed: `B`
+  --> $DIR/const-and-self.rs:33:5
+   |
+LL |     B,
+   |     ^
+   |
+note: the lint level is defined here
+  --> $DIR/const-and-self.rs:3:9
+   |
+LL | #![warn(dead_code)]
+   |         ^^^^^^^^^
+
+warning: variant is never constructed: `C`
+  --> $DIR/const-and-self.rs:34:5
+   |
+LL |     C,
+   |     ^
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Record that we are processing a pattern so that code responsible for
handling path resolution can correctly decide whether to mark it as
used or not.

Closes #76788.