### PR TITLE
rustdoc-json: Fix has_body

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -162,8 +162,8 @@ impl From<clean::ItemKind> for ItemEnum {
             ForeignFunctionItem(f) => ItemEnum::FunctionItem(f.into()),
             TraitItem(t) => ItemEnum::TraitItem(t.into()),
             TraitAliasItem(t) => ItemEnum::TraitAliasItem(t.into()),
-            MethodItem(m, _) => ItemEnum::MethodItem(m.into()),
-            TyMethodItem(m) => ItemEnum::MethodItem(m.into()),
+            MethodItem(m, _) => ItemEnum::MethodItem(from_function_method(m, true)),
+            TyMethodItem(m) => ItemEnum::MethodItem(from_function_method(m, false)),
             ImplItem(i) => ItemEnum::ImplItem(i.into()),
             StaticItem(s) => ItemEnum::StaticItem(s.into()),
             ForeignStaticItem(s) => ItemEnum::StaticItem(s.into()),
@@ -435,15 +435,13 @@ impl From<clean::Impl> for Impl {
     }
 }
 
-impl From<clean::Function> for Method {
-    fn from(function: clean::Function) -> Self {
-        let clean::Function { header, decl, generics, all_types: _, ret_types: _ } = function;
-        Method {
-            decl: decl.into(),
-            generics: generics.into(),
-            header: stringify_header(&header),
-            has_body: true,
-        }
+crate fn from_function_method(function: clean::Function, has_body: bool) -> Method {
+    let clean::Function { header, decl, generics, all_types: _, ret_types: _ } = function;
+    Method {
+        decl: decl.into(),
+        generics: generics.into(),
+        header: stringify_header(&header),
+        has_body,
     }
 }
 

--- a/src/test/rustdoc-json/traits/has_body.rs
+++ b/src/test/rustdoc-json/traits/has_body.rs
@@ -1,4 +1,3 @@
-
 // @has has_body.json "$.index[*][?(@.name=='Foo')]"
 pub trait Foo {
     // @has - "$.index[*][?(@.name=='no_self')].inner.has_body" false

--- a/src/test/rustdoc-json/traits/has_body.rs
+++ b/src/test/rustdoc-json/traits/has_body.rs
@@ -1,0 +1,22 @@
+
+// @has has_body.json "$.index[*][?(@.name=='Foo')]"
+pub trait Foo {
+    // @has - "$.index[*][?(@.name=='no_self')].inner.has_body" false
+    fn no_self();
+    // @has - "$.index[*][?(@.name=='move_self')].inner.has_body" false
+    fn move_self(self);
+    // @has - "$.index[*][?(@.name=='ref_self')].inner.has_body" false
+    fn ref_self(&self);
+
+    // @has - "$.index[*][?(@.name=='no_self_def')].inner.has_body" true
+    fn no_self_def() {}
+    // @has - "$.index[*][?(@.name=='move_self_def')].inner.has_body" true
+    fn move_self_def(self) {}
+    // @has - "$.index[*][?(@.name=='ref_self_def')].inner.has_body" true
+    fn ref_self_def(&self) {}
+}
+
+pub trait Bar: Clone {
+    // @has - "$.index[*][?(@.name=='method')].inner.has_body" false
+    fn method(&self, param: usize);
+}


### PR DESCRIPTION
Previously, `has_body` was always true. Now propagate the type of the method to set it correctly. Relies on #81287, that will need to be merged first.