### PR TITLE
Make bad shlex parsing a pretty error

### DIFF
--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -149,15 +149,17 @@ fn get_commands(template: &str) -> Result<Vec<Command>, ()> {
             }
         }
 
-        let args = cap.name("args")
-            .map_or(Some(vec![]), |m| shlex::split(m.as_str()));
+        let args = cap.name("args").map_or(Some(vec![]), |m| shlex::split(m.as_str()));
 
         let args = match args {
             Some(args) => args,
             None => {
                 print_err(
-                    &format!("Invalid arguments to shlex::split: `{}`", cap.name("args").unwrap().as_str()),
-                    lineno
+                    &format!(
+                        "Invalid arguments to shlex::split: `{}`",
+                        cap.name("args").unwrap().as_str()
+                    ),
+                    lineno,
                 );
                 errors = true;
                 continue;

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -149,7 +149,20 @@ fn get_commands(template: &str) -> Result<Vec<Command>, ()> {
             }
         }
 
-        let args = cap.name("args").map_or(vec![], |m| shlex::split(m.as_str()).unwrap());
+        let args = cap.name("args")
+            .map_or(Some(vec![]), |m| shlex::split(m.as_str()));
+
+        let args = match args {
+            Some(args) => args,
+            None => {
+                print_err(
+                    &format!("Invalid arguments to shlex::split: `{}`", cap.name("args").unwrap().as_str()),
+                    lineno
+                );
+                errors = true;
+                continue;
+            }
+        };
 
         if !cmd.validate(&args, commands.len(), lineno) {
             errors = true;


### PR DESCRIPTION
Closes #81319

Old Output:
<details><summary>Backtrace</summary>
<p>

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src\too
ls\jsondocck\src\main.rs:152:81
stack backtrace:
   0:     0x7ff79a011405 - std::backtrace_rs::backtrace::dbghelp::trace
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\..\..\backtrace\src\backtrace\dbghelp.rs:98
   1:     0x7ff79a011405 - std::backtrace_rs::backtrace::trace_unsynchronized
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2:     0x7ff79a011405 - std::sys_common::backtrace::_print_fmt
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\sys_common\backtrace.rs:67
   3:     0x7ff79a011405 - std::sys_common::backtrace::_print::{{impl}}::fmt
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\sys_common\backtrace.rs:46
   4:     0x7ff79a026c7b - core::fmt::write
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\core\src\fmt\mod.rs:1078
   5:     0x7ff79a00e74d - std::io::Write::write_fmt<std::sys::windows::stdio::S
tderr>
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\io\mod.rs:1519
   6:     0x7ff79a01413d - std::sys_common::backtrace::_print
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\sys_common\backtrace.rs:49
   7:     0x7ff79a01413d - std::sys_common::backtrace::print
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\sys_common\backtrace.rs:36
   8:     0x7ff79a01413d - std::panicking::default_hook::{{closure}}
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panicking.rs:208
   9:     0x7ff79a013c4a - std::panicking::default_hook
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panicking.rs:225
  10:     0x7ff79a014a7e - std::panicking::rust_panic_with_hook
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panicking.rs:591
  11:     0x7ff79a014573 - std::panicking::begin_panic_handler::{{closure}}
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panicking.rs:495
  12:     0x7ff79a011ddf - std::sys_common::backtrace::__rust_end_short_backtrac
e<closure-0,!>
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\sys_common\backtrace.rs:141
  13:     0x7ff79a0144f9 - std::panicking::begin_panic_handler
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panicking.rs:493
  14:     0x7ff79a025230 - core::panicking::panic_fmt
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\core\src\panicking.rs:92
  15:     0x7ff79a02517c - core::panicking::panic
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\core\src\panicking.rs:50
  16:     0x7ff799f5245f - indexmap::map::core::raw::<impl indexmap::map::core::
IndexMapCore<K,V>>::get_index_of::had34e726f99bd999
  17:     0x7ff799f48fea - std::sys_common::backtrace::__rust_begin_short_backtr
ace::h1ac92efa44350e74
  18:     0x7ff799f41015 - std::rt::lang_start::{{closure}}::hdfe733a6a1ad9a18
  19:     0x7ff79a014c34 - core::ops::function::impls::{{impl}}::call_once
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\library\core\src\ops\function.rs:280
  20:     0x7ff79a014c34 - std::panicking::try::do_call
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panicking.rs:379
  21:     0x7ff79a014c34 - std::panicking::try
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panicking.rs:343
  22:     0x7ff79a014c34 - std::panic::catch_unwind
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\panic.rs:396
  23:     0x7ff79a014c34 - std::rt::lang_start_internal
                               at /rustc/05b6023675d77979637b04a350c85903fbf5925
7\/library\std\src\rt.rs:51
  24:     0x7ff799f536a7 - main
  25:     0x7ff79a02d788 - invoke_main
                               at d:\A01\_work\6\s\src\vctools\crt\vcstartup\src
\startup\exe_common.inl:78
  26:     0x7ff79a02d788 - __scrt_common_main_seh
                               at d:\A01\_work\6\s\src\vctools\crt\vcstartup\src
\startup\exe_common.inl:288
  27:     0x7ffe6bf47034 - BaseThreadInitThunk
  28:     0x7ffe6c89d241 - RtlUserThreadStart
```

</p>
</details>

New Output:
```
Invalid command: Invalid arguments to shlex::split: ` - "$foo` on line 26
```

I've hit this a couple times, makes debugging a little nicer.