### PR TITLE
Implementation of `Result::swap` and tests

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -592,6 +592,28 @@ impl<T, E> Result<T, E> {
         }
     }
 
+    /// Maps a `Result<T, E>` to a `Result<E, T>` by swapping the success/failure
+    /// semantics of the stored variant.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(result_swap)]
+    ///
+    /// assert_eq!(Ok("Error :(").swap(), Err("Error :("));
+    /// assert_eq!(Err("Success!").swap(), Ok("Success!"));
+    /// ```
+    #[inline]
+    #[unstable(feature = "result_swap", issue = "none")]
+    pub fn swap(self) -> Result<E, T> {
+        match self {
+            Ok(t) => Err(t),
+            Err(e) => Ok(e),
+        }
+    }
+
     /////////////////////////////////////////////////////////////////////////
     // Iterator constructors
     /////////////////////////////////////////////////////////////////////////

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -76,6 +76,7 @@
 #![feature(integer_atomics)]
 #![feature(slice_group_by)]
 #![feature(trusted_random_access)]
+#![feature(result_swap)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate test;

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -358,3 +358,10 @@ fn result_opt_conversions() {
 
     assert_eq!(res, Err(BadNumErr))
 }
+
+#[test]
+fn test_result_swap() {
+    assert_eq!(Ok("err").swap(), Err("err"));
+    assert_eq!(Err("ok").swap(), Ok("ok"));
+    assert_eq!(Ok("ok").swap().swap(), Ok("ok"));
+}

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -361,7 +361,7 @@ fn result_opt_conversions() {
 
 #[test]
 fn test_result_swap() {
-    assert_eq!(Ok("err").swap(), Err("err"));
-    assert_eq!(Err("ok").swap(), Ok("ok"));
-    assert_eq!(Ok("ok").swap().swap(), Ok("ok"));
+    assert_eq!(Ok::<_, u8>("err").swap(), Err("err"));
+    assert_eq!(Err::<u8, _>("ok").swap(), Ok("ok"));
+    assert_eq!(Ok::<_, u8>("ok").swap().swap(), Ok("ok"));
 }


### PR DESCRIPTION
This adds the `swap` method on `Result` as well as a test function for it.

Tracking issue: [#81332](https://github.com/rust-lang/rust/issues/81322)