### PR TITLE
rustc_expand: Avoid ICE when creating AST with invalid Id if the error was already reported

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -333,7 +333,8 @@ impl Ident {
             panic!("`{:?}` is not a valid identifier", string)
         }
         if is_raw && !sym.can_be_raw() {
-            panic!("`{}` cannot be a raw identifier", string);
+            sess.span_diagnostic
+                .delay_span_bug(span, &format!("`{}` cannot be a raw identifier", string));
         }
         sess.symbol_gallery.insert(sym, span);
         Ident { sym, is_raw, span }


### PR DESCRIPTION
Fixes #81321

I don't know if this is the right fix.. reviews would be appreciated!

If you think this is the right fix I'll try to add a test.