### PR TITLE
Don't display `mut` in arguments for functions documentation

### DIFF
--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1408,7 +1408,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .map(|f| match self.tcx.sess.source_map().span_to_snippet(f.pat.span) {
                             Ok(f) => f,
                             Err(_) => rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
-                                s.print_pat(f.pat)
+                                s.print_pat(f.pat, true)
                             }),
                         })
                         .collect::<Vec<String>>()

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -962,7 +962,10 @@ impl<'a> Clean<Arguments> for (&'a [hir::Ty<'a>], hir::BodyId) {
                 .iter()
                 .enumerate()
                 .map(|(i, ty)| Argument {
-                    name: Symbol::intern(&rustc_hir_pretty::param_to_string(&body.params[i])),
+                    name: Symbol::intern(&rustc_hir_pretty::param_to_string(
+                        &body.params[i],
+                        false,
+                    )),
                     type_: ty.clean(cx),
                 })
                 .collect(),

--- a/src/test/rustdoc/elided-self-type.rs
+++ b/src/test/rustdoc/elided-self-type.rs
@@ -1,0 +1,15 @@
+// Checks that `: Self` never gets emitted for simple `self` parameters.
+
+#![crate_name = "foo"]
+
+pub struct Foo;
+
+// @!has foo/struct.Foo.html '//*[@class="impl-items"]' Self
+impl Foo {
+    pub fn by_value(self) {}
+    pub fn by_value_mut(mut self) {}
+    pub fn by_ref(&self) {}
+    pub fn by_mut_ref(&mut self) {}
+    pub fn by_value_explicit(self: Self) {}
+    pub fn by_value_mut_explicit(mut self: Self) {}
+}

--- a/src/test/rustdoc/mut-params.rs
+++ b/src/test/rustdoc/mut-params.rs
@@ -1,0 +1,16 @@
+// Rustdoc shouldn't display `mut` in function arguments, which are
+// implementation details. Regression test for #81289.
+
+#![crate_name = "foo"]
+
+pub struct Foo;
+
+// @!has foo/struct.Foo.html '//*[@class="impl-items"]//*[@class="method"]' 'mut'
+impl Foo {
+    pub fn foo(mut self) {}
+
+    pub fn bar(mut bar: ()) {}
+}
+
+// @!has foo/fn.baz.html '//*[@class="rust fn"]' 'mut'
+pub fn baz(mut foo: Foo) {}


### PR DESCRIPTION
This mostly touches `rustc_hir_pretty`, I don't know who should review this.

Fixes #81289.
r? @jyn514