### PR TITLE
suppress errors in const eval during selection

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -62,7 +62,7 @@ pub(crate) fn check_constants(fx: &mut FunctionCx<'_, '_, impl Module>) {
                         ErrorHandled::Silent => {
                             span_bug!(
                                 constant.span,
-                                "codgen encountered silent error",
+                                "codegen encountered silent error",
                             );
                         }
                     }

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -59,6 +59,12 @@ pub(crate) fn check_constants(fx: &mut FunctionCx<'_, '_, impl Module>) {
                                 err
                             );
                         }
+                        ErrorHandled::Silent => {
+                            span_bug!(
+                                constant.span,
+                                "codgen encountered silent error",
+                            );
+                        }
                     }
                 }
             }

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -194,7 +194,10 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 // errored or at least linted
                 ErrorHandled::Reported(ErrorReported) | ErrorHandled::Linted => {}
                 ErrorHandled::TooGeneric => {
-                    span_bug!(const_.span, "codgen encountered polymorphic constant: {:?}", err)
+                    span_bug!(const_.span, "codegen encountered polymorphic constant: {:?}", err)
+                }
+                ErrorHandled::Silent => {
+                    span_bug!(const_.span, "silent error during codegen")
                 }
             }
         }

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -446,6 +446,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         ErrorHandled::TooGeneric => {
                             bug!("codegen encountered polymorphic constant")
                         }
+                        ErrorHandled::Silent => {
+                            bug!("silent error encountered codegen for {:?}", operand)
+                        }
                     }
                     // Allow RalfJ to sleep soundly knowing that even refactorings that remove
                     // the above error (or silence it under some conditions) will not cause UB.

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -18,6 +18,9 @@ pub enum ErrorHandled {
     Reported(ErrorReported),
     /// Already emitted a lint for this evaluation.
     Linted,
+    /// Encountered an error without emitting anything. Only returned
+    /// with `Reveal::Selection`.
+    Silent,
     /// Don't emit an error, the evaluation failed because the MIR was generic
     /// and the substs didn't fully monomorphize it.
     TooGeneric,
@@ -72,7 +75,7 @@ fn print_backtrace(backtrace: &Backtrace) {
 impl From<ErrorHandled> for InterpErrorInfo<'_> {
     fn from(err: ErrorHandled) -> Self {
         match err {
-            ErrorHandled::Reported(ErrorReported) | ErrorHandled::Linted => {
+            ErrorHandled::Reported(ErrorReported) | ErrorHandled::Linted | ErrorHandled::Silent => {
                 err_inval!(ReferencedConstant)
             }
             ErrorHandled::TooGeneric => err_inval!(TooGeneric),

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -38,6 +38,12 @@ pub use self::chalk::{ChalkEnvironmentAndGoal, RustInterner as ChalkRustInterner
 /// more or less conservative.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, HashStable)]
 pub enum Reveal {
+    // Similar to `Reveal::UserFacing`, except that we also do not emit errors
+    // when failing const evaluation.
+    //
+    // Used by `feature(const_evaluatable_checked)` to allow for `ConstEvaluatable`
+    // predicates to not hold without emitting an error.
+    Selection,
     /// At type-checking time, we refuse to project any associated
     /// type that is marked `default`. Non-`default` ("final") types
     /// are always projected. This is necessary in general for

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -129,7 +129,7 @@ impl<'tcx> ConstKind<'tcx> {
                 // (which may be identity substs, see above),
                 // can leak through `val` into the const we return.
                 Ok(val) => Some(Ok(val)),
-                Err(ErrorHandled::TooGeneric | ErrorHandled::Linted) => None,
+                Err(ErrorHandled::TooGeneric | ErrorHandled::Linted | ErrorHandled::Silent) => None,
                 Err(ErrorHandled::Reported(e)) => Some(Err(e)),
             }
         } else {

--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -655,6 +655,10 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                         "collection encountered polymorphic constant: {}",
                         substituted_constant
                     ),
+                    Err(ErrorHandled::Silent) => span_bug!(
+                        self.body.source_info(location).span,
+                        "silent error emitted during collection",
+                    ),
                 }
             }
             _ => {}

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -147,7 +147,8 @@ pub fn is_const_evaluatable<'cx, 'tcx>(
     // and hopefully soon change this to an error.
     //
     // See #74595 for more details about this.
-    let concrete = infcx.const_eval_resolve(param_env, def, substs, None, Some(span));
+    let concrete =
+        infcx.const_eval_resolve(param_env.with_reveal_selection(), def, substs, None, Some(span));
 
     if concrete.is_ok() && substs.has_param_types_or_consts() {
         match infcx.tcx.def_kind(def.did) {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -739,6 +739,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let violations = self.tcx.object_safety_violations(did);
                 report_object_safety_error(self.tcx, span, did, violations)
             }
+            ConstEvalFailure(ErrorHandled::Silent) => {
+                tcx.sess.struct_span_err(span, "failed to evaluate the given constant")
+            }
             ConstEvalFailure(ErrorHandled::TooGeneric) => {
                 bug!("too generic should have been handled in `is_const_evaluatable`");
             }

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -589,6 +589,11 @@ impl<'a, 'b, 'tcx> FulfillProcessor<'a, 'b, 'tcx> {
                                 "ConstEquate: const_eval_resolve returned an unexpected error"
                             )
                         }
+                        (Err(ErrorHandled::Silent), _) | (_, Err(ErrorHandled::Silent)) => {
+                            ProcessResult::Error(CodeSelectionError(ConstEvalFailure(
+                                ErrorHandled::Silent,
+                            )))
+                        }
                         (Err(ErrorHandled::TooGeneric), _) | (_, Err(ErrorHandled::TooGeneric)) => {
                             ProcessResult::Unchanged
                         }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -341,7 +341,7 @@ impl<'a, 'b, 'tcx> TypeFolder<'tcx> for AssocTypeNormalizer<'a, 'b, 'tcx> {
             ty::Opaque(def_id, substs) if !substs.has_escaping_bound_vars() => {
                 // Only normalize `impl Trait` after type-checking, usually in codegen.
                 match self.param_env.reveal() {
-                    Reveal::UserFacing => ty,
+                    Reveal::Selection | Reveal::UserFacing => ty,
 
                     Reveal::All => {
                         let recursion_limit = self.tcx().sess.recursion_limit();

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -112,7 +112,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
             ty::Opaque(def_id, substs) if !substs.has_escaping_bound_vars() => {
                 // Only normalize `impl Trait` after type-checking, usually in codegen.
                 match self.param_env.reveal() {
-                    Reveal::UserFacing => ty,
+                    Reveal::Selection | Reveal::UserFacing => ty,
 
                     Reveal::All => {
                         let recursion_limit = self.tcx().sess.recursion_limit();

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -562,7 +562,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         if let ty::ConstKind::Unevaluated(def, substs, promoted) = c.val {
                             self.infcx
                                 .const_eval_resolve(
-                                    obligation.param_env,
+                                    obligation.param_env.with_reveal_selection(),
                                     def,
                                     substs,
                                     promoted,
@@ -585,8 +585,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                 Err(_) => Ok(EvaluatedToErr),
                             }
                         }
-                        (Err(ErrorHandled::Reported(ErrorReported)), _)
-                        | (_, Err(ErrorHandled::Reported(ErrorReported))) => Ok(EvaluatedToErr),
+                        (Err(ErrorHandled::Reported(ErrorReported) | ErrorHandled::Silent), _)
+                        | (_, Err(ErrorHandled::Reported(ErrorReported) | ErrorHandled::Silent)) => {
+                            Ok(EvaluatedToErr)
+                        }
                         (Err(ErrorHandled::Linted), _) | (_, Err(ErrorHandled::Linted)) => {
                             span_bug!(
                                 obligation.cause.span(self.tcx()),

--- a/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-cyclic-fail.stderr
@@ -10,12 +10,22 @@ note: ...which requires simplifying constant for the type system `Tr::A`...
    |
 LL |     const A: u8 = Self::B;
    |     ^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `Tr::A`...
+  --> $DIR/defaults-cyclic-fail.rs:6:5
+   |
+LL |     const A: u8 = Self::B;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `Tr::A`...
   --> $DIR/defaults-cyclic-fail.rs:6:5
    |
 LL |     const A: u8 = Self::B;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires normalizing `<() as Tr>::B`...
+note: ...which requires simplifying constant for the type system `Tr::B`...
+  --> $DIR/defaults-cyclic-fail.rs:8:5
+   |
+LL |     const B: u8 = Self::A;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires simplifying constant for the type system `Tr::B`...
   --> $DIR/defaults-cyclic-fail.rs:8:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-impl.stderr
@@ -9,12 +9,22 @@ note: ...which requires simplifying constant for the type system `IMPL_REF_BAR`.
    |
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `IMPL_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
+   |
+LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `IMPL_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:7:1
    |
 LL | const IMPL_REF_BAR: u32 = GlobalImplRef::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires normalizing `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
+   |
+LL |     const BAR: u32 = IMPL_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-impl.rs:11:1: 13:2>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-impl.rs:12:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait-default.stderr
@@ -9,12 +9,22 @@ note: ...which requires simplifying constant for the type system `DEFAULT_REF_BA
    |
 LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `DEFAULT_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
+   |
+LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `DEFAULT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:11:1
    |
 LL | const DEFAULT_REF_BAR: u32 = <GlobalDefaultRef>::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires normalizing `<GlobalDefaultRef as FooDefault>::BAR`...
+note: ...which requires simplifying constant for the type system `FooDefault::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
+   |
+LL |     const BAR: u32 = DEFAULT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires simplifying constant for the type system `FooDefault::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait-default.rs:8:5
    |

--- a/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
+++ b/src/test/ui/associated-consts/issue-24949-assoc-const-static-recursion-trait.stderr
@@ -9,12 +9,22 @@ note: ...which requires simplifying constant for the type system `TRAIT_REF_BAR`
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `TRAIT_REF_BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
+   |
+LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `TRAIT_REF_BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:7:1
    |
 LL | const TRAIT_REF_BAR: u32 = <GlobalTraitRef>::BAR;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which requires normalizing `<GlobalTraitRef as Foo>::BAR`...
+note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 13:2>::BAR`...
+  --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
+   |
+LL |     const BAR: u32 = TRAIT_REF_BAR;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires simplifying constant for the type system `<impl at $DIR/issue-24949-assoc-const-static-recursion-trait.rs:11:1: 13:2>::BAR`...
   --> $DIR/issue-24949-assoc-const-static-recursion-trait.rs:12:5
    |

--- a/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.rs
@@ -2,10 +2,11 @@
 #![allow(incomplete_features)]
 
 fn test<const N: usize>() -> [u8; N - 1] {
-    //~^ ERROR evaluation of constant
     todo!()
 }
 
 fn main() {
     test::<0>();
+    //~^ ERROR failed to evaluate the given constant
+    //~| ERROR failed to evaluate the given constant
 }

--- a/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/from-sig-fail.stderr
@@ -1,9 +1,20 @@
-error[E0080]: evaluation of constant value failed
-  --> $DIR/from-sig-fail.rs:4:35
+error: failed to evaluate the given constant
+  --> $DIR/from-sig-fail.rs:9:5
    |
 LL | fn test<const N: usize>() -> [u8; N - 1] {
-   |                                   ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+   |                                   ----- required by this bound in `test`
+...
+LL |     test::<0>();
+   |     ^^^^^^^^^
 
-error: aborting due to previous error
+error: failed to evaluate the given constant
+  --> $DIR/from-sig-fail.rs:9:5
+   |
+LL | fn test<const N: usize>() -> [u8; N - 1] {
+   |                                   ----- required by this bound in `test`
+...
+LL |     test::<0>();
+   |     ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0080`.
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/const_evaluatable_checked/silent-selection-err.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/silent-selection-err.rs
@@ -1,0 +1,43 @@
+// run-pass
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+struct Array<const N: usize>;
+
+trait Matrix {
+    fn do_it(&self) -> usize;
+}
+
+impl Matrix for Array<0> {
+    fn do_it(&self) -> usize {
+        0
+    }
+}
+
+impl Matrix for Array<1> {
+    fn do_it(&self) -> usize {
+        1
+    }
+}
+
+impl Matrix for Array<2> {
+    fn do_it(&self) -> usize {
+        2
+    }
+}
+
+impl<const N: usize> Matrix for Array<N>
+where
+    [u8; N - 3]: Sized,
+{
+    fn do_it(&self) -> usize {
+        N + 1
+    }
+}
+
+fn main() {
+    assert_eq!(Array::<0>.do_it(), 0);
+    assert_eq!(Array::<1>.do_it(), 1);
+    assert_eq!(Array::<2>.do_it(), 2);
+    assert_eq!(Array::<3>.do_it(), 4);
+}

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.full.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.full.stderr
@@ -1,9 +1,17 @@
-error[E0080]: evaluation of constant value failed
-  --> $DIR/simple_fail.rs:6:33
+error: failed to evaluate the given constant
+  --> $DIR/simple_fail.rs:14:5
    |
-LL | type Arr<const N: usize> = [u8; N - 1];
-   |                                 ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+LL | fn test<const N: usize>() -> Arr<N> where Arr<N>: Sized {
+   |                                           ------ required by this bound in `test`
+...
+LL |     test::<0>();
+   |     ^^^^^^^^^
 
-error: aborting due to previous error
+error: failed to evaluate the given constant
+  --> $DIR/simple_fail.rs:14:5
+   |
+LL |     test::<0>();
+   |     ^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0080`.
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.rs
@@ -3,7 +3,7 @@
 #![feature(const_evaluatable_checked)]
 #![allow(incomplete_features)]
 
-type Arr<const N: usize> = [u8; N - 1]; //[full]~ ERROR evaluation of constant
+type Arr<const N: usize> = [u8; N - 1];
 //[min]~^ ERROR generic parameters may not be used in const operations
 
 fn test<const N: usize>() -> Arr<N> where Arr<N>: Sized {
@@ -12,4 +12,6 @@ fn test<const N: usize>() -> Arr<N> where Arr<N>: Sized {
 
 fn main() {
     test::<0>();
+    //[full]~^ ERROR failed to evaluate the given constant
+    //[full]~| ERROR failed to evaluate the given constant
 }

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3.rs
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3.rs
@@ -17,6 +17,7 @@ const A_I8_I
     : [u32; (i8::MAX as usize) + 1]
     = [0; (i8::MAX + 1) as usize];
 //~^ ERROR evaluation of constant value failed
+//~| ERROR failed to evaluate the given constant
 
 fn main() {
     foo(&A_I8_I[..]);

--- a/src/test/ui/consts/const-eval/const-eval-overflow-3.stderr
+++ b/src/test/ui/consts/const-eval/const-eval-overflow-3.stderr
@@ -4,6 +4,12 @@ error[E0080]: evaluation of constant value failed
 LL |     = [0; (i8::MAX + 1) as usize];
    |           ^^^^^^^^^^^^^ attempt to compute `i8::MAX + 1_i8`, which would overflow
 
-error: aborting due to previous error
+error: failed to evaluate the given constant
+  --> $DIR/const-eval-overflow-3.rs:18:11
+   |
+LL |     = [0; (i8::MAX + 1) as usize];
+   |           ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
@@ -36,7 +36,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:37:5
    |
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc18, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc24, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -76,7 +76,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:52:5
    |
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc38, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc50, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -100,7 +100,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:61:5
    |
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc50, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc64, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -148,7 +148,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:79:5
    |
 LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc71, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc98, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -188,7 +188,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:94:5
    |
 LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc86, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc125, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
@@ -212,7 +212,7 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:103:5
    |
 LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc95, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc140, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 

--- a/src/test/ui/consts/const-eval/infinite_loop.rs
+++ b/src/test/ui/consts/const-eval/infinite_loop.rs
@@ -1,7 +1,7 @@
 fn main() {
     // Tests the Collatz conjecture with an incorrect base case (0 instead of 1).
     // The value of `n` will loop indefinitely (4 - 2 - 1 - 4).
-    let _ = [(); {
+    let _ = [(); { //~ ERROR failed to evaluate the given constant
         let mut n = 113383; // #20 in https://oeis.org/A006884
         while n != 0 {
             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };

--- a/src/test/ui/consts/const-eval/infinite_loop.stderr
+++ b/src/test/ui/consts/const-eval/infinite_loop.stderr
@@ -1,9 +1,22 @@
+error: failed to evaluate the given constant
+  --> $DIR/infinite_loop.rs:4:18
+   |
+LL |       let _ = [(); {
+   |  __________________^
+LL | |         let mut n = 113383; // #20 in https://oeis.org/A006884
+LL | |         while n != 0 {
+LL | |             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
+...  |
+LL | |         n
+LL | |     }];
+   | |_____^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/infinite_loop.rs:7:17
    |
 LL |             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exceeded interpreter step limit (see `#[const_eval_limit]`)
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/issue-49296.stderr
+++ b/src/test/ui/consts/const-eval/issue-49296.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | const X: u64 = *wat(42);
    | ---------------^^^^^^^^-
    |                |
-   |                pointer to alloc1 was dereferenced after this allocation got freed
+   |                pointer to alloc4 was dereferenced after this allocation got freed
    |
    = note: `#[deny(const_err)]` on by default
 

--- a/src/test/ui/consts/const-eval/issue-52475.rs
+++ b/src/test/ui/consts/const-eval/issue-52475.rs
@@ -1,5 +1,5 @@
 fn main() {
-    let _ = [(); {
+    let _ = [(); { //~ ERROR failed to evaluate the given constant
         let mut x = &0;
         let mut n = 0;
         while n < 5 {

--- a/src/test/ui/consts/const-eval/issue-52475.stderr
+++ b/src/test/ui/consts/const-eval/issue-52475.stderr
@@ -1,9 +1,22 @@
+error: failed to evaluate the given constant
+  --> $DIR/issue-52475.rs:2:18
+   |
+LL |       let _ = [(); {
+   |  __________________^
+LL | |         let mut x = &0;
+LL | |         let mut n = 0;
+LL | |         while n < 5 {
+...  |
+LL | |         0
+LL | |     }];
+   | |_____^
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-52475.rs:6:17
    |
 LL |             n = (n + 1) % 5;
    |                 ^^^^^^^^^^^ exceeded interpreter step limit (see `#[const_eval_limit]`)
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-size_of-cycle.stderr
+++ b/src/test/ui/consts/const-size_of-cycle.stderr
@@ -9,6 +9,11 @@ note: ...which requires simplifying constant for the type system `Foo::bytes::{c
    |
 LL |     bytes: [u8; std::mem::size_of::<Foo>()]
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `Foo::bytes::{constant#0}`...
+  --> $DIR/const-size_of-cycle.rs:4:17
+   |
+LL |     bytes: [u8; std::mem::size_of::<Foo>()]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
   --> $DIR/const-size_of-cycle.rs:4:17
    |

--- a/src/test/ui/consts/issue-36163.stderr
+++ b/src/test/ui/consts/issue-36163.stderr
@@ -9,12 +9,22 @@ note: ...which requires simplifying constant for the type system `Foo::B::{const
    |
 LL |     B = A,
    |         ^
+note: ...which requires simplifying constant for the type system `Foo::B::{constant#0}`...
+  --> $DIR/issue-36163.rs:4:9
+   |
+LL |     B = A,
+   |         ^
 note: ...which requires const-evaluating + checking `Foo::B::{constant#0}`...
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
    |         ^
    = note: ...which requires normalizing `A`...
+note: ...which requires simplifying constant for the type system `A`...
+  --> $DIR/issue-36163.rs:1:1
+   |
+LL | const A: isize = Foo::B as isize;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires simplifying constant for the type system `A`...
   --> $DIR/issue-36163.rs:1:1
    |

--- a/src/test/ui/consts/issue-44415.stderr
+++ b/src/test/ui/consts/issue-44415.stderr
@@ -9,6 +9,11 @@ note: ...which requires simplifying constant for the type system `Foo::bytes::{c
    |
 LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
    |                 ^^^^^^
+note: ...which requires simplifying constant for the type system `Foo::bytes::{constant#0}`...
+  --> $DIR/issue-44415.rs:6:17
+   |
+LL |     bytes: [u8; unsafe { intrinsics::size_of::<Foo>() }],
+   |                 ^^^^^^
 note: ...which requires const-evaluating + checking `Foo::bytes::{constant#0}`...
   --> $DIR/issue-44415.rs:6:17
    |

--- a/src/test/ui/consts/issue-52432.rs
+++ b/src/test/ui/consts/issue-52432.rs
@@ -6,5 +6,5 @@ fn main() {
     //~| ERROR: type annotations needed
     [(); &(static || {}) as *const _ as usize];
     //~^ ERROR: closures cannot be static
-    //~| ERROR evaluation of constant value failed
+    //~| ERROR: failed to evaluate the given constant
 }

--- a/src/test/ui/consts/issue-52432.stderr
+++ b/src/test/ui/consts/issue-52432.stderr
@@ -16,13 +16,13 @@ error[E0282]: type annotations needed
 LL |     [(); &(static |x| {}) as *const _ as usize];
    |                    ^ consider giving this closure parameter a type
 
-error[E0080]: evaluation of constant value failed
+error: failed to evaluate the given constant
   --> $DIR/issue-52432.rs:7:10
    |
 LL |     [(); &(static || {}) as *const _ as usize];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 
-Some errors have detailed explanations: E0080, E0282, E0697.
-For more information about an error, try `rustc --explain E0080`.
+Some errors have detailed explanations: E0282, E0697.
+For more information about an error, try `rustc --explain E0282`.

--- a/src/test/ui/consts/recursive-zst-static.default.stderr
+++ b/src/test/ui/consts/recursive-zst-static.default.stderr
@@ -9,6 +9,11 @@ note: ...which requires const-evaluating + checking `FOO`...
    |
 LL | static FOO: () = FOO;
    | ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `FOO`...
+  --> $DIR/recursive-zst-static.rs:10:1
+   |
+LL | static FOO: () = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `FOO`, completing the cycle
    = note: cycle used when running analysis passes on this crate
 

--- a/src/test/ui/consts/recursive-zst-static.unleash.stderr
+++ b/src/test/ui/consts/recursive-zst-static.unleash.stderr
@@ -9,6 +9,11 @@ note: ...which requires const-evaluating + checking `FOO`...
    |
 LL | static FOO: () = FOO;
    | ^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `FOO`...
+  --> $DIR/recursive-zst-static.rs:10:1
+   |
+LL | static FOO: () = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `FOO`, completing the cycle
    = note: cycle used when running analysis passes on this crate
 

--- a/src/test/ui/issues/issue-17252.stderr
+++ b/src/test/ui/issues/issue-17252.stderr
@@ -10,6 +10,11 @@ note: ...which requires simplifying constant for the type system `FOO`...
    |
 LL | const FOO: usize = FOO;
    | ^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `FOO`...
+  --> $DIR/issue-17252.rs:1:1
+   |
+LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `FOO`...
   --> $DIR/issue-17252.rs:1:1
    |

--- a/src/test/ui/issues/issue-23302-1.stderr
+++ b/src/test/ui/issues/issue-23302-1.stderr
@@ -9,6 +9,11 @@ note: ...which requires simplifying constant for the type system `X::A::{constan
    |
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `X::A::{constant#0}`...
+  --> $DIR/issue-23302-1.rs:4:9
+   |
+LL |     A = X::A as isize,
+   |         ^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `X::A::{constant#0}`...
   --> $DIR/issue-23302-1.rs:4:9
    |

--- a/src/test/ui/issues/issue-23302-2.stderr
+++ b/src/test/ui/issues/issue-23302-2.stderr
@@ -9,6 +9,11 @@ note: ...which requires simplifying constant for the type system `Y::A::{constan
    |
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `Y::A::{constant#0}`...
+  --> $DIR/issue-23302-2.rs:4:9
+   |
+LL |     A = Y::B as isize,
+   |         ^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `Y::A::{constant#0}`...
   --> $DIR/issue-23302-2.rs:4:9
    |

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -9,12 +9,22 @@ note: ...which requires simplifying constant for the type system `A`...
    |
 LL | const A: i32 = B;
    | ^^^^^^^^^^^^^^^^^
+note: ...which requires simplifying constant for the type system `A`...
+  --> $DIR/issue-23302-3.rs:1:1
+   |
+LL | const A: i32 = B;
+   | ^^^^^^^^^^^^^^^^^
 note: ...which requires const-evaluating + checking `A`...
   --> $DIR/issue-23302-3.rs:1:1
    |
 LL | const A: i32 = B;
    | ^^^^^^^^^^^^^^^^^
    = note: ...which requires normalizing `B`...
+note: ...which requires simplifying constant for the type system `B`...
+  --> $DIR/issue-23302-3.rs:3:1
+   |
+LL | const B: i32 = A;
+   | ^^^^^^^^^^^^^^^^^
 note: ...which requires simplifying constant for the type system `B`...
   --> $DIR/issue-23302-3.rs:3:1
    |

--- a/src/test/ui/mir/issue-80742.rs
+++ b/src/test/ui/mir/issue-80742.rs
@@ -28,6 +28,8 @@ where
 }
 
 fn main() {
-    let dst = Inline::<dyn Debug>::new(0); //~ ERROR
-    //~^ ERROR
+    let dst = Inline::<dyn Debug>::new(0);
+    //~^ ERROR failed to evaluate the given constant
+    //~| ERROR the size for values of type
+    //~| ERROR no function or associated item
 }

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -1,17 +1,3 @@
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-LL |     intrinsics::size_of::<T>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     size_of called on unsized type `dyn Debug`
-   |     inside `std::mem::size_of::<dyn Debug>` at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   | 
-  ::: $DIR/issue-80742.rs:23:10
-   |
-LL |     [u8; size_of::<T>() + 1]: ,
-   |          -------------- inside `Inline::<dyn Debug>::{constant#0}` at $DIR/issue-80742.rs:23:10
-
 error[E0599]: no function or associated item named `new` found for struct `Inline<dyn Debug>` in the current scope
   --> $DIR/issue-80742.rs:31:36
    |
@@ -35,20 +21,6 @@ LL |   pub trait Debug {
    = note: the method `new` exists but the following trait bounds were not satisfied:
            `dyn Debug: Sized`
 
-error[E0080]: evaluation of constant value failed
-  --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-LL |     intrinsics::size_of::<T>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     size_of called on unsized type `dyn Debug`
-   |     inside `std::mem::size_of::<dyn Debug>` at $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   | 
-  ::: $DIR/issue-80742.rs:15:10
-   |
-LL |     [u8; size_of::<T>() + 1]: ,
-   |          -------------- inside `Inline::<dyn Debug>::{constant#0}` at $DIR/issue-80742.rs:15:10
-
 error[E0277]: the size for values of type `dyn Debug` cannot be known at compilation time
   --> $DIR/issue-80742.rs:31:15
    |
@@ -64,7 +36,19 @@ help: consider relaxing the implicit `Sized` restriction
 LL | struct Inline<T: ?Sized>
    |                ^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: failed to evaluate the given constant
+  --> $DIR/issue-80742.rs:31:15
+   |
+LL | struct Inline<T>
+   |        ------ required by a bound in this
+LL | where
+LL |     [u8; size_of::<T>() + 1]: ,
+   |          ------------------ required by this bound in `Inline`
+...
+LL |     let dst = Inline::<dyn Debug>::new(0);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Some errors have detailed explanations: E0080, E0277, E0599.
-For more information about an error, try `rustc --explain E0080`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/recursion/recursive-static-definition.stderr
+++ b/src/test/ui/recursion/recursive-static-definition.stderr
@@ -9,6 +9,11 @@ note: ...which requires const-evaluating + checking `FOO`...
    |
 LL | pub static FOO: u32 = FOO;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `FOO`...
+  --> $DIR/recursive-static-definition.rs:1:1
+   |
+LL | pub static FOO: u32 = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `FOO`, completing the cycle
    = note: cycle used when running analysis passes on this crate
 

--- a/src/test/ui/type-alias-enum-variants/self-in-enum-definition.stderr
+++ b/src/test/ui/type-alias-enum-variants/self-in-enum-definition.stderr
@@ -9,6 +9,11 @@ note: ...which requires simplifying constant for the type system `Alpha::V3::{co
    |
 LL |     V3 = Self::V1 {} as u8 + 2,
    |          ^^^^^^^^
+note: ...which requires simplifying constant for the type system `Alpha::V3::{constant#0}`...
+  --> $DIR/self-in-enum-definition.rs:5:10
+   |
+LL |     V3 = Self::V1 {} as u8 + 2,
+   |          ^^^^^^^^
 note: ...which requires const-evaluating + checking `Alpha::V3::{constant#0}`...
   --> $DIR/self-in-enum-definition.rs:5:10
    |

--- a/src/test/ui/write-to-static-mut-in-static.stderr
+++ b/src/test/ui/write-to-static-mut-in-static.stderr
@@ -15,6 +15,11 @@ note: ...which requires const-evaluating + checking `C`...
    |
 LL | pub static mut C: u32 = unsafe { C = 1; 0 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires const-evaluating + checking `C`...
+  --> $DIR/write-to-static-mut-in-static.rs:5:1
+   |
+LL | pub static mut C: u32 = unsafe { C = 1; 0 };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires const-evaluating + checking `C`, completing the cycle
    = note: cycle used when running analysis passes on this crate
 


### PR DESCRIPTION
needs MCP but was surprisingly simple to implement.

Do not emit errors during const eval when checking constants inside of the trait system.
We do this by adding a `Reveal::Selection` which behaves similar to `Reveal::UserFacing` but
supresses errors during const eval.
This allows coherence to work properly with `feature(const_evaluatable_checked)` and
improves the error location from abysmal to somewhat acceptable.

r? @oli-obk 