### PR TITLE
Check initialization of ZSTs in 'invalid value' lint

### DIFF
--- a/src/test/ui/lint/zst_initialization.rs
+++ b/src/test/ui/lint/zst_initialization.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+enum Never {}
+
+fn main() {
+    unsafe {
+        std::mem::transmute::<(), Never>(());
+        //~^ WARNING: the type `Never` does not permit zero-initialization
+        std::mem::transmute::<Option<Never>, Never>(None);
+        //~^ WARNING: the type `Never` does not permit initialization
+    }
+}

--- a/src/test/ui/lint/zst_initialization.stderr
+++ b/src/test/ui/lint/zst_initialization.stderr
@@ -1,0 +1,25 @@
+warning: the type `Never` does not permit zero-initialization
+  --> $DIR/zst_initialization.rs:7:9
+   |
+LL |         std::mem::transmute::<(), Never>(());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         this code causes undefined behavior when executed
+   |         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |
+   = note: `#[warn(invalid_value)]` on by default
+   = note: enums with no variants have no valid value
+
+warning: the type `Never` does not permit initialization
+  --> $DIR/zst_initialization.rs:9:9
+   |
+LL |         std::mem::transmute::<Option<Never>, Never>(None);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         this code causes undefined behavior when executed
+   |         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |
+   = note: enums with no variants have no valid value
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/never_type/never_transmute_never.rs
+++ b/src/test/ui/never_type/never_transmute_never.rs
@@ -18,6 +18,7 @@ pub fn ub() {
     // but we still want to make sure it compiles.
     let x: ! = unsafe {
         std::mem::transmute::<Foo, !>(Foo)
+        //~^ WARNING: the type `!` does not permit initialization
     };
     f(x)
 }

--- a/src/test/ui/never_type/never_transmute_never.stderr
+++ b/src/test/ui/never_type/never_transmute_never.stderr
@@ -1,0 +1,14 @@
+warning: the type `!` does not permit initialization
+  --> $DIR/never_transmute_never.rs:20:9
+   |
+LL |         std::mem::transmute::<Foo, !>(Foo)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         this code causes undefined behavior when executed
+   |         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |
+   = note: `#[warn(invalid_value)]` on by default
+   = note: the `!` type has no valid value
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Previously this code

    enum Never {}

    fn main() {
        unsafe {
            std::mem::transmute::<(), Never>(());
            std::mem::transmute::<Option<Never>, Never>(None);
        }
    }

would generate this warning:

    warning: the type `Never` does not permit zero-initialization
     --> test.rs:5:9
      |
    5 |         std::mem::transmute::<(), Never>(());
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |         |
      |         this code causes undefined behavior when executed
      |         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
      |
      = note: `#[warn(invalid_value)]` on by default
      = note: enums with no variants have no valid value

    warning: 1 warning emitted

Note that the second transmute doesn't cause a warning. This is because
the check, when it sees a "zero initialization", check is the value is a
valid for the type.

The problem is "zero initialization" check is very simple and can only
detect two cases:

- A tuple with all fields "0" (e.g. (), (0,), (0,0), ...)
- The literal "0"

In the example, `None` is also represented as "zero", but this check is
unable to detect it.

Instead of making "is zero" check more sophisticated, this commit
instead detects the issue in the second transmute above by checking if
the transmute is initializing a ZST, using the conservative
`TyS::conservative_is_privately_uninhabited` check.

Warnings with this commit:

    warning: the type `Never` does not permit zero-initialization
     --> test.rs:5:9
      |
    5 |         std::mem::transmute::<(), Never>(());
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |         |
      |         this code causes undefined behavior when executed
      |         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
      |
      = note: `#[warn(invalid_value)]` on by default
      = note: enums with no variants have no valid value

    warning: the type `Never` does not permit initialization
     --> test.rs:6:9
      |
    6 |         std::mem::transmute::<Option<Never>, Never>(None);
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |         |
      |         this code causes undefined behavior when executed
      |         help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
      |
      = note: enums with no variants have no valid value

    warning: 2 warnings emitted