### PR TITLE
Remove unnecessary `self_ty` parameter to `get_blanket_impls`

### DIFF
--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -14,10 +14,9 @@ crate struct BlanketImplFinder<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
-    // FIXME(eddyb) figure out a better way to pass information about
-    // parametrization of `ty` than `param_env_def_id`.
-    crate fn get_blanket_impls(&mut self, ty: Ty<'tcx>, param_env_def_id: DefId) -> Vec<Item> {
-        let param_env = self.cx.tcx.param_env(param_env_def_id);
+    crate fn get_blanket_impls(&mut self, item_def_id: DefId) -> Vec<Item> {
+        let param_env = self.cx.tcx.param_env(item_def_id);
+        let ty = self.cx.tcx.type_of(item_def_id);
 
         debug!("get_blanket_impls({:?})", ty);
         let mut impls = Vec::new();
@@ -39,7 +38,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                         _ => return false,
                     }
 
-                    let substs = infcx.fresh_substs_for_item(DUMMY_SP, param_env_def_id);
+                    let substs = infcx.fresh_substs_for_item(DUMMY_SP, item_def_id);
                     let ty = ty.subst(infcx.tcx, substs);
                     let param_env = param_env.subst(infcx.tcx, substs);
 

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -13,7 +13,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::interpret::ConstValue;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
-use rustc_middle::ty::{self, DefIdTree, Ty, TyCtxt};
+use rustc_middle::ty::{self, DefIdTree, TyCtxt};
 use rustc_span::symbol::{kw, sym, Symbol};
 use std::mem;
 
@@ -426,19 +426,18 @@ crate fn resolve_type(cx: &mut DocContext<'_>, path: Path, id: hir::HirId) -> Ty
 
 crate fn get_auto_trait_and_blanket_impls(
     cx: &mut DocContext<'tcx>,
-    ty: Ty<'tcx>,
-    param_env_def_id: DefId,
+    item_def_id: DefId,
 ) -> impl Iterator<Item = Item> {
     let auto_impls = cx
         .sess()
         .prof
         .generic_activity("get_auto_trait_impls")
-        .run(|| AutoTraitFinder::new(cx).get_auto_trait_impls(ty, param_env_def_id));
+        .run(|| AutoTraitFinder::new(cx).get_auto_trait_impls(item_def_id));
     let blanket_impls = cx
         .sess()
         .prof
         .generic_activity("get_blanket_impls")
-        .run(|| BlanketImplFinder { cx }.get_blanket_impls(ty, param_env_def_id));
+        .run(|| BlanketImplFinder { cx }.get_blanket_impls(item_def_id));
     auto_impls.into_iter().chain(blanket_impls)
 }
 

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -46,9 +46,7 @@ crate fn collect_trait_impls(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
 
                 // FIXME(eddyb) is this `doc(hidden)` check needed?
                 if !cx.tcx.get_attrs(def_id).lists(sym::doc).has_word(sym::hidden) {
-                    let self_ty = cx.tcx.type_of(def_id);
-                    let impls = get_auto_trait_and_blanket_impls(cx, self_ty, def_id);
-
+                    let impls = get_auto_trait_and_blanket_impls(cx, def_id);
                     new_items.extend(impls.filter(|i| cx.renderinfo.inlined.insert(i.def_id)));
                 }
             });
@@ -170,11 +168,7 @@ impl<'a, 'tcx> DocFolder for SyntheticImplCollector<'a, 'tcx> {
         if i.is_struct() || i.is_enum() || i.is_union() {
             // FIXME(eddyb) is this `doc(hidden)` check needed?
             if !self.cx.tcx.get_attrs(i.def_id).lists(sym::doc).has_word(sym::hidden) {
-                self.impls.extend(get_auto_trait_and_blanket_impls(
-                    self.cx,
-                    self.cx.tcx.type_of(i.def_id),
-                    i.def_id,
-                ));
+                self.impls.extend(get_auto_trait_and_blanket_impls(self.cx, i.def_id));
             }
         }
 


### PR DESCRIPTION
It can be calculated when necessary at the callsite, there's no need to
pass it separately.

This also renames `param_env_def_id` to `item_def_id`.

cc @eddyb