### PR TITLE
combine: stop eagerly evaluating consts

### DIFF
--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -33,15 +33,6 @@ pub trait TypeRelation<'tcx>: Sized {
     /// relation. Just affects error messages.
     fn a_is_expected(&self) -> bool;
 
-    /// Whether we should look into the substs of unevaluated constants
-    /// even if `feature(const_evaluatable_checked)` is active.
-    ///
-    /// This is needed in `combine` to prevent accidentially creating
-    /// infinite types as we abuse `TypeRelation` to walk a type there.
-    fn visit_ct_substs(&self) -> bool {
-        false
-    }
-
     fn with_cause<F, R>(&mut self, _cause: Cause, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
@@ -532,7 +523,7 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
         }
 
         (ty::ConstKind::Unevaluated(au), ty::ConstKind::Unevaluated(bu))
-            if tcx.features().const_evaluatable_checked && !relation.visit_ct_substs() =>
+            if tcx.features().const_evaluatable_checked =>
         {
             tcx.try_unify_abstract_consts(((au.def, au.substs), (bu.def, bu.substs)))
         }

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -423,9 +423,9 @@ pub fn super_relate_tys<R: TypeRelation<'tcx>>(
                     let sz_a = sz_a.try_eval_usize(tcx, relation.param_env());
                     let sz_b = sz_b.try_eval_usize(tcx, relation.param_env());
                     match (sz_a, sz_b) {
-                        (Some(sz_a_val), Some(sz_b_val)) => Err(TypeError::FixedArraySize(
-                            expected_found(relation, sz_a_val, sz_b_val),
-                        )),
+                        (Some(sz_a_val), Some(sz_b_val)) if sz_a_val != sz_b_val => Err(
+                            TypeError::FixedArraySize(expected_found(relation, sz_a_val, sz_b_val)),
+                        ),
                         _ => Err(err),
                     }
                 }

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
@@ -14,5 +14,5 @@ where
 
 fn main() {
     Foo::foo();
-    //~^ ERROR no function or associated item
+    //~^ ERROR the function or associated item
 }

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
@@ -1,4 +1,3 @@
-// run-pass
 #![feature(const_generics)]
 #![allow(incomplete_features, unused_braces)]
 
@@ -15,4 +14,5 @@ where
 
 fn main() {
     Foo::foo();
+    //~^ ERROR no function or associated item
 }

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
@@ -1,13 +1,13 @@
-error[E0599]: no function or associated item named `foo` found for struct `Foo<{_: usize}>` in the current scope
+error[E0599]: the function or associated item `foo` exists for struct `Foo<{_: usize}>`, but its trait bounds were not satisfied
   --> $DIR/issue-69654-run-pass.rs:16:10
    |
 LL | struct Foo<const N: usize> {}
    | -------------------------- function or associated item `foo` not found for this
 ...
 LL |     Foo::foo();
-   |          ^^^ function or associated item not found in `Foo<{_: usize}>`
+   |          ^^^ function or associated item cannot be called on `Foo<{_: usize}>` due to unsatisfied trait bounds
    |
-   = note: the method `foo` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `[u8; _]: Bar<[(); _]>`
 
 error: aborting due to previous error

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
@@ -1,11 +1,5 @@
-error[E0423]: expected value, found type parameter `T`
-  --> $DIR/issue-69654.rs:5:25
-   |
-LL | impl<T> Bar<T> for [u8; T] {}
-   |                         ^ not a value
-
 error[E0599]: no function or associated item named `foo` found for struct `Foo<{_: usize}>` in the current scope
-  --> $DIR/issue-69654.rs:17:10
+  --> $DIR/issue-69654-run-pass.rs:16:10
    |
 LL | struct Foo<const N: usize> {}
    | -------------------------- function or associated item `foo` not found for this
@@ -16,7 +10,6 @@ LL |     Foo::foo();
    = note: the method `foo` exists but the following trait bounds were not satisfied:
            `[u8; _]: Bar<[(); _]>`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0423, E0599.
-For more information about an error, try `rustc --explain E0423`.
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/const-generics/issues/issue-69654.rs
+++ b/src/test/ui/const-generics/issues/issue-69654.rs
@@ -15,5 +15,5 @@ where
 
 fn main() {
     Foo::foo();
-    //~^ ERROR no function or associated item
+    //~^ ERROR the function or associated item
 }

--- a/src/test/ui/const-generics/issues/issue-69654.rs
+++ b/src/test/ui/const-generics/issues/issue-69654.rs
@@ -15,4 +15,5 @@ where
 
 fn main() {
     Foo::foo();
+    //~^ ERROR no function or associated item
 }

--- a/src/test/ui/const-generics/issues/issue-69654.stderr
+++ b/src/test/ui/const-generics/issues/issue-69654.stderr
@@ -4,16 +4,16 @@ error[E0423]: expected value, found type parameter `T`
 LL | impl<T> Bar<T> for [u8; T] {}
    |                         ^ not a value
 
-error[E0599]: no function or associated item named `foo` found for struct `Foo<{_: usize}>` in the current scope
+error[E0599]: the function or associated item `foo` exists for struct `Foo<{_: usize}>`, but its trait bounds were not satisfied
   --> $DIR/issue-69654.rs:17:10
    |
 LL | struct Foo<const N: usize> {}
    | -------------------------- function or associated item `foo` not found for this
 ...
 LL |     Foo::foo();
-   |          ^^^ function or associated item not found in `Foo<{_: usize}>`
+   |          ^^^ function or associated item cannot be called on `Foo<{_: usize}>` due to unsatisfied trait bounds
    |
-   = note: the method `foo` exists but the following trait bounds were not satisfied:
+   = note: the following trait bounds were not satisfied:
            `[u8; _]: Bar<[(); _]>`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/const-generics/occurs-check/unused-substs-1.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-1.rs
@@ -1,4 +1,3 @@
-// build-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -10,5 +9,5 @@ where
     A<N>: Bar<N>;
 
 fn main() {
-    let _ = A;
+    let _ = A; //~ERROR the trait bound
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `A<{_: usize}>: Bar<{_: usize}>` is not satisfied
+  --> $DIR/unused-substs-1.rs:12:13
+   |
+LL | / struct A<const N: usize>
+LL | | where
+LL | |     A<N>: Bar<N>;
+   | |_________________- required by `A`
+...
+LL |       let _ = A;
+   |               ^ the trait `Bar<{_: usize}>` is not implemented for `A<{_: usize}>`
+   |
+   = help: the following implementations were found:
+             <A<7_usize> as Bar<N>>
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/occurs-check/unused-substs-2.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-2.rs
@@ -1,4 +1,3 @@
-// check-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -24,4 +23,6 @@ fn main() {
     // `t` is `ty::Infer(TyVar(_#1t))`
     // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
     t = foo;
+    //~^ ERROR mismatched types
+    //~| NOTE cyclic type
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-2.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-2.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-2.rs:25:9
+   |
+LL |     t = foo;
+   |         ^^^ cyclic type of infinite size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/occurs-check/unused-substs-3.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-3.rs
@@ -1,4 +1,3 @@
-// check-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -15,4 +14,6 @@ fn main() {
     // `t` is `ty::Infer(TyVar(_#1t))`
     // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
     t = foo;
+    //~^ ERROR mismatched types
+    //~| NOTE cyclic type
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-3.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-3.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-3.rs:16:9
+   |
+LL |     t = foo;
+   |         ^^^
+   |         |
+   |         cyclic type of infinite size
+   |         help: try using a conversion method: `foo.to_vec()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/occurs-check/unused-substs-4.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-4.rs
@@ -1,4 +1,3 @@
-// build-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -8,5 +7,5 @@ fn bind<const N: usize>(value: [u8; N]) -> [u8; 3 + 4] {
 
 fn main() {
     let mut arr = Default::default();
-    arr = bind(arr);
+    arr = bind(arr); //~ ERROR mismatched type
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-4.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-4.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-4.rs:10:11
+   |
+LL |     arr = bind(arr);
+   |           ^^^^^^^^^ encountered a self-referencing constant
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
`super_relate_consts` eagerly evaluates constants which doesn't seem too great.

I now also finally understand why all of the unused substs test passed. The reason being
that we just evaluated the constants in `super_relate_consts` :laughing:

While this change isn't strictly necessary as evaluating consts here doesn't hurt, it still feels a lot cleaner to do it this way

r? @oli-obk @nikomatsakis 
