### PR TITLE
Fix spelling in documentation for error E0207

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0207.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0207.md
@@ -14,7 +14,7 @@ impl<T: Default> Foo {
 }
 ```
 
-Any type parameter parameter of an `impl` must meet at least one of
+Any type parameter of an `impl` must meet at least one of
 the following criteria:
 
  - it appears in the _implementing type_ of the impl, e.g. `impl<T> Foo<T>`


### PR DESCRIPTION
I have trouble parsing the the wording "type parameter parameter".