### PR TITLE
Add a check for ASCII characters in to_upper and to_lower

### DIFF
--- a/library/core/benches/char/methods.rs
+++ b/library/core/benches/char/methods.rs
@@ -47,11 +47,31 @@ fn bench_to_ascii_lowercase(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_char_to_uppercase(b: &mut Bencher) {
+fn bench_ascii_mix_to_uppercase(b: &mut Bencher) {
     b.iter(|| (0..=255).cycle().take(10_000).map(|b| char::from(b).to_uppercase()).count())
 }
 
 #[bench]
-fn bench_char_to_lowercase(b: &mut Bencher) {
+fn bench_ascii_mix_to_lowercase(b: &mut Bencher) {
     b.iter(|| (0..=255).cycle().take(10_000).map(|b| char::from(b).to_lowercase()).count())
+}
+
+#[bench]
+fn bench_ascii_char_to_uppercase(b: &mut Bencher) {
+    b.iter(|| (0..=127).cycle().take(10_000).map(|b| char::from(b).to_uppercase()).count())
+}
+
+#[bench]
+fn bench_ascii_char_to_lowercase(b: &mut Bencher) {
+    b.iter(|| (0..=127).cycle().take(10_000).map(|b| char::from(b).to_lowercase()).count())
+}
+
+#[bench]
+fn bench_non_ascii_char_to_uppercase(b: &mut Bencher) {
+    b.iter(|| (128..=255).cycle().take(10_000).map(|b| char::from(b).to_uppercase()).count())
+}
+
+#[bench]
+fn bench_non_ascii_char_to_lowercase(b: &mut Bencher) {
+    b.iter(|| (128..=255).cycle().take(10_000).map(|b| char::from(b).to_lowercase()).count())
 }

--- a/library/core/benches/char/methods.rs
+++ b/library/core/benches/char/methods.rs
@@ -45,3 +45,13 @@ fn bench_to_ascii_uppercase(b: &mut Bencher) {
 fn bench_to_ascii_lowercase(b: &mut Bencher) {
     b.iter(|| CHARS.iter().cycle().take(10_000).map(|c| c.to_ascii_lowercase()).min())
 }
+
+#[bench]
+fn bench_char_to_uppercase(b: &mut Bencher) {
+    b.iter(|| (0..=255).cycle().take(10_000).map(|b| char::from(b).to_uppercase()).count())
+}
+
+#[bench]
+fn bench_char_to_lowercase(b: &mut Bencher) {
+    b.iter(|| (0..=255).cycle().take(10_000).map(|b| char::from(b).to_lowercase()).count())
+}

--- a/library/core/src/unicode/unicode_data.rs
+++ b/library/core/src/unicode/unicode_data.rs
@@ -549,16 +549,24 @@ pub mod white_space {
 #[rustfmt::skip]
 pub mod conversions {
     pub fn to_lower(c: char) -> [char; 3] {
-        match bsearch_case_table(c, LOWERCASE_TABLE) {
-            None => [c, '\0', '\0'],
-            Some(index) => LOWERCASE_TABLE[index].1,
+        if c.is_ascii() {
+            [(c as u8).to_ascii_lowercase() as char, '\0', '\0']
+        } else {
+            match bsearch_case_table(c, LOWERCASE_TABLE) {
+                None => [c, '\0', '\0'],
+                Some(index) => LOWERCASE_TABLE[index].1,
+            }
         }
     }
 
     pub fn to_upper(c: char) -> [char; 3] {
-        match bsearch_case_table(c, UPPERCASE_TABLE) {
-            None => [c, '\0', '\0'],
-            Some(index) => UPPERCASE_TABLE[index].1,
+        if c.is_ascii() {
+            [(c as u8).to_ascii_uppercase() as char, '\0', '\0']
+        } else {
+            match bsearch_case_table(c, UPPERCASE_TABLE) {
+                None => [c, '\0', '\0'],
+                Some(index) => UPPERCASE_TABLE[index].1,
+            }
         }
     }
 


### PR DESCRIPTION
This extra check has better performance. See discussion here:
https://internals.rust-lang.org/t/to-upper-speed/13896

Thanks to @gilescope for helping discover and test this.