### PR TITLE
On irrefutable let pattern lint point only at pattern

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -532,7 +532,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let pat = self.lower_pat(&arm.pat);
         let guard = arm.guard.as_ref().map(|cond| {
             if let ExprKind::Let(ref pat, ref scrutinee) = cond.kind {
-                hir::Guard::IfLet(self.lower_pat(pat), self.lower_expr(scrutinee))
+                hir::Guard::IfLet(self.lower_pat(pat), self.lower_expr(scrutinee), cond.span)
             } else {
                 hir::Guard::If(self.lower_expr(cond))
             }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1210,7 +1210,7 @@ pub struct Arm<'hir> {
 #[derive(Debug, HashStable_Generic)]
 pub enum Guard<'hir> {
     If(&'hir Expr<'hir>),
-    IfLet(&'hir Pat<'hir>, &'hir Expr<'hir>),
+    IfLet(&'hir Pat<'hir>, &'hir Expr<'hir>, Span),
 }
 
 #[derive(Debug, HashStable_Generic)]
@@ -1881,7 +1881,7 @@ pub enum MatchSource {
     /// An `if let _ = _ { .. }` (optionally with `else { .. }`).
     IfLetDesugar { contains_else_clause: bool, let_span: Span },
     /// An `if let _ = _ => { .. }` match guard.
-    IfLetGuardDesugar,
+    IfLetGuardDesugar { let_span: Span },
     /// A `while _ { .. }` (which was desugared to a `loop { match _ { .. } }`).
     WhileDesugar,
     /// A `while let _ = _ { .. }` (which was desugared to a
@@ -1900,7 +1900,7 @@ impl MatchSource {
         use MatchSource::*;
         match self {
             Normal => "match",
-            IfLetDesugar { .. } | IfLetGuardDesugar => "if",
+            IfLetDesugar { .. } | IfLetGuardDesugar { .. } => "if",
             WhileDesugar | WhileLetDesugar { .. } => "while",
             ForLoopDesugar => "for",
             TryDesugar => "?",

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1879,14 +1879,14 @@ pub enum MatchSource {
     /// A `match _ { .. }`.
     Normal,
     /// An `if let _ = _ { .. }` (optionally with `else { .. }`).
-    IfLetDesugar { contains_else_clause: bool },
+    IfLetDesugar { contains_else_clause: bool, let_span: Span },
     /// An `if let _ = _ => { .. }` match guard.
     IfLetGuardDesugar,
     /// A `while _ { .. }` (which was desugared to a `loop { match _ { .. } }`).
     WhileDesugar,
     /// A `while let _ = _ { .. }` (which was desugared to a
     /// `loop { match _ { .. } }`).
-    WhileLetDesugar,
+    WhileLetDesugar { let_span: Span },
     /// A desugared `for _ in _ { .. }` loop.
     ForLoopDesugar,
     /// A desugared `?` operator.
@@ -1901,7 +1901,7 @@ impl MatchSource {
         match self {
             Normal => "match",
             IfLetDesugar { .. } | IfLetGuardDesugar => "if",
-            WhileDesugar | WhileLetDesugar => "while",
+            WhileDesugar | WhileLetDesugar { .. } => "while",
             ForLoopDesugar => "for",
             TryDesugar => "?",
             AwaitDesugar => ".await",

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1896,6 +1896,26 @@ pub enum MatchSource {
 }
 
 impl MatchSource {
+    pub fn equivalent(&self, other: &Self) -> bool {
+        use MatchSource::*;
+        match (self, other) {
+            (Normal, Normal)
+            | (IfLetGuardDesugar { .. }, IfLetGuardDesugar { .. })
+            | (WhileDesugar, WhileDesugar)
+            | (WhileLetDesugar { .. }, WhileLetDesugar { .. })
+            | (ForLoopDesugar, ForLoopDesugar)
+            | (TryDesugar, TryDesugar)
+            | (AwaitDesugar, AwaitDesugar) => true,
+            (
+                IfLetDesugar { contains_else_clause: l, .. },
+                IfLetDesugar { contains_else_clause: r, .. },
+            ) => l == r,
+            _ => false,
+        }
+    }
+}
+
+impl MatchSource {
     pub fn name(self) -> &'static str {
         use MatchSource::*;
         match self {

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1239,7 +1239,7 @@ pub fn walk_arm<'v, V: Visitor<'v>>(visitor: &mut V, arm: &'v Arm<'v>) {
     if let Some(ref g) = arm.guard {
         match g {
             Guard::If(ref e) => visitor.visit_expr(e),
-            Guard::IfLet(ref pat, ref e) => {
+            Guard::IfLet(ref pat, ref e, _) => {
                 visitor.visit_pat(pat);
                 visitor.visit_expr(e);
             }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2043,7 +2043,7 @@ impl<'a> State<'a> {
                     self.print_expr(&e);
                     self.s.space();
                 }
-                hir::Guard::IfLet(pat, e) => {
+                hir::Guard::IfLet(pat, e, _) => {
                     self.word_nbsp("if");
                     self.word_nbsp("let");
                     self.print_pat(&pat);

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -781,7 +781,9 @@ fn convert_arm<'tcx>(cx: &mut Cx<'_, 'tcx>, arm: &'tcx hir::Arm<'tcx>) -> Arm<'t
         pattern: cx.pattern_from_hir(&arm.pat),
         guard: arm.guard.as_ref().map(|g| match g {
             hir::Guard::If(ref e) => Guard::If(e.to_ref()),
-            hir::Guard::IfLet(ref pat, ref e) => Guard::IfLet(cx.pattern_from_hir(pat), e.to_ref()),
+            hir::Guard::IfLet(ref pat, ref e, _) => {
+                Guard::IfLet(cx.pattern_from_hir(pat), e.to_ref())
+            }
         }),
         body: arm.body.to_ref(),
         lint_level: LintLevel::Explicit(arm.hir_id),

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -373,7 +373,7 @@ fn irrefutable_let_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, source: hir::
             diag.help("consider replacing the `if let` with a `let`");
             diag.emit()
         }
-        hir::MatchSource::WhileLetDesugar => {
+        hir::MatchSource::WhileLetDesugar { .. } => {
             let mut diag = lint.build("irrefutable `while let` pattern");
             diag.note("this pattern will always match, so the loop will never exit");
             diag.help("consider instead using a `loop { ... }` with a `let` inside it");
@@ -423,13 +423,14 @@ fn report_arm_reachability<'p, 'tcx>(
                 match source {
                     hir::MatchSource::WhileDesugar => bug!(),
 
-                    hir::MatchSource::IfLetDesugar { .. } | hir::MatchSource::WhileLetDesugar => {
+                    hir::MatchSource::IfLetDesugar { let_span, .. }
+                    | hir::MatchSource::WhileLetDesugar { let_span } => {
                         // Check which arm we're on.
                         match arm_index {
                             // The arm with the user-specified pattern.
-                            0 => unreachable_pattern(cx.tcx, arm.pat.span, arm.hir_id, None),
+                            0 => unreachable_pattern(cx.tcx, let_span, arm.hir_id, None),
                             // The arm with the wildcard pattern.
-                            1 => irrefutable_let_pattern(cx.tcx, arm.pat.span, arm.hir_id, source),
+                            1 => irrefutable_let_pattern(cx.tcx, let_span, arm.hir_id, source),
                             _ => bug!(),
                         }
                     }

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -45,7 +45,9 @@ impl NonConstExpr {
                 return None;
             }
 
-            Self::Match(IfLetGuardDesugar) => bug!("`if let` guard outside a `match` expression"),
+            Self::Match(IfLetGuardDesugar { .. }) => {
+                bug!("if-let guard outside a `match` expression")
+            }
 
             // All other expressions are allowed.
             Self::Loop(Loop | While | WhileLet)

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -49,7 +49,9 @@ impl NonConstExpr {
 
             // All other expressions are allowed.
             Self::Loop(Loop | While | WhileLet)
-            | Self::Match(WhileDesugar | WhileLetDesugar | Normal | IfLetDesugar { .. }) => &[],
+            | Self::Match(WhileDesugar | WhileLetDesugar { .. } | Normal | IfLetDesugar { .. }) => {
+                &[]
+            }
         };
 
         Some(gates)
@@ -207,7 +209,7 @@ impl<'tcx> Visitor<'tcx> for CheckConstVisitor<'tcx> {
                 let non_const_expr = match source {
                     // These are handled by `ExprKind::Loop` above.
                     hir::MatchSource::WhileDesugar
-                    | hir::MatchSource::WhileLetDesugar
+                    | hir::MatchSource::WhileLetDesugar { .. }
                     | hir::MatchSource::ForLoopDesugar => None,
 
                     _ => Some(NonConstExpr::Match(*source)),

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -360,7 +360,7 @@ impl<'tcx> Visitor<'tcx> for IrMaps<'tcx> {
 
     fn visit_arm(&mut self, arm: &'tcx hir::Arm<'tcx>) {
         self.add_from_pat(&arm.pat);
-        if let Some(hir::Guard::IfLet(ref pat, _)) = arm.guard {
+        if let Some(hir::Guard::IfLet(ref pat, _, _)) = arm.guard {
             self.add_from_pat(pat);
         }
         intravisit::walk_arm(self, arm);
@@ -891,7 +891,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
 
                     let guard_succ = arm.guard.as_ref().map_or(body_succ, |g| match g {
                         hir::Guard::If(e) => self.propagate_through_expr(e, body_succ),
-                        hir::Guard::IfLet(pat, e) => {
+                        hir::Guard::IfLet(pat, e, _) => {
                             let let_bind = self.define_bindings_in_pat(pat, body_succ);
                             self.propagate_through_expr(e, let_bind)
                         }

--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -134,7 +134,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     hir::Guard::If(e) => {
                         self.check_expr_has_type_or_error(e, tcx.types.bool, |_| {});
                     }
-                    hir::Guard::IfLet(pat, e) => {
+                    hir::Guard::IfLet(pat, e, _) => {
                         let scrutinee_ty = self.demand_scrutinee_type(
                             e,
                             pat.contains_explicit_ref_binding(),

--- a/compiler/rustc_typeck/src/check/generator_interior.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior.rs
@@ -248,7 +248,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                 Guard::If(ref e) => {
                     self.visit_expr(e);
                 }
-                Guard::IfLet(ref pat, ref e) => {
+                Guard::IfLet(ref pat, ref e, _) => {
                     self.visit_pat(pat);
                     self.visit_expr(e);
                 }

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
@@ -8,13 +8,10 @@ LL | #![feature(capture_disjoint_fields)]
    = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
 
 warning: irrefutable `if let` pattern
-  --> $DIR/closure-origin-single-variant-diagnostics.rs:18:9
+  --> $DIR/closure-origin-single-variant-diagnostics.rs:18:12
    |
-LL | /         if let SingleVariant::Point(ref mut x, _) = point {
-LL | |
-LL | |             *x += 1;
-LL | |         }
-   | |_________^
+LL |         if let SingleVariant::Point(ref mut x, _) = point {
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this pattern will always match, so the `if let` is useless

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
@@ -11,11 +11,11 @@ warning: irrefutable `if let` pattern
   --> $DIR/closure-origin-single-variant-diagnostics.rs:18:12
    |
 LL |         if let SingleVariant::Point(ref mut x, _) = point {
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this pattern will always match, so the `if let` is useless
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 error[E0382]: use of moved value: `c`
   --> $DIR/closure-origin-single-variant-diagnostics.rs:25:13

--- a/src/test/ui/expr/if/if-let.stderr
+++ b/src/test/ui/expr/if/if-let.stderr
@@ -2,7 +2,7 @@ warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:6:16
    |
 LL |               if let $p = $e $b
-   |                  ^^^
+   |                  ^^^ this pattern will always match, so the `if let` is useless
 ...
 LL | /     foo!(a, 1, {
 LL | |         println!("irrefutable pattern");
@@ -10,60 +10,60 @@ LL | |     });
    | |_______- in this macro invocation
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:6:16
    |
 LL |               if let $p = $e $b
-   |                  ^^^
+   |                  ^^^ this pattern will always match, so the `if let` is useless
 ...
 LL | /     bar!(a, 1, {
 LL | |         println!("irrefutable pattern");
 LL | |     });
    | |_______- in this macro invocation
    |
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:26:8
    |
 LL |     if let a = 1 {
-   |        ^^^^^^^^^
+   |        ^^^^^^^^^ this pattern will always match, so the `if let` is useless
    |
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:30:8
    |
 LL |     if let a = 1 {
-   |        ^^^^^^^^^
+   |        ^^^^^^^^^ this pattern will always match, so the `if let` is useless
    |
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:40:15
    |
 LL |     } else if let a = 1 {
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ this pattern will always match, so the `if let` is useless
    |
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:46:15
    |
 LL |     } else if let a = 1 {
-   |               ^^^^^^^^^
+   |               ^^^^^^^^^ this pattern will always match, so the `if let` is useless
    |
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 warning: 6 warnings emitted
 

--- a/src/test/ui/expr/if/if-let.stderr
+++ b/src/test/ui/expr/if/if-let.stderr
@@ -1,8 +1,8 @@
 warning: irrefutable `if let` pattern
-  --> $DIR/if-let.rs:6:13
+  --> $DIR/if-let.rs:6:16
    |
 LL |               if let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^
+   |                  ^^^
 ...
 LL | /     foo!(a, 1, {
 LL | |         println!("irrefutable pattern");
@@ -15,10 +15,10 @@ LL | |     });
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `if let` pattern
-  --> $DIR/if-let.rs:6:13
+  --> $DIR/if-let.rs:6:16
    |
 LL |               if let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^
+   |                  ^^^
 ...
 LL | /     bar!(a, 1, {
 LL | |         println!("irrefutable pattern");
@@ -30,51 +30,37 @@ LL | |     });
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `if let` pattern
-  --> $DIR/if-let.rs:26:5
+  --> $DIR/if-let.rs:26:8
    |
-LL | /     if let a = 1 {
-LL | |         println!("irrefutable pattern");
-LL | |     }
-   | |_____^
+LL |     if let a = 1 {
+   |        ^^^^^^^^^
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
 
 warning: irrefutable `if let` pattern
-  --> $DIR/if-let.rs:30:5
+  --> $DIR/if-let.rs:30:8
    |
-LL | /     if let a = 1 {
-LL | |         println!("irrefutable pattern");
-LL | |     } else if true {
-LL | |         println!("else-if in irrefutable `if let`");
-LL | |     } else {
-LL | |         println!("else in irrefutable `if let`");
-LL | |     }
-   | |_____^
+LL |     if let a = 1 {
+   |        ^^^^^^^^^
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
 
 warning: irrefutable `if let` pattern
-  --> $DIR/if-let.rs:40:12
+  --> $DIR/if-let.rs:40:15
    |
-LL |       } else if let a = 1 {
-   |  ____________^
-LL | |         println!("irrefutable pattern");
-LL | |     }
-   | |_____^
+LL |     } else if let a = 1 {
+   |               ^^^^^^^^^
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
 
 warning: irrefutable `if let` pattern
-  --> $DIR/if-let.rs:46:12
+  --> $DIR/if-let.rs:46:15
    |
-LL |       } else if let a = 1 {
-   |  ____________^
-LL | |         println!("irrefutable pattern");
-LL | |     }
-   | |_____^
+LL |     } else if let a = 1 {
+   |               ^^^^^^^^^
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`

--- a/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
@@ -1,8 +1,8 @@
 error: irrefutable `if let` pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:7:5
+  --> $DIR/deny-irrefutable-let-patterns.rs:7:8
    |
 LL |     if let _ = 5 {}
-   |     ^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/deny-irrefutable-let-patterns.rs:4:9
@@ -13,12 +13,10 @@ LL | #![deny(irrefutable_let_patterns)]
    = help: consider replacing the `if let` with a `let`
 
 error: irrefutable `while let` pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:9:5
+  --> $DIR/deny-irrefutable-let-patterns.rs:9:11
    |
-LL | /     while let _ = 5 {
-LL | |         break;
-LL | |     }
-   | |_____^
+LL |     while let _ = 5 {
+   |           ^^^^^^^^^
    |
    = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it

--- a/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
@@ -22,10 +22,10 @@ LL |     while let _ = 5 {
    = help: consider instead using a `loop { ... }` with a `let` inside it
 
 error: irrefutable `if let` guard pattern
-  --> $DIR/deny-irrefutable-let-patterns.rs:14:18
+  --> $DIR/deny-irrefutable-let-patterns.rs:14:14
    |
 LL |         _ if let _ = 2 => {}
-   |                  ^
+   |              ^^^^^^^^^
    |
    = note: this pattern will always match, so the guard is useless
    = help: consider removing the guard and adding a `let` inside the match arm

--- a/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
@@ -2,33 +2,33 @@ error: irrefutable `if let` pattern
   --> $DIR/deny-irrefutable-let-patterns.rs:7:8
    |
 LL |     if let _ = 5 {}
-   |        ^^^^^^^^^
+   |        ^^^^^^^^^ this pattern will always match, so the `if let` is useless
    |
 note: the lint level is defined here
   --> $DIR/deny-irrefutable-let-patterns.rs:4:9
    |
 LL | #![deny(irrefutable_let_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 error: irrefutable `while let` pattern
   --> $DIR/deny-irrefutable-let-patterns.rs:9:11
    |
 LL |     while let _ = 5 {
-   |           ^^^^^^^^^
+   |           ^^^^^^^^^ this pattern will always match, so the loop will never exit
    |
-   = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 error: irrefutable `if let` guard pattern
   --> $DIR/deny-irrefutable-let-patterns.rs:14:14
    |
 LL |         _ if let _ = 2 => {}
-   |              ^^^^^^^^^
+   |              ^^^^^^^^^ this pattern will always match, so the guard is useless
    |
-   = note: this pattern will always match, so the guard is useless
    = help: consider removing the guard and adding a `let` inside the match arm
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -17,22 +17,22 @@ LL |         Some(_x) => (),
    |         ^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:61:15
+  --> $DIR/patterns_same_crate.rs:61:11
    |
 LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabited_variant() {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:65:15
+  --> $DIR/patterns_same_crate.rs:65:11
    |
 LL |     while let Some(_x) = uninhabited_struct() {
-   |               ^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:68:15
+  --> $DIR/patterns_same_crate.rs:68:11
    |
 LL |     while let Some(_x) = uninhabited_tuple_struct() {
-   |               ^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/rfc-2294-if-let-guard/warns.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/warns.stderr
@@ -2,15 +2,15 @@ error: irrefutable `if let` guard pattern
   --> $DIR/warns.rs:7:20
    |
 LL |         Some(x) if let () = x => {}
-   |                    ^^^^^^^^^^
+   |                    ^^^^^^^^^^ this pattern will always match, so the guard is useless
    |
 note: the lint level is defined here
   --> $DIR/warns.rs:4:8
    |
 LL | #[deny(irrefutable_let_patterns)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this pattern will always match, so the guard is useless
    = help: consider removing the guard and adding a `let` inside the match arm
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 error: unreachable pattern
   --> $DIR/warns.rs:16:25

--- a/src/test/ui/rfc-2294-if-let-guard/warns.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/warns.stderr
@@ -1,8 +1,8 @@
 error: irrefutable `if let` guard pattern
-  --> $DIR/warns.rs:7:24
+  --> $DIR/warns.rs:7:20
    |
 LL |         Some(x) if let () = x => {}
-   |                        ^^
+   |                    ^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/warns.rs:4:8

--- a/src/test/ui/uninhabited/uninhabited-patterns.stderr
+++ b/src/test/ui/uninhabited/uninhabited-patterns.stderr
@@ -29,10 +29,10 @@ LL |         Err(Ok(_y)) => (),
    |         ^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:44:15
+  --> $DIR/uninhabited-patterns.rs:44:11
    |
 LL |     while let Some(_y) = foo() {
-   |               ^^^^^^^^
+   |           ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -2,7 +2,7 @@ warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:7:19
    |
 LL |               while let $p = $e $b
-   |                     ^^^
+   |                     ^^^ this pattern will always match, so the loop will never exit
 ...
 LL | /     foo!(_a, 1, {
 LL | |         println!("irrefutable pattern");
@@ -10,33 +10,33 @@ LL | |     });
    | |_______- in this macro invocation
    |
    = note: `#[warn(irrefutable_let_patterns)]` on by default
-   = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:7:19
    |
 LL |               while let $p = $e $b
-   |                     ^^^
+   |                     ^^^ this pattern will always match, so the loop will never exit
 ...
 LL | /     bar!(_a, 1, {
 LL | |         println!("irrefutable pattern");
 LL | |     });
    | |_______- in this macro invocation
    |
-   = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:27:11
    |
 LL |     while let _a = 1 {
-   |           ^^^^^^^^^^
+   |           ^^^^^^^^^^ this pattern will always match, so the loop will never exit
    |
-   = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it
+   = help: for more information, visit <https://doc.rust-lang.org/book/ch18-02-refutability.html>
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -1,8 +1,8 @@
 warning: irrefutable `while let` pattern
-  --> $DIR/while-let.rs:7:13
+  --> $DIR/while-let.rs:7:19
    |
 LL |               while let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^
 ...
 LL | /     foo!(_a, 1, {
 LL | |         println!("irrefutable pattern");
@@ -15,10 +15,10 @@ LL | |     });
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `while let` pattern
-  --> $DIR/while-let.rs:7:13
+  --> $DIR/while-let.rs:7:19
    |
 LL |               while let $p = $e $b
-   |               ^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^
 ...
 LL | /     bar!(_a, 1, {
 LL | |         println!("irrefutable pattern");
@@ -30,13 +30,10 @@ LL | |     });
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `while let` pattern
-  --> $DIR/while-let.rs:27:5
+  --> $DIR/while-let.rs:27:11
    |
-LL | /     while let _a = 1 {
-LL | |         println!("irrefutable pattern");
-LL | |         break;
-LL | |     }
-   | |_____^
+LL |     while let _a = 1 {
+   |           ^^^^^^^^^^
    |
    = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it

--- a/src/tools/clippy/clippy_lints/src/collapsible_match.rs
+++ b/src/tools/clippy/clippy_lints/src/collapsible_match.rs
@@ -87,7 +87,7 @@ fn check_arm<'tcx>(arm: &Arm<'tcx>, wild_outer_arm: &Arm<'tcx>, cx: &LateContext
         let mut used_visitor = LocalUsedVisitor::new(cx, binding_id);
         if match arm.guard {
             None => true,
-            Some(Guard::If(expr) | Guard::IfLet(_, expr)) => !used_visitor.check_expr(expr),
+            Some(Guard::If(expr) | Guard::IfLet(_, expr, _)) => !used_visitor.check_expr(expr),
         };
         // ...or anywhere in the inner match
         if !arms_inner.iter().any(|arm| used_visitor.check_arm(arm));

--- a/src/tools/clippy/clippy_lints/src/if_let_mutex.rs
+++ b/src/tools/clippy/clippy_lints/src/if_let_mutex.rs
@@ -57,6 +57,7 @@ impl<'tcx> LateLintPass<'tcx> for IfLetMutex {
             ref arms,
             MatchSource::IfLetDesugar {
                 contains_else_clause: true,
+                ..
             },
         ) = ex.kind
         {

--- a/src/tools/clippy/clippy_lints/src/implicit_return.rs
+++ b/src/tools/clippy/clippy_lints/src/implicit_return.rs
@@ -92,6 +92,7 @@ fn expr_match(cx: &LateContext<'_>, expr: &Expr<'_>) {
             let check_all_arms = match source {
                 MatchSource::IfLetDesugar {
                     contains_else_clause: has_else,
+                    ..
                 } => has_else,
                 _ => true,
             };

--- a/src/tools/clippy/clippy_lints/src/loops.rs
+++ b/src/tools/clippy/clippy_lints/src/loops.rs
@@ -629,7 +629,7 @@ impl<'tcx> LateLintPass<'tcx> for Loops {
                 }
             }
         }
-        if let ExprKind::Match(ref match_expr, ref arms, MatchSource::WhileLetDesugar) = expr.kind {
+        if let ExprKind::Match(ref match_expr, ref arms, MatchSource::WhileLetDesugar { .. }) = expr.kind {
             let pat = &arms[0].pat.kind;
             if let (
                 &PatKind::TupleStruct(ref qpath, ref pat_args, _),

--- a/src/tools/clippy/clippy_lints/src/loops.rs
+++ b/src/tools/clippy/clippy_lints/src/loops.rs
@@ -1994,7 +1994,9 @@ fn check_manual_flatten<'tcx>(
         if_chain! {
             if let Some(inner_expr) = inner_expr;
             if let ExprKind::Match(
-                ref match_expr, ref match_arms, MatchSource::IfLetDesugar{ contains_else_clause: false }
+                ref match_expr,
+                ref match_arms,
+                MatchSource::IfLetDesugar { contains_else_clause: false, .. },
             ) = inner_expr.kind;
             // Ensure match_expr in `if let` statement is the same as the pat from the for-loop
             if let PatKind::Binding(_, pat_hir_id, _, _) = pat.kind;

--- a/src/tools/clippy/clippy_lints/src/matches.rs
+++ b/src/tools/clippy/clippy_lints/src/matches.rs
@@ -1627,7 +1627,7 @@ mod redundant_pattern_match {
             match match_source {
                 MatchSource::Normal => find_sugg_for_match(cx, expr, op, arms),
                 MatchSource::IfLetDesugar { .. } => find_sugg_for_if_let(cx, expr, op, arms, "if"),
-                MatchSource::WhileLetDesugar => find_sugg_for_if_let(cx, expr, op, arms, "while"),
+                MatchSource::WhileLetDesugar { .. } => find_sugg_for_if_let(cx, expr, op, arms, "while"),
                 _ => {},
             }
         }

--- a/src/tools/clippy/clippy_lints/src/option_if_let_else.rs
+++ b/src/tools/clippy/clippy_lints/src/option_if_let_else.rs
@@ -118,6 +118,7 @@ fn should_wrap_in_braces(cx: &LateContext<'_>, expr: &Expr<'_>) -> bool {
                     arms,
                     MatchSource::IfLetDesugar {
                         contains_else_clause: true,
+                        ..
                     },
                 ),
             ..
@@ -159,7 +160,7 @@ fn detect_option_if_let_else<'tcx>(
 ) -> Option<OptionIfLetElseOccurence> {
     if_chain! {
         if !utils::in_macro(expr.span); // Don't lint macros, because it behaves weirdly
-        if let ExprKind::Match(cond_expr, arms, MatchSource::IfLetDesugar{contains_else_clause: true}) = &expr.kind;
+        if let ExprKind::Match(cond_expr, arms, MatchSource::IfLetDesugar{ contains_else_clause: true, .. }) = &expr.kind;
         if arms.len() == 2;
         if !is_result_ok(cx, cond_expr); // Don't lint on Result::ok because a different lint does it already
         if let PatKind::TupleStruct(struct_qpath, &[inner_pat], _) = &arms[0].pat.kind;

--- a/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
+++ b/src/tools/clippy/clippy_lints/src/pattern_type_mismatch.rs
@@ -105,7 +105,7 @@ impl<'tcx> LateLintPass<'tcx> for PatternTypeMismatch {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) {
         if let ExprKind::Match(ref expr, arms, source) = expr.kind {
             match source {
-                MatchSource::Normal | MatchSource::IfLetDesugar { .. } | MatchSource::WhileLetDesugar => {
+                MatchSource::Normal | MatchSource::IfLetDesugar { .. } | MatchSource::WhileLetDesugar { .. }=> {
                     if let Some(expr_ty) = cx.typeck_results().node_type_opt(expr.hir_id) {
                         'pattern_checks: for arm in arms {
                             let pat = &arm.pat;

--- a/src/tools/clippy/clippy_lints/src/question_mark.rs
+++ b/src/tools/clippy/clippy_lints/src/question_mark.rs
@@ -97,7 +97,7 @@ impl QuestionMark {
     fn check_if_let_some_and_early_return_none(cx: &LateContext<'_>, expr: &Expr<'_>) {
         if_chain! {
             if let ExprKind::Match(subject, arms, source) = &expr.kind;
-            if *source == MatchSource::IfLetDesugar { contains_else_clause: true };
+            if let MatchSource::IfLetDesugar { contains_else_clause: true, .. } = source;
             if Self::is_option(cx, subject);
 
             if let PatKind::TupleStruct(path1, fields, None) = &arms[0].pat.kind;

--- a/src/tools/clippy/clippy_lints/src/returns.rs
+++ b/src/tools/clippy/clippy_lints/src/returns.rs
@@ -213,6 +213,7 @@ fn check_final_expr<'tcx>(
             },
             MatchSource::IfLetDesugar {
                 contains_else_clause: true,
+                ..
             } => {
                 if let ExprKind::Block(ref ifblock, _) = arms[0].body.kind {
                     check_block_return(cx, ifblock);

--- a/src/tools/clippy/clippy_lints/src/shadow.rs
+++ b/src/tools/clippy/clippy_lints/src/shadow.rs
@@ -349,7 +349,7 @@ fn check_expr<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, bindings: &mut
                 if let Some(ref guard) = arm.guard {
                     match guard {
                         Guard::If(if_expr) => check_expr(cx, if_expr, bindings),
-                        Guard::IfLet(guard_pat, guard_expr) => {
+                        Guard::IfLet(guard_pat, guard_expr, _) => {
                             check_pat(cx, guard_pat, Some(*guard_expr), guard_pat.span, bindings);
                             check_expr(cx, guard_expr, bindings);
                         },

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -729,9 +729,9 @@ fn desugaring_name(des: hir::MatchSource) -> String {
         hir::MatchSource::ForLoopDesugar => "MatchSource::ForLoopDesugar".to_string(),
         hir::MatchSource::TryDesugar => "MatchSource::TryDesugar".to_string(),
         hir::MatchSource::WhileDesugar => "MatchSource::WhileDesugar".to_string(),
-        hir::MatchSource::WhileLetDesugar => "MatchSource::WhileLetDesugar".to_string(),
+        hir::MatchSource::WhileLetDesugar { .. } => "MatchSource::WhileLetDesugar".to_string(),
         hir::MatchSource::Normal => "MatchSource::Normal".to_string(),
-        hir::MatchSource::IfLetDesugar { contains_else_clause } => format!(
+        hir::MatchSource::IfLetDesugar { contains_else_clause, .. } => format!(
             "MatchSource::IfLetDesugar {{ contains_else_clause: {} }}",
             contains_else_clause
         ),

--- a/src/tools/clippy/clippy_lints/src/utils/author.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/author.rs
@@ -365,11 +365,11 @@ impl<'tcx> Visitor<'tcx> for PrintVisitor {
                                 self.current = if_expr_pat;
                                 self.visit_expr(if_expr);
                             },
-                            hir::Guard::IfLet(ref if_let_pat, ref if_let_expr) => {
+                            hir::Guard::IfLet(ref if_let_pat, ref if_let_expr, _) => {
                                 let if_let_pat_pat = self.next("pat");
                                 let if_let_expr_pat = self.next("expr");
                                 println!(
-                                    "    if let Guard::IfLet(ref {}, ref {}) = {};",
+                                    "    if let Guard::IfLet(ref {}, ref {}, _) = {};",
                                     if_let_pat_pat, if_let_expr_pat, guard_pat
                                 );
                                 self.current = if_let_expr_pat;
@@ -735,7 +735,7 @@ fn desugaring_name(des: hir::MatchSource) -> String {
             "MatchSource::IfLetDesugar {{ contains_else_clause: {} }}",
             contains_else_clause
         ),
-        hir::MatchSource::IfLetGuardDesugar => "MatchSource::IfLetGuardDesugar".to_string(),
+        hir::MatchSource::IfLetGuardDesugar { .. }=> "MatchSource::IfLetGuardDesugar".to_string(),
         hir::MatchSource::AwaitDesugar => "MatchSource::AwaitDesugar".to_string(),
     }
 }

--- a/src/tools/clippy/clippy_lints/src/utils/inspector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/inspector.rs
@@ -568,7 +568,7 @@ fn print_guard(cx: &LateContext<'_>, guard: &hir::Guard<'_>, indent: usize) {
             println!("{}If", ind);
             print_expr(cx, expr, indent + 1);
         },
-        hir::Guard::IfLet(pat, expr) => {
+        hir::Guard::IfLet(pat, expr, _) => {
             println!("{}IfLet", ind);
             print_pat(cx, pat, indent + 1);
             print_expr(cx, expr, indent + 1);

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -223,7 +223,7 @@ impl HirEqInterExpr<'_, '_, '_> {
     fn eq_guard(&mut self, left: &Guard<'_>, right: &Guard<'_>) -> bool {
         match (left, right) {
             (Guard::If(l), Guard::If(r)) => self.eq_expr(l, r),
-            (Guard::IfLet(lp, le), Guard::IfLet(rp, re)) => self.eq_pat(lp, rp) && self.eq_expr(le, re),
+            (Guard::IfLet(lp, le, _), Guard::IfLet(rp, re, _)) => self.eq_pat(lp, rp) && self.eq_expr(le, re),
             _ => false,
         }
     }
@@ -736,7 +736,7 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
 
     pub fn hash_guard(&mut self, g: &Guard<'_>) {
         match g {
-            Guard::If(ref expr) | Guard::IfLet(_, ref expr) => {
+            Guard::If(ref expr) | Guard::IfLet(_, ref expr, _) => {
                 self.hash_expr(expr);
             },
         }

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -177,7 +177,7 @@ impl HirEqInterExpr<'_, '_, '_> {
                 lls == rls && self.eq_block(lb, rb) && both(ll, rl, |l, r| l.ident.name == r.ident.name)
             },
             (&ExprKind::Match(ref le, ref la, ref ls), &ExprKind::Match(ref re, ref ra, ref rs)) => {
-                ls == rs
+                ls.equivalent(rs)
                     && self.eq_expr(le, re)
                     && over(la, ra, |l, r| {
                         self.eq_pat(&l.pat, &r.pat)


### PR DESCRIPTION
Add `Span` to let desugaring `MatchSource` variants to point only at
the `let` pattern when linting against irrefutable patterns in `if let`
and `while let`.