### PR TITLE
Make `is_sorted[_by_key]` require `Ord` instead of `PartialOrd` and remove `Iterator::is_sorted_by_key`

### DIFF
--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -270,13 +270,16 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                         tcx,
                                         arg,
                                         param,
-                                        !args_iter.clone().is_sorted_by_key(|arg| match arg {
-                                            GenericArg::Lifetime(_) => ParamKindOrd::Lifetime,
-                                            GenericArg::Type(_) => ParamKindOrd::Type,
-                                            GenericArg::Const(_) => ParamKindOrd::Const {
-                                                unordered: tcx.features().const_generics,
-                                            },
-                                        }),
+                                        !args_iter
+                                            .clone()
+                                            .map(|arg| match arg {
+                                                GenericArg::Lifetime(_) => ParamKindOrd::Lifetime,
+                                                GenericArg::Type(_) => ParamKindOrd::Type,
+                                                GenericArg::Const(_) => ParamKindOrd::Const {
+                                                    unordered: tcx.features().const_generics,
+                                                },
+                                            })
+                                            .is_sorted(),
                                         Some(&format!(
                                             "reorder the arguments: {}: `<{}>`",
                                             param_types_present

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3280,7 +3280,7 @@ pub trait Iterator {
     ///
     /// assert!([1, 2, 2, 9].iter().is_sorted());
     /// assert!(![1, 3, 2, 4].iter().is_sorted());
-    /// assert!([0].iter().is_sorted());
+    /// assert!(std::iter::once("ferris").is_sorted());
     /// assert!(std::iter::empty::<i32>().is_sorted());
     /// ```
     #[inline]
@@ -3304,9 +3304,9 @@ pub trait Iterator {
     /// ```
     /// #![feature(is_sorted)]
     ///
-    /// assert!([1, 2, 2, 9].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
-    /// assert!(![1, 3, 2, 4].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
-    /// assert!([0].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
+    /// assert!([8, 5, 4, 1].iter().is_sorted_by(|a, b| a.partial_cmp(b).map(|o| o.reverse())));
+    /// assert!(![1, 3, 2, 4].iter().is_sorted_by(|a, b| a.partial_cmp(b).map(|o| o.reverse())));
+    /// assert!(std::iter::once("ferris").is_sorted_by(|a, b| a.partial_cmp(b)));
     /// assert!(std::iter::empty::<i32>().is_sorted_by(|a, b| a.partial_cmp(b)));
     /// assert!(![0.0, 1.0, f32::NAN].iter().is_sorted_by(|a, b| a.partial_cmp(b)));
     /// ```

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3337,34 +3337,6 @@ pub trait Iterator {
         true
     }
 
-    /// Checks if the elements of this iterator are sorted using the given key extraction
-    /// function.
-    ///
-    /// Instead of comparing the iterator's elements directly, this function compares the keys of
-    /// the elements, as determined by `f`. Apart from that, it's equivalent to [`is_sorted`]; see
-    /// its documentation for more information.
-    ///
-    /// [`is_sorted`]: Iterator::is_sorted
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(is_sorted)]
-    ///
-    /// assert!(["c", "bb", "aaa"].iter().is_sorted_by_key(|s| s.len()));
-    /// assert!(![-2i32, -1, 0, 3].iter().is_sorted_by_key(|n| n.abs()));
-    /// ```
-    #[inline]
-    #[unstable(feature = "is_sorted", reason = "new API", issue = "53485")]
-    fn is_sorted_by_key<F, K>(self, f: F) -> bool
-    where
-        Self: Sized,
-        F: FnMut(Self::Item) -> K,
-        K: PartialOrd,
-    {
-        self.map(f).is_sorted()
-    }
-
     /// See [TrustedRandomAccess]
     // The unusual name is to avoid name collisions in method resolution
     // see #76479.

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3272,9 +3272,6 @@ pub trait Iterator {
     /// That is, for each element `a` and its following element `b`, `a <= b` must hold. If the
     /// iterator yields exactly zero or one element, `true` is returned.
     ///
-    /// Note that if `Self::Item` is only `PartialOrd`, but not `Ord`, the above definition
-    /// implies that this function returns `false` if any two consecutive items are not
-    /// comparable.
     ///
     /// # Examples
     ///
@@ -3285,16 +3282,15 @@ pub trait Iterator {
     /// assert!(![1, 3, 2, 4].iter().is_sorted());
     /// assert!([0].iter().is_sorted());
     /// assert!(std::iter::empty::<i32>().is_sorted());
-    /// assert!(![0.0, 1.0, f32::NAN].iter().is_sorted());
     /// ```
     #[inline]
     #[unstable(feature = "is_sorted", reason = "new API", issue = "53485")]
     fn is_sorted(self) -> bool
     where
         Self: Sized,
-        Self::Item: PartialOrd,
+        Self::Item: Ord,
     {
-        self.is_sorted_by(PartialOrd::partial_cmp)
+        self.is_sorted_by(|a, b| Some(a.cmp(b)))
     }
 
     /// Checks if the elements of this iterator are sorted using the given comparator function.

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3322,9 +3322,6 @@ impl<T> [T] {
     /// That is, for each element `a` and its following element `b`, `a <= b` must hold. If the
     /// slice yields exactly zero or one element, `true` is returned.
     ///
-    /// Note that if `Self::Item` is only `PartialOrd`, but not `Ord`, the above definition
-    /// implies that this function returns `false` if any two consecutive items are not
-    /// comparable.
     ///
     /// # Examples
     ///
@@ -3336,15 +3333,14 @@ impl<T> [T] {
     /// assert!(![1, 3, 2, 4].is_sorted());
     /// assert!([0].is_sorted());
     /// assert!(empty.is_sorted());
-    /// assert!(![0.0, 1.0, f32::NAN].is_sorted());
     /// ```
     #[inline]
     #[unstable(feature = "is_sorted", reason = "new API", issue = "53485")]
     pub fn is_sorted(&self) -> bool
     where
-        T: PartialOrd,
+        T: Ord,
     {
-        self.is_sorted_by(|a, b| a.partial_cmp(b))
+        self.is_sorted_by(|a, b| Some(a.cmp(b)))
     }
 
     /// Checks if the elements of this slice are sorted using the given comparator function.
@@ -3383,7 +3379,7 @@ impl<T> [T] {
     pub fn is_sorted_by_key<F, K>(&self, f: F) -> bool
     where
         F: FnMut(&T) -> K,
-        K: PartialOrd,
+        K: Ord,
     {
         self.iter().map(f).is_sorted()
     }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3385,7 +3385,7 @@ impl<T> [T] {
         F: FnMut(&T) -> K,
         K: PartialOrd,
     {
-        self.iter().is_sorted_by_key(f)
+        self.iter().map(f).is_sorted()
     }
 
     /// Returns the index of the partition point according to the given predicate

--- a/library/core/tests/iter/traits/iterator.rs
+++ b/library/core/tests/iter/traits/iterator.rs
@@ -375,9 +375,7 @@ fn test_is_sorted() {
     assert!(std::iter::empty::<i32>().is_sorted());
     assert!(![0.0, 1.0, f32::NAN].iter().is_sorted());
     assert!([-2, -1, 0, 3].iter().is_sorted());
-    assert!(![-2i32, -1, 0, 3].iter().is_sorted_by_key(|n| n.abs()));
     assert!(!["c", "bb", "aaa"].iter().is_sorted());
-    assert!(["c", "bb", "aaa"].iter().is_sorted_by_key(|s| s.len()));
 }
 
 #[test]

--- a/library/core/tests/iter/traits/iterator.rs
+++ b/library/core/tests/iter/traits/iterator.rs
@@ -373,7 +373,6 @@ fn test_is_sorted() {
     assert!(![1, 3, 2].iter().is_sorted());
     assert!([0].iter().is_sorted());
     assert!(std::iter::empty::<i32>().is_sorted());
-    assert!(![0.0, 1.0, f32::NAN].iter().is_sorted());
     assert!([-2, -1, 0, 3].iter().is_sorted());
     assert!(!["c", "bb", "aaa"].iter().is_sorted());
 }

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2005,7 +2005,6 @@ fn test_is_sorted() {
     assert!(![1, 3, 2].is_sorted());
     assert!([0].is_sorted());
     assert!(empty.is_sorted());
-    assert!(![0.0, 1.0, f32::NAN].is_sorted());
     assert!([-2, -1, 0, 3].is_sorted());
     assert!(![-2i32, -1, 0, 3].is_sorted_by_key(|n| n.abs()));
     assert!(!["c", "bb", "aaa"].is_sorted());

--- a/src/test/ui/feature-gates/feature-gate-is_sorted.rs
+++ b/src/test/ui/feature-gates/feature-gate-is_sorted.rs
@@ -2,8 +2,6 @@ fn main() {
     // Assert `Iterator` methods are unstable
     assert!([1, 2, 2, 9].iter().is_sorted());
     //~^ ERROR: use of unstable library feature 'is_sorted': new API
-    assert!(![-2i32, -1, 0, 3].iter().is_sorted_by_key(|n| n.abs()));
-    //~^ ERROR: use of unstable library feature 'is_sorted': new API
 
     // Assert `[T]` methods are unstable
     assert!([1, 2, 2, 9].is_sorted());

--- a/src/test/ui/feature-gates/feature-gate-is_sorted.stderr
+++ b/src/test/ui/feature-gates/feature-gate-is_sorted.stderr
@@ -8,16 +8,7 @@ LL |     assert!([1, 2, 2, 9].iter().is_sorted());
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
-  --> $DIR/feature-gate-is_sorted.rs:5:39
-   |
-LL |     assert!(![-2i32, -1, 0, 3].iter().is_sorted_by_key(|n| n.abs()));
-   |                                       ^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
-   = help: add `#![feature(is_sorted)]` to the crate attributes to enable
-
-error[E0658]: use of unstable library feature 'is_sorted': new API
-  --> $DIR/feature-gate-is_sorted.rs:9:26
+  --> $DIR/feature-gate-is_sorted.rs:7:26
    |
 LL |     assert!([1, 2, 2, 9].is_sorted());
    |                          ^^^^^^^^^
@@ -26,7 +17,7 @@ LL |     assert!([1, 2, 2, 9].is_sorted());
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
-  --> $DIR/feature-gate-is_sorted.rs:11:32
+  --> $DIR/feature-gate-is_sorted.rs:9:32
    |
 LL |     assert!(![-2i32, -1, 0, 3].is_sorted_by_key(|n| n.abs()));
    |                                ^^^^^^^^^^^^^^^^
@@ -34,6 +25,6 @@ LL |     assert!(![-2i32, -1, 0, 3].is_sorted_by_key(|n| n.abs()));
    = note: see issue #53485 <https://github.com/rust-lang/rust/issues/53485> for more information
    = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
See #53485 and the RFC thread for discussion about this. One of the last comments by @KodrAus:

> With #72568 I think an `Ord` bound is quite compelling.

And I agree. We should not longer block `is_sorted` in this discussion. It's better to have a stable `is_sorted` that doesn't work with `PartialOrd + !Ord` types than to have an forever unstable function. A few more arguments in favor of `Ord`:

- No more edges cases with non-comparable values that need to be explained in the docs.
- The `is_sorted_by` closure can now just return `Ordering` instead of `Option<Ordering>`.
- `Ord` is more in line with `sort*` methods.

This PR does not stabilize anything yet, but I hope that with this PR we can stabilize these methods soon.