### PR TITLE
Make weak item traversal deterministic

### DIFF
--- a/compiler/rustc_hir/src/weak_lang_items.rs
+++ b/compiler/rustc_hir/src/weak_lang_items.rs
@@ -4,7 +4,7 @@ use crate::def_id::DefId;
 use crate::{lang_items, LangItem, LanguageItems};
 
 use rustc_ast as ast;
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::stable_map::StableMap;
 use rustc_span::symbol::{sym, Symbol};
 
 use std::lazy::SyncLazy;
@@ -12,8 +12,8 @@ use std::lazy::SyncLazy;
 macro_rules! weak_lang_items {
     ($($name:ident, $item:ident, $sym:ident;)*) => (
 
-pub static WEAK_ITEMS_REFS: SyncLazy<FxHashMap<Symbol, LangItem>> = SyncLazy::new(|| {
-    let mut map = FxHashMap::default();
+pub static WEAK_ITEMS_REFS: SyncLazy<StableMap<Symbol, LangItem>> = SyncLazy::new(|| {
+    let mut map = StableMap::default();
     $(map.insert(sym::$name, LangItem::$item);)*
     map
 });

--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -59,7 +59,7 @@ fn verify<'tcx>(tcx: TyCtxt<'tcx>, items: &lang_items::LanguageItems) {
         }
     }
 
-    for (name, &item) in WEAK_ITEMS_REFS.iter() {
+    for (name, item) in WEAK_ITEMS_REFS.clone().into_sorted_vector().into_iter() {
         if missing.contains(&item) && required(tcx, item) && items.require(item).is_err() {
             if item == LangItem::PanicImpl {
                 tcx.sess.err("`#[panic_handler]` function required, but not found");


### PR DESCRIPTION
Fix #81296.

(No test added. The relevant test *is* ui/panic-handler/weak-lang-item.rs, and this change should make it less flaky.)

