### PR TITLE
Box `ast::ItemKind`

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2581,7 +2581,7 @@ pub struct Item<K = ItemKind> {
     /// It might be a dummy name in case of anonymous items.
     pub ident: Ident,
 
-    pub kind: K,
+    pub kind: Box<K>,
 
     /// Original tokens this item was parsed from. This isn't necessarily
     /// available for all items, although over time more and more items should
@@ -2593,6 +2593,10 @@ pub struct Item<K = ItemKind> {
     pub tokens: Option<LazyTokenStream>,
 }
 
+rustc_data_structures::static_assert_size!(Item<ItemKind>, 96);
+rustc_data_structures::static_assert_size!(Item<AssocItemKind>, 96);
+rustc_data_structures::static_assert_size!(Item<ForeignItemKind>, 96);
+
 impl Item {
     /// Return the span that encompasses the attributes.
     pub fn span_with_attributes(&self) -> Span {
@@ -2603,7 +2607,7 @@ impl Item {
 impl<K: Into<ItemKind>> Item<K> {
     pub fn into_item(self) -> Item {
         let Item { attrs, id, span, vis, ident, kind, tokens } = self;
-        Item { attrs, id, span, vis, ident, kind: kind.into(), tokens }
+        Item { attrs, id, span, vis, ident, kind: box (*kind).into(), tokens }
     }
 }
 

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -971,7 +971,7 @@ pub fn noop_flat_map_assoc_item<T: MutVisitor>(
     visitor.visit_ident(ident);
     visitor.visit_vis(vis);
     visit_attrs(attrs, visitor);
-    match kind {
+    match &mut **kind {
         AssocItemKind::Const(_, ty, expr) => {
             visitor.visit_ty(ty);
             visit_opt(expr, |expr| visitor.visit_expr(expr));
@@ -1014,7 +1014,7 @@ pub fn noop_visit_crate<T: MutVisitor>(krate: &mut Crate, vis: &mut T) {
             id: DUMMY_NODE_ID,
             vis: item_vis,
             span,
-            kind: ItemKind::Mod(module),
+            kind: box ItemKind::Mod(module),
             tokens: None,
         });
         let items = vis.flat_map_item(item);
@@ -1025,7 +1025,7 @@ pub fn noop_visit_crate<T: MutVisitor>(krate: &mut Crate, vis: &mut T) {
             Crate { module, attrs: vec![], span, proc_macros }
         } else if len == 1 {
             let Item { attrs, span, kind, .. } = items.into_iter().next().unwrap().into_inner();
-            match kind {
+            match *kind {
                 ItemKind::Mod(module) => Crate { module, attrs, span, proc_macros },
                 _ => panic!("visitor converted a module to not a module"),
             }
@@ -1061,7 +1061,7 @@ pub fn noop_flat_map_foreign_item<T: MutVisitor>(
     visitor.visit_ident(ident);
     visitor.visit_vis(vis);
     visit_attrs(attrs, visitor);
-    match kind {
+    match &mut **kind {
         ForeignItemKind::Static(ty, _, expr) => {
             visitor.visit_ty(ty);
             visit_opt(expr, |expr| visitor.visit_expr(expr));

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -805,7 +805,7 @@ impl Nonterminal {
 
         let name = item.ident.name;
         if name == sym::ProceduralMasqueradeDummyType || name == sym::ProcMacroHack {
-            if let ast::ItemKind::Enum(enum_def, _) = &item.kind {
+            if let ast::ItemKind::Enum(enum_def, _) = &*item.kind {
                 if let [variant] = &*enum_def.variants {
                     return variant.ident.name == sym::Input;
                 }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -281,7 +281,7 @@ pub fn walk_trait_ref<'a, V: Visitor<'a>>(visitor: &mut V, trait_ref: &'a TraitR
 pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
     visitor.visit_vis(&item.vis);
     visitor.visit_ident(item.ident);
-    match item.kind {
+    match *item.kind {
         ItemKind::ExternCrate(orig_name) => {
             if let Some(orig_name) = orig_name {
                 visitor.visit_name(item.span, orig_name);
@@ -538,7 +538,7 @@ pub fn walk_foreign_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a ForeignI
     visitor.visit_vis(vis);
     visitor.visit_ident(ident);
     walk_list!(visitor, visit_attribute, attrs);
-    match kind {
+    match &**kind {
         ForeignItemKind::Static(ty, _, expr) => {
             visitor.visit_ty(ty);
             walk_list!(visitor, visit_expr, expr);
@@ -648,7 +648,7 @@ pub fn walk_assoc_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a AssocItem,
     visitor.visit_vis(vis);
     visitor.visit_ident(ident);
     walk_list!(visitor, visit_attribute, attrs);
-    match kind {
+    match &**kind {
         AssocItemKind::Const(_, ty, expr) => {
             visitor.visit_ty(ty);
             walk_list!(visitor, visit_expr, expr);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -497,7 +497,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             fn visit_item(&mut self, item: &'tcx Item) {
                 let hir_id = self.lctx.allocate_hir_id_counter(item.id);
 
-                match item.kind {
+                match *item.kind {
                     ItemKind::Struct(_, ref generics)
                     | ItemKind::Union(_, ref generics)
                     | ItemKind::Enum(_, ref generics)

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -919,7 +919,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             self.check_nomangle_item_asciionly(item.ident, item.span);
         }
 
-        match item.kind {
+        match *item.kind {
             ItemKind::Impl {
                 unsafety,
                 polarity,
@@ -1090,7 +1090,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
     }
 
     fn visit_foreign_item(&mut self, fi: &'a ForeignItem) {
-        match &fi.kind {
+        match &*fi.kind {
             ForeignItemKind::Fn(def, sig, _, body) => {
                 self.check_defaultness(fi.span, *def);
                 self.check_foreign_fn_bodyless(fi.ident, body.as_deref());
@@ -1332,7 +1332,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
         }
 
         if ctxt == AssocCtxt::Impl {
-            match &item.kind {
+            match &*item.kind {
                 AssocItemKind::Const(_, _, body) => {
                     self.check_impl_item_provided(item.span, body, "constant", " = <expr>;");
                 }
@@ -1349,13 +1349,13 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
 
         if ctxt == AssocCtxt::Trait || self.in_trait_impl {
             self.invalid_visibility(&item.vis, None);
-            if let AssocItemKind::Fn(_, sig, _, _) = &item.kind {
+            if let AssocItemKind::Fn(_, sig, _, _) = &*item.kind {
                 self.check_trait_fn_not_const(sig.header.constness);
                 self.check_trait_fn_not_async(item.span, sig.header.asyncness);
             }
         }
 
-        if let AssocItemKind::Const(..) = item.kind {
+        if let AssocItemKind::Const(..) = *item.kind {
             self.check_item_named(item.ident, "const");
         }
 

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -292,7 +292,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_item(&mut self, i: &'a ast::Item) {
-        match i.kind {
+        match *i.kind {
             ast::ItemKind::ForeignMod(ref foreign_module) => {
                 if let Some(abi) = foreign_module.abi {
                     self.check_abi(abi);
@@ -408,7 +408,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_foreign_item(&mut self, i: &'a ast::ForeignItem) {
-        match i.kind {
+        match *i.kind {
             ast::ForeignItemKind::Fn(..) | ast::ForeignItemKind::Static(..) => {
                 let link_name = self.sess.first_attr_value_str_by_name(&i.attrs, sym::link_name);
                 let links_to_llvm =
@@ -554,7 +554,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_assoc_item(&mut self, i: &'a ast::AssocItem, ctxt: AssocCtxt) {
-        let is_fn = match i.kind {
+        let is_fn = match *i.kind {
             ast::AssocItemKind::Fn(_, ref sig, _, _) => {
                 if let (ast::Const::Yes(_), AssocCtxt::Trait) = (sig.header.constness, ctxt) {
                     gate_feature_post!(&self, const_fn, i.span, "const fn is unstable");

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1021,7 +1021,7 @@ impl<'a> State<'a> {
         self.hardbreak_if_not_bol();
         self.maybe_print_comment(span.lo());
         self.print_outer_attributes(attrs);
-        match kind {
+        match &**kind {
             ast::ForeignItemKind::Fn(def, sig, gen, body) => {
                 self.print_fn_full(sig, ident, gen, vis, *def, body.as_deref(), attrs);
             }
@@ -1106,7 +1106,7 @@ impl<'a> State<'a> {
         self.maybe_print_comment(item.span.lo());
         self.print_outer_attributes(&item.attrs);
         self.ann.pre(self, AnnNode::Item(item));
-        match item.kind {
+        match *item.kind {
             ast::ItemKind::ExternCrate(orig_name) => {
                 self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let Some(orig_name) = orig_name {
@@ -1452,7 +1452,7 @@ impl<'a> State<'a> {
         self.hardbreak_if_not_bol();
         self.maybe_print_comment(span.lo());
         self.print_outer_attributes(attrs);
-        match kind {
+        match &**kind {
             ast::AssocItemKind::Fn(def, sig, gen, body) => {
                 self.print_fn_full(sig, ident, gen, vis, *def, body.as_deref(), attrs);
             }

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -33,7 +33,7 @@ pub fn expand_deriving_clone(
     let substructure;
     let is_shallow;
     match *item {
-        Annotatable::Item(ref annitem) => match annitem.kind {
+        Annotatable::Item(ref annitem) => match *annitem.kind {
             ItemKind::Struct(_, Generics { ref params, .. })
             | ItemKind::Enum(_, Generics { ref params, .. }) => {
                 let container_id = cx.current_expansion.id.expn_data().parent;

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -401,7 +401,7 @@ impl<'a> TraitDef<'a> {
                     }
                     false
                 });
-                let has_no_type_params = match item.kind {
+                let has_no_type_params = match *item.kind {
                     ast::ItemKind::Struct(_, ref generics)
                     | ast::ItemKind::Enum(_, ref generics)
                     | ast::ItemKind::Union(_, ref generics) => !generics
@@ -414,7 +414,7 @@ impl<'a> TraitDef<'a> {
                 let always_copy = has_no_type_params && cx.resolver.has_derive_copy(container_id);
                 let use_temporaries = is_packed && always_copy;
 
-                let newitem = match item.kind {
+                let newitem = match *item.kind {
                     ast::ItemKind::Struct(ref struct_def, ref generics) => self.expand_struct_def(
                         cx,
                         &struct_def,
@@ -527,7 +527,7 @@ impl<'a> TraitDef<'a> {
                     tokens: None,
                 },
                 attrs: Vec::new(),
-                kind: ast::AssocItemKind::TyAlias(
+                kind: box ast::AssocItemKind::TyAlias(
                     ast::Defaultness::Final,
                     Generics::default(),
                     Vec::new(),
@@ -929,7 +929,7 @@ impl<'a> MethodDef<'a> {
                 tokens: None,
             },
             ident: method_ident,
-            kind: ast::AssocItemKind::Fn(def, sig, fn_generics, Some(body_block)),
+            kind: box ast::AssocItemKind::Fn(def, sig, fn_generics, Some(body_block)),
             tokens: None,
         })
     }
@@ -1732,7 +1732,7 @@ where
 /// (for an enum, no variant has any fields)
 pub fn is_type_without_fields(item: &Annotatable) -> bool {
     if let Annotatable::Item(ref item) = *item {
-        match item.kind {
+        match *item.kind {
             ast::ItemKind::Enum(ref enum_def, _) => {
                 enum_def.variants.iter().all(|v| v.data.fields().is_empty())
             }

--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -120,7 +120,7 @@ fn inject_impl_of_structural_trait(
         _ => unreachable!(),
     };
 
-    let generics = match item.kind {
+    let generics = match *item.kind {
         ItemKind::Struct(_, ref generics) | ItemKind::Enum(_, ref generics) => generics,
         // Do not inject `impl Structural for Union`. (`PartialEq` does not
         // support unions, so we will see error downstream.)

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -34,7 +34,7 @@ pub fn expand(
     }
 
     let item = match item {
-        Annotatable::Item(item) => match item.kind {
+        Annotatable::Item(item) => match *item.kind {
             ItemKind::Static(..) => item,
             _ => return not_static(Annotatable::Item(item)),
         },

--- a/compiler/rustc_builtin_macros/src/global_asm.rs
+++ b/compiler/rustc_builtin_macros/src/global_asm.rs
@@ -28,7 +28,7 @@ pub fn expand_global_asm<'cx>(
             ident: Ident::invalid(),
             attrs: Vec::new(),
             id: ast::DUMMY_NODE_ID,
-            kind: ast::ItemKind::GlobalAsm(P(global_asm)),
+            kind: box ast::ItemKind::GlobalAsm(P(global_asm)),
             vis: ast::Visibility {
                 span: sp.shrink_to_lo(),
                 kind: ast::VisibilityKind::Inherited,

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -2,6 +2,7 @@
 //! injecting code into the crate before it is lowered to HIR.
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![feature(box_syntax)]
 #![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(decl_macro)]

--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -244,7 +244,7 @@ impl<'a> CollectProcMacros<'a> {
 
 impl<'a> Visitor<'a> for CollectProcMacros<'a> {
     fn visit_item(&mut self, item: &'a ast::Item) {
-        if let ast::ItemKind::MacroDef(..) = item.kind {
+        if let ast::ItemKind::MacroDef(..) = *item.kind {
             if self.is_proc_macro_crate && self.sess.contains_name(&item.attrs, sym::macro_export) {
                 let msg =
                     "cannot export macro_rules! macros from a `proc-macro` crate type currently";
@@ -256,7 +256,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
         // we're just not interested in this item.
         //
         // If we find one, try to locate a `#[proc_macro_derive]` attribute on it.
-        let is_fn = matches!(item.kind, ast::ItemKind::Fn(..));
+        let is_fn = matches!(*item.kind, ast::ItemKind::Fn(..));
 
         let mut found_attr: Option<&'a ast::Attribute> = None;
 

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -99,7 +99,7 @@ pub fn expand_test_or_bench(
         }
     };
 
-    if let ast::ItemKind::MacCall(_) = item.kind {
+    if let ast::ItemKind::MacCall(_) = *item.kind {
         cx.sess.parse_sess.span_diagnostic.span_warn(
             item.span,
             "`#[test]` attribute should not be used on macros. Use `#[cfg(test)]` instead.",
@@ -425,7 +425,7 @@ fn test_type(cx: &ExtCtxt<'_>) -> TestType {
 fn has_test_signature(cx: &ExtCtxt<'_>, i: &ast::Item) -> bool {
     let has_should_panic_attr = cx.sess.contains_name(&i.attrs, sym::should_panic);
     let sd = &cx.sess.parse_sess.span_diagnostic;
-    if let ast::ItemKind::Fn(_, ref sig, ref generics, _) = i.kind {
+    if let ast::ItemKind::Fn(_, ref sig, ref generics, _) = *i.kind {
         if let ast::Unsafe::Yes(span) = sig.header.unsafety {
             sd.struct_span_err(i.span, "unsafe functions cannot be used for tests")
                 .span_label(span, "`unsafe` because of this")
@@ -474,7 +474,7 @@ fn has_test_signature(cx: &ExtCtxt<'_>, i: &ast::Item) -> bool {
 }
 
 fn has_bench_signature(cx: &ExtCtxt<'_>, i: &ast::Item) -> bool {
-    let has_sig = if let ast::ItemKind::Fn(_, ref sig, _, _) = i.kind {
+    let has_sig = if let ast::ItemKind::Fn(_, ref sig, _, _) = *i.kind {
         // N.B., inadequate check, but we're running
         // well before resolve, can't get too deep.
         sig.decl.inputs.len() == 1

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -103,7 +103,7 @@ impl<'a> MutVisitor for TestHarnessGenerator<'a> {
 
         // We don't want to recurse into anything other than mods, since
         // mods or tests inside of functions will break things
-        if let ast::ItemKind::Mod(mut module) = item.kind {
+        if let ast::ItemKind::Mod(mut module) = *item.kind {
             let tests = mem::take(&mut self.tests);
             noop_visit_mod(&mut module, self);
             let mut tests = mem::replace(&mut self.tests, tests);
@@ -126,7 +126,7 @@ impl<'a> MutVisitor for TestHarnessGenerator<'a> {
                 }
                 self.cx.test_cases.extend(tests);
             }
-            item.kind = ast::ItemKind::Mod(module);
+            item.kind = box ast::ItemKind::Mod(module);
         }
         smallvec![P(item)]
     }
@@ -135,7 +135,7 @@ impl<'a> MutVisitor for TestHarnessGenerator<'a> {
 // Beware, this is duplicated in librustc_passes/entry.rs (with
 // `rustc_hir::Item`), so make sure to keep them in sync.
 fn entry_point_type(sess: &Session, item: &ast::Item, depth: usize) -> EntryPointType {
-    match item.kind {
+    match *item.kind {
         ast::ItemKind::Fn(..) => {
             if sess.contains_name(&item.attrs, sym::start) {
                 EntryPointType::Start
@@ -323,7 +323,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
         ident: main_id,
         attrs: vec![main_attr],
         id: ast::DUMMY_NODE_ID,
-        kind: main,
+        kind: box main,
         vis: ast::Visibility { span: sp, kind: ast::VisibilityKind::Public, tokens: None },
         span: sp,
         tokens: None,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -239,12 +239,12 @@ impl Annotatable {
         match *self {
             Annotatable::Stmt(ref stmt) => match stmt.kind {
                 ast::StmtKind::Item(ref item) => matches!(
-                    item.kind,
+                    *item.kind,
                     ast::ItemKind::Struct(..) | ast::ItemKind::Enum(..) | ast::ItemKind::Union(..)
                 ),
                 _ => false,
             },
-            Annotatable::Item(ref item) => match item.kind {
+            Annotatable::Item(ref item) => match *item.kind {
                 ast::ItemKind::Struct(..) | ast::ItemKind::Enum(..) | ast::ItemKind::Union(..) => {
                     true
                 }

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -529,7 +529,7 @@ impl<'a> ExtCtxt<'a> {
             ident: name,
             attrs,
             id: ast::DUMMY_NODE_ID,
-            kind,
+            kind: box kind,
             vis: ast::Visibility {
                 span: span.shrink_to_lo(),
                 kind: ast::VisibilityKind::Inherited,

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -376,7 +376,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         let krate_item = AstFragment::Items(smallvec![P(ast::Item {
             attrs: krate.attrs,
             span: krate.span,
-            kind: ast::ItemKind::Mod(krate.module),
+            kind: box ast::ItemKind::Mod(krate.module),
             ident: Ident::invalid(),
             id: ast::DUMMY_NODE_ID,
             vis: ast::Visibility {
@@ -388,7 +388,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         })]);
 
         match self.fully_expand_fragment(krate_item).make_items().pop().map(P::into_inner) {
-            Some(ast::Item { attrs, kind: ast::ItemKind::Mod(module), .. }) => {
+            Some(ast::Item { attrs, kind: box ast::ItemKind::Mod(module), .. }) => {
                 krate.attrs = attrs;
                 krate.module = module;
             }
@@ -859,7 +859,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
 
         impl<'ast, 'a> Visitor<'ast> for GateProcMacroInput<'a> {
             fn visit_item(&mut self, item: &'ast ast::Item) {
-                match &item.kind {
+                match &*item.kind {
                     ast::ItemKind::Mod(module) if !module.inline => {
                         feature_err(
                             self.parse_sess,
@@ -1366,11 +1366,11 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
         let ident = item.ident;
         let span = item.span;
 
-        match item.kind {
+        match *item.kind {
             ast::ItemKind::MacCall(..) => {
                 item.attrs = attrs;
                 self.check_attributes(&item.attrs);
-                item.and_then(|item| match item.kind {
+                item.and_then(|item| match *item.kind {
                     ItemKind::MacCall(mac) => {
                         self.collect_bang(mac, span, AstFragmentKind::Items).make_items()
                     }
@@ -1458,10 +1458,10 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
                 .make_trait_items();
         }
 
-        match item.kind {
+        match *item.kind {
             ast::AssocItemKind::MacCall(..) => {
                 self.check_attributes(&item.attrs);
-                item.and_then(|item| match item.kind {
+                item.and_then(|item| match *item.kind {
                     ast::AssocItemKind::MacCall(mac) => self
                         .collect_bang(mac, item.span, AstFragmentKind::TraitItems)
                         .make_trait_items(),
@@ -1481,10 +1481,10 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
                 .make_impl_items();
         }
 
-        match item.kind {
+        match *item.kind {
             ast::AssocItemKind::MacCall(..) => {
                 self.check_attributes(&item.attrs);
-                item.and_then(|item| match item.kind {
+                item.and_then(|item| match *item.kind {
                     ast::AssocItemKind::MacCall(mac) => self
                         .collect_bang(mac, item.span, AstFragmentKind::ImplItems)
                         .make_impl_items(),
@@ -1528,10 +1528,10 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
                 .make_foreign_items();
         }
 
-        match foreign_item.kind {
+        match *foreign_item.kind {
             ast::ForeignItemKind::MacCall(..) => {
                 self.check_attributes(&foreign_item.attrs);
-                foreign_item.and_then(|item| match item.kind {
+                foreign_item.and_then(|item| match *item.kind {
                     ast::ForeignItemKind::MacCall(mac) => self
                         .collect_bang(mac, item.span, AstFragmentKind::ForeignItems)
                         .make_foreign_items(),

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(bool_to_option)]
+#![feature(box_patterns)]
+#![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
 #![feature(decl_macro)]
 #![feature(or_patterns)]

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -376,7 +376,7 @@ pub fn compile_declarative_macro(
     let tt_spec = Some(NonterminalKind::TT);
 
     // Parse the macro_rules! invocation
-    let (macro_rules, body) = match &def.kind {
+    let (macro_rules, body) = match &*def.kind {
         ast::ItemKind::MacroDef(def) => (def.macro_rules, def.body.inner_tokens()),
         _ => unreachable!(),
     };

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -55,7 +55,7 @@ pub fn placeholder(
             ident,
             vis,
             attrs,
-            kind: ast::ItemKind::MacCall(mac_placeholder()),
+            kind: box ast::ItemKind::MacCall(mac_placeholder()),
             tokens: None,
         })]),
         AstFragmentKind::TraitItems => AstFragment::TraitItems(smallvec![P(ast::AssocItem {
@@ -64,7 +64,7 @@ pub fn placeholder(
             ident,
             vis,
             attrs,
-            kind: ast::AssocItemKind::MacCall(mac_placeholder()),
+            kind: box ast::AssocItemKind::MacCall(mac_placeholder()),
             tokens: None,
         })]),
         AstFragmentKind::ImplItems => AstFragment::ImplItems(smallvec![P(ast::AssocItem {
@@ -73,7 +73,7 @@ pub fn placeholder(
             ident,
             vis,
             attrs,
-            kind: ast::AssocItemKind::MacCall(mac_placeholder()),
+            kind: box ast::AssocItemKind::MacCall(mac_placeholder()),
             tokens: None,
         })]),
         AstFragmentKind::ForeignItems => {
@@ -83,7 +83,7 @@ pub fn placeholder(
                 ident,
                 vis,
                 attrs,
-                kind: ast::ForeignItemKind::MacCall(mac_placeholder()),
+                kind: box ast::ForeignItemKind::MacCall(mac_placeholder()),
                 tokens: None,
             })])
         }
@@ -257,21 +257,21 @@ impl<'a, 'b> MutVisitor for PlaceholderExpander<'a, 'b> {
     }
 
     fn flat_map_item(&mut self, item: P<ast::Item>) -> SmallVec<[P<ast::Item>; 1]> {
-        match item.kind {
+        match *item.kind {
             ast::ItemKind::MacCall(_) => self.remove(item.id).make_items(),
             _ => noop_flat_map_item(item, self),
         }
     }
 
     fn flat_map_trait_item(&mut self, item: P<ast::AssocItem>) -> SmallVec<[P<ast::AssocItem>; 1]> {
-        match item.kind {
+        match *item.kind {
             ast::AssocItemKind::MacCall(_) => self.remove(item.id).make_trait_items(),
             _ => noop_flat_map_assoc_item(item, self),
         }
     }
 
     fn flat_map_impl_item(&mut self, item: P<ast::AssocItem>) -> SmallVec<[P<ast::AssocItem>; 1]> {
-        match item.kind {
+        match *item.kind {
             ast::AssocItemKind::MacCall(_) => self.remove(item.id).make_impl_items(),
             _ => noop_flat_map_assoc_item(item, self),
         }
@@ -281,7 +281,7 @@ impl<'a, 'b> MutVisitor for PlaceholderExpander<'a, 'b> {
         &mut self,
         item: P<ast::ForeignItem>,
     ) -> SmallVec<[P<ast::ForeignItem>; 1]> {
-        match item.kind {
+        match *item.kind {
             ast::ForeignItemKind::MacCall(_) => self.remove(item.id).make_foreign_items(),
             _ => noop_flat_map_foreign_item(item, self),
         }
@@ -376,7 +376,7 @@ impl<'a, 'b> MutVisitor for PlaceholderExpander<'a, 'b> {
         noop_visit_mod(module, self);
         // remove macro definitions
         module.items.retain(
-            |item| !matches!(item.kind, ast::ItemKind::MacCall(_) if !self.cx.ecfg.keep_macs),
+            |item| !matches!(*item.kind, ast::ItemKind::MacCall(_) if !self.cx.ecfg.keep_macs),
         );
     }
 }

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -766,7 +766,7 @@ impl<'a> MutVisitor for ReplaceBodyWithLoop<'a, '_> {
     }
 
     fn flat_map_trait_item(&mut self, i: P<ast::AssocItem>) -> SmallVec<[P<ast::AssocItem>; 1]> {
-        let is_const = match i.kind {
+        let is_const = match *i.kind {
             ast::AssocItemKind::Const(..) => true,
             ast::AssocItemKind::Fn(_, ref sig, _, _) => Self::is_sig_const(sig),
             _ => false,

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -356,7 +356,7 @@ impl EarlyLintPass for UnsafeCode {
     }
 
     fn check_item(&mut self, cx: &EarlyContext<'_>, it: &ast::Item) {
-        match it.kind {
+        match *it.kind {
             ast::ItemKind::Trait(_, ast::Unsafe::Yes(_), ..) => {
                 self.report_unsafe(cx, it.span, |lint| {
                     lint.build("declaration of an `unsafe` trait").emit()
@@ -872,7 +872,7 @@ declare_lint_pass!(
 
 impl EarlyLintPass for AnonymousParameters {
     fn check_trait_item(&mut self, cx: &EarlyContext<'_>, it: &ast::AssocItem) {
-        if let ast::AssocItemKind::Fn(_, ref sig, _, _) = it.kind {
+        if let ast::AssocItemKind::Fn(_, ref sig, _, _) = *it.kind {
             for arg in sig.decl.inputs.iter() {
                 if let ast::PatKind::Ident(_, ident, None) = arg.pat.kind {
                     if ident.name == kw::Empty {

--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -243,7 +243,7 @@ declare_lint_pass!(LintPassImpl => [LINT_PASS_IMPL_WITHOUT_MACRO]);
 
 impl EarlyLintPass for LintPassImpl {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
-        if let ItemKind::Impl { of_trait: Some(lint_pass), .. } = &item.kind {
+        if let ItemKind::Impl { of_trait: Some(lint_pass), .. } = &*item.kind {
             if let Some(last) = lint_pass.path.segments.last() {
                 if last.ident.name == sym::LintPass {
                     let expn_data = lint_pass.path.span.ctxt().outer_expn_data();

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -157,7 +157,7 @@ impl EarlyLintPass for NonCamelCaseTypes {
             return;
         }
 
-        match it.kind {
+        match *it.kind {
             ast::ItemKind::TyAlias(..)
             | ast::ItemKind::Enum(..)
             | ast::ItemKind::Struct(..)
@@ -168,7 +168,7 @@ impl EarlyLintPass for NonCamelCaseTypes {
     }
 
     fn check_trait_item(&mut self, cx: &EarlyContext<'_>, it: &ast::AssocItem) {
-        if let ast::AssocItemKind::TyAlias(..) = it.kind {
+        if let ast::AssocItemKind::TyAlias(..) = *it.kind {
             self.check_case(cx, "associated type", &it.ident);
         }
     }

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -694,7 +694,7 @@ trait UnusedDelimLint {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
         use ast::ItemKind::*;
 
-        if let Const(.., Some(expr)) | Static(.., Some(expr)) = &item.kind {
+        if let Const(.., Some(expr)) | Static(.., Some(expr)) = &*item.kind {
             self.check_unused_delims_expr(
                 cx,
                 expr,
@@ -1139,7 +1139,7 @@ impl UnusedImportBraces {
 
 impl EarlyLintPass for UnusedImportBraces {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
-        if let ast::ItemKind::Use(ref use_tree) = item.kind {
+        if let ast::ItemKind::Use(ref use_tree) = *item.kind {
             self.check_use_tree(cx, use_tree, item);
         }
     }

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -901,7 +901,7 @@ impl<'a> CrateLoader<'a> {
         definitions: &Definitions,
         def_id: LocalDefId,
     ) -> CrateNum {
-        match item.kind {
+        match *item.kind {
             ast::ItemKind::ExternCrate(orig_name) => {
                 debug!(
                     "resolving extern crate stmt. ident: {} orig_name: {:?}",

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![feature(box_syntax)]
 #![feature(core_intrinsics)]
 #![feature(crate_visibility_modifier)]
 #![feature(drain_filter)]

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -433,7 +433,7 @@ impl CStore {
                 id: ast::DUMMY_NODE_ID,
                 span,
                 attrs,
-                kind: ast::ItemKind::MacroDef(data.get_macro(id.index, sess)),
+                kind: box ast::ItemKind::MacroDef(data.get_macro(id.index, sess)),
                 vis: ast::Visibility {
                     span: span.shrink_to_lo(),
                     kind: ast::VisibilityKind::Inherited,

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -1,6 +1,7 @@
 //! The main parser interface.
 
 #![feature(crate_visibility_modifier)]
+#![feature(box_syntax)]
 #![feature(bindings_after_at)]
 #![feature(iter_order_by)]
 #![feature(or_patterns)]

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1073,7 +1073,7 @@ impl<'a> Parser<'a> {
             );
             if !items.is_empty() {
                 let previous_item = &items[items.len() - 1];
-                let previous_item_kind_name = match previous_item.kind {
+                let previous_item_kind_name = match *previous_item.kind {
                     // Say "braced struct" because tuple-structs and
                     // braceless-empty-struct declarations do take a semicolon.
                     ItemKind::Struct(..) => Some("braced struct"),

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -147,6 +147,7 @@ impl<'a> Parser<'a> {
             self.error_on_unconsumed_default(def, &kind);
             let span = lo.to(self.prev_token.span);
             let id = DUMMY_NODE_ID;
+            let kind = box kind;
             let item = Item { ident, attrs, id, kind, vis, span, tokens: None };
             return Ok(Some(item));
         }
@@ -734,7 +735,7 @@ impl<'a> Parser<'a> {
     fn parse_assoc_item(&mut self, req_name: ReqName) -> PResult<'a, Option<Option<P<AssocItem>>>> {
         Ok(self.parse_item_(req_name, ForceCollect::No)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
-                let kind = match AssocItemKind::try_from(kind) {
+                let kind = box match AssocItemKind::try_from(*kind) {
                     Ok(kind) => kind,
                     Err(kind) => match kind {
                         ItemKind::Static(a, _, b) => {
@@ -926,7 +927,7 @@ impl<'a> Parser<'a> {
     pub fn parse_foreign_item(&mut self) -> PResult<'a, Option<Option<P<ForeignItem>>>> {
         Ok(self.parse_item_(|_| true, ForceCollect::No)?.map(
             |Item { attrs, id, span, vis, ident, kind, tokens }| {
-                let kind = match ForeignItemKind::try_from(kind) {
+                let kind = box match ForeignItemKind::try_from(*kind) {
                     Ok(kind) => kind,
                     Err(kind) => match kind {
                         ItemKind::Const(_, a, b) => {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -656,7 +656,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
 
     /// Constructs the reduced graph for one item.
     fn build_reduced_graph_for_item(&mut self, item: &'b Item) {
-        if matches!(item.kind, ItemKind::Mod(..)) && item.ident.name == kw::Empty {
+        if matches!(*item.kind, ItemKind::Mod(..)) && item.ident.name == kw::Empty {
             // Fake crate root item from expand.
             return;
         }
@@ -672,7 +672,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
 
         self.r.visibilities.insert(local_def_id, vis);
 
-        match item.kind {
+        match *item.kind {
             ItemKind::Use(ref use_tree) => {
                 self.build_reduced_graph_for_use_tree(
                     // This particular use tree
@@ -900,7 +900,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
     fn build_reduced_graph_for_foreign_item(&mut self, item: &ForeignItem) {
         let local_def_id = self.r.local_def_id(item.id);
         let def_id = local_def_id.to_def_id();
-        let (def_kind, ns) = match item.kind {
+        let (def_kind, ns) = match *item.kind {
             ForeignItemKind::Fn(..) => (DefKind::Fn, ValueNS),
             ForeignItemKind::Static(..) => (DefKind::Static, ValueNS),
             ForeignItemKind::TyAlias(..) => (DefKind::ForeignTy, TypeNS),
@@ -1047,7 +1047,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                     )
                     .emit();
                 }
-                if let ItemKind::ExternCrate(Some(orig_name)) = item.kind {
+                if let ItemKind::ExternCrate(Some(orig_name)) = *item.kind {
                     if orig_name == kw::SelfLower {
                         self.r
                             .session
@@ -1214,7 +1214,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
         let parent_scope = self.parent_scope;
         let expansion = parent_scope.expansion;
         let def_id = self.r.local_def_id(item.id);
-        let (ext, ident, span, macro_rules) = match &item.kind {
+        let (ext, ident, span, macro_rules) = match &*item.kind {
             ItemKind::MacroDef(def) => {
                 let ext = Lrc::new(self.r.compile_macro(item, self.r.session.edition()));
                 (ext, item.ident, item.span, def.macro_rules)
@@ -1262,7 +1262,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             ))
         } else {
             let module = parent_scope.module;
-            let vis = match item.kind {
+            let vis = match *item.kind {
                 // Visibilities must not be resolved non-speculatively twice
                 // and we already resolved this one as a `fn` item visibility.
                 ItemKind::Fn(..) => self
@@ -1299,7 +1299,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
 
     fn visit_item(&mut self, item: &'b Item) {
         let orig_module_scope = self.parent_scope.module;
-        self.parent_scope.macro_rules = match item.kind {
+        self.parent_scope.macro_rules = match *item.kind {
             ItemKind::MacroDef(..) => {
                 let macro_rules_scope = self.define_macro(item);
                 visit::walk_item(self, item);
@@ -1314,7 +1314,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
                 let orig_macro_rules_scope = self.parent_scope.macro_rules;
                 self.build_reduced_graph_for_item(item);
                 visit::walk_item(self, item);
-                match item.kind {
+                match *item.kind {
                     ItemKind::Mod(..) if self.contains_macro_use(&item.attrs) => {
                         self.parent_scope.macro_rules
                     }
@@ -1334,7 +1334,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
     }
 
     fn visit_foreign_item(&mut self, foreign_item: &'b ForeignItem) {
-        if let ForeignItemKind::MacCall(_) = foreign_item.kind {
+        if let ForeignItemKind::MacCall(_) = *foreign_item.kind {
             self.visit_invoc_in_module(foreign_item.id);
             return;
         }
@@ -1353,7 +1353,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
     }
 
     fn visit_assoc_item(&mut self, item: &'b AssocItem, ctxt: AssocCtxt) {
-        if let AssocItemKind::MacCall(_) = item.kind {
+        if let AssocItemKind::MacCall(_) = *item.kind {
             match ctxt {
                 AssocCtxt::Trait => {
                     self.visit_invoc_in_module(item.id);
@@ -1369,7 +1369,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
         let def_id = local_def_id.to_def_id();
         let vis = match ctxt {
             AssocCtxt::Trait => {
-                let (def_kind, ns) = match item.kind {
+                let (def_kind, ns) = match *item.kind {
                     AssocItemKind::Const(..) => (DefKind::AssocConst, ValueNS),
                     AssocItemKind::Fn(_, ref sig, _, _) => {
                         if sig.decl.has_self() {

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -104,7 +104,7 @@ impl<'a, 'b> Visitor<'a> for UnusedImportCheckVisitor<'a, 'b> {
         // whether they're used or not. Also ignore imports with a dummy span
         // because this means that they were generated in some fashion by the
         // compiler and we don't need to consider them.
-        if let ast::ItemKind::Use(..) = item.kind {
+        if let ast::ItemKind::Use(..) = *item.kind {
             if item.vis.kind.is_pub() || item.span.is_dummy() {
                 return;
             }

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -72,7 +72,7 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
 
         // Pick the def data. This need not be unique, but the more
         // information we encapsulate into, the better
-        let def_data = match &i.kind {
+        let def_data = match &*i.kind {
             ItemKind::Impl { .. } => DefPathData::Impl,
             ItemKind::Mod(..) if i.ident.name == kw::Empty => {
                 // Fake crate root item from expand.
@@ -103,7 +103,7 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
         let def = self.create_def(i.id, def_data, i.span);
 
         self.with_parent(def, |this| {
-            match i.kind {
+            match *i.kind {
                 ItemKind::Struct(ref struct_def, _) | ItemKind::Union(ref struct_def, _) => {
                     // If this is a unit or tuple-like struct, register the constructor.
                     if let Some(ctor_hir_id) = struct_def.ctor_id() {
@@ -141,7 +141,7 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
     }
 
     fn visit_foreign_item(&mut self, foreign_item: &'a ForeignItem) {
-        if let ForeignItemKind::MacCall(_) = foreign_item.kind {
+        if let ForeignItemKind::MacCall(_) = *foreign_item.kind {
             return self.visit_macro_invoc(foreign_item.id);
         }
 
@@ -195,7 +195,7 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
     }
 
     fn visit_assoc_item(&mut self, i: &'a AssocItem, ctxt: visit::AssocCtxt) {
-        let def_data = match &i.kind {
+        let def_data = match &*i.kind {
             AssocItemKind::Fn(..) | AssocItemKind::Const(..) => DefPathData::ValueNs(i.ident.name),
             AssocItemKind::TyAlias(..) => DefPathData::TypeNs(i.ident.name),
             AssocItemKind::MacCall(..) => return self.visit_macro_invoc(i.id),

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -492,7 +492,7 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
         visit::walk_poly_trait_ref(self, tref, m);
     }
     fn visit_foreign_item(&mut self, foreign_item: &'ast ForeignItem) {
-        match foreign_item.kind {
+        match *foreign_item.kind {
             ForeignItemKind::Fn(_, _, ref generics, _)
             | ForeignItemKind::TyAlias(_, ref generics, ..) => {
                 self.with_generic_param_rib(generics, ItemRibKind(HasGenericParams::Yes), |this| {
@@ -937,7 +937,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         let name = item.ident.name;
         debug!("(resolving item) resolving {} ({:?})", name, item.kind);
 
-        match item.kind {
+        match *item.kind {
             ItemKind::TyAlias(_, ref generics, _, _) | ItemKind::Fn(_, _, ref generics, _) => {
                 self.with_generic_param_rib(generics, ItemRibKind(HasGenericParams::Yes), |this| {
                     visit::walk_item(this, item)
@@ -976,7 +976,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
 
                         this.with_trait_items(trait_items, |this| {
                             for item in trait_items {
-                                match &item.kind {
+                                match &*item.kind {
                                     AssocItemKind::Const(_, ty, default) => {
                                         this.visit_ty(ty);
                                         // Only impose the restrictions of `ConstRibKind` for an
@@ -1033,7 +1033,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 self.with_item_rib(HasGenericParams::No, |this| {
                     this.visit_ty(ty);
                     if let Some(expr) = expr {
-                        let constant_item_kind = match item.kind {
+                        let constant_item_kind = match *item.kind {
                             ItemKind::Const(..) => ConstantItemKind::Const,
                             ItemKind::Static(..) => ConstantItemKind::Static,
                             _ => unreachable!(),
@@ -1276,7 +1276,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                                 debug!("resolve_implementation with_self_rib_ns(ValueNS, ...)");
                                 for item in impl_items {
                                     use crate::ResolutionError::*;
-                                    match &item.kind {
+                                    match &*item.kind {
                                         AssocItemKind::Const(_default, _ty, _expr) => {
                                             debug!("resolve_implementation AssocItemKind::Const",);
                                             // If this is a trait impl, ensure the const
@@ -2201,7 +2201,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         // Descend into the block.
         for stmt in &block.stmts {
             if let StmtKind::Item(ref item) = stmt.kind {
-                if let ItemKind::MacroDef(..) = item.kind {
+                if let ItemKind::MacroDef(..) = *item.kind {
                     num_macro_definition_ribs += 1;
                     let res = self.r.local_def_id(item.id).to_def_id();
                     self.ribs[ValueNS].push(Rib::new(MacroDefinition(res)));

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1107,7 +1107,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         if let Some(items) = self.diagnostic_metadata.current_trait_assoc_items {
             for assoc_item in &items[..] {
                 if assoc_item.ident == ident {
-                    return Some(match &assoc_item.kind {
+                    return Some(match &*assoc_item.kind {
                         ast::AssocItemKind::Const(..) => AssocSuggestion::AssocConst,
                         ast::AssocItemKind::Fn(_, sig, ..) if sig.decl.has_self() => {
                             AssocSuggestion::MethodWithSelf
@@ -1547,16 +1547,16 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
             return None;
         }
         match (self.diagnostic_metadata.current_item, single_uppercase_char) {
-            (Some(Item { kind: ItemKind::Fn(..), ident, .. }), _) if ident.name == sym::main => {
+            (Some(Item { kind: box ItemKind::Fn(..), ident, .. }), _) if ident.name == sym::main => {
                 // Ignore `fn main()` as we don't want to suggest `fn main<T>()`
             }
             (
                 Some(Item {
                     kind:
-                        kind @ ItemKind::Fn(..)
-                        | kind @ ItemKind::Enum(..)
-                        | kind @ ItemKind::Struct(..)
-                        | kind @ ItemKind::Union(..),
+                        kind @ box ItemKind::Fn(..)
+                        | kind @ box ItemKind::Enum(..)
+                        | kind @ box ItemKind::Struct(..)
+                        | kind @ box ItemKind::Union(..),
                     ..
                 }),
                 true,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -10,6 +10,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(bool_to_option)]
+#![feature(box_patterns)]
 #![feature(crate_visibility_modifier)]
 #![feature(format_args_capture)]
 #![feature(nll)]
@@ -305,7 +306,7 @@ impl<'tcx> Visitor<'tcx> for UsePlacementFinder {
         }
         // find a use statement
         for item in &module.items {
-            match item.kind {
+            match *item.kind {
                 ItemKind::Use(..) => {
                     // don't suggest placing a use before the prelude
                     // import or other generated ones

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -172,7 +172,7 @@ crate fn record_extern_fqn(cx: &DocContext<'_>, did: DefId, kind: clean::TypeKin
         if matches!(
             cx.enter_resolver(|r| r.cstore().load_macro_untracked(did, cx.sess())),
             LoadedMacro::MacroDef(def, _)
-                if matches!(&def.kind, ast::ItemKind::MacroDef(ast_def)
+                if matches!(&*def.kind, ast::ItemKind::MacroDef(ast_def)
                     if !ast_def.macro_rules)
         ) {
             once(crate_name).chain(relative).collect()
@@ -526,7 +526,7 @@ fn build_macro(cx: &DocContext<'_>, did: DefId, name: Symbol) -> clean::ItemKind
     let imported_from = cx.tcx.original_crate_name(did.krate);
     match cx.enter_resolver(|r| r.cstore().load_macro_untracked(did, cx.sess())) {
         LoadedMacro::MacroDef(def, _) => {
-            let matchers: Vec<Span> = if let ast::ItemKind::MacroDef(ref def) = def.kind {
+            let matchers: Vec<Span> = if let ast::ItemKind::MacroDef(ref def) = *def.kind {
                 let tts: Vec<_> = def.body.inner_tokens().into_trees().collect();
                 tts.chunks(4).map(|arm| arm[0].span()).collect()
             } else {

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -466,7 +466,7 @@ crate fn make_test(
                 match parser.parse_item(ForceCollect::No) {
                     Ok(Some(item)) => {
                         if !found_main {
-                            if let ast::ItemKind::Fn(..) = item.kind {
+                            if let ast::ItemKind::Fn(..) = *item.kind {
                                 if item.ident.name == sym::main {
                                     found_main = true;
                                 }
@@ -474,7 +474,7 @@ crate fn make_test(
                         }
 
                         if !found_extern_crate {
-                            if let ast::ItemKind::ExternCrate(original) = item.kind {
+                            if let ast::ItemKind::ExternCrate(original) = *item.kind {
                                 // This code will never be reached if `cratename` is none because
                                 // `found_extern_crate` is initialized to `true` if it is none.
                                 let cratename = cratename.unwrap();
@@ -487,7 +487,7 @@ crate fn make_test(
                         }
 
                         if !found_macro {
-                            if let ast::ItemKind::MacCall(..) = item.kind {
+                            if let ast::ItemKind::MacCall(..) = *item.kind {
                                 found_macro = true;
                             }
                         }

--- a/src/tools/clippy/clippy_lints/src/doc.rs
+++ b/src/tools/clippy/clippy_lints/src/doc.rs
@@ -485,7 +485,7 @@ fn check_code(cx: &LateContext<'_>, text: &str, edition: Edition, span: Span) {
                 let mut relevant_main_found = false;
                 loop {
                     match parser.parse_item(ForceCollect::No) {
-                        Ok(Some(item)) => match &item.kind {
+                        Ok(Some(item)) => match &*item.kind {
                             // Tests with one of these items are ignored
                             ItemKind::Static(..)
                             | ItemKind::Const(..)

--- a/src/tools/clippy/clippy_lints/src/enum_variants.rs
+++ b/src/tools/clippy/clippy_lints/src/enum_variants.rs
@@ -276,7 +276,7 @@ impl EarlyLintPass for EnumVariantNames {
                 // constants don't have surrounding modules
                 if !mod_camel.is_empty() {
                     if mod_name == &item.ident.name {
-                        if let ItemKind::Mod(..) = item.kind {
+                        if let ItemKind::Mod(..) = *item.kind {
                             span_lint(
                                 cx,
                                 MODULE_INCEPTION,
@@ -315,7 +315,7 @@ impl EarlyLintPass for EnumVariantNames {
                 }
             }
         }
-        if let ItemKind::Enum(ref def, _) = item.kind {
+        if let ItemKind::Enum(ref def, _) = *item.kind {
             let lint = match item.vis.kind {
                 VisibilityKind::Public => PUB_ENUM_VARIANT_NAMES,
                 _ => ENUM_VARIANT_NAMES,

--- a/src/tools/clippy/clippy_lints/src/excessive_bools.rs
+++ b/src/tools/clippy/clippy_lints/src/excessive_bools.rs
@@ -135,7 +135,7 @@ impl EarlyLintPass for ExcessiveBools {
         if in_macro(item.span) {
             return;
         }
-        match &item.kind {
+        match &*item.kind {
             ItemKind::Struct(variant_data, _) => {
                 if attr_by_name(&item.attrs, "repr").is_some() {
                     return;
@@ -164,7 +164,7 @@ impl EarlyLintPass for ExcessiveBools {
             }
             | ItemKind::Trait(_, _, _, _, items) => {
                 for item in items {
-                    if let AssocItemKind::Fn(_, fn_sig, _, _) = &item.kind {
+                    if let AssocItemKind::Fn(_, fn_sig, _, _) = &*item.kind {
                         self.check_fn_sig(cx, fn_sig, item.span);
                     }
                 }

--- a/src/tools/clippy/clippy_lints/src/items_after_statements.rs
+++ b/src/tools/clippy/clippy_lints/src/items_after_statements.rs
@@ -71,7 +71,7 @@ impl EarlyLintPass for ItemsAfterStatements {
                 if in_external_macro(cx.sess(), it.span) {
                     return;
                 }
-                if let ItemKind::MacroDef(..) = it.kind {
+                if let ItemKind::MacroDef(..) = *it.kind {
                     // do not lint `macro_rules`, but continue processing further statements
                     continue;
                 }

--- a/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
@@ -78,7 +78,7 @@ impl EarlyLintPass for ManualNonExhaustive {
             return;
         }
 
-        match &item.kind {
+        match &*item.kind {
             ItemKind::Enum(def, _) => {
                 check_manual_non_exhaustive_enum(cx, item, &def.variants);
             },

--- a/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
+++ b/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
@@ -360,7 +360,7 @@ impl EarlyLintPass for NonExpressiveNames {
             return;
         }
 
-        if let ItemKind::Fn(_, ref sig, _, Some(ref blk)) = item.kind {
+        if let ItemKind::Fn(_, ref sig, _, Some(ref blk)) = *item.kind {
             do_check(self, cx, &item.attrs, &sig.decl, blk);
         }
     }
@@ -370,7 +370,7 @@ impl EarlyLintPass for NonExpressiveNames {
             return;
         }
 
-        if let AssocItemKind::Fn(_, ref sig, _, Some(ref blk)) = item.kind {
+        if let AssocItemKind::Fn(_, ref sig, _, Some(ref blk)) = *item.kind {
             do_check(self, cx, &item.attrs, &sig.decl, blk);
         }
     }

--- a/src/tools/clippy/clippy_lints/src/redundant_static_lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_static_lifetimes.rs
@@ -103,13 +103,13 @@ impl EarlyLintPass for RedundantStaticLifetimes {
         }
 
         if !item.span.from_expansion() {
-            if let ItemKind::Const(_, ref var_type, _) = item.kind {
+            if let ItemKind::Const(_, ref var_type, _) = *item.kind {
                 self.visit_type(var_type, cx, "constants have by default a `'static` lifetime");
                 // Don't check associated consts because `'static` cannot be elided on those (issue
                 // #2438)
             }
 
-            if let ItemKind::Static(ref var_type, _, _) = item.kind {
+            if let ItemKind::Static(ref var_type, _, _) = *item.kind {
                 self.visit_type(var_type, cx, "statics have by default a `'static` lifetime");
             }
         }

--- a/src/tools/clippy/clippy_lints/src/single_component_path_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/single_component_path_imports.rs
@@ -42,7 +42,7 @@ impl EarlyLintPass for SingleComponentPathImports {
             if !in_macro(item.span);
             if cx.sess.opts.edition >= Edition::Edition2018;
             if !item.vis.kind.is_pub();
-            if let ItemKind::Use(use_tree) = &item.kind;
+            if let ItemKind::Use(use_tree) = &*item.kind;
             if let segments = &use_tree.prefix.segments;
             if segments.len() == 1;
             if let UseTreeKind::Simple(None, _, _) = use_tree.kind;

--- a/src/tools/clippy/clippy_lints/src/unsafe_removed_from_name.rs
+++ b/src/tools/clippy/clippy_lints/src/unsafe_removed_from_name.rs
@@ -30,7 +30,7 @@ declare_lint_pass!(UnsafeNameRemoval => [UNSAFE_REMOVED_FROM_NAME]);
 
 impl EarlyLintPass for UnsafeNameRemoval {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &Item) {
-        if let ItemKind::Use(ref use_tree) = item.kind {
+        if let ItemKind::Use(ref use_tree) = *item.kind {
             check_use_tree(use_tree, cx, item.span);
         }
     }

--- a/src/tools/clippy/clippy_lints/src/write.rs
+++ b/src/tools/clippy/clippy_lints/src/write.rs
@@ -233,7 +233,7 @@ impl EarlyLintPass for Write {
         if let ItemKind::Impl {
             of_trait: Some(trait_ref),
             ..
-        } = &item.kind
+        } = &*item.kind
         {
             let trait_name = trait_ref
                 .path


### PR DESCRIPTION
This reduces the size of ast::Item from 296 to 96 bytes.

See https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/windows-rs.20perf/near/223974946 for context; the hope is this will save memory compiling windows-rs.