### PR TITLE
Slight simplification of chars().count()

### DIFF
--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -47,7 +47,7 @@ impl<'a> Iterator for Chars<'a> {
     #[inline]
     fn count(self) -> usize {
         // length in `char` is equal to the number of non-continuation bytes
-        self.iter.map(|&byte| !utf8_is_cont_byte(byte) as usize).sum()
+        self.iter.filter(|&&byte| !utf8_is_cont_byte(byte)).count()
     }
 
     #[inline]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -47,12 +47,13 @@ impl<'a> Iterator for Chars<'a> {
     #[inline]
     fn count(self) -> usize {
         // length in `char` is equal to the number of non-continuation bytes
-        let bytes_len = self.iter.len();
-        let mut cont_bytes = 0;
+        let mut char_count = 0;
         for &byte in self.iter {
-            cont_bytes += utf8_is_cont_byte(byte) as usize;
+            if !utf8_is_cont_byte(byte) {
+                char_count += 1;
+            }
         }
-        bytes_len - cont_bytes
+        char_count
     }
 
     #[inline]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -49,9 +49,7 @@ impl<'a> Iterator for Chars<'a> {
         // length in `char` is equal to the number of non-continuation bytes
         let mut char_count = 0;
         for &byte in self.iter {
-            if !utf8_is_cont_byte(byte) {
-                char_count += 1;
-            }
+            char_count += !utf8_is_cont_byte(byte) as usize;
         }
         char_count
     }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -47,11 +47,7 @@ impl<'a> Iterator for Chars<'a> {
     #[inline]
     fn count(self) -> usize {
         // length in `char` is equal to the number of non-continuation bytes
-        let mut char_count = 0;
-        for &byte in self.iter {
-            char_count += !utf8_is_cont_byte(byte) as usize;
-        }
-        char_count
+        self.iter.map(|&byte| !utf8_is_cont_byte(byte) as usize).sum()
     }
 
     #[inline]


### PR DESCRIPTION
Slight simplification: No need to call len(), we can just count the number of non continuation bytes.

I can't see any reason not to do this, can you?