### PR TITLE
Remove usages of `expr_method_call` in derive(Ord,PartialOrd,RustcEncode,RustcDecode)

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
@@ -47,9 +47,10 @@ pub fn ordering_collapsed(
     span: Span,
     self_arg_tags: &[Ident],
 ) -> P<ast::Expr> {
-    let lft = cx.expr_ident(span, self_arg_tags[0]);
+    let lft = cx.expr_addr_of(span, cx.expr_ident(span, self_arg_tags[0]));
     let rgt = cx.expr_addr_of(span, cx.expr_ident(span, self_arg_tags[1]));
-    cx.expr_method_call(span, lft, Ident::new(sym::cmp, span), vec![rgt])
+    let fn_cmp_path = cx.std_path(&[sym::cmp, sym::Ord, sym::cmp]);
+    cx.expr_call_global(span, fn_cmp_path, vec![lft, rgt])
 }
 
 pub fn cs_cmp(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -107,9 +107,11 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_
             if self_args.len() != 2 {
                 cx.span_bug(span, "not exactly 2 arguments in `derive(PartialOrd)`")
             } else {
-                let lft = cx.expr_ident(span, tag_tuple[0]);
+                let lft = cx.expr_addr_of(span, cx.expr_ident(span, tag_tuple[0]));
                 let rgt = cx.expr_addr_of(span, cx.expr_ident(span, tag_tuple[1]));
-                cx.expr_method_call(span, lft, Ident::new(sym::partial_cmp, span), vec![rgt])
+                let fn_partial_cmp_path =
+                    cx.std_path(&[sym::cmp, sym::PartialOrd, sym::partial_cmp]);
+                cx.expr_call_global(span, fn_partial_cmp_path, vec![lft, rgt])
             }
         }),
         cx,

--- a/compiler/rustc_builtin_macros/src/deriving/decodable.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/decodable.rs
@@ -91,18 +91,19 @@ fn decodable_substructure(
                 Unnamed(ref fields, _) => fields.len(),
                 Named(ref fields) => fields.len(),
             };
-            let read_struct_field = Ident::new(sym::read_struct_field, trait_span);
+            let fn_read_struct_field_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_struct_field]);
 
             let path = cx.path_ident(trait_span, substr.type_ident);
             let result =
                 decode_static_fields(cx, trait_span, path, summary, |cx, span, name, field| {
                     cx.expr_try(
                         span,
-                        cx.expr_method_call(
+                        cx.expr_call_global(
                             span,
-                            blkdecoder.clone(),
-                            read_struct_field,
+                            fn_read_struct_field_path.clone(),
                             vec![
+                                blkdecoder.clone(),
                                 cx.expr_str(span, name),
                                 cx.expr_usize(span, field),
                                 exprdecode.clone(),
@@ -111,11 +112,14 @@ fn decodable_substructure(
                     )
                 });
             let result = cx.expr_ok(trait_span, result);
-            cx.expr_method_call(
+            let fn_read_struct_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_struct]);
+
+            cx.expr_call_global(
                 trait_span,
-                decoder,
-                Ident::new(sym::read_struct, trait_span),
+                fn_read_struct_path,
                 vec![
+                    decoder,
                     cx.expr_str(trait_span, substr.type_ident.name),
                     cx.expr_usize(trait_span, nfields),
                     cx.lambda1(trait_span, result, blkarg),
@@ -127,7 +131,12 @@ fn decodable_substructure(
 
             let mut arms = Vec::with_capacity(fields.len() + 1);
             let mut variants = Vec::with_capacity(fields.len());
-            let rvariant_arg = Ident::new(sym::read_enum_variant_arg, trait_span);
+
+            let fn_read_enum_variant_arg_path: Vec<_> = cx.def_site_path(&[
+                sym::rustc_serialize,
+                sym::Decodable,
+                sym::read_enum_variant_arg,
+            ]);
 
             for (i, &(ident, v_span, ref parts)) in fields.iter().enumerate() {
                 variants.push(cx.expr_str(v_span, ident.name));
@@ -138,11 +147,10 @@ fn decodable_substructure(
                         let idx = cx.expr_usize(span, field);
                         cx.expr_try(
                             span,
-                            cx.expr_method_call(
+                            cx.expr_call_global(
                                 span,
-                                blkdecoder.clone(),
-                                rvariant_arg,
-                                vec![idx, exprdecode.clone()],
+                                fn_read_enum_variant_arg_path.clone(),
+                                vec![blkdecoder.clone(), idx, exprdecode.clone()],
                             ),
                         )
                     });
@@ -159,17 +167,21 @@ fn decodable_substructure(
             let lambda = cx.lambda(trait_span, vec![blkarg, variant], result);
             let variant_vec = cx.expr_vec(trait_span, variants);
             let variant_vec = cx.expr_addr_of(trait_span, variant_vec);
-            let result = cx.expr_method_call(
+            let fn_read_enum_variant_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_enum_variant]);
+            let result = cx.expr_call_global(
                 trait_span,
-                blkdecoder,
-                Ident::new(sym::read_enum_variant, trait_span),
-                vec![variant_vec, lambda],
+                fn_read_enum_variant_path,
+                vec![blkdecoder, variant_vec, lambda],
             );
-            cx.expr_method_call(
+            let fn_read_enum_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_enum]);
+
+            cx.expr_call_global(
                 trait_span,
-                decoder,
-                Ident::new(sym::read_enum, trait_span),
+                fn_read_enum_path,
                 vec![
+                    decoder,
                     cx.expr_str(trait_span, substr.type_ident.name),
                     cx.lambda1(trait_span, result, blkarg),
                 ],

--- a/compiler/rustc_builtin_macros/src/deriving/decodable.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/decodable.rs
@@ -92,7 +92,7 @@ fn decodable_substructure(
                 Named(ref fields) => fields.len(),
             };
             let fn_read_struct_field_path: Vec<_> =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_struct_field]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decoder, sym::read_struct_field]);
 
             let path = cx.path_ident(trait_span, substr.type_ident);
             let result =
@@ -113,7 +113,7 @@ fn decodable_substructure(
                 });
             let result = cx.expr_ok(trait_span, result);
             let fn_read_struct_path: Vec<_> =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_struct]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decoder, sym::read_struct]);
 
             cx.expr_call_global(
                 trait_span,
@@ -132,11 +132,8 @@ fn decodable_substructure(
             let mut arms = Vec::with_capacity(fields.len() + 1);
             let mut variants = Vec::with_capacity(fields.len());
 
-            let fn_read_enum_variant_arg_path: Vec<_> = cx.def_site_path(&[
-                sym::rustc_serialize,
-                sym::Decodable,
-                sym::read_enum_variant_arg,
-            ]);
+            let fn_read_enum_variant_arg_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decoder, sym::read_enum_variant_arg]);
 
             for (i, &(ident, v_span, ref parts)) in fields.iter().enumerate() {
                 variants.push(cx.expr_str(v_span, ident.name));
@@ -168,14 +165,14 @@ fn decodable_substructure(
             let variant_vec = cx.expr_vec(trait_span, variants);
             let variant_vec = cx.expr_addr_of(trait_span, variant_vec);
             let fn_read_enum_variant_path: Vec<_> =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_enum_variant]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decoder, sym::read_enum_variant]);
             let result = cx.expr_call_global(
                 trait_span,
                 fn_read_enum_variant_path,
                 vec![blkdecoder, variant_vec, lambda],
             );
             let fn_read_enum_path: Vec<_> =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Decodable, sym::read_enum]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Decoder, sym::read_enum]);
 
             cx.expr_call_global(
                 trait_span,

--- a/compiler/rustc_builtin_macros/src/deriving/encodable.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/encodable.rs
@@ -179,7 +179,8 @@ fn encodable_substructure(
 
     match *substr.fields {
         Struct(_, ref fields) => {
-            let emit_struct_field = Ident::new(sym::emit_struct_field, trait_span);
+            let fn_emit_struct_field_path =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_struct_field]);
             let mut stmts = Vec::new();
             for (i, &FieldInfo { name, ref self_, span, .. }) in fields.iter().enumerate() {
                 let name = match name {
@@ -189,11 +190,15 @@ fn encodable_substructure(
                 let self_ref = cx.expr_addr_of(span, self_.clone());
                 let enc = cx.expr_call(span, fn_path.clone(), vec![self_ref, blkencoder.clone()]);
                 let lambda = cx.lambda1(span, enc, blkarg);
-                let call = cx.expr_method_call(
+                let call = cx.expr_call_global(
                     span,
-                    blkencoder.clone(),
-                    emit_struct_field,
-                    vec![cx.expr_str(span, name), cx.expr_usize(span, i), lambda],
+                    fn_emit_struct_field_path.clone(),
+                    vec![
+                        blkencoder.clone(),
+                        cx.expr_str(span, name),
+                        cx.expr_usize(span, i),
+                        lambda,
+                    ],
                 );
 
                 // last call doesn't need a try!
@@ -216,11 +221,14 @@ fn encodable_substructure(
                 cx.lambda_stmts_1(trait_span, stmts, blkarg)
             };
 
-            cx.expr_method_call(
+            let fn_emit_struct_path =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_struct]);
+
+            cx.expr_call_global(
                 trait_span,
-                encoder,
-                Ident::new(sym::emit_struct, trait_span),
+                fn_emit_struct_path,
                 vec![
+                    encoder,
                     cx.expr_str(trait_span, substr.type_ident.name),
                     cx.expr_usize(trait_span, fields.len()),
                     blk,
@@ -235,7 +243,13 @@ fn encodable_substructure(
             // actually exist.
             let me = cx.stmt_let(trait_span, false, blkarg, encoder);
             let encoder = cx.expr_ident(trait_span, blkarg);
-            let emit_variant_arg = Ident::new(sym::emit_enum_variant_arg, trait_span);
+
+            let fn_emit_enum_variant_arg_path: Vec<_> = cx.def_site_path(&[
+                sym::rustc_serialize,
+                sym::Encodable,
+                sym::emit_enum_variant_arg,
+            ]);
+
             let mut stmts = Vec::new();
             if !fields.is_empty() {
                 let last = fields.len() - 1;
@@ -244,11 +258,11 @@ fn encodable_substructure(
                     let enc =
                         cx.expr_call(span, fn_path.clone(), vec![self_ref, blkencoder.clone()]);
                     let lambda = cx.lambda1(span, enc, blkarg);
-                    let call = cx.expr_method_call(
+
+                    let call = cx.expr_call_global(
                         span,
-                        blkencoder.clone(),
-                        emit_variant_arg,
-                        vec![cx.expr_usize(span, i), lambda],
+                        fn_emit_enum_variant_arg_path.clone(),
+                        vec![blkencoder.clone(), cx.expr_usize(span, i), lambda],
                     );
                     let call = if i != last {
                         cx.expr_try(span, call)
@@ -265,23 +279,29 @@ fn encodable_substructure(
 
             let blk = cx.lambda_stmts_1(trait_span, stmts, blkarg);
             let name = cx.expr_str(trait_span, variant.ident.name);
-            let call = cx.expr_method_call(
+
+            let fn_emit_enum_variant_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_enum_variant]);
+
+            let call = cx.expr_call_global(
                 trait_span,
-                blkencoder,
-                Ident::new(sym::emit_enum_variant, trait_span),
+                fn_emit_enum_variant_path,
                 vec![
+                    blkencoder,
                     name,
                     cx.expr_usize(trait_span, idx),
                     cx.expr_usize(trait_span, fields.len()),
                     blk,
                 ],
             );
+
             let blk = cx.lambda1(trait_span, call, blkarg);
-            let ret = cx.expr_method_call(
+            let fn_emit_enum_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_enum]);
+            let ret = cx.expr_call_global(
                 trait_span,
-                encoder,
-                Ident::new(sym::emit_enum, trait_span),
-                vec![cx.expr_str(trait_span, substr.type_ident.name), blk],
+                fn_emit_enum_path,
+                vec![encoder, cx.expr_str(trait_span, substr.type_ident.name), blk],
             );
             cx.expr_block(cx.block(trait_span, vec![me, cx.stmt_expr(ret)]))
         }

--- a/compiler/rustc_builtin_macros/src/deriving/encodable.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/encodable.rs
@@ -180,7 +180,7 @@ fn encodable_substructure(
     match *substr.fields {
         Struct(_, ref fields) => {
             let fn_emit_struct_field_path =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_struct_field]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encoder, sym::emit_struct_field]);
             let mut stmts = Vec::new();
             for (i, &FieldInfo { name, ref self_, span, .. }) in fields.iter().enumerate() {
                 let name = match name {
@@ -222,7 +222,7 @@ fn encodable_substructure(
             };
 
             let fn_emit_struct_path =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_struct]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encoder, sym::emit_struct]);
 
             cx.expr_call_global(
                 trait_span,
@@ -244,11 +244,8 @@ fn encodable_substructure(
             let me = cx.stmt_let(trait_span, false, blkarg, encoder);
             let encoder = cx.expr_ident(trait_span, blkarg);
 
-            let fn_emit_enum_variant_arg_path: Vec<_> = cx.def_site_path(&[
-                sym::rustc_serialize,
-                sym::Encodable,
-                sym::emit_enum_variant_arg,
-            ]);
+            let fn_emit_enum_variant_arg_path: Vec<_> =
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encoder, sym::emit_enum_variant_arg]);
 
             let mut stmts = Vec::new();
             if !fields.is_empty() {
@@ -281,7 +278,7 @@ fn encodable_substructure(
             let name = cx.expr_str(trait_span, variant.ident.name);
 
             let fn_emit_enum_variant_path: Vec<_> =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_enum_variant]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encoder, sym::emit_enum_variant]);
 
             let call = cx.expr_call_global(
                 trait_span,
@@ -297,7 +294,7 @@ fn encodable_substructure(
 
             let blk = cx.lambda1(trait_span, call, blkarg);
             let fn_emit_enum_path: Vec<_> =
-                cx.def_site_path(&[sym::rustc_serialize, sym::Encodable, sym::emit_enum]);
+                cx.def_site_path(&[sym::rustc_serialize, sym::Encoder, sym::emit_enum]);
             let ret = cx.expr_call_global(
                 trait_span,
                 fn_emit_enum_path,

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1043,6 +1043,10 @@ impl<'a> ExtCtxt<'a> {
             .chain(components.iter().map(|&s| Ident::with_dummy_span(s)))
             .collect()
     }
+    pub fn def_site_path(&self, components: &[Symbol]) -> Vec<Ident> {
+        let def_site = self.with_def_site_ctxt(DUMMY_SP);
+        components.iter().map(|&s| Ident::new(s, def_site)).collect()
+    }
 
     pub fn check_unused_macros(&mut self) {
         self.resolver.check_unused_macros();


### PR DESCRIPTION
Preparing for deprecation of `expr_method_call`  (#81295), by removing the remaining usages not covered by (#81294).

I am not sure about the changes to `derive(RustcEncode,RustcDecode)` 