### PR TITLE
Tweak suggestion for missing field in patterns

### DIFF
--- a/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/struct_destructure_fail.stderr
@@ -32,12 +32,12 @@ LL |     Struct { a, _ } = Struct { a: 1, b: 2 };
    |
 help: include the missing field in the pattern
    |
-LL |     Struct { a, b _ } = Struct { a: 1, b: 2 };
-   |               ^^^
+LL |     Struct { a, b } = Struct { a: 1, b: 2 };
+   |               ^^^^^
 help: if you don't care about this missing field, you can explicitly ignore it
    |
-LL |     Struct { a, .. _ } = Struct { a: 1, b: 2 };
-   |               ^^^^
+LL |     Struct { a, .. } = Struct { a: 1, b: 2 };
+   |               ^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/error-codes/E0027.stderr
+++ b/src/test/ui/error-codes/E0027.stderr
@@ -7,11 +7,11 @@ LL |         Dog { age: x } => {}
 help: include the missing field in the pattern
    |
 LL |         Dog { age: x, name } => {}
-   |                     ^^^^^^
+   |                     ^^^^^^^^
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Dog { age: x, .. } => {}
-   |                     ^^^^
+   |                     ^^^^^^
 
 error[E0027]: pattern does not mention field `age`
   --> $DIR/E0027.rs:15:9
@@ -22,11 +22,11 @@ LL |         Dog { name: x, } => {}
 help: include the missing field in the pattern
    |
 LL |         Dog { name: x, age } => {}
-   |                      ^^^^^
+   |                      ^^^^^^^
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Dog { name: x, .. } => {}
-   |                      ^^^^
+   |                      ^^^^^^
 
 error[E0027]: pattern does not mention field `age`
   --> $DIR/E0027.rs:19:9
@@ -37,11 +37,11 @@ LL |         Dog { name: x  , } => {}
 help: include the missing field in the pattern
    |
 LL |         Dog { name: x, age } => {}
-   |                      ^^^^^
+   |                      ^^^^^^^
 help: if you don't care about this missing field, you can explicitly ignore it
    |
 LL |         Dog { name: x, .. } => {}
-   |                      ^^^^
+   |                      ^^^^^^
 
 error[E0027]: pattern does not mention fields `name`, `age`
   --> $DIR/E0027.rs:22:9

--- a/src/test/ui/structs/struct-pat-derived-error.stderr
+++ b/src/test/ui/structs/struct-pat-derived-error.stderr
@@ -19,11 +19,11 @@ LL |         let A { x, y } = self.d;
 help: include the missing fields in the pattern
    |
 LL |         let A { x, y, b, c } = self.d;
-   |                     ^^^^^^
+   |                     ^^^^^^^^
 help: if you don't care about these missing fields, you can explicitly ignore them
    |
 LL |         let A { x, y, .. } = self.d;
-   |                     ^^^^
+   |                     ^^^^^^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Account for parser recovered struct and tuple patterns to avoid invalid
suggestion.

Follow up to #81103.