### PR TITLE
compiletest: Add two more unit tests

### DIFF
--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -174,7 +174,7 @@ impl fmt::Display for Debugger {
 /// Configuration for compiletest
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// `true` to to overwrite stderr/stdout files instead of complaining about changes in output.
+    /// `true` to overwrite stderr/stdout files instead of complaining about changes in output.
     pub bless: bool,
 
     /// The library paths required for running the compiler.

--- a/src/tools/compiletest/src/util/tests.rs
+++ b/src/tools/compiletest/src/util/tests.rs
@@ -30,3 +30,22 @@ fn test_matches_os() {
     assert!(matches_os("nvptx64-nvidia-cuda", "cuda"));
     assert!(matches_os("x86_64-fortanix-unknown-sgx", "sgx"));
 }
+
+#[test]
+fn is_big_endian_test() {
+    assert!(!is_big_endian("no"));
+    assert!(is_big_endian("sparc-unknown-unknown"));
+}
+
+#[test]
+fn path_buf_with_extra_extension_test() {
+    assert_eq!(
+        PathBuf::from("foo.rs.stderr"),
+        PathBuf::from("foo.rs").with_extra_extension("stderr")
+    );
+    assert_eq!(
+        PathBuf::from("foo.rs.stderr"),
+        PathBuf::from("foo.rs").with_extra_extension(".stderr")
+    );
+    assert_eq!(PathBuf::from("foo.rs"), PathBuf::from("foo.rs").with_extra_extension(""));
+}


### PR DESCRIPTION
This adds two more unit tests and fixes spelling in `compiletest`.