### PR TITLE
Multiline string attr display

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -3332,6 +3332,16 @@ fn render_attributes(w: &mut Buffer, it: &clean::Item, top: bool) {
                 None
             }
         })
+        // This whole `map` is to correctly print the "cut" strings in attributes arguments like:
+        //
+        // #[x = "string with \
+        //   backline"]
+        .map(|a| {
+            a.split("\\\n").fold(String::new(), |mut acc, a| {
+                acc.push_str(a.trim_start());
+                acc
+            })
+        })
         .join("\n");
 
     if !attrs.is_empty() {

--- a/src/test/rustdoc/attributes-backline.rs
+++ b/src/test/rustdoc/attributes-backline.rs
@@ -1,0 +1,14 @@
+#![crate_name = "foo"]
+
+// @has 'foo/struct.Fly.html'
+// @has - '//h4[@id="method.drosophilae"]//span[@class="docblock attributes"]' ''
+// @has - '//h4[@id="method.drosophilae"]//span[@class="docblock attributes"]' \
+//    'Just a sentence with a backline in the middle'
+// @!has - '//h4[@id="method.drosophilae"]//span[@class="doblock attributes"]' '\\'
+pub struct Fly;
+
+impl Fly {
+    #[must_use = "Just a sentence with a backline in \
+                  the middle"]
+    pub fn drosophilae(&self) {}
+}


### PR DESCRIPTION
Fixes #81482.

As you see [here](https://doc.rust-lang.org/nightly/std/string/struct.String.html#method.replace) (or on the screenshot below):

![Screenshot from 2021-01-27 14-23-49](https://user-images.githubusercontent.com/3050060/105997028-654ab100-60ab-11eb-9e74-6a656b448092.png)

The backslash is kept in the string literal in the end. This fix removes it, however I wonder if there isn't a function to do that already in the compiler (couldn't find anything so...). Maybe you might have some information about it @oli-obk ?

cc @CraftSpider 
r? @camelid 