### PR TITLE
Promote Vec and RawVec functions to const fn

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -241,7 +241,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     ///
     /// This will always be `usize::MAX` if `T` is zero-sized.
     #[inline(always)]
-    pub fn capacity(&self) -> usize {
+    pub const fn capacity(&self) -> usize {
         if mem::size_of::<T>() == 0 { usize::MAX } else { self.cap }
     }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -746,7 +746,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn capacity(&self) -> usize {
+    pub const fn capacity(&self) -> usize {
         self.buf.capacity()
     }
 
@@ -1646,7 +1646,7 @@ impl<T, A: Allocator> Vec<T, A> {
     #[doc(alias = "length")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
@@ -1662,7 +1662,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert!(!v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 


### PR DESCRIPTION
Patch to change the following functions to be const fn:

- `RawVec::capacity`
- `Vec::capacity`
- `Vec::len`
- `Vec::is_empty`

It would be great if these functions would be const fn, since I have a use-case where I need to convert from and to `Vec<T>` types at compile time. Especially `capacity()` needs to be const, since I need to take ownership of the entire vector at compile time.