### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crates-io"
-version = "0.31.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "curl",
@@ -1337,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.14"
+version = "0.13.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186dd99cc77576e58344ad614fa9bb27bad9d048f85de3ca850c1f4e8b048260"
+checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
 dependencies = [
  "bitflags",
  "libc",
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.16+1.1.0"
+version = "0.12.18+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f91b2f931ee975a98155195be8cd82d02e8e029d7d793d2bac1b8181ac97020"
+checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
7 commits in 783bc43c660bf39c1e562c8c429b32078ad3099b..c3abcfe8a75901c7c701557a728941e8fb19399e
2021-01-20 19:02:26 +0000 to 2021-01-25 16:16:43 +0000
- Minor update to tracking issue template. (rust-lang/cargo#9097)
- Add some extra help to `cargo new` and invalid package names. (rust-lang/cargo#9098)
- Fix compilation with serde 1.0.122 (rust-lang/cargo#9102)
- Add suggestion for bad package id. (rust-lang/cargo#9095)
- Remove Registry::new. (rust-lang/cargo#9093)
- Fix: set default git config search path for tests (rust-lang/cargo#9035)
- Unstable updates (rust-lang/cargo#9092)