### PR TITLE
Add #[must_use] to process::Command, process::Child and process::ExitStatus

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -170,6 +170,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 ///
 /// [`wait`]: Child::wait
 #[stable(feature = "process", since = "1.0.0")]
+#[must_use = "this Child should probably be `wait`ed, or `status` used instead of `spawn`"]
 pub struct Child {
     handle: imp::Process,
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -493,7 +493,8 @@ impl fmt::Debug for ChildStderr {
 /// let mut list_dir = Command::new("ls");
 ///
 /// // Execute `ls` in the current directory of the program.
-/// list_dir.status().expect("process failed to execute");
+/// let status = list_dir.status().expect("process failed to execute");
+/// assert!(status.success());
 ///
 /// println!();
 ///
@@ -501,7 +502,8 @@ impl fmt::Debug for ChildStderr {
 /// list_dir.current_dir("/");
 ///
 /// // And then execute `ls` again but in the root directory.
-/// list_dir.status().expect("process failed to execute");
+/// let status = list_dir.status().expect("process failed to execute");
+/// assert!(status.success());
 /// ```
 #[stable(feature = "process", since = "1.0.0")]
 pub struct Command {
@@ -1596,8 +1598,8 @@ impl Child {
     ///
     /// let mut command = Command::new("ls");
     /// if let Ok(mut child) = command.spawn() {
-    ///     child.wait().expect("command wasn't running");
-    ///     println!("Child has finished its execution!");
+    ///     let status = child.wait().expect("command wasn't running");
+    ///     println!("Child has finished its execution, status = {}!", status);
     /// } else {
     ///     println!("ls command didn't start");
     /// }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -507,6 +507,7 @@ impl fmt::Debug for ChildStderr {
 /// assert!(status.success());
 /// ```
 #[stable(feature = "process", since = "1.0.0")]
+#[must_use = "this Command does not do anything unless it is run, eg using `status` or `spawn`"]
 pub struct Command {
     inner: imp::Command,
 }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -525,9 +525,11 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("sh")
-    ///         .spawn()
+    /// let status = Command::new("sh")
+    ///         .status()
     ///         .expect("sh command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn new<S: AsRef<OsStr>>(program: S) -> Command {
@@ -569,11 +571,13 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .arg("-l")
     ///         .arg("-a")
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Command {
@@ -599,10 +603,12 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .args(&["-l", "-a"])
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn args<I, S>(&mut self, args: I) -> &mut Command
@@ -628,10 +634,12 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .env("PATH", "/bin")
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Command
@@ -659,13 +667,15 @@ impl Command {
     ///         k == "TERM" || k == "TZ" || k == "LANG" || k == "PATH"
     ///     ).collect();
     ///
-    /// Command::new("printenv")
+    /// let status = Command::new("printenv")
     ///         .stdin(Stdio::null())
     ///         .stdout(Stdio::inherit())
     ///         .env_clear()
     ///         .envs(&filtered_env)
-    ///         .spawn()
+    ///         .status()
     ///         .expect("printenv failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "command_envs", since = "1.19.0")]
     pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Command
@@ -689,10 +699,12 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .env_remove("PATH")
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Command {
@@ -709,10 +721,12 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .env_clear()
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn env_clear(&mut self) -> &mut Command {
@@ -737,10 +751,12 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .current_dir("/bin")
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     ///
     /// [`canonicalize`]: crate::fs::canonicalize
@@ -765,10 +781,12 @@ impl Command {
     /// ```no_run
     /// use std::process::{Command, Stdio};
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .stdin(Stdio::null())
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn stdin<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Command {
@@ -791,10 +809,12 @@ impl Command {
     /// ```no_run
     /// use std::process::{Command, Stdio};
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .stdout(Stdio::null())
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn stdout<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Command {
@@ -817,10 +837,12 @@ impl Command {
     /// ```no_run
     /// use std::process::{Command, Stdio};
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .stderr(Stdio::null())
-    ///         .spawn()
+    ///         .status()
     ///         .expect("ls command failed to start");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn stderr<T: Into<Stdio>>(&mut self, cfg: T) -> &mut Command {

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1416,6 +1416,7 @@ impl From<fs::File> for Stdio {
 /// [`wait`]: Child::wait
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[stable(feature = "process", since = "1.0.0")]
+#[must_use = "this ExitStatus might represent an error that should be checked and handled"]
 pub struct ExitStatus(imp::ExitStatus);
 
 impl ExitStatus {

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -132,15 +132,25 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 ///
 /// # Warning
 ///
+/// A `Child` which is simply dropped may continue running in parallel,
+/// possibly even after the program which launched it exits.
+/// If it inherited stdin/stdout, it may still read and write to them
+/// later, causing confusion and disruption.
+///
 /// On some systems, calling [`wait`] or similar is necessary for the OS to
 /// release resources. A process that terminated but has not been waited on is
 /// still around as a "zombie". Leaving too many zombies around may exhaust
 /// global resources (for example process IDs).
 ///
+/// Unless [`wait`] is called, any failure of the child will not be
+/// visible.
+///
 /// The standard library does *not* automatically wait on child processes (not
 /// even if the `Child` is dropped), it is up to the application developer to do
-/// so. As a consequence, dropping `Child` handles without waiting on them first
-/// is not recommended in long-running applications.
+/// so.
+///
+/// For these reasons, dropping `Child` handles without waiting on them first
+/// is usually incorrect.
 ///
 /// # Examples
 ///

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -832,6 +832,9 @@ impl Command {
     ///
     /// By default, stdin, stdout and stderr are inherited from the parent.
     ///
+    /// If you just want to run the command and wait for it to complete, consider using
+    /// [`Command::status`] instead.
+    ///
     /// # Examples
     ///
     /// Basic usage:

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -839,9 +839,13 @@ impl Command {
     /// ```no_run
     /// use std::process::Command;
     ///
-    /// Command::new("ls")
+    /// let status = Command::new("ls")
     ///         .spawn()
-    ///         .expect("ls command failed to start");
+    ///         .expect("ls command failed to start")
+    ///         .wait()
+    ///         .expect("failed to wait for child");
+    ///
+    /// assert!(status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn spawn(&mut self) -> io::Result<Child> {

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -179,7 +179,10 @@ fn main() {
     }
 
     if let Some(mut on_fail) = on_fail {
-        on_fail.status().expect("Could not run the on_fail command");
+        let status = on_fail.status().expect("Could not run the on_fail command");
+        if !status.success() {
+            eprintln!("\nwarning: the on-fail command also failed: {}\n", status);
+        }
     }
 
     // Preserve the exit code. In case of signal, exit with 0xfe since it's

--- a/src/test/ui/fds-are-cloexec.rs
+++ b/src/test/ui/fds-are-cloexec.rs
@@ -66,7 +66,9 @@ fn parent() {
                         .status()
                         .unwrap();
     assert!(status.success());
-    child.wait().unwrap();
+
+    let status = child.wait().unwrap();
+    assert!(status.success());
 }
 
 fn child(args: &[String]) {

--- a/src/test/ui/try-wait.rs
+++ b/src/test/ui/try-wait.rs
@@ -31,7 +31,8 @@ fn main() {
     assert!(maybe_status.is_none());
 
     me.kill().unwrap();
-    me.wait().unwrap();
+    let status = me.wait().unwrap();
+    assert!(!status.success());
 
     let status = me.try_wait().unwrap().unwrap();
     assert!(!status.success());

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -869,17 +869,23 @@ impl<'test> TestCx<'test> {
 
             let adb_path = &self.config.adb_path;
 
-            Command::new(adb_path)
+            let status = Command::new(adb_path)
                 .arg("push")
                 .arg(&exe_file)
                 .arg(&self.config.adb_test_dir)
                 .status()
                 .unwrap_or_else(|_| panic!("failed to exec `{:?}`", adb_path));
+            if !status.success() {
+                panic!("Program failed `{:}`", adb_path);
+            }
 
-            Command::new(adb_path)
+            let status = Command::new(adb_path)
                 .args(&["forward", "tcp:5039", "tcp:5039"])
                 .status()
                 .unwrap_or_else(|_| panic!("failed to exec `{:?}`", adb_path));
+            if !status.success() {
+                panic!("Program failed `{:}`", adb_path);
+            }
 
             let adb_arg = format!(
                 "export LD_LIBRARY_PATH={}; \


### PR DESCRIPTION
## Motivation

These three critical types in `std::process` should all be `#[must_use]`.  Failure to use a `Command` is hopefully fairly obvious but it seems friendly to mark this one for the same reason as futures.

Failure to use a `Child` or `ExitStatus` are more serious.

On unix, failure to use a `Child` leaks the process.  It continues running in parallel, even after we have exited (or crashed), possibly interfering with the user's terminal or driveling nonsense into a logfile long after the original event.  In a long-running process, the child will become a zombie when it exits, and accumulation of zombies can prevent the spawning of new children.  IDK what failure to use a `Child` does on Windows but the docs are not encouraging.

Failure to use an `ExitStatus` is the kind of error-handling bug Rust usually tries to save us from.

## Contents of this MR

The main aim is just to mark these three types `#[must_use]`.  However, I reviewed the documentation and it was missing two of the problems with leaking `Child`.  I also felt `.spawn()` ought to direct the reader to `.status()`.

More worryingly, the `#[must_use]` changes revealed that most of the examples were broken.  Most of them leak the `Child` and nearly none of them check the exit status.  So I fixed that.

### Bugs this revealed in other parts of rust-lang/rust, outside the stdlib

The bootstrap wrapper for rustc ignored the status of the `on_fail` command.  Although failing to run it at all produces a panic, I felt that was a bit much for if it simply fails.  So I chose to print a warning to stderr.  We are already failing here, so the shim will exit nonzero in any case.

Two tests in `src/ui/test` failed to check the exit status; in one case this is a clear bug.

The runtest wrapper failed to check the exit status from two of its invocations of adb.

## Concern

During a [pre-RFC discussion](https://internals.rust-lang.org/t/pre-rfc-overhaul-command-for-2021-ed/13755) I was told that adding a `#[must_use]` is not considered a breaking change because it's only a lint.

But I worry that this imay be too disruptive a change, given the problems in the stdlib examples themselves, and the rest of the lang tree.

On the other hand: almost all of the things that this found in the stdlib were actual bugs - bugs which would have been quite serious in deployed code.  Perhaps it is better to do our community the service of highlighting these problems rather than tolerating them.

A friend observed that adding these `#[must_use]` would be "doing the community a favour, but I'm not sure they'll enjoy it".