### PR TITLE
Avoid using shrink_to_fit in the middle of optimization pipeline

### DIFF
--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -470,6 +470,8 @@ fn run_post_borrowck_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tc
     ];
 
     run_passes(tcx, body, MirPhase::DropLowering, &[post_borrowck_cleanup]);
+
+    body.basic_blocks_mut().shrink_to_fit();
 }
 
 fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -583,6 +585,9 @@ fn inner_optimized_mir(tcx: TyCtxt<'_>, did: LocalDefId) -> Body<'_> {
     run_optimization_passes(tcx, &mut body);
 
     debug_assert!(!body.has_free_regions(), "Free regions in optimized MIR");
+
+    body.basic_blocks_mut().shrink_to_fit();
+    body.local_decls.shrink_to_fit();
 
     body
 }

--- a/compiler/rustc_mir/src/transform/simplify.rs
+++ b/compiler/rustc_mir/src/transform/simplify.rs
@@ -50,9 +50,6 @@ impl SimplifyCfg {
 pub fn simplify_cfg(body: &mut Body<'_>) {
     CfgSimplifier::new(body).simplify();
     remove_dead_blocks(body);
-
-    // FIXME: Should probably be moved into some kind of pass manager
-    body.basic_blocks_mut().raw.shrink_to_fit();
 }
 
 impl<'tcx> MirPass<'tcx> for SimplifyCfg {
@@ -340,8 +337,6 @@ impl<'tcx> MirPass<'tcx> for SimplifyLocals {
             // Update references to all vars and tmps now
             let mut updater = LocalUpdater { map, tcx };
             updater.visit_body(body);
-
-            body.local_decls.shrink_to_fit();
         }
     }
 }


### PR DESCRIPTION
The SimplifyCfg and SimplifyLocals shrink allocations used for basic
blocks data and locals after running. This could be counter-productive
in the middle of the pipeline. Move shrink_to_fit to the end of it.