### PR TITLE
Add some tests for associated-type-bounds issues

### DIFF
--- a/src/test/ui/associated-types/issue-38917.rs
+++ b/src/test/ui/associated-types/issue-38917.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+use std::borrow::Borrow;
+
+trait TNode: Sized {
+    type ConcreteElement: TElement<ConcreteNode = Self>;
+}
+
+trait TElement: Sized {
+    type ConcreteNode: TNode<ConcreteElement = Self>;
+}
+
+trait DomTraversal<N: TNode> {
+    type BorrowElement: Borrow<N::ConcreteElement>;
+}
+
+#[allow(dead_code)]
+fn recalc_style_at<E, D>()
+where
+    E: TElement,
+    D: DomTraversal<E::ConcreteNode>,
+{
+}
+
+fn main() {}

--- a/src/test/ui/associated-types/issue-40093.rs
+++ b/src/test/ui/associated-types/issue-40093.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+pub trait Test {
+    type Item;
+    type Bundle: From<Self::Item>;
+}
+
+fn fails<T>()
+where
+    T: Test<Item = String>,
+{
+}
+
+fn main() {}

--- a/src/test/ui/associated-types/issue-43475.rs
+++ b/src/test/ui/associated-types/issue-43475.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+trait Foo { type FooT: Foo; }
+impl Foo for () { type FooT = (); }
+trait Bar<T: Foo> { type BarT: Bar<T::FooT>; }
+impl Bar<()> for () { type BarT = (); }
+
+#[allow(dead_code)]
+fn test<C: Bar<()>>() { }
+fn main() { }

--- a/src/test/ui/associated-types/issue-63591.rs
+++ b/src/test/ui/associated-types/issue-63591.rs
@@ -1,0 +1,24 @@
+// check-pass
+
+#![feature(associated_type_bounds)]
+#![feature(type_alias_impl_trait)]
+
+fn main() {}
+
+trait Bar { type Assoc; }
+
+trait Thing {
+    type Out;
+    fn func() -> Self::Out;
+}
+
+struct AssocIsCopy;
+impl Bar for AssocIsCopy { type Assoc = u8; }
+
+impl Thing for AssocIsCopy {
+    type Out = impl Bar<Assoc: Copy>;
+
+    fn func() -> Self::Out {
+        AssocIsCopy
+    }
+}


### PR DESCRIPTION
Closes #38917
Closes #40093
Closes #43475
Closes #63591

#47897 is likely closable too, but it needs an MCVE
~~#38917, #40093, #43475, #47897 all are mislabeled and shouldn't have the `F-associated-type-bounds` label~~

~~#71685 is also mislabeled as commented on in that thread~~