### PR TITLE
rustdoc: Note why `rustdoc::html::markdown` is public

### DIFF
--- a/src/librustdoc/html/mod.rs
+++ b/src/librustdoc/html/mod.rs
@@ -2,6 +2,7 @@ crate mod escape;
 crate mod format;
 crate mod highlight;
 crate mod layout;
+// used by the error-index generator, so it needs to be public
 pub mod markdown;
 crate mod render;
 crate mod sources;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -83,7 +83,8 @@ mod doctree;
 mod error;
 mod doctest;
 mod fold;
-crate mod formats;
+mod formats;
+// used by the error-index generator, so it needs to be public
 pub mod html;
 mod json;
 mod markdown;


### PR DESCRIPTION
Almost all of the modules are crate-private, except for
`rustdoc::json::types`, which I believe is intended to be for public
use; and `rustdoc::html::markdown`, which is used externally by the
error-index generator and so has to be public.

r? @GuillaumeGomez
