### PR TITLE
rustdoc: Remove unnecessary optional

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -460,7 +460,7 @@ crate fn run_global_ctxt(
     mut default_passes: passes::DefaultPassOption,
     mut manual_passes: Vec<String>,
     render_options: RenderOptions,
-    output_format: Option<OutputFormat>,
+    output_format: OutputFormat,
 ) -> (clean::Crate, RenderInfo, RenderOptions) {
     // Certain queries assume that some checks were run elsewhere
     // (see https://github.com/rust-lang/rust/pull/73566#issuecomment-656954425),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -578,7 +578,7 @@ fn main_options(options: config::Options) -> MainResult {
                 let (error_format, edition, debugging_options) = diag_opts;
                 let diag = core::new_handler(error_format, None, &debugging_options);
                 match output_format {
-                    None | Some(config::OutputFormat::Html) => sess.time("render_html", || {
+                    config::OutputFormat::Html => sess.time("render_html", || {
                         run_renderer::<html::render::Context<'_>>(
                             krate,
                             render_opts,
@@ -588,7 +588,7 @@ fn main_options(options: config::Options) -> MainResult {
                             tcx,
                         )
                     }),
-                    Some(config::OutputFormat::Json) => sess.time("render_json", || {
+                    config::OutputFormat::Json => sess.time("render_json", || {
                         run_renderer::<json::JsonRenderer<'_>>(
                             krate,
                             render_opts,

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -132,7 +132,7 @@ impl<'a, 'b> CoverageCalculator<'a, 'b> {
 
     fn print_results(&self) {
         let output_format = self.ctx.renderinfo.borrow().output_format;
-        if output_format.map(|o| o.is_json()).unwrap_or_else(|| false) {
+        if output_format.is_json() {
             println!("{}", self.to_json());
             return;
         }


### PR DESCRIPTION
Previously, the HTML output format was represented by both
`Some(OutputFormat::Html)` and `None` so there's no need to have an
optional. Instead, `OutputFormat::Html` is explicitly the default and we
no longer have a "tri-state enum".

r? @GuillaumeGomez
