### PR TITLE
rustdoc: Move `display_fn` struct inside `display_fn`

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1322,16 +1322,16 @@ impl clean::GenericArg {
 }
 
 crate fn display_fn(f: impl FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result) -> impl fmt::Display {
-    WithFormatter(Cell::new(Some(f)))
-}
+    struct WithFormatter<F>(Cell<Option<F>>);
 
-struct WithFormatter<F>(Cell<Option<F>>);
-
-impl<F> fmt::Display for WithFormatter<F>
-where
-    F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        (self.0.take()).unwrap()(f)
+    impl<F> fmt::Display for WithFormatter<F>
+    where
+        F: FnOnce(&mut fmt::Formatter<'_>) -> fmt::Result,
+    {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            (self.0.take()).unwrap()(f)
+        }
     }
+
+    WithFormatter(Cell::new(Some(f)))
 }


### PR DESCRIPTION
This makes it clear that it's an implementation detail of `display_fn`
and shouldn't be used elsewhere, and it enforces in the compiler that no
one else can use it.

r? @GuillaumeGomez
