### PR TITLE
Apply workaround from #72003 for #56935 to allow for cross-compilation of `rustc_index` crate

### DIFF
--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -8,3 +8,7 @@
 
 pub mod bit_set;
 pub mod vec;
+
+// FIXME(#56935): Work around ICEs during cross-compilation.
+#[allow(unused)]
+extern crate rustc_macros;


### PR DESCRIPTION
This patch applies the same workaround as #72003 to the `rustc_index` crate. This allows recent versions of rustfmt to compile to wasm again.

Related: #72017.