### PR TITLE
Remove struct_type from union output

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -154,7 +154,7 @@ impl From<clean::ItemKind> for ItemEnum {
             }
             ImportItem(i) => ItemEnum::ImportItem(i.into()),
             StructItem(s) => ItemEnum::StructItem(s.into()),
-            UnionItem(u) => ItemEnum::StructItem(u.into()),
+            UnionItem(u) => ItemEnum::UnionItem(u.into()),
             StructFieldItem(f) => ItemEnum::StructFieldItem(f.into()),
             EnumItem(e) => ItemEnum::EnumItem(e.into()),
             VariantItem(v) => ItemEnum::VariantItem(v.into()),
@@ -205,11 +205,10 @@ impl From<clean::Struct> for Struct {
     }
 }
 
-impl From<clean::Union> for Struct {
+impl From<clean::Union> for Union {
     fn from(struct_: clean::Union) -> Self {
         let clean::Union { generics, fields, fields_stripped } = struct_;
-        Struct {
-            struct_type: StructType::Union,
+        Union {
             generics: generics.into(),
             fields_stripped,
             fields: ids(fields),

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -243,7 +243,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 2,
+            format_version: 3,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -194,6 +194,7 @@ pub enum ItemEnum {
     },
     ImportItem(Import),
 
+    UnionItem(Union),
     StructItem(Struct),
     StructFieldItem(Type),
     EnumItem(Enum),
@@ -239,6 +240,14 @@ pub struct Module {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Union {
+    pub generics: Generics,
+    pub fields_stripped: bool,
+    pub fields: Vec<Id>,
+    pub impls: Vec<Id>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Struct {
     pub struct_type: StructType,
     pub generics: Generics,
@@ -270,7 +279,6 @@ pub enum StructType {
     Plain,
     Tuple,
     Unit,
-    Union,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]

--- a/src/test/rustdoc-json/unions/union.rs
+++ b/src/test/rustdoc-json/unions/union.rs
@@ -1,0 +1,7 @@
+// @has union.json "$.index[*][?(@.name=='Union')].visibility" \"public\"
+// @has - "$.index[*][?(@.name=='Union')].kind" \"union\"
+// @!has - "$.index[*][?(@.name=='Union')].inner.struct_type"
+pub union Union {
+    int: i32,
+    float: f32,
+}


### PR DESCRIPTION
Also bumps the format number and adds a test

Rationale: It's illegal to have unions of the form `union Union(i32, f32);`, or `union Union;`. The struct_type field was recently removed from the rustdoc Union AST, at which time this field was changed to always just read "union". It makes sense to completely remove it, as it provides no information.