### PR TITLE
Add abi field to `Method`

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -434,12 +434,14 @@ impl From<clean::Impl> for Impl {
     }
 }
 
+<<<<<<< HEAD
 crate fn from_function_method(function: clean::Function, has_body: bool) -> Method {
     let clean::Function { header, decl, generics, all_types: _, ret_types: _ } = function;
     Method {
         decl: decl.into(),
         generics: generics.into(),
         header: stringify_header(&header),
+        abi: header.abi.to_string(),
         has_body,
     }
 }

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -434,7 +434,6 @@ impl From<clean::Impl> for Impl {
     }
 }
 
-<<<<<<< HEAD
 crate fn from_function_method(function: clean::Function, has_body: bool) -> Method {
     let clean::Function { header, decl, generics, all_types: _, ret_types: _ } = function;
     Method {

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -294,6 +294,7 @@ pub struct Method {
     pub decl: FnDecl,
     pub generics: Generics,
     pub header: String,
+    pub abi: String,
     pub has_body: bool,
 }
 

--- a/src/test/rustdoc-json/method_abi.rs
+++ b/src/test/rustdoc-json/method_abi.rs
@@ -1,0 +1,25 @@
+// @has method_abi.json "$.index[*][?(@.name=='Foo')]"
+pub struct Foo;
+
+impl Foo {
+    // @has - "$.index[*][?(@.name=='abi_rust')].inner.abi" '"\"Rust\""'
+    pub fn abi_rust() {}
+
+    // @has - "$.index[*][?(@.name=='abi_c')].inner.abi" '"\"C\""'
+    pub extern "C" fn abi_c() {}
+
+    // @has - "$.index[*][?(@.name=='abi_system')].inner.abi" '"\"system\""'
+    pub extern "system" fn abi_system() {}
+}
+
+// @has method_abi.json "$.index[*][?(@.name=='Bar')]"
+pub trait Bar {
+    // @has - "$.index[*][?(@.name=='trait_abi_rust')].inner.abi" '"\"Rust\""'
+    fn trait_abi_rust();
+
+    // @has - "$.index[*][?(@.name=='trait_abi_c')].inner.abi" '"\"C\""'
+    extern "C" fn trait_abi_c();
+
+    // @has - "$.index[*][?(@.name=='trait_abi_system')].inner.abi" '"\"system\""'
+    extern "system" fn trait_abi_system();
+}


### PR DESCRIPTION
Also bumps version and adds a test (Will conflict with #81500, whichever is merged first)

Rationale: It's possible for methods to have an ABI. This should be exposed in the JSON.