### PR TITLE
Suggest to create a new `const` item if the `fn` in the array is a `const fn`

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -228,7 +228,10 @@ pub enum ObligationCauseCode<'tcx> {
     /// Inline asm operand type must be `Sized`.
     InlineAsmSized,
     /// `[T, ..n]` implies that `T` must be `Copy`.
-    RepeatVec,
+    /// If the function in the array repeat expression is a `const fn`,
+    /// display a help message suggesting to move the function call to a
+    /// new `const` item while saying that `T` doesn't implement `Copy`.
+    RepeatVec(bool),
 
     /// Types of fields (other than the last, except for packed structs) in a struct must be sized.
     FieldSized {

--- a/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
@@ -43,6 +43,9 @@ use rustc_trait_selection::traits::{self, ObligationCause, PredicateObligations}
 use crate::dataflow::impls::MaybeInitializedPlaces;
 use crate::dataflow::move_paths::MoveData;
 use crate::dataflow::ResultsCursor;
+use crate::transform::{
+    check_consts::ConstCx, promote_consts::is_const_fn_in_array_repeat_expression,
+};
 
 use crate::borrow_check::{
     borrow_set::BorrowSet,
@@ -1988,18 +1991,24 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                         Operand::Copy(..) | Operand::Constant(..) => {
                             // These are always okay: direct use of a const, or a value that can evidently be copied.
                         }
-                        Operand::Move(_) => {
+                        Operand::Move(place) => {
                             // Make sure that repeated elements implement `Copy`.
                             let span = body.source_info(location).span;
                             let ty = operand.ty(body, tcx);
                             if !self.infcx.type_is_copy_modulo_regions(self.param_env, ty, span) {
+                                let ccx = ConstCx::new_with_param_env(tcx, body, self.param_env);
+                                let is_const_fn =
+                                    is_const_fn_in_array_repeat_expression(&ccx, &place, &body);
+
+                                debug!("check_rvalue: is_const_fn={:?}", is_const_fn);
+
                                 let def_id = body.source.def_id().expect_local();
                                 self.infcx.report_selection_error(
                                     &traits::Obligation::new(
                                         ObligationCause::new(
                                             span,
                                             self.tcx().hir().local_def_id_to_hir_id(def_id),
-                                            traits::ObligationCauseCode::RepeatVec,
+                                            traits::ObligationCauseCode::RepeatVec(is_const_fn),
                                         ),
                                         self.param_env,
                                         ty::Binder::bind(ty::TraitRef::new(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1881,10 +1881,26 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             ObligationCauseCode::Coercion { source: _, target } => {
                 err.note(&format!("required by cast to type `{}`", self.ty_to_string(target)));
             }
-            ObligationCauseCode::RepeatVec => {
+            ObligationCauseCode::RepeatVec(is_const_fn) => {
                 err.note(
                     "the `Copy` trait is required because the repeated element will be copied",
                 );
+                if is_const_fn && !self.tcx.sess.is_nightly_build() {
+                    err.help(
+                        "consider creating a new `const` item and initializing with the result \
+                        of the function call to be used in the repeat position, like \
+                        `const VAL: Type = const_fn();` and `let x = [VAL; 42];`",
+                    );
+                } else if self.tcx.sess.is_nightly_build() && is_const_fn {
+                    err.help(
+                        "create an inline `const` block, see PR \
+                        #2920 <https://github.com/rust-lang/rfcs/pull/2920> \
+                        for more information",
+                    );
+                } else {
+                    // Don't suggest anything to the user as suggesting the user to make the function `const`
+                    // could lead them down the wrong path.
+                }
             }
             ObligationCauseCode::VariableType(hir_id) => {
                 let parent_node = self.tcx.hir().get_parent_node(hir_id);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -1885,21 +1885,21 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 err.note(
                     "the `Copy` trait is required because the repeated element will be copied",
                 );
-                if is_const_fn && !self.tcx.sess.is_nightly_build() {
+
+                if is_const_fn {
                     err.help(
                         "consider creating a new `const` item and initializing with the result \
                         of the function call to be used in the repeat position, like \
                         `const VAL: Type = const_fn();` and `let x = [VAL; 42];`",
                     );
-                } else if self.tcx.sess.is_nightly_build() && is_const_fn {
+                }
+
+                if self.tcx.sess.is_nightly_build() && is_const_fn {
                     err.help(
                         "create an inline `const` block, see PR \
                         #2920 <https://github.com/rust-lang/rfcs/pull/2920> \
                         for more information",
                     );
-                } else {
-                    // Don't suggest anything to the user as suggesting the user to make the function `const`
-                    // could lead them down the wrong path.
                 }
             }
             ObligationCauseCode::VariableType(hir_id) => {

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,5 @@
 This directory contains the source code of the rust project, including:
+
 - The test suite
 - The bootstrapping build system
 - Various submodules for tools, like rustdoc, rls, etc.

--- a/src/test/ui/consts/const-blocks/fn-call-in-non-const.stderr
+++ b/src/test/ui/consts/const-blocks/fn-call-in-non-const.stderr
@@ -7,6 +7,7 @@ LL |     let _: [Option<Bar>; 2] = [no_copy(); 2];
    = help: the following implementations were found:
              <Option<T> as Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
+   = help: create an inline `const` block, see PR #2920 <https://github.com/rust-lang/rfcs/pull/2920> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-blocks/fn-call-in-non-const.stderr
+++ b/src/test/ui/consts/const-blocks/fn-call-in-non-const.stderr
@@ -7,6 +7,7 @@ LL |     let _: [Option<Bar>; 2] = [no_copy(); 2];
    = help: the following implementations were found:
              <Option<T> as Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
+   = help: consider creating a new `const` item and initializing with the result of the function call to be used in the repeat position, like `const VAL: Type = const_fn();` and `let x = [VAL; 42];`
    = help: create an inline `const` block, see PR #2920 <https://github.com/rust-lang/rfcs/pull/2920> for more information
 
 error: aborting due to previous error

--- a/src/test/ui/consts/const-fn-in-vec.rs
+++ b/src/test/ui/consts/const-fn-in-vec.rs
@@ -1,6 +1,6 @@
 fn main() {
-    // should hint to create an inline const block
-    // as all tests are on "nightly"
+    // should hint to create an inline `const` block
+    // or to create a new `const` item
     let strings: [String; 5] = [String::new(); 5];
     //~^ ERROR the trait bound `String: Copy` is not satisfied
     println!("{:?}", strings);

--- a/src/test/ui/consts/const-fn-in-vec.rs
+++ b/src/test/ui/consts/const-fn-in-vec.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // should hint to create an inline const block
+    // as all tests are on "nightly"
+    let strings: [String; 5] = [String::new(); 5];
+    //~^ ERROR the trait bound `String: Copy` is not satisfied
+    println!("{:?}", strings);
+}

--- a/src/test/ui/consts/const-fn-in-vec.stderr
+++ b/src/test/ui/consts/const-fn-in-vec.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `String: Copy` is not satisfied
+  --> $DIR/const-fn-in-vec.rs:4:32
+   |
+LL |     let strings: [String; 5] = [String::new(); 5];
+   |                                ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
+   |
+   = note: the `Copy` trait is required because the repeated element will be copied
+   = help: create an inline `const` block, see PR #2920 <https://github.com/rust-lang/rfcs/pull/2920> for more information
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/consts/const-fn-in-vec.stderr
+++ b/src/test/ui/consts/const-fn-in-vec.stderr
@@ -5,6 +5,7 @@ LL |     let strings: [String; 5] = [String::new(); 5];
    |                                ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
    |
    = note: the `Copy` trait is required because the repeated element will be copied
+   = help: consider creating a new `const` item and initializing with the result of the function call to be used in the repeat position, like `const VAL: Type = const_fn();` and `let x = [VAL; 42];`
    = help: create an inline `const` block, see PR #2920 <https://github.com/rust-lang/rfcs/pull/2920> for more information
 
 error: aborting due to previous error


### PR DESCRIPTION
Fixes #73734. If the `fn` in the array repeat expression is a `const fn`, suggest creating a new `const` item. On nightly, suggest creating an inline `const` block. This PR also removes the `suggest_const_in_array_repeat_expressions` as it is no longer necessary. 

Example:

```rust
fn main() {
    // Should not compile but hint to create a new const item (stable) or an inline const block (nightly)
    let strings: [String; 5] = [String::new(); 5];
    println!("{:?}", strings);
}

```

Gives this error:

```
error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
 --> $DIR/const-fn-in-vec.rs:3:32
  |
2 |     let strings: [String; 5] = [String::new(); 5];
  |                             ^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `String`
  |
  = note: the `Copy` trait is required because the repeated element will be copied
```

With this change, this is the error message:

```
error[E0277]: the trait bound `String: Copy` is not satisfied
  --> $DIR/const-fn-in-vec.rs:3:32
   |
LL |     let strings: [String; 5] = [String::new(); 5];
   |                                ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
   |
   = help: moving the function call to a new `const` item will resolve the error
```