### PR TITLE
Don't print error output from rustup when detecting default build triple

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -194,7 +194,8 @@ def default_build_triple(verbose):
     # being detected as GNU instead of MSVC.
     default_encoding = sys.getdefaultencoding()
     try:
-        version = subprocess.check_output(["rustc", "--version", "--verbose"])
+        version = subprocess.check_output(["rustc", "--version", "--verbose"],
+                stderr=subprocess.DEVNULL)
         version = version.decode(default_encoding)
         host = next(x for x in version.split('\n') if x.startswith("host: "))
         triple = host.split("host: ")[1]


### PR DESCRIPTION
Before, it could print this error if no toolchain was configured:

```
error: no default toolchain configured
error: backtrace:
error: stack backtrace:
   0: error_chain::backtrace::imp::InternalBacktrace::new
   1: rustup::config::Cfg::toolchain_for_dir
   2: rustup_init::run_rustup_inner
   3: rustup_init::main
   4: std::rt::lang_start::{{closure}}
   5: main
   6: __libc_start_main
   7: _start
```