### PR TITLE
Update dist-various to Ubuntu 20.04

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-1/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   g++ \
   automake \
   bison \
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   g++-aarch64-linux-gnu \
   g++-mips64-linux-gnuabi64 \
   g++-mips64el-linux-gnuabi64 \
+  gcc-arm-none-eabi \
   gcc-sparc64-linux-gnu \
   libc6-dev-sparc64-cross \
   bzip2 \
@@ -42,11 +43,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   software-properties-common
 
 WORKDIR /build
-
-# Use the team-gcc-arm-embedded PPA for a newer version of Arm GCC
-RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends gcc-arm-embedded
 
 COPY host-x86_64/dist-various-1/build-rumprun.sh /build
 RUN ./build-rumprun.sh

--- a/src/ci/docker/host-x86_64/dist-various-1/build-rumprun.sh
+++ b/src/ci/docker/host-x86_64/dist-various-1/build-rumprun.sh
@@ -20,9 +20,10 @@ exit 1
 
 git clone https://github.com/rumpkernel/rumprun
 cd rumprun
-git reset --hard 39a97f37a85e44c69b662f6b97b688fbe892603b
+git reset --hard b04d42225a12a6fae57a78a9c1cf23642e46cd00
 git submodule update --init
 
-CC=cc hide_output ./build-rr.sh -d /usr/local hw
+# Disable -Werror, to avoid breaking the build with newer compilers.
+CC=cc NOGCCERROR=1 hide_output ./build-rr.sh -d /usr/local hw
 cd ..
 rm -rf rumprun

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh
@@ -9,12 +9,13 @@ RUN sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
 RUN apt-get update && apt-get build-dep -y clang llvm && apt-get install -y --no-install-recommends \
   build-essential \
 # gcc-multilib can not be installed together with gcc-arm-linux-gnueabi
-  gcc-7-multilib \
+  g++-8-multilib \
   libedit-dev \
   libgmp-dev \
   libisl-dev \
   libmpc-dev \
   libmpfr-dev \
+  libtinfo5 \
   ninja-build \
   nodejs \
   python3-dev \
@@ -23,7 +24,7 @@ RUN apt-get update && apt-get build-dep -y clang llvm && apt-get install -y --no
   # Needed for apt-key to work:
   dirmngr \
   gpg-agent \
-  g++-7-arm-linux-gnueabi
+  g++-8-arm-linux-gnueabi
 
 RUN apt-key adv --batch --yes --keyserver keyserver.ubuntu.com --recv-keys 74DA7924C5513486
 RUN add-apt-repository -y 'deb http://apt.dilos.org/dilos dilos2 main'
@@ -41,8 +42,8 @@ ENV \
     AR_x86_64_sun_solaris=x86_64-sun-solaris2.10-ar \
     CC_x86_64_sun_solaris=x86_64-sun-solaris2.10-gcc \
     CXX_x86_64_sun_solaris=x86_64-sun-solaris2.10-g++ \
-    CC_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-gcc-7 \
-    CXX_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-g++-7 \
+    CC_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-gcc-8 \
+    CXX_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-g++-8 \
     AR_x86_64_fortanix_unknown_sgx=ar \
     CC_x86_64_fortanix_unknown_sgx=x86_64-fortanix-unknown-sgx-clang-11 \
     CFLAGS_x86_64_fortanix_unknown_sgx="-mlvi-hardening -mllvm -x86-experimental-lvi-inline-asm-hardening" \
@@ -51,14 +52,14 @@ ENV \
     AR_i686_unknown_freebsd=i686-unknown-freebsd11-ar \
     CC_i686_unknown_freebsd=i686-unknown-freebsd11-clang \
     CXX_i686_unknown_freebsd=i686-unknown-freebsd11-clang++ \
-    CC=gcc-7 \
-    CXX=g++-7
+    CC=gcc-8 \
+    CXX=g++-8
 
 WORKDIR /build
 COPY scripts/musl.sh /build
 RUN env \
-    CC=arm-linux-gnueabi-gcc-7 CFLAGS="-march=armv7-a" \
-    CXX=arm-linux-gnueabi-g++-7 CXXFLAGS="-march=armv7-a" \
+    CC=arm-linux-gnueabi-gcc-8 CFLAGS="-march=armv7-a" \
+    CXX=arm-linux-gnueabi-g++-8 CXXFLAGS="-march=armv7-a" \
     bash musl.sh armv7 && \
     rm -rf /build/*
 
@@ -108,7 +109,7 @@ ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabi
 ENV TARGETS=$TARGETS,i686-unknown-freebsd
 
 # As per https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1300211
-# we need asm in the search path for gcc-7 (for gnux32) but not in the search path of the
+# we need asm in the search path for gcc-8 (for gnux32) but not in the search path of the
 # cross compilers.
 # Luckily one of the folders is /usr/local/include so symlink /usr/include/asm-generic there
 RUN ln -s /usr/include/asm-generic /usr/local/include/asm

--- a/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
@@ -7,7 +7,7 @@ ARCH=$1
 LIB_ARCH=$2
 APT_ARCH=$3
 BINUTILS=2.28.1
-GCC=6.4.0
+GCC=6.5.0
 
 # First up, build binutils
 mkdir binutils

--- a/src/ci/docker/host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh
@@ -7,7 +7,7 @@ target="x86_64-fortanix-unknown-sgx"
 
 install_prereq() {
     curl https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -
-    add-apt-repository -y 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
+    add-apt-repository -y 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
     apt-get update
     apt-get install -y --no-install-recommends \
             build-essential \

--- a/src/ci/docker/scripts/cross-apt-packages.sh
+++ b/src/ci/docker/scripts/cross-apt-packages.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-apt-get update && apt-get install -y --no-install-recommends \
+apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   automake \
   bison \
   bzip2 \


### PR DESCRIPTION
This updates the dist-various-1 and dist-various-2 images to Ubuntu
20.04. This requires some adjustments:

 * `DEBIAN_FRONTEND=noninteractive` required for apt install.
 * `team-gcc-argm-embedded` PPA does not support focal. However,
   we can simply use the distro-provided `gcc-arm-none-eabi`. Per
   the comment, the PPA was only used to get a newer version.
 * rumprun has to be updated to avoid a linker error.
 * We need to build rumrun with `NOGCCERROR`, which disables use
   of `-Werror` and allows building with a newer compiler.
 * We need to install `libtinfo5`, which appears to be a dependency
   of the clang used during the fuchsia build.
 * We need to switch to `g++-8` rather than `g++-7`, as at least
   `g++-7-arm-linux-gnueabi` is not available on focal.
 * We need to upgrade to GCC 6.5 for the Solaris build, as GCC 6.4
   does not support the newer libisl version.

r? @Mark-Simulacrum 