### PR TITLE
sys: use `process::abort()` instead of `arch::wasm32::unreachable()`

### DIFF
--- a/library/std/src/sys/wasm/thread.rs
+++ b/library/std/src/sys/wasm/thread.rs
@@ -86,7 +86,7 @@ pub fn my_id() -> u32 {
         if MY_ID == 0 {
             let mut cur = NEXT_ID.load(SeqCst);
             MY_ID = loop {
-                let next = cur.checked_add(1).unwrap_or_else(|| crate::arch::wasm32::unreachable());
+                let next = cur.checked_add(1).unwrap_or_else(|| crate::process::abort());
                 match NEXT_ID.compare_exchange(cur, next, SeqCst, SeqCst) {
                     Ok(_) => break next,
                     Err(i) => cur = i,


### PR DESCRIPTION
Rationale:

  - `abort()` lowers to `wasm32::unreachable()` anyway.
  - `abort()` isn't `unsafe`.
  - `abort()` matches the comment better.
  - `abort()` avoids confusion by future readers (e.g. https://github.com/rust-lang/rust/pull/81527): the naming of wasm's `unreachable` instruction is a bit unfortunate because it is not related to the `unreachable()` intrinsic (intended to trigger UB).

Codegen is likely to be different since `unreachable()` is `inline` while `abort()` is `cold`. Since it doesn't look like we are expecting here to trigger this case, the latter seems better anyway.