### PR TITLE
Remove incorrect `delay_span_bug`

### DIFF
--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -192,7 +192,6 @@ pub(super) fn check_fn<'a, 'tcx>(
         // possible cases.
         fcx.check_expr(&body.value);
         fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
-        tcx.sess.delay_span_bug(decl.output.span(), "`!Sized` return type");
     } else {
         fcx.require_type_is_sized(declared_ret_ty, decl.output.span(), traits::SizedReturnType);
         fcx.check_return_expr(&body.value);

--- a/src/test/ui/typeck/issue-80207-unsized-return.rs
+++ b/src/test/ui/typeck/issue-80207-unsized-return.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+trait Foo {
+    fn do_stuff() -> Self;
+}
+
+trait Bar {
+    type Output;
+}
+
+impl<T> Foo for dyn Bar<Output = T>
+where
+    Self: Sized,
+{
+    fn do_stuff() -> Self {
+        todo!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
The following code is supposed to compile

```rust
use std::ops::BitOr;

pub trait IntWrapper {
    type InternalStorage;
}

impl<T> BitOr for dyn IntWrapper<InternalStorage = T>
where
    Self: Sized,
    T: BitOr + BitOr<Output = T>,
{
    type Output = Self;
    fn bitor(self, _other: Self) -> Self {
        todo!()
    }
}
```

Before this change it would ICE. In #70998 the removed logic was added
to provide better suggestions, and the `delay_span_bug` guard was added
to  protect against a potential logic error when returning traits. As it
happens, there are cases, like the one above, where traits can indeed be
returned, so valid code was being rejected.

Fix (but not close) #80207.