### PR TITLE
Update test-various to Ubuntu 20.04

### DIFF
--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   g++ \
   make \
   ninja-build \

--- a/src/test/ui/command/command-setgroups.rs
+++ b/src/test/ui/command/command-setgroups.rs
@@ -3,6 +3,7 @@
 // ignore-cloudabi
 // ignore-emscripten
 // ignore-sgx
+// ignore-musl - returns dummy result for _SC_NGROUPS_MAX
 
 #![feature(rustc_private)]
 #![feature(setgroups)]


### PR DESCRIPTION
The test command-setgroups.rs is adjusted to skip on musl, where `sysconf(_SC_NGROUPS_MAX)` always returns a dummy value of 32, even though the actual value is 65536. I'm not sure why this only became a problem now, as the information I found indicates that this value changed in kernel version 2.6.4, which is ages ago.

I'm a bit unsure whether this one will go through, because I locally also saw a failure in std-backtrace.rs which went away on subsequent runs, and also had port assignment failures, but I think those might be on my side. I'm kind of curious how the code in https://github.com/rust-lang/rust/blob/b122908617436af187252572ed5db96850551380/library/std/src/net/test.rs#L43-L56 is supposed to work, as the directory names it checks don't seem to appear anywhere else.

r? @Mark-Simulacrum 