### PR TITLE
rustc_codegen_ssa: add time-passes output for each CGU compilation

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -119,6 +119,10 @@ fn reuse_workproduct_for_cgu(
 
 fn module_codegen(tcx: TyCtxt<'_>, cgu_name: rustc_span::Symbol) -> ModuleCodegenResult {
     let cgu = tcx.codegen_unit(cgu_name);
+    let _prof_timer = tcx.prof.extra_verbose_generic_activity(
+        "codegen_module",
+        &[cgu_name.to_string(), cgu.size_estimate().to_string()],
+    );
     let mono_items = cgu.items_in_deterministic_order(tcx);
 
     let mut module = new_module(tcx, cgu_name.as_str().to_string());

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -571,7 +571,7 @@ pub(crate) fn run_pass_manager(
     config: &ModuleConfig,
     thin: bool,
 ) {
-    let _timer = cgcx.prof.extra_verbose_generic_activity("LLVM_lto_optimize", &module.name[..]);
+    let _timer = cgcx.prof.extra_verbose_generic_activity("LLVM_lto_optimize", &[&module.name[..]]);
 
     // Now we have one massive module inside of llmod. Time to run the
     // LTO-specific optimization passes that LLVM provides.

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -620,14 +620,14 @@ pub(crate) unsafe fn optimize(
         {
             let _timer = cgcx.prof.extra_verbose_generic_activity(
                 "LLVM_module_optimize_function_passes",
-                &module.name[..],
+                &[&module.name[..]],
             );
             llvm::LLVMRustRunFunctionPassManager(fpm, llmod);
         }
         {
             let _timer = cgcx.prof.extra_verbose_generic_activity(
                 "LLVM_module_optimize_module_passes",
-                &module.name[..],
+                &[&module.name[..]],
             );
             llvm::LLVMRunPassManager(mpm, llmod);
         }

--- a/compiler/rustc_codegen_llvm/src/base.rs
+++ b/compiler/rustc_codegen_llvm/src/base.rs
@@ -108,7 +108,7 @@ pub fn compile_codegen_unit(
 
     fn module_codegen(tcx: TyCtxt<'_>, cgu_name: Symbol) -> ModuleCodegen<ModuleLlvm> {
         let cgu = tcx.codegen_unit(cgu_name);
-        let _prof_timer = tcx.prof.generic_activity_with_args(
+        let _prof_timer = tcx.prof.extra_verbose_generic_activity(
             "codegen_module",
             &[cgu_name.to_string(), cgu.size_estimate().to_string()],
         );

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1544,7 +1544,7 @@ fn start_executing_work<B: ExtraBackendMethods>(
         llvm_start_time: &mut Option<VerboseTimingGuard<'a>>,
     ) {
         if config.time_module && llvm_start_time.is_none() {
-            *llvm_start_time = Some(prof.extra_verbose_generic_activity("LLVM_passes", "crate"));
+            *llvm_start_time = Some(prof.extra_verbose_generic_activity("LLVM_passes", &["crate"]));
         }
     }
 }

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -363,7 +363,7 @@ pub fn check_ast_crate<T: EarlyLintPass>(
     } else {
         for pass in &mut passes {
             buffered =
-                sess.prof.extra_verbose_generic_activity("run_lint", pass.name()).run(|| {
+                sess.prof.extra_verbose_generic_activity("run_lint", &[pass.name()]).run(|| {
                     early_lint_crate(
                         sess,
                         lint_store,

--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -462,20 +462,23 @@ fn late_lint_crate<'tcx, T: LateLintPass<'tcx>>(tcx: TyCtxt<'tcx>, builtin_lints
         late_lint_pass_crate(tcx, builtin_lints);
     } else {
         for pass in &mut passes {
-            tcx.sess.prof.extra_verbose_generic_activity("run_late_lint", pass.name()).run(|| {
-                late_lint_pass_crate(tcx, LateLintPassObjects { lints: slice::from_mut(pass) });
-            });
+            tcx.sess.prof.extra_verbose_generic_activity("run_late_lint", &[pass.name()]).run(
+                || {
+                    late_lint_pass_crate(tcx, LateLintPassObjects { lints: slice::from_mut(pass) });
+                },
+            );
         }
 
         let mut passes: Vec<_> =
             unerased_lint_store(tcx).late_module_passes.iter().map(|pass| (pass)()).collect();
 
         for pass in &mut passes {
-            tcx.sess.prof.extra_verbose_generic_activity("run_late_module_lint", pass.name()).run(
-                || {
+            tcx.sess
+                .prof
+                .extra_verbose_generic_activity("run_late_module_lint", &[pass.name()])
+                .run(|| {
                     late_lint_pass_crate(tcx, LateLintPassObjects { lints: slice::from_mut(pass) });
-                },
-            );
+                });
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -1242,7 +1242,7 @@ where
     let _timer = tcx
         .sess
         .prof
-        .extra_verbose_generic_activity("encode_query_results_for", std::any::type_name::<Q>());
+        .extra_verbose_generic_activity("encode_query_results_for", &[std::any::type_name::<Q>()]);
 
     let state = Q::query_state(tcx);
     assert!(state.all_inactive());

--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -66,7 +66,7 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
     let prof = &tcx.sess.prof;
 
     let (mut format_renderer, mut krate) = prof
-        .extra_verbose_generic_activity("create_renderer", T::descr())
+        .extra_verbose_generic_activity("create_renderer", &[T::descr()])
         .run(|| T::init(krate, options, render_info, edition, cache, tcx))?;
 
     let mut item = match krate.module.take() {
@@ -106,6 +106,6 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
                 .run(|| cx.item(item))?;
         }
     }
-    prof.extra_verbose_generic_activity("renderer_after_krate", T::descr())
+    prof.extra_verbose_generic_activity("renderer_after_krate", &[T::descr()])
         .run(|| format_renderer.after_krate(&krate, diag))
 }


### PR DESCRIPTION
Add time-passes event for each CGU compilation to LLVM IR. This is
useful to measure, as the event can cause a large increase in RSS.

Also, allow `extra_verbose_generic_activity` to accept multiple event
arguments.