### PR TITLE
Fix early lints inside an async desugaring

### DIFF
--- a/src/test/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.rs
+++ b/src/test/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.rs
@@ -1,4 +1,5 @@
 // check-pass
+// edition:2018
 #![warn(semicolon_in_expressions_from_macros)]
 
 #[allow(dead_code)]
@@ -9,6 +10,11 @@ macro_rules! foo {
               //~| WARN trailing
               //~| WARN this was previously
     }
+}
+
+#[allow(semicolon_in_expressions_from_macros)]
+async fn bar() {
+    foo!(first);
 }
 
 fn main() {

--- a/src/test/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
+++ b/src/test/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
@@ -1,5 +1,5 @@
 warning: trailing semicolon in macro used in expression position
-  --> $DIR/semicolon-in-expressions-from-macros.rs:7:13
+  --> $DIR/semicolon-in-expressions-from-macros.rs:8:13
    |
 LL |         true;
    |             ^
@@ -8,7 +8,7 @@ LL |         foo!(first)
    |         ----------- in this macro invocation
    |
 note: the lint level is defined here
-  --> $DIR/semicolon-in-expressions-from-macros.rs:2:9
+  --> $DIR/semicolon-in-expressions-from-macros.rs:3:9
    |
 LL | #![warn(semicolon_in_expressions_from_macros)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | #![warn(semicolon_in_expressions_from_macros)]
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: trailing semicolon in macro used in expression position
-  --> $DIR/semicolon-in-expressions-from-macros.rs:7:13
+  --> $DIR/semicolon-in-expressions-from-macros.rs:8:13
    |
 LL |         true;
    |             ^


### PR DESCRIPTION
Fixes #81531

When we buffer an early lint for a macro invocation,
we need to determine which NodeId to take the lint level from.
Currently, we use the NodeId of the closest def parent. However, if
the macro invocation is inside the desugared closure from an `async fn`
or async closure, that NodeId does not actually exist in the AST.

This commit uses the parent of a desugared closure when computing
`lint_node_id`, which is something that actually exists in the AST (an
`async fn` or async closure).