### PR TITLE
Edit rustc_typeck top-level docs

### DIFF
--- a/compiler/rustc_typeck/src/check/mod.rs
+++ b/compiler/rustc_typeck/src/check/mod.rs
@@ -52,13 +52,13 @@ The types of top-level items, which never contain unbound type
 variables, are stored directly into the `tcx` typeck_results.
 
 N.B., a type variable is not the same thing as a type parameter.  A
-type variable is rather an "instance" of a type parameter: that is,
-given a generic function `fn foo<T>(t: T)`: while checking the
+type variable is an instance of a type parameter. That is,
+given a generic function `fn foo<T>(t: T)`, while checking the
 function `foo`, the type `ty_param(0)` refers to the type `T`, which
-is treated in abstract.  When `foo()` is called, however, `T` will be
+is treated in abstract. However, when `foo()` is called, `T` will be
 substituted for a fresh type variable `N`.  This variable will
 eventually be resolved to some concrete type (which might itself be
-type parameter).
+a type parameter).
 
 */
 

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -7,9 +7,9 @@ The type checker is responsible for:
 1. Determining the type of each expression.
 2. Resolving methods and traits.
 3. Guaranteeing that most type rules are met. ("Most?", you say, "why most?"
-   Well, dear reader, read on)
+   Well, dear reader, read on.)
 
-The main entry point is `check_crate()`. Type checking operates in
+The main entry point is [`check_crate()`]. Type checking operates in
 several major phases:
 
 1. The collect phase first passes over all items and determines their
@@ -25,7 +25,7 @@ several major phases:
    containing function).  Inference is used to supply types wherever
    they are unknown. The actual checking of a function itself has
    several phases (check, regionck, writeback), as discussed in the
-   documentation for the `check` module.
+   documentation for the [`check`] module.
 
 The type checker is defined into various submodules which are documented
 independently:


### PR DESCRIPTION
Edit punctuation and wording in note on type variables vs. type parameters.

Also add missing punctuation and two inter-doc links.