### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5388,7 +5388,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.0",
+ "parking_lot 0.9.0",
  "regex",
  "serde",
  "serde_json",

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -507,7 +507,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         let count = generics
                             .params
                             .iter()
-                            .filter(|param| matches!(param.kind, ast::GenericParamKind::Lifetime { .. }))
+                            .filter(|param| {
+                                matches!(param.kind, ast::GenericParamKind::Lifetime { .. })
+                            })
                             .count();
                         self.lctx.type_def_lifetime_params.insert(def_id.to_def_id(), count);
                     }

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -598,7 +598,7 @@ impl<'a> TraitDef<'a> {
 
             let mut ty_params = params
                 .iter()
-                .filter(|param| matches!(param.kind,  ast::GenericParamKind::Type{..}))
+                .filter(|param| matches!(param.kind, ast::GenericParamKind::Type { .. }))
                 .peekable();
 
             if ty_params.peek().is_some() {

--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -36,7 +36,7 @@ macro_rules! forward_inner_docs {
     ($e:expr => $i:item) => {
         #[doc = $e]
         $i
-    }
+    };
 }
 
 /// In general, the `DiagnosticBuilder` uses deref to allow access to

--- a/compiler/rustc_errors/src/snippet.rs
+++ b/compiler/rustc_errors/src/snippet.rs
@@ -122,11 +122,13 @@ impl Annotation {
     }
 
     pub fn is_multiline(&self) -> bool {
-        matches!(self.annotation_type,
+        matches!(
+            self.annotation_type,
             AnnotationType::Multiline(_)
-            | AnnotationType::MultilineStart(_)
-            | AnnotationType::MultilineLine(_)
-            | AnnotationType::MultilineEnd(_))
+                | AnnotationType::MultilineStart(_)
+                | AnnotationType::MultilineLine(_)
+                | AnnotationType::MultilineEnd(_)
+        )
     }
 
     pub fn len(&self) -> usize {
@@ -158,7 +160,10 @@ impl Annotation {
 
     pub fn takes_space(&self) -> bool {
         // Multiline annotations always have to keep vertical space.
-        matches!(self.annotation_type, AnnotationType::MultilineStart(_) | AnnotationType::MultilineEnd(_))
+        matches!(
+            self.annotation_type,
+            AnnotationType::MultilineStart(_) | AnnotationType::MultilineEnd(_)
+        )
     }
 }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1543,10 +1543,10 @@ pub fn is_range_literal(expr: &Expr<'_>) -> bool {
             **qpath,
             QPath::LangItem(
                 LangItem::Range
-                | LangItem::RangeTo
-                | LangItem::RangeFrom
-                | LangItem::RangeFull
-                | LangItem::RangeToInclusive,
+                    | LangItem::RangeTo
+                    | LangItem::RangeFrom
+                    | LangItem::RangeFull
+                    | LangItem::RangeToInclusive,
                 _,
             )
         ),

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -543,10 +543,6 @@ impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
         true
     }
 
-    fn visit_ct_substs(&self) -> bool {
-        true
-    }
-
     fn binders<T>(
         &mut self,
         a: ty::Binder<T>,
@@ -737,6 +733,16 @@ impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
                     }
                 }
             }
+            ty::ConstKind::Unevaluated(def, substs, promoted)
+                if self.tcx().lazy_normalization() =>
+            {
+                assert_eq!(promoted, None);
+                let substs = self.relate_with_variance(ty::Variance::Invariant, substs, substs)?;
+                Ok(self.tcx().mk_const(ty::Const {
+                    ty: c.ty,
+                    val: ty::ConstKind::Unevaluated(def, substs, promoted),
+                }))
+            }
             _ => relate::super_relate_consts(self, c, c),
         }
     }
@@ -819,10 +825,6 @@ impl TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
     }
 
     fn a_is_expected(&self) -> bool {
-        true
-    }
-
-    fn visit_ct_substs(&self) -> bool {
         true
     }
 
@@ -958,6 +960,16 @@ impl TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
                         }
                     }
                 }
+            }
+            ty::ConstKind::Unevaluated(def, substs, promoted)
+                if self.tcx().lazy_normalization() =>
+            {
+                assert_eq!(promoted, None);
+                let substs = self.relate_with_variance(ty::Variance::Invariant, substs, substs)?;
+                Ok(self.tcx().mk_const(ty::Const {
+                    ty: c.ty,
+                    val: ty::ConstKind::Unevaluated(def, substs, promoted),
+                }))
             }
             _ => relate::super_relate_consts(self, c, c),
         }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -132,7 +132,12 @@ impl Visitor<'tcx> for TypeParamSpanVisitor<'tcx> {
                 [segment]
                     if segment
                         .res
-                        .map(|res| matches!(res, Res::SelfTy(_, _) | Res::Def(hir::def::DefKind::TyParam, _)))
+                        .map(|res| {
+                            matches!(
+                                res,
+                                Res::SelfTy(_, _) | Res::Def(hir::def::DefKind::TyParam, _)
+                            )
+                        })
                         .unwrap_or(false) =>
                 {
                     self.types.push(path.span);

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3002,7 +3002,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// # #![deny(disjoint_capture_drop_reorder)]
     /// # #![allow(unused)]
     /// struct FancyInteger(i32);

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2968,6 +2968,7 @@ declare_lint_pass! {
         UNSUPPORTED_NAKED_FUNCTIONS,
         MISSING_ABI,
         SEMICOLON_IN_EXPRESSIONS_FROM_MACROS,
+        DISJOINT_CAPTURE_DROP_REORDER,
     ]
 }
 
@@ -2992,6 +2993,51 @@ declare_lint! {
     pub UNUSED_DOC_COMMENTS,
     Warn,
     "detects doc comments that aren't used by rustdoc"
+}
+
+declare_lint! {
+    /// The `disjoint_capture_drop_reorder` lint detects variables that aren't completely
+    /// captured when the feature `capture_disjoint_fields` is enabled and it affects the Drop
+    /// order of at least one path starting at this variable.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # #![deny(disjoint_capture_drop_reorder)]
+    /// # #![allow(unused)]
+    /// struct FancyInteger(i32);
+    ///
+    /// impl Drop for FancyInteger {
+    ///     fn drop(&mut self) {
+    ///         println!("Just dropped {}", self.0);
+    ///     }
+    /// }
+    ///
+    /// struct Point { x: FancyInteger, y: FancyInteger }
+    ///
+    /// fn main() {
+    ///   let p = Point { x: FancyInteger(10), y: FancyInteger(20) };
+    ///
+    ///   let c = || {
+    ///      let x = p.x;
+    ///   };
+    ///
+    ///   c();
+    ///
+    ///   // ... More code ...
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// In the above example `p.y` will be dropped at the end of `f` instead of with `c` if
+    /// the feature `capture_disjoint_fields` is enabled.
+    pub DISJOINT_CAPTURE_DROP_REORDER,
+    Allow,
+    "Drop reorder because of `capture_disjoint_fields`"
+
 }
 
 declare_lint_pass!(UnusedDocComment => [UNUSED_DOC_COMMENTS]);

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -559,9 +559,9 @@ impl<'hir> Map<'hir> {
             self.find(self.get_parent_node(id)),
             Some(
                 Node::Item(_)
-                | Node::TraitItem(_)
-                | Node::ImplItem(_)
-                | Node::Expr(Expr { kind: ExprKind::Closure(..), .. }),
+                    | Node::TraitItem(_)
+                    | Node::ImplItem(_)
+                    | Node::Expr(Expr { kind: ExprKind::Closure(..), .. }),
             )
         )
     }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -962,8 +962,7 @@ impl<'tcx> LocalDecl<'tcx> {
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,
-                })
-                | BindingForm::ImplicitSelf(ImplicitSelfKind::Imm),
+                }) | BindingForm::ImplicitSelf(ImplicitSelfKind::Imm),
             )))
         )
     }
@@ -980,8 +979,7 @@ impl<'tcx> LocalDecl<'tcx> {
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,
-                })
-                | BindingForm::ImplicitSelf(_),
+                }) | BindingForm::ImplicitSelf(_),
             )))
         )
     }

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -13,13 +13,17 @@ impl<'tcx> TyS<'tcx> {
     pub fn is_primitive_ty(&self) -> bool {
         matches!(
             self.kind(),
-            Bool | Char | Str | Int(_) | Uint(_) | Float(_)
-            | Infer(
-                InferTy::IntVar(_)
-                | InferTy::FloatVar(_)
-                | InferTy::FreshIntTy(_)
-                | InferTy::FreshFloatTy(_)
-            )
+            Bool | Char
+                | Str
+                | Int(_)
+                | Uint(_)
+                | Float(_)
+                | Infer(
+                    InferTy::IntVar(_)
+                        | InferTy::FloatVar(_)
+                        | InferTy::FreshIntTy(_)
+                        | InferTy::FreshFloatTy(_)
+                )
         )
     }
 

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -647,11 +647,14 @@ impl<T> Trait<T> for X {
         let current_method_ident = body_owner.and_then(|n| n.ident()).map(|i| i.name);
 
         // We don't want to suggest calling an assoc fn in a scope where that isn't feasible.
-        let callable_scope = matches!(body_owner, Some(
+        let callable_scope = matches!(
+            body_owner,
+            Some(
                 hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(..), .. })
-                | hir::Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Fn(..), .. })
-                | hir::Node::ImplItem(hir::ImplItem { kind: hir::ImplItemKind::Fn(..), .. }),
-            ));
+                    | hir::Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Fn(..), .. })
+                    | hir::Node::ImplItem(hir::ImplItem { kind: hir::ImplItemKind::Fn(..), .. }),
+            )
+        );
         let impl_comparison = matches!(
             cause_code,
             ObligationCauseCode::CompareImplMethodObligation { .. }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -675,6 +675,8 @@ pub struct CapturedPlace<'tcx> {
 }
 
 impl CapturedPlace<'tcx> {
+    /// Returns the hir-id of the root variable for the captured place.
+    /// e.g., if `a.b.c` was captured, would return the hir-id for `a`.
     pub fn get_root_variable(&self) -> hir::HirId {
         match self.place.base {
             HirPlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -674,6 +674,15 @@ pub struct CapturedPlace<'tcx> {
     pub mutability: hir::Mutability,
 }
 
+impl CapturedPlace<'tcx> {
+    pub fn get_root_variable(&self) -> hir::HirId {
+        match self.place.base {
+            HirPlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
+            base => bug!("Expected upvar, found={:?}", base),
+        }
+    }
+}
+
 pub fn place_to_string_for_capture(tcx: TyCtxt<'tcx>, place: &HirPlace<'tcx>) -> String {
     let name = match place.base {
         HirPlaceBase::Upvar(upvar_id) => tcx.hir().name(upvar_id.var_path.hir_id).to_string(),

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -661,11 +661,17 @@ pub type RootVariableMinCaptureList<'tcx> = FxIndexMap<hir::HirId, MinCaptureLis
 /// Part of `MinCaptureInformationMap`; List of `CapturePlace`s.
 pub type MinCaptureList<'tcx> = Vec<CapturedPlace<'tcx>>;
 
-/// A `Place` and the corresponding `CaptureInfo`.
+/// A composite describing a `Place` that is captured by a closure.
 #[derive(PartialEq, Clone, Debug, TyEncodable, TyDecodable, TypeFoldable, HashStable)]
 pub struct CapturedPlace<'tcx> {
+    /// The `Place` that is captured.
     pub place: HirPlace<'tcx>,
+
+    /// `CaptureKind` and expression(s) that resulted in such capture of `place`.
     pub info: CaptureInfo<'tcx>,
+
+    /// Represents if `place` can be mutated or not.
+    pub mutability: hir::Mutability,
 }
 
 pub fn place_to_string_for_capture(tcx: TyCtxt<'tcx>, place: &HirPlace<'tcx>) -> String {

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -33,15 +33,6 @@ pub trait TypeRelation<'tcx>: Sized {
     /// relation. Just affects error messages.
     fn a_is_expected(&self) -> bool;
 
-    /// Whether we should look into the substs of unevaluated constants
-    /// even if `feature(const_evaluatable_checked)` is active.
-    ///
-    /// This is needed in `combine` to prevent accidentially creating
-    /// infinite types as we abuse `TypeRelation` to walk a type there.
-    fn visit_ct_substs(&self) -> bool {
-        false
-    }
-
     fn with_cause<F, R>(&mut self, _cause: Cause, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
@@ -588,7 +579,7 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
         (
             ty::ConstKind::Unevaluated(a_def, a_substs, None),
             ty::ConstKind::Unevaluated(b_def, b_substs, None),
-        ) if tcx.features().const_evaluatable_checked && !relation.visit_ct_substs() => {
+        ) if tcx.features().const_evaluatable_checked => {
             if tcx.try_unify_abstract_consts(((a_def, a_substs), (b_def, b_substs))) {
                 Ok(a.val)
             } else {

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1927,8 +1927,14 @@ impl<'tcx> TyS<'tcx> {
     pub fn is_scalar(&self) -> bool {
         matches!(
             self.kind(),
-            Bool | Char | Int(_) | Float(_) | Uint(_) | FnDef(..) | FnPtr(_) | RawPtr(_)
-            | Infer(IntVar(_) | FloatVar(_))
+            Bool | Char
+                | Int(_)
+                | Float(_)
+                | Uint(_)
+                | FnDef(..)
+                | FnPtr(_)
+                | RawPtr(_)
+                | Infer(IntVar(_) | FloatVar(_))
         )
     }
 

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
@@ -215,6 +215,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             PlaceRef { local, projection: [proj_base @ .., elem] } => {
                 match elem {
                     ProjectionElem::Deref => {
+                        // FIXME(project-rfc_2229#36): print capture precisely here.
                         let upvar_field_projection = self.is_upvar_field_projection(place);
                         if let Some(field) = upvar_field_projection {
                             let var_index = field.index();
@@ -259,6 +260,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     ProjectionElem::Field(field, _ty) => {
                         autoderef = true;
 
+                        // FIXME(project-rfc_2229#36): print capture precisely here.
                         let upvar_field_projection = self.is_upvar_field_projection(place);
                         if let Some(field) = upvar_field_projection {
                             let var_index = field.index();

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/move_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/move_errors.rs
@@ -345,7 +345,9 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 };
 
                 let upvar = &self.upvars[upvar_field.unwrap().index()];
-                let upvar_hir_id = upvar.var_hir_id;
+                // FIXME(project-rfc-2229#8): Improve borrow-check diagnostics in case of precise
+                //                            capture.
+                let upvar_hir_id = upvar.place.get_root_variable();
                 let upvar_name = upvar.name;
                 let upvar_span = self.infcx.tcx.hir().span(upvar_hir_id);
 

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
@@ -64,12 +64,29 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     Place::ty_from(local, proj_base, self.body, self.infcx.tcx).ty
                 ));
 
-                item_msg = format!("`{}`", access_place_desc.unwrap());
-                if self.is_upvar_field_projection(access_place.as_ref()).is_some() {
-                    reason = ", as it is not declared as mutable".to_string();
+                let imm_borrow_derefed = self.upvars[upvar_index.index()]
+                    .place
+                    .place
+                    .deref_tys()
+                    .any(|ty| matches!(ty.kind(), ty::Ref(.., hir::Mutability::Not)));
+
+                // If the place is immutable then:
+                //
+                // - Either we deref a immutable ref to get to our final place.
+                //    - We don't capture derefs of raw ptrs
+                // - Or the final place is immut because the root variable of the capture
+                //   isn't marked mut and we should suggest that to the user.
+                if imm_borrow_derefed {
+                    // If we deref an immutable ref then the suggestion here doesn't help.
+                    return;
                 } else {
-                    let name = self.upvars[upvar_index.index()].name;
-                    reason = format!(", as `{}` is not declared as mutable", name);
+                    item_msg = format!("`{}`", access_place_desc.unwrap());
+                    if self.is_upvar_field_projection(access_place.as_ref()).is_some() {
+                        reason = ", as it is not declared as mutable".to_string();
+                    } else {
+                        let name = self.upvars[upvar_index.index()].name;
+                        reason = format!(", as `{}` is not declared as mutable", name);
+                    }
                 }
             }
 
@@ -259,9 +276,12 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     Place::ty_from(local, proj_base, self.body, self.infcx.tcx).ty
                 ));
 
+                let captured_place = &self.upvars[upvar_index.index()].place;
+
                 err.span_label(span, format!("cannot {ACT}", ACT = act));
 
-                let upvar_hir_id = self.upvars[upvar_index.index()].var_hir_id;
+                let upvar_hir_id = captured_place.get_root_variable();
+
                 if let Some(Node::Binding(pat)) = self.infcx.tcx.hir().find(upvar_hir_id) {
                     if let hir::PatKind::Binding(
                         hir::BindingAnnotation::Unannotated,

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/var_name.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/var_name.rs
@@ -12,7 +12,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         tcx: TyCtxt<'tcx>,
         body: &Body<'tcx>,
         local_names: &IndexVec<Local, Option<Symbol>>,
-        upvars: &[Upvar],
+        upvars: &[Upvar<'tcx>],
         fr: RegionVid,
     ) -> Option<(Option<Symbol>, Span)> {
         debug!("get_var_name_and_span_for_region(fr={:?})", fr);
@@ -21,6 +21,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         debug!("get_var_name_and_span_for_region: attempting upvar");
         self.get_upvar_index_for_region(tcx, fr)
             .map(|index| {
+                // FIXME(project-rfc-2229#8): Use place span for diagnostics
                 let (name, span) = self.get_upvar_name_and_span_for_region(tcx, upvars, index);
                 (Some(name), span)
             })
@@ -59,10 +60,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     crate fn get_upvar_name_and_span_for_region(
         &self,
         tcx: TyCtxt<'tcx>,
-        upvars: &[Upvar],
+        upvars: &[Upvar<'tcx>],
         upvar_index: usize,
     ) -> (Symbol, Span) {
-        let upvar_hir_id = upvars[upvar_index].var_hir_id;
+        let upvar_hir_id = upvars[upvar_index].place.get_root_variable();
         debug!("get_upvar_name_and_span_for_region: upvar_hir_id={:?}", upvar_hir_id);
 
         let upvar_name = tcx.hir().name(upvar_hir_id);

--- a/compiler/rustc_mir/src/borrow_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/mod.rs
@@ -1358,10 +1358,10 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
     fn propagate_closure_used_mut_upvar(&mut self, operand: &Operand<'tcx>) {
         let propagate_closure_used_mut_place = |this: &mut Self, place: Place<'tcx>| {
-            // We have three possiblities here:
+            // We have three possibilities here:
             // a. We are modifying something through a mut-ref
             // b. We are modifying something that is local to our parent
-            // c. Current body is a nested clsoure, and we are modifying path starting from
+            // c. Current body is a nested closure, and we are modifying path starting from
             //    a Place captured by our parent closure.
 
             // Handle (c), the path being modified is exactly the path captured by our parent

--- a/compiler/rustc_mir/src/borrow_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/mod.rs
@@ -170,17 +170,12 @@ fn do_mir_borrowck<'a, 'tcx>(
                 ty::UpvarCapture::ByValue(_) => false,
                 ty::UpvarCapture::ByRef(..) => true,
             };
-            let mut upvar = Upvar {
+            Upvar {
                 name: tcx.hir().name(var_hir_id),
                 var_hir_id,
                 by_ref,
-                mutability: Mutability::Not,
-            };
-            let bm = *tables.pat_binding_modes().get(var_hir_id).expect("missing binding mode");
-            if bm == ty::BindByValue(hir::Mutability::Mut) {
-                upvar.mutability = Mutability::Mut;
+                mutability: captured_place.mutability,
             }
-            upvar
         })
         .collect();
 

--- a/compiler/rustc_mir/src/borrow_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/mod.rs
@@ -5,11 +5,10 @@ use rustc_data_structures::graph::dominators::Dominators;
 use rustc_errors::{Applicability, Diagnostic, DiagnosticBuilder, ErrorReported};
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
-use rustc_hir::{HirId, Node};
+use rustc_hir::Node;
 use rustc_index::bit_set::BitSet;
 use rustc_index::vec::IndexVec;
 use rustc_infer::infer::{InferCtxt, TyCtxtInferExt};
-use rustc_middle::hir::place::PlaceBase as HirPlaceBase;
 use rustc_middle::mir::{
     traversal, Body, ClearCrossCrate, Local, Location, Mutability, Operand, Place, PlaceElem,
     PlaceRef, VarDebugInfoContents,
@@ -18,7 +17,7 @@ use rustc_middle::mir::{AggregateKind, BasicBlock, BorrowCheckResult, BorrowKind
 use rustc_middle::mir::{Field, ProjectionElem, Promoted, Rvalue, Statement, StatementKind};
 use rustc_middle::mir::{InlineAsmOperand, Terminator, TerminatorKind};
 use rustc_middle::ty::query::Providers;
-use rustc_middle::ty::{self, ParamEnv, RegionVid, TyCtxt};
+use rustc_middle::ty::{self, CapturedPlace, ParamEnv, RegionVid, TyCtxt};
 use rustc_session::lint::builtin::{MUTABLE_BORROW_RESERVATION_CONFLICT, UNUSED_MUT};
 use rustc_span::{Span, Symbol, DUMMY_SP};
 
@@ -73,16 +72,15 @@ crate use region_infer::RegionInferenceContext;
 
 // FIXME(eddyb) perhaps move this somewhere more centrally.
 #[derive(Debug)]
-crate struct Upvar {
+crate struct Upvar<'tcx> {
+    // FIXME(project-rfc-2229#8): ty::CapturePlace should have a to_string(), or similar
+    //                           then this should not be needed.
     name: Symbol,
 
-    // FIXME(project-rfc-2229#8): This should use Place or something similar
-    var_hir_id: HirId,
+    place: CapturedPlace<'tcx>,
 
     /// If true, the capture is behind a reference.
     by_ref: bool,
-
-    mutability: Mutability,
 }
 
 const DEREF_PROJECTION: &[PlaceElem<'_>; 1] = &[ProjectionElem::Deref];
@@ -161,21 +159,13 @@ fn do_mir_borrowck<'a, 'tcx>(
     let upvars: Vec<_> = tables
         .closure_min_captures_flattened(def.did.to_def_id())
         .map(|captured_place| {
-            let var_hir_id = match captured_place.place.base {
-                HirPlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
-                _ => bug!("Expected upvar"),
-            };
+            let var_hir_id = captured_place.get_root_variable();
             let capture = captured_place.info.capture_kind;
             let by_ref = match capture {
                 ty::UpvarCapture::ByValue(_) => false,
                 ty::UpvarCapture::ByRef(..) => true,
             };
-            Upvar {
-                name: tcx.hir().name(var_hir_id),
-                var_hir_id,
-                by_ref,
-                mutability: captured_place.mutability,
-            }
+            Upvar { name: tcx.hir().name(var_hir_id), place: captured_place.clone(), by_ref }
         })
         .collect();
 
@@ -544,7 +534,7 @@ crate struct MirBorrowckCtxt<'cx, 'tcx> {
     dominators: Dominators<BasicBlock>,
 
     /// Information about upvars not necessarily preserved in types or MIR
-    upvars: Vec<Upvar>,
+    upvars: Vec<Upvar<'tcx>>,
 
     /// Names of local (user) variables (extracted from `var_debug_info`).
     local_names: IndexVec<Local, Option<Symbol>>,
@@ -2251,7 +2241,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                  place={:?}",
                                 upvar, is_local_mutation_allowed, place
                             );
-                            match (upvar.mutability, is_local_mutation_allowed) {
+                            match (upvar.place.mutability, is_local_mutation_allowed) {
                                 (
                                     Mutability::Not,
                                     LocalMutationIsAllowed::No

--- a/compiler/rustc_mir/src/borrow_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/mod.rs
@@ -73,8 +73,7 @@ crate use region_infer::RegionInferenceContext;
 // FIXME(eddyb) perhaps move this somewhere more centrally.
 #[derive(Debug)]
 crate struct Upvar<'tcx> {
-    // FIXME(project-rfc-2229#8): ty::CapturePlace should have a to_string(), or similar
-    //                           then this should not be needed.
+    // FIXME(project-rfc_2229#36): print capture precisely here.
     name: Symbol,
 
     place: CapturedPlace<'tcx>,
@@ -2156,6 +2155,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         place: PlaceRef<'tcx>,
         is_local_mutation_allowed: LocalMutationIsAllowed,
     ) -> Result<RootPlace<'tcx>, PlaceRef<'tcx>> {
+        debug!("is_mutable: place={:?}, is_local...={:?}", place, is_local_mutation_allowed);
         match place.last_projection() {
             None => {
                 let local = &self.body.local_decls[place.local];
@@ -2237,9 +2237,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         if let Some(field) = upvar_field_projection {
                             let upvar = &self.upvars[field.index()];
                             debug!(
-                                "upvar.mutability={:?} local_mutation_is_allowed={:?} \
-                                 place={:?}",
-                                upvar, is_local_mutation_allowed, place
+                                "is_mutable: upvar.mutability={:?} local_mutation_is_allowed={:?} \
+                                 place={:?}, place_base={:?}",
+                                upvar, is_local_mutation_allowed, place, place_base
                             );
                             match (upvar.place.mutability, is_local_mutation_allowed) {
                                 (

--- a/compiler/rustc_mir/src/borrow_check/nll.rs
+++ b/compiler/rustc_mir/src/borrow_check/nll.rs
@@ -165,7 +165,7 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
     flow_inits: &mut ResultsCursor<'cx, 'tcx, MaybeInitializedPlaces<'cx, 'tcx>>,
     move_data: &MoveData<'tcx>,
     borrow_set: &BorrowSet<'tcx>,
-    upvars: &[Upvar],
+    upvars: &[Upvar<'tcx>],
 ) -> NllOutput<'tcx> {
     let mut all_facts = AllFacts::enabled(infcx.tcx).then_some(AllFacts::default());
 

--- a/compiler/rustc_mir/src/borrow_check/path_utils.rs
+++ b/compiler/rustc_mir/src/borrow_check/path_utils.rs
@@ -143,7 +143,7 @@ pub(super) fn borrow_of_local_data(place: Place<'_>) -> bool {
 /// of a closure type.
 pub(crate) fn is_upvar_field_projection(
     tcx: TyCtxt<'tcx>,
-    upvars: &[Upvar],
+    upvars: &[Upvar<'tcx>],
     place_ref: PlaceRef<'tcx>,
     body: &Body<'tcx>,
 ) -> Option<Field> {

--- a/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
@@ -132,7 +132,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
     flow_inits: &mut ResultsCursor<'mir, 'tcx, MaybeInitializedPlaces<'mir, 'tcx>>,
     move_data: &MoveData<'tcx>,
     elements: &Rc<RegionValueElements>,
-    upvars: &[Upvar],
+    upvars: &[Upvar<'tcx>],
 ) -> MirTypeckResults<'tcx> {
     let implicit_region_bound = infcx.tcx.mk_region(ty::ReVar(universal_regions.fr_fn_body));
     let mut constraints = MirTypeckRegionConstraints {
@@ -821,7 +821,7 @@ struct BorrowCheckContext<'a, 'tcx> {
     all_facts: &'a mut Option<AllFacts>,
     borrow_set: &'a BorrowSet<'tcx>,
     constraints: &'a mut MirTypeckRegionConstraints<'tcx>,
-    upvars: &'a [Upvar],
+    upvars: &'a [Upvar<'tcx>],
 }
 
 crate struct MirTypeckResults<'tcx> {
@@ -2490,7 +2490,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             body,
         );
         let category = if let Some(field) = field {
-            ConstraintCategory::ClosureUpvar(self.borrowck_context.upvars[field.index()].var_hir_id)
+            let var_hir_id = self.borrowck_context.upvars[field.index()].place.get_root_variable();
+            // FIXME(project-rfc-2229#8): Use Place for better diagnostics
+            ConstraintCategory::ClosureUpvar(var_hir_id)
         } else {
             ConstraintCategory::Boring
         };

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -10,7 +10,7 @@ use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir as hir;
 use rustc_middle::middle::region;
 use rustc_middle::mir::*;
-use rustc_middle::ty::{CanonicalUserTypeAnnotation};
+use rustc_middle::ty::CanonicalUserTypeAnnotation;
 
 use std::slice;
 
@@ -38,7 +38,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let expr_span = expr.span;
         let source_info = this.source_info(expr_span);
 
-        let expr_is_block_or_scope = matches!(expr.kind, ExprKind::Block { .. } | ExprKind::Scope { .. });
+        let expr_is_block_or_scope =
+            matches!(expr.kind, ExprKind::Block { .. } | ExprKind::Scope { .. });
 
         let schedule_drop = move |this: &mut Self| {
             if let Some(drop_scope) = scope {
@@ -68,7 +69,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.match_expr(destination, scope, expr_span, block, scrutinee, arms)
             }
             ExprKind::If { cond, then, else_opt } => {
-                let place = unpack!(block = this.as_temp(block, Some(this.local_scope()), cond, Mutability::Mut));
+                let place = unpack!(
+                    block = this.as_temp(block, Some(this.local_scope()), cond, Mutability::Mut)
+                );
                 let operand = Operand::Move(Place::from(place));
 
                 let mut then_block = this.cfg.start_new_block();
@@ -100,14 +103,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 );
 
                 join_block.unit()
-            },
+            }
             ExprKind::NeverToAny { source } => {
                 let source = this.hir.mirror(source);
-                let is_call = matches!(source.kind, ExprKind::Call { .. } | ExprKind::InlineAsm { .. });
+                let is_call =
+                    matches!(source.kind, ExprKind::Call { .. } | ExprKind::InlineAsm { .. });
 
                 // (#66975) Source could be a const of type `!`, so has to
                 // exist in the generated MIR.
-                unpack!(block = this.as_temp(block, Some(this.local_scope()), source, Mutability::Mut,));
+                unpack!(
+                    block = this.as_temp(block, Some(this.local_scope()), source, Mutability::Mut,)
+                );
 
                 // This is an optimization. If the expression was a call then we already have an
                 // unreachable block. Don't bother to terminate it and create a new one.

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -1673,15 +1673,21 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let e = self.hir.mirror(e.clone());
                     let source_info = self.source_info(e.span);
                     (e.span, self.test_bool(block, e, source_info))
-                },
+                }
                 Guard::IfLet(pat, scrutinee) => {
                     let scrutinee_span = scrutinee.span();
-                    let scrutinee_place = unpack!(block = self.lower_scrutinee(block, scrutinee.clone(), scrutinee_span));
+                    let scrutinee_place = unpack!(
+                        block = self.lower_scrutinee(block, scrutinee.clone(), scrutinee_span)
+                    );
                     let mut guard_candidate = Candidate::new(scrutinee_place, &pat, false);
                     let wildcard = Pat::wildcard_from_ty(pat.ty);
                     let mut otherwise_candidate = Candidate::new(scrutinee_place, &wildcard, false);
-                    let fake_borrow_temps =
-                        self.lower_match_tree(block, pat.span, false, &mut [&mut guard_candidate, &mut otherwise_candidate]);
+                    let fake_borrow_temps = self.lower_match_tree(
+                        block,
+                        pat.span,
+                        false,
+                        &mut [&mut guard_candidate, &mut otherwise_candidate],
+                    );
                     self.declare_bindings(
                         None,
                         pat.span.to(arm_span.unwrap()),

--- a/compiler/rustc_mir_build/src/build/matches/util.rs
+++ b/compiler/rustc_mir_build/src/build/matches/util.rs
@@ -32,9 +32,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) {
         let tcx = self.hir.tcx();
         let (min_length, exact_size) = match place.ty(&self.local_decls, tcx).ty.kind() {
-            ty::Array(_, length) => {
-                (length.eval_usize(tcx, self.hir.param_env), true)
-            }
+            ty::Array(_, length) => (length.eval_usize(tcx, self.hir.param_env), true),
             _ => ((prefix.len() + suffix.len()).try_into().unwrap(), false),
         };
 

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -851,22 +851,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         _ => bug!("Expected an upvar")
                     };
 
-                    let mut mutability = Mutability::Not;
+                    let mutability = captured_place.mutability;
 
                     // FIXME(project-rfc-2229#8): Store more precise information
                     let mut name = kw::Empty;
                     if let Some(Node::Binding(pat)) = tcx_hir.find(var_id) {
                         if let hir::PatKind::Binding(_, _, ident, _) = pat.kind {
                             name = ident.name;
-                            match hir_typeck_results
-                                .extract_binding_mode(tcx.sess, pat.hir_id, pat.span)
-                            {
-                                Some(ty::BindByValue(hir::Mutability::Mut)) => {
-                                    mutability = Mutability::Mut;
-                                }
-                                Some(_) => mutability = Mutability::Not,
-                                _ => {}
-                            }
                         }
                     }
 

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -838,9 +838,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 _ => span_bug!(self.fn_span, "upvars with non-closure env ty {:?}", closure_ty),
             };
             let capture_tys = upvar_substs.upvar_tys();
-            let captures_with_tys = hir_typeck_results
-                .closure_min_captures_flattened(fn_def_id)
-                .zip(capture_tys);
+            let captures_with_tys =
+                hir_typeck_results.closure_min_captures_flattened(fn_def_id).zip(capture_tys);
 
             self.upvar_mutbls = captures_with_tys
                 .enumerate()
@@ -848,7 +847,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     let capture = captured_place.info.capture_kind;
                     let var_id = match captured_place.place.base {
                         HirPlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
-                        _ => bug!("Expected an upvar")
+                        _ => bug!("Expected an upvar"),
                     };
 
                     let mut mutability = Mutability::Not;

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -931,10 +931,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let local_scope = self.local_scope();
         let scope = self.scopes.scopes.last_mut().unwrap();
 
-        assert_eq!(
-            scope.region_scope, local_scope,
-            "local scope is not the topmost scope!",
-        );
+        assert_eq!(scope.region_scope, local_scope, "local scope is not the topmost scope!",);
 
         // look for moves of a local variable, like `MOVE(_X)`
         let locals_moved = operands
@@ -1046,9 +1043,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             matches!(
                 self.cfg.block_data(start).terminator().kind,
                 TerminatorKind::Assert { .. }
-                | TerminatorKind::Call {..}
-                | TerminatorKind::DropAndReplace { .. }
-                | TerminatorKind::FalseUnwind { .. }
+                    | TerminatorKind::Call { .. }
+                    | TerminatorKind::DropAndReplace { .. }
+                    | TerminatorKind::FalseUnwind { .. }
             ),
             "diverge_from called on block with terminator that cannot unwind."
         );

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -41,13 +41,16 @@ impl<'a> Parser<'a> {
             },
             NonterminalKind::Block => match token.kind {
                 token::OpenDelim(token::Brace) => true,
-                token::Interpolated(ref nt) => !matches!(**nt, token::NtItem(_)
-                    | token::NtPat(_)
-                    | token::NtTy(_)
-                    | token::NtIdent(..)
-                    | token::NtMeta(_)
-                    | token::NtPath(_)
-                    | token::NtVis(_)),
+                token::Interpolated(ref nt) => !matches!(
+                    **nt,
+                    token::NtItem(_)
+                        | token::NtPat(_)
+                        | token::NtTy(_)
+                        | token::NtIdent(..)
+                        | token::NtMeta(_)
+                        | token::NtPath(_)
+                        | token::NtVis(_)
+                ),
                 _ => false,
             },
             NonterminalKind::Path | NonterminalKind::Meta => match token.kind {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -553,7 +553,8 @@ impl<'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'tcx> {
         // optional. They inherit stability from their parents when unannotated.
         if !matches!(
             i.kind,
-            hir::ItemKind::Impl(hir::Impl { of_trait: None, .. }) | hir::ItemKind::ForeignMod { .. }
+            hir::ItemKind::Impl(hir::Impl { of_trait: None, .. })
+                | hir::ItemKind::ForeignMod { .. }
         ) {
             self.check_missing_stability(i.hir_id, i.span);
         }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1659,12 +1659,15 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
             match missing {
                 MissingLifetimeSpot::Generics(generics) => {
                     let (span, sugg) = if let Some(param) = generics.params.iter().find(|p| {
-                        !matches!(p.kind, hir::GenericParamKind::Type {
-                            synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
-                            ..
-                        } | hir::GenericParamKind::Lifetime {
-                            kind: hir::LifetimeParamKind::Elided,
-                        })
+                        !matches!(
+                            p.kind,
+                            hir::GenericParamKind::Type {
+                                synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+                                ..
+                            } | hir::GenericParamKind::Lifetime {
+                                kind: hir::LifetimeParamKind::Elided,
+                            }
+                        )
                     }) {
                         (param.span.shrink_to_lo(), format!("{}, ", lifetime_ref))
                     } else {
@@ -1844,10 +1847,13 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                         msg = "consider introducing a named lifetime parameter".to_string();
                         should_break = true;
                         if let Some(param) = generics.params.iter().find(|p| {
-                            !matches!(p.kind, hir::GenericParamKind::Type {
-                                synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
-                                ..
-                            })
+                            !matches!(
+                                p.kind,
+                                hir::GenericParamKind::Type {
+                                    synthetic: Some(hir::SyntheticTyParamKind::ImplTrait),
+                                    ..
+                                }
+                            )
                         }) {
                             (param.span.shrink_to_lo(), "'a, ".to_string())
                         } else {

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -521,7 +521,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
     }
 
     pub fn is_indirect(&self) -> bool {
-        matches!(self.mode, PassMode::Indirect {..})
+        matches!(self.mode, PassMode::Indirect { .. })
     }
 
     pub fn is_sized_indirect(&self) -> bool {

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1190,9 +1190,12 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                     normalized_ty, data.ty
                 );
 
-                let is_normalized_ty_expected = !matches!(obligation.cause.code, ObligationCauseCode::ItemObligation(_)
-                    | ObligationCauseCode::BindingObligation(_, _)
-                    | ObligationCauseCode::ObjectCastObligation(_));
+                let is_normalized_ty_expected = !matches!(
+                    obligation.cause.code,
+                    ObligationCauseCode::ItemObligation(_)
+                        | ObligationCauseCode::BindingObligation(_, _)
+                        | ObligationCauseCode::ObjectCastObligation(_)
+                );
 
                 if let Err(error) = self.at(&obligation.cause, obligation.param_env).eq_exp(
                     is_normalized_ty_expected,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -290,9 +290,9 @@ fn suggest_restriction(
             generics
                 .params
                 .iter()
-                .filter(
-                    |p| !matches!(p.kind, hir::GenericParamKind::Type { synthetic: Some(_), ..}),
-                )
+                .filter(|p| {
+                    !matches!(p.kind, hir::GenericParamKind::Type { synthetic: Some(_), .. })
+                })
                 .next(),
             super_traits,
         ) {

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -496,14 +496,15 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     ) -> bool {
         let explicit = !seg.infer_args;
         let impl_trait = generics.params.iter().any(|param| {
-            matches!(param.kind, ty::GenericParamDefKind::Type {
-                synthetic:
-                    Some(
-                        hir::SyntheticTyParamKind::ImplTrait
-                        | hir::SyntheticTyParamKind::FromAttr,
+            matches!(
+                param.kind,
+                ty::GenericParamDefKind::Type {
+                    synthetic: Some(
+                        hir::SyntheticTyParamKind::ImplTrait | hir::SyntheticTyParamKind::FromAttr,
                     ),
-                ..
-            })
+                    ..
+                }
+            )
         });
 
         if explicit && impl_trait {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -274,10 +274,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         let autoborrow_mut = adj.iter().any(|adj| {
-            matches!(adj, &Adjustment {
-                kind: Adjust::Borrow(AutoBorrow::Ref(_, AutoBorrowMutability::Mut { .. })),
-                ..
-            })
+            matches!(
+                adj,
+                &Adjustment {
+                    kind: Adjust::Borrow(AutoBorrow::Ref(_, AutoBorrowMutability::Mut { .. })),
+                    ..
+                }
+            )
         });
 
         match self.typeck_results.borrow_mut().adjustments_mut().entry(expr.hir_id) {

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -1173,7 +1173,7 @@ fn migration_suggestion_for_2229(tcx: TyCtxt<'_>, need_migrations: &Vec<hir::Hir
         need_migrations.iter().map(|v| format!("{}", var_name(tcx, *v))).collect::<Vec<_>>();
     let migrations_list_concat = need_migrations_strings.join(", ");
 
-    format!("let ({}) = ({});", migrations_list_concat, migrations_list_concat)
+    format!("drop(&({}));", migrations_list_concat)
 }
 
 /// Helper function to determine if we need to escalate CaptureKind from

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -252,8 +252,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let capture = captured_place.info.capture_kind;
 
                 debug!(
-                    "place={:?} upvar_ty={:?} capture={:?}",
-                    captured_place.place, upvar_ty, capture
+                    "final_upvar_tys: place={:?} upvar_ty={:?} capture={:?}, mutability={:?}",
+                    captured_place.place, upvar_ty, capture, captured_place.mutability,
                 );
 
                 match capture {
@@ -423,7 +423,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let min_cap_list = match root_var_min_capture_list.get_mut(&var_hir_id) {
                 None => {
-                    let min_cap_list = vec![ty::CapturedPlace { place, info: capture_info }];
+                    let mutability = self.determine_capture_mutability(&place);
+                    let min_cap_list =
+                        vec![ty::CapturedPlace { place, info: capture_info, mutability }];
                     root_var_min_capture_list.insert(var_hir_id, min_cap_list);
                     continue;
                 }
@@ -486,8 +488,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             // Only need to insert when we don't have an ancestor in the existing min capture list
             if !ancestor_found {
+                let mutability = self.determine_capture_mutability(&place);
                 let captured_place =
-                    ty::CapturedPlace { place: place.clone(), info: updated_capture_info };
+                    ty::CapturedPlace { place, info: updated_capture_info, mutability };
                 min_cap_list.push(captured_place);
             }
         }
@@ -606,6 +609,49 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 diag.emit();
             }
         }
+    }
+
+    /// A captured place is mutable if
+    /// 1. Projections don't include a Deref of an immut-borrow, **and**
+    /// 2. PlaceBase is mut or projections include a Deref of a mut-borrow.
+    fn determine_capture_mutability(&self, place: &Place<'tcx>) -> hir::Mutability {
+        let var_hir_id = match place.base {
+            PlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
+            _ => unreachable!(),
+        };
+
+        let bm = *self
+            .typeck_results
+            .borrow()
+            .pat_binding_modes()
+            .get(var_hir_id)
+            .expect("missing binding mode");
+
+        let mut is_mutbl = match bm {
+            ty::BindByValue(mutability) => mutability,
+            ty::BindByReference(_) => hir::Mutability::Not,
+        };
+
+        for pointer_ty in place.deref_tys() {
+            match pointer_ty.kind() {
+                // We don't capture derefs of raw ptrs
+                ty::RawPtr(_) => unreachable!(),
+
+                // Derefencing a mut-ref allows us to mut the Place if we don't deref
+                // an immut-ref after on top of this.
+                ty::Ref(.., hir::Mutability::Mut) => is_mutbl = hir::Mutability::Mut,
+
+                // The place isn't mutable once we dereference a immutable reference.
+                ty::Ref(.., hir::Mutability::Not) => return hir::Mutability::Not,
+
+                // Dereferencing a box doesn't change mutability
+                ty::Adt(def, ..) if def.is_box() => {}
+
+                unexpected_ty => bug!("deref of unexpected pointer type {:?}", unexpected_ty),
+            }
+        }
+
+        is_mutbl
     }
 }
 

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -184,10 +184,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let origin = if self.tcx.features().capture_disjoint_fields {
                     origin
                 } else {
-                    // FIXME(project-rfc-2229#26): Once rust-lang#80092 is merged, we should restrict the
-                    // precision of origin as well. Otherwise, this will cause issues when project-rfc-2229#26
-                    // is fixed as we might see Index projections in the origin, which we can't print because
-                    // we don't store enough information.
+                    // FIXME(project-rfc-2229#31): Once the changes to support reborrowing are
+                    //                             made, make sure we are selecting and restricting
+                    //                             the origin correctly.
                     (origin.0, Place { projections: vec![], ..origin.1 })
                 };
 

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -162,34 +162,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let closure_hir_id = self.tcx.hir().local_def_id_to_hir_id(local_def_id);
         if should_do_migration_analysis(self.tcx, closure_hir_id) {
-            let need_migrations = self.compute_2229_migrations_first_pass(
-                closure_def_id,
-                span,
-                capture_clause,
-                body,
-                self.typeck_results.borrow().closure_min_captures.get(&closure_def_id),
-            );
-
-            if !need_migrations.is_empty() {
-                let need_migrations_hir_id =
-                    need_migrations.iter().map(|m| m.0).collect::<Vec<_>>();
-
-                let migrations_text =
-                    migration_suggestion_for_2229(self.tcx, &need_migrations_hir_id);
-
-                self.tcx.struct_span_lint_hir(
-                    lint::builtin::DISJOINT_CAPTURE_DROP_REORDER,
-                    closure_hir_id,
-                    span,
-                    |lint| {
-                        let mut diagnostics_builder = lint.build(
-                            "Drop order affected for closure because of `capture_disjoint_fields`",
-                        );
-                        diagnostics_builder.note(&migrations_text);
-                        diagnostics_builder.emit();
-                    },
-                );
-            }
+            self.perform_2229_migration_anaysis(closure_def_id, capture_clause, span, body);
         }
 
         // We now fake capture information for all variables that are mentioned within the closure
@@ -560,6 +533,45 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         debug!("For closure={:?}, min_captures={:#?}", closure_def_id, root_var_min_capture_list);
     }
 
+    /// Perform the migration analysis for RFC 2229, and emit lint
+    /// `disjoint_capture_drop_reorder` if needed.
+    fn perform_2229_migration_anaysis(
+        &self,
+        closure_def_id: DefId,
+        capture_clause: hir::CaptureBy,
+        span: Span,
+        body: &'tcx hir::Body<'tcx>,
+    ) {
+        let need_migrations = self.compute_2229_migrations_first_pass(
+            closure_def_id,
+            span,
+            capture_clause,
+            body,
+            self.typeck_results.borrow().closure_min_captures.get(&closure_def_id),
+        );
+
+        if !need_migrations.is_empty() {
+            let need_migrations_hir_id = need_migrations.iter().map(|m| m.0).collect::<Vec<_>>();
+
+            let migrations_text = migration_suggestion_for_2229(self.tcx, &need_migrations_hir_id);
+
+            let local_def_id = closure_def_id.expect_local();
+            let closure_hir_id = self.tcx.hir().local_def_id_to_hir_id(local_def_id);
+            self.tcx.struct_span_lint_hir(
+                lint::builtin::DISJOINT_CAPTURE_DROP_REORDER,
+                closure_hir_id,
+                span,
+                |lint| {
+                    let mut diagnostics_builder = lint.build(
+                        "Drop order affected for closure because of `capture_disjoint_fields`",
+                    );
+                    diagnostics_builder.note(&migrations_text);
+                    diagnostics_builder.emit();
+                },
+            );
+        }
+    }
+
     /// Figures out the list of root variables (and their types) that aren't completely
     /// captured by the closure when `capture_disjoint_fields` is enabled and drop order of
     /// some path starting at that root variable **might** be affected.
@@ -622,17 +634,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let is_moved = root_var_min_capture_list
                 .iter()
-                .find(|capture| matches!(capture.info.capture_kind, ty::UpvarCapture::ByValue(_)))
-                .is_some();
+                .any(|capture| matches!(capture.info.capture_kind, ty::UpvarCapture::ByValue(_)));
 
-            // 1. If we capture more than one path starting at the root variabe then the root variable
-            //    isn't being captured in its entirety
-            // 2. If we only capture one path starting at the root variable, it's still possible
-            //    that it isn't the root variable completely.
-            if is_moved
-                && ((root_var_min_capture_list.len() > 1)
-                    || (root_var_min_capture_list[0].place.projections.len() > 0))
-            {
+            let is_not_completely_captured =
+                root_var_min_capture_list.iter().any(|capture| capture.place.projections.len() > 0);
+
+            if is_moved && is_not_completely_captured {
                 need_migrations.push((var_hir_id, ty));
             }
         }

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -55,6 +55,11 @@ enum PlaceAncestryRelation {
     Divergent,
 }
 
+/// Intermediate format to store a captured `Place` and associated `ty::CaptureInfo`
+/// during capture analysis. Information in this map feeds into the minimum capture
+/// analysis pass.
+type InferredCaptureInformation<'tcx> = FxIndexMap<Place<'tcx>, ty::CaptureInfo<'tcx>>;
+
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn closure_analyze(&self, body: &'tcx hir::Body<'tcx>) {
         InferBorrowKindVisitor { fcx: self }.visit_body(body);
@@ -124,28 +129,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let local_def_id = closure_def_id.expect_local();
 
-        let mut capture_information: FxIndexMap<Place<'tcx>, ty::CaptureInfo<'tcx>> =
-            Default::default();
-        if !self.tcx.features().capture_disjoint_fields {
-            if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
-                for (&var_hir_id, _) in upvars.iter() {
-                    let place = self.place_for_root_variable(local_def_id, var_hir_id);
-
-                    debug!("seed place {:?}", place);
-
-                    let upvar_id = ty::UpvarId::new(var_hir_id, local_def_id);
-                    let capture_kind = self.init_capture_kind(capture_clause, upvar_id, span);
-                    let info = ty::CaptureInfo {
-                        capture_kind_expr_id: None,
-                        path_expr_id: None,
-                        capture_kind,
-                    };
-
-                    capture_information.insert(place, info);
-                }
-            }
-        }
-
         let body_owner_def_id = self.tcx.hir().body_owner_def_id(body.id());
         assert_eq!(body_owner_def_id.to_def_id(), closure_def_id);
         let mut delegate = InferBorrowKind {
@@ -155,7 +138,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             capture_clause,
             current_closure_kind: ty::ClosureKind::LATTICE_BOTTOM,
             current_origin: None,
-            capture_information,
+            capture_information: Default::default(),
         };
         euv::ExprUseVisitor::new(
             &mut delegate,
@@ -171,6 +154,35 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             closure_def_id, delegate.capture_information
         );
         self.log_capture_analysis_first_pass(closure_def_id, &delegate.capture_information, span);
+
+        self.compute_min_captures(closure_def_id, delegate.capture_information);
+
+        // We now fake capture information for all variables that are mentioned within the closure
+        // We do this after handling migrations so that min_captures computes before
+        if !self.tcx.features().capture_disjoint_fields {
+            let mut capture_information: InferredCaptureInformation<'tcx> = Default::default();
+
+            if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
+                for var_hir_id in upvars.keys() {
+                    let place = self.place_for_root_variable(local_def_id, *var_hir_id);
+
+                    debug!("seed place {:?}", place);
+
+                    let upvar_id = ty::UpvarId::new(*var_hir_id, local_def_id);
+                    let capture_kind = self.init_capture_kind(capture_clause, upvar_id, span);
+                    let fake_info = ty::CaptureInfo {
+                        capture_kind_expr_id: None,
+                        path_expr_id: None,
+                        capture_kind,
+                    };
+
+                    capture_information.insert(place, fake_info);
+                }
+            }
+
+            // This will update the min captures based on this new fake information.
+            self.compute_min_captures(closure_def_id, capture_information);
+        }
 
         if let Some(closure_substs) = infer_kind {
             // Unify the (as yet unbound) type variable in the closure
@@ -198,7 +210,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         }
 
-        self.compute_min_captures(closure_def_id, delegate);
         self.log_closure_min_capture_info(closure_def_id, span);
 
         self.min_captures_to_closure_captures_bridge(closure_def_id);
@@ -345,6 +356,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Places (and corresponding capture kind) that we need to keep track of to support all
     /// the required captured paths.
     ///
+    ///
+    /// Note: If this function is called multiple times for the same closure, it will update
+    ///       the existing min_capture map that is stored in TypeckResults.
+    ///
     /// Eg:
     /// ```rust,no_run
     /// struct Point { x: i32, y: i32 }
@@ -409,11 +424,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn compute_min_captures(
         &self,
         closure_def_id: DefId,
-        inferred_info: InferBorrowKind<'_, 'tcx>,
+        capture_information: InferredCaptureInformation<'tcx>,
     ) {
-        let mut root_var_min_capture_list: ty::RootVariableMinCaptureList<'_> = Default::default();
+        if capture_information.is_empty() {
+            return;
+        }
 
-        for (place, capture_info) in inferred_info.capture_information.into_iter() {
+        let mut typeck_results = self.typeck_results.borrow_mut();
+
+        let root_var_min_capture_list =
+            typeck_results.closure_min_captures.entry(closure_def_id).or_insert(Default::default());
+
+        for (place, capture_info) in capture_information.into_iter() {
             let var_hir_id = match place.base {
                 PlaceBase::Upvar(upvar_id) => upvar_id.var_path.hir_id,
                 base => bug!("Expected upvar, found={:?}", base),
@@ -501,13 +523,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         debug!("For closure={:?}, min_captures={:#?}", closure_def_id, root_var_min_capture_list);
-
-        if !root_var_min_capture_list.is_empty() {
-            self.typeck_results
-                .borrow_mut()
-                .closure_min_captures
-                .insert(closure_def_id, root_var_min_capture_list);
-        }
     }
 
     fn init_capture_kind(
@@ -661,9 +676,11 @@ struct InferBorrowKind<'a, 'tcx> {
     ///
     /// For closure `fix_s`, (at a high level) the map contains
     ///
+    /// ```
     /// Place { V1, [ProjectionKind::Field(Index=0, Variant=0)] } : CaptureKind { E1, ImmutableBorrow }
     /// Place { V1, [ProjectionKind::Field(Index=1, Variant=0)] } : CaptureKind { E2, MutableBorrow }
-    capture_information: FxIndexMap<Place<'tcx>, ty::CaptureInfo<'tcx>>,
+    /// ```
+    capture_information: InferredCaptureInformation<'tcx>,
 }
 
 impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -30,6 +30,7 @@
 //! then mean that all later passes would have to check for these figments
 //! and report an error, and it just seems like more mess in the end.)
 
+use super::writeback::Resolver;
 use super::FnCtxt;
 
 use crate::expr_use_visitor as euv;
@@ -40,7 +41,9 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_infer::infer::UpvarRegion;
 use rustc_middle::hir::place::{Place, PlaceBase, PlaceWithHirId, ProjectionKind};
+use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{self, Ty, TyCtxt, UpvarSubsts};
+use rustc_session::lint;
 use rustc_span::sym;
 use rustc_span::{MultiSpan, Span, Symbol};
 
@@ -97,7 +100,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         closure_hir_id: hir::HirId,
         span: Span,
-        body: &hir::Body<'_>,
+        body: &'tcx hir::Body<'tcx>,
         capture_clause: hir::CaptureBy,
     ) {
         debug!("analyze_closure(id={:?}, body.id={:?})", closure_hir_id, body.id());
@@ -156,6 +159,38 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.log_capture_analysis_first_pass(closure_def_id, &delegate.capture_information, span);
 
         self.compute_min_captures(closure_def_id, delegate.capture_information);
+
+        let closure_hir_id = self.tcx.hir().local_def_id_to_hir_id(local_def_id);
+        if should_do_migration_analysis(self.tcx, closure_hir_id) {
+            let need_migrations = self.compute_2229_migrations_first_pass(
+                closure_def_id,
+                span,
+                capture_clause,
+                body,
+                self.typeck_results.borrow().closure_min_captures.get(&closure_def_id),
+            );
+
+            if !need_migrations.is_empty() {
+                let need_migrations_hir_id =
+                    need_migrations.iter().map(|m| m.0).collect::<Vec<_>>();
+
+                let migrations_text =
+                    migration_suggestion_for_2229(self.tcx, &need_migrations_hir_id);
+
+                self.tcx.struct_span_lint_hir(
+                    lint::builtin::DISJOINT_CAPTURE_DROP_REORDER,
+                    closure_hir_id,
+                    span,
+                    |lint| {
+                        let mut diagnostics_builder = lint.build(
+                            "Drop order affected for closure because of `capture_disjoint_fields`",
+                        );
+                        diagnostics_builder.note(&migrations_text);
+                        diagnostics_builder.emit();
+                    },
+                );
+            }
+        }
 
         // We now fake capture information for all variables that are mentioned within the closure
         // We do this after handling migrations so that min_captures computes before
@@ -523,6 +558,86 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         debug!("For closure={:?}, min_captures={:#?}", closure_def_id, root_var_min_capture_list);
+    }
+
+    /// Figures out the list of root variables (and their types) that aren't completely
+    /// captured by the closure when `capture_disjoint_fields` is enabled and drop order of
+    /// some path starting at that root variable **might** be affected.
+    ///
+    /// The output list would include a root variable if:
+    /// - It would have been moved into the closure when `capture_disjoint_fields` wasn't
+    ///   enabled, **and**
+    /// - It wasn't completely captured by the closure, **and**
+    /// - The type of the root variable needs Drop.
+    fn compute_2229_migrations_first_pass(
+        &self,
+        closure_def_id: DefId,
+        closure_span: Span,
+        closure_clause: hir::CaptureBy,
+        body: &'tcx hir::Body<'tcx>,
+        min_captures: Option<&ty::RootVariableMinCaptureList<'tcx>>,
+    ) -> Vec<(hir::HirId, Ty<'tcx>)> {
+        fn resolve_ty<T: TypeFoldable<'tcx>>(
+            fcx: &FnCtxt<'_, 'tcx>,
+            span: Span,
+            body: &'tcx hir::Body<'tcx>,
+            ty: T,
+        ) -> T {
+            let mut resolver = Resolver::new(fcx, &span, body);
+            ty.fold_with(&mut resolver)
+        }
+
+        let upvars = if let Some(upvars) = self.tcx.upvars_mentioned(closure_def_id) {
+            upvars
+        } else {
+            return vec![];
+        };
+
+        let mut need_migrations = Vec::new();
+
+        for (&var_hir_id, _) in upvars.iter() {
+            let ty = resolve_ty(self, closure_span, body, self.node_ty(var_hir_id));
+
+            if !ty.needs_drop(self.tcx, self.tcx.param_env(closure_def_id.expect_local())) {
+                continue;
+            }
+
+            let root_var_min_capture_list = if let Some(root_var_min_capture_list) =
+                min_captures.and_then(|m| m.get(&var_hir_id))
+            {
+                root_var_min_capture_list
+            } else {
+                // The upvar is mentioned within the closure but no path starting from it is
+                // used.
+
+                match closure_clause {
+                    // Only migrate if closure is a move closure
+                    hir::CaptureBy::Value => need_migrations.push((var_hir_id, ty)),
+
+                    hir::CaptureBy::Ref => {}
+                }
+
+                continue;
+            };
+
+            let is_moved = root_var_min_capture_list
+                .iter()
+                .find(|capture| matches!(capture.info.capture_kind, ty::UpvarCapture::ByValue(_)))
+                .is_some();
+
+            // 1. If we capture more than one path starting at the root variabe then the root variable
+            //    isn't being captured in its entirety
+            // 2. If we only capture one path starting at the root variable, it's still possible
+            //    that it isn't the root variable completely.
+            if is_moved
+                && ((root_var_min_capture_list.len() > 1)
+                    || (root_var_min_capture_list[0].place.projections.len() > 0))
+            {
+                need_migrations.push((var_hir_id, ty));
+            }
+        }
+
+        need_migrations
     }
 
     fn init_capture_kind(
@@ -1037,6 +1152,21 @@ fn construct_capture_info_string(
 
 fn var_name(tcx: TyCtxt<'_>, var_hir_id: hir::HirId) -> Symbol {
     tcx.hir().name(var_hir_id)
+}
+
+fn should_do_migration_analysis(tcx: TyCtxt<'_>, closure_id: hir::HirId) -> bool {
+    let (level, _) =
+        tcx.lint_level_at_node(lint::builtin::DISJOINT_CAPTURE_DROP_REORDER, closure_id);
+
+    !matches!(level, lint::Level::Allow)
+}
+
+fn migration_suggestion_for_2229(tcx: TyCtxt<'_>, need_migrations: &Vec<hir::HirId>) -> String {
+    let need_migrations_strings =
+        need_migrations.iter().map(|v| format!("{}", var_name(tcx, *v))).collect::<Vec<_>>();
+    let migrations_list_concat = need_migrations_strings.join(", ");
+
+    format!("let ({}) = ({});", migrations_list_concat, migrations_list_concat)
 }
 
 /// Helper function to determine if we need to escalate CaptureKind from

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -650,7 +650,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
     }
 }
 
-trait Locatable {
+crate trait Locatable {
     fn to_span(&self, tcx: TyCtxt<'_>) -> Span;
 }
 
@@ -668,7 +668,7 @@ impl Locatable for hir::HirId {
 
 /// The Resolver. This is the type folding engine that detects
 /// unresolved types and so forth.
-struct Resolver<'cx, 'tcx> {
+crate struct Resolver<'cx, 'tcx> {
     tcx: TyCtxt<'tcx>,
     infcx: &'cx InferCtxt<'cx, 'tcx>,
     span: &'cx dyn Locatable,
@@ -679,7 +679,7 @@ struct Resolver<'cx, 'tcx> {
 }
 
 impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
-    fn new(
+    crate fn new(
         fcx: &'cx FnCtxt<'cx, 'tcx>,
         span: &'cx dyn Locatable,
         body: &'tcx hir::Body<'tcx>,

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -173,9 +173,11 @@ macro_rules! default_impl {
         impl Default for $t {
             #[inline]
             #[doc = $doc]
-            fn default() -> $t { $v }
+            fn default() -> $t {
+                $v
+            }
         }
-    }
+    };
 }
 
 default_impl! { (), (), "Returns the default value of `()`" }

--- a/library/std/src/collections/mod.rs
+++ b/library/std/src/collections/mod.rs
@@ -110,10 +110,10 @@
 //!
 //! For Sets, all operations have the cost of the equivalent Map operation.
 //!
-//! |              | get       | insert    | remove    | predecessor | append |
-//! |--------------|-----------|-----------|-----------|-------------|--------|
-//! | [`HashMap`]  | O(1)~     | O(1)~*    | O(1)~     | N/A         | N/A    |
-//! | [`BTreeMap`] | O(log(n)) | O(log(n)) | O(log(n)) | O(log(n))   | O(n+m) |
+//! |              | get       | insert    | remove    | range     | append |
+//! |--------------|-----------|-----------|-----------|-----------|--------|
+//! | [`HashMap`]  | O(1)~     | O(1)~*    | O(1)~     | N/A       | N/A    |
+//! | [`BTreeMap`] | O(log(n)) | O(log(n)) | O(log(n)) | O(log(n)) | O(n+m) |
 //!
 //! # Correct and Efficient Usage of Collections
 //!

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,7 +6,7 @@ merge_derives = false
 # by default we ignore everything in the repository
 # tidy only checks files which are not ignored, each entry follows gitignore style
 ignore = [
-    "build",
+    "/build/",
     "/vendor/",
 
     # tests for now are not formatted, as they are sometimes pretty-printing constrained

--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -15,7 +15,7 @@ fn main() {
 
     // check_version warnings are not printed during setup
     let changelog_suggestion =
-        if matches!(config.cmd, Subcommand::Setup {..}) { None } else { check_version(&config) };
+        if matches!(config.cmd, Subcommand::Setup { .. }) { None } else { check_version(&config) };
 
     // NOTE: Since `./configure` generates a `config.toml`, distro maintainers will see the
     // changelog warning, not the `x.py setup` message.

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -19,7 +19,7 @@ rustc: beta
 # bootstrapping issues with use of new syntax in this repo. If you're looking at
 # the beta/stable branch, this key should be omitted, as we don't want to depend
 # on rustfmt from nightly there.
-rustfmt: nightly-2020-11-19
+rustfmt: nightly-2021-01-28
 
 # When making a stable release the process currently looks like:
 #

--- a/src/test/ui/closures/2229_closure_analysis/by_value.rs
+++ b/src/test/ui/closures/2229_closure_analysis/by_value.rs
@@ -1,0 +1,41 @@
+// Test that we handle derferences properly when only some of the captures are being moved with
+// `capture_disjoint_fields` enabled.
+
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+//~| NOTE: `#[warn(incomplete_features)]` on by default
+//~| NOTE: see issue #53488 <https://github.com/rust-lang/rust/issues/53488>
+#![feature(rustc_attrs)]
+
+#[derive(Debug, Default)]
+struct SomeLargeType;
+struct MuchLargerType([SomeLargeType; 32]);
+
+// Ensure that we don't capture any derefs when moving captures into the closures,
+// i.e. only data from the enclosing stack is moved.
+fn big_box() {
+    let s = MuchLargerType(Default::default());
+    let b = Box::new(s);
+    let t = (b, 10);
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    || {
+    //~^ First Pass analysis includes:
+    //~| Min Capture analysis includes:
+        let p = t.0.0;
+        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
+        //~| NOTE: Min Capture t[(0, 0)] -> ByValue
+        println!("{} {:?}", t.1, p);
+        //~^ NOTE: Capturing t[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture t[(1, 0)] -> ImmBorrow
+    };
+
+    c();
+}
+
+fn main() {
+    big_box();
+}

--- a/src/test/ui/closures/2229_closure_analysis/by_value.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/by_value.stderr
@@ -1,0 +1,67 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/by_value.rs:22:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/by_value.rs:5:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+error: First Pass analysis includes:
+  --> $DIR/by_value.rs:25:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         let p = t.0.0;
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
+  --> $DIR/by_value.rs:28:17
+   |
+LL |         let p = t.0.0;
+   |                 ^^^^^
+note: Capturing t[(1, 0)] -> ImmBorrow
+  --> $DIR/by_value.rs:31:29
+   |
+LL |         println!("{} {:?}", t.1, p);
+   |                             ^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/by_value.rs:25:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         let p = t.0.0;
+...  |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture t[(0, 0)] -> ByValue
+  --> $DIR/by_value.rs:28:17
+   |
+LL |         let p = t.0.0;
+   |                 ^^^^^
+note: Min Capture t[(1, 0)] -> ImmBorrow
+  --> $DIR/by_value.rs:31:29
+   |
+LL |         println!("{} {:?}", t.1, p);
+   |                             ^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.rs
@@ -14,7 +14,6 @@ fn main() {
     let mut c = || {
     //~^ ERROR: cannot borrow `z.0.0.0` as mutable, as it is behind a `&` reference
         z.0.0.0 = format!("X1");
-        //~^ ERROR: cannot assign to `z`, as it is not declared as mutable
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.rs
@@ -1,0 +1,21 @@
+// Test that if we deref an immutable borrow to access a Place,
+// then we can't mutate the final place.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+fn main() {
+    let mut x = (format!(""), format!("X2"));
+    let mut y = (&x, "Y");
+    let z = (&mut y, "Z");
+
+    // `x.0` is mutable but we access `x` via `z.0.0`, which is an immutable reference and
+    // therefore can't be mutated.
+    let mut c = || {
+    //~^ ERROR: cannot borrow `z.0.0.0` as mutable, as it is behind a `&` reference
+        z.0.0.0 = format!("X1");
+        //~^ ERROR: cannot assign to `z`, as it is not declared as mutable
+    };
+
+    c();
+}

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.stderr
@@ -7,15 +7,6 @@ LL | #![feature(capture_disjoint_fields)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
 
-error[E0594]: cannot assign to `z`, as it is not declared as mutable
-  --> $DIR/cant-mutate-imm-borrow.rs:16:9
-   |
-LL |     let z = (&mut y, "Z");
-   |         - help: consider changing this to be mutable: `mut z`
-...
-LL |         z.0.0.0 = format!("X1");
-   |         ^^^^^^^ cannot assign
-
 error[E0596]: cannot borrow `z.0.0.0` as mutable, as it is behind a `&` reference
   --> $DIR/cant-mutate-imm-borrow.rs:14:17
    |
@@ -25,7 +16,6 @@ LL |
 LL |         z.0.0.0 = format!("X1");
    |         - mutable borrow occurs due to use of `z.0.0.0` in closure
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to previous error; 1 warning emitted
 
-Some errors have detailed explanations: E0594, E0596.
-For more information about an error, try `rustc --explain E0594`.
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm-borrow.stderr
@@ -1,0 +1,31 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/cant-mutate-imm-borrow.rs:4:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+error[E0594]: cannot assign to `z`, as it is not declared as mutable
+  --> $DIR/cant-mutate-imm-borrow.rs:16:9
+   |
+LL |     let z = (&mut y, "Z");
+   |         - help: consider changing this to be mutable: `mut z`
+...
+LL |         z.0.0.0 = format!("X1");
+   |         ^^^^^^^ cannot assign
+
+error[E0596]: cannot borrow `z.0.0.0` as mutable, as it is behind a `&` reference
+  --> $DIR/cant-mutate-imm-borrow.rs:14:17
+   |
+LL |     let mut c = || {
+   |                 ^^ cannot borrow as mutable
+LL |
+LL |         z.0.0.0 = format!("X1");
+   |         - mutable borrow occurs due to use of `z.0.0.0` in closure
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.rs
@@ -1,0 +1,35 @@
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+// Ensure that diagnostics for mutability error (because the root variable
+// isn't mutable) work with `capture_disjoint_fields` enabled.
+
+fn mut_error_struct() {
+    let x = (10, 10);
+    let y = (x, 10);
+    let z = (y, 10);
+
+    let mut c = || {
+        z.0.0.0 = 20;
+        //~^ ERROR: cannot assign to `z`, as it is not declared as mutable
+    };
+
+    c();
+}
+
+fn mut_error_box() {
+    let x = (10, 10);
+    let bx = Box::new(x);
+
+    let mut c = || {
+        bx.0 = 20;
+        //~^ ERROR: cannot assign to `bx`, as it is not declared as mutable
+    };
+
+    c();
+}
+
+fn main() {
+    mut_error_struct();
+    mut_error_box();
+}

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.stderr
@@ -1,0 +1,30 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/cant-mutate-imm.rs:1:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+error[E0594]: cannot assign to `z`, as it is not declared as mutable
+  --> $DIR/cant-mutate-imm.rs:13:9
+   |
+LL |     let z = (y, 10);
+   |         - help: consider changing this to be mutable: `mut z`
+...
+LL |         z.0.0.0 = 20;
+   |         ^^^^^^^^^^^^ cannot assign
+
+error[E0594]: cannot assign to `bx`, as it is not declared as mutable
+  --> $DIR/cant-mutate-imm.rs:25:9
+   |
+LL |     let bx = Box::new(x);
+   |         -- help: consider changing this to be mutable: `mut bx`
+...
+LL |         bx.0 = 20;
+   |         ^^^^^^^^^ cannot assign
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.rs
@@ -13,7 +13,6 @@ fn imm_mut_ref() {
     let c = || {
     //~^ ERROR: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` reference
         **ref_mref_x = y;
-        //~^ERROR: cannot assign to `ref_mref_x`, as it is not declared as mutable
     };
 
     c();
@@ -28,7 +27,6 @@ fn mut_imm_ref() {
     let c = || {
     //~^ ERROR: cannot borrow `**mref_ref_x` as mutable, as it is behind a `&` reference
         **mref_ref_x = y;
-        //~^ERROR: cannot assign to `mref_ref_x`, as it is not declared as mutable
     };
 
     c();

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.rs
@@ -1,0 +1,40 @@
+// Test that we can't mutate a place if we need to deref an imm-borrow
+// to reach it.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+fn imm_mut_ref() {
+    let mut x = String::new();
+    let y = String::new();
+    let mref_x = &mut x;
+    let ref_mref_x = &mref_x;
+
+    let c = || {
+    //~^ ERROR: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` reference
+        **ref_mref_x = y;
+        //~^ERROR: cannot assign to `ref_mref_x`, as it is not declared as mutable
+    };
+
+    c();
+}
+
+fn mut_imm_ref() {
+    let x = String::new();
+    let y = String::new();
+    let mut ref_x = &x;
+    let mref_ref_x = &mut ref_x;
+
+    let c = || {
+    //~^ ERROR: cannot borrow `**mref_ref_x` as mutable, as it is behind a `&` reference
+        **mref_ref_x = y;
+        //~^ERROR: cannot assign to `mref_ref_x`, as it is not declared as mutable
+    };
+
+    c();
+}
+
+fn main() {
+    imm_mut_ref();
+    mut_imm_ref();
+}

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -1,0 +1,52 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/mut_ref.rs:4:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+error[E0594]: cannot assign to `ref_mref_x`, as it is not declared as mutable
+  --> $DIR/mut_ref.rs:15:9
+   |
+LL |     let ref_mref_x = &mref_x;
+   |         ---------- help: consider changing this to be mutable: `mut ref_mref_x`
+...
+LL |         **ref_mref_x = y;
+   |         ^^^^^^^^^^^^ cannot assign
+
+error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` reference
+  --> $DIR/mut_ref.rs:13:13
+   |
+LL |     let ref_mref_x = &mref_x;
+   |                      ------- help: consider changing this to be a mutable reference: `&mut mref_x`
+LL | 
+LL |     let c = || {
+   |             ^^ `ref_mref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
+LL |
+LL |         **ref_mref_x = y;
+   |           ---------- mutable borrow occurs due to use of `**ref_mref_x` in closure
+
+error[E0594]: cannot assign to `mref_ref_x`, as it is not declared as mutable
+  --> $DIR/mut_ref.rs:30:9
+   |
+LL |     let mref_ref_x = &mut ref_x;
+   |         ---------- help: consider changing this to be mutable: `mut mref_ref_x`
+...
+LL |         **mref_ref_x = y;
+   |         ^^^^^^^^^^^^ cannot assign
+
+error[E0596]: cannot borrow `**mref_ref_x` as mutable, as it is behind a `&` reference
+  --> $DIR/mut_ref.rs:28:13
+   |
+LL |     let c = || {
+   |             ^^ cannot borrow as mutable
+LL |
+LL |         **mref_ref_x = y;
+   |           ---------- mutable borrow occurs due to use of `**mref_ref_x` in closure
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0594, E0596.
+For more information about an error, try `rustc --explain E0594`.

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -7,15 +7,6 @@ LL | #![feature(capture_disjoint_fields)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
 
-error[E0594]: cannot assign to `ref_mref_x`, as it is not declared as mutable
-  --> $DIR/mut_ref.rs:15:9
-   |
-LL |     let ref_mref_x = &mref_x;
-   |         ---------- help: consider changing this to be mutable: `mut ref_mref_x`
-...
-LL |         **ref_mref_x = y;
-   |         ^^^^^^^^^^^^ cannot assign
-
 error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` reference
   --> $DIR/mut_ref.rs:13:13
    |
@@ -28,17 +19,8 @@ LL |
 LL |         **ref_mref_x = y;
    |           ---------- mutable borrow occurs due to use of `**ref_mref_x` in closure
 
-error[E0594]: cannot assign to `mref_ref_x`, as it is not declared as mutable
-  --> $DIR/mut_ref.rs:30:9
-   |
-LL |     let mref_ref_x = &mut ref_x;
-   |         ---------- help: consider changing this to be mutable: `mut mref_ref_x`
-...
-LL |         **mref_ref_x = y;
-   |         ^^^^^^^^^^^^ cannot assign
-
 error[E0596]: cannot borrow `**mref_ref_x` as mutable, as it is behind a `&` reference
-  --> $DIR/mut_ref.rs:28:13
+  --> $DIR/mut_ref.rs:27:13
    |
 LL |     let c = || {
    |             ^^ cannot borrow as mutable
@@ -46,7 +28,6 @@ LL |
 LL |         **mref_ref_x = y;
    |           ---------- mutable borrow occurs due to use of `**mref_ref_x` in closure
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 
-Some errors have detailed explanations: E0594, E0596.
-For more information about an error, try `rustc --explain E0594`.
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -1,0 +1,130 @@
+#![deny(disjoint_capture_drop_reorder)]
+//~^ NOTE: the lint level is defined here
+
+// Test cases for types that implement a insignificant drop (stlib defined)
+
+// `t` needs Drop because one of its elements needs drop,
+// therefore precise capture might affect drop ordering
+fn test1_all_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let t2 = (String::new(), String::new());
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2.0;
+    };
+
+    c();
+}
+
+// String implements drop and therefore should be migrated.
+// But in this test cases, `t2` is completely captured and when it is dropped won't be affected
+fn test2_only_precise_paths_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let t2 = (String::new(), String::new());
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1) = (t, t1);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2;
+    };
+
+    c();
+}
+
+// If a variable would've not been captured by value then it would've not been
+// dropped with the closure and therefore doesn't need migration.
+fn test3_only_by_value_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        println!("{}", t1.1);
+    };
+
+    c();
+}
+
+// Copy types get copied into the closure instead of move. Therefore we don't need to
+// migrate then as their drop order isn't tied to the closure.
+fn test4_only_non_copy_types_need_migration() {
+    let t = (String::new(), String::new());
+
+    // `t1` is Copy because all of its elements are Copy
+    let t1 = (0i32, 0i32);
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        let _t1 = t1.0;
+    };
+
+    c();
+}
+
+fn test5_only_drop_types_need_migration() {
+    struct S(i32, i32);
+
+    let t = (String::new(), String::new());
+
+    // `s` doesn't implement Drop or any elements within it, and doesn't need migration
+    let s = S(0i32, 0i32);
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        let _s = s.0;
+    };
+
+    c();
+}
+
+// Since we are using a move closure here, both `t` and `t1` get moved
+// even though they are being used by ref inside the closure.
+fn test6_move_closures_non_copy_types_might_need_migration() {
+    let t = (String::new(), String::new());
+    let t1 = (String::new(), String::new());
+    let c = move || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t1, t) = (t1, t);
+        println!("{} {}", t1.1, t.1);
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Drop + Non Drop aggregates.
+// Note we need migration here only because the non-copy (because Drop type) is captured,
+// otherwise we won't need to, since we can get away with just by ref capture in that case.
+fn test7_drop_non_drop_aggregate_need_migration() {
+    let t = (String::new(), 0i32);
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+    };
+
+    c();
+}
+
+fn main() {
+    test1_all_need_migration();
+    test2_only_precise_paths_need_migration();
+    test3_only_by_value_need_migration();
+    test4_only_non_copy_types_need_migration();
+    test5_only_drop_types_need_migration();
+    test6_move_closures_non_copy_types_might_need_migration();
+    test7_drop_non_drop_aggregate_need_migration();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -12,7 +12,7 @@ fn test1_all_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+    //~| NOTE: drop(&(t, t1, t2));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -30,7 +30,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1) = (t, t1);
+    //~| NOTE: drop(&(t, t1));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -46,7 +46,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (String::new(), String::new());
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         println!("{}", t1.1);
     };
@@ -64,7 +64,7 @@ fn test4_only_non_copy_types_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         let _t1 = t1.0;
     };
@@ -82,7 +82,7 @@ fn test5_only_drop_types_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         let _s = s.0;
     };
@@ -97,7 +97,7 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t1 = (String::new(), String::new());
     let c = move || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t1, t) = (t1, t);
+    //~| NOTE: drop(&(t1, t));
         println!("{} {}", t1.1, t.1);
     };
 
@@ -112,7 +112,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -108,7 +108,7 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
 // Note we need migration here only because the non-copy (because Drop type) is captured,
 // otherwise we won't need to, since we can get away with just by ref capture in that case.
 fn test7_drop_non_drop_aggregate_need_migration() {
-    let t = (String::new(), 0i32);
+    let t = (String::new(), String::new(), 0i32);
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -1,0 +1,105 @@
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:13:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2.0;
+LL | |     };
+   | |_____^
+   |
+note: the lint level is defined here
+  --> $DIR/insignificant_drop.rs:1:9
+   |
+LL | #![deny(disjoint_capture_drop_reorder)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: let (t, t1, t2) = (t, t1, t2);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:31:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t, t1) = (t, t1);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:47:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         println!("{}", t1.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:65:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:83:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _s = s.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:98:13
+   |
+LL |       let c = move || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         println!("{} {}", t1.1, t.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t1, t) = (t1, t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/insignificant_drop.rs:113:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: aborting due to 7 previous errors
+

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: let (t, t1, t2) = (t, t1, t2);
+   = note: drop(&(t, t1, t2));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:31:13
@@ -31,7 +31,7 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-   = note: let (t, t1) = (t, t1);
+   = note: drop(&(t, t1));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:47:13
@@ -45,7 +45,7 @@ LL | |         println!("{}", t1.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:65:13
@@ -59,7 +59,7 @@ LL | |         let _t1 = t1.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:83:13
@@ -73,7 +73,7 @@ LL | |         let _s = s.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:98:13
@@ -86,7 +86,7 @@ LL | |         println!("{} {}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t1, t) = (t1, t);
+   = note: drop(&(t1, t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/insignificant_drop.rs:113:13
@@ -99,7 +99,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/no_migrations.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/no_migrations.rs
@@ -1,0 +1,84 @@
+// run-pass
+
+// Set of test cases that don't need migrations
+
+#![deny(disjoint_capture_drop_reorder)]
+
+
+// Copy types as copied by the closure instead of being moved into the closure
+// Therefore their drop order isn't tied to the closure and won't be requiring any
+// migrations.
+fn test1_only_copy_types() {
+    let t = (0i32, 0i32);
+
+    let c = || {
+        let _t = t.0;
+    };
+
+    c();
+}
+
+// Same as test1 but using a move closure
+fn test2_only_copy_types_move_closure() {
+    let t = (0i32, 0i32);
+
+    let c = move || {
+        println!("{}", t.0);
+    };
+
+    c();
+}
+
+// Don't need to migrate if captured by ref
+fn test3_only_copy_types_move_closure() {
+    let t = (String::new(), String::new());
+
+    let c = || {
+        println!("{}", t.0);
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Insignificant Drop + Non Drop aggregates.
+// Note in this test the closure captures a non Drop type and therefore the variable
+// is only captured by ref.
+fn test4_insignificant_drop_non_drop_aggregate() {
+    let t = (String::new(), 0i32);
+
+    let c = || {
+        let _t = t.1;
+    };
+
+    c();
+}
+
+
+struct Foo(i32);
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("{:?} dropped", self.0);
+    }
+}
+
+// Test migration analysis in case of Significant Drop + Non Drop aggregates.
+// Note in this test the closure captures a non Drop type and therefore the variable
+// is only captured by ref.
+fn test5_significant_drop_non_drop_aggregate() {
+    let t = (Foo(0), 0i32);
+
+    let c = || {
+        let _t = t.1;
+    };
+
+    c();
+}
+
+fn main() {
+    test1_only_copy_types();
+    test2_only_copy_types_move_closure();
+    test3_only_copy_types_move_closure();
+    test4_insignificant_drop_non_drop_aggregate();
+    test5_significant_drop_non_drop_aggregate();
+
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -1,0 +1,137 @@
+#![deny(disjoint_capture_drop_reorder)]
+//~^ NOTE: the lint level is defined here
+
+// Test cases for types that implement a significant drop (user defined)
+
+#[derive(Debug)]
+struct Foo(i32);
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("{:?} dropped", self.0);
+    }
+}
+
+#[derive(Debug)]
+struct ConstainsDropField(Foo, Foo);
+
+// `t` needs Drop because one of its elements needs drop,
+// therefore precise capture might affect drop ordering
+fn test1_all_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0));
+    let t2 = (Foo(0), Foo(0));
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2.0;
+    };
+
+    c();
+}
+
+// String implements drop and therefore should be migrated.
+// But in this test cases, `t2` is completely captured and when it is dropped won't be affected
+fn test2_only_precise_paths_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0));
+    let t2 = (Foo(0), Foo(0));
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t, t1) = (t, t1);
+        let _t = t.0;
+        let _t1 = t1.0;
+        let _t2 = t2;
+    };
+
+    c();
+}
+
+// If a variable would've not been captured by value then it would've not been
+// dropped with the closure and therefore doesn't need migration.
+fn test3_only_by_value_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0));
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+        println!("{:?}", t1.1);
+    };
+
+    c();
+}
+
+// The root variable might not implement drop themselves but some path starting
+// at the root variable might implement Drop.
+//
+// If this path isn't captured we need to migrate for the root variable.
+fn test4_type_contains_drop_need_migration() {
+    let t = ConstainsDropField(Foo(0), Foo(0));
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Drop + Non Drop aggregates.
+// Note we need migration here only because the non-copy (because Drop type) is captured,
+// otherwise we won't need to, since we can get away with just by ref capture in that case.
+fn test5_drop_non_drop_aggregate_need_migration() {
+    let t = (Foo(0), 0i32);
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.0;
+    };
+
+    c();
+}
+
+// Test migration analysis in case of Significant and Insignificant Drop aggregates.
+fn test6_significant_insignificant_drop_aggregate_need_migration() {
+    struct S(i32, i32);
+
+    let t = (Foo(0), String::new());
+
+    let c = || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t) = (t);
+        let _t = t.1;
+    };
+
+    c();
+}
+
+// Since we are using a move closure here, both `t` and `t1` get moved
+// even though they are being used by ref inside the closure.
+fn test7_move_closures_non_copy_types_might_need_migration() {
+    let t = (Foo(0), Foo(0));
+    let t1 = (Foo(0), Foo(0), Foo(0));
+
+    let c = move || {
+    //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
+    //~| NOTE: let (t1, t) = (t1, t);
+        println!("{:?} {:?}", t1.1, t.1);
+    };
+
+    c();
+}
+
+fn main() {
+    test1_all_need_migration();
+    test2_only_precise_paths_need_migration();
+    test3_only_by_value_need_migration();
+    test4_type_contains_drop_need_migration();
+    test5_drop_non_drop_aggregate_need_migration();
+    test6_significant_insignificant_drop_aggregate_need_migration();
+    test7_move_closures_non_copy_types_might_need_migration();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -23,7 +23,7 @@ fn test1_all_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1, t2) = (t, t1, t2);
+    //~| NOTE: drop(&(t, t1, t2));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -41,7 +41,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t, t1) = (t, t1);
+    //~| NOTE: drop(&(t, t1));
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -57,7 +57,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
         println!("{:?}", t1.1);
     };
@@ -74,7 +74,7 @@ fn test4_type_contains_drop_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
     };
 
@@ -89,7 +89,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.0;
     };
 
@@ -104,7 +104,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t) = (t);
+    //~| NOTE: drop(&(t));
         let _t = t.1;
     };
 
@@ -119,7 +119,7 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
 
     let c = move || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`
-    //~| NOTE: let (t1, t) = (t1, t);
+    //~| NOTE: drop(&(t1, t));
         println!("{:?} {:?}", t1.1, t.1);
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -85,7 +85,7 @@ fn test4_type_contains_drop_need_migration() {
 // Note we need migration here only because the non-copy (because Drop type) is captured,
 // otherwise we won't need to, since we can get away with just by ref capture in that case.
 fn test5_drop_non_drop_aggregate_need_migration() {
-    let t = (Foo(0), 0i32);
+    let t = (Foo(0), Foo(0), 0i32);
 
     let c = || {
     //~^ERROR: Drop order affected for closure because of `capture_disjoint_fields`

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -1,0 +1,103 @@
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:24:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2.0;
+LL | |     };
+   | |_____^
+   |
+note: the lint level is defined here
+  --> $DIR/significant_drop.rs:1:9
+   |
+LL | #![deny(disjoint_capture_drop_reorder)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: let (t, t1, t2) = (t, t1, t2);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:42:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         let _t1 = t1.0;
+LL | |         let _t2 = t2;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t, t1) = (t, t1);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:58:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |         println!("{:?}", t1.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:75:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:90:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.0;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:105:13
+   |
+LL |       let c = || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         let _t = t.1;
+LL | |     };
+   | |_____^
+   |
+   = note: let (t) = (t);
+
+error: Drop order affected for closure because of `capture_disjoint_fields`
+  --> $DIR/significant_drop.rs:120:13
+   |
+LL |       let c = move || {
+   |  _____________^
+LL | |
+LL | |
+LL | |         println!("{:?} {:?}", t1.1, t.1);
+LL | |     };
+   | |_____^
+   |
+   = note: let (t1, t) = (t1, t);
+
+error: aborting due to 7 previous errors
+

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: let (t, t1, t2) = (t, t1, t2);
+   = note: drop(&(t, t1, t2));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:42:13
@@ -31,7 +31,7 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-   = note: let (t, t1) = (t, t1);
+   = note: drop(&(t, t1));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:58:13
@@ -45,7 +45,7 @@ LL | |         println!("{:?}", t1.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:75:13
@@ -58,7 +58,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:90:13
@@ -71,7 +71,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:105:13
@@ -84,7 +84,7 @@ LL | |         let _t = t.1;
 LL | |     };
    | |_____^
    |
-   = note: let (t) = (t);
+   = note: drop(&(t));
 
 error: Drop order affected for closure because of `capture_disjoint_fields`
   --> $DIR/significant_drop.rs:120:13
@@ -97,7 +97,7 @@ LL | |         println!("{:?} {:?}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-   = note: let (t1, t) = (t1, t);
+   = note: drop(&(t1, t));
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.rs
@@ -1,0 +1,72 @@
+// Test that move closures drop derefs with `capture_disjoint_fields` enabled.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+//~| NOTE: `#[warn(incomplete_features)]` on by default
+//~| NOTE: see issue #53488 <https://github.com/rust-lang/rust/issues/53488>
+#![feature(rustc_attrs)]
+
+// Test we truncate derefs properly
+fn simple_ref() {
+    let mut s = 10;
+    let ref_s = &mut s;
+
+    let mut c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    move || {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        *ref_s += 10;
+        //~^ NOTE: Capturing ref_s[Deref] -> ByValue
+        //~| NOTE: Min Capture ref_s[] -> ByValue
+    };
+    c();
+}
+
+// Test we truncate derefs properly
+fn struct_contains_ref_to_another_struct() {
+    struct S(String);
+    struct T<'a>(&'a mut S);
+
+    let mut s = S("s".into());
+    let t = T(&mut s);
+
+    let mut c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    move || {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        t.0.0 = "new s".into();
+        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
+        //~| NOTE: Min Capture t[(0, 0)] -> ByValue
+    };
+
+    c();
+}
+
+// Test that we don't reduce precision when there is nothing deref.
+fn no_ref() {
+    struct S(String);
+    struct T(S);
+
+    let t = T(S("s".into()));
+    let mut c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    move || {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        t.0.0 = "new S".into();
+        //~^ NOTE: Capturing t[(0, 0),(0, 0)] -> ByValue
+        //~| NOTE: Min Capture t[(0, 0),(0, 0)] -> ByValue
+    };
+    c();
+}
+
+fn main() {
+    simple_ref();
+    struct_contains_ref_to_another_struct();
+    no_ref();
+}

--- a/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/move_closure.stderr
@@ -1,0 +1,147 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/move_closure.rs:14:17
+   |
+LL |     let mut c = #[rustc_capture_analysis]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/move_closure.rs:35:17
+   |
+LL |     let mut c = #[rustc_capture_analysis]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/move_closure.rs:55:17
+   |
+LL |     let mut c = #[rustc_capture_analysis]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/move_closure.rs:3:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+error: First Pass analysis includes:
+  --> $DIR/move_closure.rs:17:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         *ref_s += 10;
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing ref_s[Deref] -> ByValue
+  --> $DIR/move_closure.rs:20:9
+   |
+LL |         *ref_s += 10;
+   |         ^^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/move_closure.rs:17:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         *ref_s += 10;
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture ref_s[] -> ByValue
+  --> $DIR/move_closure.rs:20:9
+   |
+LL |         *ref_s += 10;
+   |         ^^^^^^
+
+error: First Pass analysis includes:
+  --> $DIR/move_closure.rs:38:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         t.0.0 = "new s".into();
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
+  --> $DIR/move_closure.rs:41:9
+   |
+LL |         t.0.0 = "new s".into();
+   |         ^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/move_closure.rs:38:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         t.0.0 = "new s".into();
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture t[(0, 0)] -> ByValue
+  --> $DIR/move_closure.rs:41:9
+   |
+LL |         t.0.0 = "new s".into();
+   |         ^^^^^
+
+error: First Pass analysis includes:
+  --> $DIR/move_closure.rs:58:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         t.0.0 = "new S".into();
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing t[(0, 0),(0, 0)] -> ByValue
+  --> $DIR/move_closure.rs:61:9
+   |
+LL |         t.0.0 = "new S".into();
+   |         ^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/move_closure.rs:58:5
+   |
+LL | /     move || {
+LL | |
+LL | |
+LL | |         t.0.0 = "new S".into();
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture t[(0, 0),(0, 0)] -> ByValue
+  --> $DIR/move_closure.rs:61:9
+   |
+LL |         t.0.0 = "new S".into();
+   |         ^^^^^
+
+error: aborting due to 9 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/by_value.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/by_value.rs
@@ -1,0 +1,28 @@
+// run-pass
+
+// Test that ByValue captures compile sucessefully especially when the captures are
+// derefenced within the closure.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+#[derive(Debug, Default)]
+struct SomeLargeType;
+struct MuchLargerType([SomeLargeType; 32]);
+
+fn big_box() {
+    let s = MuchLargerType(Default::default());
+    let b = Box::new(s);
+    let t = (b, 10);
+
+    let c = || {
+        let p = t.0.0;
+        println!("{} {:?}", t.1, p);
+    };
+
+    c();
+}
+
+fn main() {
+    big_box();
+}

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/by_value.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/by_value.stderr
@@ -1,0 +1,11 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/by_value.rs:6:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.rs
@@ -1,0 +1,47 @@
+// run-pass
+
+// Test that move closures compile properly with `capture_disjoint_fields` enabled.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+fn simple_ref() {
+    let mut s = 10;
+    let ref_s = &mut s;
+
+    let mut c = move || {
+        *ref_s += 10;
+    };
+    c();
+}
+
+fn struct_contains_ref_to_another_struct() {
+    struct S(String);
+    struct T<'a>(&'a mut S);
+
+    let mut s = S("s".into());
+    let t = T(&mut s);
+
+    let mut c = move || {
+        t.0.0 = "new s".into();
+    };
+
+    c();
+}
+
+fn no_ref() {
+    struct S(String);
+    struct T(S);
+
+    let t = T(S("s".into()));
+    let mut c = move || {
+        t.0.0 = "new S".into();
+    };
+    c();
+}
+
+fn main() {
+    simple_ref();
+    struct_contains_ref_to_another_struct();
+    no_ref();
+}

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.rs
@@ -29,13 +29,29 @@ fn struct_contains_ref_to_another_struct() {
     c();
 }
 
-fn no_ref() {
-    struct S(String);
-    struct T(S);
+#[derive(Debug)]
+struct S(String);
 
-    let t = T(S("s".into()));
+#[derive(Debug)]
+struct T(S);
+
+fn no_ref() {
+    let mut t = T(S("s".into()));
     let mut c = move || {
         t.0.0 = "new S".into();
+    };
+    c();
+}
+
+fn no_ref_nested() {
+    let mut t = T(S("s".into()));
+    let c = || {
+        println!("{:?}", t.0);
+        let mut c = move || {
+            t.0.0 = "new S".into();
+            println!("{:?}", t.0.0);
+        };
+        c();
     };
     c();
 }
@@ -44,4 +60,5 @@ fn main() {
     simple_ref();
     struct_contains_ref_to_another_struct();
     no_ref();
+    no_ref_nested();
 }

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.stderr
@@ -1,0 +1,21 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/move_closure.rs:5:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+warning: variable does not need to be mutable
+  --> $DIR/move_closure.rs:36:9
+   |
+LL |     let mut t = T(S("s".into()));
+   |         ----^
+   |         |
+   |         help: remove this `mut`
+   |
+   = note: `#[warn(unused_mut)]` on by default
+
+warning: 2 warnings emitted
+

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/move_closure.stderr
@@ -7,15 +7,5 @@ LL | #![feature(capture_disjoint_fields)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
 
-warning: variable does not need to be mutable
-  --> $DIR/move_closure.rs:36:9
-   |
-LL |     let mut t = T(S("s".into()));
-   |         ----^
-   |         |
-   |         help: remove this `mut`
-   |
-   = note: `#[warn(unused_mut)]` on by default
-
-warning: 2 warnings emitted
+warning: 1 warning emitted
 

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref.rs
@@ -1,0 +1,56 @@
+// run-pass
+
+// Test that we can mutate a place through a mut-borrow
+// that is captured by the closure
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+// Check that we can mutate when one deref is required
+fn mut_ref_1() {
+    let mut x = String::new();
+    let rx = &mut x;
+
+    let mut c = || {
+        *rx = String::new();
+    };
+
+    c();
+}
+
+// Similar example as mut_ref_1, we don't deref the imm-borrow here,
+// and so we are allowed to mutate.
+fn mut_ref_2() {
+    let x = String::new();
+    let y = String::new();
+    let mut ref_x = &x;
+    let m_ref_x = &mut ref_x;
+
+    let mut c = || {
+        *m_ref_x = &y;
+    };
+
+    c();
+}
+
+// Check that we can mutate when multiple derefs of mut-borrows are required to reach
+// the target place.
+// It works because all derefs are mutable, if either of them was an immutable
+// borrow, then we would not be able to deref.
+fn mut_mut_ref() {
+    let mut x = String::new();
+    let mut mref_x = &mut x;
+    let m_mref_x = &mut mref_x;
+
+    let mut c = || {
+        **m_mref_x = String::new();
+    };
+
+    c();
+}
+
+fn main() {
+    mut_ref_1();
+    mut_ref_2();
+    mut_mut_ref();
+}

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref.stderr
@@ -1,0 +1,11 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/mut_ref.rs:6:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref_struct_mem.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref_struct_mem.rs
@@ -2,14 +2,14 @@
 
 // Test that we can mutate a place through a mut-borrow
 // that is captured by the closure
-//
+
 // More specifically we test that the if the mutable reference isn't root variable of a capture
 // but rather accessed while acessing the precise capture.
 
 #![feature(capture_disjoint_fields)]
 //~^ WARNING: the feature `capture_disjoint_fields` is incomplete
 
-fn main() {
+fn mut_tuple() {
     let mut t = (10, 10);
 
     let t1 = (&mut t, 10);
@@ -20,4 +20,26 @@ fn main() {
     };
 
     c();
+}
+
+fn mut_tuple_nested() {
+    let mut t = (10, 10);
+
+    let t1 = (&mut t, 10);
+
+    let mut c = || {
+        let mut c = || {
+            // Mutable because (*t.0) is mutable
+            t1.0.0 += 10;
+        };
+
+        c();
+    };
+
+    c();
+}
+
+fn main() {
+    mut_tuple();
+    mut_tuple_nested();
 }

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref_struct_mem.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref_struct_mem.rs
@@ -1,0 +1,23 @@
+// run-pass
+
+// Test that we can mutate a place through a mut-borrow
+// that is captured by the closure
+//
+// More specifically we test that the if the mutable reference isn't root variable of a capture
+// but rather accessed while acessing the precise capture.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+fn main() {
+    let mut t = (10, 10);
+
+    let t1 = (&mut t, 10);
+
+    let mut c = || {
+        // Mutable because (*t.0) is mutable
+        t1.0.0 += 10;
+    };
+
+    c();
+}

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref_struct_mem.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/mut_ref_struct_mem.stderr
@@ -1,0 +1,11 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/mut_ref_struct_mem.rs:9:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/unsafe_ptr.rs
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/unsafe_ptr.rs
@@ -1,0 +1,47 @@
+// run-pass
+
+// Test that we can use raw ptrs when using `capture_disjoint_fields`.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+
+#[derive(Debug)]
+struct S {
+    s: String,
+    t: String,
+}
+
+struct T(*const S);
+
+fn unsafe_imm() {
+    let s = "".into();
+    let t = "".into();
+    let my_speed: Box<S> = Box::new(S { s, t });
+
+    let p : *const S = Box::into_raw(my_speed);
+    let t = T(p);
+
+    let c = || unsafe {
+        println!("{:?}", (*t.0).s);
+    };
+
+    c();
+}
+
+fn unsafe_mut() {
+    let s = "".into();
+    let t = "".into();
+    let mut my_speed: Box<S> = Box::new(S { s, t });
+    let p : *mut S = &mut *my_speed;
+
+    let c = || {
+        let x = unsafe { &mut (*p).s };
+        *x = "s".into();
+    };
+    c();
+}
+
+fn main() {
+    unsafe_mut();
+    unsafe_imm();
+}

--- a/src/test/ui/closures/2229_closure_analysis/run_pass/unsafe_ptr.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/run_pass/unsafe_ptr.stderr
@@ -1,0 +1,11 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unsafe_ptr.rs:5:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+warning: 1 warning emitted
+

--- a/src/test/ui/closures/2229_closure_analysis/unsafe_ptr.rs
+++ b/src/test/ui/closures/2229_closure_analysis/unsafe_ptr.rs
@@ -1,0 +1,63 @@
+// Test that we restrict precision of a capture when we access a raw ptr,
+// i.e. the capture doesn't deref the raw ptr.
+
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+//~| `#[warn(incomplete_features)]` on by default
+//~| see issue #53488 <https://github.com/rust-lang/rust/issues/53488>
+#![feature(rustc_attrs)]
+
+#[derive(Debug)]
+struct S {
+    s: String,
+    t: String,
+}
+
+struct T(*const S);
+
+fn unsafe_imm() {
+    let s = "".into();
+    let t = "".into();
+    let my_speed: Box<S> = Box::new(S { s, t });
+
+    let p : *const S = Box::into_raw(my_speed);
+    let t = T(p);
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+     || unsafe {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        println!("{:?}", (*t.0).s);
+        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture t[(0, 0)] -> ImmBorrow
+    };
+
+    c();
+}
+
+fn unsafe_mut() {
+    let s = "".into();
+    let t = "".into();
+    let mut my_speed: Box<S> = Box::new(S { s, t });
+    let p : *mut S = &mut *my_speed;
+
+    let c = #[rustc_capture_analysis]
+    //~^ ERROR: attributes on expressions are experimental
+    //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
+    || {
+    //~^ ERROR: First Pass analysis includes:
+    //~| ERROR: Min Capture analysis includes:
+        let x = unsafe { &mut (*p).s };
+        //~^ NOTE: Capturing p[Deref,(0, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture p[] -> ImmBorrow
+        *x = "s".into();
+    };
+    c();
+}
+
+fn main() {
+    unsafe_mut();
+    unsafe_imm();
+}

--- a/src/test/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
@@ -1,0 +1,102 @@
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/unsafe_ptr.rs:26:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+error[E0658]: attributes on expressions are experimental
+  --> $DIR/unsafe_ptr.rs:46:13
+   |
+LL |     let c = #[rustc_capture_analysis]
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
+
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/unsafe_ptr.rs:4:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+error: First Pass analysis includes:
+  --> $DIR/unsafe_ptr.rs:29:6
+   |
+LL | /      || unsafe {
+LL | |
+LL | |
+LL | |         println!("{:?}", (*t.0).s);
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
+  --> $DIR/unsafe_ptr.rs:32:26
+   |
+LL |         println!("{:?}", (*t.0).s);
+   |                          ^^^^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/unsafe_ptr.rs:29:6
+   |
+LL | /      || unsafe {
+LL | |
+LL | |
+LL | |         println!("{:?}", (*t.0).s);
+LL | |
+LL | |
+LL | |     };
+   | |_____^
+   |
+note: Min Capture t[(0, 0)] -> ImmBorrow
+  --> $DIR/unsafe_ptr.rs:32:26
+   |
+LL |         println!("{:?}", (*t.0).s);
+   |                          ^^^^^^^^
+
+error: First Pass analysis includes:
+  --> $DIR/unsafe_ptr.rs:49:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         let x = unsafe { &mut (*p).s };
+...  |
+LL | |         *x = "s".into();
+LL | |     };
+   | |_____^
+   |
+note: Capturing p[Deref,(0, 0)] -> ImmBorrow
+  --> $DIR/unsafe_ptr.rs:52:31
+   |
+LL |         let x = unsafe { &mut (*p).s };
+   |                               ^^^^^^
+
+error: Min Capture analysis includes:
+  --> $DIR/unsafe_ptr.rs:49:5
+   |
+LL | /     || {
+LL | |
+LL | |
+LL | |         let x = unsafe { &mut (*p).s };
+...  |
+LL | |         *x = "s".into();
+LL | |     };
+   | |_____^
+   |
+note: Min Capture p[] -> ImmBorrow
+  --> $DIR/unsafe_ptr.rs:52:31
+   |
+LL |         let x = unsafe { &mut (*p).s };
+   |                               ^^^^^^
+
+error: aborting due to 6 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.rs
@@ -1,4 +1,3 @@
-// run-pass
 #![feature(const_generics)]
 #![allow(incomplete_features, unused_braces)]
 
@@ -15,4 +14,5 @@ where
 
 fn main() {
     Foo::foo();
+    //~^ ERROR no function or associated item
 }

--- a/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
+++ b/src/test/ui/const-generics/issues/issue-69654-run-pass.stderr
@@ -1,11 +1,5 @@
-error[E0423]: expected value, found type parameter `T`
-  --> $DIR/issue-69654.rs:5:25
-   |
-LL | impl<T> Bar<T> for [u8; T] {}
-   |                         ^ not a value
-
 error[E0599]: no function or associated item named `foo` found for struct `Foo<{_: usize}>` in the current scope
-  --> $DIR/issue-69654.rs:17:10
+  --> $DIR/issue-69654-run-pass.rs:16:10
    |
 LL | struct Foo<const N: usize> {}
    | -------------------------- function or associated item `foo` not found for this
@@ -16,7 +10,6 @@ LL |     Foo::foo();
    = note: the method `foo` exists but the following trait bounds were not satisfied:
            `[u8; _]: Bar<[(); _]>`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0423, E0599.
-For more information about an error, try `rustc --explain E0423`.
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/const-generics/issues/issue-69654.rs
+++ b/src/test/ui/const-generics/issues/issue-69654.rs
@@ -15,4 +15,5 @@ where
 
 fn main() {
     Foo::foo();
+    //~^ ERROR no function or associated item
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-1.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-1.rs
@@ -1,4 +1,3 @@
-// build-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -10,5 +9,5 @@ where
     A<N>: Bar<N>;
 
 fn main() {
-    let _ = A;
+    let _ = A; //~ERROR the trait bound
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `A<{_: usize}>: Bar<{_: usize}>` is not satisfied
+  --> $DIR/unused-substs-1.rs:12:13
+   |
+LL | / struct A<const N: usize>
+LL | | where
+LL | |     A<N>: Bar<N>;
+   | |_________________- required by `A`
+...
+LL |       let _ = A;
+   |               ^ the trait `Bar<{_: usize}>` is not implemented for `A<{_: usize}>`
+   |
+   = help: the following implementations were found:
+             <A<7_usize> as Bar<N>>
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/occurs-check/unused-substs-2.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-2.rs
@@ -1,4 +1,3 @@
-// check-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -24,4 +23,6 @@ fn main() {
     // `t` is `ty::Infer(TyVar(_#1t))`
     // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
     t = foo;
+    //~^ ERROR mismatched types
+    //~| NOTE cyclic type
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-2.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-2.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-2.rs:25:9
+   |
+LL |     t = foo;
+   |         ^^^ cyclic type of infinite size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/occurs-check/unused-substs-3.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-3.rs
@@ -1,4 +1,3 @@
-// check-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -15,4 +14,6 @@ fn main() {
     // `t` is `ty::Infer(TyVar(_#1t))`
     // `foo` contains `ty::Infer(TyVar(_#1t))` in its substs
     t = foo;
+    //~^ ERROR mismatched types
+    //~| NOTE cyclic type
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-3.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-3.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-3.rs:16:9
+   |
+LL |     t = foo;
+   |         ^^^
+   |         |
+   |         cyclic type of infinite size
+   |         help: try using a conversion method: `foo.to_vec()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/occurs-check/unused-substs-4.rs
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-4.rs
@@ -1,4 +1,3 @@
-// build-pass
 #![feature(const_generics)]
 #![allow(incomplete_features)]
 
@@ -8,5 +7,5 @@ fn bind<const N: usize>(value: [u8; N]) -> [u8; 3 + 4] {
 
 fn main() {
     let mut arr = Default::default();
-    arr = bind(arr);
+    arr = bind(arr); //~ ERROR mismatched type
 }

--- a/src/test/ui/const-generics/occurs-check/unused-substs-4.stderr
+++ b/src/test/ui/const-generics/occurs-check/unused-substs-4.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/unused-substs-4.rs:10:11
+   |
+LL |     arr = bind(arr);
+   |           ^^^^^^^^^ encountered a self-referencing constant
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -7,10 +7,10 @@ LL |             let mut closure1 = || p = &y;
    = note: defining type: test::{closure#0}::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r i32, &'_#2r mut &'_#3r i32),
+               (&'_#1r mut &'_#2r i32, &'_#3r i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#1r: '_#3r
+   = note: where '_#3r: '_#2r
 
 note: external requirements
   --> $DIR/escape-upvar-nested.rs:20:27
@@ -25,10 +25,10 @@ LL | |         };
    = note: defining type: test::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r i32, &'_#2r mut &'_#3r i32),
+               (&'_#1r mut &'_#2r i32, &'_#3r i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#1r: '_#3r
+   = note: where '_#3r: '_#2r
 
 note: no external requirements
   --> $DIR/escape-upvar-nested.rs:13:1

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -7,10 +7,10 @@ LL |         let mut closure = || p = &y;
    = note: defining type: test::{closure#0} with closure substs [
                i16,
                extern "rust-call" fn(()),
-               (&'_#1r i32, &'_#2r mut &'_#3r i32),
+               (&'_#1r mut &'_#2r i32, &'_#3r i32),
            ]
    = note: number of external vids: 4
-   = note: where '_#1r: '_#3r
+   = note: where '_#3r: '_#2r
 
 note: no external requirements
   --> $DIR/escape-upvar-ref.rs:17:1

--- a/src/test/ui/pattern/pat-tuple-underfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-underfield.stderr
@@ -122,8 +122,8 @@ LL |         Point4(   a   ,     _    , _, _) => {}
    |                                  ^^^^^^
 help: use `..` to ignore the rest of the fields
    |
-LL |         Point4(   a   ,     _    , ..) => {}
-   |                                  ^^^^
+LL |         Point4(   a, ..) => {}
+   |                    ^^^^
 
 error: aborting due to 8 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #79023 (Add `core::stream::Stream`)
 - #80092 (2229: Fix issues with move closures and mutability)
 - #80562 (Consider Scalar to be a bool only if its unsigned)
 - #80629 (Add lint for 2229 migrations)
 - #80843 (Bump rustfmt version)
 - #80959 (Stabilize `unsigned_abs`)
 - #81351 (combine: stop eagerly evaluating consts)
 - #81409 (Slight simplification of chars().count())
 - #81422 (Account for existing `_` field pattern when suggesting `..`)
 - #81484 (Optimize decimal formatting of 128-bit integers)
 - #81550 (Replace predecessor with range in collections documentation)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=79023,80092,80562,80629,80843,80959,81351,81409,81422,81484,81550)
<!-- homu-ignore:end -->