### PR TITLE
introduce future-compatibility warning for forbidden lint groups

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -39,6 +39,7 @@ use rustc_session::SessionLintStore;
 use rustc_span::lev_distance::find_best_match_for_name;
 use rustc_span::{symbol::Symbol, MultiSpan, Span, DUMMY_SP};
 use rustc_target::abi::LayoutOf;
+use tracing::debug;
 
 use std::cell::Cell;
 use std::slice;
@@ -333,6 +334,20 @@ impl LintStore {
             );
             db.note(&msg);
             db.emit();
+        }
+    }
+
+    /// True if this symbol represents a lint group name.
+    pub fn is_lint_group(&self, lint_name: Symbol) -> bool {
+        debug!(
+            "is_lint_group(lint_name={:?}, lint_groups={:?})",
+            lint_name,
+            self.lint_groups.keys().collect::<Vec<_>>()
+        );
+        let lint_name_str = &*lint_name.as_str();
+        self.lint_groups.contains_key(&lint_name_str) || {
+            let warnings_name_str = crate::WARNINGS.name_lower();
+            lint_name_str == &*warnings_name_str
         }
     }
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4,9 +4,47 @@
 //! compiler code, rather than using their own custom pass. Those
 //! lints are all available in `rustc_lint::builtin`.
 
+// ignore-tidy-filelength
+
 use crate::{declare_lint, declare_lint_pass};
 use rustc_span::edition::Edition;
 use rustc_span::symbol::sym;
+
+declare_lint! {
+    /// The `forbidden_lint_groups` lint detects violations of
+    /// `forbid` applied to a lint group. Due to a bug in the compiler,
+    /// these used to be overlooked entirely. They now generate a warning.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// #![forbid(warnings)]
+    /// #![deny(bad_style)]
+    ///
+    /// fn main() {}
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Recommended fix
+    ///
+    /// If your crate is using `#![forbid(warnings)]`,
+    /// we recommend that you change to `#![deny(warnings)]`.
+    ///
+    /// ### Explanation
+    ///
+    /// Due to a compiler bug, applying `forbid` to lint groups
+    /// previously had no effect. The bug is now fixed but instead of
+    /// enforcing `forbid` we issue this future-compatibility warning
+    /// to avoid breaking existing crates.
+    pub FORBIDDEN_LINT_GROUPS,
+    Warn,
+    "applying forbid to lint-groups",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #81670 <https://github.com/rust-lang/rust/issues/81670>",
+        edition: None,
+    };
+}
 
 declare_lint! {
     /// The `ill_formed_attribute_input` lint detects ill-formed attribute
@@ -2837,6 +2875,7 @@ declare_lint_pass! {
     /// Does nothing as a lint pass, but registers some `Lint`s
     /// that are used by other parts of the compiler.
     HardwiredLints => [
+        FORBIDDEN_LINT_GROUPS,
         ILLEGAL_FLOATING_POINT_LITERAL_PATTERN,
         ARITHMETIC_OVERFLOW,
         UNCONDITIONAL_PANIC,

--- a/src/test/ui/lint/forbid-group-group-1.rs
+++ b/src/test/ui/lint/forbid-group-group-1.rs
@@ -1,0 +1,13 @@
+// Check what happens when we forbid a smaller group but
+// then allow a superset of that group.
+
+#![forbid(nonstandard_style)]
+
+// FIXME: Arguably this should be an error, but the WARNINGS group is
+// treated in a very special (and rather ad-hoc) way and
+// it fails to trigger.
+#[allow(warnings)]
+fn main() {
+    let A: ();
+    //~^ ERROR should have a snake case name
+}

--- a/src/test/ui/lint/forbid-group-group-1.stderr
+++ b/src/test/ui/lint/forbid-group-group-1.stderr
@@ -1,0 +1,15 @@
+error: variable `A` should have a snake case name
+  --> $DIR/forbid-group-group-1.rs:11:9
+   |
+LL |     let A: ();
+   |         ^ help: convert the identifier to snake case: `a`
+   |
+note: the lint level is defined here
+  --> $DIR/forbid-group-group-1.rs:4:11
+   |
+LL | #![forbid(nonstandard_style)]
+   |           ^^^^^^^^^^^^^^^^^
+   = note: `#[forbid(non_snake_case)]` implied by `#[forbid(nonstandard_style)]`
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/forbid-group-group-2.rs
+++ b/src/test/ui/lint/forbid-group-group-2.rs
@@ -1,0 +1,26 @@
+// Check what happens when we forbid a bigger group but
+// then deny a subset of that group.
+
+#![forbid(warnings)]
+#![deny(forbidden_lint_groups)]
+
+#[allow(nonstandard_style)]
+//~^ ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+//~| ERROR incompatible with previous
+//~| WARNING previously accepted by the compiler
+fn main() {}

--- a/src/test/ui/lint/forbid-group-group-2.stderr
+++ b/src/test/ui/lint/forbid-group-group-2.stderr
@@ -1,0 +1,115 @@
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+note: the lint level is defined here
+  --> $DIR/forbid-group-group-2.rs:5:9
+   |
+LL | #![deny(forbidden_lint_groups)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: allow(nonstandard_style) incompatible with previous forbid
+  --> $DIR/forbid-group-group-2.rs:7:9
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+...
+LL | #[allow(nonstandard_style)]
+   |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: aborting due to 9 previous errors
+

--- a/src/test/ui/lint/forbid-group-member.rs
+++ b/src/test/ui/lint/forbid-group-member.rs
@@ -1,0 +1,19 @@
+// Check what happens when we forbid a group but
+// then allow a member of that group.
+//
+// check-pass
+
+#![forbid(unused)]
+
+#[allow(unused_variables)]
+//~^ WARNING incompatible with previous forbid
+//~| WARNING previously accepted
+//~| WARNING incompatible with previous forbid
+//~| WARNING previously accepted
+//~| WARNING incompatible with previous forbid
+//~| WARNING previously accepted
+//~| WARNING incompatible with previous forbid
+//~| WARNING previously accepted
+fn main() {
+    let a: ();
+}

--- a/src/test/ui/lint/forbid-group-member.stderr
+++ b/src/test/ui/lint/forbid-group-member.stderr
@@ -1,0 +1,51 @@
+warning: allow(unused_variables) incompatible with previous forbid
+  --> $DIR/forbid-group-member.rs:8:9
+   |
+LL | #![forbid(unused)]
+   |           ------ `forbid` level set here
+LL | 
+LL | #[allow(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = note: `#[warn(forbidden_lint_groups)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: allow(unused_variables) incompatible with previous forbid
+  --> $DIR/forbid-group-member.rs:8:9
+   |
+LL | #![forbid(unused)]
+   |           ------ `forbid` level set here
+LL | 
+LL | #[allow(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: allow(unused_variables) incompatible with previous forbid
+  --> $DIR/forbid-group-member.rs:8:9
+   |
+LL | #![forbid(unused)]
+   |           ------ `forbid` level set here
+LL | 
+LL | #[allow(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: allow(unused_variables) incompatible with previous forbid
+  --> $DIR/forbid-group-member.rs:8:9
+   |
+LL | #![forbid(unused)]
+   |           ------ `forbid` level set here
+LL | 
+LL | #[allow(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: 4 warnings emitted
+

--- a/src/test/ui/lint/forbid-member-group.rs
+++ b/src/test/ui/lint/forbid-member-group.rs
@@ -1,0 +1,12 @@
+// Check what happens when we forbid a member of
+// a group but then allow the group.
+
+#![forbid(unused_variables)]
+
+#[allow(unused)]
+//~^ ERROR incompatible with previous forbid
+//~| ERROR incompatible with previous forbid
+//~| ERROR incompatible with previous forbid
+fn main() {
+    let a: ();
+}

--- a/src/test/ui/lint/forbid-member-group.stderr
+++ b/src/test/ui/lint/forbid-member-group.stderr
@@ -1,0 +1,30 @@
+error[E0453]: allow(unused) incompatible with previous forbid
+  --> $DIR/forbid-member-group.rs:6:9
+   |
+LL | #![forbid(unused_variables)]
+   |           ---------------- `forbid` level set here
+LL | 
+LL | #[allow(unused)]
+   |         ^^^^^^ overruled by previous forbid
+
+error[E0453]: allow(unused) incompatible with previous forbid
+  --> $DIR/forbid-member-group.rs:6:9
+   |
+LL | #![forbid(unused_variables)]
+   |           ---------------- `forbid` level set here
+LL | 
+LL | #[allow(unused)]
+   |         ^^^^^^ overruled by previous forbid
+
+error[E0453]: allow(unused) incompatible with previous forbid
+  --> $DIR/forbid-member-group.rs:6:9
+   |
+LL | #![forbid(unused_variables)]
+   |           ---------------- `forbid` level set here
+LL | 
+LL | #[allow(unused)]
+   |         ^^^^^^ overruled by previous forbid
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0453`.

--- a/src/test/ui/lint/issue-70819-dont-override-forbid-in-same-scope.rs
+++ b/src/test/ui/lint/issue-70819-dont-override-forbid-in-same-scope.rs
@@ -14,14 +14,17 @@
 
 // compile-flags: -Z deduplicate-diagnostics=yes
 
+#![forbid(forbidden_lint_groups)]
+
 fn forbid_first(num: i32) -> i32 {
     #![forbid(unused)]
     #![deny(unused)]
     //~^ ERROR: deny(unused) incompatible with previous forbid
+    //~| WARNING being phased out
+    //~| ERROR: deny(unused) incompatible with previous forbid
+    //~| WARNING being phased out
     #![warn(unused)]
-    //~^ ERROR: warn(unused) incompatible with previous forbid
     #![allow(unused)]
-    //~^ ERROR: allow(unused) incompatible with previous forbid
 
     num * num
 }

--- a/src/test/ui/lint/issue-70819-dont-override-forbid-in-same-scope.stderr
+++ b/src/test/ui/lint/issue-70819-dont-override-forbid-in-same-scope.stderr
@@ -1,29 +1,29 @@
-error[E0453]: deny(unused) incompatible with previous forbid
-  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:19:13
+error: deny(unused) incompatible with previous forbid
+  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:21:13
    |
 LL |     #![forbid(unused)]
    |               ------ `forbid` level set here
 LL |     #![deny(unused)]
    |             ^^^^^^ overruled by previous forbid
+   |
+note: the lint level is defined here
+  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:17:11
+   |
+LL | #![forbid(forbidden_lint_groups)]
+   |           ^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
 
-error[E0453]: warn(unused) incompatible with previous forbid
+error: deny(unused) incompatible with previous forbid
   --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:21:13
    |
 LL |     #![forbid(unused)]
    |               ------ `forbid` level set here
-...
-LL |     #![warn(unused)]
+LL |     #![deny(unused)]
    |             ^^^^^^ overruled by previous forbid
-
-error[E0453]: allow(unused) incompatible with previous forbid
-  --> $DIR/issue-70819-dont-override-forbid-in-same-scope.rs:23:14
    |
-LL |     #![forbid(unused)]
-   |               ------ `forbid` level set here
-...
-LL |     #![allow(unused)]
-   |              ^^^^^^ overruled by previous forbid
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0453`.

--- a/src/test/ui/lint/issue-80988.rs
+++ b/src/test/ui/lint/issue-80988.rs
@@ -1,0 +1,16 @@
+// Regression test for #80988
+//
+// check-pass
+
+#![forbid(warnings)]
+
+#[deny(warnings)]
+//~^ WARNING incompatible with previous forbid
+//~| WARNING being phased out
+//~| WARNING incompatible with previous forbid
+//~| WARNING being phased out
+//~| WARNING incompatible with previous forbid
+//~| WARNING being phased out
+//~| WARNING incompatible with previous forbid
+//~| WARNING being phased out
+fn main() {}

--- a/src/test/ui/lint/issue-80988.stderr
+++ b/src/test/ui/lint/issue-80988.stderr
@@ -1,0 +1,51 @@
+warning: deny(warnings) incompatible with previous forbid
+  --> $DIR/issue-80988.rs:7:8
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+LL | 
+LL | #[deny(warnings)]
+   |        ^^^^^^^^ overruled by previous forbid
+   |
+   = note: `#[warn(forbidden_lint_groups)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: deny(warnings) incompatible with previous forbid
+  --> $DIR/issue-80988.rs:7:8
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+LL | 
+LL | #[deny(warnings)]
+   |        ^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: deny(warnings) incompatible with previous forbid
+  --> $DIR/issue-80988.rs:7:8
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+LL | 
+LL | #[deny(warnings)]
+   |        ^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: deny(warnings) incompatible with previous forbid
+  --> $DIR/issue-80988.rs:7:8
+   |
+LL | #![forbid(warnings)]
+   |           -------- `forbid` level set here
+LL | 
+LL | #[deny(warnings)]
+   |        ^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+warning: 4 warnings emitted
+

--- a/src/test/ui/lint/issue-81218.rs
+++ b/src/test/ui/lint/issue-81218.rs
@@ -1,0 +1,14 @@
+// Regression test for #81218
+//
+// check-pass
+
+#![forbid(warnings)]
+
+#[allow(unused_variables)]
+fn main() {
+    // We want to ensure that you don't get an error
+    // here. The idea is that a derive might generate
+    // code that would otherwise trigger the "unused variables"
+    // lint, but it is meant to be suppressed.
+    let x: ();
+}

--- a/src/test/ui/lint/outer-forbid.rs
+++ b/src/test/ui/lint/outer-forbid.rs
@@ -15,11 +15,16 @@
 // compile-flags: -Z deduplicate-diagnostics=yes
 
 #![forbid(unused, non_snake_case)]
+#![forbid(forbidden_lint_groups)]
 
 #[allow(unused_variables)] //~ ERROR incompatible with previous
+//~^ ERROR incompatible with previous
+//~| WARNING this was previously accepted by the compiler
+//~| WARNING this was previously accepted by the compiler
 fn foo() {}
 
 #[allow(unused)] //~ ERROR incompatible with previous
+//~^ WARNING this was previously accepted by the compiler
 fn bar() {}
 
 #[allow(nonstandard_style)] //~ ERROR incompatible with previous

--- a/src/test/ui/lint/outer-forbid.stderr
+++ b/src/test/ui/lint/outer-forbid.stderr
@@ -1,23 +1,34 @@
-error[E0453]: allow(unused_variables) incompatible with previous forbid
-  --> $DIR/outer-forbid.rs:19:9
+error: allow(unused_variables) incompatible with previous forbid
+  --> $DIR/outer-forbid.rs:20:9
    |
 LL | #![forbid(unused, non_snake_case)]
    |           ------ `forbid` level set here
-LL | 
+...
 LL | #[allow(unused_variables)]
    |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+note: the lint level is defined here
+  --> $DIR/outer-forbid.rs:18:11
+   |
+LL | #![forbid(forbidden_lint_groups)]
+   |           ^^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
 
-error[E0453]: allow(unused) incompatible with previous forbid
-  --> $DIR/outer-forbid.rs:22:9
+error: allow(unused) incompatible with previous forbid
+  --> $DIR/outer-forbid.rs:26:9
    |
 LL | #![forbid(unused, non_snake_case)]
    |           ------ `forbid` level set here
 ...
 LL | #[allow(unused)]
    |         ^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
 
 error[E0453]: allow(nonstandard_style) incompatible with previous forbid
-  --> $DIR/outer-forbid.rs:25:9
+  --> $DIR/outer-forbid.rs:30:9
    |
 LL | #![forbid(unused, non_snake_case)]
    |                   -------------- `forbid` level set here
@@ -25,6 +36,18 @@ LL | #![forbid(unused, non_snake_case)]
 LL | #[allow(nonstandard_style)]
    |         ^^^^^^^^^^^^^^^^^ overruled by previous forbid
 
-error: aborting due to 3 previous errors
+error: allow(unused_variables) incompatible with previous forbid
+  --> $DIR/outer-forbid.rs:20:9
+   |
+LL | #![forbid(unused, non_snake_case)]
+   |           ------ `forbid` level set here
+...
+LL | #[allow(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0453`.


### PR DESCRIPTION
We used to ignore `forbid(group)` scenarios completely. This changed in #78864, but that led to a number of regressions (#80988, #81218).

This PR introduces a future compatibility warning for the case where a group is forbidden but then an individual lint within that group is allowed. We now issue a FCW when we see the "allow", but permit it to take effect.

r? @Mark-Simulacrum 