### PR TITLE
Fix ascii art text wrapping in mobile

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -156,6 +156,7 @@ code, pre, a.test-arrow {
 }
 .docblock pre code, .docblock-short pre code, .docblock code.spotlight {
 	padding: 0;
+	padding-right: 1ex;
 }
 .docblock code.spotlight :last-child {
 	padding-bottom: 0.6em;
@@ -403,9 +404,6 @@ nav.sub {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	margin: 0;
-}
-.docblock code, .docblock-short code {
-	white-space: pre-wrap;
 }
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -405,6 +405,9 @@ nav.sub {
 	text-overflow: ellipsis;
 	margin: 0;
 }
+.docblock-short code {
+	white-space: pre-wrap;
+}
 
 .docblock h1, .docblock h2, .docblock h3, .docblock h4, .docblock h5 {
 	border-bottom: 1px solid;


### PR DESCRIPTION
Fix #81377

Before

![image](https://user-images.githubusercontent.com/4687791/106362405-a1a53800-635d-11eb-87b9-2f40bbd023bf.png)
![image](https://user-images.githubusercontent.com/4687791/106362410-aa960980-635d-11eb-96ee-979251b213a3.png)
![image](https://user-images.githubusercontent.com/4687791/106362562-80911700-635e-11eb-97ee-b19a6ea2fc6d.png)

After

![image](https://user-images.githubusercontent.com/4687791/106362428-b4b80800-635d-11eb-8d5b-e4f51f5501ee.png)
![image](https://user-images.githubusercontent.com/4687791/106362433-bbdf1600-635d-11eb-96af-7043c74b3a0a.png)
![image](https://user-images.githubusercontent.com/4687791/106362570-8f77c980-635e-11eb-928d-ef1d26c13136.png)

Note the second image is scrolled to the back (right), I added some padding for the text block (not the code block) to make it more comfortable to read since the last character is stuck to the last character.