### PR TITLE
Clarify that InPlaceIterable guarantees extend to all advancing iterator methods.

### DIFF
--- a/library/core/src/iter/traits/marker.rs
+++ b/library/core/src/iter/traits/marker.rs
@@ -43,12 +43,14 @@ unsafe impl<I: TrustedLen + ?Sized> TrustedLen for &mut I {}
 /// An iterator that when yielding an item will have taken at least one element
 /// from its underlying [`SourceIter`].
 ///
-/// Calling [`next()`] guarantees that at least one value of the iterator's underlying source
-/// has been moved out and the result of the iterator chain could be inserted in its place,
-/// assuming structural constraints of the source allow such an insertion.
+/// Calling any method that advances the iterator, e.g.  [`next()`] or [`try_fold()`],
+/// guarantees that for each step at least one value of the iterator's underlying source
+/// has been moved out and the result of the iterator chain could be inserted
+/// in its place, assuming structural constraints of the source allow such an insertion.
 /// In other words this trait indicates that an iterator pipeline can be collected in place.
 ///
 /// [`SourceIter`]: crate::iter::SourceIter
 /// [`next()`]: Iterator::next
+/// [`try_fold()`]: Iterator::try_fold
 #[unstable(issue = "none", feature = "inplace_iteration")]
 pub unsafe trait InPlaceIterable: Iterator {}


### PR DESCRIPTION
A documentation update that should answer a question that came up in [this zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Safety.20guarantees.20of.20InPlaceIterable/near/223743336)

CC @SkiFire13

