### PR TITLE
Improve docblock readability on small screen

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1624,7 +1624,7 @@ h4 > .notable-traits {
 	#settings-menu {
 		top: 7px;
 	}
-	
+
 	.docblock {
 		margin-left: 12px;
 	}

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1624,6 +1624,10 @@ h4 > .notable-traits {
 	#settings-menu {
 		top: 7px;
 	}
+	
+	.docblock {
+		margin-left: 12px;
+	}
 }
 
 h3.notable {


### PR DESCRIPTION
Before

![image](https://user-images.githubusercontent.com/4687791/106363174-f77bdf00-6361-11eb-898f-d480b8460ab3.png)

After

![image](https://user-images.githubusercontent.com/4687791/106363259-6bb68280-6362-11eb-85a1-ef9262681dd7.png)

Too much space is wasted on the left side. I wanted to make that 0 but it breaks some part with error symbols.

0

![image](https://user-images.githubusercontent.com/4687791/106363287-90aaf580-6362-11eb-88c1-62a8313988a7.png)

After

![image](https://user-images.githubusercontent.com/4687791/106363276-825cd980-6362-11eb-86eb-6f4611b4ab99.png)
