### PR TITLE
Revert dist-x86_64-linux update to Clang 11

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -201,7 +201,7 @@ impl Step for Llvm {
         if builder.config.llvm_thin_lto {
             cfg.define("LLVM_ENABLE_LTO", "Thin");
             if !target.contains("apple") {
-                cfg.define("LLVM_USE_LINKER", "lld");
+                cfg.define("LLVM_ENABLE_LLD", "ON");
             }
         }
 
@@ -556,9 +556,6 @@ impl Step for Lld {
         t!(fs::create_dir_all(&out_dir));
 
         let mut cfg = cmake::Config::new(builder.src.join("src/llvm-project/lld"));
-        if let Some(ref linker) = builder.config.llvm_use_linker {
-            cfg.define("LLVM_USE_LINKER", linker);
-        }
         configure_cmake(builder, target, &mut cfg, true);
 
         // This is an awful, awful hack. Discovered when we migrated to using

--- a/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-i686-linux/Dockerfile
@@ -68,11 +68,11 @@ RUN ./build-binutils.sh
 COPY host-x86_64/dist-x86_64-linux/build-gcc.sh /tmp/
 RUN ./build-gcc.sh && apt-get remove -y gcc g++
 
-# Debian 6 has Python 2.6 by default, but LLVM >= 12 needs Python 3
+# Debian 6 has Python 2.6 by default, but LLVM needs 2.7+
 COPY host-x86_64/dist-x86_64-linux/build-python.sh /tmp/
 RUN ./build-python.sh
 
-# LLVM needs cmake 3.13.4 or higher
+# LLVM needs cmake 3.4.3 or higher, and is planning to raise to 3.13.4.
 COPY host-x86_64/dist-x86_64-linux/build-cmake.sh /tmp/
 RUN ./build-cmake.sh
 
@@ -94,10 +94,8 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.i686-unknown-linux-gnu.linker=clang \
       --build=i686-unknown-linux-gnu \
       --set llvm.ninja=false \
-      --set llvm.use-linker=lld \
-      --set rust.use-lld=true \
       --set rust.jemalloc
-ENV SCRIPT python3 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS
+ENV SCRIPT python2.7 ../x.py dist --build $HOSTS --host $HOSTS --target $HOSTS
 ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=clang
 
 # This was added when we switched from gcc to clang. It's not clear why this is

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -68,11 +68,11 @@ RUN ./build-binutils.sh
 COPY host-x86_64/dist-x86_64-linux/build-gcc.sh /tmp/
 RUN ./build-gcc.sh && apt-get remove -y gcc g++
 
-# Debian 6 has Python 2.6 by default, but LLVM >= 12 needs Python 3
+# Debian 6 has Python 2.6 by default, but LLVM needs 2.7+
 COPY host-x86_64/dist-x86_64-linux/build-python.sh /tmp/
 RUN ./build-python.sh
 
-# LLVM needs cmake 3.13.4 or higher
+# LLVM needs cmake 3.4.3 or higher, and is planning to raise to 3.13.4.
 COPY host-x86_64/dist-x86_64-linux/build-cmake.sh /tmp/
 RUN ./build-cmake.sh
 
@@ -99,10 +99,8 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
       --set llvm.ninja=false \
-      --set llvm.use-linker=lld \
-      --set rust.use-lld=true \
       --set rust.jemalloc
-ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \
+ENV SCRIPT ../src/ci/pgo.sh python2.7 ../x.py dist \
     --host $HOSTS --target $HOSTS \
     --include-default-paths \
     src/tools/build-manifest

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-11.0.1
+LLVM=llvmorg-10.0.0
 
 mkdir llvm-project
 cd llvm-project

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-python.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-python.sh
@@ -3,7 +3,7 @@
 set -ex
 source shared.sh
 
-curl https://www.python.org/ftp/python/3.9.1/Python-3.9.1.tgz | \
+curl https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz | \
   tar xzf -
 
 mkdir python-build
@@ -12,10 +12,10 @@ cd python-build
 # Gotta do some hackery to tell python about our custom OpenSSL build, but other
 # than that fairly normal.
 CFLAGS='-I /rustroot/include' LDFLAGS='-L /rustroot/lib -L /rustroot/lib64' \
-    hide_output ../Python-3.9.1/configure --prefix=/rustroot
+    hide_output ../Python-2.7.12/configure --prefix=/rustroot
 hide_output make -j10
 hide_output make install
 
 cd ..
 rm -rf python-build
-rm -rf Python-3.9.1
+rm -rf Python-2.7.12

--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 rm -rf /tmp/rustc-pgo
 
-python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
+python2.7 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
     --stage 2 library/std --rust-profile-generate=/tmp/rustc-pgo
 
 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \


### PR DESCRIPTION
This reverts commit cb6787ae82d388045cdf6b5dc73787d828d91feb, reversing changes made to 0248c6f178ab3a4d2ec702b7d418ff8375ab0515.

The change causes errors when linking rustc shared objects with the binutils linker.

Fixes #81554.

r? @Mark-Simulacrum 