### PR TITLE
Add a test for #71202

### DIFF
--- a/src/test/ui/const-generics/issue-71202.rs
+++ b/src/test/ui/const-generics/issue-71202.rs
@@ -1,0 +1,33 @@
+// check-pass
+
+#![feature(const_generics)]
+#![allow(incomplete_features, const_evaluatable_unchecked)]
+
+use std::marker::PhantomData;
+
+struct DataHolder<T> {
+    item: T,
+}
+
+impl<T: Copy> DataHolder<T> {
+    const ITEM_IS_COPY: [(); 1 - {
+        trait NotCopy {
+            const VALUE: bool = false;
+        }
+
+        impl<__Type: ?Sized> NotCopy for __Type {}
+
+        struct IsCopy<__Type: ?Sized>(PhantomData<__Type>);
+
+        impl<__Type> IsCopy<__Type>
+        where
+            __Type: Sized + Copy,
+        {
+            const VALUE: bool = true;
+        }
+
+        <IsCopy<T>>::VALUE
+    } as usize] = [];
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #71202

---

Note that the test normally generates this warning:

```
warning: cannot use constants which depend on generic parameters in types
  --> test.rs:10:5
   |
10 | /     const ITEM_IS_COPY: [(); 1 - {
11 | |         trait NotCopy {
12 | |             const VALUE: bool = false;
13 | |         }
...  |
26 | |         <IsCopy<T>>::VALUE
27 | |     } as usize] = [];
   | |_____________________^
   |
   = note: `#[warn(const_evaluatable_unchecked)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #76200 <https://github.com/rust-lang/rust/issues/76200>
```

I added `allow(const_evaluatable_unchecked)`, but maybe we just don't want to add a test for this as the program is not really valid?