### PR TITLE
Rewrite local labels in inline assembly

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -213,18 +213,11 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                             }
                         }
                     } else {
-                        let mut ts = s.to_owned();
+                        let ts = s.to_owned();
                         // Labels should be made local to prevent issues with inlined `asm!` and duplicate labels
                         // Fixes https://github.com/rust-lang/rust/issues/74262
                         if let Some(label) = get_llvm_label_from_str(&ts) {
                             labels.push(label.to_owned());
-                        }
-
-                        for label in &labels {
-                            ts = ts.replace(
-                                label,
-                                format!("${{:private}}{}${{:uid}}", label).as_ref(),
-                            );
                         }
 
                         template_str.push_str(&ts)
@@ -257,6 +250,11 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                     }
                 }
             }
+        }
+
+        for label in &labels {
+            template_str =
+                template_str.replace(label, format!("${{:private}}{}${{:uid}}", label).as_ref());
         }
 
         if !options.contains(InlineAsmOptions::PRESERVES_FLAGS) {

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -198,34 +198,6 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
             }
         }
 
-        /// Gets a LLVM label from a &str if it exists
-        /// Uses this as reference: https://llvm.org/docs/AMDGPUOperandSyntax.html#symbols
-        fn get_label(s: &str) -> Option<&str> {
-            if let Some(colon_idx) = s.find(':') {
-                let substr = &s[..colon_idx];
-                let mut chars = substr.chars();
-                if let Some(c) = chars.next() {
-                    // First char is [a-zA-Z_.]
-                    if ('a'..='z').contains(&c) || ('A'..='Z').contains(&c) || '_' == c || '.' == c
-                    {
-                        // All subsequent chars are [a-zA-Z0-9_$.@]
-                        if chars.all(|c| {
-                            ('a'..='z').contains(&c)
-                                || ('A'..='Z').contains(&c)
-                                || '_' == c
-                                || '$' == c
-                                || '.' == c
-                                || '@' == c
-                        }) {
-                            return Some(substr);
-                        }
-                    }
-                }
-            }
-
-            None
-        }
-
         // Build the template string
         let mut template_str = String::new();
         let mut labels = vec![];
@@ -244,7 +216,7 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                         let mut ts = s.to_owned();
                         // Labels should be made local to prevent issues with inlined `asm!` and duplicate labels
                         // Fixes https://github.com/rust-lang/rust/issues/74262
-                        if let Some(label) = get_label(&ts) {
+                        if let Some(label) = get_llvm_label_from_str(&ts) {
                             labels.push(label.to_owned());
                         }
 
@@ -916,4 +888,31 @@ fn llvm_fixup_output_type(
         },
         _ => layout.llvm_type(cx),
     }
+}
+
+/// Gets a LLVM label from a &str if it exists
+/// Uses this as reference: https://llvm.org/docs/AMDGPUOperandSyntax.html#symbols
+fn get_llvm_label_from_str(s: &str) -> Option<&str> {
+    if let Some(colon_idx) = s.find(':') {
+        let substr = &s[..colon_idx];
+        let mut chars = substr.chars();
+        if let Some(c) = chars.next() {
+            // First char is [a-zA-Z_.]
+            if ('a'..='z').contains(&c) || ('A'..='Z').contains(&c) || '_' == c || '.' == c {
+                // All subsequent chars are [a-zA-Z0-9_$.@]
+                if chars.all(|c| {
+                    ('a'..='z').contains(&c)
+                        || ('A'..='Z').contains(&c)
+                        || '_' == c
+                        || '$' == c
+                        || '.' == c
+                        || '@' == c
+                }) {
+                    return Some(substr);
+                }
+            }
+        }
+    }
+
+    None
 }

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -262,10 +262,9 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
         }
 
         for label in labels.iter() {
-            let indices: Vec<_> = template_str.match_indices(label).map(|(idx, _)| idx).collect();
-            let ranges: Vec<_> = indices
-                .iter()
-                .filter_map(|&idx| {
+            let ranges: Vec<_> = template_str
+                .match_indices(label)
+                .filter_map(|(idx, _)| {
                     let label_end_idx = idx + label.len();
                     let next_char = template_str[label_end_idx..].chars().nth(0);
                     if next_char.is_none() || !valid_ident_continuation(next_char.unwrap()) {

--- a/src/test/ui/asm/duplicate-labels-inline.rs
+++ b/src/test/ui/asm/duplicate-labels-inline.rs
@@ -3,19 +3,14 @@
 
 #![feature(asm)]
 
-fn asm1() {
+#[inline(always)]
+fn asm() {
     unsafe {
         asm!("duplabel: nop",);
     }
 }
 
-fn asm2() {
-    unsafe {
-        asm!("nop", "duplabel: nop",);
-    }
-}
-
 fn main() {
-    asm1();
-    asm2();
+    asm();
+    asm();
 }

--- a/src/test/ui/asm/duplicate-labels.rs
+++ b/src/test/ui/asm/duplicate-labels.rs
@@ -1,0 +1,16 @@
+// compile-flags: -g
+// build-pass
+
+#![feature(asm)]
+
+#[inline(always)]
+fn asm() {
+    unsafe {
+        asm!("duplabel: nop",);
+    }
+}
+
+fn main() {
+    asm();
+    asm();
+}

--- a/src/test/ui/asm/label-substr-instruction.rs
+++ b/src/test/ui/asm/label-substr-instruction.rs
@@ -1,0 +1,10 @@
+// compile-flags: -g
+// build-pass
+
+#![feature(asm)]
+
+fn main() {
+    unsafe {
+        asm!("jmp j", "nop", "j: nop");
+    }
+}

--- a/src/test/ui/asm/label-substr-label.rs
+++ b/src/test/ui/asm/label-substr-label.rs
@@ -1,0 +1,10 @@
+// compile-flags: -g
+// build-pass
+
+#![feature(asm)]
+
+fn main() {
+    unsafe {
+        asm!("jmp l", "l: nop", "jmp l2", "l2: nop");
+    }
+}

--- a/src/test/ui/asm/label-use-before-declaration.rs
+++ b/src/test/ui/asm/label-use-before-declaration.rs
@@ -1,0 +1,10 @@
+// compile-flags: -g
+// build-pass
+
+#![feature(asm)]
+
+fn main() {
+    unsafe {
+        asm!("jmp l", "nop", "l: nop");
+    }
+}


### PR DESCRIPTION
It is possible for certain `asm!` blocks to be duplicated and emitted more than once by the compiler through inlining or other optimizations.  If a duplicated `asm!` block has a label, the compiler will error with a `invalid symbol redefinition` error.  If the `-g` flag is passed to the compiler, the compiler will abort due to a crash with no output. #74262 shows an example of one such error and crash.  This bug also occurs if two separate `asm!` blocks have the same label, preventing the reuse of simple labels like `loop:`.

This PR aims to fix these issues by making all labels in `asm!` blocks local labels using LLVM's `${:private}` and `${:uid}` as suggested in #81088.  Local labels do not suffer from the same crashes and errors that previously occurred.

Closes #74262
Closes #81088
Addresses part of [this comment](https://github.com/rust-lang/rust/issues/72016#issuecomment-761616910) in the inline assembly tracking issue