### PR TITLE
Edit multiple error code Markdown files

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0013.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0013.md
@@ -8,7 +8,7 @@ static X: i32 = 42;
 const Y: i32 = X;
 ```
 
-In this example, `Y` cannot refer to `X` here. To fix this, the value can be
+In this example, `Y` cannot refer to `X`. To fix this, the value can be
 extracted as a const and then used:
 
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0038.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0038.md
@@ -287,5 +287,5 @@ the method `get_a()` would return an object of unknown type when called on the
 function. `Self` type parameters let us make object safe traits no longer safe,
 so they are forbidden when specifying supertraits.
 
-There's no easy fix for this, generally code will need to be refactored so that
+There's no easy fix for this. Generally, code will need to be refactored so that
 you no longer need to derive from `Super<Self>`.

--- a/compiler/rustc_error_codes/src/error_codes/E0107.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0107.md
@@ -1,4 +1,4 @@
-An incorrect number of generic arguments were provided.
+An incorrect number of generic arguments was provided.
 
 Erroneous code example:
 

--- a/compiler/rustc_error_codes/src/error_codes/E0116.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0116.md
@@ -10,7 +10,7 @@ You can only define an inherent implementation for a type in the same crate
 where the type was defined. For example, an `impl` block as above is not allowed
 since `Vec` is defined in the standard library.
 
-To fix this problem, you can do either of these things:
+To fix this problem, you can either:
 
  - define a trait that has the desired associated functions/types/constants and
    implement the trait for the type in question

--- a/compiler/rustc_error_codes/src/error_codes/E0277.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0277.md
@@ -59,9 +59,9 @@ fn main() {
 }
 ```
 
-Note that the error here is in the definition of the generic function: Although
+Note that the error here is in the definition of the generic function. Although
 we only call it with a parameter that does implement `Debug`, the compiler
-still rejects the function: It must work with all possible input types. In
+still rejects the function. It must work with all possible input types. In
 order to make this example compile, we need to restrict the generic type we're
 accepting:
 

--- a/compiler/rustc_error_codes/src/error_codes/E0309.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0309.md
@@ -25,7 +25,7 @@ where
 
 The type definition contains some field whose type requires an outlives
 annotation. Outlives annotations (e.g., `T: 'a`) are used to guarantee that all
-the data in T is valid for at least the lifetime `'a`. This scenario most
+the data in `T` is valid for at least the lifetime `'a`. This scenario most
 commonly arises when the type contains an associated type reference like
 `<T as SomeTrait<'a>>::Output`, as shown in the previous code.
 

--- a/compiler/rustc_error_codes/src/error_codes/E0597.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0597.md
@@ -1,4 +1,4 @@
-This error occurs because a value was dropped while it was still borrowed
+This error occurs because a value was dropped while it was still borrowed.
 
 Erroneous code example:
 
@@ -15,7 +15,7 @@ let mut x = Foo { x: None };
 println!("{:?}", x.x);
 ```
 
-In here, `y` is dropped at the end of the inner scope, but it is borrowed by
+Here, `y` is dropped at the end of the inner scope, but it is borrowed by
 `x` until the `println`. To fix the previous example, just remove the scope
 so that `y` isn't dropped until after the println
 

--- a/compiler/rustc_error_codes/src/error_codes/E0658.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0658.md
@@ -11,7 +11,7 @@ enum Foo {
 
 If you're using a stable or a beta version of rustc, you won't be able to use
 any unstable features. In order to do so, please switch to a nightly version of
-rustc (by using rustup).
+rustc (by using [rustup]).
 
 If you're using a nightly version of rustc, just add the corresponding feature
 to be able to use it:
@@ -24,3 +24,5 @@ enum Foo {
     Bar(u64),
 }
 ```
+
+[rustup]: https://rust-lang.github.io/rustup/concepts/channels.html

--- a/compiler/rustc_error_codes/src/error_codes/E0754.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0754.md
@@ -1,4 +1,4 @@
-An non-ascii identifier was used in an invalid context.
+A non-ASCII identifier was used in an invalid context.
 
 Erroneous code examples:
 
@@ -13,7 +13,7 @@ fn řųśť() {} // error!
 fn main() {}
 ```
 
-Non-ascii can be used as module names if it is inlined or if a `#[path]`
+Non-ASCII can be used as module names if it is inlined or if a `#[path]`
 attribute is specified. For example:
 
 ```


### PR DESCRIPTION
Makes small edits to several error code files. Fixes some missing punctuation. Changes some wording, grammar, and formatting for clarity and readability.

Adds a link to the rustup book in E0658.