### PR TITLE
Rustdoc UI fixes

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1688,15 +1688,6 @@ function defocusSearchBar() {
 
             search.innerHTML = output;
             showSearchResults(search);
-            var tds = search.getElementsByTagName("td");
-            var td_width = 0;
-            if (tds.length > 0) {
-                td_width = tds[0].offsetWidth;
-            }
-            var width = search.offsetWidth - 40 - td_width;
-            onEachLazy(search.getElementsByClassName("desc"), function(e) {
-                e.style.width = width + "px";
-            });
             initSearchNav();
             var elems = document.getElementById("titles").childNodes;
             elems[0].onclick = function() { printTab(0); };

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1578,7 +1578,7 @@ h4 > .notable-traits {
 	}
 }
 
-@media (max-width: 416px) {
+@media (max-width: 464px) {
 	#titles, #titles > button {
 		height: 73px;
 	}

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1424,7 +1424,7 @@ h4 > .notable-traits {
 		margin-left: 0px;
 	}
 
-	#main {
+	#main, #search {
 		margin-top: 45px;
 		padding: 0;
 	}


### PR DESCRIPTION
The first commit fixes this bug (I couldn't figure out why we were setting the width manually and it works as expected without so...):

![Screenshot from 2021-01-31 12-58-46](https://user-images.githubusercontent.com/3050060/106384371-d56a7700-63ca-11eb-9e04-c06b40c2ab5e.png)

The second commit fixes a small bug. On tablets or computer with very little width, the search section goes "over" the search input, making it impossible to click on the search input:

![Screenshot from 2021-01-31 13-22-37](https://user-images.githubusercontent.com/3050060/106384413-021e8e80-63cb-11eb-8321-391a1f8a4c7e.png)

The third and last commit fixes two bugs that you can see in this screenshot:

![Screenshot from 2021-01-31 13-41-05](https://user-images.githubusercontent.com/3050060/106384424-0cd92380-63cb-11eb-82de-76218286c3fb.png)

The wheel is going over the search input and the search tab is going under the search results text. The bug was fixed by simply switching to "mobile mode" at a bigger width:

![Screenshot from 2021-01-31 13-49-50](https://user-images.githubusercontent.com/3050060/106384466-4447d000-63cb-11eb-9330-a7cd29403905.png)

cc @pickfire 
r? @Nemo157 