### PR TITLE
Avoid building LLVM just for llvm-dwp

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1050,8 +1050,10 @@ impl Step for Assemble {
             builder.copy(&lld_install.join("bin").join(&src_exe), &libdir_bin.join(&dst_exe));
         }
 
-        // Similarly, copy `llvm-dwp` into libdir for Split DWARF.
-        {
+        // Similarly, copy `llvm-dwp` into libdir for Split DWARF. Only copy it when the LLVM
+        // backend is used to avoid unnecessarily building LLVM and because LLVM is not checked
+        // out by default when the LLVM backend is not enabled.
+        if builder.config.rust_codegen_backends.contains(&INTERNER.intern_str("llvm")) {
             let src_exe = exe("llvm-dwp", target_compiler.host);
             let dst_exe = exe("rust-llvm-dwp", target_compiler.host);
             let llvm_config_bin = builder.ensure(native::Llvm { target: target_compiler.host });


### PR DESCRIPTION
When the LLVM backend is disabled, the llvm-project submodule is not checked out by default. This breaks the bootstrap test for cg_clif. As cg_clif doesn't support split debuginfo anyway llvm-dwp is not necessary. Other backends would likely not want to build LLVM just for llvm-dwp either.

Fixes https://github.com/bjorn3/rustc_codegen_cranelift/issues/1119