### PR TITLE
Fix overflowing text on mobile when sidebar is displayed

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1489,6 +1489,14 @@ h4 > .notable-traits {
 		background-color: rgba(0,0,0,0);
 		height: 100%;
 	}
+	/*
+	This allows to prevent the version text to overflow the sidebar title on mobile mode when the
+	sidebar is displayed (after clicking on the "hamburger" button).
+	*/
+	.sidebar.mobile > div.version {
+		overflow: hidden;
+		max-height: 33px;
+	}
 	.sidebar {
 		width: calc(100% + 30px);
 	}


### PR DESCRIPTION
Fixes #81597.

Before:

![Screenshot from 2021-02-01 17-21-15](https://user-images.githubusercontent.com/3050060/106486857-610b0300-64b2-11eb-96d3-12b939f5b661.png)

After:

![Screenshot from 2021-02-01 17-20-59](https://user-images.githubusercontent.com/3050060/106486840-5cdee580-64b2-11eb-9492-4df27bb39e59.png)

cc @pickfire 
r? @Nemo157 