### PR TITLE
Remove unneeded `mut` variable

### DIFF
--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -2083,17 +2083,10 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         output: Option<&'tcx hir::Ty<'tcx>>,
     ) {
         debug!("visit_fn_like_elision: enter");
-        let mut arg_elide = Elide::FreshLateAnon(Cell::new(0));
-        let arg_scope = Scope::Elision { elide: arg_elide.clone(), s: self.scope };
+        let arg_scope = Scope::Elision { elide: Elide::FreshLateAnon(Cell::new(0)), s: self.scope };
         self.with(arg_scope, |_, this| {
             for input in inputs {
                 this.visit_ty(input);
-            }
-            match *this.scope {
-                Scope::Elision { ref elide, .. } => {
-                    arg_elide = elide.clone();
-                }
-                _ => bug!(),
             }
         });
 


### PR DESCRIPTION
`arg_elide` gets initialized, immediately cloned, and only written to after that.
The last reading access was removed back in
https://github.com/rust-lang/rust/commit/7704762604a8bf4504a06e8c9713bc7c158d362a