### PR TITLE
Directly use `Option<&[T]>` instead of converting from `Option<&Vec<T>>` later on

### DIFF
--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -2422,7 +2422,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                                     _ => break,
                                 }
                             }
-                            break Some(e);
+                            break Some(&e[..]);
                         }
                         Elide::Forbid => break None,
                     };
@@ -2452,7 +2452,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             lifetime_refs.len(),
             &lifetime_names,
             lifetime_spans,
-            error.map(|p| &p[..]).unwrap_or(&[]),
+            error.unwrap_or(&[]),
         );
         err.emit();
     }


### PR DESCRIPTION
@rustbot modify labels +C-cleanup +T-compiler