### PR TITLE
Fix bug with assert!() calling the wrong edition of panic!().

### DIFF
--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -29,11 +29,11 @@ pub fn expand_assert<'cx>(
 
     let panic_call = if let Some(tokens) = custom_message {
         let path = if span.rust_2021() {
-            // On edition 2021, we always call `$crate::panic!()`.
+            // On edition 2021, we always call `$crate::panic::panic_2021!()`.
             Path {
                 span: sp,
                 segments: cx
-                    .std_path(&[sym::panic])
+                    .std_path(&[sym::panic, sym::panic_2021])
                     .into_iter()
                     .map(|ident| PathSegment::from_ident(ident))
                     .collect(),

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1234,7 +1234,7 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[macro_export]
     #[rustc_diagnostic_item = "assert_macro"]
-    #[allow_internal_unstable(core_panic)]
+    #[allow_internal_unstable(core_panic, edition_panic)]
     macro_rules! assert {
         ($cond:expr $(,)?) => {{ /* compiler built-in */ }};
         ($cond:expr, $($arg:tt)+) => {{ /* compiler built-in */ }};

--- a/src/test/ui/panics/panic-2021.rs
+++ b/src/test/ui/panics/panic-2021.rs
@@ -1,0 +1,9 @@
+// edition:2021
+
+fn main() {
+    panic!(123); //~ ERROR: format argument must be a string literal
+    panic!("{}"); //~ ERROR: 1 positional argument in format string
+    core::panic!("{}"); //~ ERROR: 1 positional argument in format string
+    assert!(false, 123); //~ ERROR: format argument must be a string literal
+    assert!(false, "{}"); //~ ERROR: 1 positional argument in format string
+}

--- a/src/test/ui/panics/panic-2021.stderr
+++ b/src/test/ui/panics/panic-2021.stderr
@@ -1,0 +1,42 @@
+error: format argument must be a string literal
+  --> $DIR/panic-2021.rs:4:12
+   |
+LL |     panic!(123);
+   |            ^^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     panic!("{}", 123);
+   |            ^^^^^
+
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/panic-2021.rs:5:13
+   |
+LL |     panic!("{}");
+   |             ^^
+
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/panic-2021.rs:6:19
+   |
+LL |     core::panic!("{}");
+   |                   ^^
+
+error: format argument must be a string literal
+  --> $DIR/panic-2021.rs:7:20
+   |
+LL |     assert!(false, 123);
+   |                    ^^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     assert!(false, "{}", 123);
+   |                    ^^^^^
+
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/panic-2021.rs:8:21
+   |
+LL |     assert!(false, "{}");
+   |                     ^^
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
The span of `panic!` produced by the `assert` macro did not carry the right edition. This changes `assert` to call the right version.

Also adds tests for the 2021 edition of panic and assert, that would've caught this.