### PR TITLE
[Do Not Merge] Bit set explicitly track count

### DIFF
--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(extend_one)]
 #![feature(unboxed_closures)]
 #![feature(test)]
+#![feature(trusted_len)]
 #![feature(fn_traits)]
 
 pub mod bit_set;


### PR DESCRIPTION
This is an experiment to see if adding an explicit `len` in bit-set and implementing some iterator traits will improve speed.

r? @ghost