### PR TITLE
Improve wording of suggestion about accessing field

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1855,7 +1855,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         diag.span_suggestion(
                             span,
                             &format!(
-                                "you might have meant to use field `{}` of type `{}`",
+                                "you might have meant to use field `{}` whose type is `{}`",
                                 name, ty
                             ),
                             suggestion,

--- a/src/test/ui/suggestions/field-access.fixed
+++ b/src/test/ui/suggestions/field-access.fixed
@@ -18,17 +18,17 @@ union Foo {
 fn main() {
     let a = A { b: B::Fst };
     if let B::Fst = a.b {}; //~ ERROR mismatched types [E0308]
-    //~^ HELP you might have meant to use field `b` of type `B`
+    //~^ HELP you might have meant to use field `b` whose type is `B`
     match a.b {
-        //~^ HELP you might have meant to use field `b` of type `B`
-        //~| HELP you might have meant to use field `b` of type `B`
+        //~^ HELP you might have meant to use field `b` whose type is `B`
+        //~| HELP you might have meant to use field `b` whose type is `B`
         B::Fst => (), //~ ERROR mismatched types [E0308]
         B::Snd => (), //~ ERROR mismatched types [E0308]
     }
 
     let foo = Foo { bar: 42 };
     match unsafe { foo.bar } {
-        //~^ HELP you might have meant to use field `bar` of type `u32`
+        //~^ HELP you might have meant to use field `bar` whose type is `u32`
         1u32 => (), //~ ERROR mismatched types [E0308]
         _ => (),
     }

--- a/src/test/ui/suggestions/field-access.rs
+++ b/src/test/ui/suggestions/field-access.rs
@@ -18,17 +18,17 @@ union Foo {
 fn main() {
     let a = A { b: B::Fst };
     if let B::Fst = a {}; //~ ERROR mismatched types [E0308]
-    //~^ HELP you might have meant to use field `b` of type `B`
+    //~^ HELP you might have meant to use field `b` whose type is `B`
     match a {
-        //~^ HELP you might have meant to use field `b` of type `B`
-        //~| HELP you might have meant to use field `b` of type `B`
+        //~^ HELP you might have meant to use field `b` whose type is `B`
+        //~| HELP you might have meant to use field `b` whose type is `B`
         B::Fst => (), //~ ERROR mismatched types [E0308]
         B::Snd => (), //~ ERROR mismatched types [E0308]
     }
 
     let foo = Foo { bar: 42 };
     match foo {
-        //~^ HELP you might have meant to use field `bar` of type `u32`
+        //~^ HELP you might have meant to use field `bar` whose type is `u32`
         1u32 => (), //~ ERROR mismatched types [E0308]
         _ => (),
     }

--- a/src/test/ui/suggestions/field-access.stderr
+++ b/src/test/ui/suggestions/field-access.stderr
@@ -9,7 +9,7 @@ LL |     if let B::Fst = a {};
    |            |
    |            expected struct `A`, found enum `B`
    |
-help: you might have meant to use field `b` of type `B`
+help: you might have meant to use field `b` whose type is `B`
    |
 LL |     if let B::Fst = a.b {};
    |                     ^^^
@@ -26,7 +26,7 @@ LL |     match a {
 LL |         B::Fst => (),
    |         ^^^^^^ expected struct `A`, found enum `B`
    |
-help: you might have meant to use field `b` of type `B`
+help: you might have meant to use field `b` whose type is `B`
    |
 LL |     match a.b {
    |           ^^^
@@ -43,7 +43,7 @@ LL |     match a {
 LL |         B::Snd => (),
    |         ^^^^^^ expected struct `A`, found enum `B`
    |
-help: you might have meant to use field `b` of type `B`
+help: you might have meant to use field `b` whose type is `B`
    |
 LL |     match a.b {
    |           ^^^
@@ -57,7 +57,7 @@ LL |
 LL |         1u32 => (),
    |         ^^^^ expected union `Foo`, found `u32`
    |
-help: you might have meant to use field `bar` of type `u32`
+help: you might have meant to use field `bar` whose type is `u32`
    |
 LL |     match unsafe { foo.bar } {
    |           ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Follow-up to #81504

The compiler at this moment suggests "you might have meant to use field `b` of type `B`", sounding like it's type `B` which has the field `b`.
r? @estebank