### PR TITLE
Experiment: Allow to push a result to another query

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1615,7 +1615,7 @@ CloneLiftImpls! { for<'tcx> { Constness, } }
 pub mod tls {
     use super::{ptr_eq, GlobalCtxt, TyCtxt};
 
-    use crate::dep_graph::{DepKind, TaskDeps};
+    use crate::dep_graph::{DepKind, DepNodeIndex, TaskDeps};
     use crate::ty::query;
     use rustc_data_structures::sync::{self, Lock};
     use rustc_data_structures::thin_vec::ThinVec;
@@ -1652,12 +1652,22 @@ pub mod tls {
         /// The current dep graph task. This is used to add dependencies to queries
         /// when executing them.
         pub task_deps: Option<&'a Lock<TaskDeps>>,
+
+        /// Current active dep node.
+        pub dep_node_index: Option<DepNodeIndex>,
     }
 
     impl<'a, 'tcx> ImplicitCtxt<'a, 'tcx> {
         pub fn new(gcx: &'tcx GlobalCtxt<'tcx>) -> Self {
             let tcx = TyCtxt { gcx };
-            ImplicitCtxt { tcx, query: None, diagnostics: None, layout_depth: 0, task_deps: None }
+            ImplicitCtxt {
+                tcx,
+                query: None,
+                diagnostics: None,
+                layout_depth: 0,
+                task_deps: None,
+                dep_node_index: None,
+            }
         }
     }
 

--- a/compiler/rustc_middle/src/ty/query/plumbing.rs
+++ b/compiler/rustc_middle/src/ty/query/plumbing.rs
@@ -60,13 +60,8 @@ impl QueryContext for TyCtxt<'tcx> {
         // when accessing the `ImplicitCtxt`.
         tls::with_related_context(*self, move |current_icx| {
             // Update the `ImplicitCtxt` to point to our new query job.
-            let new_icx = ImplicitCtxt {
-                tcx: *self,
-                query: Some(token),
-                diagnostics,
-                layout_depth: current_icx.layout_depth,
-                task_deps: current_icx.task_deps,
-            };
+            let new_icx =
+                ImplicitCtxt { tcx: *self, query: Some(token), diagnostics, ..*current_icx };
 
             // Use the `ImplicitCtxt` while we execute the query.
             tls::enter_context(&new_icx, |_| {

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -73,6 +73,14 @@ pub trait DepKind: Copy + fmt::Debug + Eq + Hash {
     /// Implementation of `std::fmt::Debug` for `DepNode`.
     fn debug_node(node: &DepNode<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 
+    /// Declare that we are forcing this dep_node_index.
+    fn current_node() -> Option<DepNodeIndex>;
+
+    /// Declare that we are forcing this dep_node_index.
+    fn within_node<OP, R>(dep_node_index: DepNodeIndex, op: OP) -> R
+    where
+        OP: FnOnce() -> R;
+
     /// Execute the operation with provided dependencies.
     fn with_deps<OP, R>(deps: Option<&Lock<TaskDeps<Self>>>, op: OP) -> R
     where

--- a/src/test/incremental/hashes/extern_mods.rs
+++ b/src/test/incremental/hashes/extern_mods.rs
@@ -22,7 +22,7 @@ extern "C" {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_dirty(cfg = "cfail2", except = "hir_owner_nodes")]
+#[rustc_dirty(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
 extern "C" {
     pub fn change_function_name2(c: i64) -> i32;
@@ -113,7 +113,7 @@ extern "C" {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_dirty(cfg = "cfail2", except = "hir_owner_nodes")]
+#[rustc_dirty(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
 extern "rust-call" {
     pub fn change_calling_convention(c: i32);
@@ -126,7 +126,7 @@ extern "C" {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_dirty(cfg = "cfail2", except = "hir_owner_nodes")]
+#[rustc_dirty(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
 extern "C" {
     pub fn make_function_public(c: i32);
@@ -139,7 +139,7 @@ extern "C" {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_dirty(cfg = "cfail2", except = "hir_owner_nodes")]
+#[rustc_dirty(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
 extern "C" {
     pub fn add_function1(c: i32);
@@ -154,7 +154,7 @@ extern "C" {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_dirty(cfg = "cfail2", except = "hir_owner_nodes")]
+#[rustc_dirty(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
 #[link_args = "-foo -bar -baz"]
 extern "C" {
@@ -169,7 +169,7 @@ extern "C" {
 }
 
 #[cfg(not(cfail1))]
-#[rustc_dirty(cfg = "cfail2", except = "hir_owner_nodes")]
+#[rustc_dirty(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
 #[link(name = "bar")]
 extern "C" {


### PR DESCRIPTION
Some queries are trivial projections of an earlier query's result.
The point of this PR is to measure whether we can gain some time by directly putting the result in the cache,
instead of doing the full query setup.

For this experiment: `hir_owner`, `hir_owner_nodes`, `def_span` and `def_kind`.

r? @ghost 