### PR TITLE
Make rustdoc respect `--error-format short` in doctests

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -296,7 +296,12 @@ fn run_test(
         }
     });
     if let ErrorOutputType::HumanReadable(kind) = options.error_format {
-        let (_, color_config) = kind.unzip();
+        let (short, color_config) = kind.unzip();
+
+        if short {
+            compiler.arg("--error-format").arg("short");
+        }
+
         match color_config {
             ColorConfig::Never => {
                 compiler.arg("--color").arg("never");

--- a/src/test/rustdoc-ui/issue-81662-shortness.rs
+++ b/src/test/rustdoc-ui/issue-81662-shortness.rs
@@ -1,0 +1,12 @@
+// compile-flags:--test --error-format=short
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+// failure-status: 101
+
+/// ```rust
+/// foo();
+/// ```
+//~^^ ERROR cannot find function `foo` in this scope
+fn foo() {
+    println!("Hello, world!");
+}

--- a/src/test/rustdoc-ui/issue-81662-shortness.stdout
+++ b/src/test/rustdoc-ui/issue-81662-shortness.stdout
@@ -1,0 +1,16 @@
+
+running 1 test
+test $DIR/issue-81662-shortness.rs - foo (line 6) ... FAILED
+
+failures:
+
+---- $DIR/issue-81662-shortness.rs - foo (line 6) stdout ----
+$DIR/issue-81662-shortness.rs:7:1: error[E0425]: cannot find function `foo` in this scope
+error: aborting due to previous error
+Couldn't compile the test.
+
+failures:
+    $DIR/issue-81662-shortness.rs - foo (line 6)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Note that this will not work with `cargo test`, only with `rustdoc --test`, I'll have to modify `cargo` as well.

Fix #81662.

@rustbot label +T-rustdoc +A-doctests