### PR TITLE
Better styling of "Switch result tab" shortcut

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2910,7 +2910,7 @@ function defocusSearchBar() {
             ["-", "Collapse all sections"],
         ].map(x => "<dt>" +
             x[0].split(" ")
-                .map((y, index) => (index & 1) === 0 ? "<kbd>" + y + "</kbd>" : y)
+                .map((y, index) => (index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " ")
                 .join("") + "</dt><dd>" + x[1] + "</dd>").join("");
         var div_shortcuts = document.createElement("div");
         addClass(div_shortcuts, "shortcuts");

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -798,6 +798,7 @@ body.blur > :not(#help) {
 	float: left;
 	clear: left;
 	display: block;
+	margin-right: 0.5rem;
 }
 #help > div > span {
 	text-align: center;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -239,7 +239,6 @@ a.test-arrow {
 #help dt {
 	border-color: #bfbfbf;
 	background: rgba(0,0,0,0);
-	color: black;
 }
 
 .since {


### PR DESCRIPTION
Before:
![](https://user-images.githubusercontent.com/10530973/106663877-544de400-6572-11eb-98a4-77b6b3d9cd42.png)
![image](https://user-images.githubusercontent.com/10530973/106664790-8d3a8880-6573-11eb-811f-29c4ade31848.png)

After:
![](https://user-images.githubusercontent.com/10530973/106663945-6b8cd180-6572-11eb-911a-12c69d935ee5.png) 
![](https://user-images.githubusercontent.com/10530973/106664403-05547e80-6573-11eb-84bf-fdd0dfc7dac8.png)



