### PR TITLE
Box all fields of ast::*ItemKind

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2725,11 +2725,11 @@ pub enum ItemKind {
     /// A module declaration (`mod`).
     ///
     /// E.g., `mod foo;` or `mod foo { .. }`.
-    Mod(Mod),
+    Mod(Box<Mod>),
     /// An external module (`extern`).
     ///
     /// E.g., `extern {}` or `extern "C" {}`.
-    ForeignMod(ForeignMod),
+    ForeignMod(Box<ForeignMod>),
     /// Module-level inline assembly (from `global_asm!()`).
     GlobalAsm(Box<GlobalAsm>),
     /// A type alias (`type`).
@@ -2770,7 +2770,7 @@ pub enum ItemKind {
 }
 
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(ItemKind, 72);
+rustc_data_structures::static_assert_size!(ItemKind, 24);
 
 impl ItemKind {
     pub fn article(&self) -> &str {

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2698,6 +2698,9 @@ pub struct StructUnionKind(pub VariantData, pub Generics);
 pub struct EnumKind(pub EnumDef, pub Generics);
 
 #[derive(Clone, Encodable, Decodable, Debug)]
+pub struct TraitAliasKind(pub Generics, pub GenericBounds);
+
+#[derive(Clone, Encodable, Decodable, Debug)]
 pub enum ItemKind {
     /// An `extern crate` item, with the optional *original* crate name if the crate was renamed.
     ///
@@ -2752,7 +2755,7 @@ pub enum ItemKind {
     /// Trait alias
     ///
     /// E.g., `trait Foo = Bar + Quux;`.
-    TraitAlias(Generics, GenericBounds),
+    TraitAlias(Box<TraitAliasKind>),
     /// An implementation.
     ///
     /// E.g., `impl<A> Foo<A> { .. }` or `impl<A> Trait for Foo<A> { .. }`.
@@ -2767,7 +2770,7 @@ pub enum ItemKind {
 }
 
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(ItemKind, 104);
+rustc_data_structures::static_assert_size!(ItemKind, 72);
 
 impl ItemKind {
     pub fn article(&self) -> &str {
@@ -2809,7 +2812,7 @@ impl ItemKind {
             | Self::Struct(box StructUnionKind(_, generics))
             | Self::Union(box StructUnionKind(_, generics))
             | Self::Trait(box TraitKind(_, _, generics, ..))
-            | Self::TraitAlias(generics, _)
+            | Self::TraitAlias(box TraitAliasKind(generics, _))
             | Self::Impl(box ImplKind { generics, .. }) => Some(generics),
             _ => None,
         }

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2694,7 +2694,7 @@ pub enum ItemKind {
     /// A use declaration item (`use`).
     ///
     /// E.g., `use foo;`, `use foo::bar;` or `use foo::bar as FooBar;`.
-    Use(P<UseTree>),
+    Use(Box<UseTree>),
     /// A static item (`static`).
     ///
     /// E.g., `static FOO: i32 = 42;` or `static FOO: &'static str = "bar";`.
@@ -2716,7 +2716,7 @@ pub enum ItemKind {
     /// E.g., `extern {}` or `extern "C" {}`.
     ForeignMod(ForeignMod),
     /// Module-level inline assembly (from `global_asm!()`).
-    GlobalAsm(P<GlobalAsm>),
+    GlobalAsm(Box<GlobalAsm>),
     /// A type alias (`type`).
     ///
     /// E.g., `type Foo = Bar<u8>;`.

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2695,6 +2695,9 @@ pub struct ConstKind(pub Defaultness, pub P<Ty>, pub Option<P<Expr>>);
 pub struct StructUnionKind(pub VariantData, pub Generics);
 
 #[derive(Clone, Encodable, Decodable, Debug)]
+pub struct EnumKind(pub EnumDef, pub Generics);
+
+#[derive(Clone, Encodable, Decodable, Debug)]
 pub enum ItemKind {
     /// An `extern crate` item, with the optional *original* crate name if the crate was renamed.
     ///
@@ -2733,7 +2736,7 @@ pub enum ItemKind {
     /// An enum definition (`enum`).
     ///
     /// E.g., `enum Foo<A, B> { C<A>, D<B> }`.
-    Enum(EnumDef, Generics),
+    Enum(Box<EnumKind>),
     /// A struct definition (`struct`).
     ///
     /// E.g., `struct Foo<A> { x: A }`.
@@ -2802,7 +2805,7 @@ impl ItemKind {
         match self {
             Self::Fn(box FnKind(_, _, generics, _))
             | Self::TyAlias(box TyAliasKind(_, generics, ..))
-            | Self::Enum(_, generics)
+            | Self::Enum(box EnumKind(_, generics))
             | Self::Struct(box StructUnionKind(_, generics))
             | Self::Union(box StructUnionKind(_, generics))
             | Self::Trait(box TraitKind(_, _, generics, ..))

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2766,11 +2766,11 @@ pub enum ItemKind {
     MacCall(Box<MacCall>),
 
     /// A macro definition.
-    MacroDef(MacroDef),
+    MacroDef(Box<MacroDef>),
 }
 
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(ItemKind, 24);
+rustc_data_structures::static_assert_size!(ItemKind, 16);
 
 impl ItemKind {
     pub fn article(&self) -> &str {

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2692,6 +2692,9 @@ pub struct StaticKind(pub P<Ty>, pub Mutability, pub Option<P<Expr>>);
 pub struct ConstKind(pub Defaultness, pub P<Ty>, pub Option<P<Expr>>);
 
 #[derive(Clone, Encodable, Decodable, Debug)]
+pub struct StructUnionKind(pub VariantData, pub Generics);
+
+#[derive(Clone, Encodable, Decodable, Debug)]
 pub enum ItemKind {
     /// An `extern crate` item, with the optional *original* crate name if the crate was renamed.
     ///
@@ -2734,11 +2737,11 @@ pub enum ItemKind {
     /// A struct definition (`struct`).
     ///
     /// E.g., `struct Foo<A> { x: A }`.
-    Struct(VariantData, Generics),
+    Struct(Box<StructUnionKind>),
     /// A union definition (`union`).
     ///
     /// E.g., `union Foo<A, B> { x: A, y: B }`.
-    Union(VariantData, Generics),
+    Union(Box<StructUnionKind>),
     /// A trait declaration (`trait`).
     ///
     /// E.g., `trait Foo { .. }`, `trait Foo<T> { .. }` or `auto trait Foo {}`.
@@ -2761,7 +2764,7 @@ pub enum ItemKind {
 }
 
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(ItemKind, 112);
+rustc_data_structures::static_assert_size!(ItemKind, 104);
 
 impl ItemKind {
     pub fn article(&self) -> &str {
@@ -2800,8 +2803,8 @@ impl ItemKind {
             Self::Fn(box FnKind(_, _, generics, _))
             | Self::TyAlias(box TyAliasKind(_, generics, ..))
             | Self::Enum(_, generics)
-            | Self::Struct(_, generics)
-            | Self::Union(_, generics)
+            | Self::Struct(box StructUnionKind(_, generics))
+            | Self::Union(box StructUnionKind(_, generics))
             | Self::Trait(box TraitKind(_, _, generics, ..))
             | Self::TraitAlias(generics, _)
             | Self::Impl(box ImplKind { generics, .. }) => Some(generics),

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -926,7 +926,7 @@ pub fn noop_visit_item_kind<T: MutVisitor>(kind: &mut ItemKind, vis: &mut T) {
             visit_bounds(bounds, vis);
             visit_opt(ty, |ty| vis.visit_ty(ty));
         }
-        ItemKind::Enum(EnumDef { variants }, generics) => {
+        ItemKind::Enum(box EnumKind(EnumDef { variants }, generics)) => {
             variants.flat_map_in_place(|variant| vis.flat_map_variant(variant));
             vis.visit_generics(generics);
         }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -930,7 +930,8 @@ pub fn noop_visit_item_kind<T: MutVisitor>(kind: &mut ItemKind, vis: &mut T) {
             variants.flat_map_in_place(|variant| vis.flat_map_variant(variant));
             vis.visit_generics(generics);
         }
-        ItemKind::Struct(variant_data, generics) | ItemKind::Union(variant_data, generics) => {
+        ItemKind::Struct(box StructUnionKind(variant_data, generics))
+        | ItemKind::Union(box StructUnionKind(variant_data, generics)) => {
             vis.visit_variant_data(variant_data);
             vis.visit_generics(generics);
         }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -955,7 +955,7 @@ pub fn noop_visit_item_kind<T: MutVisitor>(kind: &mut ItemKind, vis: &mut T) {
             visit_bounds(bounds, vis);
             items.flat_map_in_place(|item| vis.flat_map_trait_item(item));
         }
-        ItemKind::TraitAlias(generics, bounds) => {
+        ItemKind::TraitAlias(box TraitAliasKind(generics, bounds)) => {
             vis.visit_generics(generics);
             visit_bounds(bounds, vis);
         }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1016,7 +1016,7 @@ pub fn noop_visit_crate<T: MutVisitor>(krate: &mut Crate, vis: &mut T) {
             id: DUMMY_NODE_ID,
             vis: item_vis,
             span,
-            kind: ItemKind::Mod(module),
+            kind: ItemKind::Mod(box module),
             tokens: None,
         });
         let items = vis.flat_map_item(item);
@@ -1028,7 +1028,7 @@ pub fn noop_visit_crate<T: MutVisitor>(krate: &mut Crate, vis: &mut T) {
         } else if len == 1 {
             let Item { attrs, span, kind, .. } = items.into_iter().next().unwrap().into_inner();
             match kind {
-                ItemKind::Mod(module) => Crate { module, attrs, span, proc_macros },
+                ItemKind::Mod(box module) => Crate { module, attrs, span, proc_macros },
                 _ => panic!("visitor converted a module to not a module"),
             }
         } else {

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -908,7 +908,8 @@ pub fn noop_visit_item_kind<T: MutVisitor>(kind: &mut ItemKind, vis: &mut T) {
     match kind {
         ItemKind::ExternCrate(_orig_name) => {}
         ItemKind::Use(use_tree) => vis.visit_use_tree(use_tree),
-        ItemKind::Static(ty, _, expr) | ItemKind::Const(_, ty, expr) => {
+        ItemKind::Static(box StaticKind(ty, _, expr))
+        | ItemKind::Const(box ConstKind(_, ty, expr)) => {
             vis.visit_ty(ty);
             visit_opt(expr, |expr| vis.visit_expr(expr));
         }
@@ -972,7 +973,7 @@ pub fn noop_flat_map_assoc_item<T: MutVisitor>(
     visitor.visit_vis(vis);
     visit_attrs(attrs, visitor);
     match kind {
-        AssocItemKind::Const(_, ty, expr) => {
+        AssocItemKind::Const(box ConstKind(_, ty, expr)) => {
             visitor.visit_ty(ty);
             visit_opt(expr, |expr| visitor.visit_expr(expr));
         }
@@ -1062,7 +1063,7 @@ pub fn noop_flat_map_foreign_item<T: MutVisitor>(
     visitor.visit_vis(vis);
     visit_attrs(attrs, visitor);
     match kind {
-        ForeignItemKind::Static(ty, _, expr) => {
+        ForeignItemKind::Static(box StaticKind(ty, _, expr)) => {
             visitor.visit_ty(ty);
             visit_opt(expr, |expr| visitor.visit_expr(expr));
         }

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -805,7 +805,7 @@ impl Nonterminal {
 
         let name = item.ident.name;
         if name == sym::ProceduralMasqueradeDummyType || name == sym::ProcMacroHack {
-            if let ast::ItemKind::Enum(enum_def, _) = &item.kind {
+            if let ast::ItemKind::Enum(box ast::EnumKind(enum_def, _)) = &item.kind {
                 if let [variant] = &*enum_def.variants {
                     return variant.ident.name == sym::Input;
                 }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -327,8 +327,8 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             visitor.visit_ty(self_ty);
             walk_list!(visitor, visit_assoc_item, items, AssocCtxt::Impl);
         }
-        ItemKind::Struct(ref struct_definition, ref generics)
-        | ItemKind::Union(ref struct_definition, ref generics) => {
+        ItemKind::Struct(box StructUnionKind(ref struct_definition, ref generics))
+        | ItemKind::Union(box StructUnionKind(ref struct_definition, ref generics)) => {
             visitor.visit_generics(generics);
             visitor.visit_variant_data(struct_definition);
         }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -308,7 +308,7 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             walk_list!(visitor, visit_param_bound, bounds);
             walk_list!(visitor, visit_ty, ty);
         }
-        ItemKind::Enum(ref enum_definition, ref generics) => {
+        ItemKind::Enum(box EnumKind(ref enum_definition, ref generics)) => {
             visitor.visit_generics(generics);
             visitor.visit_enum_def(enum_definition, generics, item.id, item.span)
         }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -337,7 +337,7 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             walk_list!(visitor, visit_param_bound, bounds);
             walk_list!(visitor, visit_assoc_item, items, AssocCtxt::Trait);
         }
-        ItemKind::TraitAlias(ref generics, ref bounds) => {
+        ItemKind::TraitAlias(box TraitAliasKind(ref generics, ref bounds)) => {
             visitor.visit_generics(generics);
             walk_list!(visitor, visit_param_bound, bounds);
         }

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -288,7 +288,8 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             }
         }
         ItemKind::Use(ref use_tree) => visitor.visit_use_tree(use_tree, item.id, false),
-        ItemKind::Static(ref typ, _, ref expr) | ItemKind::Const(_, ref typ, ref expr) => {
+        ItemKind::Static(box StaticKind(ref typ, _, ref expr))
+        | ItemKind::Const(box ConstKind(_, ref typ, ref expr)) => {
             visitor.visit_ty(typ);
             walk_list!(visitor, visit_expr, expr);
         }
@@ -539,7 +540,7 @@ pub fn walk_foreign_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a ForeignI
     visitor.visit_ident(ident);
     walk_list!(visitor, visit_attribute, attrs);
     match kind {
-        ForeignItemKind::Static(ty, _, expr) => {
+        ForeignItemKind::Static(box StaticKind(ty, _, expr)) => {
             visitor.visit_ty(ty);
             walk_list!(visitor, visit_expr, expr);
         }
@@ -649,7 +650,7 @@ pub fn walk_assoc_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a AssocItem,
     visitor.visit_ident(ident);
     walk_list!(visitor, visit_attribute, attrs);
     match kind {
-        AssocItemKind::Const(_, ty, expr) => {
+        AssocItemKind::Const(box ConstKind(_, ty, expr)) => {
             visitor.visit_ty(ty);
             walk_list!(visitor, visit_expr, expr);
         }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -363,14 +363,14 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 },
                 self.lower_generics(generics, ImplTraitContext::disallowed()),
             ),
-            ItemKind::Struct(ref struct_def, ref generics) => {
+            ItemKind::Struct(box StructUnionKind(ref struct_def, ref generics)) => {
                 let struct_def = self.lower_variant_data(struct_def);
                 hir::ItemKind::Struct(
                     struct_def,
                     self.lower_generics(generics, ImplTraitContext::disallowed()),
                 )
             }
-            ItemKind::Union(ref vdata, ref generics) => {
+            ItemKind::Union(box StructUnionKind(ref vdata, ref generics)) => {
                 let vdata = self.lower_variant_data(vdata);
                 hir::ItemKind::Union(
                     vdata,

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -469,10 +469,12 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     items,
                 )
             }
-            ItemKind::TraitAlias(ref generics, ref bounds) => hir::ItemKind::TraitAlias(
-                self.lower_generics(generics, ImplTraitContext::disallowed()),
-                self.lower_param_bounds(bounds, ImplTraitContext::disallowed()),
-            ),
+            ItemKind::TraitAlias(box TraitAliasKind(ref generics, ref bounds)) => {
+                hir::ItemKind::TraitAlias(
+                    self.lower_generics(generics, ImplTraitContext::disallowed()),
+                    self.lower_param_bounds(bounds, ImplTraitContext::disallowed()),
+                )
+            }
             ItemKind::MacroDef(..) | ItemKind::MacCall(..) => {
                 panic!("`TyMac` should have been expanded by now")
             }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -355,7 +355,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let generics = self.lower_generics(generics, ImplTraitContext::disallowed());
                 hir::ItemKind::TyAlias(ty, generics)
             }
-            ItemKind::Enum(ref enum_definition, ref generics) => hir::ItemKind::Enum(
+            ItemKind::Enum(box EnumKind(ref enum_definition, ref generics)) => hir::ItemKind::Enum(
                 hir::EnumDef {
                     variants: self.arena.alloc_from_iter(
                         enum_definition.variants.iter().map(|x| self.lower_variant(x)),

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -230,7 +230,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let mut vis = self.lower_visibility(&i.vis, None);
         let attrs = self.lower_attrs(&i.attrs);
 
-        if let ItemKind::MacroDef(MacroDef { ref body, macro_rules }) = i.kind {
+        if let ItemKind::MacroDef(box MacroDef { ref body, macro_rules }) = i.kind {
             if !macro_rules || self.sess.contains_name(&i.attrs, sym::macro_export) {
                 let hir_id = self.lower_node_id(i.id);
                 let body = P(self.lower_mac_args(body));

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -500,7 +500,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 match item.kind {
                     ItemKind::Struct(box StructUnionKind(_, ref generics))
                     | ItemKind::Union(box StructUnionKind(_, ref generics))
-                    | ItemKind::Enum(_, ref generics)
+                    | ItemKind::Enum(box EnumKind(_, ref generics))
                     | ItemKind::TyAlias(box TyAliasKind(_, ref generics, ..))
                     | ItemKind::Trait(box TraitKind(_, _, ref generics, ..)) => {
                         let def_id = self.lctx.resolver.local_def_id(item.id);

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -498,8 +498,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 let hir_id = self.lctx.allocate_hir_id_counter(item.id);
 
                 match item.kind {
-                    ItemKind::Struct(_, ref generics)
-                    | ItemKind::Union(_, ref generics)
+                    ItemKind::Struct(box StructUnionKind(_, ref generics))
+                    | ItemKind::Union(box StructUnionKind(_, ref generics))
                     | ItemKind::Enum(_, ref generics)
                     | ItemKind::TyAlias(box TyAliasKind(_, ref generics, ..))
                     | ItemKind::Trait(box TraitKind(_, _, ref generics, ..)) => {

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1063,7 +1063,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.check_mod_file_item_asciionly(item.ident);
                 }
             }
-            ItemKind::Union(ref vdata, _) => {
+            ItemKind::Union(box StructUnionKind(ref vdata, _)) => {
                 if let VariantData::Tuple(..) | VariantData::Unit(..) = vdata {
                     self.err_handler()
                         .span_err(item.span, "tuple and unit unions are not permitted");

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1006,7 +1006,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.error_item_without_body(item.span, "function", msg, " { <body> }");
                 }
             }
-            ItemKind::ForeignMod(ForeignMod { unsafety, .. }) => {
+            ItemKind::ForeignMod(box ForeignMod { unsafety, .. }) => {
                 let old_item = mem::replace(&mut self.extern_mod, Some(item));
                 self.invalid_visibility(
                     &item.vis,
@@ -1054,7 +1054,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 walk_list!(self, visit_attribute, &item.attrs);
                 return;
             }
-            ItemKind::Mod(Mod { inline, unsafety, .. }) => {
+            ItemKind::Mod(box Mod { inline, unsafety, .. }) => {
                 if let Unsafe::Yes(span) = unsafety {
                     self.err_handler().span_err(span, "module cannot be declared unsafe");
                 }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1072,12 +1072,12 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.err_handler().span_err(item.span, "unions cannot have zero fields");
                 }
             }
-            ItemKind::Const(def, .., None) => {
+            ItemKind::Const(box ConstKind(def, .., None)) => {
                 self.check_defaultness(item.span, def);
                 let msg = "free constant item without body";
                 self.error_item_without_body(item.span, "constant", msg, " = <expr>;");
             }
-            ItemKind::Static(.., None) => {
+            ItemKind::Static(box StaticKind(.., None)) => {
                 let msg = "free static item without body";
                 self.error_item_without_body(item.span, "static", msg, " = <expr>;");
             }
@@ -1108,7 +1108,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self.check_type_no_bounds(bounds, "`extern` blocks");
                 self.check_foreign_ty_genericless(generics);
             }
-            ForeignItemKind::Static(_, _, body) => {
+            ForeignItemKind::Static(box StaticKind(_, _, body)) => {
                 self.check_foreign_kind_bodyless(fi.ident, "static", body.as_ref().map(|b| b.span));
             }
             ForeignItemKind::MacCall(..) => {}
@@ -1339,7 +1339,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
 
         if ctxt == AssocCtxt::Impl {
             match &item.kind {
-                AssocItemKind::Const(_, _, body) => {
+                AssocItemKind::Const(box ConstKind(_, _, body)) => {
                     self.check_impl_item_provided(item.span, body, "constant", " = <expr>;");
                 }
                 AssocItemKind::Fn(box FnKind(_, _, _, body)) => {

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1019,7 +1019,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self.extern_mod = old_item;
                 return; // Avoid visiting again.
             }
-            ItemKind::Enum(ref def, _) => {
+            ItemKind::Enum(box EnumKind(ref def, _)) => {
                 for variant in &def.variants {
                     self.invalid_visibility(&variant.vis, None);
                     for field in variant.data.fields() {

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -345,7 +345,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemKind::Enum(ast::EnumDef { ref variants, .. }, ..) => {
+            ast::ItemKind::Enum(box ast::EnumKind(ast::EnumDef { ref variants, .. }, ..)) => {
                 for variant in variants {
                     match (&variant.data, &variant.disr_expr) {
                         (ast::VariantData::Unit(..), _) => {}

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -396,7 +396,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 gate_feature_post!(&self, trait_alias, i.span, "trait aliases are experimental");
             }
 
-            ast::ItemKind::MacroDef(ast::MacroDef { macro_rules: false, .. }) => {
+            ast::ItemKind::MacroDef(box ast::MacroDef { macro_rules: false, .. }) => {
                 let msg = "`macro` is experimental";
                 gate_feature_post!(&self, decl_macro, i.span, msg);
             }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1267,7 +1267,7 @@ impl<'a> State<'a> {
                 }
                 self.bclose(item.span);
             }
-            ast::ItemKind::TraitAlias(ref generics, ref bounds) => {
+            ast::ItemKind::TraitAlias(box ast::TraitAliasKind(ref generics, ref bounds)) => {
                 self.head("");
                 self.print_visibility(&item.vis);
                 self.word_nbsp("trait");

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1179,7 +1179,7 @@ impl<'a> State<'a> {
                 let ty = ty.as_deref();
                 self.print_associated_type(item.ident, generics, bounds, ty, &item.vis, def);
             }
-            ast::ItemKind::Enum(ref enum_definition, ref params) => {
+            ast::ItemKind::Enum(box ast::EnumKind(ref enum_definition, ref params)) => {
                 self.print_enum_def(enum_definition, params, item.ident, item.span, &item.vis);
             }
             ast::ItemKind::Struct(box ast::StructUnionKind(ref struct_def, ref generics)) => {

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1182,11 +1182,11 @@ impl<'a> State<'a> {
             ast::ItemKind::Enum(ref enum_definition, ref params) => {
                 self.print_enum_def(enum_definition, params, item.ident, item.span, &item.vis);
             }
-            ast::ItemKind::Struct(ref struct_def, ref generics) => {
+            ast::ItemKind::Struct(box ast::StructUnionKind(ref struct_def, ref generics)) => {
                 self.head(visibility_qualified(&item.vis, "struct"));
                 self.print_struct(struct_def, generics, item.ident, item.span, true);
             }
-            ast::ItemKind::Union(ref struct_def, ref generics) => {
+            ast::ItemKind::Union(box ast::StructUnionKind(ref struct_def, ref generics)) => {
                 self.head(visibility_qualified(&item.vis, "union"));
                 self.print_struct(struct_def, generics, item.ident, item.span, true);
             }

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1025,7 +1025,7 @@ impl<'a> State<'a> {
             ast::ForeignItemKind::Fn(box ast::FnKind(def, sig, gen, body)) => {
                 self.print_fn_full(sig, ident, gen, vis, *def, body.as_deref(), attrs);
             }
-            ast::ForeignItemKind::Static(ty, mutbl, body) => {
+            ast::ForeignItemKind::Static(box ast::StaticKind(ty, mutbl, body)) => {
                 let def = ast::Defaultness::Final;
                 self.print_item_const(ident, Some(*mutbl), ty, body.as_deref(), vis, def);
             }
@@ -1127,11 +1127,11 @@ impl<'a> State<'a> {
                 self.end(); // end inner head-block
                 self.end(); // end outer head-block
             }
-            ast::ItemKind::Static(ref ty, mutbl, ref body) => {
+            ast::ItemKind::Static(box ast::StaticKind(ref ty, mutbl, ref body)) => {
                 let def = ast::Defaultness::Final;
                 self.print_item_const(item.ident, Some(mutbl), ty, body.as_deref(), &item.vis, def);
             }
-            ast::ItemKind::Const(def, ref ty, ref body) => {
+            ast::ItemKind::Const(box ast::ConstKind(def, ref ty, ref body)) => {
                 self.print_item_const(item.ident, None, ty, body.as_deref(), &item.vis, def);
             }
             ast::ItemKind::Fn(box ast::FnKind(def, ref sig, ref gen, ref body)) => {
@@ -1462,7 +1462,7 @@ impl<'a> State<'a> {
             ast::AssocItemKind::Fn(box ast::FnKind(def, sig, gen, body)) => {
                 self.print_fn_full(sig, ident, gen, vis, *def, body.as_deref(), attrs);
             }
-            ast::AssocItemKind::Const(def, ty, body) => {
+            ast::AssocItemKind::Const(box ast::ConstKind(def, ty, body)) => {
                 self.print_item_const(ident, None, ty, body.as_deref(), vis, *def);
             }
             ast::AssocItemKind::TyAlias(box ast::TyAliasKind(def, generics, bounds, ty)) => {

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -3,7 +3,9 @@ use crate::deriving::generic::*;
 use crate::deriving::path_std;
 
 use rustc_ast::ptr::P;
-use rustc_ast::{self as ast, Expr, GenericArg, Generics, ItemKind, MetaItem, VariantData};
+use rustc_ast::{
+    self as ast, Expr, GenericArg, Generics, ItemKind, MetaItem, StructUnionKind, VariantData,
+};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::Span;
@@ -34,7 +36,7 @@ pub fn expand_deriving_clone(
     let is_shallow;
     match *item {
         Annotatable::Item(ref annitem) => match annitem.kind {
-            ItemKind::Struct(_, Generics { ref params, .. })
+            ItemKind::Struct(box StructUnionKind(_, Generics { ref params, .. }))
             | ItemKind::Enum(_, Generics { ref params, .. }) => {
                 let container_id = cx.current_expansion.id.expn_data().parent;
                 if cx.resolver.has_derive_copy(container_id)

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -4,7 +4,8 @@ use crate::deriving::path_std;
 
 use rustc_ast::ptr::P;
 use rustc_ast::{
-    self as ast, Expr, GenericArg, Generics, ItemKind, MetaItem, StructUnionKind, VariantData,
+    self as ast, EnumKind, Expr, GenericArg, Generics, ItemKind, MetaItem, StructUnionKind,
+    VariantData,
 };
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
@@ -37,7 +38,7 @@ pub fn expand_deriving_clone(
     match *item {
         Annotatable::Item(ref annitem) => match annitem.kind {
             ItemKind::Struct(box StructUnionKind(_, Generics { ref params, .. }))
-            | ItemKind::Enum(_, Generics { ref params, .. }) => {
+            | ItemKind::Enum(box EnumKind(_, Generics { ref params, .. })) => {
                 let container_id = cx.current_expansion.id.expn_data().parent;
                 if cx.resolver.has_derive_copy(container_id)
                     && !params

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -403,7 +403,7 @@ impl<'a> TraitDef<'a> {
                 });
                 let has_no_type_params = match item.kind {
                     ast::ItemKind::Struct(box ast::StructUnionKind(_, ref generics))
-                    | ast::ItemKind::Enum(_, ref generics)
+                    | ast::ItemKind::Enum(box ast::EnumKind(_, ref generics))
                     | ast::ItemKind::Union(box ast::StructUnionKind(_, ref generics)) => !generics
                         .params
                         .iter()
@@ -426,7 +426,7 @@ impl<'a> TraitDef<'a> {
                         from_scratch,
                         use_temporaries,
                     ),
-                    ast::ItemKind::Enum(ref enum_def, ref generics) => {
+                    ast::ItemKind::Enum(box ast::EnumKind(ref enum_def, ref generics)) => {
                         // We ignore `use_temporaries` here, because
                         // `repr(packed)` enums cause an error later on.
                         //
@@ -1739,7 +1739,7 @@ where
 pub fn is_type_without_fields(item: &Annotatable) -> bool {
     if let Annotatable::Item(ref item) = *item {
         match item.kind {
-            ast::ItemKind::Enum(ref enum_def, _) => {
+            ast::ItemKind::Enum(box ast::EnumKind(ref enum_def, _)) => {
                 enum_def.variants.iter().all(|v| v.data.fields().is_empty())
             }
             ast::ItemKind::Struct(box ast::StructUnionKind(ref variant_data, _)) => {

--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -2,7 +2,7 @@
 
 use rustc_ast as ast;
 use rustc_ast::ptr::P;
-use rustc_ast::{ImplKind, ItemKind, MetaItem};
+use rustc_ast::{ImplKind, ItemKind, MetaItem, StructUnionKind};
 use rustc_expand::base::{Annotatable, ExpandResult, ExtCtxt, MultiItemModifier};
 use rustc_span::symbol::{sym, Ident, Symbol};
 use rustc_span::Span;
@@ -121,7 +121,8 @@ fn inject_impl_of_structural_trait(
     };
 
     let generics = match item.kind {
-        ItemKind::Struct(_, ref generics) | ItemKind::Enum(_, ref generics) => generics,
+        ItemKind::Struct(box StructUnionKind(_, ref generics))
+        | ItemKind::Enum(_, ref generics) => generics,
         // Do not inject `impl Structural for Union`. (`PartialEq` does not
         // support unions, so we will see error downstream.)
         ItemKind::Union(..) => return,

--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -2,7 +2,7 @@
 
 use rustc_ast as ast;
 use rustc_ast::ptr::P;
-use rustc_ast::{ImplKind, ItemKind, MetaItem, StructUnionKind};
+use rustc_ast::{EnumKind, ImplKind, ItemKind, MetaItem, StructUnionKind};
 use rustc_expand::base::{Annotatable, ExpandResult, ExtCtxt, MultiItemModifier};
 use rustc_span::symbol::{sym, Ident, Symbol};
 use rustc_span::Span;
@@ -122,7 +122,7 @@ fn inject_impl_of_structural_trait(
 
     let generics = match item.kind {
         ItemKind::Struct(box StructUnionKind(_, ref generics))
-        | ItemKind::Enum(_, ref generics) => generics,
+        | ItemKind::Enum(box EnumKind(_, ref generics)) => generics,
         // Do not inject `impl Structural for Union`. (`PartialEq` does not
         // support unions, so we will see error downstream.)
         ItemKind::Union(..) => return,

--- a/compiler/rustc_builtin_macros/src/global_asm.rs
+++ b/compiler/rustc_builtin_macros/src/global_asm.rs
@@ -28,7 +28,7 @@ pub fn expand_global_asm<'cx>(
             ident: Ident::invalid(),
             attrs: Vec::new(),
             id: ast::DUMMY_NODE_ID,
-            kind: ast::ItemKind::GlobalAsm(P(global_asm)),
+            kind: ast::ItemKind::GlobalAsm(box global_asm),
             vis: ast::Visibility {
                 span: sp.shrink_to_lo(),
                 kind: ast::VisibilityKind::Inherited,

--- a/compiler/rustc_builtin_macros/src/standard_library_imports.rs
+++ b/compiler/rustc_builtin_macros/src/standard_library_imports.rs
@@ -1,5 +1,4 @@
 use rustc_ast as ast;
-use rustc_ast::ptr::P;
 use rustc_expand::base::{ExtCtxt, ResolverExpand};
 use rustc_expand::expand::ExpansionConfig;
 use rustc_session::Session;
@@ -72,11 +71,11 @@ pub fn inject(
         span,
         Ident::invalid(),
         vec![cx.attribute(cx.meta_word(span, sym::prelude_import))],
-        ast::ItemKind::Use(P(ast::UseTree {
+        ast::ItemKind::Use(box ast::UseTree {
             prefix: cx.path(span, import_path),
             kind: ast::UseTreeKind::Glob,
             span,
-        })),
+        }),
     );
 
     krate.module.items.insert(0, use_item);

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -212,7 +212,7 @@ pub fn expand_test_or_bench(
             cx.attribute(cx.meta_word(attr_sp, sym::rustc_test_marker)),
         ],
         // const $ident: test::TestDescAndFn =
-        ast::ItemKind::Const(
+        ast::ItemKind::Const(box ast::ConstKind(
             ast::Defaultness::Final,
             cx.ty(sp, ast::TyKind::Path(None, test_path("TestDescAndFn"))),
             // test::TestDescAndFn {
@@ -301,7 +301,7 @@ pub fn expand_test_or_bench(
                     ],
                 ), // }
             ),
-        ),
+        )),
     );
     test_const = test_const.map(|mut tc| {
         tc.vis.kind = ast::VisibilityKind::Public;

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -548,7 +548,12 @@ impl<'a> ExtCtxt<'a> {
         mutbl: ast::Mutability,
         expr: P<ast::Expr>,
     ) -> P<ast::Item> {
-        self.item(span, name, Vec::new(), ast::ItemKind::Static(ty, mutbl, Some(expr)))
+        self.item(
+            span,
+            name,
+            Vec::new(),
+            ast::ItemKind::Static(box ast::StaticKind(ty, mutbl, Some(expr))),
+        )
     }
 
     pub fn item_const(
@@ -559,7 +564,12 @@ impl<'a> ExtCtxt<'a> {
         expr: P<ast::Expr>,
     ) -> P<ast::Item> {
         let def = ast::Defaultness::Final;
-        self.item(span, name, Vec::new(), ast::ItemKind::Const(def, ty, Some(expr)))
+        self.item(
+            span,
+            name,
+            Vec::new(),
+            ast::ItemKind::Const(box ast::ConstKind(def, ty, Some(expr))),
+        )
     }
 
     pub fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -459,7 +459,7 @@ impl<'a> StripUnconfigured<'a> {
             | ast::ItemKind::Union(box ast::StructUnionKind(def, _generics)) => {
                 self.configure_variant_data(def)
             }
-            ast::ItemKind::Enum(ast::EnumDef { variants }, _generics) => {
+            ast::ItemKind::Enum(box ast::EnumKind(ast::EnumDef { variants }, _generics)) => {
                 variants.flat_map_in_place(|variant| self.configure(variant));
                 for variant in variants {
                     self.configure_variant_data(&mut variant.data);

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -455,7 +455,8 @@ impl<'a> StripUnconfigured<'a> {
 
     pub fn configure_item_kind(&mut self, item: &mut ast::ItemKind) {
         match item {
-            ast::ItemKind::Struct(def, _generics) | ast::ItemKind::Union(def, _generics) => {
+            ast::ItemKind::Struct(box ast::StructUnionKind(def, _generics))
+            | ast::ItemKind::Union(box ast::StructUnionKind(def, _generics)) => {
                 self.configure_variant_data(def)
             }
             ast::ItemKind::Enum(ast::EnumDef { variants }, _generics) => {

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1373,7 +1373,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
                 item.attrs = attrs;
                 self.check_attributes(&item.attrs);
                 item.and_then(|item| match item.kind {
-                    ItemKind::MacCall(mac) => {
+                    ItemKind::MacCall(box mac) => {
                         self.collect_bang(mac, span, AstFragmentKind::Items).make_items()
                     }
                     _ => unreachable!(),
@@ -1464,7 +1464,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
             ast::AssocItemKind::MacCall(..) => {
                 self.check_attributes(&item.attrs);
                 item.and_then(|item| match item.kind {
-                    ast::AssocItemKind::MacCall(mac) => self
+                    ast::AssocItemKind::MacCall(box mac) => self
                         .collect_bang(mac, item.span, AstFragmentKind::TraitItems)
                         .make_trait_items(),
                     _ => unreachable!(),
@@ -1487,7 +1487,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
             ast::AssocItemKind::MacCall(..) => {
                 self.check_attributes(&item.attrs);
                 item.and_then(|item| match item.kind {
-                    ast::AssocItemKind::MacCall(mac) => self
+                    ast::AssocItemKind::MacCall(box mac) => self
                         .collect_bang(mac, item.span, AstFragmentKind::ImplItems)
                         .make_impl_items(),
                     _ => unreachable!(),
@@ -1534,7 +1534,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
             ast::ForeignItemKind::MacCall(..) => {
                 self.check_attributes(&foreign_item.attrs);
                 foreign_item.and_then(|item| match item.kind {
-                    ast::ForeignItemKind::MacCall(mac) => self
+                    ast::ForeignItemKind::MacCall(box mac) => self
                         .collect_bang(mac, item.span, AstFragmentKind::ForeignItems)
                         .make_foreign_items(),
                     _ => unreachable!(),

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(bool_to_option)]
+#![feature(box_patterns)]
+#![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]
 #![feature(decl_macro)]
 #![feature(or_patterns)]

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -55,7 +55,7 @@ pub fn placeholder(
             ident,
             vis,
             attrs,
-            kind: ast::ItemKind::MacCall(mac_placeholder()),
+            kind: ast::ItemKind::MacCall(box mac_placeholder()),
             tokens: None,
         })]),
         AstFragmentKind::TraitItems => AstFragment::TraitItems(smallvec![P(ast::AssocItem {
@@ -64,7 +64,7 @@ pub fn placeholder(
             ident,
             vis,
             attrs,
-            kind: ast::AssocItemKind::MacCall(mac_placeholder()),
+            kind: ast::AssocItemKind::MacCall(box mac_placeholder()),
             tokens: None,
         })]),
         AstFragmentKind::ImplItems => AstFragment::ImplItems(smallvec![P(ast::AssocItem {
@@ -73,7 +73,7 @@ pub fn placeholder(
             ident,
             vis,
             attrs,
-            kind: ast::AssocItemKind::MacCall(mac_placeholder()),
+            kind: ast::AssocItemKind::MacCall(box mac_placeholder()),
             tokens: None,
         })]),
         AstFragmentKind::ForeignItems => {
@@ -83,7 +83,7 @@ pub fn placeholder(
                 ident,
                 vis,
                 attrs,
-                kind: ast::ForeignItemKind::MacCall(mac_placeholder()),
+                kind: ast::ForeignItemKind::MacCall(box mac_placeholder()),
                 tokens: None,
             })])
         }

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -694,7 +694,9 @@ trait UnusedDelimLint {
     fn check_item(&mut self, cx: &EarlyContext<'_>, item: &ast::Item) {
         use ast::ItemKind::*;
 
-        if let Const(.., Some(expr)) | Static(.., Some(expr)) = &item.kind {
+        if let Const(box ast::ConstKind(.., Some(expr)))
+        | Static(box ast::StaticKind(.., Some(expr))) = &item.kind
+        {
             self.check_unused_delims_expr(
                 cx,
                 expr,

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -433,7 +433,7 @@ impl CStore {
                 id: ast::DUMMY_NODE_ID,
                 span,
                 attrs,
-                kind: ast::ItemKind::MacroDef(data.get_macro(id.index, sess)),
+                kind: ast::ItemKind::MacroDef(Box::new(data.get_macro(id.index, sess))),
                 vis: ast::Visibility {
                     span: span.shrink_to_lo(),
                     kind: ast::VisibilityKind::Inherited,

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1094,7 +1094,7 @@ impl<'a> Parser<'a> {
 
         let enum_definition =
             EnumDef { variants: variants.into_iter().filter_map(|v| v).collect() };
-        Ok((id, ItemKind::Enum(enum_definition, generics)))
+        Ok((id, ItemKind::Enum(box EnumKind(enum_definition, generics))))
     }
 
     fn parse_enum_variant(&mut self) -> PResult<'a, Option<Variant>> {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -46,7 +46,7 @@ impl<'a> Parser<'a> {
             self.parse_mod(&token::CloseDelim(token::Brace), unsafety)?
         };
         attrs.append(&mut inner_attrs);
-        Ok((id, ItemKind::Mod(module)))
+        Ok((id, ItemKind::Mod(box module)))
     }
 
     /// Parses the contents of a module (inner attributes followed by module items).
@@ -919,7 +919,7 @@ impl<'a> Parser<'a> {
         let abi = self.parse_abi(); // ABI?
         let items = self.parse_item_list(attrs, |p| p.parse_foreign_item())?;
         let module = ast::ForeignMod { unsafety, abi, items };
-        Ok((Ident::invalid(), ItemKind::ForeignMod(module)))
+        Ok((Ident::invalid(), ItemKind::ForeignMod(box module)))
     }
 
     /// Parses a foreign item (one in an `extern { ... }` block).

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -713,7 +713,7 @@ impl<'a> Parser<'a> {
 
             self.sess.gated_spans.gate(sym::trait_alias, whole_span);
 
-            Ok((ident, ItemKind::TraitAlias(tps, bounds)))
+            Ok((ident, ItemKind::TraitAlias(box TraitAliasKind(tps, bounds))))
         } else {
             // It's a normal trait.
             tps.where_clause = self.parse_where_clause()?;

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -225,7 +225,7 @@ impl<'a> Parser<'a> {
                 return Err(e);
             }
 
-            (Ident::invalid(), ItemKind::Use(P(tree)))
+            (Ident::invalid(), ItemKind::Use(box tree))
         } else if self.check_fn_front_matter() {
             // FUNCTION ITEM
             let (ident, sig, generics, body) = self.parse_fn(attrs, req_name, lo)?;

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1418,7 +1418,7 @@ impl<'a> Parser<'a> {
         };
 
         self.sess.gated_spans.gate(sym::decl_macro, lo.to(self.prev_token.span));
-        Ok((ident, ItemKind::MacroDef(ast::MacroDef { body, macro_rules: false })))
+        Ok((ident, ItemKind::MacroDef(box ast::MacroDef { body, macro_rules: false })))
     }
 
     /// Is this unambiguously the start of a `macro_rules! foo` item defnition?
@@ -1438,7 +1438,7 @@ impl<'a> Parser<'a> {
         self.eat_semi_for_macro_if_needed(&body);
         self.complain_if_pub_macro(vis, true);
 
-        Ok((ident, ItemKind::MacroDef(ast::MacroDef { body, macro_rules: true })))
+        Ok((ident, ItemKind::MacroDef(box ast::MacroDef { body, macro_rules: true })))
     }
 
     /// Item macro invocations or `macro_rules!` definitions need inherited visibility.

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1188,7 +1188,7 @@ impl<'a> Parser<'a> {
             return Err(err);
         };
 
-        Ok((class_name, ItemKind::Struct(vdata, generics)))
+        Ok((class_name, ItemKind::Struct(box StructUnionKind(vdata, generics))))
     }
 
     /// Parses `union Foo { ... }`.
@@ -1212,7 +1212,7 @@ impl<'a> Parser<'a> {
             return Err(err);
         };
 
-        Ok((class_name, ItemKind::Union(vdata, generics)))
+        Ok((class_name, ItemKind::Union(box StructUnionKind(vdata, generics))))
     }
 
     fn parse_record_struct_body(

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -17,7 +17,9 @@ use crate::{Module, ModuleData, ModuleKind, NameBinding, NameBindingKind, Segmen
 
 use rustc_ast::visit::{self, AssocCtxt, Visitor};
 use rustc_ast::{self as ast, AssocItem, AssocItemKind, MetaItemKind, StmtKind};
-use rustc_ast::{Block, FnKind, ForeignItem, ForeignItemKind, ImplKind, Item, ItemKind, NodeId};
+use rustc_ast::{
+    Block, FnKind, ForeignItem, ForeignItemKind, ImplKind, Item, ItemKind, NodeId, StructUnionKind,
+};
 use rustc_ast_lowering::ResolverAstLowering;
 use rustc_attr as attr;
 use rustc_data_structures::sync::Lrc;
@@ -817,7 +819,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             }
 
             // These items live in both the type and value namespaces.
-            ItemKind::Struct(ref vdata, _) => {
+            ItemKind::Struct(box StructUnionKind(ref vdata, _)) => {
                 // Define a name in the type namespace.
                 let res = Res::Def(DefKind::Struct, def_id);
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
@@ -864,7 +866,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 }
             }
 
-            ItemKind::Union(ref vdata, _) => {
+            ItemKind::Union(box StructUnionKind(ref vdata, _)) => {
                 let res = Res::Def(DefKind::Union, def_id);
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
 

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -800,7 +800,7 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 self.r.define(parent, ident, TypeNS, (res, vis, sp, expansion));
             }
 
-            ItemKind::Enum(_, _) => {
+            ItemKind::Enum(_) => {
                 let module_kind = ModuleKind::Def(DefKind::Enum, def_id, ident.name);
                 let module = self.r.new_module(
                     parent,

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -104,7 +104,8 @@ impl<'a, 'b> visit::Visitor<'a> for DefCollector<'a, 'b> {
 
         self.with_parent(def, |this| {
             match i.kind {
-                ItemKind::Struct(ref struct_def, _) | ItemKind::Union(ref struct_def, _) => {
+                ItemKind::Struct(box StructUnionKind(ref struct_def, _))
+                | ItemKind::Union(box StructUnionKind(ref struct_def, _)) => {
                     // If this is a unit or tuple-like struct, register the constructor.
                     if let Some(ctor_hir_id) = struct_def.ctor_id() {
                         this.create_def(ctor_hir_id, DefPathData::Ctor, i.span);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -978,7 +978,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                         this.with_trait_items(trait_items, |this| {
                             for item in trait_items {
                                 match &item.kind {
-                                    AssocItemKind::Const(_, ty, default) => {
+                                    AssocItemKind::Const(box ConstKind(_, ty, default)) => {
                                         this.visit_ty(ty);
                                         // Only impose the restrictions of `ConstRibKind` for an
                                         // actual constant expression in a provided default.
@@ -1029,7 +1029,8 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 });
             }
 
-            ItemKind::Static(ref ty, _, ref expr) | ItemKind::Const(_, ref ty, ref expr) => {
+            ItemKind::Static(box StaticKind(ref ty, _, ref expr))
+            | ItemKind::Const(box ConstKind(_, ref ty, ref expr)) => {
                 debug!("resolve_item ItemKind::Const");
                 self.with_item_rib(HasGenericParams::No, |this| {
                     this.visit_ty(ty);
@@ -1278,7 +1279,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                                 for item in impl_items {
                                     use crate::ResolutionError::*;
                                     match &item.kind {
-                                        AssocItemKind::Const(_default, _ty, _expr) => {
+                                        AssocItemKind::Const(_) => {
                                             debug!("resolve_implementation AssocItemKind::Const",);
                                             // If this is a trait impl, ensure the const
                                             // exists in trait

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -945,7 +945,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 });
             }
 
-            ItemKind::Enum(_, ref generics)
+            ItemKind::Enum(box EnumKind(_, ref generics))
             | ItemKind::Struct(box StructUnionKind(_, ref generics))
             | ItemKind::Union(box StructUnionKind(_, ref generics)) => {
                 self.resolve_adt(item, generics);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -946,8 +946,8 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             }
 
             ItemKind::Enum(_, ref generics)
-            | ItemKind::Struct(_, ref generics)
-            | ItemKind::Union(_, ref generics) => {
+            | ItemKind::Struct(box StructUnionKind(_, ref generics))
+            | ItemKind::Union(box StructUnionKind(_, ref generics)) => {
                 self.resolve_adt(item, generics);
             }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1012,7 +1012,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 });
             }
 
-            ItemKind::TraitAlias(ref generics, ref bounds) => {
+            ItemKind::TraitAlias(box TraitAliasKind(ref generics, ref bounds)) => {
                 // Create a new rib for the trait-wide type parameters.
                 self.with_generic_param_rib(generics, ItemRibKind(HasGenericParams::Yes), |this| {
                     let local_def_id = this.r.local_def_id(item.id).to_def_id();

--- a/src/tools/clippy/clippy_lints/src/enum_variants.rs
+++ b/src/tools/clippy/clippy_lints/src/enum_variants.rs
@@ -2,7 +2,7 @@
 
 use crate::utils::{camel_case, is_present_in_source};
 use crate::utils::{span_lint, span_lint_and_help};
-use rustc_ast::ast::{EnumDef, Item, ItemKind, VisibilityKind};
+use rustc_ast::ast::{EnumDef, EnumKind, Item, ItemKind, VisibilityKind};
 use rustc_lint::{EarlyContext, EarlyLintPass, Lint};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::source_map::Span;
@@ -315,7 +315,7 @@ impl EarlyLintPass for EnumVariantNames {
                 }
             }
         }
-        if let ItemKind::Enum(ref def, _) = item.kind {
+        if let ItemKind::Enum(box EnumKind(ref def, _)) = item.kind {
             let lint = match item.vis.kind {
                 VisibilityKind::Public => PUB_ENUM_VARIANT_NAMES,
                 _ => ENUM_VARIANT_NAMES,

--- a/src/tools/clippy/clippy_lints/src/excessive_bools.rs
+++ b/src/tools/clippy/clippy_lints/src/excessive_bools.rs
@@ -1,6 +1,7 @@
 use crate::utils::{attr_by_name, in_macro, match_path_ast, span_lint_and_help};
 use rustc_ast::ast::{
-    AssocItemKind, Extern, FnKind, FnSig, ImplKind, Item, ItemKind, TraitKind, Ty, TyKind,
+    AssocItemKind, Extern, FnKind, FnSig, ImplKind, Item, ItemKind, StructUnionKind, TraitKind, Ty,
+    TyKind,
 };
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
@@ -138,7 +139,7 @@ impl EarlyLintPass for ExcessiveBools {
             return;
         }
         match &item.kind {
-            ItemKind::Struct(variant_data, _) => {
+            ItemKind::Struct(box StructUnionKind(variant_data, _)) => {
                 if attr_by_name(&item.attrs, "repr").is_some() {
                     return;
                 }

--- a/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
@@ -1,6 +1,8 @@
 use crate::utils::{meets_msrv, snippet_opt, span_lint_and_then};
 use if_chain::if_chain;
-use rustc_ast::ast::{Attribute, Item, ItemKind, StructField, Variant, VariantData, VisibilityKind};
+use rustc_ast::ast::{
+    Attribute, Item, ItemKind, StructField, StructUnionKind, Variant, VariantData, VisibilityKind,
+};
 use rustc_attr as attr;
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
@@ -81,8 +83,8 @@ impl EarlyLintPass for ManualNonExhaustive {
         match &item.kind {
             ItemKind::Enum(def, _) => {
                 check_manual_non_exhaustive_enum(cx, item, &def.variants);
-            },
-            ItemKind::Struct(variant_data, _) => {
+            }
+            ItemKind::Struct(box StructUnionKind(variant_data, _)) => {
                 if let VariantData::Unit(..) = variant_data {
                     return;
                 }

--- a/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
@@ -1,7 +1,8 @@
 use crate::utils::{meets_msrv, snippet_opt, span_lint_and_then};
 use if_chain::if_chain;
 use rustc_ast::ast::{
-    Attribute, Item, ItemKind, StructField, StructUnionKind, Variant, VariantData, VisibilityKind,
+    Attribute, EnumKind, Item, ItemKind, StructField, StructUnionKind, Variant, VariantData,
+    VisibilityKind,
 };
 use rustc_attr as attr;
 use rustc_errors::Applicability;
@@ -81,7 +82,7 @@ impl EarlyLintPass for ManualNonExhaustive {
         }
 
         match &item.kind {
-            ItemKind::Enum(def, _) => {
+            ItemKind::Enum(box EnumKind(def, _)) => {
                 check_manual_non_exhaustive_enum(cx, item, &def.variants);
             }
             ItemKind::Struct(box StructUnionKind(variant_data, _)) => {

--- a/src/tools/clippy/clippy_lints/src/redundant_static_lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_static_lifetimes.rs
@@ -1,5 +1,5 @@
 use crate::utils::{meets_msrv, snippet, span_lint_and_then};
-use rustc_ast::ast::{Item, ItemKind, Ty, TyKind};
+use rustc_ast::ast::{ConstKind, Item, ItemKind, StaticKind, Ty, TyKind};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_semver::RustcVersion;
@@ -103,13 +103,13 @@ impl EarlyLintPass for RedundantStaticLifetimes {
         }
 
         if !item.span.from_expansion() {
-            if let ItemKind::Const(_, ref var_type, _) = item.kind {
+            if let ItemKind::Const(box ConstKind(_, ref var_type, _)) = item.kind {
                 self.visit_type(var_type, cx, "constants have by default a `'static` lifetime");
                 // Don't check associated consts because `'static` cannot be elided on those (issue
                 // #2438)
             }
 
-            if let ItemKind::Static(ref var_type, _, _) = item.kind {
+            if let ItemKind::Static(box StaticKind(ref var_type, _, _)) = item.kind {
                 self.visit_type(var_type, cx, "statics have by default a `'static` lifetime");
             }
         }

--- a/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
@@ -253,8 +253,8 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 && eq_generics(lg, rg)
                 && over(lb, rb, |l, r| eq_generic_bound(l, r))
                 && both(lt, rt, |l, r| eq_ty(l, r))
-        },
-        (Enum(le, lg), Enum(re, rg)) => {
+        }
+        (Enum(box EnumKind(le, lg)), Enum(box EnumKind(re, rg))) => {
             over(&le.variants, &re.variants, |l, r| eq_variant(l, r)) && eq_generics(lg, rg)
         }
         (Struct(box StructUnionKind(lv, lg)), Struct(box StructUnionKind(rv, rg)))

--- a/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
@@ -229,10 +229,10 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
     match (l, r) {
         (ExternCrate(l), ExternCrate(r)) => l == r,
         (Use(l), Use(r)) => eq_use_tree(l, r),
-        (Static(lt, lm, le), Static(rt, rm, re)) => {
+        (Static(box StaticKind(lt, lm, le)), Static(box StaticKind(rt, rm, re))) => {
             lm == rm && eq_ty(lt, rt) && eq_expr_opt(le, re)
         }
-        (Const(ld, lt, le), Const(rd, rt, re)) => {
+        (Const(box ConstKind(ld, lt, le)), Const(box ConstKind(rd, rt, re))) => {
             eq_defaultness(*ld, *rd) && eq_ty(lt, rt) && eq_expr_opt(le, re)
         }
         (Fn(box FnKind(ld, lf, lg, lb)), Fn(box FnKind(rd, rf, rg, rb))) => {
@@ -308,7 +308,7 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
 pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
     use ForeignItemKind::*;
     match (l, r) {
-        (Static(lt, lm, le), Static(rt, rm, re)) => {
+        (Static(box StaticKind(lt, lm, le)), Static(box StaticKind(rt, rm, re))) => {
             lm == rm && eq_ty(lt, rt) && eq_expr_opt(le, re)
         }
         (Fn(box FnKind(ld, lf, lg, lb)), Fn(box FnKind(rd, rf, rg, rb))) => {
@@ -331,7 +331,7 @@ pub fn eq_foreign_item_kind(l: &ForeignItemKind, r: &ForeignItemKind) -> bool {
 pub fn eq_assoc_item_kind(l: &AssocItemKind, r: &AssocItemKind) -> bool {
     use AssocItemKind::*;
     match (l, r) {
-        (Const(ld, lt, le), Const(rd, rt, re)) => {
+        (Const(box ConstKind(ld, lt, le)), Const(box ConstKind(rd, rt, re))) => {
             eq_defaultness(*ld, *rd) && eq_ty(lt, rt) && eq_expr_opt(le, re)
         }
         (Fn(box FnKind(ld, lf, lg, lb)), Fn(box FnKind(rd, rf, rg, rb))) => {

--- a/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
@@ -267,8 +267,10 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
                 && eq_generics(lg, rg)
                 && over(lb, rb, |l, r| eq_generic_bound(l, r))
                 && over(li, ri, |l, r| eq_item(l, r, eq_assoc_item_kind))
-        },
-        (TraitAlias(lg, lb), TraitAlias(rg, rb)) => eq_generics(lg, rg) && over(lb, rb, |l, r| eq_generic_bound(l, r)),
+        }
+        (TraitAlias(box TraitAliasKind(lg, lb)), TraitAlias(box TraitAliasKind(rg, rb))) => {
+            eq_generics(lg, rg) && over(lb, rb, |l, r| eq_generic_bound(l, r))
+        }
         (
             Impl(box ImplKind {
                 unsafety: lu,

--- a/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/ast_utils.rs
@@ -256,8 +256,9 @@ pub fn eq_item_kind(l: &ItemKind, r: &ItemKind) -> bool {
         },
         (Enum(le, lg), Enum(re, rg)) => {
             over(&le.variants, &re.variants, |l, r| eq_variant(l, r)) && eq_generics(lg, rg)
-        },
-        (Struct(lv, lg), Struct(rv, rg)) | (Union(lv, lg), Union(rv, rg)) => {
+        }
+        (Struct(box StructUnionKind(lv, lg)), Struct(box StructUnionKind(rv, rg)))
+        | (Union(box StructUnionKind(lv, lg)), Union(box StructUnionKind(rv, rg))) => {
             eq_variant_data(lv, rv) && eq_generics(lg, rg)
         }
         (Trait(box TraitKind(la, lu, lg, lb, li)), Trait(box TraitKind(ra, ru, rg, rb, ri))) => {


### PR DESCRIPTION
Follow up to #81405, this PR boxes all fields, making `ast::ItemKind`, `ast::AssocItemKind` and `ast::ForeignItemKind` all 16 bytes. This results in less wasted memory when the smaller variants are instantiated a lot.