### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -11,12 +11,10 @@
 //! mutate it.
 //!
 //! Shareable mutable containers exist to permit mutability in a controlled manner, even in the
-//! presence of aliasing. Both `Cell<T>` and `RefCell<T>` allow doing this in a single-threaded
+//! presence of aliasing. Both [`Cell<T>`] and [`RefCell<T>`] allow doing this in a single-threaded
 //! way. However, neither `Cell<T>` nor `RefCell<T>` are thread safe (they do not implement
-//! `Sync`). If you need to do aliasing and mutation between multiple threads it is possible to
-//! use [`Mutex`](../../std/sync/struct.Mutex.html),
-//! [`RwLock`](../../std/sync/struct.RwLock.html) or
-//! [`atomic`](../../core/sync/atomic/index.html) types.
+//! [`Sync`]). If you need to do aliasing and mutation between multiple threads it is possible to
+//! use [`Mutex<T>`], [`RwLock<T>`] or [`atomic`] types.
 //!
 //! Values of the `Cell<T>` and `RefCell<T>` types may be mutated through shared references (i.e.
 //! the common `&T` type), whereas most Rust types can only be mutated through unique (`&mut T`)
@@ -28,13 +26,14 @@
 //! one must use the `RefCell<T>` type, acquiring a write lock before mutating. `Cell<T>` provides
 //! methods to retrieve and change the current interior value:
 //!
-//!  - For types that implement `Copy`, the `get` method retrieves the current interior value.
-//!  - For types that implement `Default`, the `take` method replaces the current interior value
-//!    with `Default::default()` and returns the replaced value.
-//!  - For all types, the `replace` method replaces the current interior value and returns the
-//!    replaced value and the `into_inner` method consumes the `Cell<T>` and returns the interior
-//!    value. Additionally, the `set` method replaces the interior value, dropping the replaced
-//!    value.
+//!  - For types that implement [`Copy`], the [`get`](Cell::get) method retrieves the current
+//!    interior value.
+//!  - For types that implement [`Default`], the [`take`](Cell::take) method replaces the current
+//!    interior value with [`Default::default()`] and returns the replaced value.
+//!  - For all types, the [`replace`](Cell::replace) method replaces the current interior value and
+//!    returns the replaced value and the [`into_inner`](Cell::into_inner) method consumes the
+//!    `Cell<T>` and returns the interior value. Additionally, the [`set`](Cell::set) method
+//!    replaces the interior value, dropping the replaced value.
 //!
 //! `RefCell<T>` uses Rust's lifetimes to implement 'dynamic borrowing', a process whereby one can
 //! claim temporary, exclusive, mutable access to the inner value. Borrows for `RefCell<T>`s are
@@ -54,12 +53,12 @@
 //!
 //! * Introducing mutability 'inside' of something immutable
 //! * Implementation details of logically-immutable methods.
-//! * Mutating implementations of `Clone`.
+//! * Mutating implementations of [`Clone`].
 //!
 //! ## Introducing mutability 'inside' of something immutable
 //!
-//! Many shared smart pointer types, including `Rc<T>` and `Arc<T>`, provide containers that can be
-//! cloned and shared between multiple parties. Because the contained values may be
+//! Many shared smart pointer types, including [`Rc<T>`] and [`Arc<T>`], provide containers that can
+//! be cloned and shared between multiple parties. Because the contained values may be
 //! multiply-aliased, they can only be borrowed with `&`, not `&mut`. Without cells it would be
 //! impossible to mutate data inside of these smart pointers at all.
 //!
@@ -91,7 +90,7 @@
 //! ```
 //!
 //! Note that this example uses `Rc<T>` and not `Arc<T>`. `RefCell<T>`s are for single-threaded
-//! scenarios. Consider using `RwLock<T>` or `Mutex<T>` if you need shared mutability in a
+//! scenarios. Consider using [`RwLock<T>`] or [`Mutex<T>`] if you need shared mutability in a
 //! multi-threaded situation.
 //!
 //! ## Implementation details of logically-immutable methods
@@ -127,10 +126,10 @@
 //! ## Mutating implementations of `Clone`
 //!
 //! This is simply a special - but common - case of the previous: hiding mutability for operations
-//! that appear to be immutable. The `clone` method is expected to not change the source value, and
-//! is declared to take `&self`, not `&mut self`. Therefore, any mutation that happens in the
-//! `clone` method must use cell types. For example, `Rc<T>` maintains its reference counts within a
-//! `Cell<T>`.
+//! that appear to be immutable. The [`clone`](Clone::clone) method is expected to not change the
+//! source value, and is declared to take `&self`, not `&mut self`. Therefore, any mutation that
+//! happens in the `clone` method must use cell types. For example, [`Rc<T>`] maintains its
+//! reference counts within a `Cell<T>`.
 //!
 //! ```
 //! use std::cell::Cell;
@@ -185,6 +184,11 @@
 //! }
 //! ```
 //!
+//! [`Arc<T>`]: ../../std/sync/struct.Arc.html
+//! [`Rc<T>`]: ../../std/rc/struct.Rc.html
+//! [`RwLock<T>`]: ../../std/sync/struct.RwLock.html
+//! [`Mutex<T>`]: ../../std/sync/struct.Mutex.html
+//! [`atomic`]: ../../core/sync/atomic/index.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1171,7 +1171,7 @@ pub trait Iterator {
     /// the iteration should stop, but wasn't placed back into the iterator.
     ///
     /// Note that unlike [`take_while`] this iterator is **not** fused.
-    /// It is also not specified what this iterator returns after the first` None` is returned.
+    /// It is also not specified what this iterator returns after the first [`None`] is returned.
     /// If you need fused iterator, use [`fuse`].
     ///
     /// [`fuse`]: Iterator::fuse

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -214,8 +214,16 @@ fn get_index_type_name(clean_type: &clean::Type, accept_generic: bool) -> Option
         clean::Generic(s) if accept_generic => Some(s),
         clean::Primitive(ref p) => Some(p.as_sym()),
         clean::BorrowedRef { ref type_, .. } => get_index_type_name(type_, accept_generic),
-        // FIXME: add all from clean::Type.
-        _ => None,
+        clean::Generic(_)
+        | clean::BareFunction(_)
+        | clean::Tuple(_)
+        | clean::Slice(_)
+        | clean::Array(_, _)
+        | clean::Never
+        | clean::RawPointer(_, _)
+        | clean::QPath { .. }
+        | clean::Infer
+        | clean::ImplTrait(_) => None,
     }
 }
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2910,7 +2910,7 @@ function defocusSearchBar() {
             ["-", "Collapse all sections"],
         ].map(x => "<dt>" +
             x[0].split(" ")
-                .map((y, index) => (index & 1) === 0 ? "<kbd>" + y + "</kbd>" : y)
+                .map((y, index) => (index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " ")
                 .join("") + "</dt><dd>" + x[1] + "</dd>").join("");
         var div_shortcuts = document.createElement("div");
         addClass(div_shortcuts, "shortcuts");

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -798,6 +798,7 @@ body.blur > :not(#help) {
 	float: left;
 	clear: left;
 	display: block;
+	margin-right: 0.5rem;
 }
 #help > div > span {
 	text-align: center;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -239,7 +239,6 @@ a.test-arrow {
 #help dt {
 	border-color: #bfbfbf;
 	background: rgba(0,0,0,0);
-	color: black;
 }
 
 .since {


### PR DESCRIPTION
Successful merges:

 - #81144 (Fixed formatting typo in map_while docs)
 - #81573 (Add some links to the cell docs.)
 - #81679 (Bind all clean::Type variants and remove FIXME)
 - #81681 (Better styling of "Switch result tab" shortcut)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=81144,81573,81679,81681)
<!-- homu-ignore:end -->