### PR TITLE
Add "every" as a doc alias for "all".

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2196,6 +2196,7 @@ pub trait Iterator {
     /// // we can still use `iter`, as there are more elements.
     /// assert_eq!(iter.next(), Some(&3));
     /// ```
+    #[doc(alias = "every")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn all<F>(&mut self, f: F) -> bool


### PR DESCRIPTION
This matches [Array#every](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every) in JavaScript.

Oddly enough, `core::iter::Iterator::all` appears twice. This appears to be a rustdoc bug which I decided to fill in as #81696.

![image](https://user-images.githubusercontent.com/1297598/106717890-94f43e80-6600-11eb-9428-2cd425823df9.png)
