### PR TITLE
Account for associated consts in the "unstable assoc item name colission" lint

### DIFF
--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -345,12 +345,12 @@ pub fn struct_lint_level<'s, 'd>(
                  it will become a hard error";
 
             let explanation = if lint_id == LintId::of(builtin::UNSTABLE_NAME_COLLISIONS) {
-                "once this method is added to the standard library, \
-                 the ambiguity may cause an error or change in behavior!"
+                "once this associated item is added to the standard library, the ambiguity may \
+                 cause an error or change in behavior!"
                     .to_owned()
             } else if lint_id == LintId::of(builtin::MUTABLE_BORROW_RESERVATION_CONFLICT) {
-                "this borrowing pattern was not meant to be accepted, \
-                 and may become a hard error in the future"
+                "this borrowing pattern was not meant to be accepted, and may become a hard error \
+                 in the future"
                     .to_owned()
             } else if let Some(edition) = future_incompatible.edition {
                 format!("{} in the {} edition!", STANDARD_MESSAGE, edition)

--- a/src/test/ui/inference/auxiliary/inference_unstable_iterator.rs
+++ b/src/test/ui/inference/auxiliary/inference_unstable_iterator.rs
@@ -8,7 +8,11 @@ pub trait IpuIterator {
     fn ipu_flatten(&self) -> u32 {
         0
     }
+    #[unstable(feature = "assoc_const_ipu_iter", issue = "99999")]
+    const C: i32;
 }
 
 #[stable(feature = "ipu_iterator", since = "1.0.0")]
-impl IpuIterator for char {}
+impl IpuIterator for char {
+    const C: i32 = 42;
+}

--- a/src/test/ui/inference/auxiliary/inference_unstable_itertools.rs
+++ b/src/test/ui/inference/auxiliary/inference_unstable_itertools.rs
@@ -2,6 +2,10 @@ pub trait IpuItertools {
     fn ipu_flatten(&self) -> u32 {
         1
     }
+
+    const C: i32;
 }
 
-impl IpuItertools for char {}
+impl IpuItertools for char {
+    const C: i32 = 1;
+}

--- a/src/test/ui/inference/inference_unstable.rs
+++ b/src/test/ui/inference/inference_unstable.rs
@@ -14,6 +14,9 @@ use inference_unstable_itertools::IpuItertools;
 
 fn main() {
     assert_eq!('x'.ipu_flatten(), 1);
-    //~^ WARN a method with this name may be added to the standard library in the future
-    //~^^ WARN once this method is added to the standard library, the ambiguity may cause an error
+//~^ WARN an associated function with this name may be added to the standard library in the future
+//~| WARN once this associated item is added to the standard library, the ambiguity may cause an
+    assert_eq!(char::C, 1);
+//~^ WARN an associated constant with this name may be added to the standard library in the future
+//~| WARN once this associated item is added to the standard library, the ambiguity may cause an
 }

--- a/src/test/ui/inference/inference_unstable.stderr
+++ b/src/test/ui/inference/inference_unstable.stderr
@@ -1,14 +1,24 @@
-warning: a method with this name may be added to the standard library in the future
+warning: an associated function with this name may be added to the standard library in the future
   --> $DIR/inference_unstable.rs:16:20
    |
 LL |     assert_eq!('x'.ipu_flatten(), 1);
    |                    ^^^^^^^^^^^
    |
    = note: `#[warn(unstable_name_collisions)]` on by default
-   = warning: once this method is added to the standard library, the ambiguity may cause an error or change in behavior!
+   = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_flatten(...)` to keep using the current method
    = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
 
-warning: 1 warning emitted
+warning: an associated constant with this name may be added to the standard library in the future
+  --> $DIR/inference_unstable.rs:19:16
+   |
+LL |     assert_eq!(char::C, 1);
+   |                ^^^^^^^ help: use the fully qualified path to the associated const: `<char as IpuItertools>::C`
+   |
+   = warning: once this associated item is added to the standard library, the ambiguity may cause an error or change in behavior!
+   = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
+   = help: add `#![feature(assoc_const_ipu_iter)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::C`
+
+warning: 2 warnings emitted
 


### PR DESCRIPTION
Fix #81663.