### PR TITLE
Reduce tab formatting assertions to debug only

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -645,7 +645,7 @@ impl EmitterWriter {
         margin: Margin,
     ) {
         // Tabs are assumed to have been replaced by spaces in calling code.
-        assert!(!source_string.contains('\t'));
+        debug_assert!(!source_string.contains('\t'));
         let line_len = source_string.len();
         // Create the source line we will highlight.
         let left = margin.left(line_len);

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -15,7 +15,7 @@ impl StyledBuffer {
 
     pub fn render(&self) -> Vec<Vec<StyledString>> {
         // Tabs are assumed to have been replaced by spaces in calling code.
-        assert!(self.text.iter().all(|r| !r.contains(&'\t')));
+        debug_assert!(self.text.iter().all(|r| !r.contains(&'\t')));
 
         let mut output: Vec<Vec<StyledString>> = vec![];
         let mut styled_vec: Vec<StyledString> = vec![];


### PR DESCRIPTION
The tab replacement for diagnostics added in #79757 included a few assertions to ensure all tab characters are handled appropriately. We've started getting reports of these assertions firing (#81614). Since it's only a cosmetic issue, this downgrades the assertions to debug only, so we at least continue compiling even if the diagnostics might be a tad wonky.

Minimizes the impact of #81614