### PR TITLE
Fix non-existent-field ICE for generic fields.

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1974,7 +1974,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             field_path.push(candidate_field.ident.normalize_to_macros_2_0());
             let field_ty = candidate_field.ty(self.tcx, subst);
-            if let Some((nested_fields, _)) = self.get_field_candidates(span, &field_ty) {
+            if let Some((nested_fields, subst)) = self.get_field_candidates(span, &field_ty) {
                 for field in nested_fields.iter() {
                     let ident = field.ident.normalize_to_macros_2_0();
                     if ident == target_field {

--- a/src/test/ui/suggestions/non-existent-field-present-in-subfield.fixed
+++ b/src/test/ui/suggestions/non-existent-field-present-in-subfield.fixed
@@ -3,7 +3,7 @@
 struct Foo {
     first: Bar,
     _second: u32,
-    _third: u32,
+    _third: Vec<String>,
 }
 
 struct Bar {
@@ -32,7 +32,7 @@ fn main() {
     let d = D { test: e };
     let c = C { c: d };
     let bar = Bar { bar: c };
-    let fooer = Foo { first: bar, _second: 4, _third: 5 };
+    let fooer = Foo { first: bar, _second: 4, _third: Vec::new() };
 
     let _test = &fooer.first.bar.c;
     //~^ ERROR no field

--- a/src/test/ui/suggestions/non-existent-field-present-in-subfield.rs
+++ b/src/test/ui/suggestions/non-existent-field-present-in-subfield.rs
@@ -3,7 +3,7 @@
 struct Foo {
     first: Bar,
     _second: u32,
-    _third: u32,
+    _third: Vec<String>,
 }
 
 struct Bar {
@@ -32,7 +32,7 @@ fn main() {
     let d = D { test: e };
     let c = C { c: d };
     let bar = Bar { bar: c };
-    let fooer = Foo { first: bar, _second: 4, _third: 5 };
+    let fooer = Foo { first: bar, _second: 4, _third: Vec::new() };
 
     let _test = &fooer.c;
     //~^ ERROR no field


### PR DESCRIPTION
I mentioned this ICE in a chat and it took about 3 milliseconds before @eddyb found the problem and said this change would fix it. :)

This also changes one the field types in the related test to one that triggered the ICE.

Fixes #81627.
Fixes #81672.
Fixes #81709.

Cc https://github.com/rust-lang/rust/pull/81480 @b-naber @estebank.