### PR TITLE
Fix panic when emitting diagnostic for closure mutable binding error

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
@@ -514,7 +514,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             let upvar = ty::place_to_string_for_capture(tcx, place);
             match tables.upvar_capture(upvar_id) {
                 ty::UpvarCapture::ByRef(ty::UpvarBorrow {
-                    kind: ty::BorrowKind::MutBorrow,
+                    kind: ty::BorrowKind::MutBorrow | ty::BorrowKind::UniqueImmBorrow,
                     ..
                 }) => {
                     format!("mutable borrow of `{}`", upvar)
@@ -522,7 +522,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 ty::UpvarCapture::ByValue(_) => {
                     format!("possible mutation of `{}`", upvar)
                 }
-                _ => bug!("upvar `{}` borrowed, but not mutably", upvar),
+                val => bug!("upvar `{}` borrowed, but not mutably: {:?}", upvar, val),
             }
         } else {
             bug!("not an upvar")

--- a/src/test/ui/closures/issue-81700-mut-borrow.rs
+++ b/src/test/ui/closures/issue-81700-mut-borrow.rs
@@ -1,0 +1,5 @@
+fn foo(x: &mut u32) {
+    let bar = || { foo(x); };
+    bar(); //~ ERROR cannot borrow
+}
+fn main() {}

--- a/src/test/ui/closures/issue-81700-mut-borrow.stderr
+++ b/src/test/ui/closures/issue-81700-mut-borrow.stderr
@@ -1,0 +1,13 @@
+error[E0596]: cannot borrow `bar` as mutable, as it is not declared as mutable
+  --> $DIR/issue-81700-mut-borrow.rs:3:5
+   |
+LL |     let bar = || { foo(x); };
+   |         ---            - calling `bar` requires mutable binding due to mutable borrow of `x`
+   |         |
+   |         help: consider changing this to be mutable: `mut bar`
+LL |     bar();
+   |     ^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
Fixes #81700

The upvar borrow kind may be `ty::BorrowKind::UniqueImmBorrow`, which is
still a mutable borrow for the purposes of this diagnostic code.