### PR TITLE
[beta] Rename `panic_fmt` lint to `non_fmt_panic`

### DIFF
--- a/src/test/ui/fmt/format-args-capture.rs
+++ b/src/test/ui/fmt/format-args-capture.rs
@@ -31,7 +31,7 @@ fn panic_with_single_argument_does_not_get_formatted() {
     // RFC #2795 suggests that this may need to change so that captured arguments are formatted.
     // For stability reasons this will need to part of an edition change.
 
-    #[allow(panic_fmt)]
+    #[allow(non_fmt_panic)]
     let msg = std::panic::catch_unwind(|| {
         panic!("{foo}");
     }).unwrap_err();

--- a/src/test/ui/macros/macro-comma-behavior-rpass.rs
+++ b/src/test/ui/macros/macro-comma-behavior-rpass.rs
@@ -57,7 +57,7 @@ fn writeln_1arg() {
 //
 // (Example: Issue #48042)
 #[test]
-#[allow(panic_fmt)]
+#[allow(non_fmt_panic)]
 fn to_format_or_not_to_format() {
     // ("{}" is the easiest string to test because if this gets
     // sent to format_args!, it'll simply fail to compile.

--- a/src/test/ui/panic-brace.stderr
+++ b/src/test/ui/panic-brace.stderr
@@ -4,7 +4,7 @@ warning: panic message contains a brace
 LL |     panic!("here's a brace: {");
    |                             ^
    |
-   = note: `#[warn(panic_fmt)]` on by default
+   = note: `#[warn(non_fmt_panic)]` on by default
    = note: this message is not used as a format string, but will be in a future Rust edition
 help: add a "{}" format string to use the message literally
    |


### PR DESCRIPTION
While extending the recently-added `panic_fmt` lint, we're renaming it to `non_fmt_panic` to follow the [lint naming guidelines](https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md#lints): https://github.com/rust-lang/rust/pull/81645

The `panic_fmt` lint has not yet reached stable. If we don't do anything, `#[allow(panic_fmt)]` will work in 1.50, but give an 'unknown lint' warning in 1.51 later. I'm not sure if this warrants a backport to beta, and if it does, whether it'd be best to just rename the lint (as this PR does) or entirely remove the lint from beta. Opening this PR against `beta` as a possible option. Feel free to close or suggest a different course of action. :)

r? @Mark-Simulacrum