### PR TITLE
Make `Allocator` object-safe

### DIFF
--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -342,7 +342,10 @@ pub unsafe trait Allocator {
     ///
     /// The returned adaptor also implements `Allocator` and will simply borrow this.
     #[inline(always)]
-    fn by_ref(&self) -> &Self {
+    fn by_ref(&self) -> &Self
+    where
+        Self: Sized,
+    {
         self
     }
 }

--- a/src/test/ui/allocator/object-safe.rs
+++ b/src/test/ui/allocator/object-safe.rs
@@ -1,0 +1,13 @@
+// run-pass
+
+// Check that `Allocator` is object safe, this allows for polymorphic allocators
+
+#![feature(allocator_api)]
+
+use std::alloc::{Allocator, System};
+
+fn ensure_object_safe(_: &dyn Allocator) {}
+
+fn main() {
+    ensure_object_safe(&System);
+}


### PR DESCRIPTION
This allows rust-lang/wg-allocators#83: polymorphic allocators