### PR TITLE
Use `#[rustc_inherit_overflow_checks]` instead of Add::add etc.

### DIFF
--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -1,7 +1,7 @@
 use crate::char;
 use crate::convert::TryFrom;
 use crate::mem;
-use crate::ops::{self, Add, Sub, Try};
+use crate::ops::{self, Try};
 
 use super::{FusedIterator, TrustedLen};
 
@@ -201,11 +201,12 @@ macro_rules! step_identical_methods {
 
         #[inline]
         #[allow(arithmetic_overflow)]
+        #[rustc_inherit_overflow_checks]
         fn forward(start: Self, n: usize) -> Self {
             // In debug builds, trigger a panic on overflow.
             // This should optimize completely out in release builds.
             if Self::forward_checked(start, n).is_none() {
-                let _ = Add::add(Self::MAX, 1);
+                let _ = Self::MAX + 1;
             }
             // Do wrapping math to allow e.g. `Step::forward(-128i8, 255)`.
             start.wrapping_add(n as Self)
@@ -213,11 +214,12 @@ macro_rules! step_identical_methods {
 
         #[inline]
         #[allow(arithmetic_overflow)]
+        #[rustc_inherit_overflow_checks]
         fn backward(start: Self, n: usize) -> Self {
             // In debug builds, trigger a panic on overflow.
             // This should optimize completely out in release builds.
             if Self::backward_checked(start, n).is_none() {
-                let _ = Sub::sub(Self::MIN, 1);
+                let _ = Self::MIN - 1;
             }
             // Do wrapping math to allow e.g. `Step::backward(127i8, 255)`.
             start.wrapping_sub(n as Self)

--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -1,6 +1,5 @@
 use crate::iter;
 use crate::num::Wrapping;
-use crate::ops::{Add, Mul};
 
 /// Trait to represent types that can be created by summing up an iterator.
 ///
@@ -37,34 +36,49 @@ pub trait Product<A = Self>: Sized {
     fn product<I: Iterator<Item = A>>(iter: I) -> Self;
 }
 
-// N.B., explicitly use Add and Mul here to inherit overflow checks
 macro_rules! integer_sum_product {
     (@impls $zero:expr, $one:expr, #[$attr:meta], $($a:ty)*) => ($(
         #[$attr]
         impl Sum for $a {
             fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold($zero, Add::add)
+                iter.fold(
+                    $zero,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a + b,
+                )
             }
         }
 
         #[$attr]
         impl Product for $a {
             fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold($one, Mul::mul)
+                iter.fold(
+                    $one,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a * b,
+                )
             }
         }
 
         #[$attr]
         impl<'a> Sum<&'a $a> for $a {
             fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold($zero, Add::add)
+                iter.fold(
+                    $zero,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a + b,
+                )
             }
         }
 
         #[$attr]
         impl<'a> Product<&'a $a> for $a {
             fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold($one, Mul::mul)
+                iter.fold(
+                    $one,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a * b,
+                )
             }
         }
     )*);
@@ -83,28 +97,44 @@ macro_rules! float_sum_product {
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl Sum for $a {
             fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold(0.0, Add::add)
+                iter.fold(
+                    0.0,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a + b,
+                )
             }
         }
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl Product for $a {
             fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
-                iter.fold(1.0, Mul::mul)
+                iter.fold(
+                    1.0,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a * b,
+                )
             }
         }
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl<'a> Sum<&'a $a> for $a {
             fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold(0.0, Add::add)
+                iter.fold(
+                    0.0,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a + b,
+                )
             }
         }
 
         #[stable(feature = "iter_arith_traits", since = "1.12.0")]
         impl<'a> Product<&'a $a> for $a {
             fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
-                iter.fold(1.0, Mul::mul)
+                iter.fold(
+                    1.0,
+                    #[rustc_inherit_overflow_checks]
+                    |a, b| a * b,
+                )
             }
         }
     )*)


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/81721