### PR TITLE
faster few span methods

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -22,6 +22,7 @@
 #![feature(nll)]
 #![feature(min_specialization)]
 #![feature(option_expect_none)]
+#![feature(str_split_once)]
 
 #[macro_use]
 extern crate rustc_macros;


### PR DESCRIPTION
Touched few methods, so it should be (hopefully) faster.

First two changes: instead splitting string from start and taking only last piece, split it from the end.
Last: swapped conditions, to first check boolean parameter.