### PR TITLE
rustc_codegen_ssa: tune codegen scheduling to reduce memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,6 +3626,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "cc",
+ "itertools 0.9.0",
  "jobserver",
  "libc",
  "memmap",

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -10,6 +10,7 @@ test = false
 [dependencies]
 bitflags = "1.2.1"
 cc = "1.0.1"
+itertools = "0.9"
 num_cpus = "1.0"
 memmap = "0.7"
 tracing = "0.1"


### PR DESCRIPTION
For better throughput during parallel processing by LLVM, we used to sort
CGUs largest to smallest. This would lead to better thread utilization
by, for example, preventing a large CGU from being processed last and
having only one LLVM thread working while the rest remained idle.

However, this strategy would lead to high memory usage, as it meant the
LLVM-IR for all of the largest CGUs would be resident in memory at once.

Instead, we can compromise by ordering CGUs such that the largest and
smallest are first, second largest and smallest are next, etc. If there
are large size variations, this can reduce memory usage significantly.