### PR TITLE
typeck: Emit structured suggestions for tuple struct syntax

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1460,28 +1460,33 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ),
                     );
                     err.span_label(field.ident.span, "field does not exist");
-                    err.span_label(
+                    err.span_suggestion(
                         ty_span,
-                        format!(
-                            "`{adt}::{variant}` is a tuple {kind_name}, \
-                             use the appropriate syntax: `{adt}::{variant}(/* fields */)`",
+                        &format!(
+                            "`{adt}::{variant}` is a tuple {kind_name}, use the appropriate syntax",
                             adt = ty,
                             variant = variant.ident,
-                            kind_name = kind_name
                         ),
+                        format!(
+                            "{adt}::{variant}(/* fields */)",
+                            adt = ty,
+                            variant = variant.ident,
+                        ),
+                        Applicability::HasPlaceholders,
                     );
                 }
                 _ => {
                     err.span_label(variant.ident.span, format!("`{adt}` defined here", adt = ty));
                     err.span_label(field.ident.span, "field does not exist");
-                    err.span_label(
+                    err.span_suggestion(
                         ty_span,
-                        format!(
-                            "`{adt}` is a tuple {kind_name}, \
-                                 use the appropriate syntax: `{adt}(/* fields */)`",
+                        &format!(
+                            "`{adt}` is a tuple {kind_name}, use the appropriate syntax",
                             adt = ty,
-                            kind_name = kind_name
+                            kind_name = kind_name,
                         ),
+                        format!("{adt}(/* fields */)", adt = ty),
+                        Applicability::HasPlaceholders,
                     );
                 }
             },

--- a/src/test/ui/issues/issue-4736.stderr
+++ b/src/test/ui/issues/issue-4736.stderr
@@ -7,7 +7,7 @@ LL | struct NonCopyable(());
 LL |     let z = NonCopyable{ p: () };
    |             -----------  ^ field does not exist
    |             |
-   |             `NonCopyable` is a tuple struct, use the appropriate syntax: `NonCopyable(/* fields */)`
+   |             help: `NonCopyable` is a tuple struct, use the appropriate syntax: `NonCopyable(/* fields */)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-80607.stderr
+++ b/src/test/ui/issues/issue-80607.stderr
@@ -7,7 +7,7 @@ LL |     V1(i32),
 LL |     Enum::V1 { x }
    |     --------   ^ field does not exist
    |     |
-   |     `Enum::V1` is a tuple variant, use the appropriate syntax: `Enum::V1(/* fields */)`
+   |     help: `Enum::V1` is a tuple variant, use the appropriate syntax: `Enum::V1(/* fields */)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/numeric/numeric-fields.stderr
+++ b/src/test/ui/numeric/numeric-fields.stderr
@@ -7,7 +7,7 @@ LL | struct S(u8, u16);
 LL |     let s = S{0b1: 10, 0: 11};
    |             - ^^^ field does not exist
    |             |
-   |             `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
+   |             help: `S` is a tuple struct, use the appropriate syntax: `S(/* fields */)`
 
 error[E0026]: struct `S` does not have a field named `0x1`
   --> $DIR/numeric-fields.rs:7:17


### PR DESCRIPTION
And tuple variant syntax, but that didn't fit in the subject :)

Now the fact that these are suggestions is exposed both to the layout
engine and to IDEs and rustfix for automatic application.
