### PR TITLE
Increment `self.index` before calling `Iterator::self.a.__iterator_ge…

### DIFF
--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -198,12 +198,13 @@ where
                 Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
             }
         } else if A::may_have_side_effect() && self.index < self.a.size() {
-            // match the base implementation's potential side effects
-            // SAFETY: we just checked that `self.index` < `self.a.len()`
-            unsafe {
-                self.a.__iterator_get_unchecked(self.index);
-            }
+            let i = self.index;
             self.index += 1;
+            // match the base implementation's potential side effects
+            // SAFETY: we just checked that `i` < `self.a.len()`
+            unsafe {
+                self.a.__iterator_get_unchecked(i);
+            }
             None
         } else {
             None


### PR DESCRIPTION
…`t_unchecked` in `Zip` `TrustedRandomAccess` specialization

Otherwise if `Iterator::self.a.__iterator_get_unchecked` panics the
index would not have been incremented yet and another call to
`Iterator::next` would read from the same index again, which is not
allowed according to the API contract of `TrustedRandomAccess` for
`!Clone`.

Fixes https://github.com/rust-lang/rust/issues/81740