### PR TITLE
Stabilize poison API of Once, rename poisoned()

### DIFF
--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -125,7 +125,7 @@ unsafe impl Send for Once {}
 
 /// State yielded to [`Once::call_once_force()`]’s closure parameter. The state
 /// can be used to query the poison status of the [`Once`].
-#[unstable(feature = "once_poison", issue = "33577")]
+#[stable(feature = "once_poison", since = "1.51.0")]
 #[derive(Debug)]
 pub struct OnceState {
     poisoned: bool,
@@ -280,8 +280,6 @@ impl Once {
     /// # Examples
     ///
     /// ```
-    /// #![feature(once_poison)]
-    ///
     /// use std::sync::Once;
     /// use std::thread;
     ///
@@ -301,13 +299,13 @@ impl Once {
     ///
     /// // call_once_force will still run and reset the poisoned state
     /// INIT.call_once_force(|state| {
-    ///     assert!(state.poisoned());
+    ///     assert!(state.is_poisoned());
     /// });
     ///
     /// // once any success happens, we stop propagating the poison
     /// INIT.call_once(|| {});
     /// ```
-    #[unstable(feature = "once_poison", issue = "33577")]
+    #[stable(feature = "once_poison", since = "1.51.0")]
     pub fn call_once_force<F>(&self, f: F)
     where
         F: FnOnce(&OnceState),
@@ -526,8 +524,6 @@ impl OnceState {
     /// A poisoned [`Once`]:
     ///
     /// ```
-    /// #![feature(once_poison)]
-    ///
     /// use std::sync::Once;
     /// use std::thread;
     ///
@@ -540,24 +536,22 @@ impl OnceState {
     /// assert!(handle.join().is_err());
     ///
     /// INIT.call_once_force(|state| {
-    ///     assert!(state.poisoned());
+    ///     assert!(state.is_poisoned());
     /// });
     /// ```
     ///
     /// An unpoisoned [`Once`]:
     ///
     /// ```
-    /// #![feature(once_poison)]
-    ///
     /// use std::sync::Once;
     ///
     /// static INIT: Once = Once::new();
     ///
     /// INIT.call_once_force(|state| {
-    ///     assert!(!state.poisoned());
+    ///     assert!(!state.is_poisoned());
     /// });
-    #[unstable(feature = "once_poison", issue = "33577")]
-    pub fn poisoned(&self) -> bool {
+    #[stable(feature = "once_poison", since = "1.51.0")]
+    pub fn is_poisoned(&self) -> bool {
         self.poisoned
     }
 

--- a/library/std/src/sync/once/tests.rs
+++ b/library/std/src/sync/once/tests.rs
@@ -69,7 +69,7 @@ fn poison_bad() {
     let mut called = false;
     O.call_once_force(|p| {
         called = true;
-        assert!(p.poisoned())
+        assert!(p.is_poisoned())
     });
     assert!(called);
 
@@ -92,7 +92,7 @@ fn wait_for_force_to_finish() {
     let (tx2, rx2) = channel();
     let t1 = thread::spawn(move || {
         O.call_once_force(|p| {
-            assert!(p.poisoned());
+            assert!(p.is_poisoned());
             tx1.send(()).unwrap();
             rx2.recv().unwrap();
         });


### PR DESCRIPTION
This stabilizes:

* `OnceState`
* `OnceState::is_poisoned()` (previously named `poisoned()`)
* `Once::call_once_force()`

`poisoned()` was renamed because the new name is more clear as a few
people agreed and nobody objected.

Closes #33577

Notes:

* I'm not entirely sure it's supposed to be 1.51, LMK if I did it wrong
* I failed to run tests locally, so we will have to leave it to bors or someone else can try