### PR TITLE
rustc_target: [RISC-V] Enable non-CAS atomics on all targets

### DIFF
--- a/compiler/rustc_target/src/spec/riscv32i_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/riscv32i_unknown_none_elf.rs
@@ -12,7 +12,7 @@ pub fn target() -> Target {
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             linker: Some("rust-lld".to_string()),
             cpu: "generic-rv32".to_string(),
-            max_atomic_width: Some(0),
+            max_atomic_width: Some(32),
             atomic_cas: false,
             features: String::new(),
             executables: true,

--- a/compiler/rustc_target/src/spec/riscv32imc_unknown_none_elf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imc_unknown_none_elf.rs
@@ -12,7 +12,7 @@ pub fn target() -> Target {
             linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
             linker: Some("rust-lld".to_string()),
             cpu: "generic-rv32".to_string(),
-            max_atomic_width: Some(0),
+            max_atomic_width: Some(32),
             atomic_cas: false,
             features: "+m,+c".to_string(),
             executables: true,


### PR DESCRIPTION
While targets without the atomic (`A`) ISA extension do not support CAS atomic operations, the standard guarantees that normal loads/stores to aligned addresses are atomic:

> Furthermore, whereas naturally aligned loads and stores are guaranteed to execute atomically,
> misaligned loads and stores might not, and hence require additional synchronization to ensure atomicity.
>
> - RISC-V Unprivileged ISA V20191213, p. 25

This change is necessary for `core::sync::atomics` to contain at least `.load()` and `.store()` implementations for atomic types.

This was explicitly disabled in #66548 - @lenary, do we have a different interpretation of the standard, has the standard changed since that PR, or something else?