### PR TITLE
CI: only copy python.exe to python3.exe if the latter does not exist

### DIFF
--- a/src/ci/scripts/install-msys2.sh
+++ b/src/ci/scripts/install-msys2.sh
@@ -24,7 +24,9 @@ if isWindows; then
     # baked in which break LLVM's build system one way or another, so let's use the
     # native version which keeps everything as native as possible.
     python_home="/c/hostedtoolcache/windows/Python/${native_python_version}/x64"
-    cp "${python_home}/python.exe" "${python_home}/python3.exe"
+    if ! [[ -f "${python_home}/python3.exe" ]]; then
+        cp "${python_home}/python.exe" "${python_home}/python3.exe"
+    fi
     ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64"
     ciCommandAddPath "C:\\hostedtoolcache\\windows\\Python\\${native_python_version}\\x64\\Scripts"
 fi


### PR DESCRIPTION
We're copying the binary to make sure we can call `python3.exe` around, but it seems like the base image of GitHub Actions changed, copying the file before we do so. This PR changes the CI script to only copy the file if it doesn't already exist.

r? @m-ou-se 
cc @Mark-Simulacrum 