### PR TITLE
Cleanup rustdoc pass descriptions a bit

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -435,7 +435,7 @@ crate fn create_resolver<'a>(
 
     // Before we actually clone it, let's force all the extern'd crates to
     // actually be loaded, just in case they're only referred to inside
-    // intra-doc-links
+    // intra-doc links
     resolver.borrow_mut().access(|resolver| {
         sess.time("load_extern_crates", || {
             for extern_name in &extern_names {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -44,7 +44,7 @@ use super::span_of_attrs;
 crate const COLLECT_INTRA_DOC_LINKS: Pass = Pass {
     name: "collect-intra-doc-links",
     run: collect_intra_doc_links,
-    description: "reads a crate's documentation to resolve intra-doc-links",
+    description: "resolves intra-doc links",
 };
 
 crate fn collect_intra_doc_links(krate: Crate, cx: &DocContext<'_>) -> Crate {
@@ -981,7 +981,7 @@ impl LinkCollector<'_, '_> {
         let link_text =
             disambiguator.map(|d| d.display_for(path_str)).unwrap_or_else(|| path_str.to_owned());
 
-        // In order to correctly resolve intra-doc-links we need to
+        // In order to correctly resolve intra-doc links we need to
         // pick a base AST node to work from.  If the documentation for
         // this module came from an inner comment (//!) then we anchor
         // our name resolution *inside* the module.  If, on the other

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -1,7 +1,7 @@
 //! This pass is overloaded and runs two different lints.
 //!
-//! - MISSING_DOC_CODE_EXAMPLES: this lint is **UNSTABLE** and looks for public items missing doc-tests
-//! - PRIVATE_DOC_TESTS: this lint is **STABLE** and looks for private items with doc-tests.
+//! - MISSING_DOC_CODE_EXAMPLES: this lint is **UNSTABLE** and looks for public items missing doctests
+//! - PRIVATE_DOC_TESTS: this lint is **STABLE** and looks for private items with doctests.
 
 use super::{span_of_attrs, Pass};
 use crate::clean;

--- a/src/librustdoc/passes/non_autolinks.rs
+++ b/src/librustdoc/passes/non_autolinks.rs
@@ -12,7 +12,7 @@ use rustc_session::lint;
 crate const CHECK_NON_AUTOLINKS: Pass = Pass {
     name: "check-non-autolinks",
     run: check_non_autolinks,
-    description: "detects URLS that could be written using angle brackets",
+    description: "detects URLs that could be linkified",
 };
 
 const URL_REGEX: &str = concat!(

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -11,7 +11,7 @@ use crate::passes::{ImplStripper, Pass};
 crate const STRIP_HIDDEN: Pass = Pass {
     name: "strip-hidden",
     run: strip_hidden,
-    description: "strips all doc(hidden) items from the output",
+    description: "strips all `#[doc(hidden)]` items from the output",
 };
 
 /// Strip items marked `#[doc(hidden)]`


### PR DESCRIPTION
Also changed a couple of comments from "intra-doc-links" to
"intra-doc links" (my understanding is that "intra-doc links" is the
standard way to refer to them).
