### PR TITLE
Update LayoutError/LayoutErr stability attributes

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -400,7 +400,7 @@ impl Layout {
 
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[rustc_deprecated(
-    since = "1.51.0",
+    since = "1.52.0",
     reason = "Name does not follow std convention, use LayoutError",
     suggestion = "LayoutError"
 )]
@@ -409,7 +409,7 @@ pub type LayoutErr = LayoutError;
 /// The parameters given to `Layout::from_size_align`
 /// or some other `Layout` constructor
 /// do not satisfy its documented constraints.
-#[stable(feature = "alloc_layout_error", since = "1.49.0")]
+#[stable(feature = "alloc_layout_error", since = "1.50.0")]
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct LayoutError {
     private: (),

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -11,14 +11,14 @@ pub use self::global::GlobalAlloc;
 pub use self::layout::Layout;
 #[stable(feature = "alloc_layout", since = "1.28.0")]
 #[rustc_deprecated(
-    since = "1.51.0",
+    since = "1.52.0",
     reason = "Name does not follow std convention, use LayoutError",
     suggestion = "LayoutError"
 )]
 #[allow(deprecated, deprecated_in_future)]
 pub use self::layout::LayoutErr;
 
-#[stable(feature = "alloc_layout_error", since = "1.49.0")]
+#[stable(feature = "alloc_layout_error", since = "1.50.0")]
 pub use self::layout::LayoutError;
 
 use crate::fmt;


### PR DESCRIPTION
`LayoutError` ended up not making it into 1.49.0, updating the stability attributes to reflect that.

I also pushed `LayoutErr` deprecation back a release to allow 2 releases before the deprecation comes into effect.

This change should be backported to beta.