### PR TITLE
improve error message for disallowed ptr-to-int casts in const eval

### DIFF
--- a/compiler/rustc_mir/src/const_eval/error.rs
+++ b/compiler/rustc_mir/src/const_eval/error.rs
@@ -16,6 +16,7 @@ use crate::interpret::{
 #[derive(Clone, Debug)]
 pub enum ConstEvalErrKind {
     NeedsRfc(String),
+    PtrToIntCast,
     ConstAccessesStatic,
     ModifiedGlobal,
     AssertFailure(AssertKind<ConstInt>),
@@ -38,6 +39,12 @@ impl fmt::Display for ConstEvalErrKind {
         match *self {
             NeedsRfc(ref msg) => {
                 write!(f, "\"{}\" needs an rfc before being allowed inside constants", msg)
+            }
+            PtrToIntCast => {
+                write!(
+                    f,
+                    "cannot cast pointer to integer because it was not created by cast from integer"
+                )
             }
             ConstAccessesStatic => write!(f, "constant accesses static"),
             ModifiedGlobal => {

--- a/compiler/rustc_mir/src/const_eval/machine.rs
+++ b/compiler/rustc_mir/src/const_eval/machine.rs
@@ -352,7 +352,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
     }
 
     fn ptr_to_int(_mem: &Memory<'mir, 'tcx, Self>, _ptr: Pointer) -> InterpResult<'tcx, u64> {
-        Err(ConstEvalErrKind::NeedsRfc("pointer-to-integer cast".to_string()).into())
+        Err(ConstEvalErrKind::PtrToIntCast.into())
     }
 
     fn binary_ptr_op(

--- a/src/test/ui/const-ptr/ptr_to_usize_cast.rs
+++ b/src/test/ui/const-ptr/ptr_to_usize_cast.rs
@@ -1,0 +1,13 @@
+#![feature(const_raw_ptr_to_usize_cast)]
+
+fn main() {
+    const OK: usize = unsafe { 0 as *const i32 as usize };
+
+    const _ERROR: usize = unsafe { &0 as *const i32 as usize };
+    //~^ ERROR [const_err]
+    //~| NOTE cannot cast pointer to integer because it was not created by cast from integer
+    //~| NOTE
+    //~| NOTE `#[deny(const_err)]` on by default
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    //~| NOTE see issue #71800
+}

--- a/src/test/ui/const-ptr/ptr_to_usize_cast.stderr
+++ b/src/test/ui/const-ptr/ptr_to_usize_cast.stderr
@@ -1,0 +1,14 @@
+error: any use of this value will cause an error
+  --> $DIR/ptr_to_usize_cast.rs:6:36
+   |
+LL |     const _ERROR: usize = unsafe { &0 as *const i32 as usize };
+   |     -------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                                    |
+   |                                    cannot cast pointer to integer because it was not created by cast from integer
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops2.stderr
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops2.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | const Y2: usize = unsafe { &1 as *const i32 as usize + 1 };
    | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^-------
    |                            |
-   |                            "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |                            cannot cast pointer to integer because it was not created by cast from integer
    |
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/consts/issue-51559.stderr
+++ b/src/test/ui/consts/issue-51559.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | pub const FOO: usize = unsafe { BAR as usize };
    | --------------------------------^^^^^^^^^^^^---
    |                                 |
-   |                                 "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |                                 cannot cast pointer to integer because it was not created by cast from integer
    |
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/consts/issue-52432.stderr
+++ b/src/test/ui/consts/issue-52432.stderr
@@ -20,7 +20,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/issue-52432.rs:7:10
    |
 LL |     [(); &(static || {}) as *const _ as usize];
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot cast pointer to integer because it was not created by cast from integer
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.rs
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.rs
@@ -15,7 +15,7 @@ static INT_PTR_ARITH: () = unsafe {
     let x: usize = std::mem::transmute(&0);
     let _v = x + 0;
     //~^ ERROR could not evaluate static initializer
-    //~| NOTE pointer-to-integer cast
+    //~| NOTE cannot cast pointer to integer
 };
 
 fn main() {}

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
@@ -8,7 +8,7 @@ error[E0080]: could not evaluate static initializer
   --> $DIR/ptr_arith.rs:16:14
    |
 LL |     let _v = x + 0;
-   |              ^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |              ^^^^^ cannot cast pointer to integer because it was not created by cast from integer
 
 warning: skipping const checks
    |

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -71,14 +71,14 @@ const _: *const u8 =
 
 const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
 //~^ ERROR any use of this value will cause an error
-//~| NOTE "pointer-to-integer cast" needs an rfc
+//~| NOTE cannot cast pointer to integer
 //~| NOTE
 //~| WARN this was previously accepted by the compiler but is being phased out
 //~| NOTE
 
 const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
 //~^ ERROR any use of this value will cause an error
-//~| NOTE "pointer-to-integer cast" needs an rfc
+//~| NOTE cannot cast pointer to integer
 //~| NOTE
 //~| WARN this was previously accepted by the compiler but is being phased out
 //~| NOTE

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -36,7 +36,7 @@ error: any use of this value will cause an error
 LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                           |
-   |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |                           cannot cast pointer to integer because it was not created by cast from integer
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
@@ -47,7 +47,7 @@ error: any use of this value will cause an error
 LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                           |
-   |                           "pointer-to-integer cast" needs an rfc before being allowed inside constants
+   |                           cannot cast pointer to integer because it was not created by cast from integer
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>


### PR DESCRIPTION
Improves an error message as [suggested](https://github.com/rust-lang/rust/issues/80875#issuecomment-762754580) in #80875.

Does the wording make enough sense? I tried to follow precedent for error message style while maintaining brevity.

It seems like the rest of the `ConstEvalErrKind::NeedsRfc` error messages could be improved as well. I could give that a go if this approach works.

Closes #80875