### PR TITLE
Fix `install-awscli.sh` error in CI

### DIFF
--- a/src/ci/scripts/install-awscli.sh
+++ b/src/ci/scripts/install-awscli.sh
@@ -27,7 +27,7 @@ if isLinux; then
     pip="pip3"
     pipflags="--user"
 
-    sudo apt-get install -y python3-setuptools
+    sudo apt-get install -y python3-setuptools python3-wheel
     ciCommandAddPath "${HOME}/.local/bin"
 fi
 


### PR DESCRIPTION
This fixes the `install-awscli.sh` error about missing `'bdist_wheel'`.