### PR TITLE
update tracking issue for `relaxed_struct_unsize`

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -633,7 +633,7 @@ declare_features! (
     (active, abi_c_cmse_nonsecure_call, "1.51.0", Some(81391), None),
 
     /// Lessens the requirements for structs to implement `Unsize`.
-    (active, relaxed_struct_unsize, "1.51.0", Some(1), None),
+    (active, relaxed_struct_unsize, "1.51.0", Some(81793), None),
 
     /// Allows macro attributes to observe output of `#[derive]`.
     (active, macro_attributes_in_derive_output, "1.51.0", Some(81119), None),


### PR DESCRIPTION
forgot to do this before #80726 got merged. The tracking issue is #81793