### PR TITLE
Add a test for escaping LLVMisms in inline asm

### DIFF
--- a/src/test/codegen/asm-sanitize-llvm.rs
+++ b/src/test/codegen/asm-sanitize-llvm.rs
@@ -1,0 +1,32 @@
+// FIXME(nagisa): remove the flags here once all targets support `asm!`.
+// compile-flags: --target x86_64-unknown-linux-gnu
+
+// Verify we sanitize the special tokens for the LLVM inline-assembly, ensuring people won't
+// inadvertently rely on the LLVM-specific syntax and features.
+#![no_core]
+#![feature(no_core, lang_items, rustc_attrs)]
+#![crate_type = "rlib"]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+pub unsafe fn we_escape_dollar_signs() {
+    // CHECK: call void asm sideeffect alignstack inteldialect "banana$$:"
+    asm!(
+        r"banana$:",
+    )
+}
+
+pub unsafe fn we_escape_escapes_too() {
+    // CHECK: call void asm sideeffect alignstack inteldialect "banana\{{(\\|5C)}}36:"
+    asm!(
+        r"banana\36:",
+    )
+}


### PR DESCRIPTION
We escape certain LLVM-specific features when passing the inline
assembly string to the LLVM. Until now, however, there was no test
making sure this behaviour stays intact. This commit adds such a test!

r? @Amanieu
cc @joshtriplett 