### PR TITLE
Upgrade wasm32 image to Ubuntu 20.04

### DIFF
--- a/library/std/src/lazy/tests.rs
+++ b/library/std/src/lazy/tests.rs
@@ -48,6 +48,7 @@ fn spawn_and_wait<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> 
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn sync_once_cell() {
     static ONCE_CELL: SyncOnceCell<i32> = SyncOnceCell::new();
 
@@ -81,6 +82,7 @@ fn sync_once_cell_get_unchecked() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn sync_once_cell_drop() {
     static DROP_CNT: AtomicUsize = AtomicUsize::new(0);
     struct Dropper;
@@ -158,6 +160,7 @@ fn into_inner() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn sync_lazy_new() {
     static CALLED: AtomicUsize = AtomicUsize::new(0);
     static SYNC_LAZY: SyncLazy<i32> = SyncLazy::new(|| {
@@ -204,6 +207,7 @@ fn sync_lazy_default() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn static_sync_lazy() {
     static XS: SyncLazy<Vec<i32>> = SyncLazy::new(|| {
         let mut xs = Vec::new();
@@ -279,6 +283,7 @@ fn eval_once_macro() {
 }
 
 #[test]
+#[cfg_attr(target_os = "emscripten", ignore)]
 fn sync_once_cell_does_not_leak_partially_constructed_boxes() {
     static ONCE_CELL: SyncOnceCell<String> = SyncOnceCell::new();
 

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -27,7 +27,6 @@ use crate::{
     },
     time::{TestTimeOptions, TimeThreshold},
 };
-use std::any::TypeId;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 
@@ -198,6 +197,7 @@ fn test_should_panic_bad_message() {
 #[cfg(not(target_os = "emscripten"))]
 fn test_should_panic_non_string_message_type() {
     use crate::tests::TrFailedMsg;
+    use std::any::TypeId;
     fn f() {
         panic!(1i32);
     }

--- a/src/ci/docker/host-x86_64/wasm32/Dockerfile
+++ b/src/ci/docker/host-x86_64/wasm32/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   g++ \
   make \
   ninja-build \
@@ -51,12 +51,6 @@ ENV EMCC_CFLAGS=-O1
 # Emscripten installation is user-specific
 ENV NO_CHANGE_USER=1
 
-# FIXME: Re-enable these tests once https://github.com/rust-lang/cargo/pull/7476
-# is picked up by CI
+# Exclude library/alloc due to OOM in benches.
 ENV SCRIPT python3 ../x.py test --stage 2 --host='' --target $TARGETS \
-    --exclude library/core \
-    --exclude library/alloc \
-    --exclude library/proc_macro \
-    --exclude library/std \
-    --exclude library/term \
-    --exclude library/test
+    --exclude library/alloc


### PR DESCRIPTION
This switches the wasm32 image, which is used to test
wasm32-unknown-emscripten, to Ubuntu 20.04. While at it, enable
most of the excluded tests, as they seem to work fine with some
minor fixes.