### PR TITLE
parse_format: treat r" as a literal

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -730,7 +730,7 @@ fn find_skips_from_snippet(
     str_style: Option<usize>,
 ) -> (Vec<usize>, bool) {
     let snippet = match snippet {
-        Some(ref s) if s.starts_with('"') || s.starts_with("r#") => s,
+        Some(ref s) if s.starts_with('"') || s.starts_with("r\"") || s.starts_with("r#") => s,
         _ => return (vec![], false),
     };
 

--- a/src/test/ui/fmt/format-args-capture.rs
+++ b/src/test/ui/fmt/format-args-capture.rs
@@ -5,6 +5,7 @@
 fn main() {
     named_argument_takes_precedence_to_captured();
     formatting_parameters_can_be_captured();
+    capture_raw_strings_and_idents();
 
     #[cfg(panic = "unwind")]
     {
@@ -23,6 +24,16 @@ fn named_argument_takes_precedence_to_captured() {
 
     let s = format!("{}-{bar}-{foo}", "positional", bar="named");
     assert_eq!(&s, "positional-named-captured");
+}
+
+fn capture_raw_strings_and_idents() {
+    let r#type = "apple";
+    let s = format!(r#"The fruit is an {type}"#);
+    assert_eq!(&s, "The fruit is an apple");
+
+    let r#type = "orange";
+    let s = format!(r"The fruit is an {type}");
+    assert_eq!(&s, "The fruit is an orange");
 }
 
 #[cfg(panic = "unwind")]

--- a/src/test/ui/issues/issue-75307.stderr
+++ b/src/test/ui/issues/issue-75307.stderr
@@ -1,8 +1,8 @@
 error: invalid reference to positional arguments 1 and 2 (there is 1 argument)
-  --> $DIR/issue-75307.rs:2:13
+  --> $DIR/issue-75307.rs:2:17
    |
 LL |     format!(r"{}{}{}", named_arg=1);
-   |             ^^^^^^^^^
+   |                 ^^^^
    |
    = note: positional arguments are zero-based
 


### PR DESCRIPTION
This PR changes `format_args!` internal parsing machinery to treat raw strings starting `r"` as a literal.

Currently `"` and `r#` are recognised as valid starting combinations for string literals, but `r"` is not.

This was noticed when debugging https://github.com/rust-lang/rust/issues/67984#issuecomment-753413156

As well as fixing the behavior observed in that comment, this improves diagnostic spans for `r"` formatting strings.