### PR TITLE
Resolve typedef in HashMap lldb pretty-printer only if possible

### DIFF
--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -531,7 +531,9 @@ class StdHashMapSyntheticProvider:
         ctrl = table.GetChildMemberWithName("ctrl").GetChildAtIndex(0)
 
         self.size = table.GetChildMemberWithName("items").GetValueAsUnsigned()
-        self.pair_type = table.type.template_args[0].GetTypedefedType()
+        self.pair_type = table.type.template_args[0]
+        if self.pair_type.IsTypedefType():
+            self.pair_type = self.pair_type.GetTypedefedType()
         self.pair_type_size = self.pair_type.GetByteSize()
 
         self.new_layout = not table.GetChildMemberWithName("data").IsValid()


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/81814

Previously, `GetTypedefedType` was invoked unconditionally.
But this did not work in case of `rust-lldb` without Rust patches since there was no typedef.