### PR TITLE
Slight perf improvement on char::to_ascii_lowercase

### DIFF
--- a/library/core/benches/ascii.rs
+++ b/library/core/benches/ascii.rs
@@ -66,6 +66,8 @@ macro_rules! benches {
 use test::black_box;
 use test::Bencher;
 
+const ASCII_CASE_MASK: u8 = 0b0010_0000;
+
 benches! {
     fn case00_alloc_only(_bytes: &mut [u8]) {}
 
@@ -204,7 +206,7 @@ benches! {
             }
         }
         for byte in bytes {
-            *byte &= !((is_ascii_lowercase(*byte) as u8) << 5)
+            *byte &= !((is_ascii_lowercase(*byte) as u8) * ASCII_CASE_MASK)
         }
     }
 
@@ -216,7 +218,7 @@ benches! {
             }
         }
         for byte in bytes {
-            *byte -= (is_ascii_lowercase(*byte) as u8) << 5
+            *byte -= (is_ascii_lowercase(*byte) as u8) * ASCII_CASE_MASK
         }
     }
 

--- a/library/core/benches/char/methods.rs
+++ b/library/core/benches/char/methods.rs
@@ -35,3 +35,13 @@ fn bench_to_digit_radix_var(b: &mut Bencher) {
             .min()
     })
 }
+
+#[bench]
+fn bench_to_ascii_uppercase(b: &mut Bencher) {
+    b.iter(|| CHARS.iter().cycle().take(10_000).map(|c| c.to_ascii_uppercase()).min())
+}
+
+#[bench]
+fn bench_to_ascii_lowercase(b: &mut Bencher) {
+    b.iter(|| CHARS.iter().cycle().take(10_000).map(|c| c.to_ascii_lowercase()).min())
+}

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -7,6 +7,9 @@ use crate::unicode::{self, conversions};
 
 use super::*;
 
+/// If 6th bit set ascii is upper case.
+const ASCII_CASE_MASK: u8 = 0b10_0000u8;
+
 #[lang = "char"]
 impl char {
     /// The highest valid code point a `char` can have.
@@ -1090,8 +1093,7 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> char {
-        // 6th bit dictates ascii case.
-        if self.is_ascii_lowercase() { ((*self as u8) & !0b10_0000u8) as char } else { *self }
+        if self.is_ascii_lowercase() { ((*self as u8) & !ASCII_CASE_MASK) as char } else { *self }
     }
 
     /// Makes a copy of the value in its ASCII lower case equivalent.
@@ -1119,8 +1121,7 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> char {
-        // 6th bit dictates ascii case.
-        if self.is_ascii_uppercase() { ((*self as u8) | 0b10_0000u8) as char } else { *self }
+        if self.is_ascii_uppercase() { ((*self as u8) | ASCII_CASE_MASK) as char } else { *self }
     }
 
     /// Checks that two values are an ASCII case-insensitive match.

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1090,7 +1090,8 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> char {
-        if self.is_ascii() { (*self as u8).to_ascii_uppercase() as char } else { *self }
+        // 6th bit dictates ascii case.
+        if self.is_ascii_lowercase() { ((*self as u8) & !0b10_0000u8) as char } else { *self }
     }
 
     /// Makes a copy of the value in its ASCII lower case equivalent.
@@ -1118,7 +1119,8 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> char {
-        if self.is_ascii() { (*self as u8).to_ascii_lowercase() as char } else { *self }
+        // 6th bit dictates ascii case.
+        if self.is_ascii_uppercase() { ((*self as u8) | 0b10_0000u8) as char } else { *self }
     }
 
     /// Checks that two values are an ASCII case-insensitive match.

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -3,12 +3,9 @@
 use crate::slice;
 use crate::str::from_utf8_unchecked_mut;
 use crate::unicode::printable::is_printable;
-use crate::unicode::{self, conversions};
+use crate::unicode::{self, conversions, ASCII_CASE_MASK};
 
 use super::*;
-
-/// If 6th bit set ascii is upper case.
-const ASCII_CASE_MASK: u8 = 0b10_0000u8;
 
 #[lang = "char"]
 impl char {

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -3,7 +3,7 @@
 use crate::slice;
 use crate::str::from_utf8_unchecked_mut;
 use crate::unicode::printable::is_printable;
-use crate::unicode::{self, conversions, ASCII_CASE_MASK};
+use crate::unicode::{self, conversions};
 
 use super::*;
 
@@ -1090,7 +1090,11 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_uppercase(&self) -> char {
-        if self.is_ascii_lowercase() { ((*self as u8) & !ASCII_CASE_MASK) as char } else { *self }
+        if self.is_ascii_lowercase() {
+            (*self as u8).ascii_change_case_unchecked() as char
+        } else {
+            *self
+        }
     }
 
     /// Makes a copy of the value in its ASCII lower case equivalent.
@@ -1118,7 +1122,11 @@ impl char {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn to_ascii_lowercase(&self) -> char {
-        if self.is_ascii_uppercase() { ((*self as u8) | ASCII_CASE_MASK) as char } else { *self }
+        if self.is_ascii_uppercase() {
+            (*self as u8).ascii_change_case_unchecked() as char
+        } else {
+            *self
+        }
     }
 
     /// Checks that two values are an ASCII case-insensitive match.

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -6,9 +6,6 @@ use crate::intrinsics;
 use crate::mem;
 use crate::str::FromStr;
 
-/// If 6th bit set ascii is upper case.
-const ASCII_CASE_MASK: u8 = 0b0010_0000;
-
 // Used because the `?` operator is not allowed in a const context.
 macro_rules! try_opt {
     ($e:expr) => {
@@ -154,6 +151,9 @@ impl isize {
      "[0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56]",
      usize_isize_to_xe_bytes_doc!(), usize_isize_from_xe_bytes_doc!() }
 }
+
+/// If 6th bit set ascii is upper case.
+const ASCII_CASE_MASK: u8 = 0b0010_0000;
 
 #[lang = "u8"]
 impl u8 {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -5,6 +5,7 @@
 use crate::intrinsics;
 use crate::mem;
 use crate::str::FromStr;
+use crate::unicode::ASCII_CASE_MASK;
 
 // Used because the `?` operator is not allowed in a const context.
 macro_rules! try_opt {
@@ -195,7 +196,7 @@ impl u8 {
     #[inline]
     pub fn to_ascii_uppercase(&self) -> u8 {
         // Unset the fifth bit if this is a lowercase letter
-        *self & !((self.is_ascii_lowercase() as u8) << 5)
+        *self & !((self.is_ascii_lowercase() as u8) * ASCII_CASE_MASK)
     }
 
     /// Makes a copy of the value in its ASCII lower case equivalent.
@@ -218,7 +219,7 @@ impl u8 {
     #[inline]
     pub fn to_ascii_lowercase(&self) -> u8 {
         // Set the fifth bit if this is an uppercase letter
-        *self | ((self.is_ascii_uppercase() as u8) << 5)
+        *self | (self.is_ascii_uppercase() as u8 * ASCII_CASE_MASK)
     }
 
     /// Checks that two values are an ASCII case-insensitive match.

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -5,7 +5,9 @@
 use crate::intrinsics;
 use crate::mem;
 use crate::str::FromStr;
-use crate::unicode::ASCII_CASE_MASK;
+
+/// If 6th bit set ascii is upper case.
+const ASCII_CASE_MASK: u8 = 0b0010_0000;
 
 // Used because the `?` operator is not allowed in a const context.
 macro_rules! try_opt {
@@ -220,6 +222,12 @@ impl u8 {
     pub fn to_ascii_lowercase(&self) -> u8 {
         // Set the fifth bit if this is an uppercase letter
         *self | (self.is_ascii_uppercase() as u8 * ASCII_CASE_MASK)
+    }
+
+    /// Assumes self is ascii
+    #[inline]
+    pub(crate) fn ascii_change_case_unchecked(&self) -> u8 {
+        *self ^ ASCII_CASE_MASK
     }
 
     /// Checks that two values are an ASCII case-insensitive match.

--- a/library/core/src/unicode/mod.rs
+++ b/library/core/src/unicode/mod.rs
@@ -17,9 +17,6 @@ mod unicode_data;
 #[stable(feature = "unicode_version", since = "1.45.0")]
 pub const UNICODE_VERSION: (u8, u8, u8) = unicode_data::UNICODE_VERSION;
 
-/// If 6th bit set ascii is upper case.
-pub(crate) const ASCII_CASE_MASK: u8 = 0b0010_0000;
-
 // For use in liballoc, not re-exported in libstd.
 pub use unicode_data::{
     case_ignorable::lookup as Case_Ignorable, cased::lookup as Cased, conversions,

--- a/library/core/src/unicode/mod.rs
+++ b/library/core/src/unicode/mod.rs
@@ -17,6 +17,9 @@ mod unicode_data;
 #[stable(feature = "unicode_version", since = "1.45.0")]
 pub const UNICODE_VERSION: (u8, u8, u8) = unicode_data::UNICODE_VERSION;
 
+/// If 6th bit set ascii is upper case.
+pub(crate) const ASCII_CASE_MASK: u8 = 0b0010_0000;
+
 // For use in liballoc, not re-exported in libstd.
 pub use unicode_data::{
     case_ignorable::lookup as Case_Ignorable, cased::lookup as Cased, conversions,


### PR DESCRIPTION
`char::to_ascii_lowercase()` was checking if it was ascii and then if it was in the right range. Instead propose to check once (I think removing a compare and a shift in the process: [godbolt](https://godbolt.org/z/e5Tora) ).

before:
```
        test char::methods::bench_to_ascii_lowercase                    ... bench:      11,196 ns/iter (+/- 632)
        test char::methods::bench_to_ascii_uppercase                    ... bench:      11,656 ns/iter (+/- 671)
```
after:
```
         test char::methods::bench_to_ascii_lowercase                    ... bench:       9,612 ns/iter (+/- 979)
         test char::methods::bench_to_ascii_uppercase                    ... bench:       8,241 ns/iter (+/- 701)
```

(calling u8::to_ascii_lowercase and letting that flip the 5th bit is also an option, but it's more instructions. I'm thinking for things around ascii and char we want to be as efficient as possible.)