### PR TITLE
Remove rustc-dev-guide submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "library/stdarch"]
 	path = library/stdarch
 	url = https://github.com/rust-lang/stdarch.git
-[submodule "src/doc/rustc-dev-guide"]
-	path = src/doc/rustc-dev-guide
-	url = https://github.com/rust-lang/rustc-dev-guide.git
 [submodule "src/doc/edition-guide"]
 	path = src/doc/edition-guide
 	url = https://github.com/rust-lang/edition-guide.git

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,7 +23,6 @@ ignore = [
     "src/doc/nomicon",
     "src/doc/reference",
     "src/doc/rust-by-example",
-    "src/doc/rustc-dev-guide",
     "src/llvm-project",
     "src/tools/cargo",
     "src/tools/clippy",

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -413,7 +413,6 @@ impl<'a> Builder<'a> {
                 test::UnstableBook,
                 test::RustcBook,
                 test::LintDocs,
-                test::RustcGuide,
                 test::EmbeddedBook,
                 test::EditionGuide,
                 test::Rustfmt,

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1537,34 +1537,6 @@ fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> 
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct RustcGuide;
-
-impl Step for RustcGuide {
-    type Output = ();
-    const DEFAULT: bool = false;
-    const ONLY_HOSTS: bool = true;
-
-    fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("src/doc/rustc-dev-guide")
-    }
-
-    fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(RustcGuide);
-    }
-
-    fn run(self, builder: &Builder<'_>) {
-        let src = builder.src.join("src/doc/rustc-dev-guide");
-        let mut rustbook_cmd = builder.tool_cmd(Tool::Rustbook);
-        let toolstate = if try_run(builder, rustbook_cmd.arg("linkcheck").arg(&src)) {
-            ToolState::TestPass
-        } else {
-            ToolState::TestFail
-        };
-        builder.save_toolstate("rustc-dev-guide", toolstate);
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CrateLibrustc {
     compiler: Compiler,
     target: TargetSelection,

--- a/src/bootstrap/toolstate.rs
+++ b/src/bootstrap/toolstate.rs
@@ -85,11 +85,8 @@ static STABLE_TOOLS: &[(&str, &str)] = &[
 // We do require that we checked whether they build or not on the tools builder,
 // though, as otherwise we will be unable to file an issue if they start
 // failing.
-static NIGHTLY_TOOLS: &[(&str, &str)] = &[
-    ("miri", "src/tools/miri"),
-    ("embedded-book", "src/doc/embedded-book"),
-    // ("rustc-dev-guide", "src/doc/rustc-dev-guide"),
-];
+static NIGHTLY_TOOLS: &[(&str, &str)] =
+    &[("miri", "src/tools/miri"), ("embedded-book", "src/doc/embedded-book")];
 
 fn print_error(tool: &str, submodule: &str) {
     eprintln!();

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -173,7 +173,6 @@ fn skip_markdown_path(path: &Path) -> bool {
         "src/doc/nomicon",
         "src/doc/reference",
         "src/doc/rust-by-example",
-        "src/doc/rustc-dev-guide",
     ];
     SKIP_MD.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
Rationale:

* The submodule hasn't been updated in 10 months (since April 2020)
* It's unlikely that there's a need for it to be a submodule -- people
  can just clone the rust-lang/rustc-dev-guide repo
* Submodules are a pain

See also the [discussion on Zulip][z].

[z]: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/rustc-dev-guide.20submodule
