### PR TITLE
Expand the docs for ops::ControlFlow a bit

### DIFF
--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -15,6 +15,7 @@
 #![feature(const_maybe_uninit_assume_init)]
 #![feature(const_ptr_read)]
 #![feature(const_ptr_offset)]
+#![feature(control_flow_enum)]
 #![feature(core_intrinsics)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]

--- a/library/core/tests/ops.rs
+++ b/library/core/tests/ops.rs
@@ -1,3 +1,5 @@
+mod control_flow;
+
 use core::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use core::ops::{Deref, DerefMut};
 

--- a/library/core/tests/ops/control_flow.rs
+++ b/library/core/tests/ops/control_flow.rs
@@ -1,0 +1,18 @@
+use core::intrinsics::discriminant_value;
+use core::ops::ControlFlow;
+
+#[test]
+fn control_flow_discriminants_match_result() {
+    // This isn't stable surface area, but helps keep `?` cheap between them,
+    // even if LLVM can't always take advantage of it right now.
+    // (Sadly Result and Option are inconsistent, so ControlFlow can't match both.)
+
+    assert_eq!(
+        discriminant_value(&ControlFlow::<i32, i32>::Break(3)),
+        discriminant_value(&Result::<i32, i32>::Err(3)),
+    );
+    assert_eq!(
+        discriminant_value(&ControlFlow::<i32, i32>::Continue(3)),
+        discriminant_value(&Result::<i32, i32>::Ok(3)),
+    );
+}


### PR DESCRIPTION
Since I was writing some examples for an RFC anyway.

And I almost made the mistake of reordering the variants, so added a note and a test about that.