### PR TITLE
use RWlock when accessing os::env

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -491,7 +491,7 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     extern "C" {
         static mut environ: *const *const c_char;
     }
-    &mut environ
+    ptr::addr_of_mut!(environ)
 }
 
 pub unsafe fn env_rwlock(readonly: bool) -> RWLockGuard {

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -22,7 +22,7 @@ use crate::str;
 use crate::sys::cvt;
 use crate::sys::fd;
 use crate::sys_common::mutex::{StaticMutex, StaticMutexGuard};
-use crate::sys_common::rwlock::{RWLockGuard, StaticRWLock};
+use crate::sys_common::rwlock::{RWLockReadGuard, StaticRWLock};
 use crate::vec;
 
 use libc::{c_char, c_int, c_void};
@@ -496,7 +496,7 @@ pub unsafe fn environ() -> *mut *const *const c_char {
 
 static ENV_LOCK: StaticRWLock = StaticRWLock::new();
 
-pub fn env_read_lock() -> RWLockGuard {
+pub fn env_read_lock() -> RWLockReadGuard {
     ENV_LOCK.read_with_guard()
 }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -47,7 +47,7 @@ impl Command {
         // a lock any more because the parent won't do anything and the child is
         // in its own process.
         let result = unsafe {
-            let _env_lock = sys::os::env_rwlock(true);
+            let _env_lock = sys::os::env_read_lock();
             cvt(libc::fork())?
         };
 
@@ -124,7 +124,7 @@ impl Command {
                     // Similar to when forking, we want to ensure that access to
                     // the environment is synchronized, so make sure to grab the
                     // environment lock before we try to exec.
-                    let _lock = sys::os::env_rwlock(true);
+                    let _lock = sys::os::env_read_lock();
 
                     let Err(e) = self.do_exec(theirs, envp.as_ref());
                     e
@@ -404,7 +404,7 @@ impl Command {
             cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;
 
             // Make sure we synchronize access to the global `environ` resource
-            let _env_lock = sys::os::env_rwlock(true);
+            let _env_lock = sys::os::env_read_lock();
             let envp = envp.map(|c| c.as_ptr()).unwrap_or_else(|| *sys::os::environ() as *const _);
             cvt_nz(libc::posix_spawnp(
                 &mut p.pid,

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -47,7 +47,7 @@ impl Command {
         // a lock any more because the parent won't do anything and the child is
         // in its own process.
         let result = unsafe {
-            let _env_lock = sys::os::env_lock();
+            let _env_lock = sys::os::env_rwlock(true);
             cvt(libc::fork())?
         };
 
@@ -124,7 +124,7 @@ impl Command {
                     // Similar to when forking, we want to ensure that access to
                     // the environment is synchronized, so make sure to grab the
                     // environment lock before we try to exec.
-                    let _lock = sys::os::env_lock();
+                    let _lock = sys::os::env_rwlock(true);
 
                     let Err(e) = self.do_exec(theirs, envp.as_ref());
                     e
@@ -404,7 +404,7 @@ impl Command {
             cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;
 
             // Make sure we synchronize access to the global `environ` resource
-            let _env_lock = sys::os::env_lock();
+            let _env_lock = sys::os::env_rwlock(true);
             let envp = envp.map(|c| c.as_ptr()).unwrap_or_else(|| *sys::os::environ() as *const _);
             cvt_nz(libc::posix_spawnp(
                 &mut p.pid,

--- a/library/std/src/sys_common/rwlock.rs
+++ b/library/std/src/sys_common/rwlock.rs
@@ -1,12 +1,15 @@
 use crate::sys::rwlock as imp;
 
+#[cfg(unix)]
 enum GuardType {
     Read,
     Write,
 }
 
+#[cfg(unix)]
 pub struct RWLockGuard(&'static RWLock, GuardType);
 
+#[cfg(unix)]
 impl Drop for RWLockGuard {
     fn drop(&mut self) {
         unsafe {
@@ -52,6 +55,7 @@ impl RWLock {
     /// Behavior is undefined if the rwlock has been moved between this and any
     /// previous method call.
     #[inline]
+    #[cfg(unix)]
     pub unsafe fn read_with_guard(&'static self) -> RWLockGuard {
         self.read();
         RWLockGuard(&self, GuardType::Read)
@@ -87,6 +91,7 @@ impl RWLock {
     /// Behavior is undefined if the rwlock has been moved between this and any
     /// previous method call.
     #[inline]
+    #[cfg(unix)]
     pub unsafe fn write_with_guard(&'static self) -> RWLockGuard {
         self.write();
         RWLockGuard(&self, GuardType::Write)


### PR DESCRIPTION
Multiple threads modifying the current process environment is fairly uncommon. Optimize for the more common read case.

r? @m-ou-se 