### PR TITLE
parser: Fix panic in 'const impl' recovery

### DIFF
--- a/src/test/ui/parser/issue-81806.rs
+++ b/src/test/ui/parser/issue-81806.rs
@@ -1,0 +1,5 @@
+trait T { const
+impl //~ ERROR: expected identifier, found keyword `impl`
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-81806.stderr
+++ b/src/test/ui/parser/issue-81806.stderr
@@ -1,0 +1,17 @@
+error: expected identifier, found keyword `impl`
+  --> $DIR/issue-81806.rs:2:1
+   |
+LL | trait T { const
+   |         - while parsing this item list starting here
+LL | impl
+   | ^^^^ expected identifier, found keyword
+LL | }
+   | - the item list ends here
+   |
+help: you can escape reserved keywords to use them as identifiers
+   |
+LL | r#impl
+   | ^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
The panic happens when in recovery parsing a full `impl`
(`parse_item_impl`) fails and we drop the `DiagnosticBuilder` for the
recovery suggestion and return the `parse_item_impl` error.

We now raise the original error "expected identifier found `impl`" when
parsing the `impl` fails.

Note that the regression test is slightly simplified version of the
original repro in #81806, to make the error output smaller and more
resilient to unrelated changes in parser error messages.

Fixes #81806