### PR TITLE
Fix pretty printer macro_rules with semicolon.

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1311,6 +1311,9 @@ impl<'a> State<'a> {
                     true,
                     item.span,
                 );
+                if macro_def.body.need_semicolon() {
+                    self.word(";");
+                }
             }
         }
         self.ann.post(self, AnnNode::Item(item))

--- a/src/test/pretty/macro_rules.rs
+++ b/src/test/pretty/macro_rules.rs
@@ -1,0 +1,19 @@
+// pp-exact
+
+macro_rules! brace { () => { } ; }
+
+macro_rules! bracket[() => { } ;];
+
+macro_rules! paren(() => { } ;);
+
+macro_rules! matcher_brackets {
+    (paren) => { } ; (bracket) => { } ; (brace) => { } ;
+}
+
+macro_rules! all_fragments {
+    ($ b : block, $ e : expr, $ i : ident, $ it : item, $ l : lifetime, $ lit
+     : literal, $ m : meta, $ p : pat, $ pth : path, $ s : stmt, $ tt : tt, $
+     ty : ty, $ vis : vis) => { } ;
+}
+
+fn main() { }


### PR DESCRIPTION
The pretty printer was not including the trailing semicolon for a macro_rules definition that used parenthesis or brackets, which results in invalid code. This adds the semicolon in those two cases.
