### PR TITLE
[rustdoc-json] Make `header` a vec of modifiers, and FunctionPointer consistent

### DIFF
--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -108,7 +108,7 @@ def check_type(ty):
     elif ty["kind"] == "function_pointer":
         for param in ty["inner"]["generic_params"]:
             check_generic_param(param)
-        check_decl(ty["inner"]["inner"])
+        check_decl(ty["inner"]["decl"])
     elif ty["kind"] == "qualified_path":
         check_type(ty["inner"]["self_type"])
         check_type(ty["inner"]["trait"])

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -14,6 +14,7 @@ use rustdoc_json_types::*;
 use crate::clean;
 use crate::formats::item_type::ItemType;
 use crate::json::JsonRenderer;
+use std::collections::HashSet;
 
 impl JsonRenderer<'_> {
     pub(super) fn convert_item(&self, item: clean::Item) -> Option<Item> {
@@ -225,19 +226,19 @@ crate fn from_ctor_kind(struct_type: CtorKind) -> StructType {
     }
 }
 
-crate fn from_fn_header(header: &rustc_hir::FnHeader) -> Vec<Modifiers> {
-    let mut v = Vec::new();
+crate fn from_fn_header(header: &rustc_hir::FnHeader) -> HashSet<Modifiers> {
+    let mut v = HashSet::new();
 
     if let rustc_hir::Unsafety::Unsafe = header.unsafety {
-        v.push(Modifiers::Unsafe);
+        v.insert(Modifiers::Unsafe);
     }
 
     if let rustc_hir::IsAsync::Async = header.asyncness {
-        v.push(Modifiers::Async);
+        v.insert(Modifiers::Async);
     }
 
     if let rustc_hir::Constness::Const = header.constness {
-        v.push(Modifiers::Const);
+        v.insert(Modifiers::Const);
     }
 
     v
@@ -372,9 +373,11 @@ impl From<clean::BareFunctionDecl> for FunctionPointer {
         let clean::BareFunctionDecl { unsafety, generic_params, decl, abi } = bare_decl;
         FunctionPointer {
             header: if let rustc_hir::Unsafety::Unsafe = unsafety {
-                vec![Modifiers::Unsafe]
+                let mut hs = HashSet::new();
+                hs.insert(Modifiers::Unsafe);
+                hs
             } else {
-                vec![]
+                HashSet::new()
             },
             generic_params: generic_params.into_iter().map(Into::into).collect(),
             decl: decl.into(),

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -2,6 +2,8 @@
 //! the `clean` types but with some fields removed or stringified to simplify the output and not
 //! expose unstable compiler internals.
 
+#![allow(rustc::default_hash_types)]
+
 use std::convert::From;
 
 use rustc_ast::ast;

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -228,19 +228,19 @@ crate fn from_ctor_kind(struct_type: CtorKind) -> StructType {
     }
 }
 
-crate fn from_fn_header(header: &rustc_hir::FnHeader) -> HashSet<Modifiers> {
+crate fn from_fn_header(header: &rustc_hir::FnHeader) -> HashSet<Qualifiers> {
     let mut v = HashSet::new();
 
     if let rustc_hir::Unsafety::Unsafe = header.unsafety {
-        v.insert(Modifiers::Unsafe);
+        v.insert(Qualifiers::Unsafe);
     }
 
     if let rustc_hir::IsAsync::Async = header.asyncness {
-        v.insert(Modifiers::Async);
+        v.insert(Qualifiers::Async);
     }
 
     if let rustc_hir::Constness::Const = header.constness {
-        v.insert(Modifiers::Const);
+        v.insert(Qualifiers::Const);
     }
 
     v
@@ -376,7 +376,7 @@ impl From<clean::BareFunctionDecl> for FunctionPointer {
         FunctionPointer {
             header: if let rustc_hir::Unsafety::Unsafe = unsafety {
                 let mut hs = HashSet::new();
-                hs.insert(Modifiers::Unsafe);
+                hs.insert(Qualifiers::Unsafe);
                 hs
             } else {
                 HashSet::new()

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -243,7 +243,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 3,
+            format_version: 4,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -3,7 +3,7 @@
 //! These types are the public API exposed through the `--output-format json` flag. The [`Crate`]
 //! struct is the root of the JSON blob and all other items are contained within.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -282,7 +282,7 @@ pub enum StructType {
 }
 
 #[non_exhaustive]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum Modifiers {
     Const,
@@ -294,7 +294,7 @@ pub enum Modifiers {
 pub struct Function {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub header: Vec<Modifiers>,
+    pub header: HashSet<Modifiers>,
     pub abi: String,
 }
 
@@ -302,7 +302,7 @@ pub struct Function {
 pub struct Method {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub header: Vec<Modifiers>,
+    pub header: HashSet<Modifiers>,
     pub abi: String,
     pub has_body: bool,
 }
@@ -415,7 +415,7 @@ pub enum Type {
 pub struct FunctionPointer {
     pub decl: FnDecl,
     pub generic_params: Vec<GenericParamDef>,
-    pub header: Vec<Modifiers>,
+    pub header: HashSet<Modifiers>,
     pub abi: String,
 }
 

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -281,11 +281,20 @@ pub enum StructType {
     Unit,
 }
 
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum Modifiers {
+    Const,
+    Unsafe,
+    Async,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Function {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub header: String,
+    pub header: Vec<Modifiers>,
     pub abi: String,
 }
 
@@ -293,7 +302,7 @@ pub struct Function {
 pub struct Method {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub header: String,
+    pub header: Vec<Modifiers>,
     pub abi: String,
     pub has_body: bool,
 }
@@ -404,9 +413,9 @@ pub enum Type {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct FunctionPointer {
-    pub is_unsafe: bool,
-    pub generic_params: Vec<GenericParamDef>,
     pub decl: FnDecl,
+    pub generic_params: Vec<GenericParamDef>,
+    pub header: Vec<Modifiers>,
     pub abi: String,
 }
 

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -282,8 +282,8 @@ pub enum StructType {
 }
 
 #[non_exhaustive]
-#[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum Modifiers {
     Const,
     Unsafe,

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -284,7 +284,7 @@ pub enum StructType {
 #[non_exhaustive]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
-pub enum Modifiers {
+pub enum Qualifiers {
     Const,
     Unsafe,
     Async,
@@ -294,7 +294,7 @@ pub enum Modifiers {
 pub struct Function {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub header: HashSet<Modifiers>,
+    pub header: HashSet<Qualifiers>,
     pub abi: String,
 }
 
@@ -302,7 +302,7 @@ pub struct Function {
 pub struct Method {
     pub decl: FnDecl,
     pub generics: Generics,
-    pub header: HashSet<Modifiers>,
+    pub header: HashSet<Qualifiers>,
     pub abi: String,
     pub has_body: bool,
 }
@@ -415,7 +415,7 @@ pub enum Type {
 pub struct FunctionPointer {
     pub decl: FnDecl,
     pub generic_params: Vec<GenericParamDef>,
-    pub header: HashSet<Modifiers>,
+    pub header: HashSet<Qualifiers>,
     pub abi: String,
 }
 

--- a/src/test/rustdoc-json/fn_pointer/header.rs
+++ b/src/test/rustdoc-json/fn_pointer/header.rs
@@ -1,0 +1,5 @@
+// @has header.json "$.index[*][?(@.name=='FnPointer')].inner.type.inner.header" "[]"
+pub type FnPointer = fn();
+
+// @has - "$.index[*][?(@.name=='UnsafePointer')].inner.type.inner.header" '["unsafe"]'
+pub type UnsafePointer = unsafe fn();

--- a/src/test/rustdoc-json/fns/header.rs
+++ b/src/test/rustdoc-json/fns/header.rs
@@ -1,0 +1,20 @@
+// edition:2018
+
+// @has header.json "$.index[*][?(@.name=='nothing_fn')].inner.header" "[]"
+pub fn nothing_fn() {}
+
+// @has - "$.index[*][?(@.name=='const_fn')].inner.header" '["const"]'
+pub const fn const_fn() {}
+
+// @has - "$.index[*][?(@.name=='async_fn')].inner.header" '["async"]'
+pub async fn async_fn() {}
+
+// @count - "$.index[*][?(@.name=='async_unsafe_fn')].inner.header[*]" 2
+// @has - "$.index[*][?(@.name=='async_unsafe_fn')].inner.header[*]" '"async"'
+// @has - "$.index[*][?(@.name=='async_unsafe_fn')].inner.header[*]" '"unsafe"'
+pub async unsafe fn async_unsafe_fn() {}
+
+// @count - "$.index[*][?(@.name=='const_unsafe_fn')].inner.header[*]" 2
+// @has - "$.index[*][?(@.name=='const_unsafe_fn')].inner.header[*]" '"const"'
+// @has - "$.index[*][?(@.name=='const_unsafe_fn')].inner.header[*]" '"unsafe"'
+pub const unsafe fn const_unsafe_fn() {}

--- a/src/test/rustdoc-json/fns/header.rs
+++ b/src/test/rustdoc-json/fns/header.rs
@@ -18,3 +18,5 @@ pub async unsafe fn async_unsafe_fn() {}
 // @has - "$.index[*][?(@.name=='const_unsafe_fn')].inner.header[*]" '"const"'
 // @has - "$.index[*][?(@.name=='const_unsafe_fn')].inner.header[*]" '"unsafe"'
 pub const unsafe fn const_unsafe_fn() {}
+
+// It's impossible for a function to be both const and async, so no test for that

--- a/src/test/rustdoc-json/methods/header.rs
+++ b/src/test/rustdoc-json/methods/header.rs
@@ -21,4 +21,6 @@ impl Foo {
     // @has - "$.index[*][?(@.name=='const_unsafe_meth')].inner.header[*]" '"const"'
     // @has - "$.index[*][?(@.name=='const_unsafe_meth')].inner.header[*]" '"unsafe"'
     pub const unsafe fn const_unsafe_meth() {}
+
+    // It's impossible for a method to be both const and async, so no test for that
 }

--- a/src/test/rustdoc-json/methods/header.rs
+++ b/src/test/rustdoc-json/methods/header.rs
@@ -1,0 +1,24 @@
+// edition:2018
+
+pub struct Foo;
+
+impl Foo {
+    // @has header.json "$.index[*][?(@.name=='nothing_meth')].inner.header" "[]"
+    pub fn nothing_meth() {}
+
+    // @has - "$.index[*][?(@.name=='const_meth')].inner.header" '["const"]'
+    pub const fn const_meth() {}
+
+    // @has - "$.index[*][?(@.name=='async_meth')].inner.header" '["async"]'
+    pub async fn async_meth() {}
+
+    // @count - "$.index[*][?(@.name=='async_unsafe_meth')].inner.header[*]" 2
+    // @has - "$.index[*][?(@.name=='async_unsafe_meth')].inner.header[*]" '"async"'
+    // @has - "$.index[*][?(@.name=='async_unsafe_meth')].inner.header[*]" '"unsafe"'
+    pub async unsafe fn async_unsafe_meth() {}
+
+    // @count - "$.index[*][?(@.name=='const_unsafe_meth')].inner.header[*]" 2
+    // @has - "$.index[*][?(@.name=='const_unsafe_meth')].inner.header[*]" '"const"'
+    // @has - "$.index[*][?(@.name=='const_unsafe_meth')].inner.header[*]" '"unsafe"'
+    pub const unsafe fn const_unsafe_meth() {}
+}


### PR DESCRIPTION
Bumps version number and adds tests, this is a breaking change. I can split this into two (`is_unsafe` -> `header` and `header: Vec<Modifiers>`) if desired.

Rationale: Modifiers are individual notes on a function, it makes more sense for them to be a list of an independent enum over a String which is inconsistently exposing the HIR representation (prefix_str vs custom literals).
Function pointers currently only support `unsafe`, but there has been talk on and off about allowing them to also support `const`, and this makes handling their modifiers consistent with handling those of a function, allowing better shared code.

@rustbot modify labels: +A-rustdoc-json +T-rustdoc
CC: @HeroicKatora 
r? @jyn514 