### PR TITLE
Remove outdated comment in windows' mutex.rs

### DIFF
--- a/library/std/src/sys/windows/mutex.rs
+++ b/library/std/src/sys/windows/mutex.rs
@@ -23,8 +23,6 @@ pub struct Mutex {
 }
 
 // Windows SRW Locks are movable (while not borrowed).
-// ReentrantMutexes (in Inner) are not, but those are stored indirectly through
-// a Box, so do not move when the Mutex it self is moved.
 pub type MovableMutex = Mutex;
 
 unsafe impl Send for Mutex {}


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/81250, this `Mutex` no longer falls back to the `ReentrantMutex` implementation, so this comment is no longer relevant.