### PR TITLE
Add match pattern diagnostics regression test

### DIFF
--- a/src/test/ui/pattern/usefulness/issue-72377.rs
+++ b/src/test/ui/pattern/usefulness/issue-72377.rs
@@ -1,0 +1,17 @@
+#[derive(PartialEq, Eq)]
+enum X { A, B, C, }
+
+fn main() {
+    let x = X::A;
+    let y = Some(X::A);
+
+    match (x, y) {
+        //~^ ERROR non-exhaustive patterns: `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2
+        //~| more not covered
+        (_, None) => false,
+        (v, Some(w)) if v == w => true,
+        (X::B, Some(X::C)) => false,
+        (X::B, Some(X::A)) => false,
+        (X::A, Some(X::C)) | (X::C, Some(X::A)) => false,
+    };
+}

--- a/src/test/ui/pattern/usefulness/issue-72377.stderr
+++ b/src/test/ui/pattern/usefulness/issue-72377.stderr
@@ -1,0 +1,12 @@
+error[E0004]: non-exhaustive patterns: `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2 more not covered
+  --> $DIR/issue-72377.rs:8:11
+   |
+LL |     match (x, y) {
+   |           ^^^^^^ patterns `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2 more not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(X, Option<X>)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Closes #72377 by adding a regression test.

This test case fails on stable but now works on beta and nightly. It *should* have worked already for years, the crucial point whether it is mentioned that some uncovered patterns are not explicitly mentioned.