### PR TITLE
Use format string in bootstrap panic instead of a string directly

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1490,7 +1490,7 @@ impl<'a> Builder<'a> {
                 for el in stack.iter().rev() {
                     out += &format!("\t{:?}\n", el);
                 }
-                panic!(out);
+                panic!("{}", out);
             }
             if let Some(out) = self.cache.get(&step) {
                 self.verbose(&format!("{}c {:?}", "  ".repeat(stack.len()), step));


### PR DESCRIPTION
This fixes the following warning when compiling with nightly:

```
warning: panic message is not a string literal
    --> src/bootstrap/builder.rs:1515:24
     |
1515 |                 panic!(out);
     |                        ^^^
     |
     = note: `#[warn(non_fmt_panic)]` on by default
     = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
     |
1515 |                 panic!("{}", out);
     |                        ^^^^^
help: or use std::panic::panic_any instead
     |
1515 |                 std::panic::panic_any(out);
     |                 ^^^^^^^^^^^^^^^^^^^^^^
```

Found while working on https://github.com/rust-lang/rust/pull/79540. cc https://github.com/rust-lang/rust/pull/81645, which landed in 1.51.