### PR TITLE
Allow unstable features in some PGO benchmarks

### DIFF
--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -7,7 +7,7 @@ rm -rf /tmp/rustc-pgo
 python2.7 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
     --stage 2 library/std --rust-profile-generate=/tmp/rustc-pgo
 
-./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \
+RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \
     --crate-type=lib ../library/core/src/lib.rs
 
 # Download and build a single-file stress test benchmark on perf.rust-lang.org.
@@ -16,7 +16,9 @@ function pgo_perf_benchmark {
     local github_prefix=https://raw.githubusercontent.com/rust-lang/rustc-perf/$PERF
     local name=$1
     curl -o /tmp/$name.rs $github_prefix/collector/benchmarks/$name/src/lib.rs
-    ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 --crate-type=lib /tmp/$name.rs
+
+    RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \
+        --crate-type=lib /tmp/$name.rs
 }
 
 pgo_perf_benchmark externs


### PR DESCRIPTION
Some of the benchmarks we're using for PGO require unstable features (such as compiling the standard library and some rustc-perf benchmarks), breaking CI on the beta and stable branches. For the past two releases we cherry-picked a commit directly onto the beta branch that unconditionally sets `RUSTC_BOOTSTRAP=1`, and this PR backports a similar change to the master branch.

The difference between this commit and the one we backported previously (483c1a83ca7cf53fd8f3432edb32cbe70ba39d45) is that this is more scoped in which benchmarks we allow unstable features, to prevent unintentionally enabling unstable features.

r? @Mark-Simulacrum 