### PR TITLE
BTree: adapt range support functions to the root's optionality

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1009,13 +1009,12 @@ impl<K, V> BTreeMap<K, V> {
         K: Borrow<T> + Ord,
         R: RangeBounds<T>,
     {
-        if let Some(root) = &self.root {
-            let (f, b) = root.reborrow().range_search(range);
-
-            Range { front: Some(f), back: Some(b) }
+        let (front, back) = if let Some(root) = &self.root {
+            root.reborrow().range_search(range)
         } else {
-            Range { front: None, back: None }
-        }
+            (None, None)
+        };
+        Range { front, back }
     }
 
     /// Constructs a mutable double-ended iterator over a sub-range of elements in the map.
@@ -1055,13 +1054,12 @@ impl<K, V> BTreeMap<K, V> {
         K: Borrow<T> + Ord,
         R: RangeBounds<T>,
     {
-        if let Some(root) = &mut self.root {
-            let (f, b) = root.borrow_valmut().range_search(range);
-
-            RangeMut { front: Some(f), back: Some(b), _marker: PhantomData }
+        let (front, back) = if let Some(root) = &mut self.root {
+            root.borrow_valmut().range_search(range)
         } else {
-            RangeMut { front: None, back: None, _marker: PhantomData }
-        }
+            (None, None)
+        };
+        RangeMut { front, back, _marker: PhantomData }
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
@@ -1400,13 +1398,12 @@ impl<K, V> IntoIterator for BTreeMap<K, V> {
 
     fn into_iter(self) -> IntoIter<K, V> {
         let mut me = ManuallyDrop::new(self);
-        if let Some(root) = me.root.take() {
-            let (f, b) = root.into_dying().full_range();
-
-            IntoIter { front: Some(f), back: Some(b), length: me.length }
+        let (front, back) = if let Some(root) = me.root.take() {
+            root.into_dying().full_range()
         } else {
-            IntoIter { front: None, back: None, length: 0 }
-        }
+            (None, None)
+        };
+        IntoIter { front, back, length: me.length }
     }
 }
 
@@ -2046,13 +2043,9 @@ impl<K, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn iter(&self) -> Iter<'_, K, V> {
-        if let Some(root) = &self.root {
-            let (f, b) = root.reborrow().full_range();
-
-            Iter { range: Range { front: Some(f), back: Some(b) }, length: self.length }
-        } else {
-            Iter { range: Range { front: None, back: None }, length: 0 }
-        }
+        let (front, back) =
+            if let Some(root) = &self.root { root.reborrow().full_range() } else { (None, None) };
+        Iter { range: Range { front, back }, length: self.length }
     }
 
     /// Gets a mutable iterator over the entries of the map, sorted by key.
@@ -2078,16 +2071,12 @@ impl<K, V> BTreeMap<K, V> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
-        if let Some(root) = &mut self.root {
-            let (f, b) = root.borrow_valmut().full_range();
-
-            IterMut {
-                range: RangeMut { front: Some(f), back: Some(b), _marker: PhantomData },
-                length: self.length,
-            }
+        let (front, back) = if let Some(root) = &mut self.root {
+            root.borrow_valmut().full_range()
         } else {
-            IterMut { range: RangeMut { front: None, back: None, _marker: PhantomData }, length: 0 }
-        }
+            (None, None)
+        };
+        IterMut { range: RangeMut { front, back, _marker: PhantomData }, length: self.length }
     }
 
     /// Gets an iterator over the keys of the map, in sorted order.

--- a/library/alloc/src/collections/btree/navigate.rs
+++ b/library/alloc/src/collections/btree/navigate.rs
@@ -16,8 +16,8 @@ fn range_search<BorrowType: marker::BorrowType, K, V, Q, R>(
     root2: NodeRef<BorrowType, K, V, marker::LeafOrInternal>,
     range: R,
 ) -> (
-    Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>,
-    Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>,
+    Option<Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>>,
+    Option<Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>>,
 )
 where
     Q: ?Sized + Ord,
@@ -92,7 +92,7 @@ where
         }
         match (front.force(), back.force()) {
             (Leaf(f), Leaf(b)) => {
-                return (f, b);
+                return (Some(f), Some(b));
             }
             (Internal(min_int), Internal(max_int)) => {
                 min_node = min_int.descend();
@@ -108,8 +108,8 @@ fn full_range<BorrowType: marker::BorrowType, K, V>(
     root1: NodeRef<BorrowType, K, V, marker::LeafOrInternal>,
     root2: NodeRef<BorrowType, K, V, marker::LeafOrInternal>,
 ) -> (
-    Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>,
-    Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>,
+    Option<Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>>,
+    Option<Handle<NodeRef<BorrowType, K, V, marker::Leaf>, marker::Edge>>,
 ) {
     let mut min_node = root1;
     let mut max_node = root2;
@@ -118,7 +118,7 @@ fn full_range<BorrowType: marker::BorrowType, K, V>(
         let back = max_node.last_edge();
         match (front.force(), back.force()) {
             (Leaf(f), Leaf(b)) => {
-                return (f, b);
+                return (Some(f), Some(b));
             }
             (Internal(min_int), Internal(max_int)) => {
                 min_node = min_int.descend();
@@ -138,8 +138,8 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::Immut<'a>, K, V, marker::LeafOrInternal> 
         self,
         range: R,
     ) -> (
-        Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>,
-        Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>,
+        Option<Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>>,
+        Option<Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>>,
     )
     where
         Q: ?Sized + Ord,
@@ -153,8 +153,8 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::Immut<'a>, K, V, marker::LeafOrInternal> 
     pub fn full_range(
         self,
     ) -> (
-        Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>,
-        Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>,
+        Option<Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>>,
+        Option<Handle<NodeRef<marker::Immut<'a>, K, V, marker::Leaf>, marker::Edge>>,
     ) {
         full_range(self, self)
     }
@@ -171,8 +171,8 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::ValMut<'a>, K, V, marker::LeafOrInternal>
         self,
         range: R,
     ) -> (
-        Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>,
-        Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>,
+        Option<Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>>,
+        Option<Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>>,
     )
     where
         Q: ?Sized + Ord,
@@ -191,8 +191,8 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::ValMut<'a>, K, V, marker::LeafOrInternal>
     pub fn full_range(
         self,
     ) -> (
-        Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>,
-        Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>,
+        Option<Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>>,
+        Option<Handle<NodeRef<marker::ValMut<'a>, K, V, marker::Leaf>, marker::Edge>>,
     ) {
         // We duplicate the root NodeRef here -- we will never visit the same KV
         // twice, and never end up with overlapping value references.
@@ -208,8 +208,8 @@ impl<K, V> NodeRef<marker::Dying, K, V, marker::LeafOrInternal> {
     pub fn full_range(
         self,
     ) -> (
-        Handle<NodeRef<marker::Dying, K, V, marker::Leaf>, marker::Edge>,
-        Handle<NodeRef<marker::Dying, K, V, marker::Leaf>, marker::Edge>,
+        Option<Handle<NodeRef<marker::Dying, K, V, marker::Leaf>, marker::Edge>>,
+        Option<Handle<NodeRef<marker::Dying, K, V, marker::Leaf>, marker::Edge>>,
     ) {
         // We duplicate the root NodeRef here -- we will never access it in a way
         // that overlaps references obtained from the root.


### PR DESCRIPTION
The functions in navigate.rs only exist to support iterators, and these look easier on my eyes if the functions follow the lead of #70111. This is also a preparation for (or assessment of) the same thing in #81094.

r? @Mark-Simulacrum 