### PR TITLE
Add suggestion `.collect()` for iterators in iterators

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -93,6 +93,7 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
     message = "`{Self}` is not an iterator"
 )]
 #[doc(spotlight)]
+#[rustc_diagnostic_item = "Iterator"]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub trait Iterator {
     /// The type of the elements being iterated over.

--- a/src/test/ui/issues/issue-81584.fixed
+++ b/src/test/ui/issues/issue-81584.fixed
@@ -1,0 +1,8 @@
+// run-rustfix
+fn main() {
+        let _ = vec![vec![0, 1], vec![2]]
+            .into_iter()
+            .map(|y| y.iter().map(|x| x + 1).collect::<Vec<_>>())
+                  //~^ ERROR cannot return value referencing function parameter `y`
+            .collect::<Vec<_>>();
+}

--- a/src/test/ui/issues/issue-81584.rs
+++ b/src/test/ui/issues/issue-81584.rs
@@ -1,0 +1,8 @@
+// run-rustfix
+fn main() {
+        let _ = vec![vec![0, 1], vec![2]]
+            .into_iter()
+            .map(|y| y.iter().map(|x| x + 1))
+                  //~^ ERROR cannot return value referencing function parameter `y`
+            .collect::<Vec<_>>();
+}

--- a/src/test/ui/issues/issue-81584.stderr
+++ b/src/test/ui/issues/issue-81584.stderr
@@ -1,0 +1,14 @@
+error[E0515]: cannot return value referencing function parameter `y`
+  --> $DIR/issue-81584.rs:5:22
+   |
+LL |             .map(|y| y.iter().map(|x| x + 1))
+   |                      -^^^^^^^^^^^^^^^^^^^^^^
+   |                      |
+   |                      returns a value referencing data owned by the current function
+   |                      `y` is borrowed here
+   |
+   = help: use `.collect()` to allocate the iterator
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/static/static-reference-to-fn-2.stderr
+++ b/src/test/ui/static/static-reference-to-fn-2.stderr
@@ -40,6 +40,8 @@ LL | |         statefn: &id(state1 as StateMachineFunc)
    | |                   ------------------------------ temporary value created here
 LL | |     }
    | |_____^ returns a value referencing data owned by the current function
+   |
+   = help: use `.collect()` to allocate the iterator
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Closes #81584

```
error[E0515]: cannot return value referencing function parameter `y`
 --> main3.rs:4:38
  |
4 | ...                   .map(|y| y.iter().map(|x| x + 1))
  |                                -^^^^^^^^^^^^^^^^^^^^^^
  |                                |
  |                                returns a value referencing data owned by the current function
  |                                `y` is borrowed here
  |                                help: Maybe use `.collect()` to allocate the iterator
```

Added the suggestion: `help: Maybe use `.collect()` to allocate the iterator`