### PR TITLE
reduce threads spawned by ui-tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1156,6 +1156,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         hostflags.push(format!("-Lnative={}", builder.test_helpers_out(compiler.host).display()));
         if builder.is_fuse_ld_lld(compiler.host) {
             hostflags.push("-Clink-args=-fuse-ld=lld".to_string());
+            hostflags.push("-Clink-arg=-Wl,--threads=1".to_string());
         }
         cmd.arg("--host-rustcflags").arg(hostflags.join(" "));
 
@@ -1163,6 +1164,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
         targetflags.push(format!("-Lnative={}", builder.test_helpers_out(target).display()));
         if builder.is_fuse_ld_lld(target) {
             targetflags.push("-Clink-args=-fuse-ld=lld".to_string());
+            targetflags.push("-Clink-arg=-Wl,--threads=1".to_string());
         }
         cmd.arg("--target-rustcflags").arg(targetflags.join(" "));
 

--- a/src/test/ui/asm/sym.rs
+++ b/src/test/ui/asm/sym.rs
@@ -1,4 +1,6 @@
 // min-llvm-version: 10.0.1
+// FIXME(#84025): codegen-units=1 leads to linkage errors
+// compile-flags: -C codegen-units=2
 // only-x86_64
 // only-linux
 // run-pass

--- a/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
+++ b/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
@@ -19,7 +19,9 @@
 
 // revisions: no thin fat
 //[no]compile-flags: -C lto=no
-//[thin]compile-flags: -C lto=thin
+// FIXME(#83854) running this revision with 1 CGU triggers llvm assert in register allocator
+//  when executed in i686-gnu-nopt runner.
+//[thin]compile-flags: -C lto=thin -Ccodegen-units=2
 //[fat]compile-flags: -C lto=fat
 
 #![feature(core_panic)]

--- a/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
+++ b/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
@@ -40,7 +40,9 @@
 //[no1]compile-flags: -C opt-level=1 -C lto=no
 //[no2]compile-flags: -C opt-level=2 -C lto=no
 //[no3]compile-flags: -C opt-level=3 -C lto=no
-//[thin0]compile-flags: -C opt-level=0 -C lto=thin
+// FIXME(#83854) running this revision with 1 CGU triggers llvm assert in register allocator
+//  when executed in dist-i586-gnu-i586-i686-musl runner.
+//[thin0]compile-flags: -C opt-level=0 -C lto=thin -Ccodegen-units=2
 //[thin1]compile-flags: -C opt-level=1 -C lto=thin
 //[thin2]compile-flags: -C opt-level=2 -C lto=thin
 //[thin3]compile-flags: -C opt-level=3 -C lto=thin

--- a/src/test/ui/issues/issue-69225-SCEVAddExpr-wrap-flag.rs
+++ b/src/test/ui/issues/issue-69225-SCEVAddExpr-wrap-flag.rs
@@ -1,5 +1,6 @@
 // run-fail
 // compile-flags: -C opt-level=3
+// min-llvm-version: 11.0
 // error-pattern: index out of bounds: the len is 0 but the index is 16777216
 // ignore-wasm no panic or subprocess support
 // ignore-emscripten no panic or subprocess support

--- a/src/test/ui/linkage-attr/linkage-detect-extern-generated-name-collision.rs
+++ b/src/test/ui/linkage-attr/linkage-detect-extern-generated-name-collision.rs
@@ -4,6 +4,8 @@
 
 // build-fail
 // aux-build:def_colliding_external.rs
+// FIXME(#83838) codegen-units=1 triggers llvm asserts
+// compile-flags: -Ccodegen-units=16
 
 extern crate def_colliding_external as dep1;
 

--- a/src/test/ui/linkage-attr/linkage-detect-local-generated-name-collision.rs
+++ b/src/test/ui/linkage-attr/linkage-detect-local-generated-name-collision.rs
@@ -1,5 +1,6 @@
 // build-fail
-
+// FIXME(#83838) codegen-units=1 triggers llvm asserts
+// compile-flags: -Ccodegen-units=16
 #![feature(linkage)]
 
 mod dep1 {

--- a/src/test/ui/linkage-attr/linkage-detect-local-generated-name-collision.stderr
+++ b/src/test/ui/linkage-attr/linkage-detect-local-generated-name-collision.stderr
@@ -1,5 +1,5 @@
 error: symbol `collision` is already defined
-  --> $DIR/linkage-detect-local-generated-name-collision.rs:9:9
+  --> $DIR/linkage-detect-local-generated-name-collision.rs:10:9
    |
 LL |         pub static collision: *const i32;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/sanitize/hwaddress.rs
+++ b/src/test/ui/sanitize/hwaddress.rs
@@ -1,7 +1,8 @@
 // needs-sanitizer-support
 // needs-sanitizer-hwaddress
 //
-// compile-flags: -Z sanitizer=hwaddress -O -g
+// FIXME(#83989): codegen-units=1 triggers linker errors on aarch64-gnu
+// compile-flags: -Z sanitizer=hwaddress -O -g -C codegen-units=16
 //
 // run-fail
 // error-pattern: HWAddressSanitizer: tag-mismatch

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1952,6 +1952,7 @@ impl<'test> TestCx<'test> {
                 if !self.props.compile_flags.iter().any(|s| s.starts_with("--error-format")) {
                     rustc.args(&["--error-format", "json"]);
                 }
+                rustc.arg("-Ccodegen-units=1");
                 rustc.arg("-Zui-testing");
                 rustc.arg("-Zdeduplicate-diagnostics=no");
                 rustc.arg("-Zemit-future-incompat-report");


### PR DESCRIPTION
The test harness already spawns enough tests to keep all cores busy.
Individual tests should keep their own threading to a minimum to avoid context switch overhead.

When running ui tests with lld enabled this shaves about 10% off that testsuite on my machine.

Resolves #81946