### PR TITLE
bootstrap: Locate llvm-dwp based on llvm-config bindir

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -1075,8 +1075,11 @@ impl Step for Assemble {
             let src_exe = exe("llvm-dwp", target_compiler.host);
             let dst_exe = exe("rust-llvm-dwp", target_compiler.host);
             let llvm_config_bin = builder.ensure(native::Llvm { target: target_compiler.host });
-            let llvm_bin_dir = llvm_config_bin.parent().unwrap();
-            builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
+            if !builder.config.dry_run {
+                let llvm_bin_dir = output(Command::new(llvm_config_bin).arg("--bindir"));
+                let llvm_bin_dir = Path::new(llvm_bin_dir.trim());
+                builder.copy(&llvm_bin_dir.join(&src_exe), &libdir_bin.join(&dst_exe));
+            }
         }
 
         // Ensure that `libLLVM.so` ends up in the newly build compiler directory,


### PR DESCRIPTION
Fixes #81949.

Tested by successfully building 1.50.0 pre-release, which is where I originally hit the issue (https://internals.rust-lang.org/t/rust-1-50-0-pre-release-testing/14012/4?u=dtolnay). Tested both with and without prebuilt LLVM. The check for dry_run is necessary in the non-prebuilt case because the llvm-config built by bootstrap won't exist yet.