### PR TITLE
Fix assosiated typo

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mutability_errors.rs
@@ -540,7 +540,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         );
     }
 
-    // Attempt to search similar mutable assosiated items for suggestion.
+    // Attempt to search similar mutable associated items for suggestion.
     // In the future, attempt in all path but initially for RHS of for_loop
     fn suggest_similar_mut_method_for_for_loop(&self, err: &mut DiagnosticBuilder<'_>) {
         let hir = self.infcx.tcx.hir();


### PR DESCRIPTION
Introduced in d3c4dbd85d63c8bdfa362d7cac8b3e8cbca51272, noticed only
after the fact, sorry. 😅

Signed-off-by: Daniel Egger <daniel@eggers-club.de>