### PR TITLE
bootstrap: fix wrong docs installation path

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -29,7 +29,7 @@ fn install_sh(
     let prefix = default_path(&builder.config.prefix, "/usr/local");
     let sysconfdir = prefix.join(default_path(&builder.config.sysconfdir, "/etc"));
     let datadir = prefix.join(default_path(&builder.config.datadir, "share"));
-    let docdir = prefix.join(default_path(&builder.config.docdir, "share/doc"));
+    let docdir = prefix.join(default_path(&builder.config.docdir, "share/doc/rust"));
     let mandir = prefix.join(default_path(&builder.config.mandir, "share/man"));
     let libdir = prefix.join(default_path(&builder.config.libdir, "lib"));
     let bindir = prefix.join(&builder.config.bindir); // Default in config.rs


### PR DESCRIPTION
This PR fixes https://github.com/rust-lang/rust/issues/81967, a regression introduced by https://github.com/rust-lang/rust/pull/80797. The commit has already been backported to stable 1.50.0.

r? @Mark-Simulacrum 