### PR TITLE
Avoid `cfg_if` in `std::os`

### DIFF
--- a/library/std/src/os/mod.rs
+++ b/library/std/src/os/mod.rs
@@ -3,40 +3,40 @@
 #![stable(feature = "os", since = "1.0.0")]
 #![allow(missing_docs, nonstandard_style, missing_debug_implementations)]
 
-cfg_if::cfg_if! {
-    if #[cfg(doc)] {
+// When documenting libstd we want to show unix/windows/linux modules as these are the "main
+// modules" that are used across platforms, so all modules are enabled when `cfg(doc)` is set.
+// This should help show platform-specific functionality in a hopefully cross-platform way in the
+// documentation.
+// Note that we deliberately avoid `cfg_if!` here to work around a rust-analyzer bug that would make
+// `std::os` submodules unusable: https://github.com/rust-analyzer/rust-analyzer/issues/6038
 
-        // When documenting libstd we want to show unix/windows/linux modules as
-        // these are the "main modules" that are used across platforms. This
-        // should help show platform-specific functionality in a hopefully
-        // cross-platform way in the documentation
+#[cfg(doc)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::sys::unix_ext as unix;
 
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub use crate::sys::unix_ext as unix;
+#[cfg(doc)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::sys::windows_ext as windows;
 
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub use crate::sys::windows_ext as windows;
+#[cfg(doc)]
+#[doc(cfg(target_os = "linux"))]
+pub mod linux;
 
-        #[doc(cfg(target_os = "linux"))]
-        pub mod linux;
-    } else {
+// If we're not documenting libstd then we just expose the main modules as we otherwise would.
 
-        // If we're not documenting libstd then we just expose the main modules
-        // as we otherwise would.
+#[cfg(not(doc))]
+#[cfg(any(target_os = "redox", unix, target_os = "vxworks", target_os = "hermit"))]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::sys::ext as unix;
 
-        #[cfg(any(target_os = "redox", unix, target_os = "vxworks", target_os = "hermit"))]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub use crate::sys::ext as unix;
+#[cfg(not(doc))]
+#[cfg(windows)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use crate::sys::ext as windows;
 
-        #[cfg(windows)]
-        #[stable(feature = "rust1", since = "1.0.0")]
-        pub use crate::sys::ext as windows;
-
-        #[cfg(any(target_os = "linux", target_os = "l4re"))]
-        pub mod linux;
-
-    }
-}
+#[cfg(not(doc))]
+#[cfg(any(target_os = "linux", target_os = "l4re"))]
+pub mod linux;
 
 #[cfg(target_os = "android")]
 pub mod android;


### PR DESCRIPTION
rust-analyzer cannot currently load the `cfg_if` crate, which means that rust-analyzer is unable to see `std::os::{unix, windows, linux}` here. This works around that by avoiding `cfg_if`; the `#[cfg]` expressions are simple enough to reasonably write by hand.

Fixes https://github.com/rust-analyzer/rust-analyzer/issues/6038