### PR TITLE
Inline hot part of PatStack::head_ctor

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/usefulness.rs
@@ -439,6 +439,7 @@ impl<'p, 'tcx> PatStack<'p, 'tcx> {
         self.pats[0]
     }
 
+    #[inline]
     fn head_ctor<'a>(&'a self, cx: &MatchCheckCtxt<'p, 'tcx>) -> &'a Constructor<'tcx> {
         self.head_ctor.get_or_init(|| Constructor::from_pat(cx, self.head()))
     }


### PR DESCRIPTION
When building rustc with `-Codegen-units=1` this inline hint ensures
that obtaining already initialized head constructor does not involve
a function call overhead and reduces the instruction count in
match-stress-enum-check full benchmark from 11.9G to 9.8G.

It shouldn't have significant impact on the currently default
configuration where it reflects existing inlining decisions.

