### PR TITLE
Make WASI's `hard_link` behavior match other platforms.

### DIFF
--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -558,12 +558,7 @@ pub fn link(original: &Path, link: &Path) -> io::Result<()> {
     let (original, original_file) = open_parent(original)?;
     let (link, link_file) = open_parent(link)?;
     // Pass 0 as the flags argument, meaning don't follow symlinks.
-    original.link(
-        0,
-        osstr2str(original_file.as_ref())?,
-        &link,
-        osstr2str(link_file.as_ref())?,
-    )
+    original.link(0, osstr2str(original_file.as_ref())?, &link, osstr2str(link_file.as_ref())?)
 }
 
 pub fn stat(p: &Path) -> io::Result<FileAttr> {

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -557,8 +557,9 @@ pub fn symlink(original: &Path, link: &Path) -> io::Result<()> {
 pub fn link(original: &Path, link: &Path) -> io::Result<()> {
     let (original, original_file) = open_parent(original)?;
     let (link, link_file) = open_parent(link)?;
+    // Pass 0 as the flags argument, meaning don't follow symlinks.
     original.link(
-        wasi::LOOKUPFLAGS_SYMLINK_FOLLOW,
+        0,
         osstr2str(original_file.as_ref())?,
         &link,
         osstr2str(link_file.as_ref())?,


### PR DESCRIPTION
Following #78026, `std::fs::hard_link` on most platforms does not follow
symlinks. Change the WASI implementation to also not follow symlinks.

r? @alexcrichton 