### PR TITLE
Add doc aliases for a lot of the C standard library

### DIFF
--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -108,6 +108,7 @@ macro_rules! vec {
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "format_macro")]
+#[doc(alias = "sprintf")]
 macro_rules! format {
     ($($arg:tt)*) => {{
         let res = $crate::fmt::format($crate::__export::format_args!($($arg)*));

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -820,6 +820,7 @@ impl String {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "strcat")]
     pub fn push_str(&mut self, string: &str) {
         self.vec.extend_from_slice(string.as_bytes())
     }
@@ -1750,6 +1751,7 @@ impl fmt::Display for FromUtf16Error {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Clone for String {
+    #[doc(alias = "strdup")]
     fn clone(&self) -> Self {
         String { vec: self.vec.clone() }
     }

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -280,6 +280,7 @@ impl char {
     /// '1'.is_digit(37);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "isxdigit")]
     #[inline]
     pub fn is_digit(self, radix: u32) -> bool {
         self.to_digit(radix).is_some()
@@ -844,6 +845,7 @@ impl char {
     /// assert!(!'q'.is_control());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "iscntrl")]
     #[inline]
     pub fn is_control(self) -> bool {
         unicode::Cc(self)
@@ -1093,6 +1095,7 @@ impl char {
     /// [`to_uppercase()`]: #method.to_uppercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.52.0")]
+    #[doc(alias = "toupper")]
     #[inline]
     pub const fn to_ascii_uppercase(&self) -> char {
         if self.is_ascii_lowercase() {
@@ -1126,6 +1129,7 @@ impl char {
     /// [`to_lowercase()`]: #method.to_lowercase
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.52.0")]
+    #[doc(alias = "tolower")]
     #[inline]
     pub const fn to_ascii_lowercase(&self) -> char {
         if self.is_ascii_uppercase() {
@@ -1237,6 +1241,7 @@ impl char {
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+    #[doc(alias = "isalpha")]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
         matches!(*self, 'A'..='Z' | 'a'..='z')
@@ -1270,6 +1275,7 @@ impl char {
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+    #[doc(alias = "isupper")]
     #[inline]
     pub const fn is_ascii_uppercase(&self) -> bool {
         matches!(*self, 'A'..='Z')
@@ -1303,6 +1309,7 @@ impl char {
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+    #[doc(alias = "islower")]
     #[inline]
     pub const fn is_ascii_lowercase(&self) -> bool {
         matches!(*self, 'a'..='z')
@@ -1339,6 +1346,7 @@ impl char {
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+    #[doc(alias = "isalnum")]
     #[inline]
     pub const fn is_ascii_alphanumeric(&self) -> bool {
         matches!(*self, '0'..='9' | 'A'..='Z' | 'a'..='z')
@@ -1372,6 +1380,7 @@ impl char {
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+    #[doc(alias = "isdigit")]
     #[inline]
     pub const fn is_ascii_digit(&self) -> bool {
         matches!(*self, '0'..='9')
@@ -1445,6 +1454,7 @@ impl char {
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+    #[doc(alias = "ispunct")]
     #[inline]
     pub const fn is_ascii_punctuation(&self) -> bool {
         matches!(*self, '!'..='/' | ':'..='@' | '['..='`' | '{'..='~')
@@ -1528,6 +1538,7 @@ impl char {
     /// ```
     #[stable(feature = "ascii_ctype_on_intrinsics", since = "1.24.0")]
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
+    #[doc(alias = "isspace")]
     #[inline]
     pub const fn is_ascii_whitespace(&self) -> bool {
         matches!(*self, '\t' | '\n' | '\x0C' | '\r' | ' ')

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -887,6 +887,7 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 ///
 /// [`RefCell`]: crate::cell::RefCell
 #[doc(alias = "delete")]
+#[doc(alias = "free")]
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn drop<T>(_x: T) {}

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -782,6 +782,10 @@ macro_rules! from_str_radix_int_impl {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl FromStr for $t {
             type Err = ParseIntError;
+            #[doc(alias = "atoi")]
+            #[doc(alias = "atol")]
+            #[doc(alias = "strtod")]
+            #[doc(alias = "strtol")]
             fn from_str(src: &str) -> Result<Self, ParseIntError> {
                 from_str_radix(src, 10)
             }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -162,6 +162,8 @@ pub enum Option<T> {
     /// No value
     #[lang = "None"]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "null")]
+    #[doc(alias = "nil")]
     None,
     /// Some value `T`
     #[lang = "Some"]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -1034,6 +1034,8 @@ impl str {
     /// assert_eq!(s.find(x), None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "strstr")]
+    #[doc(alias = "strchr")]
     #[inline]
     pub fn find<'a, P: Pattern<'a>>(&'a self, pat: P) -> Option<usize> {
         pat.into_searcher(self).next_match().map(|(i, _)| i)
@@ -1080,6 +1082,7 @@ impl str {
     /// assert_eq!(s.rfind(x), None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "strrchr")]
     #[inline]
     pub fn rfind<'a, P>(&'a self, pat: P) -> Option<usize>
     where
@@ -1202,6 +1205,7 @@ impl str {
     ///
     /// [`split_whitespace`]: str::split_whitespace
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(alias = "strtok")]
     #[inline]
     pub fn split<'a, P: Pattern<'a>>(&'a self, pat: P) -> Split<'a, P> {
         Split(SplitInternal {

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -201,6 +201,7 @@ impl fmt::Debug for VarsOs {
 /// }
 /// ```
 #[stable(feature = "env", since = "1.0.0")]
+#[doc(alias = "getenv")]
 pub fn var<K: AsRef<OsStr>>(key: K) -> Result<String, VarError> {
     _var(key.as_ref())
 }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -304,6 +304,8 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
 /// }
 /// ```
 #[stable(feature = "fs_read_write_bytes", since = "1.26.0")]
+#[doc(alias = "fputs")]
+#[doc(alias = "fprintf")]
 pub fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     fn inner(path: &Path, contents: &[u8]) -> io::Result<()> {
         File::create(path)?.write_all(contents)

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -91,6 +91,7 @@ macro_rules! print {
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow_internal_unstable(print_internals, format_args_nl)]
+#[doc(alias = "printf")]
 macro_rules! println {
     () => ($crate::print!("\n"));
     ($($arg:tt)*) => ({

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -342,6 +342,7 @@ mod prim_never {}
 /// assert_eq!(32, std::mem::size_of_val(&v[..]));
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(alias = "char32_t")]
 mod prim_char {}
 
 #[doc(primitive = "unit")]
@@ -789,6 +790,7 @@ mod prim_str {}
 mod prim_tuple {}
 
 #[doc(primitive = "f32")]
+#[doc(alias = "float")]
 /// A 32-bit floating point type (specifically, the "binary32" type defined in IEEE 754-2008).
 ///
 /// This type can represent a wide range of decimal numbers, like `3.5`, `27`,
@@ -830,6 +832,7 @@ mod prim_tuple {}
 mod prim_f32 {}
 
 #[doc(primitive = "f64")]
+#[doc(alias = "double")]
 /// A 64-bit floating point type (specifically, the "binary64" type defined in IEEE 754-2008).
 ///
 /// This type is very similar to [`f32`], but has increased
@@ -845,25 +848,25 @@ mod prim_f32 {}
 mod prim_f64 {}
 
 #[doc(primitive = "i8")]
-//
+#[doc(alias = "int8_t")]
 /// The 8-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i8 {}
 
 #[doc(primitive = "i16")]
-//
+#[doc(alias = "int16_t")]
 /// The 16-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i16 {}
 
 #[doc(primitive = "i32")]
-//
+#[doc(alias = "int32_t")]
 /// The 32-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i32 {}
 
 #[doc(primitive = "i64")]
-//
+#[doc(alias = "int64_t")]
 /// The 64-bit signed integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_i64 {}
@@ -875,25 +878,25 @@ mod prim_i64 {}
 mod prim_i128 {}
 
 #[doc(primitive = "u8")]
-//
+#[doc(alias = "uint8_t")]
 /// The 8-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u8 {}
 
 #[doc(primitive = "u16")]
-//
+#[doc(alias = "uint16_t")]
 /// The 16-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u16 {}
 
 #[doc(primitive = "u32")]
-//
+#[doc(alias = "uint32_t")]
 /// The 32-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u32 {}
 
 #[doc(primitive = "u64")]
-//
+#[doc(alias = "uint64_t")]
 /// The 64-bit unsigned integer type.
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_u64 {}
@@ -905,17 +908,19 @@ mod prim_u64 {}
 mod prim_u128 {}
 
 #[doc(primitive = "isize")]
-//
 /// The pointer-sized signed integer type.
 ///
 /// The size of this primitive is how many bytes it takes to reference any
 /// location in memory. For example, on a 32 bit target, this is 4 bytes
 /// and on a 64 bit target, this is 8 bytes.
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(alias = "ssize_t")]
+#[doc(alias = "intptr_t")] // FIXME(#65473): maybe these should be different
 mod prim_isize {}
 
 #[doc(primitive = "usize")]
-//
+#[doc(alias = "size_t")]
+#[doc(alias = "uintptr_t")] // FIXME(#65473): maybe these should be different
 /// The pointer-sized unsigned integer type.
 ///
 /// The size of this primitive is how many bytes it takes to reference any

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -881,6 +881,7 @@ impl Command {
     /// assert!(output.status.success());
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
+    #[doc(alias = "system")]
     pub fn output(&mut self) -> io::Result<Output> {
         self.inner
             .spawn(imp::Stdio::MakePipe, false)

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -447,6 +447,7 @@ impl SystemTime {
     /// let sys_time = SystemTime::now();
     /// ```
     #[stable(feature = "time2", since = "1.8.0")]
+    #[doc(alias = "time")]
     pub fn now() -> SystemTime {
         SystemTime(time::SystemTime::now())
     }


### PR DESCRIPTION
I took the very scientific approach of "ask some friends what parts of
the standard library they use a lot". They suggested
https://www.tutorialspoint.com/c_standard_library/ and also the short
list `strcpy, strncpy, memcpy, memcpy, printf, scanf, fprintf, sprintf,
asprintf, sscanf, strtok, strntok, malloc, calloc, free, strdup,
strndup, err, errx`. Many of these already have aliases; those with
`*n*` have no analogy in rust; `asprintf`, `err`, and `errx` have no analogy in Rust.
I added most of the rest.