### PR TITLE
Make suggestion of changing mutability of arguments broader

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -468,22 +468,21 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                                 trait_ref,
                                 obligation.cause.body_id,
                             );
-                        } else {
-                            if !have_alt_message {
-                                // Can't show anything else useful, try to find similar impls.
-                                let impl_candidates = self.find_similar_impl_candidates(trait_ref);
-                                self.report_similar_impl_candidates(impl_candidates, &mut err);
-                            }
-                            // Changing mutability doesn't make a difference to whether we have
-                            // an `Unsize` impl (Fixes ICE in #71036)
-                            if !is_unsize {
-                                self.suggest_change_mut(
-                                    &obligation,
-                                    &mut err,
-                                    trait_ref,
-                                    points_at_arg,
-                                );
-                            }
+                        } else if !have_alt_message {
+                            // Can't show anything else useful, try to find similar impls.
+                            let impl_candidates = self.find_similar_impl_candidates(trait_ref);
+                            self.report_similar_impl_candidates(impl_candidates, &mut err);
+                        }
+
+                        // Changing mutability doesn't make a difference to whether we have
+                        // an `Unsize` impl (Fixes ICE in #71036)
+                        if !is_unsize {
+                            self.suggest_change_mut(
+                                &obligation,
+                                &mut err,
+                                trait_ref,
+                                points_at_arg,
+                            );
                         }
 
                         // If this error is due to `!: Trait` not implemented but `(): Trait` is

--- a/src/test/ui/suggestions/suggest-change-mut.rs
+++ b/src/test/ui/suggestions/suggest-change-mut.rs
@@ -1,0 +1,21 @@
+#![allow(warnings)]
+
+use std::io::{BufRead, BufReader, Read, Write};
+
+fn issue_81421<T: Read + Write>(mut stream: T) {
+    let initial_message = format!("Hello world");
+    let mut buffer: Vec<u8> = Vec::new();
+    let bytes_written = stream.write_all(initial_message.as_bytes());
+    let flush = stream.flush();
+
+    loop {
+        let mut stream_reader = BufReader::new(&stream);
+        //~^ ERROR the trait bound `&T: std::io::Read` is not satisfied [E0277]
+        //~| HELP consider removing the leading `&`-reference
+        //~| HELP consider changing this borrow's mutability
+        stream_reader.read_until(b'\n', &mut buffer).expect("Reading into buffer failed");
+        //~^ ERROR the method `read_until` exists for struct `BufReader<&T>`,
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/suggest-change-mut.stderr
+++ b/src/test/ui/suggestions/suggest-change-mut.stderr
@@ -1,0 +1,35 @@
+error[E0277]: the trait bound `&T: std::io::Read` is not satisfied
+  --> $DIR/suggest-change-mut.rs:12:48
+   |
+LL |         let mut stream_reader = BufReader::new(&stream);
+   |                                                ^^^^^^^ the trait `std::io::Read` is not implemented for `&T`
+   |
+   = note: required by `BufReader::<R>::new`
+help: consider removing the leading `&`-reference
+   |
+LL |         let mut stream_reader = BufReader::new(stream);
+   |                                               --
+help: consider changing this borrow's mutability
+   |
+LL |         let mut stream_reader = BufReader::new(&mut stream);
+   |                                                ^^^^
+
+error[E0599]: the method `read_until` exists for struct `BufReader<&T>`, but its trait bounds were not satisfied
+  --> $DIR/suggest-change-mut.rs:16:23
+   |
+LL |         stream_reader.read_until(b'\n', &mut buffer).expect("Reading into buffer failed");
+   |                       ^^^^^^^^^^ method cannot be called on `BufReader<&T>` due to unsatisfied trait bounds
+   | 
+  ::: $SRC_DIR/std/src/io/buffered/bufreader.rs:LL:COL
+   |
+LL | pub struct BufReader<R> {
+   | ----------------------- doesn't satisfy `BufReader<&T>: BufRead`
+   |
+   = note: the following trait bounds were not satisfied:
+           `&T: std::io::Read`
+           which is required by `BufReader<&T>: BufRead`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fix #81421

Previously rustc tries to emit the suggestion of changing mutablity unless `!trait_ref.has_infer_types_or_consts() && self.predicate_can_apply(obligation.param_env, trait_ref)` and this led to some false negatives to occur.