### PR TITLE
Deny WHERE_CLAUSE_OBJECT_SAFETY in Rust 2021

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2000,8 +2000,9 @@ declare_lint! {
     "checks the object safety of where clauses",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #51443 <https://github.com/rust-lang/rust/issues/51443>",
-        edition: None,
+        edition: Some(Edition::Edition2021),
     };
+    @lint_edition = (Edition::Edition2021, Deny);
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -408,13 +408,14 @@ macro_rules! declare_lint {
     ($(#[$attr:meta])* $vis: vis $NAME: ident, $Level: ident, $desc: expr,
      $(@feature_gate = $gate:expr;)?
      $(@future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
+     $(@lint_edition = ($lint_edition: expr, $edition_level: ident);)?
      $($v:ident),*) => (
         $(#[$attr])*
         $vis static $NAME: &$crate::Lint = &$crate::Lint {
             name: stringify!($NAME),
             default_level: $crate::$Level,
             desc: $desc,
-            edition_lint_opts: None,
+            $(edition_lint_opts: Some(($lint_edition, $crate::Level::$edition_level)),)*
             is_plugin: false,
             $($v: true,)*
             $(feature_gate: Some($gate),)*

--- a/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-where-bounds.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/object-safety-err-where-bounds.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(where_clauses_object_safety)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
    = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-err-where-bounds.rs:9:8

--- a/src/test/ui/issues/issue-50781.stderr
+++ b/src/test/ui/issues/issue-50781.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(where_clauses_object_safety)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
    = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-50781.rs:6:8

--- a/src/test/ui/traits/trait-object-safety-where-clause-2021.rs
+++ b/src/test/ui/traits/trait-object-safety-where-clause-2021.rs
@@ -1,0 +1,20 @@
+// edition:2021
+
+trait Trait {}
+
+trait X {
+    fn foo(&self)
+    //~^ ERROR the trait `X` cannot be made into an object
+    where
+        Self: Trait;
+}
+
+impl X for () {
+    fn foo(&self) {}
+}
+
+impl Trait for dyn X {}
+
+pub fn main() {
+    <dyn X as X>::foo(&());
+}

--- a/src/test/ui/traits/trait-object-safety-where-clause-2021.stderr
+++ b/src/test/ui/traits/trait-object-safety-where-clause-2021.stderr
@@ -1,0 +1,18 @@
+error: the trait `X` cannot be made into an object
+  --> $DIR/trait-object-safety-where-clause-2021.rs:6:8
+   |
+LL |     fn foo(&self)
+   |        ^^^
+   |
+   = note: `#[deny(where_clauses_object_safety)]` on by default
+note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/trait-object-safety-where-clause-2021.rs:6:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     fn foo(&self)
+   |        ^^^ ...because method `foo` references the `Self` type in its `where` clause
+   = help: consider moving `foo` to another trait
+
+error: aborting due to previous error
+

--- a/src/tools/lint-docs/src/groups.rs
+++ b/src/tools/lint-docs/src/groups.rs
@@ -13,6 +13,7 @@ static GROUP_DESCRIPTIONS: &[(&str, &str)] = &[
     ("nonstandard-style", "Violation of standard naming conventions"),
     ("future-incompatible", "Lints that detect code that has future-compatibility problems"),
     ("rust-2018-compatibility", "Lints used to transition code from the 2015 edition to 2018"),
+    ("rust-2021-compatibility", "Lints used to transition code from the 2018 edition to 2021"),
 ];
 
 type LintGroups = BTreeMap<String, BTreeSet<String>>;


### PR DESCRIPTION
As part of #80165 this upgrades the WHERE_CLAUSE_OBJECT_SAFETY lint from Warn to Deny in the 2021 edition. In practice this doesn't change very much as the compiler is still compiled in 2018 edition.

There is active discussion on whether a deny by default lint is the right path or whether this should be handled in another part of the compiler as a hard error. This PR can be used to further that discussion.

r? @nikomatsakis