### PR TITLE
Fix suggestion to introduce explicit lifetime

### DIFF
--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.nll.stderr
@@ -1,0 +1,17 @@
+error[E0311]: the parameter type `T` may not live long enough
+  --> $DIR/missing-lifetimes-in-signature-2.rs:20:5
+   |
+LL | /     foo.bar(move |_| {
+LL | |
+LL | |         t.test();
+LL | |     });
+   | |______^
+   |
+note: the parameter type `T` must be valid for the anonymous lifetime #2 defined on the function body at 19:1...
+  --> $DIR/missing-lifetimes-in-signature-2.rs:19:1
+   |
+LL | fn func<T: Test>(foo: &Foo, t: T) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.rs
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.rs
@@ -1,0 +1,26 @@
+// Regression test for #81650
+
+struct Foo<'a> {
+    x: &'a mut &'a i32,
+}
+
+impl<'a> Foo<'a> {
+    fn bar<F, T>(&self, f: F)
+    where
+        F: FnOnce(&Foo<'a>) -> T,
+        F: 'a,
+    {}
+}
+
+trait Test {
+    fn test(&self);
+}
+
+fn func<T: Test>(foo: &Foo, t: T) {
+    foo.bar(move |_| {
+    //~^ ERROR the parameter type `T` may not live long enough
+        t.test();
+    });
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
@@ -1,0 +1,21 @@
+error[E0311]: the parameter type `T` may not live long enough
+  --> $DIR/missing-lifetimes-in-signature-2.rs:20:9
+   |
+LL | fn func<T: Test>(foo: &Foo, t: T) {
+   |         -- help: consider adding an explicit lifetime bound...: `T: 'a +`
+LL |     foo.bar(move |_| {
+   |         ^^^
+   |
+note: the parameter type `T` must be valid for the anonymous lifetime #2 defined on the function body at 19:1...
+  --> $DIR/missing-lifetimes-in-signature-2.rs:19:1
+   |
+LL | fn func<T: Test>(foo: &Foo, t: T) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature-2.rs:20:13: 23:6]` will meet its required lifetime bounds
+  --> $DIR/missing-lifetimes-in-signature-2.rs:20:9
+   |
+LL |     foo.bar(move |_| {
+   |         ^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Addresses #81650

Error message after fix:

```
error[E0311]: the parameter type `T` may not live long enough
  --> src/main.rs:25:11
   |
24 | fn play_with<T: Animal + Send>(scope: &Scope, animal: T) {
   |              -- help: consider adding an explicit lifetime bound...: `T: 'a +`
25 |     scope.spawn(move |_| {
   |           ^^^^^
   |
note: the parameter type `T` must be valid for the anonymous lifetime #2 defined on the function body at 24:1...
  --> src/main.rs:24:1
   |
24 | fn play_with<T: Animal + Send>(scope: &Scope, animal: T) {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: ...so that the type `[closure@src/main.rs:25:17: 27:6]` will meet its required lifetime bounds
  --> src/main.rs:25:11
   |
25 |     scope.spawn(move |_| {
   |           ^^^^^
```