### PR TITLE
dist: include src/build_helper as part of the crate graph for rustc-dev

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -645,6 +645,14 @@ impl Step for RustcDev {
             &[],
             &tarball.image_dir().join("lib/rustlib/rustc-src/rust"),
         );
+        // This particular crate is used as a build dependency of the above.
+        copy_src_dirs(
+            builder,
+            &builder.src,
+            &["src/build_helper"],
+            &[],
+            &tarball.image_dir().join("lib/rustlib/rustc-src/rust"),
+        );
         for file in src_files {
             tarball.add_file(builder.src.join(file), "lib/rustlib/rustc-src/rust", 0o644);
         }


### PR DESCRIPTION
The build_helper dependency is used to build the compiler/rustc_llvm build script.

Since it was missing, it wasn't possible to really use rustc-dev to
build, see for instance: https://github.com/rust-analyzer/rust-analyzer/issues/7589.