### PR TITLE
clean up clean::Static struct

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -510,7 +510,7 @@ fn build_static(cx: &DocContext<'_>, did: DefId, mutable: bool) -> clean::Static
     clean::Static {
         type_: cx.tcx.type_of(did).clean(cx),
         mutability: if mutable { Mutability::Mut } else { Mutability::Not },
-        expr: "\n\n\n".to_string(), // trigger the "[definition]" links
+        expr: None,
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -408,7 +408,7 @@ impl Clean<Constant> for hir::ConstArg {
                 .tcx
                 .type_of(cx.tcx.hir().body_owner_def_id(self.value.body).to_def_id())
                 .clean(cx),
-            expr: print_const_expr(cx, self.value.body),
+            expr: print_const_expr(cx.tcx, self.value.body),
             value: None,
             is_literal: is_literal_expr(cx, self.value.body.hir_id),
         }
@@ -1052,7 +1052,7 @@ impl Clean<Item> for hir::TraitItem<'_> {
         cx.with_param_env(local_did, || {
             let inner = match self.kind {
                 hir::TraitItemKind::Const(ref ty, default) => {
-                    AssocConstItem(ty.clean(cx), default.map(|e| print_const_expr(cx, e)))
+                    AssocConstItem(ty.clean(cx), default.map(|e| print_const_expr(cx.tcx, e)))
                 }
                 hir::TraitItemKind::Fn(ref sig, hir::TraitFn::Provided(body)) => {
                     let mut m = (sig, &self.generics, body).clean(cx);
@@ -1093,7 +1093,7 @@ impl Clean<Item> for hir::ImplItem<'_> {
         cx.with_param_env(local_did, || {
             let inner = match self.kind {
                 hir::ImplItemKind::Const(ref ty, expr) => {
-                    AssocConstItem(ty.clean(cx), Some(print_const_expr(cx, expr)))
+                    AssocConstItem(ty.clean(cx), Some(print_const_expr(cx.tcx, expr)))
                 }
                 hir::ImplItemKind::Fn(ref sig, body) => {
                     let mut m = (sig, &self.generics, body).clean(cx);
@@ -1954,14 +1954,12 @@ impl Clean<Vec<Item>> for (&hir::Item<'_>, Option<Symbol>) {
         let mut name = renamed.unwrap_or_else(|| cx.tcx.hir().name(item.hir_id));
         cx.with_param_env(def_id, || {
             let kind = match item.kind {
-                ItemKind::Static(ty, mutability, body_id) => StaticItem(Static {
-                    type_: ty.clean(cx),
-                    mutability,
-                    expr: print_const_expr(cx, body_id),
-                }),
+                ItemKind::Static(ty, mutability, body_id) => {
+                    StaticItem(Static { type_: ty.clean(cx), mutability, expr: Some(body_id) })
+                }
                 ItemKind::Const(ty, body_id) => ConstantItem(Constant {
                     type_: ty.clean(cx),
-                    expr: print_const_expr(cx, body_id),
+                    expr: print_const_expr(cx.tcx, body_id),
                     value: print_evaluated_const(cx, def_id),
                     is_literal: is_literal_expr(cx, body_id.hir_id),
                 }),
@@ -2263,11 +2261,9 @@ impl Clean<Item> for (&hir::ForeignItem<'_>, Option<Symbol>) {
                         },
                     })
                 }
-                hir::ForeignItemKind::Static(ref ty, mutability) => ForeignStaticItem(Static {
-                    type_: ty.clean(cx),
-                    mutability,
-                    expr: String::new(),
-                }),
+                hir::ForeignItemKind::Static(ref ty, mutability) => {
+                    ForeignStaticItem(Static { type_: ty.clean(cx), mutability, expr: None })
+                }
                 hir::ForeignItemKind::Type => ForeignTypeItem,
             };
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -19,7 +19,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, DefIndex};
 use rustc_hir::lang_items::LangItem;
-use rustc_hir::Mutability;
+use rustc_hir::{BodyId, Mutability};
 use rustc_index::vec::IndexVec;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_session::Session;
@@ -1955,10 +1955,7 @@ crate struct BareFunctionDecl {
 crate struct Static {
     crate type_: Type,
     crate mutability: Mutability,
-    /// It's useful to have the value of a static documented, but I have no
-    /// desire to represent expressions (that'd basically be all of the AST,
-    /// which is huge!). So, have a string.
-    crate expr: String,
+    crate expr: Option<BodyId>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -237,7 +237,7 @@ crate fn print_const(cx: &DocContext<'_>, n: &'tcx ty::Const<'_>) -> String {
         ty::ConstKind::Unevaluated(def, _, promoted) => {
             let mut s = if let Some(def) = def.as_local() {
                 let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def.did);
-                print_const_expr(cx, cx.tcx.hir().body_owned_by(hir_id))
+                print_const_expr(cx.tcx, cx.tcx.hir().body_owned_by(hir_id))
             } else {
                 inline::print_inlined_const(cx, def.did)
             };
@@ -326,16 +326,17 @@ crate fn is_literal_expr(cx: &DocContext<'_>, hir_id: hir::HirId) -> bool {
     false
 }
 
-crate fn print_const_expr(cx: &DocContext<'_>, body: hir::BodyId) -> String {
-    let value = &cx.tcx.hir().body(body).value;
+crate fn print_const_expr(tcx: TyCtxt<'_>, body: hir::BodyId) -> String {
+    let hir = tcx.hir();
+    let value = &hir.body(body).value;
 
     let snippet = if !value.span.from_expansion() {
-        cx.sess().source_map().span_to_snippet(value.span).ok()
+        tcx.sess.source_map().span_to_snippet(value.span).ok()
     } else {
         None
     };
 
-    snippet.unwrap_or_else(|| rustc_hir_pretty::id_to_string(&cx.tcx.hir(), body.hir_id))
+    snippet.unwrap_or_else(|| rustc_hir_pretty::id_to_string(&hir, body.hir_id))
 }
 
 /// Given a type Path, resolve it to a Type using the TyCtxt

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -6,12 +6,14 @@ use std::convert::From;
 
 use rustc_ast::ast;
 use rustc_hir::def::CtorKind;
+use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::{DefId, CRATE_DEF_INDEX};
 use rustc_span::Pos;
 
 use rustdoc_json_types::*;
 
 use crate::clean;
+use crate::clean::utils::print_const_expr;
 use crate::formats::item_type::ItemType;
 use crate::json::JsonRenderer;
 
@@ -43,7 +45,7 @@ impl JsonRenderer<'_> {
                     .collect(),
                 deprecation: deprecation.map(from_deprecation),
                 kind: item_type.into(),
-                inner: kind.into(),
+                inner: from_clean_item_kind(kind, self.tcx),
             }),
         }
     }
@@ -144,44 +146,42 @@ crate fn from_def_id(did: DefId) -> Id {
     Id(format!("{}:{}", did.krate.as_u32(), u32::from(did.index)))
 }
 
-impl From<clean::ItemKind> for ItemEnum {
-    fn from(item: clean::ItemKind) -> Self {
-        use clean::ItemKind::*;
-        match item {
-            ModuleItem(m) => ItemEnum::ModuleItem(m.into()),
-            ExternCrateItem(c, a) => {
-                ItemEnum::ExternCrateItem { name: c.to_string(), rename: a.map(|x| x.to_string()) }
-            }
-            ImportItem(i) => ItemEnum::ImportItem(i.into()),
-            StructItem(s) => ItemEnum::StructItem(s.into()),
-            UnionItem(u) => ItemEnum::UnionItem(u.into()),
-            StructFieldItem(f) => ItemEnum::StructFieldItem(f.into()),
-            EnumItem(e) => ItemEnum::EnumItem(e.into()),
-            VariantItem(v) => ItemEnum::VariantItem(v.into()),
-            FunctionItem(f) => ItemEnum::FunctionItem(f.into()),
-            ForeignFunctionItem(f) => ItemEnum::FunctionItem(f.into()),
-            TraitItem(t) => ItemEnum::TraitItem(t.into()),
-            TraitAliasItem(t) => ItemEnum::TraitAliasItem(t.into()),
-            MethodItem(m, _) => ItemEnum::MethodItem(from_function_method(m, true)),
-            TyMethodItem(m) => ItemEnum::MethodItem(from_function_method(m, false)),
-            ImplItem(i) => ItemEnum::ImplItem(i.into()),
-            StaticItem(s) => ItemEnum::StaticItem(s.into()),
-            ForeignStaticItem(s) => ItemEnum::StaticItem(s.into()),
-            ForeignTypeItem => ItemEnum::ForeignTypeItem,
-            TypedefItem(t, _) => ItemEnum::TypedefItem(t.into()),
-            OpaqueTyItem(t) => ItemEnum::OpaqueTyItem(t.into()),
-            ConstantItem(c) => ItemEnum::ConstantItem(c.into()),
-            MacroItem(m) => ItemEnum::MacroItem(m.source),
-            ProcMacroItem(m) => ItemEnum::ProcMacroItem(m.into()),
-            AssocConstItem(t, s) => ItemEnum::AssocConstItem { type_: t.into(), default: s },
-            AssocTypeItem(g, t) => ItemEnum::AssocTypeItem {
-                bounds: g.into_iter().map(Into::into).collect(),
-                default: t.map(Into::into),
-            },
-            StrippedItem(inner) => (*inner).into(),
-            PrimitiveItem(_) | KeywordItem(_) => {
-                panic!("{:?} is not supported for JSON output", item)
-            }
+fn from_clean_item_kind(item: clean::ItemKind, tcx: TyCtxt<'_>) -> ItemEnum {
+    use clean::ItemKind::*;
+    match item {
+        ModuleItem(m) => ItemEnum::ModuleItem(m.into()),
+        ExternCrateItem(c, a) => {
+            ItemEnum::ExternCrateItem { name: c.to_string(), rename: a.map(|x| x.to_string()) }
+        }
+        ImportItem(i) => ItemEnum::ImportItem(i.into()),
+        StructItem(s) => ItemEnum::StructItem(s.into()),
+        UnionItem(u) => ItemEnum::UnionItem(u.into()),
+        StructFieldItem(f) => ItemEnum::StructFieldItem(f.into()),
+        EnumItem(e) => ItemEnum::EnumItem(e.into()),
+        VariantItem(v) => ItemEnum::VariantItem(v.into()),
+        FunctionItem(f) => ItemEnum::FunctionItem(f.into()),
+        ForeignFunctionItem(f) => ItemEnum::FunctionItem(f.into()),
+        TraitItem(t) => ItemEnum::TraitItem(t.into()),
+        TraitAliasItem(t) => ItemEnum::TraitAliasItem(t.into()),
+        MethodItem(m, _) => ItemEnum::MethodItem(from_function_method(m, true)),
+        TyMethodItem(m) => ItemEnum::MethodItem(from_function_method(m, false)),
+        ImplItem(i) => ItemEnum::ImplItem(i.into()),
+        StaticItem(s) => ItemEnum::StaticItem(from_clean_static(s, tcx)),
+        ForeignStaticItem(s) => ItemEnum::StaticItem(from_clean_static(s, tcx)),
+        ForeignTypeItem => ItemEnum::ForeignTypeItem,
+        TypedefItem(t, _) => ItemEnum::TypedefItem(t.into()),
+        OpaqueTyItem(t) => ItemEnum::OpaqueTyItem(t.into()),
+        ConstantItem(c) => ItemEnum::ConstantItem(c.into()),
+        MacroItem(m) => ItemEnum::MacroItem(m.source),
+        ProcMacroItem(m) => ItemEnum::ProcMacroItem(m.into()),
+        AssocConstItem(t, s) => ItemEnum::AssocConstItem { type_: t.into(), default: s },
+        AssocTypeItem(g, t) => ItemEnum::AssocTypeItem {
+            bounds: g.into_iter().map(Into::into).collect(),
+            default: t.map(Into::into),
+        },
+        StrippedItem(inner) => from_clean_item_kind(*inner, tcx).into(),
+        PrimitiveItem(_) | KeywordItem(_) => {
+            panic!("{:?} is not supported for JSON output", item)
         }
     }
 }
@@ -534,13 +534,11 @@ impl From<clean::OpaqueTy> for OpaqueTy {
     }
 }
 
-impl From<clean::Static> for Static {
-    fn from(stat: clean::Static) -> Self {
-        Static {
-            type_: stat.type_.into(),
-            mutable: stat.mutability == ast::Mutability::Mut,
-            expr: stat.expr,
-        }
+fn from_clean_static(stat: clean::Static, tcx: TyCtxt<'_>) -> Static {
+    Static {
+        type_: stat.type_.into(),
+        mutable: stat.mutability == ast::Mutability::Mut,
+        expr: stat.expr.map(|e| print_const_expr(tcx, e)).unwrap_or_default(),
     }
 }
 


### PR DESCRIPTION
Having a `String` for the expression didn't make much sense, and even less when it's actually not used (except in json so I kept it).

r? @jyn514 