### PR TITLE
const_generics: Dont evaluate array length const when handling errors

### DIFF
--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -208,7 +208,7 @@ pub fn eval_to_const_value_raw_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc_middle::mir::interpret::EvalToConstValueResult<'tcx> {
-    // see comment in const_eval_raw_provider for what we're doing here
+    // see comment in eval_to_allocation_raw_provider for what we're doing here
     if key.param_env.reveal() == Reveal::All {
         let mut key = key;
         key.param_env = key.param_env.with_user_facing();

--- a/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.rs
+++ b/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.rs
@@ -1,0 +1,21 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+// This test is a minimized reproduction for #79518 where
+// during error handling for the type mismatch we would try
+// to evaluate std::mem::size_of::<Self::Assoc> causing an ICE
+
+trait Foo {
+    type Assoc: PartialEq;
+    const AssocInstance: Self::Assoc;
+
+    fn foo()
+    where
+        [(); std::mem::size_of::<Self::Assoc>()]: ,
+    {
+        Self::AssocInstance == [(); std::mem::size_of::<Self::Assoc>()];
+        //~^ Error: mismatched types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.stderr
+++ b/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-79518-default_trait_method_normalization.rs:16:32
+   |
+LL |         Self::AssocInstance == [(); std::mem::size_of::<Self::Assoc>()];
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found array `[(); _]`
+   |
+   = note: expected associated type `<Self as Foo>::Assoc`
+                        found array `[(); _]`
+   = help: consider constraining the associated type `<Self as Foo>::Assoc` to `[(); _]` or calling a method that returns `<Self as Foo>::Assoc`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #79518
Fixes #78246

cc @lcnr

This was ICE'ing because we dont pass in the correct ``ParamEnv`` which meant that there was no ``Self: Foo`` predicate to make ``Self::Assoc`` well formed which caused an ICE when trying to normalize ``Self::Assoc`` in the mir interpreter

r? @varkor 