### PR TITLE
Fix private intra-doc warnings on associated items

### DIFF
--- a/src/test/rustdoc-ui/intra-doc/private.private.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private.private.stderr
@@ -1,11 +1,19 @@
 warning: public documentation for `DocMe` links to private item `DontDocMe`
   --> $DIR/private.rs:5:11
    |
-LL | /// docs [DontDocMe]
+LL | /// docs [DontDocMe] [DontDocMe::f]
    |           ^^^^^^^^^ this item is private
    |
    = note: `#[warn(private_intra_doc_links)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
-warning: 1 warning emitted
+warning: public documentation for `DocMe` links to private item `DontDocMe::f`
+  --> $DIR/private.rs:5:23
+   |
+LL | /// docs [DontDocMe] [DontDocMe::f]
+   |                       ^^^^^^^^^^^^ this item is private
+   |
+   = note: this link resolves only because you passed `--document-private-items`, but will break without
+
+warning: 2 warnings emitted
 

--- a/src/test/rustdoc-ui/intra-doc/private.public.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private.public.stderr
@@ -1,11 +1,19 @@
 warning: public documentation for `DocMe` links to private item `DontDocMe`
   --> $DIR/private.rs:5:11
    |
-LL | /// docs [DontDocMe]
+LL | /// docs [DontDocMe] [DontDocMe::f]
    |           ^^^^^^^^^ this item is private
    |
    = note: `#[warn(private_intra_doc_links)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
-warning: 1 warning emitted
+warning: public documentation for `DocMe` links to private item `DontDocMe::f`
+  --> $DIR/private.rs:5:23
+   |
+LL | /// docs [DontDocMe] [DontDocMe::f]
+   |                       ^^^^^^^^^^^^ this item is private
+   |
+   = note: this link will resolve properly if you pass `--document-private-items`
+
+warning: 2 warnings emitted
 

--- a/src/test/rustdoc-ui/intra-doc/private.rs
+++ b/src/test/rustdoc-ui/intra-doc/private.rs
@@ -2,8 +2,13 @@
 // revisions: public private
 // [private]compile-flags: --document-private-items
 
-/// docs [DontDocMe]
+/// docs [DontDocMe] [DontDocMe::f]
 //~^ WARNING public documentation for `DocMe` links to private item `DontDocMe`
+//~| WARNING public documentation for `DocMe` links to private item `DontDocMe::f`
 // FIXME: for [private] we should also make sure the link was actually generated
 pub struct DocMe;
 struct DontDocMe;
+
+impl DontDocMe {
+    fn f() {}
+}


### PR DESCRIPTION
The issue was that the `kind, id` override was previously only being
considered for the disambiguator check, not the privacy check. This uses
the same ID for both.

Fixes https://github.com/rust-lang/rust/issues/81981.

r? @max-heller 