### PR TITLE
Refactor `get_word_attr` to return only `Option`

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2163,7 +2163,8 @@ fn clean_use_statement(
         return Vec::new();
     }
 
-    let (doc_meta_item, please_inline) = import.attrs.lists(sym::doc).get_word_attr(sym::inline);
+    let doc_meta_item = import.attrs.lists(sym::doc).get_word_attr(sym::inline);
+    let please_inline = doc_meta_item.is_some();
     let pub_underscore = import.vis.node.is_pub() && name == kw::Underscore;
 
     if pub_underscore && please_inline {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -438,7 +438,7 @@ impl AttributesExt for [ast::Attribute] {
 crate trait NestedAttributesExt {
     /// Returns `true` if the attribute list contains a specific `Word`
     fn has_word(self, word: Symbol) -> bool;
-    fn get_word_attr(self, word: Symbol) -> (Option<ast::NestedMetaItem>, bool);
+    fn get_word_attr(self, word: Symbol) -> Option<ast::NestedMetaItem>;
 }
 
 impl<I: Iterator<Item = ast::NestedMetaItem> + IntoIterator<Item = ast::NestedMetaItem>>
@@ -448,11 +448,8 @@ impl<I: Iterator<Item = ast::NestedMetaItem> + IntoIterator<Item = ast::NestedMe
         self.into_iter().any(|attr| attr.is_word() && attr.has_name(word))
     }
 
-    fn get_word_attr(mut self, word: Symbol) -> (Option<ast::NestedMetaItem>, bool) {
-        match self.find(|attr| attr.is_word() && attr.has_name(word)) {
-            Some(a) => (Some(a), true),
-            None => (None, false),
-        }
+    fn get_word_attr(mut self, word: Symbol) -> Option<ast::NestedMetaItem> {
+        self.find(|attr| attr.is_word() && attr.has_name(word))
     }
 }
 


### PR DESCRIPTION
This commit removes `bool` from the return type of `NestedAttributesExt::get_word_attr` so it will return only `Option<ast::NestedMetaItem>` for less redundancy.

Closes #82016

r? @jyn514 