### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,7 @@ jobs:
             env:
               SCRIPT: src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstate/toolstates.json"
+              DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
             os: windows-latest-xl
           - name: i686-mingw-1
             env:

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -53,6 +53,9 @@ pub fn sanitize(cx: &CodegenCx<'ll, '_>, no_sanitize: SanitizerSet, llfn: &'ll V
     if enabled.contains(SanitizerSet::THREAD) {
         llvm::Attribute::SanitizeThread.apply_llfn(Function, llfn);
     }
+    if enabled.contains(SanitizerSet::HWADDRESS) {
+        llvm::Attribute::SanitizeHWAddress.apply_llfn(Function, llfn);
+    }
 }
 
 /// Tell LLVM to emit or not emit the information necessary to unwind the stack for the function.

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -440,6 +440,8 @@ pub(crate) unsafe fn optimize_with_new_llvm_pass_manager(
             sanitize_memory_recover: config.sanitizer_recover.contains(SanitizerSet::MEMORY),
             sanitize_memory_track_origins: config.sanitizer_memory_track_origins as c_int,
             sanitize_thread: config.sanitizer.contains(SanitizerSet::THREAD),
+            sanitize_hwaddress: config.sanitizer.contains(SanitizerSet::HWADDRESS),
+            sanitize_hwaddress_recover: config.sanitizer_recover.contains(SanitizerSet::HWADDRESS),
         })
     } else {
         None
@@ -651,6 +653,10 @@ unsafe fn add_sanitizer_passes(config: &ModuleConfig, passes: &mut Vec<&'static 
     }
     if config.sanitizer.contains(SanitizerSet::THREAD) {
         passes.push(llvm::LLVMRustCreateThreadSanitizerPass());
+    }
+    if config.sanitizer.contains(SanitizerSet::HWADDRESS) {
+        let recover = config.sanitizer_recover.contains(SanitizerSet::HWADDRESS);
+        passes.push(llvm::LLVMRustCreateHWAddressSanitizerPass(recover));
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -131,6 +131,7 @@ pub enum Attribute {
     ReturnsTwice = 25,
     ReadNone = 26,
     InaccessibleMemOnly = 27,
+    SanitizeHWAddress = 28,
 }
 
 /// LLVMIntPredicate
@@ -439,6 +440,8 @@ pub struct SanitizerOptions {
     pub sanitize_memory_recover: bool,
     pub sanitize_memory_track_origins: c_int,
     pub sanitize_thread: bool,
+    pub sanitize_hwaddress: bool,
+    pub sanitize_hwaddress_recover: bool,
 }
 
 /// LLVMRelocMode
@@ -2128,6 +2131,7 @@ extern "C" {
         Recover: bool,
     ) -> &'static mut Pass;
     pub fn LLVMRustCreateThreadSanitizerPass() -> &'static mut Pass;
+    pub fn LLVMRustCreateHWAddressSanitizerPass(Recover: bool) -> &'static mut Pass;
     pub fn LLVMRustAddPass(PM: &PassManager<'_>, Pass: &'static mut Pass);
     pub fn LLVMRustAddLastExtensionPasses(
         PMB: &PassManagerBuilder,

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -893,6 +893,9 @@ fn link_sanitizers(sess: &Session, crate_type: CrateType, linker: &mut dyn Linke
     if sanitizer.contains(SanitizerSet::THREAD) {
         link_sanitizer_runtime(sess, linker, "tsan");
     }
+    if sanitizer.contains(SanitizerSet::HWADDRESS) {
+        link_sanitizer_runtime(sess, linker, "hwasan");
+    }
 }
 
 fn link_sanitizer_runtime(sess: &Session, linker: &mut dyn Linker, name: &str) {

--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -85,6 +85,7 @@ enum LLVMRustAttribute {
   ReturnsTwice = 25,
   ReadNone = 26,
   InaccessibleMemOnly = 27,
+  SanitizeHWAddress = 28,
 };
 
 typedef struct OpaqueRustString *RustStringRef;

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -205,6 +205,8 @@ static Attribute::AttrKind fromRust(LLVMRustAttribute Kind) {
     return Attribute::ReadNone;
   case InaccessibleMemOnly:
     return Attribute::InaccessibleMemOnly;
+  case SanitizeHWAddress:
+    return Attribute::SanitizeHWAddress;
   }
   report_fatal_error("bad AttributeKind");
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -43,6 +43,7 @@ bitflags! {
         const LEAK    = 1 << 1;
         const MEMORY  = 1 << 2;
         const THREAD  = 1 << 3;
+        const HWADDRESS  = 1 << 4;
     }
 }
 
@@ -56,6 +57,7 @@ impl fmt::Display for SanitizerSet {
                 SanitizerSet::LEAK => "leak",
                 SanitizerSet::MEMORY => "memory",
                 SanitizerSet::THREAD => "thread",
+                SanitizerSet::HWADDRESS => "hwaddress",
                 _ => panic!("unrecognized sanitizer {:?}", s),
             };
             if !first {
@@ -73,12 +75,18 @@ impl IntoIterator for SanitizerSet {
     type IntoIter = std::vec::IntoIter<SanitizerSet>;
 
     fn into_iter(self) -> Self::IntoIter {
-        [SanitizerSet::ADDRESS, SanitizerSet::LEAK, SanitizerSet::MEMORY, SanitizerSet::THREAD]
-            .iter()
-            .copied()
-            .filter(|&s| self.contains(s))
-            .collect::<Vec<_>>()
-            .into_iter()
+        [
+            SanitizerSet::ADDRESS,
+            SanitizerSet::LEAK,
+            SanitizerSet::MEMORY,
+            SanitizerSet::THREAD,
+            SanitizerSet::HWADDRESS,
+        ]
+        .iter()
+        .copied()
+        .filter(|&s| self.contains(s))
+        .collect::<Vec<_>>()
+        .into_iter()
     }
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -253,7 +253,7 @@ macro_rules! options {
         pub const parse_passes: &str = "a space-separated list of passes, or `all`";
         pub const parse_panic_strategy: &str = "either `unwind` or `abort`";
         pub const parse_relro_level: &str = "one of: `full`, `partial`, or `off`";
-        pub const parse_sanitizers: &str = "comma separated list of sanitizers: `address`, `leak`, `memory` or `thread`";
+        pub const parse_sanitizers: &str = "comma separated list of sanitizers: `address`, `hwaddress`, `leak`, `memory` or `thread`";
         pub const parse_sanitizer_memory_track_origins: &str = "0, 1, or 2";
         pub const parse_cfguard: &str =
             "either a boolean (`yes`, `no`, `on`, `off`, etc), `checks`, or `nochecks`";
@@ -476,6 +476,7 @@ macro_rules! options {
                         "leak" => SanitizerSet::LEAK,
                         "memory" => SanitizerSet::MEMORY,
                         "thread" => SanitizerSet::THREAD,
+                        "hwaddress" => SanitizerSet::HWADDRESS,
                         _ => return false,
                     }
                 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -593,6 +593,7 @@ symbols! {
         html_no_source,
         html_playground_url,
         html_root_url,
+        hwaddress,
         i,
         i128,
         i128_type,

--- a/compiler/rustc_typeck/src/check/cast.rs
+++ b/compiler/rustc_typeck/src/check/cast.rs
@@ -765,9 +765,8 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         m_expr: ty::TypeAndMut<'tcx>,
         m_cast: ty::TypeAndMut<'tcx>,
     ) -> Result<CastKind, CastError> {
-        // array-ptr-cast.
-
-        if m_expr.mutbl == hir::Mutability::Not && m_cast.mutbl == hir::Mutability::Not {
+        // array-ptr-cast: allow mut-to-mut, mut-to-const, const-to-const
+        if m_expr.mutbl == hir::Mutability::Mut || m_cast.mutbl == hir::Mutability::Not {
             if let ty::Array(ety, _) = m_expr.ty.kind() {
                 // Due to the limitations of LLVM global constants,
                 // region pointers end up pointing at copies of

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -1211,7 +1211,7 @@ fn construct_place_string(tcx: TyCtxt<'_>, place: &Place<'tcx>) -> String {
             ProjectionKind::Subslice => String::from("Subslice"),
         };
         if i != 0 {
-            projections_str.push_str(",");
+            projections_str.push(',');
         }
         projections_str.push_str(proj.as_str());
     }

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -1382,14 +1382,8 @@ fn determine_place_ancestry_relation(
     // Assume of length of projections_b = m
     let projections_b = &place_b.projections;
 
-    let mut same_initial_projections = true;
-
-    for (proj_a, proj_b) in projections_a.iter().zip(projections_b.iter()) {
-        if proj_a != proj_b {
-            same_initial_projections = false;
-            break;
-        }
-    }
+    let same_initial_projections =
+        projections_a.iter().zip(projections_b.iter()).all(|(proj_a, proj_b)| proj_a == proj_b);
 
     if same_initial_projections {
         // First min(n, m) projections are the same

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2628,10 +2628,12 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                         codegen_fn_attrs.no_sanitize |= SanitizerSet::MEMORY;
                     } else if item.has_name(sym::thread) {
                         codegen_fn_attrs.no_sanitize |= SanitizerSet::THREAD;
+                    } else if item.has_name(sym::hwaddress) {
+                        codegen_fn_attrs.no_sanitize |= SanitizerSet::HWADDRESS;
                     } else {
                         tcx.sess
                             .struct_span_err(item.span(), "invalid argument for `no_sanitize`")
-                            .note("expected one of: `address`, `memory` or `thread`")
+                            .note("expected one of: `address`, `hwaddress`, `memory` or `thread`")
                             .emit();
                     }
                 }

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -42,7 +42,7 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
             Node::Ty(hir_ty @ Ty { kind: TyKind::Path(QPath::TypeRelative(_, segment)), .. }) => {
                 // Walk up from the parent_node to find an item so that
                 // we can resolve the relative path to an actual associated type.
-                // For the code example above this item would be the Foo trait.
+                // For the code example above, this item would be the Foo trait.
                 let item_hir_id = tcx
                     .hir()
                     .parent_iter(hir_id)

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -32,7 +32,7 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
             // This matches on types who's paths couldn't be resolved without typeck'ing e.g.
             //
             // trait Foo {
-            //   type Assoc<const N1: usize>;;
+            //   type Assoc<const N1: usize>;
             //   fn foo() -> Self::Assoc<3>;
             //   // note: if the def_id argument is the 3 then in this example
             //   // parent_node would be the node for Self::Assoc<_>
@@ -41,7 +41,8 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
             // I believe this match arm is only needed for GAT but I am not 100% sure - BoxyUwU
             Node::Ty(hir_ty @ Ty { kind: TyKind::Path(QPath::TypeRelative(_, segment)), .. }) => {
                 // Walk up from the parent_node to find an item so that
-                // we can resolve the relative path to an actual associated type
+                // we can resolve the relative path to an actual associated type.
+                // For the code example above this item would be the Foo trait.
                 let item_hir_id = tcx
                     .hir()
                     .parent_iter(hir_id)
@@ -53,7 +54,8 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                 let item_ctxt = &ItemCtxt::new(tcx, item_did) as &dyn crate::astconv::AstConv<'_>;
 
                 // This ty will be the actual associated type so that we can
-                // go through its generics to find which param our def_id corresponds to
+                // go through its generics to find which param our def_id corresponds to.
+                // For the code example above, this ty would be the Assoc<const N1: usize>.
                 let ty = item_ctxt.ast_ty_to_ty(hir_ty);
                 if let ty::Projection(projection) = ty.kind() {
                     let generics = tcx.generics_of(projection.item_def_id);

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -56,6 +56,7 @@ This API is completely unstable and subject to change.
 */
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![feature(bindings_after_at)]
 #![feature(bool_to_option)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -99,13 +99,11 @@
 //! pub struct Foo;
 //!
 //! #[no_mangle]
-//! #[allow(improper_ctypes_definitions)]
 //! pub extern "C" fn foo_new() -> Box<Foo> {
 //!     Box::new(Foo)
 //! }
 //!
 //! #[no_mangle]
-//! #[allow(improper_ctypes_definitions)]
 //! pub extern "C" fn foo_delete(_: Option<Box<Foo>>) {}
 //! ```
 //!

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -198,12 +198,13 @@ where
                 Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
             }
         } else if A::may_have_side_effect() && self.index < self.a.size() {
-            // match the base implementation's potential side effects
-            // SAFETY: we just checked that `self.index` < `self.a.len()`
-            unsafe {
-                self.a.__iterator_get_unchecked(self.index);
-            }
+            let i = self.index;
             self.index += 1;
+            // match the base implementation's potential side effects
+            // SAFETY: we just checked that `i` < `self.a.len()`
+            unsafe {
+                self.a.__iterator_get_unchecked(i);
+            }
             None
         } else {
             None

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -491,7 +491,7 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     extern "C" {
         static mut environ: *const *const c_char;
     }
-    &mut environ
+    ptr::addr_of_mut!(environ)
 }
 
 pub unsafe fn env_rwlock(readonly: bool) -> RWLockGuard {

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -22,7 +22,7 @@ use crate::str;
 use crate::sys::cvt;
 use crate::sys::fd;
 use crate::sys_common::mutex::{StaticMutex, StaticMutexGuard};
-use crate::sys_common::rwlock::{RWLockGuard, StaticRWLock};
+use crate::sys_common::rwlock::{RWLockReadGuard, StaticRWLock};
 use crate::vec;
 
 use libc::{c_char, c_int, c_void};
@@ -496,7 +496,7 @@ pub unsafe fn environ() -> *mut *const *const c_char {
 
 static ENV_LOCK: StaticRWLock = StaticRWLock::new();
 
-pub fn env_read_lock() -> RWLockGuard {
+pub fn env_read_lock() -> RWLockReadGuard {
     ENV_LOCK.read_with_guard()
 }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -47,7 +47,7 @@ impl Command {
         // a lock any more because the parent won't do anything and the child is
         // in its own process.
         let result = unsafe {
-            let _env_lock = sys::os::env_rwlock(true);
+            let _env_lock = sys::os::env_read_lock();
             cvt(libc::fork())?
         };
 
@@ -124,7 +124,7 @@ impl Command {
                     // Similar to when forking, we want to ensure that access to
                     // the environment is synchronized, so make sure to grab the
                     // environment lock before we try to exec.
-                    let _lock = sys::os::env_rwlock(true);
+                    let _lock = sys::os::env_read_lock();
 
                     let Err(e) = self.do_exec(theirs, envp.as_ref());
                     e
@@ -404,7 +404,7 @@ impl Command {
             cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;
 
             // Make sure we synchronize access to the global `environ` resource
-            let _env_lock = sys::os::env_rwlock(true);
+            let _env_lock = sys::os::env_read_lock();
             let envp = envp.map(|c| c.as_ptr()).unwrap_or_else(|| *sys::os::environ() as *const _);
             cvt_nz(libc::posix_spawnp(
                 &mut p.pid,

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -47,7 +47,7 @@ impl Command {
         // a lock any more because the parent won't do anything and the child is
         // in its own process.
         let result = unsafe {
-            let _env_lock = sys::os::env_lock();
+            let _env_lock = sys::os::env_rwlock(true);
             cvt(libc::fork())?
         };
 
@@ -124,7 +124,7 @@ impl Command {
                     // Similar to when forking, we want to ensure that access to
                     // the environment is synchronized, so make sure to grab the
                     // environment lock before we try to exec.
-                    let _lock = sys::os::env_lock();
+                    let _lock = sys::os::env_rwlock(true);
 
                     let Err(e) = self.do_exec(theirs, envp.as_ref());
                     e
@@ -404,7 +404,7 @@ impl Command {
             cvt_nz(libc::posix_spawnattr_setflags(attrs.0.as_mut_ptr(), flags as _))?;
 
             // Make sure we synchronize access to the global `environ` resource
-            let _env_lock = sys::os::env_lock();
+            let _env_lock = sys::os::env_rwlock(true);
             let envp = envp.map(|c| c.as_ptr()).unwrap_or_else(|| *sys::os::environ() as *const _);
             cvt_nz(libc::posix_spawnp(
                 &mut p.pid,

--- a/library/std/src/sys_common/rwlock.rs
+++ b/library/std/src/sys_common/rwlock.rs
@@ -1,12 +1,15 @@
 use crate::sys::rwlock as imp;
 
+#[cfg(unix)]
 enum GuardType {
     Read,
     Write,
 }
 
+#[cfg(unix)]
 pub struct RWLockGuard(&'static RWLock, GuardType);
 
+#[cfg(unix)]
 impl Drop for RWLockGuard {
     fn drop(&mut self) {
         unsafe {
@@ -52,6 +55,7 @@ impl RWLock {
     /// Behavior is undefined if the rwlock has been moved between this and any
     /// previous method call.
     #[inline]
+    #[cfg(unix)]
     pub unsafe fn read_with_guard(&'static self) -> RWLockGuard {
         self.read();
         RWLockGuard(&self, GuardType::Read)
@@ -87,6 +91,7 @@ impl RWLock {
     /// Behavior is undefined if the rwlock has been moved between this and any
     /// previous method call.
     #[inline]
+    #[cfg(unix)]
     pub unsafe fn write_with_guard(&'static self) -> RWLockGuard {
         self.write();
         RWLockGuard(&self, GuardType::Write)

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -51,7 +51,7 @@ o("option-checking", None, "complain about unrecognized options in this configur
 o("ninja", "llvm.ninja", "build LLVM using the Ninja generator (for MSVC, requires building in the correct environment)")
 o("locked-deps", "build.locked-deps", "force Cargo.lock to be up to date")
 o("vendor", "build.vendor", "enable usage of vendored Rust crates")
-o("sanitizers", "build.sanitizers", "build the sanitizer runtimes (asan, lsan, msan, tsan)")
+o("sanitizers", "build.sanitizers", "build the sanitizer runtimes (asan, lsan, msan, tsan, hwasan)")
 o("dist-src", "rust.dist-src", "when building tarballs enables building a source tarball")
 o("cargo-native-static", "build.cargo-native-static", "static native libraries in cargo")
 o("profiler", "build.profiler", "build the profiler runtime")

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -804,7 +804,7 @@ fn supported_sanitizers(
         "aarch64-apple-darwin" => darwin_libs("osx", &["asan", "lsan", "tsan"]),
         "aarch64-fuchsia" => common_libs("fuchsia", "aarch64", &["asan"]),
         "aarch64-unknown-linux-gnu" => {
-            common_libs("linux", "aarch64", &["asan", "lsan", "msan", "tsan"])
+            common_libs("linux", "aarch64", &["asan", "lsan", "msan", "tsan", "hwasan"])
         }
         "x86_64-apple-darwin" => darwin_libs("osx", &["asan", "lsan", "tsan"]),
         "x86_64-fuchsia" => common_libs("fuchsia", "x86_64", &["asan"]),

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -531,6 +531,7 @@ jobs:
             env:
               SCRIPT: src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstate/toolstates.json
+              DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
             <<: *job-windows-xl
 
           # 32/64-bit MinGW builds.

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -546,9 +546,12 @@ crate fn make_test(
     // compiler.
     if !already_has_extern_crate && !opts.no_crate_inject && cratename != Some("std") {
         if let Some(cratename) = cratename {
-            // Make sure its actually used if not included.
+            // Don't inject `extern crate` if the crate is never used.
+            // NOTE: this is terribly inaccurate because it doesn't actually
+            // parse the source, but only has false positives, not false
+            // negatives.
             if s.contains(cratename) {
-                prog.push_str(&format!("extern crate {};\n", cratename));
+                prog.push_str(&format!("extern crate r#{};\n", cratename));
                 line_offset += 1;
             }
         }

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -38,7 +38,7 @@ fn make_test_crate_name() {
     let input = "use asdf::qwop;
 assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
-extern crate asdf;
+extern crate r#asdf;
 fn main() {
 use asdf::qwop;
 assert_eq!(2+2, 4);
@@ -128,7 +128,7 @@ fn make_test_opts_attrs() {
     let input = "use asdf::qwop;
 assert_eq!(2+2, 4);";
     let expected = "#![feature(sick_rad)]
-extern crate asdf;
+extern crate r#asdf;
 fn main() {
 use asdf::qwop;
 assert_eq!(2+2, 4);
@@ -141,7 +141,7 @@ assert_eq!(2+2, 4);
     opts.attrs.push("feature(hella_dope)".to_string());
     let expected = "#![feature(sick_rad)]
 #![feature(hella_dope)]
-extern crate asdf;
+extern crate r#asdf;
 fn main() {
 use asdf::qwop;
 assert_eq!(2+2, 4);
@@ -250,7 +250,7 @@ assert_eq!(asdf::foo, 4);";
 
     let expected = "#![allow(unused)]
 extern crate hella_qwop;
-extern crate asdf;
+extern crate r#asdf;
 fn main() {
 assert_eq!(asdf::foo, 4);
 }"

--- a/src/test/run-make-fulldeps/coverage-reports/Makefile
+++ b/src/test/run-make-fulldeps/coverage-reports/Makefile
@@ -1,4 +1,3 @@
-# ignore-test Broken; accidentally silently ignored on Linux CI; FIXME(#81688)
 # needs-profiler-support
 # ignore-windows-gnu
 # min-llvm-version: 11.0
@@ -128,7 +127,7 @@ endif
 			$$( \
 				for file in $(TMPDIR)/rustdoc-$@/*/rust_out; \
 				do \
-				[[ -x $$file ]] && printf "%s %s " -object $$file; \
+				[ -x "$$file" ] && printf "%s %s " -object $$file; \
 				done \
 			) \
 		2> "$(TMPDIR)"/show_coverage_stderr.$@.txt \

--- a/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.partial_eq.txt
+++ b/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.partial_eq.txt
@@ -2,11 +2,11 @@
     2|       |// structure of this test.
     3|       |
     4|      2|#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-                       ^0            ^0      ^0 ^0  ^1       ^0 ^0^0
+                       ^0            ^0      ^0 ^0  ^1       ^1 ^0^0
     5|       |pub struct Version {
     6|       |    major: usize,
-    7|      1|    minor: usize, // Count: 1 - `PartialOrd` compared `minor` values in 3.2.1 vs. 3.3.0
-    8|      0|    patch: usize, // Count: 0 - `PartialOrd` was determined by `minor` (2 < 3)
+    7|       |    minor: usize,
+    8|       |    patch: usize,
     9|       |}
    10|       |
    11|       |impl Version {
@@ -45,19 +45,4 @@
    44|       |`function_source_hash` without a code region, if necessary.
    45|       |
    46|       |*/
-   47|       |
-   48|       |// FIXME(#79626): The derived traits get coverage, which is great, but some of the traits appear
-   49|       |// to get two coverage execution counts at different positions:
-   50|       |//
-   51|       |// ```text
-   52|       |//    4|      2|#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-   53|       |//                       ^0            ^0      ^0 ^0  ^1       ^0 ^0^0
-   54|       |// ```text
-   55|       |//
-   56|       |// `PartialEq`, `PartialOrd`, and `Ord` (and possibly `Eq`, if the trait name was longer than 2
-   57|       |// characters) have counts at their first and last characters.
-   58|       |//
-   59|       |// Why is this? Why does `PartialOrd` have two values (1 and 0)? This must mean we are checking
-   60|       |// distinct coverages, so maybe we don't want to eliminate one of them. Should we merge them?
-   61|       |// If merged, do we lose some information?
 

--- a/src/test/run-make-fulldeps/coverage/coverage_tools.mk
+++ b/src/test/run-make-fulldeps/coverage/coverage_tools.mk
@@ -12,5 +12,3 @@
 # Enabling `-C link-dead-code` is not necessary when compiling with `-Z instrument-coverage`,
 # due to improvements in the coverage map generation, to add unreachable functions known to Rust.
 # Therefore, `-C link-dead-code` is no longer automatically enabled.
-
-UNAME = $(shell uname)

--- a/src/test/run-make-fulldeps/coverage/partial_eq.rs
+++ b/src/test/run-make-fulldeps/coverage/partial_eq.rs
@@ -4,8 +4,8 @@
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
     major: usize,
-    minor: usize, // Count: 1 - `PartialOrd` compared `minor` values in 3.2.1 vs. 3.3.0
-    patch: usize, // Count: 0 - `PartialOrd` was determined by `minor` (2 < 3)
+    minor: usize,
+    patch: usize,
 }
 
 impl Version {
@@ -44,18 +44,3 @@ one expression, which is allowed, but the `function_source_hash` was only passed
 `function_source_hash` without a code region, if necessary.
 
 */
-
-// FIXME(#79626): The derived traits get coverage, which is great, but some of the traits appear
-// to get two coverage execution counts at different positions:
-//
-// ```text
-//    4|      2|#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-//                       ^0            ^0      ^0 ^0  ^1       ^0 ^0^0
-// ```text
-//
-// `PartialEq`, `PartialOrd`, and `Ord` (and possibly `Eq`, if the trait name was longer than 2
-// characters) have counts at their first and last characters.
-//
-// Why is this? Why does `PartialOrd` have two values (1 and 0)? This must mean we are checking
-// distinct coverages, so maybe we don't want to eliminate one of them. Should we merge them?
-// If merged, do we lose some information?

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -21,6 +21,12 @@ CGREP := "$(S)/src/etc/cat-and-grep.sh"
 # diff with common flags for multi-platform diffs against text output
 DIFF := diff -u --strip-trailing-cr
 
+# CI platforms use `/bin/dash`. When compiling in other environments, the
+# default may be different (for example, may default to `/bin/bash`), and syntax
+# and results could be different. Ensure Makefile `$(shell ...)` invocations
+# always run in `dash`.
+SHELL := /bin/dash
+
 # This is the name of the binary we will generate and run; use this
 # e.g. for `$(CC) -o $(RUN_BINFILE)`.
 RUN_BINFILE = $(TMPDIR)/$(1)

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -21,11 +21,18 @@ CGREP := "$(S)/src/etc/cat-and-grep.sh"
 # diff with common flags for multi-platform diffs against text output
 DIFF := diff -u --strip-trailing-cr
 
-# CI platforms use `/bin/dash`. When compiling in other environments, the
-# default may be different (for example, may default to `/bin/bash`), and syntax
-# and results could be different. Ensure Makefile `$(shell ...)` invocations
-# always run in `dash`.
+# Some of the Rust CI platforms use `/bin/dash` to run `shell` script in
+# Makefiles. Other platforms, including many developer platforms, default to
+# `/bin/bash`. (In many cases, `make` is actually using `/bin/sh`, but `sh`
+# is configured to execute one or the other shell binary). `dash` features
+# support only a small subset of `bash` features, so `dash` can be thought of as
+# the lowest common denominator, and tests should be validated against `dash`
+# whenever possible. Most developer platforms include `/bin/dash`, but to ensure
+# tests still work when `/bin/dash`, if not available, this `SHELL` override is
+# conditional:
+ifneq (,$(wildcard /bin/dash))
 SHELL := /bin/dash
+endif
 
 # This is the name of the binary we will generate and run; use this
 # e.g. for `$(CC) -o $(RUN_BINFILE)`.

--- a/src/test/rustdoc/playground-arg.rs
+++ b/src/test/rustdoc/playground-arg.rs
@@ -11,4 +11,4 @@
 pub fn dummy() {}
 
 // ensure that `extern crate foo;` was inserted into code snips automatically:
-// @matches foo/index.html '//a[@class="test-arrow"][@href="https://example.com/?code=%23!%5Ballow(unused)%5D%0Aextern%20crate%20foo%3B%0Afn%20main()%20%7B%0Ause%20foo%3A%3Adummy%3B%0Adummy()%3B%0A%7D&edition=2015"]' "Run"
+// @matches foo/index.html '//a[@class="test-arrow"][@href="https://example.com/?code=%23!%5Ballow(unused)%5D%0Aextern%20crate%20r%23foo%3B%0Afn%20main()%20%7B%0Ause%20foo%3A%3Adummy%3B%0Adummy()%3B%0A%7D&edition=2015"]' "Run"

--- a/src/test/ui/array-slice-vec/vector-cast-weirdness.rs
+++ b/src/test/ui/array-slice-vec/vector-cast-weirdness.rs
@@ -1,7 +1,11 @@
 // Issue #14893. Tests that casts from vectors don't behave strangely in the
 // presence of the `_` type shorthand notation.
+//
 // Update: after a change to the way casts are done, we have more type information
 // around and so the errors here are no longer exactly the same.
+//
+// Update: With PR #81479 some of the previously rejected cases are now allowed.
+// New test cases added.
 
 struct X {
     y: [u8; 2],
@@ -12,13 +16,19 @@ fn main() {
 
     // No longer a type mismatch - the `_` can be fully resolved by type inference.
     let p1: *const u8 = &x1.y as *const _;
+    let p1: *mut u8 = &x1.y as *mut _;
+    //~^ ERROR: casting `&[u8; 2]` as `*mut u8` is invalid
     let t1: *const [u8; 2] = &x1.y as *const _;
+    let t1: *mut [u8; 2] = &x1.y as *mut _;
+    //~^ ERROR: casting `&[u8; 2]` as `*mut [u8; 2]` is invalid
     let h1: *const [u8; 2] = &x1.y as *const [u8; 2];
+    let t1: *mut [u8; 2] = &x1.y as *mut [u8; 2];
+    //~^ ERROR: casting `&[u8; 2]` as `*mut [u8; 2]` is invalid
 
     let mut x1 = X { y: [0, 0] };
 
-    // This is still an error since we don't allow casts from &mut [T; n] to *mut T.
-    let p1: *mut u8 = &mut x1.y as *mut _;  //~ ERROR casting
+    let p1: *mut u8 = &mut x1.y as *mut _;
+    let p2: *const u8 = &mut x1.y as *const _;
     let t1: *mut [u8; 2] = &mut x1.y as *mut _;
     let h1: *mut [u8; 2] = &mut x1.y as *mut [u8; 2];
 }

--- a/src/test/ui/array-slice-vec/vector-cast-weirdness.stderr
+++ b/src/test/ui/array-slice-vec/vector-cast-weirdness.stderr
@@ -1,9 +1,21 @@
-error[E0606]: casting `&mut [u8; 2]` as `*mut u8` is invalid
-  --> $DIR/vector-cast-weirdness.rs:21:23
+error[E0606]: casting `&[u8; 2]` as `*mut u8` is invalid
+  --> $DIR/vector-cast-weirdness.rs:19:23
    |
-LL |     let p1: *mut u8 = &mut x1.y as *mut _;
-   |                       ^^^^^^^^^^^^^^^^^^^
+LL |     let p1: *mut u8 = &x1.y as *mut _;
+   |                       ^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error[E0606]: casting `&[u8; 2]` as `*mut [u8; 2]` is invalid
+  --> $DIR/vector-cast-weirdness.rs:22:28
+   |
+LL |     let t1: *mut [u8; 2] = &x1.y as *mut _;
+   |                            ^^^^^^^^^^^^^^^
+
+error[E0606]: casting `&[u8; 2]` as `*mut [u8; 2]` is invalid
+  --> $DIR/vector-cast-weirdness.rs:25:28
+   |
+LL |     let t1: *mut [u8; 2] = &x1.y as *mut [u8; 2];
+   |                            ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0606`.

--- a/src/test/ui/generic-associated-types/const-generics-gat-in-trait-return-type-1.rs
+++ b/src/test/ui/generic-associated-types/const-generics-gat-in-trait-return-type-1.rs
@@ -1,0 +1,22 @@
+// run-pass
+#![feature(generic_associated_types)]
+#![allow(incomplete_features)]
+
+// This test unsures that with_opt_const_param returns the
+// def_id of the N param in the Foo::Assoc GAT.
+
+trait Foo {
+    type Assoc<const N: usize>;
+    fn foo(&self) -> Self::Assoc<3>;
+}
+
+impl Foo for () {
+    type Assoc<const N: usize> = [(); N];
+    fn foo(&self) -> Self::Assoc<3> {
+        [(); 3]
+    }
+}
+
+fn main() {
+    assert_eq!(().foo(), [(); 3]);
+}

--- a/src/test/ui/generic-associated-types/const-generics-gat-in-trait-return-type-2.rs
+++ b/src/test/ui/generic-associated-types/const-generics-gat-in-trait-return-type-2.rs
@@ -1,0 +1,22 @@
+// run-pass
+#![feature(generic_associated_types)]
+#![allow(incomplete_features)]
+
+// This test unsures that with_opt_const_param returns the
+// def_id of the N param in the Foo::Assoc GAT.
+
+trait Foo {
+    type Assoc<const N: usize>;
+    fn foo<const N: usize>(&self) -> Self::Assoc<N>;
+}
+
+impl Foo for () {
+    type Assoc<const N: usize> = [(); N];
+    fn foo<const N: usize>(&self) -> Self::Assoc<N> {
+        [(); N]
+    }
+}
+
+fn main() {
+    assert_eq!(().foo::<10>(), [(); 10]);
+}

--- a/src/test/ui/generic-associated-types/const-generics-gat-in-trait-return-type-3.rs
+++ b/src/test/ui/generic-associated-types/const-generics-gat-in-trait-return-type-3.rs
@@ -1,0 +1,27 @@
+// run-pass
+#![feature(generic_associated_types)]
+#![allow(incomplete_features)]
+
+// This test unsures that with_opt_const_param returns the
+// def_id of the N param in the Bar::Assoc GAT.
+
+trait Bar {
+    type Assoc<const N: usize>;
+}
+trait Foo: Bar {
+    fn foo(&self) -> Self::Assoc<3>;
+}
+
+impl Bar for () {
+    type Assoc<const N: usize> = [(); N];
+}
+
+impl Foo for () {
+    fn foo(&self) -> Self::Assoc<3> {
+        [(); 3]
+    }
+}
+
+fn main() {
+    assert_eq!(().foo(), [(); 3]);
+}

--- a/src/test/ui/invalid/invalid-no-sanitize.stderr
+++ b/src/test/ui/invalid/invalid-no-sanitize.stderr
@@ -4,7 +4,7 @@ error: invalid argument for `no_sanitize`
 LL | #[no_sanitize(brontosaurus)]
    |               ^^^^^^^^^^^^
    |
-   = note: expected one of: `address`, `memory` or `thread`
+   = note: expected one of: `address`, `hwaddress`, `memory` or `thread`
 
 error: aborting due to previous error
 

--- a/src/test/ui/sanitize/hwaddress.rs
+++ b/src/test/ui/sanitize/hwaddress.rs
@@ -1,0 +1,19 @@
+// needs-sanitizer-support
+// needs-sanitizer-hwaddress
+//
+// compile-flags: -Z sanitizer=hwaddress -O -g
+//
+// run-fail
+// error-pattern: HWAddressSanitizer: tag-mismatch
+
+#![feature(test)]
+
+use std::hint::black_box;
+
+fn main() {
+    let xs = vec![0, 1, 2, 3];
+    // Avoid optimizing everything out.
+    let xs = black_box(xs.as_ptr());
+    let code = unsafe { *xs.offset(4) };
+    std::process::exit(code);
+}

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -254,7 +254,10 @@ impl Builder {
         t!(self.checksums.store_cache());
     }
 
-    /// If a tool does not pass its tests, don't ship it.
+    /// If a tool does not pass its tests on *any* of Linux and Windows, don't ship
+    /// it on *all* targets, because tools like Miri can "cross-run" programs for
+    /// different targets, for example, run a program for `x86_64-pc-windows-msvc`
+    /// on `x86_64-unknown-linux-gnu`.
     /// Right now, we do this only for Miri.
     fn check_toolstate(&mut self) {
         for file in &["toolstates-linux.json", "toolstates-windows.json"] {

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -257,21 +257,20 @@ impl Builder {
     /// If a tool does not pass its tests, don't ship it.
     /// Right now, we do this only for Miri.
     fn check_toolstate(&mut self) {
-        let toolstates: Option<HashMap<String, String>> =
-            File::open(self.input.join("toolstates-linux.json"))
+        for file in &["toolstates-linux.json", "toolstates-windows.json"] {
+            let toolstates: Option<HashMap<String, String>> = File::open(self.input.join(file))
                 .ok()
                 .and_then(|f| serde_json::from_reader(&f).ok());
-        let toolstates = toolstates.unwrap_or_else(|| {
-            println!(
-                "WARNING: `toolstates-linux.json` missing/malformed; \
-                assuming all tools failed"
-            );
-            HashMap::default() // Use empty map if anything went wrong.
-        });
-        // Mark some tools as missing based on toolstate.
-        if toolstates.get("miri").map(|s| &*s as &str) != Some("test-pass") {
-            println!("Miri tests are not passing, removing component");
-            self.versions.disable_version(&PkgType::Miri);
+            let toolstates = toolstates.unwrap_or_else(|| {
+                println!("WARNING: `{}` missing/malformed; assuming all tools failed", file);
+                HashMap::default() // Use empty map if anything went wrong.
+            });
+            // Mark some tools as missing based on toolstate.
+            if toolstates.get("miri").map(|s| &*s as &str) != Some("test-pass") {
+                println!("Miri tests are not passing, removing component");
+                self.versions.disable_version(&PkgType::Miri);
+                break;
+            }
         }
     }
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -48,6 +48,7 @@ impl EarlyProps {
         let has_lsan = util::LSAN_SUPPORTED_TARGETS.contains(&&*config.target);
         let has_msan = util::MSAN_SUPPORTED_TARGETS.contains(&&*config.target);
         let has_tsan = util::TSAN_SUPPORTED_TARGETS.contains(&&*config.target);
+        let has_hwasan = util::HWASAN_SUPPORTED_TARGETS.contains(&&*config.target);
 
         iter_header(testfile, None, rdr, &mut |ln| {
             // we should check if any only-<platform> exists and if it exists
@@ -98,6 +99,10 @@ impl EarlyProps {
                 }
 
                 if !has_tsan && config.parse_name_directive(ln, "needs-sanitizer-thread") {
+                    props.ignore = true;
+                }
+
+                if !has_hwasan && config.parse_name_directive(ln, "needs-sanitizer-hwaddress") {
                     props.ignore = true;
                 }
 

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -110,6 +110,9 @@ pub const TSAN_SUPPORTED_TARGETS: &[&str] = &[
     "x86_64-unknown-linux-gnu",
 ];
 
+pub const HWASAN_SUPPORTED_TARGETS: &[&str] =
+    &["aarch64-linux-android", "aarch64-unknown-linux-gnu"];
+
 const BIG_ENDIAN: &[&str] = &[
     "aarch64_be",
     "armebv7r",


### PR DESCRIPTION
Successful merges:

 - #79775 (Fix injected errors when running doctests on a crate named after a keyword)
 - #81479 (Allow casting mut array ref to mut ptr)
 - #81506 (HWAddressSanitizer support)
 - #81666 (Don't release Miri if its tests only failed on Windows)
 - #81734 (Ensures `make` tests run under /bin/dash (if available), like CI, and fixes a Makefile)
 - #81741 (Increment `self.index` before calling `Iterator::self.a.__iterator_ge…)
 - #81850 (use RWlock when accessing os::env)
 - #81911 (GAT/const_generics: Allow with_opt_const_param to return GAT param def_id)
 - #82022 (Push a `char` instead of a `str` with len one into a String)
 - #82023 (Remove unnecessary lint allow attrs on example)
 - #82030 (Use `Iterator::all` instead of open-coding it)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=79775,81479,81506,81666,81734,81741,81850,81911,82022,82023,82030)
<!-- homu-ignore:end -->