### PR TITLE
Turn may_have_side_effect into an associated constant

### DIFF
--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -212,9 +212,7 @@ unsafe impl<T, A: Allocator> TrustedRandomAccess for IntoIter<T, A>
 where
     T: Copy,
 {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[stable(feature = "vec_into_iter_clone", since = "1.8.0")]

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -124,10 +124,7 @@ unsafe impl<I> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess,
 {
-    #[inline]
-    fn may_have_side_effect() -> bool {
-        true
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = true;
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -140,10 +140,7 @@ unsafe impl<I> TrustedRandomAccess for Copied<I>
 where
     I: TrustedRandomAccess,
 {
-    #[inline]
-    fn may_have_side_effect() -> bool {
-        I::may_have_side_effect()
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
 }
 
 #[stable(feature = "iter_copied", since = "1.36.0")]

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -209,9 +209,7 @@ unsafe impl<I> TrustedRandomAccess for Enumerate<I>
 where
     I: TrustedRandomAccess,
 {
-    fn may_have_side_effect() -> bool {
-        I::may_have_side_effect()
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
 }
 
 #[stable(feature = "fused", since = "1.26.0")]

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -201,9 +201,7 @@ unsafe impl<I> TrustedRandomAccess for Fuse<I>
 where
     I: TrustedRandomAccess,
 {
-    fn may_have_side_effect() -> bool {
-        I::may_have_side_effect()
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
 }
 
 // Fuse specialization trait

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -189,10 +189,7 @@ unsafe impl<I, F> TrustedRandomAccess for Map<I, F>
 where
     I: TrustedRandomAccess,
 {
-    #[inline]
-    fn may_have_side_effect() -> bool {
-        true
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = true;
 }
 
 #[unstable(issue = "none", feature = "inplace_iteration")]

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -197,7 +197,7 @@ where
             unsafe {
                 Some((self.a.__iterator_get_unchecked(i), self.b.__iterator_get_unchecked(i)))
             }
-        } else if A::may_have_side_effect() && self.index < self.a.size() {
+        } else if A::MAY_HAVE_SIDE_EFFECT && self.index < self.a.size() {
             let i = self.index;
             self.index += 1;
             // match the base implementation's potential side effects
@@ -224,7 +224,7 @@ where
         while self.index < end {
             let i = self.index;
             self.index += 1;
-            if A::may_have_side_effect() {
+            if A::MAY_HAVE_SIDE_EFFECT {
                 // SAFETY: the usage of `cmp::min` to calculate `delta`
                 // ensures that `end` is smaller than or equal to `self.len`,
                 // so `i` is also smaller than `self.len`.
@@ -232,7 +232,7 @@ where
                     self.a.__iterator_get_unchecked(i);
                 }
             }
-            if B::may_have_side_effect() {
+            if B::MAY_HAVE_SIDE_EFFECT {
                 // SAFETY: same as above.
                 unsafe {
                     self.b.__iterator_get_unchecked(i);
@@ -249,9 +249,7 @@ where
         A: DoubleEndedIterator + ExactSizeIterator,
         B: DoubleEndedIterator + ExactSizeIterator,
     {
-        let a_side_effect = A::may_have_side_effect();
-        let b_side_effect = B::may_have_side_effect();
-        if a_side_effect || b_side_effect {
+        if A::MAY_HAVE_SIDE_EFFECT || B::MAY_HAVE_SIDE_EFFECT {
             let sz_a = self.a.size();
             let sz_b = self.b.size();
             // Adjust a, b to equal length, make sure that only the first call
@@ -259,13 +257,13 @@ where
             // on calls to `self.next_back()` after calling `get_unchecked()`.
             if sz_a != sz_b {
                 let sz_a = self.a.size();
-                if a_side_effect && sz_a > self.len {
+                if A::MAY_HAVE_SIDE_EFFECT && sz_a > self.len {
                     for _ in 0..sz_a - cmp::max(self.len, self.index) {
                         self.a.next_back();
                     }
                 }
                 let sz_b = self.b.size();
-                if b_side_effect && sz_b > self.len {
+                if B::MAY_HAVE_SIDE_EFFECT && sz_b > self.len {
                     for _ in 0..sz_b - self.len {
                         self.b.next_back();
                     }
@@ -309,9 +307,7 @@ where
     A: TrustedRandomAccess,
     B: TrustedRandomAccess,
 {
-    fn may_have_side_effect() -> bool {
-        A::may_have_side_effect() || B::may_have_side_effect()
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = A::MAY_HAVE_SIDE_EFFECT || B::MAY_HAVE_SIDE_EFFECT;
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
@@ -422,9 +418,9 @@ pub unsafe trait TrustedRandomAccess: Sized {
     {
         self.size_hint().0
     }
-    /// Returns `true` if getting an iterator element may have
-    /// side effects. Remember to take inner iterators into account.
-    fn may_have_side_effect() -> bool;
+    /// `true` if getting an iterator element may have side effects.
+    /// Remember to take inner iterators into account.
+    const MAY_HAVE_SIDE_EFFECT: bool;
 }
 
 /// Like `Iterator::__iterator_get_unchecked`, but doesn't require the compiler to

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1305,9 +1305,7 @@ impl<T> FusedIterator for Windows<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
@@ -1473,9 +1471,7 @@ impl<T> FusedIterator for Chunks<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) mutable chunks (`chunk_size`
@@ -1638,9 +1634,7 @@ impl<T> FusedIterator for ChunksMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
@@ -1794,9 +1788,7 @@ impl<T> FusedIterator for ChunksExact<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) mutable chunks (`chunk_size`
@@ -1947,9 +1939,7 @@ impl<T> FusedIterator for ChunksExactMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// A windowed iterator over a slice in overlapping chunks (`N` elements at a
@@ -2186,9 +2176,7 @@ impl<T, const N: usize> FusedIterator for ArrayChunks<'_, T, N> {}
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunks<'a, T, N> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) mutable chunks (`N` elements
@@ -2300,9 +2288,7 @@ impl<T, const N: usize> FusedIterator for ArrayChunksMut<'_, T, N> {}
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunksMut<'a, T, N> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
@@ -2464,9 +2450,7 @@ impl<T> FusedIterator for RChunks<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) mutable chunks (`chunk_size`
@@ -2627,9 +2611,7 @@ impl<T> FusedIterator for RChunksMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) chunks (`chunk_size` elements at a
@@ -2787,9 +2769,7 @@ impl<T> FusedIterator for RChunksExact<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over a slice in (non-overlapping) mutable chunks (`chunk_size`
@@ -2944,25 +2924,19 @@ impl<T> FusedIterator for RChunksExactMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// An iterator over slice in (non-overlapping) chunks separated by a predicate.

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -321,10 +321,7 @@ unsafe impl TrustedLen for Bytes<'_> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl TrustedRandomAccess for Bytes<'_> {
-    #[inline]
-    fn may_have_side_effect() -> bool {
-        false
-    }
+    const MAY_HAVE_SIDE_EFFECT: bool = false;
 }
 
 /// This macro generates a Clone impl for string pattern API


### PR DESCRIPTION
The `may_have_side_effect` is an implementation detail of `TrustedRandomAccess`
trait. It describes if obtaining an iterator element may have side effects. It
is currently implemented as an associated function.

Turn `may_have_side_effect` into an associated constant. This makes the
value immediately available to the optimizer.