### PR TITLE
Add diagnostics for specific cases for const/type mismatch err

### DIFF
--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -70,7 +70,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     add_braces_suggestion(arg, &mut err);
                     err.set_primary_message(
                         "unresolved item provided when a constant was expected",
-                    );
+                    )
+                    .emit();
+                    return;
                 }
                 Res::Def(DefKind::TyParam, src_def_id) => {
                     if let Some(param_local_id) = param.def_id.as_local() {

--- a/src/test/ui/const-generics/const-param-shadowing.stderr
+++ b/src/test/ui/const-generics/const-param-shadowing.stderr
@@ -4,7 +4,7 @@ error[E0747]: type provided when a constant was expected
 LL | fn test<const N: usize>() -> Foo<N> {
    |                                  ^
    |
-help: if this generic argument was intended as a const parameter, try surrounding it with braces:
+help: if this generic argument was intended as a const parameter, surround it with braces
    |
 LL | fn test<const N: usize>() -> Foo<{ N }> {
    |                                  ^   ^

--- a/src/test/ui/const-generics/diagnostics.rs
+++ b/src/test/ui/const-generics/diagnostics.rs
@@ -1,13 +1,18 @@
 #![crate_type="lib"]
-#![feature(const_generics)]
+#![feature(min_const_generics)]
 #![allow(incomplete_features)]
 
 struct A<const N: u8>;
 trait Foo {}
 impl Foo for A<N> {}
-//~^ ERROR type provided when a constant
-//~| ERROR cannot find type
+//~^ ERROR cannot find type
+//~| unresolved item provided when a constant
 
 struct B<const N: u8>;
 impl<N> Foo for B<N> {}
 //~^ ERROR type provided when a constant
+
+struct C<const C: u8, const N: u8>;
+impl<const N: u8> Foo for C<N, T> {}
+//~^ ERROR cannot find type
+//~| unresolved item provided when a constant

--- a/src/test/ui/const-generics/diagnostics.rs
+++ b/src/test/ui/const-generics/diagnostics.rs
@@ -1,0 +1,13 @@
+#![crate_type="lib"]
+#![feature(const_generics)]
+#![allow(incomplete_features)]
+
+struct A<const N: u8>;
+trait Foo {}
+impl Foo for A<N> {}
+//~^ ERROR type provided when a constant
+//~| ERROR cannot find type
+
+struct B<const N: u8>;
+impl<N> Foo for B<N> {}
+//~^ ERROR type provided when a constant

--- a/src/test/ui/const-generics/diagnostics.stderr
+++ b/src/test/ui/const-generics/diagnostics.stderr
@@ -41,8 +41,6 @@ error[E0747]: unresolved item provided when a constant was expected
 LL | impl<const N: u8> Foo for C<N, T> {}
    |                                ^
    |
-   = note: type arguments must be provided before constant arguments
-   = help: reorder the arguments: consts: `<C, N>`
 help: if this generic argument was intended as a const parameter, surround it with braces
    |
 LL | impl<const N: u8> Foo for C<N, { T }> {}

--- a/src/test/ui/const-generics/diagnostics.stderr
+++ b/src/test/ui/const-generics/diagnostics.stderr
@@ -1,0 +1,27 @@
+error[E0412]: cannot find type `N` in this scope
+  --> $DIR/diagnostics.rs:7:16
+   |
+LL | struct A<const N: u8>;
+   | ---------------------- similarly named struct `A` defined here
+LL | trait Foo {}
+LL | impl Foo for A<N> {}
+   |                ^ help: a struct with a similar name exists: `A`
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/diagnostics.rs:7:16
+   |
+LL | impl Foo for A<N> {}
+   |                ^
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/diagnostics.rs:12:19
+   |
+LL | impl<N> Foo for B<N> {}
+   |      -            ^
+   |      |
+   |      help: try changing to a const-generic parameter:: `const N: u8`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0412, E0747.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/const-generics/diagnostics.stderr
+++ b/src/test/ui/const-generics/diagnostics.stderr
@@ -7,11 +7,25 @@ LL | trait Foo {}
 LL | impl Foo for A<N> {}
    |                ^ help: a struct with a similar name exists: `A`
 
-error[E0747]: type provided when a constant was expected
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/diagnostics.rs:16:32
+   |
+LL | struct A<const N: u8>;
+   | ---------------------- similarly named struct `A` defined here
+...
+LL | impl<const N: u8> Foo for C<N, T> {}
+   |                                ^ help: a struct with a similar name exists: `A`
+
+error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/diagnostics.rs:7:16
    |
 LL | impl Foo for A<N> {}
    |                ^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL | impl Foo for A<{ N }> {}
+   |                ^   ^
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/diagnostics.rs:12:19
@@ -19,9 +33,22 @@ error[E0747]: type provided when a constant was expected
 LL | impl<N> Foo for B<N> {}
    |      -            ^
    |      |
-   |      help: try changing to a const-generic parameter:: `const N: u8`
+   |      help: consider changing this type paramater to a `const`-generic: `const N: u8`
 
-error: aborting due to 3 previous errors
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/diagnostics.rs:16:32
+   |
+LL | impl<const N: u8> Foo for C<N, T> {}
+   |                                ^
+   |
+   = note: type arguments must be provided before constant arguments
+   = help: reorder the arguments: consts: `<C, N>`
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL | impl<const N: u8> Foo for C<N, { T }> {}
+   |                                ^   ^
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0412, E0747.
 For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/const-generics/invalid-enum.rs
+++ b/src/test/ui/const-generics/invalid-enum.rs
@@ -3,14 +3,14 @@
 
 #[derive(PartialEq, Eq)]
 enum CompileFlag {
-  A,
-  B,
+    A,
+    B,
 }
 
 pub fn test_1<const CF: CompileFlag>() {}
 pub fn test_2<T, const CF: CompileFlag>(x: T) {}
 pub struct Example<const CF: CompileFlag, T=u32>{
-  x: T,
+    x: T,
 }
 
 impl<const CF: CompileFlag, T> Example<CF, T> {
@@ -20,15 +20,15 @@ impl<const CF: CompileFlag, T> Example<CF, T> {
 pub fn main() {
   test_1::<CompileFlag::A>();
   //~^ ERROR: expected type, found variant
-  //~| ERROR: type provided when a constant was expected
+  //~| ERROR: unresolved item provided when a constant was expected
 
   test_2::<_, CompileFlag::A>(0);
   //~^ ERROR: expected type, found variant
-  //~| ERROR: type provided when a constant was expected
+  //~| ERROR: unresolved item provided when a constant was expected
 
   let _: Example<CompileFlag::A, _> = Example { x: 0 };
   //~^ ERROR: expected type, found variant
-  //~| ERROR: type provided when a constant was expected
+  //~| ERROR: unresolved item provided when a constant was expected
 
   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
   //~^ ERROR: type provided when a constant was expected

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -30,44 +30,24 @@ error[E0747]: type provided when a constant was expected
    |
 LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
    |                  ^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, try surrounding it with braces:
-   |
-LL |   let _: Example<{ CompileFlag::A }, _> = Example { x: 0 };
-   |                  ^                ^
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/invalid-enum.rs:33:18
    |
 LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
    |                  ^^^^^^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, try surrounding it with braces:
-   |
-LL |   let _: Example<{ Example::ASSOC_FLAG }, _> = Example { x: 0 };
-   |                  ^                     ^
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/invalid-enum.rs:21:12
    |
 LL |   test_1::<CompileFlag::A>();
    |            ^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, try surrounding it with braces:
-   |
-LL |   test_1::<{ CompileFlag::A }>();
-   |            ^                ^
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/invalid-enum.rs:25:15
    |
 LL |   test_2::<_, CompileFlag::A>(0);
    |               ^^^^^^^^^^^^^^
-   |
-help: if this generic argument was intended as a const parameter, try surrounding it with braces:
-   |
-LL |   test_2::<_, { CompileFlag::A }>(0);
-   |               ^                ^
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/const-generics/invalid-enum.stderr
+++ b/src/test/ui/const-generics/invalid-enum.stderr
@@ -25,29 +25,49 @@ LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
    |                  not a type
    |                  help: try using the variant's enum: `CompileFlag`
 
-error[E0747]: type provided when a constant was expected
+error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/invalid-enum.rs:29:18
    |
 LL |   let _: Example<CompileFlag::A, _> = Example { x: 0 };
    |                  ^^^^^^^^^^^^^^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |   let _: Example<{ CompileFlag::A }, _> = Example { x: 0 };
+   |                  ^                ^
 
 error[E0747]: type provided when a constant was expected
   --> $DIR/invalid-enum.rs:33:18
    |
 LL |   let _: Example<Example::ASSOC_FLAG, _> = Example { x: 0 };
    |                  ^^^^^^^^^^^^^^^^^^^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |   let _: Example<{ Example::ASSOC_FLAG }, _> = Example { x: 0 };
+   |                  ^                     ^
 
-error[E0747]: type provided when a constant was expected
+error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/invalid-enum.rs:21:12
    |
 LL |   test_1::<CompileFlag::A>();
    |            ^^^^^^^^^^^^^^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |   test_1::<{ CompileFlag::A }>();
+   |            ^                ^
 
-error[E0747]: type provided when a constant was expected
+error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/invalid-enum.rs:25:15
    |
 LL |   test_2::<_, CompileFlag::A>(0);
    |               ^^^^^^^^^^^^^^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |   test_2::<_, { CompileFlag::A }>(0);
+   |               ^                ^
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
For now, this adds at least more information so better diagnostics can be emitted for const mismatch errors.

I'm not sure what exactly we want to emit, so I've left notes there temporarily, also to see if this is the right approach

r? @lcnr
cc: @estebank