### PR TITLE
[beta] backports

### DIFF
--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -29,7 +29,7 @@ fn install_sh(
     let prefix = default_path(&builder.config.prefix, "/usr/local");
     let sysconfdir = prefix.join(default_path(&builder.config.sysconfdir, "/etc"));
     let datadir = prefix.join(default_path(&builder.config.datadir, "share"));
-    let docdir = prefix.join(default_path(&builder.config.docdir, "share/doc"));
+    let docdir = prefix.join(default_path(&builder.config.docdir, "share/doc/rust"));
     let mandir = prefix.join(default_path(&builder.config.mandir, "share/man"));
     let libdir = prefix.join(default_path(&builder.config.libdir, "lib"));
     let bindir = prefix.join(&builder.config.bindir); // Default in config.rs

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -962,7 +962,7 @@ impl<'a> Clean<Arguments> for (&'a [hir::Ty<'a>], hir::BodyId) {
                 .iter()
                 .enumerate()
                 .map(|(i, ty)| Argument {
-                    name: Symbol::intern(&rustc_hir_pretty::param_to_string(&body.params[i])),
+                    name: name_from_pat(&body.params[i].pat),
                     type_: ty.clean(cx),
                 })
                 .collect(),

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -409,10 +409,7 @@ crate fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
             );
             return Symbol::intern("()");
         }
-        PatKind::Range(..) => panic!(
-            "tried to get argument name from PatKind::Range, \
-             which is not allowed in function arguments"
-        ),
+        PatKind::Range(..) => return kw::Underscore,
         PatKind::Slice(ref begin, ref mid, ref end) => {
             let begin = begin.iter().map(|p| name_from_pat(&**p).to_string());
             let mid = mid.as_ref().map(|p| format!("..{}", name_from_pat(&**p))).into_iter();

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -315,6 +315,25 @@ crate fn strip_path(path: &Path) -> Path {
     Path { global: path.global, res: path.res, segments }
 }
 
+crate fn qpath_to_string(p: &hir::QPath<'_>) -> String {
+    let segments = match *p {
+        hir::QPath::Resolved(_, ref path) => &path.segments,
+        hir::QPath::TypeRelative(_, ref segment) => return segment.ident.to_string(),
+        hir::QPath::LangItem(lang_item, ..) => return lang_item.name().to_string(),
+    };
+
+    let mut s = String::new();
+    for (i, seg) in segments.iter().enumerate() {
+        if i > 0 {
+            s.push_str("::");
+        }
+        if seg.ident.name != kw::PathRoot {
+            s.push_str(&seg.ident.as_str());
+        }
+    }
+    s
+}
+
 crate fn build_deref_target_impls(cx: &DocContext<'_>, items: &[Item], ret: &mut Vec<Item>) {
     let tcx = cx.tcx;
 
@@ -350,6 +369,57 @@ impl ToSource for rustc_span::Span {
         debug!("got snippet {}", sn);
         sn
     }
+}
+
+crate fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
+    use rustc_hir::*;
+    debug!("trying to get a name from pattern: {:?}", p);
+
+    Symbol::intern(&match p.kind {
+        PatKind::Wild => return kw::Underscore,
+        PatKind::Binding(_, _, ident, _) => return ident.name,
+        PatKind::TupleStruct(ref p, ..) | PatKind::Path(ref p) => qpath_to_string(p),
+        PatKind::Struct(ref name, ref fields, etc) => format!(
+            "{} {{ {}{} }}",
+            qpath_to_string(name),
+            fields
+                .iter()
+                .map(|fp| format!("{}: {}", fp.ident, name_from_pat(&fp.pat)))
+                .collect::<Vec<String>>()
+                .join(", "),
+            if etc { ", .." } else { "" }
+        ),
+        PatKind::Or(ref pats) => pats
+            .iter()
+            .map(|p| name_from_pat(&**p).to_string())
+            .collect::<Vec<String>>()
+            .join(" | "),
+        PatKind::Tuple(ref elts, _) => format!(
+            "({})",
+            elts.iter()
+                .map(|p| name_from_pat(&**p).to_string())
+                .collect::<Vec<String>>()
+                .join(", ")
+        ),
+        PatKind::Box(ref p) => return name_from_pat(&**p),
+        PatKind::Ref(ref p, _) => return name_from_pat(&**p),
+        PatKind::Lit(..) => {
+            warn!(
+                "tried to get argument name from PatKind::Lit, which is silly in function arguments"
+            );
+            return Symbol::intern("()");
+        }
+        PatKind::Range(..) => panic!(
+            "tried to get argument name from PatKind::Range, \
+             which is not allowed in function arguments"
+        ),
+        PatKind::Slice(ref begin, ref mid, ref end) => {
+            let begin = begin.iter().map(|p| name_from_pat(&**p).to_string());
+            let mid = mid.as_ref().map(|p| format!("..{}", name_from_pat(&**p))).into_iter();
+            let end = end.iter().map(|p| name_from_pat(&**p).to_string());
+            format!("[{}]", begin.chain(mid).chain(end).collect::<Vec<_>>().join(", "))
+        }
+    })
 }
 
 crate fn print_const(cx: &DocContext<'_>, n: &'tcx ty::Const<'_>) -> String {

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # stable release's version number. `date` is the date where the release we're
 # bootstrapping off was released.
 
-date: 2021-02-09
+date: 2021-02-11
 rustc: 1.50.0
 
 # We use a nightly rustfmt to format the source because it solves some
@@ -39,4 +39,4 @@ rustc: 1.50.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1

--- a/src/test/rustdoc/mut-params.rs
+++ b/src/test/rustdoc/mut-params.rs
@@ -1,0 +1,18 @@
+// Rustdoc shouldn't display `mut` in function arguments, which are
+// implementation details. Regression test for #81289.
+
+#![crate_name = "foo"]
+
+pub struct Foo;
+
+// @count foo/struct.Foo.html '//*[@class="impl-items"]//*[@class="method"]' 2
+// @!has - '//*[@class="impl-items"]//*[@class="method"]' 'mut'
+impl Foo {
+    pub fn foo(mut self) {}
+
+    pub fn bar(mut bar: ()) {}
+}
+
+// @count foo/fn.baz.html '//*[@class="rust fn"]' 1
+// @!has - '//*[@class="rust fn"]' 'mut'
+pub fn baz(mut foo: Foo) {}

--- a/src/test/rustdoc/range-arg-pattern.rs
+++ b/src/test/rustdoc/range-arg-pattern.rs
@@ -1,5 +1,5 @@
 #![crate_name = "foo"]
 
 // @has foo/fn.f.html
-// @has - '//*[@class="rust fn"]' 'pub fn f(0u8 ...255: u8)'
+// @has - '//*[@class="rust fn"]' 'pub fn f(_: u8)'
 pub fn f(0u8...255: u8) {}

--- a/src/test/ui/parser/issue-81806.rs
+++ b/src/test/ui/parser/issue-81806.rs
@@ -1,0 +1,5 @@
+trait T { const
+impl //~ ERROR: expected identifier, found keyword `impl`
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-81806.stderr
+++ b/src/test/ui/parser/issue-81806.stderr
@@ -1,0 +1,17 @@
+error: expected identifier, found keyword `impl`
+  --> $DIR/issue-81806.rs:2:1
+   |
+LL | trait T { const
+   |         - while parsing this item list starting here
+LL | impl
+   | ^^^^ expected identifier, found keyword
+LL | }
+   | - the item list ends here
+   |
+help: you can escape reserved keywords to use them as identifiers
+   |
+LL | r#impl
+   | ^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This backports some PRs and bumps to the released stable compiler:

* bootstrap: fix wrong docs installation path #81968 
* parser: Fix panic in 'const impl' recovery #81876
* Don't display `mut` in arguments for functions documentation #81831

r? @Mark-Simulacrum 