### PR TITLE
Show macro name in 'this error originates in macro' message

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -309,8 +309,8 @@ pub trait Emitter {
                     // are some which do actually involve macros.
                     ExpnKind::Inlined | ExpnKind::Desugaring(..) | ExpnKind::AstPass(..) => None,
 
-                    ExpnKind::Macro { kind: macro_kind, name: _, proc_macro: _ } => {
-                        Some(macro_kind)
+                    ExpnKind::Macro { kind: macro_kind, name, proc_macro: _ } => {
+                        Some((macro_kind, name))
                     }
                 }
             });
@@ -322,13 +322,12 @@ pub trait Emitter {
         self.render_multispans_macro_backtrace(span, children, backtrace);
 
         if !backtrace {
-            if let Some(macro_kind) = has_macro_spans {
+            if let Some((macro_kind, name)) = has_macro_spans {
+                let descr = macro_kind.descr();
+
                 let msg = format!(
-                    "this {} originates in {} {} \
+                    "this {level} originates in the {descr} `{name}` \
                     (in Nightly builds, run with -Z macro-backtrace for more info)",
-                    level,
-                    macro_kind.article(),
-                    macro_kind.descr(),
                 );
 
                 children.push(SubDiagnostic {

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(backtrace)]
 #![feature(extended_key_value_attributes)]
+#![feature(format_args_capture)]
 #![feature(iter_zip)]
 #![feature(nll)]
 

--- a/src/test/rustdoc-ui/intra-doc/warning.stderr
+++ b/src/test/rustdoc-ui/intra-doc/warning.stderr
@@ -96,7 +96,7 @@ LL | f!("Foo\nbar [BarF] bar\nbaz");
                 ^^^^
    = note: no item named `BarF` in scope
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unresolved link to `error`
   --> $DIR/warning.rs:58:30

--- a/src/test/ui-fulldeps/hash-stable-is-unstable.stderr
+++ b/src/test/ui-fulldeps/hash-stable-is-unstable.stderr
@@ -42,7 +42,7 @@ LL | #[derive(HashStable)]
    |
    = note: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `HashStable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
@@ -21,7 +21,7 @@ LL | custom_lint_pass_macro!();
    | -------------------------- in this macro invocation
    |
    = help: try using `declare_lint_pass!` or `impl_lint_pass!` instead
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `custom_lint_pass_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui-fulldeps/session-derive-errors.stderr
+++ b/src/test/ui-fulldeps/session-derive-errors.stderr
@@ -62,7 +62,7 @@ LL | #[message = "This is missing a closing brace: {name"]
    | ^ expected `'}'` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `SessionDiagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
   --> $DIR/session-derive-errors.rs:119:1
@@ -71,7 +71,7 @@ LL | #[message = "This is missing an opening brace: name}"]
    | ^ unmatched `}` in format string
    |
    = note: if you intended to print `}`, you can escape it using `}}`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `SessionDiagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: The `#[label = ...]` attribute can only be applied to fields of type Span
   --> $DIR/session-derive-errors.rs:138:5

--- a/src/test/ui/allocator/not-an-allocator.stderr
+++ b/src/test/ui/allocator/not-an-allocator.stderr
@@ -5,7 +5,7 @@ LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: required by `std::alloc::GlobalAlloc::alloc`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:1
@@ -14,7 +14,7 @@ LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: required by `std::alloc::GlobalAlloc::dealloc`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:1
@@ -23,7 +23,7 @@ LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: required by `std::alloc::GlobalAlloc::realloc`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
   --> $DIR/not-an-allocator.rs:2:1
@@ -32,7 +32,7 @@ LL | static A: usize = 0;
    | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: required by `std::alloc::GlobalAlloc::alloc_zeroed`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/allocator/two-allocators.stderr
+++ b/src/test/ui/allocator/two-allocators.stderr
@@ -7,7 +7,7 @@ LL | #[global_allocator]
 LL | static B: System = System;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot define a new global allocator
    |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/asm/interpolated-idents.stderr
+++ b/src/test/ui/asm/interpolated-idents.stderr
@@ -9,7 +9,7 @@ LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
    | |____________________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: the `pure` and `noreturn` options are mutually exclusive
   --> $DIR/interpolated-idents.rs:13:13
@@ -22,7 +22,7 @@ LL | |        pure nomem readonly preserves_flags
 LL | |        noreturn nostack att_syntax options);
    | |____________________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm outputs are not allowed with the `noreturn` option
   --> $DIR/interpolated-idents.rs:10:32
@@ -45,7 +45,7 @@ LL | |        noreturn nostack att_syntax options);
    | |____________________________________________in this macro invocation
    |                                              in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/asm/naked-functions.stderr
+++ b/src/test/ui/asm/naked-functions.stderr
@@ -233,7 +233,7 @@ LL |     llvm_asm!("");
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #32408 <https://github.com/rust-lang/rust/issues/32408>
    = help: use the new asm! syntax specified in RFC 2873
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: naked functions must contain a single asm block
   --> $DIR/naked-functions.rs:108:1

--- a/src/test/ui/asm/parse-error.stderr
+++ b/src/test/ui/asm/parse-error.stderr
@@ -154,7 +154,7 @@ error: asm template must be a string literal
 LL |         asm!(format!("{{{}}}", 0), in(reg) foo);
    |              ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
   --> $DIR/parse-error.rs:62:21
@@ -162,7 +162,7 @@ error: asm template must be a string literal
 LL |         asm!("{1}", format!("{{{}}}", 0), in(reg) foo, out(reg) bar);
    |                     ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/parse-error.rs:37:37

--- a/src/test/ui/asm/type-check-2.stderr
+++ b/src/test/ui/asm/type-check-2.stderr
@@ -27,7 +27,7 @@ LL |         asm!("{}", in(reg) vec![0]);
    |                            ^^^^^^^
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use value of type `(i32, i32, i32)` for inline assembly
   --> $DIR/type-check-2.rs:70:28

--- a/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
+++ b/src/test/ui/associated-consts/defaults-not-assumed-fail.stderr
@@ -24,7 +24,7 @@ LL |     assert_eq!(<() as Tr>::B, 0);    // causes the error above
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/async-await/issue-73541-2.stderr
+++ b/src/test/ui/async-await/issue-73541-2.stderr
@@ -11,7 +11,7 @@ LL |                 b!();
    |                 ----- in this macro invocation
    |
    = note: labels are unreachable through functions, closures, async blocks and modules
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/attributes/key-value-expansion.stderr
+++ b/src/test/ui/attributes/key-value-expansion.stderr
@@ -13,7 +13,7 @@ LL |         bug!("bug" + stringify!(found));
 LL | bug!();
    | ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `bug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected token: `{
     let res =
@@ -33,7 +33,7 @@ LL |         doc_comment! {format!("{coor}", coor = stringify!($t1)).as_str()}
 LL | some_macro!(u8);
    | ---------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `some_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/attributes/nonterminal-expansion.stderr
+++ b/src/test/ui/attributes/nonterminal-expansion.stderr
@@ -7,7 +7,7 @@ LL |         #[repr(align($n))]
 LL | pass_nonterminal!(n!());
    | ------------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pass_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/binop/issue-77910-1.stderr
+++ b/src/test/ui/binop/issue-77910-1.stderr
@@ -7,7 +7,7 @@ LL |     assert_eq!(foo, y);
    |     for<'r> fn(&'r i32) -> &'r i32 {foo}
    |     _
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `for<'r> fn(&'r i32) -> &'r i32 {foo}` doesn't implement `Debug`
   --> $DIR/issue-77910-1.rs:8:5
@@ -21,7 +21,7 @@ LL |     T: fmt::Debug + ?Sized,
    |        ---------- required by this bound in `core::panicking::assert_failed`
    |
    = help: the trait `Debug` is not implemented for `for<'r> fn(&'r i32) -> &'r i32 {foo}`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
+++ b/src/test/ui/borrowck/borrowck-borrowed-uniq-rvalue-2.stderr
@@ -9,7 +9,7 @@ LL |     x.x[0];
    |     ------ borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-25793.stderr
+++ b/src/test/ui/borrowck/issue-25793.stderr
@@ -11,7 +11,7 @@ LL |         r.get_size(width!(self))
    |           |
    |           borrow later used by call
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `width` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-64453.stderr
+++ b/src/test/ui/borrowck/issue-64453.stderr
@@ -10,7 +10,7 @@ error[E0015]: calls in statics are limited to constant functions, tuple structs 
 LL | static settings_dir: String = format!("");
    |                               ^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
   --> $DIR/issue-64453.rs:4:31
@@ -18,7 +18,7 @@ error[E0015]: calls in statics are limited to constant functions, tuple structs 
 LL | static settings_dir: String = format!("");
    |                               ^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/move-error-snippets.stderr
+++ b/src/test/ui/borrowck/move-error-snippets.stderr
@@ -12,7 +12,7 @@ LL |         let a = $c;
 LL | sss!();
    | ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `aaa` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/bound-suggestions.stderr
+++ b/src/test/ui/bound-suggestions.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
@@ -18,7 +18,7 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
 LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
@@ -31,7 +31,7 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
@@ -44,7 +44,7 @@ LL |     println!("{:?} {:?}", x, y);
    |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `Y`
    |
 LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
@@ -57,7 +57,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
 LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
@@ -70,7 +70,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `X`
    |
 LL | fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized, X: std::fmt::Debug {

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -4,7 +4,7 @@ error: requires at least a format string argument
 LL |     format!();
    |     ^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `,`, found `1`
   --> $DIR/bad-format-args.rs:3:16

--- a/src/test/ui/codemap_tests/issue-28308.stderr
+++ b/src/test/ui/codemap_tests/issue-28308.stderr
@@ -4,7 +4,7 @@ error[E0600]: cannot apply unary operator `!` to type `&'static str`
 LL |     assert!("foo");
    |     ^^^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -61,7 +61,7 @@ LL |         #[cfg(feature = $expr)]
 LL | generate_s10!(concat!("nonexistent"));
    | -------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_s10` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected unsuffixed literal or identifier, found `concat!("nonexistent")`
   --> $DIR/cfg-attr-syntax-validation.rs:30:25
@@ -72,7 +72,7 @@ LL |         #[cfg(feature = $expr)]
 LL | generate_s10!(concat!("nonexistent"));
    | -------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_s10` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
@@ -7,7 +7,7 @@ LL |         #[cfg_attr(all(), unknown)]
 LL | foo!();
    | ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/macro_rules-braces.full.stderr
+++ b/src/test/ui/const-generics/macro_rules-braces.full.stderr
@@ -30,7 +30,7 @@ LL |     let _: foo!({{ N }});
    |            ------------- in this macro invocation
    |
    = note: this may fail depending on what value the parameter takes
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: constant expression depends on a generic parameter
   --> $DIR/macro_rules-braces.rs:20:13
@@ -42,7 +42,7 @@ LL |     let _: bar!({ N });
    |            ----------- in this macro invocation
    |
    = note: this may fail depending on what value the parameter takes
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: constant expression depends on a generic parameter
   --> $DIR/macro_rules-braces.rs:25:13
@@ -54,7 +54,7 @@ LL |     let _: baz!({{ N }});
    |            ------------- in this macro invocation
    |
    = note: this may fail depending on what value the parameter takes
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `baz` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: constant expression depends on a generic parameter
   --> $DIR/macro_rules-braces.rs:30:13
@@ -66,7 +66,7 @@ LL |     let _: biz!({ N });
    |            ----------- in this macro invocation
    |
    = note: this may fail depending on what value the parameter takes
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `biz` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
+++ b/src/test/ui/const-generics/min_const_generics/macro-fail.stderr
@@ -10,7 +10,7 @@ LL | fn make_marker() -> impl Marker<gimme_a_const!(marker)> {
 LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
   --> $DIR/macro-fail.rs:29:27
@@ -24,7 +24,7 @@ LL |   Example::<gimme_a_const!(marker)>
 LL |       ($rusty: ident) => {{ let $rusty = 3; *&$rusty }}
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gimme_a_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected type, found `{`
   --> $DIR/macro-fail.rs:4:10
@@ -43,7 +43,7 @@ LL |     let _fail = Example::<external_macro!()>;
    |                           this macro call doesn't expand to a type
    |                           in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `external_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of macro invocation
   --> $DIR/macro-fail.rs:39:25

--- a/src/test/ui/consts/const-eval/const_panic.stderr
+++ b/src/test/ui/consts/const-eval/const_panic.stderr
@@ -9,7 +9,7 @@ LL | const Z: () = std::panic!("cheese");
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:11:16
@@ -21,7 +21,7 @@ LL | const Z2: () = std::panic!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:15:15
@@ -33,7 +33,7 @@ LL | const Y: () = std::unreachable!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:19:15
@@ -45,7 +45,7 @@ LL | const X: () = std::unimplemented!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:23:15
@@ -57,7 +57,7 @@ LL | const W: () = std::panic!(MSG);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:27:20
@@ -69,7 +69,7 @@ LL | const Z_CORE: () = core::panic!("cheese");
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:31:21
@@ -81,7 +81,7 @@ LL | const Z2_CORE: () = core::panic!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:35:20
@@ -93,7 +93,7 @@ LL | const Y_CORE: () = core::unreachable!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:39:20
@@ -105,7 +105,7 @@ LL | const X_CORE: () = core::unimplemented!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic.rs:43:20
@@ -117,7 +117,7 @@ LL | const W_CORE: () = core::panic!(MSG);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
+++ b/src/test/ui/consts/const-eval/const_panic_libcore_bin.stderr
@@ -9,7 +9,7 @@ LL | const Z: () = panic!("cheese");
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic_libcore_bin.rs:13:15
@@ -21,7 +21,7 @@ LL | const Y: () = unreachable!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: any use of this value will cause an error
   --> $DIR/const_panic_libcore_bin.rs:17:15
@@ -33,7 +33,7 @@ LL | const X: () = unimplemented!();
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
+++ b/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
@@ -6,7 +6,7 @@ LL | const Z: () = panic!("cheese");
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: panicking in constants is unstable
   --> $DIR/feature-gate-const_panic.rs:6:15
@@ -16,7 +16,7 @@ LL | const Y: () = unreachable!();
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: panicking in constants is unstable
   --> $DIR/feature-gate-const_panic.rs:9:15
@@ -26,7 +26,7 @@ LL | const X: () = unimplemented!();
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type.stderr
@@ -13,7 +13,7 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
   --> $DIR/panic-assoc-never-type.rs:17:13

--- a/src/test/ui/consts/const-eval/panic-never-type.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type.stderr
@@ -13,7 +13,7 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: erroneous constant used
   --> $DIR/panic-never-type.rs:13:13

--- a/src/test/ui/consts/const-eval/unwind-abort.stderr
+++ b/src/test/ui/consts/const-eval/unwind-abort.stderr
@@ -14,7 +14,7 @@ LL | const _: () = foo();
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-external-macro-const-err.stderr
+++ b/src/test/ui/consts/const-external-macro-const-err.stderr
@@ -7,7 +7,7 @@ LL |     static_assert!(2 + 2 == 5);
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `static_assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-unwrap.stderr
+++ b/src/test/ui/consts/const-unwrap.stderr
@@ -16,7 +16,7 @@ LL | const BAR: i32 = Option::<i32>::None.unwrap();
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
+++ b/src/test/ui/consts/const_unsafe_unreachable_ub.stderr
@@ -37,7 +37,7 @@ LL |   assert_eq!(BAR, true);
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/consts/control-flow/assert.const_panic.stderr
+++ b/src/test/ui/consts/control-flow/assert.const_panic.stderr
@@ -9,7 +9,7 @@ LL | const _: () = assert!(false);
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/control-flow/assert.stock.stderr
+++ b/src/test/ui/consts/control-flow/assert.stock.stderr
@@ -6,7 +6,7 @@ LL | const _: () = assert!(true);
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: panicking in constants is unstable
   --> $DIR/assert.rs:10:15
@@ -16,7 +16,7 @@ LL | const _: () = assert!(false);
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/control-flow/issue-50577.stderr
+++ b/src/test/ui/consts/control-flow/issue-50577.stderr
@@ -6,7 +6,7 @@ LL |         Drop = assert_eq!(1, 1),
    |
    = note: `if` expressions without `else` evaluate to `()`
    = help: consider adding an `else` block that evaluates to the expected type
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/enum-discr-type-err.stderr
+++ b/src/test/ui/consts/enum-discr-type-err.stderr
@@ -10,7 +10,7 @@ LL | |     B = T,
 LL | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/enum-discr-type-err.rs:18:21
@@ -24,7 +24,7 @@ LL | |     B = T,
 LL | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/inline_asm.stderr
+++ b/src/test/ui/consts/inline_asm.stderr
@@ -4,7 +4,7 @@ error[E0015]: inline assembly is not allowed in constants
 LL | const _: () = unsafe { llvm_asm!("nop") };
    |                        ^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-32829.stderr
+++ b/src/test/ui/consts/issue-32829.stderr
@@ -6,7 +6,7 @@ LL | static S : u64 = { { panic!("foo"); 0 } };
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-66693-panic-in-array-len.stderr
+++ b/src/test/ui/consts/issue-66693-panic-in-array-len.stderr
@@ -4,7 +4,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL |     let _ = [0i32; panic!(2f32)];
    |                    ^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-66693-panic-in-array-len.rs:12:21
@@ -12,7 +12,7 @@ error[E0080]: evaluation of constant value failed
 LL |     let _ = [false; panic!()];
    |                     ^^^^^^^^ the evaluated program panicked at 'explicit panic', $DIR/issue-66693-panic-in-array-len.rs:12:21
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/issue-66693.stderr
+++ b/src/test/ui/consts/issue-66693.stderr
@@ -4,7 +4,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL |     panic!(&1);
    |     ^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:6:15
@@ -12,7 +12,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL | const _: () = panic!(1);
    |               ^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument to `panic!()` in a const context must have type `&str`
   --> $DIR/issue-66693.rs:9:19
@@ -20,7 +20,7 @@ error: argument to `panic!()` in a const context must have type `&str`
 LL | static _FOO: () = panic!(true);
    |                   ^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/issue-76064.stderr
+++ b/src/test/ui/consts/issue-76064.stderr
@@ -6,7 +6,7 @@ LL | struct Bug([u8; panic!("panic")]);
    |
    = note: see issue #51999 <https://github.com/rust-lang/rust/issues/51999> for more information
    = help: add `#![feature(const_panic)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -4,7 +4,7 @@ error[E0010]: allocations are not allowed in constant functions
 LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^ allocation not allowed in constant functions
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
   --> $DIR/bad_const_fn_body_ice.rs:2:5
@@ -12,7 +12,7 @@ error[E0015]: calls in constant functions are limited to constant functions, tup
 LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
@@ -177,7 +177,7 @@ help: skipping check that does not even have a feature gate
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors; 3 warnings emitted
 

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
@@ -177,7 +177,7 @@ help: skipping check that does not even have a feature gate
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors; 3 warnings emitted
 

--- a/src/test/ui/consts/miri_unleashed/inline_asm.stderr
+++ b/src/test/ui/consts/miri_unleashed/inline_asm.stderr
@@ -4,7 +4,7 @@ error[E0080]: could not evaluate static initializer
 LL |     unsafe { llvm_asm!("xor %eax, %eax" ::: "eax"); }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inline assembly is not supported
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0080]: could not evaluate static initializer
   --> $DIR/inline_asm.rs:19:14
@@ -24,7 +24,7 @@ help: skipping check that does not even have a feature gate
    |
 LL |     unsafe { asm!("nop"); }
    |              ^^^^^^^^^^^^
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
+++ b/src/test/ui/cross/cross-crate-macro-backtrace/main.stderr
@@ -4,7 +4,7 @@ error: 1 positional argument in format string, but no arguments were given
 LL |     myprintln!("{}");
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/cross/cross-file-errors/main.stderr
+++ b/src/test/ui/cross/cross-file-errors/main.stderr
@@ -11,7 +11,7 @@ LL |     underscore!();
    |
    = note: see issue #71126 <https://github.com/rust-lang/rust/issues/71126> for more information
    = help: add `#![feature(destructuring_assignment)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `underscore` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: in expressions, `_` can only be used on the left-hand side of an assignment
   --> $DIR/underscore.rs:8:9
@@ -24,7 +24,7 @@ LL |         _
 LL |     underscore!();
    |     -------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `underscore` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/custom_test_frameworks/mismatch.stderr
+++ b/src/test/ui/custom_test_frameworks/mismatch.stderr
@@ -5,7 +5,7 @@ LL | fn wrong_kind(){}
    | ^^^^^^^^^^^^^^^^^ the trait `Testable` is not implemented for `TestDescAndFn`
    |
    = note: required for the cast to the object type `dyn Testable`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/deprecation/deprecation-lint-2.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-2.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `macro_test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/deprecation/deprecation-lint-3.stderr
+++ b/src/test/ui/deprecation/deprecation-lint-3.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `macro_test_arg_nested` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/deref-suggestion.stderr
+++ b/src/test/ui/deref-suggestion.stderr
@@ -43,7 +43,7 @@ LL |     ($x:expr) => { &$x }
 LL |     foo3(borrow!(0));
    |          ---------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `borrow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:36:5
@@ -51,7 +51,7 @@ error[E0308]: mismatched types
 LL |     assert_eq!(3i32, &3i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `&i32`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:39:17

--- a/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
@@ -5,7 +5,7 @@ LL |      x: Error
    |      ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: required by `clone`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Clone-enum.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum.stderr
@@ -5,7 +5,7 @@ LL |      Error
    |      ^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: required by `clone`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Clone-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-struct.stderr
@@ -5,7 +5,7 @@ LL |     x: Error
    |     ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: required by `clone`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
@@ -5,7 +5,7 @@ LL |     Error
    |     ^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: required by `clone`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
@@ -8,7 +8,7 @@ LL |      x: Error
    = note: add `#[derive(Debug)]` or manually implement `Debug`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-enum.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum.stderr
@@ -8,7 +8,7 @@ LL |      Error
    = note: add `#[derive(Debug)]` or manually implement `Debug`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-struct.stderr
@@ -8,7 +8,7 @@ LL |     x: Error
    = note: add `#[derive(Debug)]` or manually implement `Debug`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
@@ -8,7 +8,7 @@ LL |     Error
    = note: add `#[derive(Debug)]` or manually implement `Debug`
    = note: required because of the requirements on the impl of `Debug` for `&Error`
    = note: required for the cast to the object type `dyn Debug`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Default-struct.stderr
+++ b/src/test/ui/derives/derives-span-Default-struct.stderr
@@ -5,7 +5,7 @@ LL |     x: Error
    |     ^^^^^^^^ the trait `Default` is not implemented for `Error`
    |
    = note: required by `std::default::Default::default`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Default-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Default-tuple-struct.stderr
@@ -5,7 +5,7 @@ LL |     Error
    |     ^^^^^ the trait `Default` is not implemented for `Error`
    |
    = note: required by `std::default::Default::default`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -9,7 +9,7 @@ LL |      x: Error
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               -- required by this bound in `AssertParamIsEq`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-enum.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum.stderr
@@ -9,7 +9,7 @@ LL |      Error
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               -- required by this bound in `AssertParamIsEq`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-struct.stderr
@@ -9,7 +9,7 @@ LL |     x: Error
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               -- required by this bound in `AssertParamIsEq`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -9,7 +9,7 @@ LL |     Error
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               -- required by this bound in `AssertParamIsEq`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -9,7 +9,7 @@ LL |      x: Error
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
    |             - required by this bound in `std::hash::Hash::hash`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -9,7 +9,7 @@ LL |      Error
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
    |             - required by this bound in `std::hash::Hash::hash`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-struct.stderr
@@ -9,7 +9,7 @@ LL |     x: Error
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
    |             - required by this bound in `std::hash::Hash::hash`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -9,7 +9,7 @@ LL |     Error
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
    |             - required by this bound in `std::hash::Hash::hash`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Ord-enum-struct-variant.stderr
@@ -5,7 +5,7 @@ LL |      x: Error
    |      ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-enum.stderr
+++ b/src/test/ui/derives/derives-span-Ord-enum.stderr
@@ -5,7 +5,7 @@ LL |      Error
    |      ^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-struct.stderr
+++ b/src/test/ui/derives/derives-span-Ord-struct.stderr
@@ -5,7 +5,7 @@ LL |     x: Error
    |     ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Ord-tuple-struct.stderr
@@ -5,7 +5,7 @@ LL |     Error
    |     ^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum-struct-variant.stderr
@@ -5,7 +5,7 @@ LL |      x: Error
    |      ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum-struct-variant.rs:9:6
@@ -14,7 +14,7 @@ LL |      x: Error
    |      ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-enum.stderr
@@ -5,7 +5,7 @@ LL |      Error
    |      ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-enum.rs:9:6
@@ -14,7 +14,7 @@ LL |      Error
    |      ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-struct.stderr
@@ -5,7 +5,7 @@ LL |     x: Error
    |     ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-struct.rs:8:5
@@ -14,7 +14,7 @@ LL |     x: Error
    |     ^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialEq-tuple-struct.stderr
@@ -5,7 +5,7 @@ LL |     Error
    |     ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `Error`
   --> $DIR/derives-span-PartialEq-tuple-struct.rs:8:5
@@ -14,7 +14,7 @@ LL |     Error
    |     ^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `Error`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
@@ -6,7 +6,7 @@ LL |      x: Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
@@ -6,7 +6,7 @@ LL |      Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
@@ -6,7 +6,7 @@ LL |     x: Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
@@ -6,7 +6,7 @@ LL |     Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -5,7 +5,7 @@ LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `!=` cannot be applied to type `NoCloneOrEq`
   --> $DIR/deriving-no-inner-impl-error-message.rs:5:5
@@ -14,7 +14,7 @@ LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^
    |
    = note: an implementation of `std::cmp::PartialEq` might be missing for `NoCloneOrEq`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NoCloneOrEq: Clone` is not satisfied
   --> $DIR/deriving-no-inner-impl-error-message.rs:10:5
@@ -23,7 +23,7 @@ LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NoCloneOrEq`
    |
    = note: required by `clone`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/derives/deriving-with-repr-packed.stderr
+++ b/src/test/ui/derives/deriving-with-repr-packed.stderr
@@ -11,7 +11,7 @@ LL | #![deny(unaligned_references)]
    |         ^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[derive]` can't be used on a `#[repr(packed)]` struct with type or const parameters (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:8:23
@@ -21,7 +21,7 @@ LL | #[derive(Copy, Clone, PartialEq, Eq)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:16:10
@@ -31,7 +31,7 @@ LL | #[derive(PartialEq, Eq)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:25:10
@@ -41,7 +41,7 @@ LL | #[derive(PartialEq)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/did_you_mean/bad-assoc-expr.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-expr.stderr
@@ -55,7 +55,7 @@ LL |     ($ty: ty) => ($ty::clone(&0))
 LL |     expr!(u8);
    |     ---------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/did_you_mean/bad-assoc-pat.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-pat.stderr
@@ -37,7 +37,7 @@ LL |     ($ty: ty) => ($ty::AssocItem)
 LL |         pat!(u8) => {}
    |         -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no associated item named `AssocItem` found for slice `[u8]` in the current scope
   --> $DIR/bad-assoc-pat.rs:3:15
@@ -72,7 +72,7 @@ LL |     ($ty: ty) => ($ty::AssocItem)
 LL |         pat!(u8) => {}
    |         -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no associated item named `AssocItem` found for type `u8` in the current scope
   --> $DIR/bad-assoc-pat.rs:32:16

--- a/src/test/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/src/test/ui/did_you_mean/bad-assoc-ty.stderr
@@ -55,7 +55,7 @@ LL |     ($ty: ty) => ($ty::AssocTy);
 LL | type J = ty!(u8);
    |          ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ty` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0223]: ambiguous associated type
   --> $DIR/bad-assoc-ty.rs:1:10
@@ -114,7 +114,7 @@ LL |     ($ty: ty) => ($ty::AssocTy);
 LL | type J = ty!(u8);
    |          ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ty` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0223]: ambiguous associated type
   --> $DIR/bad-assoc-ty.rs:44:10

--- a/src/test/ui/did_you_mean/recursion_limit_macro.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit_macro.stderr
@@ -8,7 +8,7 @@ LL |     recurse!(0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9);
    |     -------------------------------------------------- in this macro invocation
    |
    = help: consider adding a `#![recursion_limit="20"]` attribute to your crate (`recursion_limit_macro`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `recurse` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/directory_ownership/macro-expanded-mod.stderr
+++ b/src/test/ui/directory_ownership/macro-expanded-mod.stderr
@@ -7,7 +7,7 @@ LL |         mod $i;
 LL |     mod_decl!(foo);
    |     --------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mod_decl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/dollar-crate/dollar-crate-is-keyword-2.stderr
+++ b/src/test/ui/dollar-crate/dollar-crate-is-keyword-2.stderr
@@ -7,7 +7,7 @@ LL |         use a::$crate::b;
 LL | m!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0432]: unresolved import `a::$crate`
   --> $DIR/dollar-crate-is-keyword-2.rs:5:13
@@ -18,7 +18,7 @@ LL |         use a::$crate;
 LL | m!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0433]: failed to resolve: `$crate` in paths can only be used in start position
   --> $DIR/dollar-crate-is-keyword-2.rs:7:21
@@ -29,7 +29,7 @@ LL |         type A = a::$crate;
 LL | m!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/dollar-crate/dollar-crate-is-keyword.stderr
+++ b/src/test/ui/dollar-crate/dollar-crate-is-keyword.stderr
@@ -7,7 +7,7 @@ LL |             struct $crate {}
 LL | m!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier, found reserved identifier `$crate`
   --> $DIR/dollar-crate-is-keyword.rs:10:23
@@ -18,7 +18,7 @@ LL |         use $crate as $crate;
 LL | m!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `$crate` may not be imported
   --> $DIR/dollar-crate-is-keyword.rs:9:9
@@ -29,7 +29,7 @@ LL |         use $crate;
 LL | m!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `$crate` may not be imported
   --> $DIR/dollar-crate-is-keyword.rs:10:9
@@ -40,7 +40,7 @@ LL |         use $crate as $crate;
 LL | m!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/editions/edition-imports-2015.stderr
+++ b/src/test/ui/editions/edition-imports-2015.stderr
@@ -4,7 +4,7 @@ error: cannot glob-import all possible crates
 LL |     gen_glob!();
    |     ^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_glob` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/edition-imports-2018.stderr
+++ b/src/test/ui/editions/edition-imports-2018.stderr
@@ -4,7 +4,7 @@ error: cannot glob-import all possible crates
 LL |     gen_glob!();
    |     ^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_glob` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
+++ b/src/test/ui/editions/edition-imports-virtual-2015-gated.stderr
@@ -4,7 +4,7 @@ error[E0432]: unresolved import `E`
 LL |     gen_gated!();
    |     ^^^^^^^^^^^^^ could not find `E` in the list of imported crates
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gated` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
@@ -4,7 +4,7 @@ error: expected identifier, found keyword `async`
 LL |     produces_async! {}
    |     ^^^^^^^^^^^^^^^^^^ expected identifier, found keyword
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `produces_async` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     () => (pub fn r#async() {})

--- a/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
@@ -4,7 +4,7 @@ error: expected identifier, found keyword `async`
 LL |     produces_async! {}
    |     ^^^^^^^^^^^^^^^^^^ expected identifier, found keyword
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `produces_async` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     () => (pub fn r#async() {})

--- a/src/test/ui/error-codes/E0184.stderr
+++ b/src/test/ui/error-codes/E0184.stderr
@@ -4,7 +4,7 @@ error[E0184]: the trait `Copy` may not be implemented for this type; the type ha
 LL | #[derive(Copy)]
    |          ^^^^ Copy not allowed on types with destructors
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0665.stderr
+++ b/src/test/ui/error-codes/E0665.stderr
@@ -4,7 +4,7 @@ error[E0665]: `Default` cannot be derived for enums, only structs
 LL | #[derive(Default)]
    |          ^^^^^^^
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/exclusive-drop-and-copy.stderr
+++ b/src/test/ui/exclusive-drop-and-copy.stderr
@@ -4,7 +4,7 @@ error[E0184]: the trait `Copy` may not be implemented for this type; the type ha
 LL | #[derive(Copy, Clone)]
    |          ^^^^ Copy not allowed on types with destructors
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0184]: the trait `Copy` may not be implemented for this type; the type has a destructor
   --> $DIR/exclusive-drop-and-copy.rs:10:10
@@ -12,7 +12,7 @@ error[E0184]: the trait `Copy` may not be implemented for this type; the type ha
 LL | #[derive(Copy, Clone)]
    |          ^^^^ Copy not allowed on types with destructors
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/expr/if/if-let.stderr
+++ b/src/test/ui/expr/if/if-let.stderr
@@ -12,7 +12,7 @@ LL | |     });
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:6:13
@@ -27,7 +27,7 @@ LL | |     });
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:26:5

--- a/src/test/ui/extenv/extenv-not-defined-custom.stderr
+++ b/src/test/ui/extenv/extenv-not-defined-custom.stderr
@@ -4,7 +4,7 @@ error: my error message
 LL | fn main() { env!("__HOPEFULLY_NOT_DEFINED__", "my error message"); }
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/extenv/extenv-not-defined-default.stderr
+++ b/src/test/ui/extenv/extenv-not-defined-default.stderr
@@ -4,7 +4,7 @@ error: environment variable `__HOPEFULLY_NOT_DEFINED__` not defined
 LL |     env!("__HOPEFULLY_NOT_DEFINED__");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/extenv/issue-55897.stderr
+++ b/src/test/ui/extenv/issue-55897.stderr
@@ -4,7 +4,7 @@ error: environment variable `NON_EXISTENT` not defined
 LL |     include!(concat!(env!("NON_EXISTENT"), "/data.rs"));
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: suffixes on a string literal are invalid
   --> $DIR/issue-55897.rs:16:22

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
@@ -8,7 +8,7 @@ LL | bar!();
    | ------- in this macro invocation
    |
    = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
@@ -8,7 +8,7 @@ LL | bar!();
    | ------- in this macro invocation
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -13,7 +13,7 @@ error[E0425]: cannot find value `ab` in this scope
 LL |     concat_idents!(a, b);
    |     ^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat_idents` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/thread-local-const-init.stderr
+++ b/src/test/ui/feature-gates/thread-local-const-init.stderr
@@ -6,7 +6,7 @@ LL | thread_local!(static X: u32 = const { 0 });
    |
    = note: see issue #84223 <https://github.com/rust-lang/rust/issues/84223> for more information
    = help: add `#![feature(thread_local_const_init)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/trace_macros-gate.stderr
+++ b/src/test/ui/feature-gates/trace_macros-gate.stderr
@@ -42,7 +42,7 @@ LL |     expando!(true);
    |
    = note: see issue #29598 <https://github.com/rust-lang/rust/issues/29598> for more information
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `expando` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/fmt/format-args-capture-macro-hygiene.stderr
+++ b/src/test/ui/fmt/format-args-capture-macro-hygiene.stderr
@@ -6,7 +6,7 @@ LL |     format!(concat!("{foo}"));
    |
    = note: did you intend to capture a variable `foo` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: there is no argument named `bar`
   --> $DIR/format-args-capture-macro-hygiene.rs:5:13
@@ -16,7 +16,7 @@ LL |     format!(concat!("{ba", "r} {}"), 1);
    |
    = note: did you intend to capture a variable `bar` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/fmt/ifmt-bad-arg.stderr
+++ b/src/test/ui/fmt/ifmt-bad-arg.stderr
@@ -310,7 +310,7 @@ LL |     println!("{} {:.*} {}", 1, 3.2, 4);
    |
    = note: expected reference `&usize`
               found reference `&{float}`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/ifmt-bad-arg.rs:81:35
@@ -320,7 +320,7 @@ LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
    |
    = note: expected reference `&usize`
               found reference `&{float}`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 36 previous errors
 

--- a/src/test/ui/fmt/ifmt-bad-format-args.stderr
+++ b/src/test/ui/fmt/ifmt-bad-format-args.stderr
@@ -4,7 +4,7 @@ error: requires at least a format string argument
 LL |     format_args!();
    |     ^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: format argument must be a string literal
   --> $DIR/ifmt-bad-format-args.rs:3:18

--- a/src/test/ui/fmt/ifmt-unimpl.stderr
+++ b/src/test/ui/fmt/ifmt-unimpl.stderr
@@ -6,7 +6,7 @@ LL |     format!("{:X}", "3");
    |
    = note: required because of the requirements on the impl of `UpperHex` for `&str`
    = note: required by `std::fmt::UpperHex::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-dotdotdot-bad-syntax.stderr
@@ -31,7 +31,7 @@ LL |             let ...$e;
 LL |     mac!(0);
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-inclusive-no-end.stderr
@@ -40,7 +40,7 @@ LL |     mac!(0);
    |     -------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-inclusive-no-end.rs:21:19
@@ -52,7 +52,7 @@ LL |     mac!(0);
    |     -------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.nll.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.nll.stderr
@@ -8,7 +8,7 @@ LL | / check! { bound_a_b_ret_a_vs_bound_a_ret_a: (for<'a,'b> fn(&'a u32, &'b u3
 LL | | for<'a>    fn(&'a u32, &'a u32) -> &'a u32) }
    | |_____________________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_a_b_ret_a_vs_bound_a_ret_a.stderr
@@ -10,7 +10,7 @@ LL | | for<'a>    fn(&'a u32, &'a u32) -> &'a u32) }
    |
    = note: expected enum `Option<for<'a, 'b> fn(&'a u32, &'b u32) -> &'a u32>`
               found enum `Option<for<'a> fn(&'a u32, &'a u32) -> &'a u32>`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_free_x.nll.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_free_x.nll.stderr
@@ -8,7 +8,7 @@ LL | / check! { bound_a_vs_free_x: (for<'a> fn(&'a u32),
 LL | | fn(&'x u32)) }
    | |______________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_free_x.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_a_vs_free_x.stderr
@@ -10,7 +10,7 @@ LL | | fn(&'x u32)) }
    |
    = note: expected enum `Option<for<'a> fn(&'a u32)>`
               found enum `Option<fn(&'x u32)>`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.nll.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.nll.stderr
@@ -8,7 +8,7 @@ LL | / check! { bound_inv_a_b_vs_bound_inv_a: (for<'a,'b> fn(Inv<'a>, Inv<'b>),
 LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
    | |__________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: higher-ranked subtype error
   --> $DIR/hr-subtype.rs:45:13
@@ -20,7 +20,7 @@ LL | / check! { bound_inv_a_b_vs_bound_inv_a: (for<'a,'b> fn(Inv<'a>, Inv<'b>),
 LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
    | |__________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hr-subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.bound_inv_a_b_vs_bound_inv_a.stderr
@@ -10,7 +10,7 @@ LL | | for<'a>    fn(Inv<'a>, Inv<'a>)) }
    |
    = note: expected enum `Option<for<'a, 'b> fn(Inv<'a>, Inv<'b>)>`
               found enum `Option<for<'a> fn(Inv<'a>, Inv<'a>)>`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.nll.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.nll.stderr
@@ -13,7 +13,7 @@ LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
    |
    = help: consider adding the following bound: `'x: 'y`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: lifetime may not live long enough
   --> $DIR/hr-subtype.rs:45:13
@@ -30,7 +30,7 @@ LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
    |
    = help: consider adding the following bound: `'x: 'y`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_inv_x_vs_free_inv_y.stderr
@@ -28,7 +28,7 @@ LL |           fn subtype<'x, 'y: 'x, 'z: 'y>() {
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/hr-subtype.rs:45:26
@@ -60,7 +60,7 @@ LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
 LL | / check! { free_inv_x_vs_free_inv_y: (fn(Inv<'x>),
 LL | | fn(Inv<'y>)) }
    | |______________- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.nll.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.nll.stderr
@@ -13,7 +13,7 @@ LL | | fn(&'y u32)) }
    | |______________- in this macro invocation
    |
    = help: consider adding the following bound: `'x: 'y`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.stderr
+++ b/src/test/ui/hr-subtype/hr-subtype.free_x_vs_free_y.stderr
@@ -28,7 +28,7 @@ LL |           fn supertype<'x, 'y: 'x, 'z: 'y>() {
 LL | / check! { free_x_vs_free_y: (fn(&'x u32),
 LL | | fn(&'y u32)) }
    | |______________- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/assoc_item_ctxt.stderr
+++ b/src/test/ui/hygiene/assoc_item_ctxt.stderr
@@ -7,7 +7,7 @@ LL |             fn method() {}
 LL |     mac_trait_impl!();
    |     ------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac_trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0046]: not all trait items implemented, missing: `method`
   --> $DIR/assoc_item_ctxt.rs:34:9
@@ -21,7 +21,7 @@ LL |         impl Tr for u8 {
 LL |     mac_trait_impl!();
    |     ------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac_trait_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hygiene/duplicate_lifetimes.stderr
+++ b/src/test/ui/hygiene/duplicate_lifetimes.stderr
@@ -10,7 +10,7 @@ LL | m!('a);
    | |  previous declaration here
    | in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0263]: lifetime name `'a` declared twice in the same scope
   --> $DIR/duplicate_lifetimes.rs:13:14
@@ -24,7 +24,7 @@ LL | n!('a);
    | |  previous declaration here
    | in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
+++ b/src/test/ui/hygiene/extern-prelude-from-opaque-fail.stderr
@@ -16,7 +16,7 @@ LL |         use my_core;
 LL | a!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:11:18
@@ -27,7 +27,7 @@ LL |         fn f() { my_core::mem::drop(0); }
 LL | a!();
    | ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:24:14

--- a/src/test/ui/hygiene/fields-definition.stderr
+++ b/src/test/ui/hygiene/fields-definition.stderr
@@ -9,7 +9,7 @@ LL |             $a: u8,
 LL | legacy!(a);
    | ----------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/fields-move.stderr
+++ b/src/test/ui/hygiene/fields-move.stderr
@@ -10,7 +10,7 @@ LL |     assert_two_copies(copy_legacy!(foo), foo.x);
    |                       ----------------- in this macro invocation
    |
    = note: move occurs because `foo.x` has type `NonCopy`, which does not implement the `Copy` trait
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `copy_legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0382]: use of moved value: `foo.x`
   --> $DIR/fields-move.rs:28:42

--- a/src/test/ui/hygiene/fields.stderr
+++ b/src/test/ui/hygiene/fields.stderr
@@ -7,7 +7,7 @@ LL |         let s = S { x: 0 };
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `foo::S` is private
   --> $DIR/fields.rs:16:17
@@ -18,7 +18,7 @@ LL |         let _ = s.x;
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `T` is private
   --> $DIR/fields.rs:18:17
@@ -29,7 +29,7 @@ LL |         let t = T(0);
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `T` is private
   --> $DIR/fields.rs:19:17
@@ -40,7 +40,7 @@ LL |         let _ = t.0;
 LL |     let s = foo::m!(S, x);
    |             ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/hygiene/generate-mod.stderr
+++ b/src/test/ui/hygiene/generate-mod.stderr
@@ -19,7 +19,7 @@ LL |         type A = FromOutside;
 LL |     genmod_transparent!();
    |     ---------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `genmod_transparent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:20:22
@@ -30,7 +30,7 @@ LL |         type Inner = Outer;
 LL |     genmod_transparent!();
    |     ---------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `genmod_transparent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:28:18
@@ -41,7 +41,7 @@ LL |         type A = FromOutside;
 LL |     genmod_legacy!();
    |     ----------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `genmod_legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:29:22
@@ -52,7 +52,7 @@ LL |         type Inner = Outer;
 LL |     genmod_legacy!();
    |     ----------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `genmod_legacy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/hygiene/globs.stderr
+++ b/src/test/ui/hygiene/globs.stderr
@@ -22,7 +22,7 @@ LL | |         f();
 LL | |     }
    | |_____- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this function
    |
 LL | use bar::g;
@@ -39,7 +39,7 @@ LL |         n!(f);
    |
    = note: consider importing one of these items:
            foo::f
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find function `f` in this scope
   --> $DIR/globs.rs:65:17
@@ -52,7 +52,7 @@ LL |                 f
    |
    = note: consider importing one of these items:
            foo::f
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `n` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/hygiene/hygienic-label-1.stderr
+++ b/src/test/ui/hygiene/hygienic-label-1.stderr
@@ -7,7 +7,7 @@ LL |     () => { break 'x; }
 LL |     'x: loop { foo!() }
    |                ------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/hygienic-label-3.stderr
+++ b/src/test/ui/hygiene/hygienic-label-3.stderr
@@ -7,7 +7,7 @@ LL |     () => { break 'x; }
 LL |         foo!()
    |         ------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/hygienic-labels-in-let.stderr
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.stderr
@@ -10,7 +10,7 @@ LL |             // this 'x should refer to the outer loop, lexically
 LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:64:9
@@ -42,7 +42,7 @@ LL |         'x: loop {
 LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:16:9
@@ -56,7 +56,7 @@ LL |         'x: loop { $e }
 LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:16:9
@@ -70,7 +70,7 @@ LL |         'x: for _ in 0..1 {
 LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:76:9
@@ -120,7 +120,7 @@ LL |         'x: loop {
 LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:27:9
@@ -134,7 +134,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
 LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:27:9
@@ -148,7 +148,7 @@ LL |         'x: for _ in 0..1 {
 LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:27:9
@@ -162,7 +162,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
 LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:27:9
@@ -176,7 +176,7 @@ LL |         'x: for _ in 0..1 {
 LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_true` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:90:9
@@ -244,7 +244,7 @@ LL |         'x: loop {
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:39:9
@@ -258,7 +258,7 @@ LL |         'x: for _ in 0..1 { $e }
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:39:9
@@ -272,7 +272,7 @@ LL |         'x: for _ in 0..1 {
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:39:9
@@ -286,7 +286,7 @@ LL |         'x: for _ in 0..1 { $e }
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:39:9
@@ -300,7 +300,7 @@ LL |         'x: for _ in 0..1 {
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:39:9
@@ -314,7 +314,7 @@ LL |         'x: for _ in 0..1 { $e }
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels-in-let.rs:39:9
@@ -328,7 +328,7 @@ LL |         'x: for _ in 0..1 {
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 28 warnings emitted
 

--- a/src/test/ui/hygiene/hygienic-labels.stderr
+++ b/src/test/ui/hygiene/hygienic-labels.stderr
@@ -10,7 +10,7 @@ LL |         // this 'x should refer to the outer loop, lexically
 LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:54:5
@@ -42,7 +42,7 @@ LL |     'x: for _ in 0..1 {
 LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:13:9
@@ -56,7 +56,7 @@ LL |         'x: loop { $e }
 LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:13:9
@@ -70,7 +70,7 @@ LL |     'x: loop {
 LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `loop_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:63:5
@@ -120,7 +120,7 @@ LL |     'x: for _ in 0..1 {
 LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:38:9
@@ -134,7 +134,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
 LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:38:9
@@ -148,7 +148,7 @@ LL |     'x: loop {
 LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:38:9
@@ -162,7 +162,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
 LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:38:9
@@ -176,7 +176,7 @@ LL |     'x: while 1 + 1 == 2 {
 LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `while_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:73:5
@@ -244,7 +244,7 @@ LL |     'x: for _ in 0..1 {
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:24:9
@@ -258,7 +258,7 @@ LL |         'x: for _ in 0..1 { $e }
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:24:9
@@ -272,7 +272,7 @@ LL |     'x: loop {
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:24:9
@@ -286,7 +286,7 @@ LL |         'x: for _ in 0..1 { $e }
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:24:9
@@ -300,7 +300,7 @@ LL |     'x: while 1 + 1 == 2 {
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:24:9
@@ -314,7 +314,7 @@ LL |         'x: while 1 + 1 == 2 { $e }
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: label name `'x` shadows a label name that is already in scope
   --> $DIR/hygienic-labels.rs:24:9
@@ -328,7 +328,7 @@ LL |     'x: for _ in 0..1 {
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `run_once` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 28 warnings emitted
 

--- a/src/test/ui/hygiene/impl_items.stderr
+++ b/src/test/ui/hygiene/impl_items.stderr
@@ -7,7 +7,7 @@ LL |         let _: () = S.f();
 LL |     foo::m!();
    |     ---------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/intercrate.stderr
+++ b/src/test/ui/hygiene/intercrate.stderr
@@ -4,7 +4,7 @@ error: type `fn() -> u32 {foo::bar::f}` is private
 LL |     assert_eq!(intercrate::foo::m!(), 1);
    |                ^^^^^^^^^^^^^^^^^^^^^ private type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `intercrate::foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/missing-self-diag.stderr
+++ b/src/test/ui/hygiene/missing-self-diag.stderr
@@ -10,7 +10,7 @@ LL | |         call_bar!();
 LL | |     }
    | |_____- this function has a `self` parameter, but a macro invocation can only access identifiers it receives from parameters
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `call_bar` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -7,7 +7,7 @@ LL |     fn f() { ::bar::m!(); }
 LL |         Vec::new();
    |         ^^^ not found in this scope
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `::bar::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this struct
    |
 LL |     use std::vec::Vec;
@@ -25,7 +25,7 @@ LL |         ().clone()
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use std::clone::Clone;`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `::bar::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hygiene/privacy-early.stderr
+++ b/src/test/ui/hygiene/privacy-early.stderr
@@ -15,7 +15,7 @@ LL |         use f as g;
 ...
 LL |     foo::m!();
    |     ---------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/trait_items.stderr
+++ b/src/test/ui/hygiene/trait_items.stderr
@@ -13,7 +13,7 @@ LL |     pub macro m() { ().f() }
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use foo::T;`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `::baz::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/extern-prelude-extern-crate-fail.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-fail.stderr
@@ -7,7 +7,7 @@ LL |         extern crate std as non_existent;
 LL | define_std_as_non_existent!();
    | ------------------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_std_as_non_existent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0433]: failed to resolve: use of undeclared crate or module `two_macros`
   --> $DIR/extern-prelude-extern-crate-fail.rs:10:9

--- a/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
@@ -7,7 +7,7 @@ LL |         extern crate std as core;
 LL | define_other_core!();
    | --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `Vec` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:13:9
@@ -28,7 +28,7 @@ note: `Vec` could also refer to the struct defined here
    |
 LL |     pub use super::v1::*;
    |             ^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/imports/import-crate-var.stderr
+++ b/src/test/ui/imports/import-crate-var.stderr
@@ -4,7 +4,7 @@ error: `$crate` may not be imported
 LL |     m!();
    |     ^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/import-prefix-macro-1.stderr
+++ b/src/test/ui/imports/import-prefix-macro-1.stderr
@@ -7,7 +7,7 @@ LL |     ($p: path) => (use $p {S, Z});
 LL | import! { a::b::c }
    | ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/import-prefix-macro-2.stderr
+++ b/src/test/ui/imports/import-prefix-macro-2.stderr
@@ -7,7 +7,7 @@ LL |     ($p: path) => (use ::$p {S, Z});
 LL | import! { a::b::c }
    | ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -20,7 +20,7 @@ note: `exported` could also refer to the macro imported here
 LL | use inner1::*;
    |     ^^^^^^^^^
    = help: consider adding an explicit import of `exported` to disambiguate
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `exported` is ambiguous (glob import vs macro-expanded name in the same module during import/macro resolution)
   --> $DIR/local-modularized-tricky-fail-1.rs:28:1
@@ -44,7 +44,7 @@ note: `exported` could also refer to the macro imported here
 LL | use inner1::*;
    |     ^^^^^^^^^
    = help: consider adding an explicit import of `exported` to disambiguate
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `panic` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/local-modularized-tricky-fail-1.rs:36:5
@@ -64,7 +64,7 @@ LL | |     }
 LL |       define_panic!();
    |       ---------------- in this macro invocation
    = help: use `crate::panic` to refer to this macro unambiguously
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `include` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/local-modularized-tricky-fail-1.rs:47:1
@@ -84,7 +84,7 @@ LL | |     }
 LL |       define_include!();
    |       ------------------ in this macro invocation
    = help: use `crate::include` to refer to this macro unambiguously
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -17,7 +17,7 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: macro-expanded `macro_export` macros from the current crate cannot be referred to by absolute paths
   --> $DIR/local-modularized-tricky-fail-2.rs:19:5
@@ -37,7 +37,7 @@ LL | |     }
 ...
 LL |   define_exported!();
    |   ------------------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_exported` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/imports/shadow_builtin_macros.stderr
+++ b/src/test/ui/imports/shadow_builtin_macros.stderr
@@ -28,7 +28,7 @@ LL |         macro_rules! panic { () => {} }
 LL |     } }
 LL |     m!();
    |     ----- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `n` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
   --> $DIR/shadow_builtin_macros.rs:49:5

--- a/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
+++ b/src/test/ui/in-band-lifetimes/elided-lifetimes.stderr
@@ -37,7 +37,7 @@ LL |         fn $fn_name(gift: &str) -> $type_name {
 LL | autowrapper!(Autowrapped, autowrap_gift, 'a);
    | --------------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `autowrapper` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hidden lifetime parameters in types are deprecated
   --> $DIR/elided-lifetimes.rs:78:18
@@ -54,7 +54,7 @@ LL |         Ref<($($types),*)>
 LL |     let yellow: anytuple_ref_ty!(bool, &str) = laughter.borrow();
    |                 ---------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `anytuple_ref_ty` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/include-macros/mismatched-types.stderr
+++ b/src/test/ui/include-macros/mismatched-types.stderr
@@ -8,7 +8,7 @@ LL |     let b: &[u8] = include_str!("file.txt");
    |
    = note: expected reference `&[u8]`
               found reference `&'static str`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/mismatched-types.rs:3:19
@@ -20,7 +20,7 @@ LL |     let s: &str = include_bytes!("file.txt");
    |
    = note: expected reference `&str`
               found reference `&'static [u8; 0]`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/infinite/infinite-macro-expansion.stderr
+++ b/src/test/ui/infinite/infinite-macro-expansion.stderr
@@ -8,7 +8,7 @@ LL |     recursive!()
    |     ------------ in this macro invocation
    |
    = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`infinite_macro_expansion`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `recursive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/internal/internal-unstable-noallow.stderr
+++ b/src/test/ui/internal/internal-unstable-noallow.stderr
@@ -5,7 +5,7 @@ LL |     call_unstable_noallow!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `call_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'struct_field'
   --> $DIR/internal-unstable-noallow.rs:18:5
@@ -14,7 +14,7 @@ LL |     construct_unstable_noallow!(0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(struct_field)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `construct_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'method'
   --> $DIR/internal-unstable-noallow.rs:20:35
@@ -23,7 +23,7 @@ LL |     |x: internal_unstable::Foo| { call_method_noallow!(x) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(method)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `call_method_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'struct2_field'
   --> $DIR/internal-unstable-noallow.rs:22:35
@@ -32,7 +32,7 @@ LL |     |x: internal_unstable::Bar| { access_field_noallow!(x) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(struct2_field)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `access_field_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/internal/internal-unstable.stderr
+++ b/src/test/ui/internal/internal-unstable.stderr
@@ -40,7 +40,7 @@ LL |     bar!(internal_unstable::unstable());
    |     ------------------------------------ in this macro invocation
    |
    = help: add `#![feature(function)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/issues/issue-12997-2.stderr
+++ b/src/test/ui/issues/issue-12997-2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: isize) { }
    | ^^^^^^^^^^^^^^^^^^^^ expected `isize`, found `&mut Bencher`
    |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `bench` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-13446.stderr
+++ b/src/test/ui/issues/issue-13446.stderr
@@ -6,7 +6,7 @@ LL | static VEC: [u32; 256] = vec![];
    |
    = note: expected array `[u32; 256]`
              found struct `Vec<_>`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-14091-2.stderr
+++ b/src/test/ui/issues/issue-14091-2.stderr
@@ -5,7 +5,7 @@ LL |     assert!(x, x);
    |     ^^^^^^^^^^^^^^ cannot apply unary operator `!`
    |
    = note: an implementation of `std::ops::Not` might be missing for `BytePos`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-14091.stderr
+++ b/src/test/ui/issues/issue-14091.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     assert!(1,1);
    |     ^^^^^^^^^^^^^ expected `bool`, found integer
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-15167.stderr
+++ b/src/test/ui/issues/issue-15167.stderr
@@ -7,7 +7,7 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `n` in this scope
   --> $DIR/issue-15167.rs:3:25
@@ -18,7 +18,7 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `n` in this scope
   --> $DIR/issue-15167.rs:3:25
@@ -29,7 +29,7 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `n` in this scope
   --> $DIR/issue-15167.rs:3:25
@@ -40,7 +40,7 @@ LL | macro_rules! f { () => (n) }
 LL |         println!("{}", f!());
    |                        ---- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-16098.stderr
+++ b/src/test/ui/issues/issue-16098.stderr
@@ -8,7 +8,7 @@ LL |     println!("Problem 1: {}", prob1!(1000));
    |                               ------------ in this macro invocation
    |
    = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`issue_16098`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `prob1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-16966.stderr
+++ b/src/test/ui/issues/issue-16966.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     panic!(std::default::Default::default());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `M` declared on the function `begin_panic`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21160.stderr
+++ b/src/test/ui/issues/issue-21160.stderr
@@ -9,7 +9,7 @@ LL | struct Foo(Bar);
 LL |     fn hash<H: Hasher>(&self, state: &mut H);
    |             - required by this bound in `std::hash::Hash::hash`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25385.stderr
+++ b/src/test/ui/issues/issue-25385.stderr
@@ -7,7 +7,7 @@ LL |     ($e:expr) => { $e.foo() }
 LL |     foo!(a);
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no method named `foo` found for type `i32` in the current scope
   --> $DIR/issue-25385.rs:10:15

--- a/src/test/ui/issues/issue-25386.stderr
+++ b/src/test/ui/issues/issue-25386.stderr
@@ -7,7 +7,7 @@ LL |         (*$var.c_object).$member.is_some()
 LL |     println!("{}", check_ptr_exist!(item, name));
    |                    ---------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `check_ptr_exist` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0616]: field `name` of struct `CObj` is private
   --> $DIR/issue-25386.rs:26:43

--- a/src/test/ui/issues/issue-26093.stderr
+++ b/src/test/ui/issues/issue-26093.stderr
@@ -10,7 +10,7 @@ LL |     not_a_place!(99);
    |     |            cannot assign to this expression
    |     in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `not_a_place` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0067]: invalid left-hand side of assignment
   --> $DIR/issue-26093.rs:5:16
@@ -24,7 +24,7 @@ LL |     not_a_place!(99);
    |     |            cannot assign to this expression
    |     in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `not_a_place` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-27340.stderr
+++ b/src/test/ui/issues/issue-27340.stderr
@@ -7,7 +7,7 @@ LL |
 LL | struct Bar(Foo);
    |            --- this field does not implement `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-27592.stderr
+++ b/src/test/ui/issues/issue-27592.stderr
@@ -7,7 +7,7 @@ LL |     write(|| format_args!("{}", String::from("Hello world")));
    |              |                  temporary value created here
    |              returns a value referencing data owned by the current function
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0515]: cannot return reference to temporary value
   --> $DIR/issue-27592.rs:16:14
@@ -15,7 +15,7 @@ error[E0515]: cannot return reference to temporary value
 LL |     write(|| format_args!("{}", String::from("Hello world")));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returns a reference to data owned by the current function
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-29084.stderr
+++ b/src/test/ui/issues/issue-29084.stderr
@@ -7,7 +7,7 @@ LL |         bar(&mut $d);
 LL |     foo!(0u8);
    |     ---------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-31011.stderr
+++ b/src/test/ui/issues/issue-31011.stderr
@@ -10,7 +10,7 @@ LL | {
 LL |     log!(context, "entered wrapper");
    |     --------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `log` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32655.stderr
+++ b/src/test/ui/issues/issue-32655.stderr
@@ -7,7 +7,7 @@ LL |         #[derive_Clone]
 LL | foo!();
    | ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find attribute `derive_Clone` in this scope
   --> $DIR/issue-32655.rs:15:7

--- a/src/test/ui/issues/issue-32782.stderr
+++ b/src/test/ui/issues/issue-32782.stderr
@@ -8,7 +8,7 @@ LL | foo!();
    | ------- in this macro invocation
    |
    = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32950.stderr
+++ b/src/test/ui/issues/issue-32950.stderr
@@ -10,7 +10,7 @@ error[E0412]: cannot find type `FooBar` in this scope
 LL |     concat_idents!(Foo, Bar)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat_idents` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-34229.stderr
+++ b/src/test/ui/issues/issue-34229.stderr
@@ -6,7 +6,7 @@ LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
    |
    = help: the trait `PartialOrd` is not implemented for `Comparable`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-38821.stderr
+++ b/src/test/ui/issues/issue-38821.stderr
@@ -9,7 +9,7 @@ note: required because of the requirements on the impl of `IntoNullable` for `<C
    |
 LL | impl<T: NotNull> IntoNullable for T {
    |                  ^^^^^^^^^^^^     ^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-39848.stderr
+++ b/src/test/ui/issues/issue-39848.stderr
@@ -11,7 +11,7 @@ LL |         if $tgt.has_$field() {}
 LL |     get_opt!(bar, foo);
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `get_opt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-42954.stderr
+++ b/src/test/ui/issues/issue-42954.stderr
@@ -10,7 +10,7 @@ LL |         $i as u32 < 0
 LL |     is_plainly_printable!(c);
    |     ------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `is_plainly_printable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-48364.stderr
+++ b/src/test/ui/issues/issue-48364.stderr
@@ -6,7 +6,7 @@ LL |     b"".starts_with(stringify!(foo))
    |
    = note: expected reference `&[u8]`
               found reference `&'static str`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `stringify` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-48728.stderr
+++ b/src/test/ui/issues/issue-48728.stderr
@@ -8,7 +8,7 @@ LL | impl<T: Clone + ?Sized> Clone for Node<[T]> {
    | ------------------------------------------- first implementation here
    |
    = note: upstream crates may add a new impl of trait `std::clone::Clone` for type `[_]` in future versions
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50480.stderr
+++ b/src/test/ui/issues/issue-50480.stderr
@@ -30,7 +30,7 @@ LL | struct Foo(NotDefined, <i32 as Iterator>::Item, Vec<i32>, String);
    |                                                 |
    |                                                 this field does not implement `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-51848.stderr
+++ b/src/test/ui/issues/issue-51848.stderr
@@ -10,7 +10,7 @@ LL |     macro_with_error!();
    |     -------------------- in this macro invocation
    |
    = note: if you intended to print `{`, you can escape it using `{{`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `macro_with_error` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid format string: unmatched `}` found
   --> $DIR/issue-51848.rs:18:15

--- a/src/test/ui/issues/issue-53251.stderr
+++ b/src/test/ui/issues/issue-53251.stderr
@@ -14,7 +14,7 @@ note: associated function defined here, with 0 generic parameters
    |
 LL |     fn f() {}
    |        ^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0107]: this associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-53251.rs:11:20
@@ -32,7 +32,7 @@ note: associated function defined here, with 0 generic parameters
    |
 LL |     fn f() {}
    |        ^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -77,7 +77,7 @@ LL |     assert_eq!(Foo::Bar, i);
    |     fn(usize) -> Foo {Foo::Bar}
    |     fn(usize) -> Foo {Foo::Bar}
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `fn(usize) -> Foo {Foo::Bar}` doesn't implement `Debug`
   --> $DIR/issue-59488.rs:30:5
@@ -91,7 +91,7 @@ LL |     T: fmt::Debug + ?Sized,
    |        ---------- required by this bound in `core::panicking::assert_failed`
    |
    = help: the trait `Debug` is not implemented for `fn(usize) -> Foo {Foo::Bar}`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/issues/issue-6596-1.stderr
+++ b/src/test/ui/issues/issue-6596-1.stderr
@@ -7,7 +7,7 @@ LL |         $nonexistent
 LL |     e!(foo);
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `e` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-6596-2.stderr
+++ b/src/test/ui/issues/issue-6596-2.stderr
@@ -7,7 +7,7 @@ LL |         { $inp $nonexistent }
 LL |     g!(foo);
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `g` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-68091-unicode-ident-after-if.stderr
+++ b/src/test/ui/issues/issue-68091-unicode-ident-after-if.stderr
@@ -13,7 +13,7 @@ LL |         $($c)ö* {}
 LL |     x!(if);
    |     ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
+++ b/src/test/ui/issues/issue-69396-const-no-type-in-macro.stderr
@@ -14,7 +14,7 @@ LL | | }
    | |_- in this macro invocation
    |
    = note: `A` must be defined only once in the value namespace of this module
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: missing type for `const` item
   --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
@@ -28,7 +28,7 @@ LL | |     is_empty;
 LL | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/issue-69396-const-no-type-in-macro.rs:4:19
@@ -45,7 +45,7 @@ LL | |     is_empty;
 LL | | }
    | |_- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `suite` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
+++ b/src/test/ui/issues/issue-70724-add_type_neq_err_label-unwrap.stderr
@@ -8,7 +8,7 @@ LL |     assert_eq!(a, 0);
    |     {integer}
    |     help: you might have forgotten to call this function: `*left_val()`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
@@ -18,7 +18,7 @@ LL |     assert_eq!(a, 0);
    |
    = note: expected fn item `fn() -> i32 {a}`
                  found type `i32`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `fn() -> i32 {a}` doesn't implement `Debug`
   --> $DIR/issue-70724-add_type_neq_err_label-unwrap.rs:6:5
@@ -36,7 +36,7 @@ LL |     T: fmt::Debug + ?Sized,
    |
    = help: the trait `Debug` is not implemented for `fn() -> i32 {a}`
    = help: use parentheses to call the function: `a()`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
+++ b/src/test/ui/lifetimes/borrowck-let-suggestion.stderr
@@ -10,7 +10,7 @@ LL |     x.use_mut();
    |     - borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-stability2.stderr
+++ b/src/test/ui/lint/lint-stability2.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `macro_test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-stability3.stderr
+++ b/src/test/ui/lint/lint-stability3.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `macro_test_arg_nested` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-unsafe-code.stderr
+++ b/src/test/ui/lint/lint-unsafe-code.stderr
@@ -123,7 +123,7 @@ LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: declaration of a `no_mangle` static
   --> $DIR/lint-unsafe-code.rs:22:9
@@ -135,7 +135,7 @@ LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: declaration of a function with `export_name`
   --> $DIR/lint-unsafe-code.rs:23:9
@@ -147,7 +147,7 @@ LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: declaration of a static with `export_name`
   --> $DIR/lint-unsafe-code.rs:25:9
@@ -159,7 +159,7 @@ LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
    = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: usage of an `unsafe` block
   --> $DIR/lint-unsafe-code.rs:27:9
@@ -170,7 +170,7 @@ LL |         unsafe {}
 LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 22 previous errors
 

--- a/src/test/ui/lint/lints-in-foreign-macros.stderr
+++ b/src/test/ui/lint/lints-in-foreign-macros.stderr
@@ -12,7 +12,7 @@ note: the lint level is defined here
    |
 LL | #![warn(unused_imports)]
    |         ^^^^^^^^^^^^^^
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unused import: `std::string::ToString`
   --> $DIR/lints-in-foreign-macros.rs:16:18

--- a/src/test/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
+++ b/src/test/ui/lint/semicolon-in-expressions-from-macros/semicolon-in-expressions-from-macros.stderr
@@ -14,7 +14,7 @@ LL | #![warn(semicolon_in_expressions_from_macros)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: trailing semicolon in macro used in expression position
   --> $DIR/semicolon-in-expressions-from-macros.rs:8:13
@@ -27,7 +27,7 @@ LL |     let _ = foo!(second);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/test-inner-fn.stderr
+++ b/src/test/ui/lint/test-inner-fn.stderr
@@ -5,7 +5,7 @@ LL |     #[test]
    |     ^^^^^^^
    |
    = note: requested on the command line with `-D unnameable-test-items`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot test inner items
   --> $DIR/test-inner-fn.rs:13:9
@@ -13,7 +13,7 @@ error: cannot test inner items
 LL |         #[test]
    |         ^^^^^^^
    |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lint/unaligned_references_external_macro.stderr
+++ b/src/test/ui/lint/unaligned_references_external_macro.stderr
@@ -24,7 +24,7 @@ LL | | }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unaligned_references_external_crate::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/unreachable_pub-pub_crate.stderr
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.stderr
@@ -132,7 +132,7 @@ LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    |     in this macro invocation
    |
    = help: or consider exporting it for use by other crates
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `define_empty_struct_with_visibility` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unreachable `pub` item
   --> $DIR/unreachable_pub-pub_crate.rs:45:9

--- a/src/test/ui/lint/unreachable_pub.stderr
+++ b/src/test/ui/lint/unreachable_pub.stderr
@@ -132,7 +132,7 @@ LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    |     in this macro invocation
    |
    = help: or consider exporting it for use by other crates
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `define_empty_struct_with_visibility` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unreachable `pub` item
   --> $DIR/unreachable_pub.rs:41:9

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -10,7 +10,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
 LL |     test!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/liveness-return-last-stmt-semi.rs:7:19

--- a/src/test/ui/llvm-asm/inline-asm-bad-constraint.stderr
+++ b/src/test/ui/llvm-asm/inline-asm-bad-constraint.stderr
@@ -4,7 +4,7 @@ error[E0668]: malformed inline assembly
 LL |         llvm_asm!("" :"={rax"(rax))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0668]: malformed inline assembly
   --> $DIR/inline-asm-bad-constraint.rs:30:9
@@ -12,7 +12,7 @@ error[E0668]: malformed inline assembly
 LL |         llvm_asm!("callq $0" : : "0"(foo))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0668]: malformed inline assembly
   --> $DIR/inline-asm-bad-constraint.rs:37:9
@@ -20,7 +20,7 @@ error[E0668]: malformed inline assembly
 LL |         llvm_asm!("addb $1, $0" : "={rax}"((0i32, rax)));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/llvm-asm/issue-62046.stderr
+++ b/src/test/ui/llvm-asm/issue-62046.stderr
@@ -4,7 +4,7 @@ error[E0668]: malformed inline assembly
 LL |         llvm_asm!("nop" : "+r"("r15"));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macro_backtrace/main.default.stderr
+++ b/src/test/ui/macro_backtrace/main.default.stderr
@@ -7,7 +7,7 @@ LL |     () => { syntax error };
 LL |     pong!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:10:20
@@ -18,7 +18,7 @@ LL |     () => { syntax error };
 LL |     ping!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
   --> $DIR/main.rs:10:20
@@ -29,7 +29,7 @@ LL |     () => { syntax error };
 LL |     deep!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pong` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/macros/assert.stderr
+++ b/src/test/ui/macros/assert.stderr
@@ -16,7 +16,7 @@ error: macro requires a boolean expression as an argument
 LL |     debug_assert!();
    |     ^^^^^^^^^^^^^^^^ boolean expression required
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `debug_assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
   --> $DIR/assert.rs:5:19

--- a/src/test/ui/macros/cfg.stderr
+++ b/src/test/ui/macros/cfg.stderr
@@ -4,7 +4,7 @@ error: macro requires a cfg-pattern as an argument
 LL |     cfg!();
    |     ^^^^^^^ cfg-pattern required
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier, found `123`
   --> $DIR/cfg.rs:3:10

--- a/src/test/ui/macros/derive-in-eager-expansion-hang.stderr
+++ b/src/test/ui/macros/derive-in-eager-expansion-hang.stderr
@@ -12,7 +12,7 @@ LL | |     }
 LL |       format_args!(hang!());
    |                    ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hang` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you might be missing a string literal to format with
    |
 LL |     format_args!("{}", hang!());

--- a/src/test/ui/macros/format-parse-errors.stderr
+++ b/src/test/ui/macros/format-parse-errors.stderr
@@ -4,7 +4,7 @@ error: requires at least a format string argument
 LL |     format!();
    |     ^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
   --> $DIR/format-parse-errors.rs:5:13

--- a/src/test/ui/macros/issue-34421-mac-expr-bad-stmt-good-add-semi.stderr
+++ b/src/test/ui/macros/issue-34421-mac-expr-bad-stmt-good-add-semi.stderr
@@ -8,7 +8,7 @@ LL |     make_item!(A)
    |     ------------- in this macro invocation
    |
    = note: the macro call doesn't expand to an expression, but it can expand to a statement
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `make_item` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `;` to interpret the expansion as a statement
    |
 LL |     make_item!(A);
@@ -24,7 +24,7 @@ LL |     make_item!(B)
    |     ------------- in this macro invocation
    |
    = note: the macro call doesn't expand to an expression, but it can expand to a statement
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `make_item` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: add `;` to interpret the expansion as a statement
    |
 LL |     make_item!(B);

--- a/src/test/ui/macros/issue-78325-inconsistent-resolution.stderr
+++ b/src/test/ui/macros/issue-78325-inconsistent-resolution.stderr
@@ -7,7 +7,7 @@ LL |         extern crate std as core;
 LL | define_other_core!();
    | --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/issue-84195-lint-anon-const.stderr
+++ b/src/test/ui/macros/issue-84195-lint-anon-const.stderr
@@ -14,7 +14,7 @@ LL | #![deny(semicolon_in_expressions_from_macros)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `len` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
+++ b/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
@@ -7,7 +7,7 @@ LL |           1.fake()
 LL |     fake_method_stmt!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `fake_method_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0610]: `{integer}` is a primitive type and therefore doesn't have fields
   --> $DIR/macro-backtrace-invalid-internals.rs:11:13
@@ -18,7 +18,7 @@ LL |           1.fake
 LL |     fake_field_stmt!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `fake_field_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0610]: `{integer}` is a primitive type and therefore doesn't have fields
   --> $DIR/macro-backtrace-invalid-internals.rs:17:15
@@ -29,7 +29,7 @@ LL |           (1).0
 LL |     fake_anon_field_stmt!();
    |     ------------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `fake_anon_field_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
   --> $DIR/macro-backtrace-invalid-internals.rs:41:15
@@ -40,7 +40,7 @@ LL |           2.0.neg()
 LL |     real_method_stmt!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `real_method_stmt` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |           2.0_f32.neg()
@@ -55,7 +55,7 @@ LL |           1.fake()
 LL |     let _ = fake_method_expr!();
    |             ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `fake_method_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0610]: `{integer}` is a primitive type and therefore doesn't have fields
   --> $DIR/macro-backtrace-invalid-internals.rs:29:13
@@ -66,7 +66,7 @@ LL |           1.fake
 LL |     let _ = fake_field_expr!();
    |             ------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `fake_field_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0610]: `{integer}` is a primitive type and therefore doesn't have fields
   --> $DIR/macro-backtrace-invalid-internals.rs:35:15
@@ -77,7 +77,7 @@ LL |           (1).0
 LL |     let _ = fake_anon_field_expr!();
    |             ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `fake_anon_field_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
   --> $DIR/macro-backtrace-invalid-internals.rs:47:15
@@ -88,7 +88,7 @@ LL |           2.0.neg()
 LL |     let _ = real_method_expr!();
    |             ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `real_method_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |           2.0_f32.neg()

--- a/src/test/ui/macros/macro-backtrace-nested.stderr
+++ b/src/test/ui/macros/macro-backtrace-nested.stderr
@@ -7,7 +7,7 @@ LL |     () => (fake)
 LL |     1 + call_nested_expr!();
    |         ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `nested_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `fake` in this scope
   --> $DIR/macro-backtrace-nested.rs:5:12
@@ -18,7 +18,7 @@ LL |     () => (fake)
 LL |     call_nested_expr_sum!();
    |     ------------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `nested_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macro-backtrace-println.stderr
+++ b/src/test/ui/macros/macro-backtrace-println.stderr
@@ -7,7 +7,7 @@ LL |     ($fmt:expr) => (myprint!(concat!($fmt, "\n")));
 LL |     myprintln!("{}");
    |     ----------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-context.stderr
+++ b/src/test/ui/macros/macro-context.stderr
@@ -40,7 +40,7 @@ LL |     () => ( i ; typeof );
 LL |     m!();
    |     ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `i` in this scope
   --> $DIR/macro-context.rs:3:13
@@ -51,7 +51,7 @@ LL |     () => ( i ; typeof );
 LL |     let a: m!();
    |            ---- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `i` in this scope
   --> $DIR/macro-context.rs:3:13
@@ -62,7 +62,7 @@ LL |     () => ( i ; typeof );
 LL |     let i = m!();
    |             ---- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/macros/macro-lifetime-used-with-labels.stderr
+++ b/src/test/ui/macros/macro-lifetime-used-with-labels.stderr
@@ -9,7 +9,7 @@ LL |     'b: loop {
 LL |         br2!('b);
    |         --------- in this macro invocation
    |
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `br2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted
 

--- a/src/test/ui/macros/macro-local-data-key-priv.stderr
+++ b/src/test/ui/macros/macro-local-data-key-priv.stderr
@@ -9,7 +9,7 @@ note: the constant `baz` is defined here
    |
 LL |     thread_local!(static baz: f64 = 0.0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-shadowing.stderr
+++ b/src/test/ui/macros/macro-shadowing.stderr
@@ -8,7 +8,7 @@ LL | m1!();
    | ------ in this macro invocation
    |
    = note: macro-expanded `#[macro_use]`s may not shadow existing macros (see RFC 1560)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `foo` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/macro-shadowing.rs:17:1
@@ -29,7 +29,7 @@ note: `foo` could also refer to the macro defined here
    |
 LL | macro_rules! foo { () => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macros-nonfatal-errors.stderr
+++ b/src/test/ui/macros/macros-nonfatal-errors.stderr
@@ -4,7 +4,7 @@ error[E0665]: `Default` cannot be derived for enums, only structs
 LL | #[derive(Default)]
    |          ^^^^^^^
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: asm template must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:13:10
@@ -48,7 +48,7 @@ error: environment variable `RUST_HOPEFULLY_THIS_DOESNT_EXIST` not defined
 LL |     env!("RUST_HOPEFULLY_THIS_DOESNT_EXIST");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `env` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: format argument must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:23:13
@@ -79,7 +79,7 @@ error: couldn't read $DIR/i'd be quite surprised if a file with this name existe
 LL |     include_str!("i'd be quite surprised if a file with this name existed");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: argument must be a string literal
   --> $DIR/macros-nonfatal-errors.rs:29:20
@@ -93,7 +93,7 @@ error: couldn't read $DIR/i'd be quite surprised if a file with this name existe
 LL |     include_bytes!("i'd be quite surprised if a file with this name existed");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/macros-nonfatal-errors.rs:32:5

--- a/src/test/ui/macros/must-use-in-macro-55516.stderr
+++ b/src/test/ui/macros/must-use-in-macro-55516.stderr
@@ -6,7 +6,7 @@ LL |     write!(&mut example, "{}", 42);
    |
    = note: `-W unused-must-use` implied by `-W unused`
    = note: this `Result` may be an `Err` variant, which should be handled
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted
 

--- a/src/test/ui/macros/nonterminal-matching.stderr
+++ b/src/test/ui/macros/nonterminal-matching.stderr
@@ -10,7 +10,7 @@ LL |     n!(a $nt_item b);
 LL | complex_nonterminal!(enum E {});
    | -------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `complex_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/not-utf8.stderr
+++ b/src/test/ui/macros/not-utf8.stderr
@@ -4,7 +4,7 @@ error: couldn't read $DIR/not-utf8.bin: stream did not contain valid UTF-8
 LL |     include!("not-utf8.bin")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/restricted-shadowing-legacy.stderr
+++ b/src/test/ui/macros/restricted-shadowing-legacy.stderr
@@ -23,7 +23,7 @@ LL |         macro_rules! m { () => {} }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-legacy.rs:139:42
@@ -50,7 +50,7 @@ LL |         macro_rules! m { () => {} }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-legacy.rs:148:9
@@ -77,7 +77,7 @@ LL |         macro_rules! m { () => {} }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-legacy.rs:164:9
@@ -104,7 +104,7 @@ LL |         macro_rules! m { () => { Wrong } }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-legacy.rs:180:13
@@ -131,7 +131,7 @@ LL |         macro_rules! m { () => { Wrong } }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-legacy.rs:218:42
@@ -158,7 +158,7 @@ LL |         macro_rules! m { () => { Wrong } }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-legacy.rs:232:9
@@ -185,7 +185,7 @@ LL |             macro_rules! m { () => {} }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-legacy.rs:262:42
@@ -212,7 +212,7 @@ LL |             macro_rules! m { () => {} }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/macros/restricted-shadowing-modern.stderr
+++ b/src/test/ui/macros/restricted-shadowing-modern.stderr
@@ -23,7 +23,7 @@ LL |         macro m() {}
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-modern.rs:147:33
@@ -50,7 +50,7 @@ LL |         macro m() {}
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-modern.rs:156:13
@@ -77,7 +77,7 @@ LL |         macro m() {}
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-modern.rs:172:13
@@ -104,7 +104,7 @@ LL |         macro m() { Wrong }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `include` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-modern.rs:190:17
@@ -131,7 +131,7 @@ LL |         macro m() { Wrong }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_gen_inner_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `m` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/restricted-shadowing-modern.rs:233:33
@@ -158,7 +158,7 @@ LL |         macro m() { Wrong }
 ...
 LL | include!();
    | ----------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_invoc` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/macros/same-sequence-span.stderr
+++ b/src/test/ui/macros/same-sequence-span.stderr
@@ -28,7 +28,7 @@ LL | | fn main() {}
    | |_________________________________^ not allowed after `expr` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `proc_macro_sequence::make_foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `$x:expr` may be followed by `=`, which is not allowed for `expr` fragments
   --> $DIR/same-sequence-span.rs:19:1
@@ -37,7 +37,7 @@ LL | proc_macro_sequence::make_foo!();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not allowed after `expr` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `proc_macro_sequence::make_foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/macros/span-covering-argument-1.stderr
+++ b/src/test/ui/macros/span-covering-argument-1.stderr
@@ -9,7 +9,7 @@ LL |             *&mut $s = 0;
 LL |     bad!(foo whatever);
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `bad` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/trace_faulty_macros.stderr
+++ b/src/test/ui/macros/trace_faulty_macros.stderr
@@ -10,7 +10,7 @@ LL |         my_faulty_macro!(bcd);
 LL |     my_faulty_macro!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `my_faulty_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: trace_macro
   --> $DIR/trace_faulty_macros.rs:31:5
@@ -32,7 +32,7 @@ LL |     my_recursive_macro!();
    |     ---------------------- in this macro invocation
    |
    = help: consider adding a `#![recursion_limit="8"]` attribute to your crate (`trace_faulty_macros`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `my_recursive_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: trace_macro
   --> $DIR/trace_faulty_macros.rs:32:5
@@ -58,7 +58,7 @@ LL |         $a
 LL |     let a = pat_macro!();
    |             ------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pat_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0774]: `derive` may only be applied to structs, enums and unions
   --> $DIR/trace_faulty_macros.rs:42:1

--- a/src/test/ui/macros/vec-macro-in-pattern.stderr
+++ b/src/test/ui/macros/vec-macro-in-pattern.stderr
@@ -4,7 +4,7 @@ error: arbitrary expressions aren't allowed in patterns
 LL |         Some(vec![43]) => {}
    |              ^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/malformed/malformed-derive-entry.stderr
+++ b/src/test/ui/malformed/malformed-derive-entry.stderr
@@ -27,7 +27,7 @@ LL | #[derive(Copy(Bad))]
 LL | pub trait Copy: Clone {
    |                 ----- required by this bound in `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Test2: Clone` is not satisfied
   --> $DIR/malformed-derive-entry.rs:6:10
@@ -40,7 +40,7 @@ LL | #[derive(Copy="bad")]
 LL | pub trait Copy: Clone {
    |                 ----- required by this bound in `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -7,7 +7,7 @@ LL |                   $arr.len() * size_of($arr[0]));
 LL |     write!(hello);
    |     -------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `write` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: you can convert a `usize` to a `u64` and panic if the converted value doesn't fit
    |
 LL |                   ($arr.len() * size_of($arr[0])).try_into().unwrap());
@@ -22,7 +22,7 @@ LL |     ($x:expr) => ($x as ())
 LL |     cast!(2);
    |     --------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `cast` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/modules/issue-56411.stderr
+++ b/src/test/ui/modules/issue-56411.stderr
@@ -13,7 +13,7 @@ LL | import!(("issue-56411-aux.rs", issue_56411_aux));
    | ------------------------------------------------- in this macro invocation
    |
    = note: `issue_56411_aux` must be defined only once in the type namespace of this module
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0365]: `issue_56411_aux` is private, and cannot be re-exported
   --> $DIR/issue-56411.rs:6:21
@@ -25,7 +25,7 @@ LL | import!(("issue-56411-aux.rs", issue_56411_aux));
    | ------------------------------------------------- in this macro invocation
    |
    = note: consider declaring type or module `issue_56411_aux` with `pub`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `import` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/on-unimplemented/no-debug.stderr
+++ b/src/test/ui/on-unimplemented/no-debug.stderr
@@ -7,7 +7,7 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    = help: the trait `Debug` is not implemented for `Foo`
    = note: add `#[derive(Debug)]` or manually implement `Debug`
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Bar` doesn't implement `Debug`
   --> $DIR/no-debug.rs:10:32
@@ -17,7 +17,7 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    |
    = help: the trait `Debug` is not implemented for `Bar`
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Foo` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:23
@@ -28,7 +28,7 @@ LL |     println!("{} {}", Foo, Bar);
    = help: the trait `std::fmt::Display` is not implemented for `Foo`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Bar` doesn't implement `std::fmt::Display`
   --> $DIR/no-debug.rs:11:28
@@ -39,7 +39,7 @@ LL |     println!("{} {}", Foo, Bar);
    = help: the trait `std::fmt::Display` is not implemented for `Bar`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
    = note: required by `std::fmt::Display::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/src/test/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -140,7 +140,7 @@ LL |             (true
 LL |         (true | false, None | Some(t_or_f!())) => {}
    |                                    --------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `t_or_f` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:116:14

--- a/src/test/ui/out-of-order-shadowing.stderr
+++ b/src/test/ui/out-of-order-shadowing.stderr
@@ -14,7 +14,7 @@ note: `bar` could also refer to the macro defined here
    |
 LL | macro_rules! bar { () => {} }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/bad-interpolated-block.stderr
+++ b/src/test/ui/parser/bad-interpolated-block.stderr
@@ -9,7 +9,7 @@ LL |         'lab: $b;
 LL |     m!({});
    |     ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use a `block` macro fragment here
   --> $DIR/bad-interpolated-block.rs:8:16
@@ -22,7 +22,7 @@ LL |         unsafe $b;
 LL |     m!({});
    |     ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot use a `block` macro fragment here
   --> $DIR/bad-interpolated-block.rs:9:23
@@ -33,7 +33,7 @@ LL |         |x: u8| -> () $b;
 LL |     m!({});
    |     ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/parser/float-field-interpolated.stderr
+++ b/src/test/ui/parser/float-field-interpolated.stderr
@@ -7,7 +7,7 @@ LL |         { s.$b; }
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
    |     ---------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1`
   --> $DIR/float-field-interpolated.rs:8:13
@@ -18,7 +18,7 @@ LL |         { s.$b; }
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
    |     ---------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected token: `1.1`
   --> $DIR/float-field-interpolated.rs:10:13
@@ -29,7 +29,7 @@ LL |         { s.$c; }
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
    |     ---------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `1.1`
   --> $DIR/float-field-interpolated.rs:10:13
@@ -40,7 +40,7 @@ LL |         { s.$c; }
 LL |     generate_field_accesses!(1.1, 1.1, 1.1);
    |     ---------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_field_accesses` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.stderr
+++ b/src/test/ui/parser/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.stderr
@@ -16,7 +16,7 @@ LL |     expand_to_enum!();
    |     ------------------ in this macro invocation
    |
    = help: consider moving the enum out to a nearby module scope
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `expand_to_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: struct is not supported in `trait`s or `impl`s
   --> $DIR/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.rs:31:5
@@ -36,7 +36,7 @@ LL |     expand_to_enum!();
    |     ------------------ in this macro invocation
    |
    = help: consider moving the enum out to a nearby module scope
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `expand_to_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: struct is not supported in `extern` blocks
   --> $DIR/issue-48137-macros-cannot-interpolate-impl-items-bad-variants.rs:42:5
@@ -56,7 +56,7 @@ LL |     expand_to_enum!();
    |     ------------------ in this macro invocation
    |
    = help: consider moving the enum out to a nearby module scope
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `expand_to_enum` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/parser/issue-65122-mac-invoc-in-mut-patterns.stderr
+++ b/src/test/ui/parser/issue-65122-mac-invoc-in-mut-patterns.stderr
@@ -8,7 +8,7 @@ LL |     mac1! { does_not_exist!() }
    |     --------------------------- in this macro invocation
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected identifier, found `does_not_exist!()`
   --> $DIR/issue-65122-mac-invoc-in-mut-patterns.rs:13:17
@@ -19,7 +19,7 @@ LL |         let mut $eval = ();
 LL |     mac2! { does_not_exist!() }
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `mut` must be followed by a named binding
   --> $DIR/issue-65122-mac-invoc-in-mut-patterns.rs:13:13
@@ -31,7 +31,7 @@ LL |     mac2! { does_not_exist!() }
    |     --------------------------- in this macro invocation
    |
    = note: `mut` may be followed by `variable` and `variable @ pattern`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find macro `does_not_exist` in this scope
   --> $DIR/issue-65122-mac-invoc-in-mut-patterns.rs:22:13

--- a/src/test/ui/parser/issue-73568-lifetime-after-mut.stderr
+++ b/src/test/ui/parser/issue-73568-lifetime-after-mut.stderr
@@ -19,7 +19,7 @@ LL |         fn w<$lt>(w: &mut $lt i32) {}
 LL | mac!('a);
    | --------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0423]: expected value, found trait `Send`
   --> $DIR/issue-73568-lifetime-after-mut.rs:19:28

--- a/src/test/ui/parser/labeled-no-colon-expr.stderr
+++ b/src/test/ui/parser/labeled-no-colon-expr.stderr
@@ -70,7 +70,7 @@ LL |             'l5 $b;
 LL |     m!({});
    |     ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:16:8

--- a/src/test/ui/parser/macro/issue-37113.stderr
+++ b/src/test/ui/parser/macro/issue-37113.stderr
@@ -7,7 +7,7 @@ LL |             $( $t, )*
 LL |     test_macro!(String,);
    |     --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/macro/issue-37234.stderr
+++ b/src/test/ui/parser/macro/issue-37234.stderr
@@ -7,7 +7,7 @@ LL |         let x = 5 "";
 LL |     failed!();
    |     ---------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `failed` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/macro/macro-incomplete-parse.stderr
+++ b/src/test/ui/parser/macro/macro-incomplete-parse.stderr
@@ -18,7 +18,7 @@ LL |     () => ( 1,
 LL |     ignored_expr!();
    |     ---------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ignored_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: macro expansion ignores token `,` and any following
   --> $DIR/macro-incomplete-parse.rs:16:14

--- a/src/test/ui/parser/macro/pub-item-macro.stderr
+++ b/src/test/ui/parser/macro/pub-item-macro.stderr
@@ -8,7 +8,7 @@ LL |     pub_x!();
    |     --------- in this macro invocation
    |
    = help: try adjusting the macro to put `pub` inside the invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `pub_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0603]: static `x` is private
   --> $DIR/pub-item-macro.rs:20:23
@@ -24,7 +24,7 @@ LL |         static x: u32 = 0;
 ...
 LL |     pub_x!();
    |     --------- in this macro invocation
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_x` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
+++ b/src/test/ui/parser/missing-closing-angle-bracket-eq-constraint.stderr
@@ -32,7 +32,7 @@ LL |   let v : Vec<(u32,_) = vec![];
    |       |
    |       consider giving `v` the explicit type `Vec<T>`, where the type parameter `T` is specified
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0282]: type annotations needed for `Vec<T>`
   --> $DIR/missing-closing-angle-bracket-eq-constraint.rs:18:20
@@ -42,7 +42,7 @@ LL |   let v : Vec<'a = vec![];
    |       |
    |       consider giving `v` the explicit type `Vec<T>`, where the type parameter `T` is specified
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/parser/missing-semicolon.stderr
+++ b/src/test/ui/parser/missing-semicolon.stderr
@@ -7,7 +7,7 @@ LL |         $( let x = $e1 )*;
 LL | fn main() { m!(0, 0; 0, 0); }
    |             --------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/mut-patterns.stderr
+++ b/src/test/ui/parser/mut-patterns.stderr
@@ -108,7 +108,7 @@ LL |             let mut $p = 0;
 LL |     foo!(x);
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 13 previous errors
 

--- a/src/test/ui/parser/recover-range-pats.stderr
+++ b/src/test/ui/parser/recover-range-pats.stderr
@@ -167,7 +167,7 @@ LL |             let ...$e;
 LL |     mac!(0);
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:154:19
@@ -179,7 +179,7 @@ LL |     mac!(0);
    |     -------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0586]: inclusive range with no end
   --> $DIR/recover-range-pats.rs:155:19
@@ -191,7 +191,7 @@ LL |     mac!(0);
    |     -------- in this macro invocation
    |
    = note: inclusive ranges must be bounded at the end (`..=b` or `a..=b`)
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:42:13
@@ -281,7 +281,7 @@ LL |     mac2!(0, 1);
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
    = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0029]: only `char` and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:20:12

--- a/src/test/ui/pattern/rest-pat-semantic-disallowed.stderr
+++ b/src/test/ui/pattern/rest-pat-semantic-disallowed.stderr
@@ -8,7 +8,7 @@ LL |     let mk_pat!();
    |         --------- in this macro invocation
    |
    = note: only allowed in tuple, tuple struct, and slice patterns
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mk_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `..` patterns are not allowed here
   --> $DIR/rest-pat-semantic-disallowed.rs:18:9

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -7,7 +7,7 @@ LL |         let value = Pub::method;
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
   --> $DIR/associated-item-privacy-inherent.rs:15:9
@@ -18,7 +18,7 @@ LL |         value;
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `for<'r> fn(&'r priv_nominal::Pub) {priv_nominal::Pub::method}` is private
   --> $DIR/associated-item-privacy-inherent.rs:17:13
@@ -29,7 +29,7 @@ LL |         Pub.method();
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: associated constant `CONST` is private
   --> $DIR/associated-item-privacy-inherent.rs:19:9
@@ -40,7 +40,7 @@ LL |         Pub::CONST;
 LL |     priv_nominal::mac!();
    |     --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_nominal::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:37:21
@@ -51,7 +51,7 @@ LL |         let value = Pub::method;
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:39:9
@@ -62,7 +62,7 @@ LL |         value;
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:41:13
@@ -73,7 +73,7 @@ LL |         Pub.method(loop {});
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:57:21
@@ -84,7 +84,7 @@ LL |         let value = Pub::method::<Priv>;
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:59:9
@@ -95,7 +95,7 @@ LL |         value;
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:61:9
@@ -106,7 +106,7 @@ LL |         Pub.method::<Priv>();
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:80:21
@@ -117,7 +117,7 @@ LL |         let value = <Pub>::method;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:82:9
@@ -128,7 +128,7 @@ LL |         value;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:84:21
@@ -139,7 +139,7 @@ LL |         let value = Pub::method;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:86:9
@@ -150,7 +150,7 @@ LL |         value;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:88:21
@@ -161,7 +161,7 @@ LL |         let value = <Pub>::static_method;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:90:9
@@ -172,7 +172,7 @@ LL |         value;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:92:21
@@ -183,7 +183,7 @@ LL |         let value = Pub::static_method;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:94:9
@@ -194,7 +194,7 @@ LL |         value;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:96:19
@@ -205,7 +205,7 @@ LL |         Pub(Priv).method();
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:99:10
@@ -216,7 +216,7 @@ LL |         <Pub>::CONST;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:101:9
@@ -227,7 +227,7 @@ LL |         Pub::CONST;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 21 previous errors
 

--- a/src/test/ui/privacy/associated-item-privacy-trait.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-trait.stderr
@@ -7,7 +7,7 @@ LL |         let value = <Pub as PrivTr>::method;
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `for<'r> fn(&'r priv_trait::Pub) {<priv_trait::Pub as PrivTr>::method}` is private
   --> $DIR/associated-item-privacy-trait.rs:17:9
@@ -18,7 +18,7 @@ LL |         value;
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `for<'r> fn(&'r Self) {<Self as PrivTr>::method}` is private
   --> $DIR/associated-item-privacy-trait.rs:19:13
@@ -29,7 +29,7 @@ LL |         Pub.method();
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: associated constant `<Pub as PrivTr>::CONST` is private
   --> $DIR/associated-item-privacy-trait.rs:21:9
@@ -40,7 +40,7 @@ LL |         <Pub as PrivTr>::CONST;
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: associated type `<Pub as PrivTr>::AssocTy` is private
   --> $DIR/associated-item-privacy-trait.rs:23:16
@@ -51,7 +51,7 @@ LL |         let _: <Pub as PrivTr>::AssocTy;
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:25:34
@@ -62,7 +62,7 @@ LL |         pub type InSignatureTy = <Pub as PrivTr>::AssocTy;
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:27:34
@@ -73,7 +73,7 @@ LL |         pub trait InSignatureTr: PrivTr {}
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-trait.rs:29:14
@@ -84,7 +84,7 @@ LL |         impl PrivTr for u8 {}
 LL |     priv_trait::mac!();
    |     ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:46:21
@@ -95,7 +95,7 @@ LL |         let value = <Pub as PubTr>::method;
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:48:9
@@ -106,7 +106,7 @@ LL |         value;
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_signature::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:50:13
@@ -117,7 +117,7 @@ LL |         Pub.method(loop {});
 LL |     priv_signature::mac!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_signature::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:67:21
@@ -128,7 +128,7 @@ LL |         let value = <Pub as PubTr>::method::<Priv>;
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:69:9
@@ -139,7 +139,7 @@ LL |         value;
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:71:9
@@ -150,7 +150,7 @@ LL |         Pub.method::<Priv>();
 LL |     priv_substs::mac!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:91:21
@@ -161,7 +161,7 @@ LL |         let value = <Pub as PubTr>::method;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:93:9
@@ -172,7 +172,7 @@ LL |         value;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:95:21
@@ -183,7 +183,7 @@ LL |         let value = <Pub as PubTr<_>>::method;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:97:9
@@ -194,7 +194,7 @@ LL |         value;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:99:9
@@ -205,7 +205,7 @@ LL |         Pub.method();
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:102:21
@@ -216,7 +216,7 @@ LL |         let value = <Priv as PubTr<_>>::method;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:104:9
@@ -227,7 +227,7 @@ LL |         value;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:106:9
@@ -238,7 +238,7 @@ LL |         Priv.method();
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:109:9
@@ -249,7 +249,7 @@ LL |         <Pub as PubTr>::CONST;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:111:9
@@ -260,7 +260,7 @@ LL |         <Pub as PubTr<_>>::CONST;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:113:9
@@ -271,7 +271,7 @@ LL |         <Priv as PubTr<_>>::CONST;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:117:30
@@ -282,7 +282,7 @@ LL |         let _: <Pub as PubTr<_>>::AssocTy;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:119:17
@@ -293,7 +293,7 @@ LL |         let _: <Priv as PubTr<_>>::AssocTy;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:122:35
@@ -304,7 +304,7 @@ LL |         pub type InSignatureTy1 = <Pub as PubTr>::AssocTy;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:124:35
@@ -315,7 +315,7 @@ LL |         pub type InSignatureTy2 = <Priv as PubTr<Pub>>::AssocTy;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-trait.rs:126:14
@@ -326,7 +326,7 @@ LL |         impl PubTr for u8 {}
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 30 previous errors
 

--- a/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-type-binding.stderr
@@ -7,7 +7,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:11:16
@@ -18,7 +18,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:14:31
@@ -29,7 +29,7 @@ LL |         type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:16:31
@@ -40,7 +40,7 @@ LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
 LL |     priv_trait::mac1!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac1` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:13
@@ -51,7 +51,7 @@ LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:20:16
@@ -62,7 +62,7 @@ LL |         let _: Box<dyn PrivTr<AssocTy = u8>>;
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:23:31
@@ -73,7 +73,7 @@ LL |         type InSignatureTy1 = Box<dyn PrivTr<AssocTy = u8>>;
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `PrivTr` is private
   --> $DIR/associated-item-privacy-type-binding.rs:25:31
@@ -84,7 +84,7 @@ LL |         trait InSignatureTr1: PrivTr<AssocTy = u8> {}
 LL |     priv_trait::mac2!();
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_trait::mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:13
@@ -95,7 +95,7 @@ LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:44:16
@@ -106,7 +106,7 @@ LL |         let _: Box<dyn PubTrWithParam<AssocTy = u8>>;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:13
@@ -117,7 +117,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:47:16
@@ -128,7 +128,7 @@ LL |         let _: Box<dyn PubTr<AssocTy = u8>>;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:50:35
@@ -139,7 +139,7 @@ LL |         pub type InSignatureTy1 = Box<dyn PubTrWithParam<AssocTy = u8>>;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:52:35
@@ -150,7 +150,7 @@ LL |         pub type InSignatureTy2 = Box<dyn PubTr<AssocTy = u8>>;
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:54:31
@@ -161,7 +161,7 @@ LL |         trait InSignatureTr1: PubTrWithParam<AssocTy = u8> {}
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `Priv` is private
   --> $DIR/associated-item-privacy-type-binding.rs:56:31
@@ -172,7 +172,7 @@ LL |         trait InSignatureTr2: PubTr<AssocTy = u8> {}
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `priv_parent_substs::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/privacy/private-inferred-type-3.stderr
+++ b/src/test/ui/privacy/private-inferred-type-3.stderr
@@ -4,7 +4,7 @@ error: type `fn() {ext::priv_fn}` is private
 LL |     ext::m!();
    |     ^^^^^^^^^^ private type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: static `PRIV_STATIC` is private
   --> $DIR/private-inferred-type-3.rs:16:5
@@ -12,7 +12,7 @@ error: static `PRIV_STATIC` is private
 LL |     ext::m!();
    |     ^^^^^^^^^^ private static
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `ext::PrivEnum` is private
   --> $DIR/private-inferred-type-3.rs:16:5
@@ -20,7 +20,7 @@ error: type `ext::PrivEnum` is private
 LL |     ext::m!();
    |     ^^^^^^^^^^ private type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
@@ -28,7 +28,7 @@ error: type `fn() {<u8 as ext::PrivTrait>::method}` is private
 LL |     ext::m!();
    |     ^^^^^^^^^^ private type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
@@ -36,7 +36,7 @@ error: type `fn(u8) -> ext::PrivTupleStruct {ext::PrivTupleStruct}` is private
 LL |     ext::m!();
    |     ^^^^^^^^^^ private type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
@@ -44,7 +44,7 @@ error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
 LL |     ext::m!();
    |     ^^^^^^^^^^ private type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
   --> $DIR/private-inferred-type-3.rs:16:5
@@ -52,7 +52,7 @@ error: type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
 LL |     ext::m!();
    |     ^^^^^^^^^^ private type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `ext::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -115,7 +115,7 @@ LL |         priv_fn;
 LL |     m::m!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `PrivEnum` is private
   --> $DIR/private-inferred-type.rs:41:9
@@ -126,7 +126,7 @@ LL |         PrivEnum::Variant;
 LL |     m::m!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn() {<u8 as PrivTrait>::method}` is private
   --> $DIR/private-inferred-type.rs:43:9
@@ -137,7 +137,7 @@ LL |         <u8 as PrivTrait>::method;
 LL |     m::m!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn(u8) -> PrivTupleStruct {PrivTupleStruct}` is private
   --> $DIR/private-inferred-type.rs:45:9
@@ -148,7 +148,7 @@ LL |         PrivTupleStruct;
 LL |     m::m!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `fn(u8) -> PubTupleStruct {PubTupleStruct}` is private
   --> $DIR/private-inferred-type.rs:47:9
@@ -159,7 +159,7 @@ LL |         PubTupleStruct;
 LL |     m::m!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: type `for<'r> fn(&'r Pub<u8>) {Pub::<u8>::priv_method}` is private
   --> $DIR/private-inferred-type.rs:49:18
@@ -170,7 +170,7 @@ LL |         Pub(0u8).priv_method();
 LL |     m::m!();
    |     -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m::m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: trait `Trait` is private
   --> $DIR/private-inferred-type.rs:118:5

--- a/src/test/ui/proc-macro/derive-bad.stderr
+++ b/src/test/ui/proc-macro/derive-bad.stderr
@@ -4,7 +4,7 @@ error: expected `:`, found `}`
 LL | #[derive(A)]
    |          ^ expected `:`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `A` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc-macro derive produced unparseable tokens
   --> $DIR/derive-bad.rs:6:10

--- a/src/test/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.stderr
@@ -16,7 +16,7 @@ error: cannot find attribute `empty_helper` in this scope
 LL |             #[derive(GenHelperUse)]
    |                      ^^^^^^^^^^^^
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `GenHelperUse` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find attribute `empty_helper` in this scope
   --> $DIR/derive-helper-shadowing.rs:14:11
@@ -27,7 +27,7 @@ LL |         #[empty_helper]
 LL |             gen_helper_use!();
    |             ------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_helper_use` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0659]: `empty_helper` is ambiguous (name vs any other name during import resolution)
   --> $DIR/derive-helper-shadowing.rs:26:13

--- a/src/test/ui/proc-macro/expand-to-unstable-2.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.stderr
@@ -4,7 +4,7 @@ error: attributes starting with `rustc` are reserved for use by the `rustc` comp
 LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Unstable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/expand-to-unstable.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable.stderr
@@ -5,7 +5,7 @@ LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
    = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Unstable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/gen-macro-rules-hygiene.stderr
+++ b/src/test/ui/proc-macro/gen-macro-rules-hygiene.stderr
@@ -7,7 +7,7 @@ LL | gen_macro_rules!();
 LL |         generated!();
    |         ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generated` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/gen-macro-rules-hygiene.rs:12:1
@@ -18,7 +18,7 @@ LL | gen_macro_rules!();
 LL |         generated!();
    |         ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generated` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_def` in this scope
   --> $DIR/gen-macro-rules-hygiene.rs:21:9

--- a/src/test/ui/proc-macro/generate-mod.stderr
+++ b/src/test/ui/proc-macro/generate-mod.stderr
@@ -6,7 +6,7 @@ LL | generate_mod::check!();
    |
    = note: consider importing this struct:
            FromOutside
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_mod::check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `Outer` in this scope
   --> $DIR/generate-mod.rs:9:1
@@ -16,7 +16,7 @@ LL | generate_mod::check!();
    |
    = note: consider importing this struct:
            Outer
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `generate_mod::check` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:12:1
@@ -26,7 +26,7 @@ LL | #[generate_mod::check_attr]
    |
    = note: consider importing this struct:
            FromOutside
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `generate_mod::check_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `OuterAttr` in this scope
   --> $DIR/generate-mod.rs:12:1
@@ -36,7 +36,7 @@ LL | #[generate_mod::check_attr]
    |
    = note: consider importing this struct:
            OuterAttr
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `generate_mod::check_attr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:16:10
@@ -47,7 +47,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    = note: `#[warn(proc_macro_derive_resolution_fallback)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: cannot find type `OuterDerive` in this scope
   --> $DIR/generate-mod.rs:16:10
@@ -57,7 +57,7 @@ LL | #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: cannot find type `FromOutside` in this scope
   --> $DIR/generate-mod.rs:23:14
@@ -67,7 +67,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: cannot find type `OuterDerive` in this scope
   --> $DIR/generate-mod.rs:23:14
@@ -77,7 +77,7 @@ LL |     #[derive(generate_mod::CheckDerive)]
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83583 <https://github.com/rust-lang/rust/issues/83583>
-   = note: this warning originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the derive macro `generate_mod::CheckDerive` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors; 4 warnings emitted
 

--- a/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
+++ b/src/test/ui/proc-macro/group-compat-hack/group-compat-hack.stderr
@@ -13,7 +13,7 @@ LL |     impl_macros!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the `time-macros-impl` crate will stop compiling in futures version of Rust. Please update to the latest version of the `time` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `impl_macros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: using an old version of `time-macros-impl`
   --> $DIR/time-macros-impl-0.1.0/src/lib.rs:5:32
@@ -29,7 +29,7 @@ LL |     impl_macros!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the `time-macros-impl` crate will stop compiling in futures version of Rust. Please update to the latest version of the `time` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `impl_macros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: using an old version of `js-sys`
   --> $DIR/js-sys-0.3.17/src/lib.rs:5:32
@@ -45,7 +45,7 @@ LL |     arrays!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `js-sys` crate will stop compiling in future versions of Rust; please update to `js-sys` v0.3.40 or above
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `arrays` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: using an old version of `actix-web`
   --> $DIR/actix-web/src/extract.rs:5:34
@@ -61,7 +61,7 @@ LL |     tuple_from_req!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the version of `actix-web` you are using might stop compiling in future versions of Rust; please update to the latest version of the `actix-web` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `tuple_from_req` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: using an old version of `actix-web`
   --> $DIR/actix-web-2.0.0/src/extract.rs:5:34
@@ -77,7 +77,7 @@ LL |     tuple_from_req!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the version of `actix-web` you are using might stop compiling in future versions of Rust; please update to the latest version of the `actix-web` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `tuple_from_req` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 5 warnings emitted
 
@@ -97,7 +97,7 @@ LL |     impl_macros!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the `time-macros-impl` crate will stop compiling in futures version of Rust. Please update to the latest version of the `time` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `impl_macros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage date: None, diagnostic:
 warning: using an old version of `time-macros-impl`
@@ -114,7 +114,7 @@ LL |     impl_macros!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the `time-macros-impl` crate will stop compiling in futures version of Rust. Please update to the latest version of the `time` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `impl_macros` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage date: None, diagnostic:
 warning: using an old version of `js-sys`
@@ -131,7 +131,7 @@ LL |     arrays!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: older versions of the `js-sys` crate will stop compiling in future versions of Rust; please update to `js-sys` v0.3.40 or above
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `arrays` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage date: None, diagnostic:
 warning: using an old version of `actix-web`
@@ -148,7 +148,7 @@ LL |     tuple_from_req!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the version of `actix-web` you are using might stop compiling in future versions of Rust; please update to the latest version of the `actix-web` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `tuple_from_req` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 Future breakage date: None, diagnostic:
 warning: using an old version of `actix-web`
@@ -165,5 +165,5 @@ LL |     tuple_from_req!(Foo);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: the version of `actix-web` you are using might stop compiling in future versions of Rust; please update to the latest version of the `actix-web` crate to avoid breakage
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `tuple_from_req` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-4.stderr
@@ -4,7 +4,7 @@ error: unexpected closing delimiter: `)`
 LL | lexer_failure!();
    | ^^^^^^^^^^^^^^^^^ unexpected closing delimiter
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `lexer_failure` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
   --> $DIR/invalid-punct-ident-4.rs:6:1

--- a/src/test/ui/proc-macro/issue-38586.stderr
+++ b/src/test/ui/proc-macro/issue-38586.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `foo` in this scope
 LL | #[derive(A)]
    |          ^ not found in this scope
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `A` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/issue-59191-replace-root-with-fn.stderr
+++ b/src/test/ui/proc-macro/issue-59191-replace-root-with-fn.stderr
@@ -4,7 +4,7 @@ error: expected crate top-level item to be a module after macro expansion, found
 LL | #![issue_59191::no_main]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `issue_59191::no_main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/issue-83510.stderr
+++ b/src/test/ui/proc-macro/issue-83510.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `Foo` in this scope
 LL | issue_83510::dance_like_you_want_to_ice!();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0404]: expected trait, found struct `Box`
   --> $DIR/issue-83510.rs:5:1
@@ -12,7 +12,7 @@ error[E0404]: expected trait, found struct `Box`
 LL | issue_83510::dance_like_you_want_to_ice!();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a trait
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0405]: cannot find trait `Baz` in this scope
   --> $DIR/issue-83510.rs:5:1
@@ -20,7 +20,7 @@ error[E0405]: cannot find trait `Baz` in this scope
 LL | issue_83510::dance_like_you_want_to_ice!();
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0658]: inherent associated types are unstable
   --> $DIR/issue-83510.rs:5:1
@@ -30,7 +30,7 @@ LL | issue_83510::dance_like_you_want_to_ice!();
    |
    = note: see issue #8995 <https://github.com/rust-lang/rust/issues/8995> for more information
    = help: add `#![feature(inherent_associated_types)]` to the crate attributes to enable
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `issue_83510::dance_like_you_want_to_ice` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/proc-macro/lifetimes.stderr
+++ b/src/test/ui/proc-macro/lifetimes.stderr
@@ -7,7 +7,7 @@ LL | type A = single_quote_alone!();
    |          expected type
    |          this macro call doesn't expand to a type
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `single_quote_alone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/lints_in_proc_macros.stderr
+++ b/src/test/ui/proc-macro/lints_in_proc_macros.stderr
@@ -4,7 +4,7 @@ error[E0425]: cannot find value `foobar2` in this scope
 LL |     bang_proc_macro2!();
    |     ^^^^^^^^^^^^^^^^^^^^ help: a local variable with a similar name exists: `foobar`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `bang_proc_macro2` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/macro-rules-derive.stderr
+++ b/src/test/ui/proc-macro/macro-rules-derive.stderr
@@ -7,7 +7,7 @@ LL |             field: MissingType
 LL | produce_it!(MyName);
    | -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `produce_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/mixed-site-span.stderr
+++ b/src/test/ui/proc-macro/mixed-site-span.stderr
@@ -4,7 +4,7 @@ error[E0426]: use of undeclared label `'label_use`
 LL |         proc_macro_rules!();
    |         ^^^^^^^^^^^^^^^^^^^^ undeclared label `'label_use`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_use` in this scope
   --> $DIR/mixed-site-span.rs:13:9
@@ -12,7 +12,7 @@ error[E0425]: cannot find value `local_use` in this scope
 LL |         proc_macro_rules!();
    |         ^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `local_def` in this scope
   --> $DIR/mixed-site-span.rs:17:9
@@ -26,7 +26,7 @@ error[E0412]: cannot find type `ItemUse` in crate `$crate`
 LL | pass_dollar_crate!();
    | ^^^^^^^^^^^^^^^^^^^^^ not found in `$crate`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `proc_macro_rules` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/proc-macro/multispan.stderr
+++ b/src/test/ui/proc-macro/multispan.stderr
@@ -9,7 +9,7 @@ note: found these 'hi's
    |
 LL |     hello!(hi);
    |            ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
   --> $DIR/multispan.rs:15:5
@@ -22,7 +22,7 @@ note: found these 'hi's
    |
 LL |     hello!(hi hi);
    |            ^^ ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
   --> $DIR/multispan.rs:18:5
@@ -35,7 +35,7 @@ note: found these 'hi's
    |
 LL |     hello!(hi hi hi);
    |            ^^ ^^ ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
   --> $DIR/multispan.rs:21:5
@@ -48,7 +48,7 @@ note: found these 'hi's
    |
 LL |     hello!(hi hey hi yo hi beep beep hi hi);
    |            ^^     ^^    ^^           ^^ ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
   --> $DIR/multispan.rs:22:5
@@ -61,7 +61,7 @@ note: found these 'hi's
    |
 LL |     hello!(hi there, hi how are you? hi... hi.);
    |            ^^        ^^              ^^    ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
   --> $DIR/multispan.rs:23:5
@@ -74,7 +74,7 @@ note: found these 'hi's
    |
 LL |     hello!(whoah. hi di hi di ho);
    |                   ^^    ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: hello to you, too!
   --> $DIR/multispan.rs:24:5
@@ -87,7 +87,7 @@ note: found these 'hi's
    |
 LL |     hello!(hi good hi and good bye);
    |            ^^      ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `hello` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -7,7 +7,7 @@ LL |     three!($a, $b);
 LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: second final: "world"
   --> $DIR/parent-source-spans.rs:16:16
@@ -18,7 +18,7 @@ LL |     three!($a, $b);
 LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: first parent: "hello"
   --> $DIR/parent-source-spans.rs:10:5
@@ -29,7 +29,7 @@ LL |     two!($a, $b);
 LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: second parent: "world"
   --> $DIR/parent-source-spans.rs:10:5
@@ -40,7 +40,7 @@ LL |     two!($a, $b);
 LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `one` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: first grandparent: "hello"
   --> $DIR/parent-source-spans.rs:36:5
@@ -75,7 +75,7 @@ LL |     three!($a, $b);
 LL |     two!("yay", "rust");
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: second final: "rust"
   --> $DIR/parent-source-spans.rs:16:16
@@ -86,7 +86,7 @@ LL |     three!($a, $b);
 LL |     two!("yay", "rust");
    |     -------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `two` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: first parent: "yay"
   --> $DIR/parent-source-spans.rs:42:5
@@ -150,7 +150,7 @@ LL |     one!("hello", "world");
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `parent_source_spans` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
@@ -166,7 +166,7 @@ LL |     two!("yay", "rust");
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `parent_source_spans` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `ok` in this scope
   --> $DIR/parent-source-spans.rs:29:5
@@ -182,7 +182,7 @@ LL |     three!("hip", "hop");
 LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
    |     --------------------------------------------------- similarly named tuple variant `Ok` defined here
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `parent_source_spans` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 21 previous errors
 

--- a/src/test/ui/proc-macro/raw-ident.stderr
+++ b/src/test/ui/proc-macro/raw-ident.stderr
@@ -4,7 +4,7 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
 LL |     make_bad_struct!(S);
    |     ^^^^^^^^^^^^^^^^^^^^ expected one of 8 possible tokens
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `make_bad_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/resolved-located-at.stderr
+++ b/src/test/ui/proc-macro/resolved-located-at.stderr
@@ -4,7 +4,7 @@ error: expected error
 LL |     resolve_located_at!(a b)
    |                         ^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `resolve_located_at` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/resolved-located-at.rs:7:27
@@ -14,7 +14,7 @@ LL | fn main() {
 LL |     resolve_located_at!(a b)
    |                           ^ expected `()`, found struct `S`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `resolve_located_at` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/subspan.stderr
+++ b/src/test/ui/proc-macro/subspan.stderr
@@ -9,7 +9,7 @@ note: here
    |
 LL | subspan!("hi");
    |           ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: found 'hi's
   --> $DIR/subspan.rs:14:1
@@ -22,7 +22,7 @@ note: here
    |
 LL | subspan!("hihi");
    |           ^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: found 'hi's
   --> $DIR/subspan.rs:17:1
@@ -35,7 +35,7 @@ note: here
    |
 LL | subspan!("hihihi");
    |           ^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: found 'hi's
   --> $DIR/subspan.rs:20:1
@@ -48,7 +48,7 @@ note: here
    |
 LL | subspan!("why I hide? hi!");
    |                 ^^    ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: found 'hi's
   --> $DIR/subspan.rs:21:1
@@ -61,7 +61,7 @@ note: here
    |
 LL | subspan!("hey, hi, hidy, hidy, hi hi");
    |                ^^  ^^    ^^    ^^ ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: found 'hi's
   --> $DIR/subspan.rs:22:1
@@ -74,7 +74,7 @@ note: here
    |
 LL | subspan!("this is a hi, and this is another hi");
    |            ^^       ^^       ^^             ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: found 'hi's
   --> $DIR/subspan.rs:23:1
@@ -87,7 +87,7 @@ note: here
    |
 LL | subspan!("how are you this evening");
    |                        ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: found 'hi's
   --> $DIR/subspan.rs:24:1
@@ -100,7 +100,7 @@ note: here
    |
 LL | subspan!("this is highly eradic");
    |            ^^     ^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `subspan` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/proc-macro/three-equals.stderr
+++ b/src/test/ui/proc-macro/three-equals.stderr
@@ -5,7 +5,7 @@ LL |     three_equals!(==);
    |     ^^^^^^^^^^^^^^^^^^
    |
    = help: input must be: `===`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `three_equals` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected EOF, found `=`.
   --> $DIR/three-equals.rs:15:21

--- a/src/test/ui/proc-macro/weird-hygiene.stderr
+++ b/src/test/ui/proc-macro/weird-hygiene.stderr
@@ -7,7 +7,7 @@ LL |             Value = (stringify!($tokens + hidden_ident), 1).1
 LL |     other!(50);
    |     ----------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `inner` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0425]: cannot find value `hidden_ident` in this scope
   --> $DIR/weird-hygiene.rs:34:13
@@ -18,7 +18,7 @@ LL |             hidden_ident
 LL |     invoke_it!(25);
    |     --------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `invoke_it` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/range/range_traits-1.stderr
+++ b/src/test/ui/range/range_traits-1.stderr
@@ -6,7 +6,7 @@ LL |     a: Range<usize>,
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::Range<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeTo<usize>` with `std::ops::RangeTo<usize>`
   --> $DIR/range_traits-1.rs:8:5
@@ -16,7 +16,7 @@ LL |     b: RangeTo<usize>,
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeTo<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFrom<usize>` with `std::ops::RangeFrom<usize>`
   --> $DIR/range_traits-1.rs:11:5
@@ -26,7 +26,7 @@ LL |     c: RangeFrom<usize>,
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFrom<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeFull` with `std::ops::RangeFull`
   --> $DIR/range_traits-1.rs:14:5
@@ -36,7 +36,7 @@ LL |     d: RangeFull,
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeFull`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeInclusive<usize>` with `std::ops::RangeInclusive<usize>`
   --> $DIR/range_traits-1.rs:17:5
@@ -46,7 +46,7 @@ LL |     e: RangeInclusive<usize>,
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: can't compare `std::ops::RangeToInclusive<usize>` with `std::ops::RangeToInclusive<usize>`
   --> $DIR/range_traits-1.rs:20:5
@@ -56,7 +56,7 @@ LL |     f: RangeToInclusive<usize>,
    |
    = help: the trait `PartialOrd` is not implemented for `std::ops::RangeToInclusive<usize>`
    = note: required by `std::cmp::PartialOrd::partial_cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::Range<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:5:5
@@ -65,7 +65,7 @@ LL |     a: Range<usize>,
    |     ^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::Range<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeTo<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:8:5
@@ -74,7 +74,7 @@ LL |     b: RangeTo<usize>,
    |     ^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeTo<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFrom<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:11:5
@@ -83,7 +83,7 @@ LL |     c: RangeFrom<usize>,
    |     ^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFrom<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeFull: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:14:5
@@ -92,7 +92,7 @@ LL |     d: RangeFull,
    |     ^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeFull`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeInclusive<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:17:5
@@ -101,7 +101,7 @@ LL |     e: RangeInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeInclusive<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::ops::RangeToInclusive<usize>: Ord` is not satisfied
   --> $DIR/range_traits-1.rs:20:5
@@ -110,7 +110,7 @@ LL |     f: RangeToInclusive<usize>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Ord` is not implemented for `std::ops::RangeToInclusive<usize>`
    |
    = note: required by `std::cmp::Ord::cmp`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/range/range_traits-2.stderr
+++ b/src/test/ui/range/range_traits-2.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Copy, Clone)]
 LL | struct R(Range<usize>);
    |          ------------ this field does not implement `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/range/range_traits-3.stderr
+++ b/src/test/ui/range/range_traits-3.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Copy, Clone)]
 LL | struct R(RangeFrom<usize>);
    |          ---------------- this field does not implement `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/range/range_traits-6.stderr
+++ b/src/test/ui/range/range_traits-6.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Copy, Clone)]
 LL | struct R(RangeInclusive<usize>);
    |          --------------------- this field does not implement `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_again.stderr
+++ b/src/test/ui/reachable/expr_again.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_block.stderr
+++ b/src/test/ui/reachable/expr_block.stderr
@@ -20,7 +20,7 @@ LL |         return;
 LL |         println!("foo");
    |         ^^^^^^^^^^^^^^^^ unreachable statement
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_if.stderr
+++ b/src/test/ui/reachable/expr_if.stderr
@@ -24,7 +24,7 @@ LL |         return;
 LL |     println!("But I am.");
    |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_loop.stderr
+++ b/src/test/ui/reachable/expr_loop.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:21:5
@@ -21,7 +21,7 @@ LL |     loop { return; }
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_loop.rs:32:5
@@ -31,7 +31,7 @@ LL |     loop { 'middle: loop { loop { break 'middle; } } }
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unreachable statement
   --> $DIR/expr_match.rs:19:5
@@ -21,7 +21,7 @@ LL |     match () { () if false => return, () => return }
 LL |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^ unreachable statement
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/unreachable-code-ret.stderr
+++ b/src/test/ui/reachable/unreachable-code-ret.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/issue-82865.stderr
+++ b/src/test/ui/resolve/issue-82865.stderr
@@ -13,7 +13,7 @@ LL |     Box::z
 LL |     mac!();
    |     ------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -12,7 +12,7 @@ LL |   pub fn assert_test_result<T: Termination>(result: T) {
    |                                ----------- required by this bound in `assert_test_result`
    |
    = help: the trait `Termination` is not implemented for `Result<f32, ParseFloatError>`
-   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -8,7 +8,7 @@ LL |     let _: NotDebug = dbg!(NotDebug);
    = note: add `#[derive(Debug)]` or manually implement `Debug`
    = note: required because of the requirements on the impl of `Debug` for `&NotDebug`
    = note: required by `std::fmt::Debug::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
@@ -17,7 +17,7 @@ LL | |             }
 LL |       m!();
    |       ----- in this macro invocation
    = help: use `self::std` to refer to this module unambiguously
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
@@ -17,7 +17,7 @@ LL | |         }
 LL |   m!();
    |   ----- in this macro invocation
    = help: use `crate::std` to refer to this module unambiguously
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/simd/shuffle-not-out-of-bounds.stderr
+++ b/src/test/ui/simd/shuffle-not-out-of-bounds.stderr
@@ -7,7 +7,7 @@ LL |                     $y(vec1, vec2, ARR)
 LL |     test_shuffle_lanes!(2, u8x2, simd_shuffle2, (2, 1));
    |     ---------------------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle4` intrinsic: shuffle index #0 is out of bounds (limit 8)
   --> $DIR/shuffle-not-out-of-bounds.rs:163:21
@@ -18,7 +18,7 @@ LL |                     $y(vec1, vec2, ARR)
 LL |     test_shuffle_lanes!(4, u8x4, simd_shuffle4, (4, 3, 2, 1));
    |     ---------------------------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle8` intrinsic: shuffle index #0 is out of bounds (limit 16)
   --> $DIR/shuffle-not-out-of-bounds.rs:163:21
@@ -29,7 +29,7 @@ LL |                     $y(vec1, vec2, ARR)
 LL |     test_shuffle_lanes!(8, u8x8, simd_shuffle8, (8, 7, 6, 5, 4, 3, 2, 1));
    |     ---------------------------------------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle16` intrinsic: shuffle index #0 is out of bounds (limit 32)
   --> $DIR/shuffle-not-out-of-bounds.rs:163:21
@@ -41,7 +41,7 @@ LL | /     test_shuffle_lanes!(16, u8x16, simd_shuffle16,
 LL | |         (16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
    | |_________________________________________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle32` intrinsic: shuffle index #0 is out of bounds (limit 64)
   --> $DIR/shuffle-not-out-of-bounds.rs:163:21
@@ -54,7 +54,7 @@ LL | |         (32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 
 LL | |          15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
    | |_____________________________________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle64` intrinsic: shuffle index #0 is out of bounds (limit 128)
   --> $DIR/shuffle-not-out-of-bounds.rs:163:21
@@ -69,7 +69,7 @@ LL | |          32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17,
 LL | |          16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1));
    | |_________________________________________________________________- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/E0204.stderr
+++ b/src/test/ui/span/E0204.stderr
@@ -16,7 +16,7 @@ LL | struct Foo2<'a> {
 LL |     ty: &'a mut bool,
    |     ---------------- this field does not implement `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0204]: the trait `Copy` may not be implemented for this type
   --> $DIR/E0204.rs:17:6
@@ -36,7 +36,7 @@ LL | enum EFoo2<'a> {
 LL |     Bar(&'a mut bool),
    |         ------------ this field does not implement `Copy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -49,7 +49,7 @@ error[E0308]: mismatched types
 LL |     s = format!("foo");
    |         ^^^^^^^^^^^^^^ expected `&mut String`, found struct `String`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/span/issue-33884.stderr
+++ b/src/test/ui/span/issue-33884.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     stream.write_fmt(format!("message received"))
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Arguments`, found struct `String`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -13,7 +13,7 @@ note: the lint level is defined here
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted
 

--- a/src/test/ui/span/slice-borrow.stderr
+++ b/src/test/ui/span/slice-borrow.stderr
@@ -10,7 +10,7 @@ LL |     y.use_ref();
    |     - borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
+++ b/src/test/ui/suggestions/dont-suggest-deref-inside-macro-issue-58298.stderr
@@ -6,7 +6,7 @@ LL | |         "abc"
 LL | |     };
    | |______^ expected `&str`, found struct `String`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/dont-suggest-try_into-in-macros.stderr
+++ b/src/test/ui/suggestions/dont-suggest-try_into-in-macros.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |     assert_eq!(10u64, 10usize);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u64`, found `usize`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -47,7 +47,7 @@ LL | pub struct BufWriter<W: Write> {
    = note: the following trait bounds were not satisfied:
            `&dyn std::io::Write: std::io::Write`
            which is required by `BufWriter<&dyn std::io::Write>: std::io::Write`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `writeln` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/path-display.stderr
+++ b/src/test/ui/suggestions/path-display.stderr
@@ -8,7 +8,7 @@ LL |     println!("{}", path);
    = note: call `.display()` or `.to_string_lossy()` to safely print paths, as they may contain non-Unicode data
    = note: required because of the requirements on the impl of `std::fmt::Display` for `&Path`
    = note: required by `std::fmt::Display::fmt`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-71136.stderr
+++ b/src/test/ui/traits/issue-71136.stderr
@@ -6,7 +6,7 @@ LL |     the_foos: Vec<Foo>,
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<Foo>`
    = note: required by `clone`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-79458.stderr
+++ b/src/test/ui/traits/issue-79458.stderr
@@ -8,7 +8,7 @@ LL |     bar: &'a mut T
              <&T as Clone>
    = note: `Clone` is implemented for `&T`, but not for `&mut T`
    = note: required by `clone`
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/try-block/try-block-opt-init.stderr
+++ b/src/test/ui/try-block/try-block-opt-init.stderr
@@ -4,7 +4,7 @@ error[E0381]: borrow of possibly-uninitialized variable: `cfg_res`
 LL |     assert_eq!(cfg_res, 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `cfg_res`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/tuple/tuple-struct-fields/test2.stderr
+++ b/src/test/ui/tuple/tuple-struct-fields/test2.stderr
@@ -9,7 +9,7 @@ LL |         struct S3(pub $t ());
 LL |     define_struct! { (foo) }
    |     ------------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `foo` in this scope
   --> $DIR/test2.rs:11:23

--- a/src/test/ui/tuple/tuple-struct-fields/test3.stderr
+++ b/src/test/ui/tuple/tuple-struct-fields/test3.stderr
@@ -9,7 +9,7 @@ LL |         struct S3(pub($t) ());
 LL |     define_struct! { foo }
    |     ---------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_struct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `foo` in this scope
   --> $DIR/test3.rs:11:22

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -10,7 +10,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
    |                   help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::__rust_force_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -6,7 +6,7 @@ LL |     let x = vec![];
    |         |
    |         consider giving `x` the explicit type `Vec<T>`, where the type parameter `T` is specified
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -6,7 +6,7 @@ LL |     let (x, ) = (vec![], );
    |         |
    |         consider giving this pattern the explicit type `(Vec<T>,)`, where the type parameter `T` is specified
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/issue-81943.stderr
+++ b/src/test/ui/typeck/issue-81943.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |   f(|x| lib::d!(x));
    |         ^^^^^^^^^^ expected `()`, found `i32`
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `lib::d` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> $DIR/issue-81943.rs:8:28
@@ -36,7 +36,7 @@ LL |   }
 LL |   f(|x| d!(x));
    |         ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `d` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider using a semicolon here
    |
 LL |     ($e:expr) => { match $e { x => { g(x); } } }

--- a/src/test/ui/union/union-derive-clone.stderr
+++ b/src/test/ui/union/union-derive-clone.stderr
@@ -9,7 +9,7 @@ LL | #[derive(Clone)]
 LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
    |                                 ---- required by this bound in `AssertParamIsCopy`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its trait bounds were not satisfied
   --> $DIR/union-derive-clone.rs:35:15

--- a/src/test/ui/union/union-derive-eq.stderr
+++ b/src/test/ui/union/union-derive-eq.stderr
@@ -9,7 +9,7 @@ LL |     a: PartialEqNotEq,
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               -- required by this bound in `AssertParamIsEq`
    |
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/unused/unused-macro-rules.stderr
+++ b/src/test/ui/unused/unused-macro-rules.stderr
@@ -23,7 +23,7 @@ LL | |         }
 LL |   create_macro!();
    |   ---------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `create_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unused macro definition
   --> $DIR/unused-macro-rules.rs:24:5

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -12,7 +12,7 @@ LL | |     });
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:7:13
@@ -27,7 +27,7 @@ LL | |     });
    |
    = note: this pattern will always match, so the loop will never exit
    = help: consider instead using a `loop { ... }` with a `let` inside it
-   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this warning originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:27:5

--- a/src/tools/clippy/tests/ui-internal/default_lint.stderr
+++ b/src/tools/clippy/tests/ui-internal/default_lint.stderr
@@ -15,7 +15,7 @@ note: the lint level is defined here
 LL | #![deny(clippy::internal)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[deny(clippy::default_lint)]` implied by `#[deny(clippy::internal)]`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::declare_tool_lint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui-internal/if_chain_style.stderr
+++ b/src/tools/clippy/tests/ui-internal/if_chain_style.stderr
@@ -56,7 +56,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `__if_chain` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `let` expression should be above the `if_chain!`
   --> $DIR/if_chain_style.rs:40:9

--- a/src/tools/clippy/tests/ui-internal/lint_without_lint_pass.stderr
+++ b/src/tools/clippy/tests/ui-internal/lint_without_lint_pass.stderr
@@ -15,7 +15,7 @@ note: the lint level is defined here
 LL | #![deny(clippy::internal)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[deny(clippy::lint_without_lint_pass)]` implied by `#[deny(clippy::internal)]`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `declare_tool_lint` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui/assertions_on_constants.stderr
+++ b/src/tools/clippy/tests/ui/assertions_on_constants.stderr
@@ -6,7 +6,7 @@ LL |     assert!(true);
    |
    = note: `-D clippy::assertions-on-constants` implied by `-D warnings`
    = help: remove it
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert!(false)` should probably be replaced
   --> $DIR/assertions_on_constants.rs:12:5
@@ -15,7 +15,7 @@ LL |     assert!(false);
    |     ^^^^^^^^^^^^^^^
    |
    = help: use `panic!()` or `unreachable!()`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:13:5
@@ -24,7 +24,7 @@ LL |     assert!(true, "true message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: remove it
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert!(false, "false message")` should probably be replaced
   --> $DIR/assertions_on_constants.rs:14:5
@@ -33,7 +33,7 @@ LL |     assert!(false, "false message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!("false message")` or `unreachable!("false message")`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert!(false, msg.to_uppercase())` should probably be replaced
   --> $DIR/assertions_on_constants.rs:17:5
@@ -42,7 +42,7 @@ LL |     assert!(false, msg.to_uppercase());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!(msg.to_uppercase())` or `unreachable!(msg.to_uppercase())`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:20:5
@@ -51,7 +51,7 @@ LL |     assert!(B);
    |     ^^^^^^^^^^^
    |
    = help: remove it
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert!(false)` should probably be replaced
   --> $DIR/assertions_on_constants.rs:23:5
@@ -60,7 +60,7 @@ LL |     assert!(C);
    |     ^^^^^^^^^^^
    |
    = help: use `panic!()` or `unreachable!()`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert!(false, "C message")` should probably be replaced
   --> $DIR/assertions_on_constants.rs:24:5
@@ -69,7 +69,7 @@ LL |     assert!(C, "C message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!("C message")` or `unreachable!("C message")`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `debug_assert!(true)` will be optimized out by the compiler
   --> $DIR/assertions_on_constants.rs:26:5
@@ -78,7 +78,7 @@ LL |     debug_assert!(true);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = help: remove it
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 9 previous errors
 

--- a/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
+++ b/src/tools/clippy/tests/ui/checked_unwrap/simple_conditionals.stderr
@@ -55,7 +55,7 @@ LL |             $a.unwrap(); // unnecessary
 LL |     m!(x);
    |     ------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you checked before that `unwrap()` cannot fail, instead of checking and unwrapping, it's better to use `if let` or `match`
   --> $DIR/simple_conditionals.rs:54:9

--- a/src/tools/clippy/tests/ui/collapsible_match2.stderr
+++ b/src/tools/clippy/tests/ui/collapsible_match2.stderr
@@ -55,7 +55,7 @@ LL |         mac!(res_opt => Ok(val), val => Some(n), foo(n));
    |                            ^^^          ^^^^^^^ with this pattern
    |                            |
    |                            replace this binding
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unnecessary nested match
   --> $DIR/collapsible_match2.rs:51:20

--- a/src/tools/clippy/tests/ui/crashes/ice-6255.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6255.stderr
@@ -7,7 +7,7 @@ LL |         extern crate std as core;
 LL | define_other_core!();
    | --------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `define_other_core` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui/declare_interior_mutable_const/others.stderr
+++ b/src/tools/clippy/tests/ui/declare_interior_mutable_const/others.stderr
@@ -33,7 +33,7 @@ LL |         const $name: $ty = $e;
 LL | declare_const!(_ONCE: Once = Once::new()); //~ ERROR interior mutable
    | ------------------------------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/declare_interior_mutable_const/traits.stderr
+++ b/src/tools/clippy/tests/ui/declare_interior_mutable_const/traits.stderr
@@ -15,7 +15,7 @@ LL |         const $name: $ty = $e;
 LL |     declare_const!(ANOTHER_ATOMIC: AtomicUsize = Self::ATOMIC); //~ ERROR interior mutable
    |     ----------------------------------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `declare_const` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: a `const` item should never be interior mutable
   --> $DIR/traits.rs:43:5

--- a/src/tools/clippy/tests/ui/deref_addrof.stderr
+++ b/src/tools/clippy/tests/ui/deref_addrof.stderr
@@ -57,7 +57,7 @@ LL |         *& $visitor
 LL |         m!(self)
    |         -------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: immediately dereferencing a reference
   --> $DIR/deref_addrof.rs:51:9
@@ -68,7 +68,7 @@ LL |         *& mut $visitor
 LL |         m_mut!(self)
    |         ------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `m_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 10 previous errors
 

--- a/src/tools/clippy/tests/ui/derive_hash_xor_eq.stderr
+++ b/src/tools/clippy/tests/ui/derive_hash_xor_eq.stderr
@@ -14,7 +14,7 @@ LL | |         true
 LL | |     }
 LL | | }
    | |_^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `Hash` but have implemented `PartialEq` explicitly
   --> $DIR/derive_hash_xor_eq.rs:19:10
@@ -31,7 +31,7 @@ LL | |         true
 LL | |     }
 LL | | }
    | |_^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are implementing `Hash` explicitly but have derived `PartialEq`
   --> $DIR/derive_hash_xor_eq.rs:31:1
@@ -46,7 +46,7 @@ note: `PartialEq` implemented here
    |
 LL | #[derive(PartialEq)]
    |          ^^^^^^^^^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are implementing `Hash` explicitly but have derived `PartialEq`
   --> $DIR/derive_hash_xor_eq.rs:49:5
@@ -61,7 +61,7 @@ note: `PartialEq` implemented here
    |
 LL |     #[derive(PartialEq)]
    |              ^^^^^^^^^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/derive_ord_xor_partial_ord.stderr
+++ b/src/tools/clippy/tests/ui/derive_ord_xor_partial_ord.stderr
@@ -14,7 +14,7 @@ LL | |         Some(other.cmp(self))
 LL | |     }
 LL | | }
    | |_^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `Ord` but have implemented `PartialOrd` explicitly
   --> $DIR/derive_ord_xor_partial_ord.rs:30:10
@@ -31,7 +31,7 @@ LL | |         Some(other.cmp(self))
 LL | |     }
 LL | | }
    | |_^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are implementing `Ord` explicitly but have derived `PartialOrd`
   --> $DIR/derive_ord_xor_partial_ord.rs:42:1
@@ -48,7 +48,7 @@ note: `PartialOrd` implemented here
    |
 LL | #[derive(PartialOrd, PartialEq, Eq)]
    |          ^^^^^^^^^^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are implementing `Ord` explicitly but have derived `PartialOrd`
   --> $DIR/derive_ord_xor_partial_ord.rs:62:5
@@ -65,7 +65,7 @@ note: `PartialOrd` implemented here
    |
 LL |     #[derive(PartialOrd, PartialEq, Eq)]
    |              ^^^^^^^^^^
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/doc_unsafe.stderr
+++ b/src/tools/clippy/tests/ui/doc_unsafe.stderr
@@ -41,7 +41,7 @@ LL | |         }
 LL |   very_unsafe!();
    |   --------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `very_unsafe` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 5 previous errors
 

--- a/src/tools/clippy/tests/ui/eq_op_macros.stderr
+++ b/src/tools/clippy/tests/ui/eq_op_macros.stderr
@@ -8,7 +8,7 @@ LL |     assert_in_macro_def!();
    |     ----------------------- in this macro invocation
    |
    = note: `-D clippy::eq-op` implied by `-D warnings`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `assert_ne!` macro call
   --> $DIR/eq_op_macros.rs:8:20
@@ -19,7 +19,7 @@ LL |         assert_ne!(a, a);
 LL |     assert_in_macro_def!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `assert_eq!` macro call
   --> $DIR/eq_op_macros.rs:22:16
@@ -54,7 +54,7 @@ LL |         debug_assert_eq!(a, a);
 LL |     assert_in_macro_def!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `debug_assert_ne!` macro call
   --> $DIR/eq_op_macros.rs:10:26
@@ -65,7 +65,7 @@ LL |         debug_assert_ne!(a, a);
 LL |     assert_in_macro_def!();
    |     ----------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_in_macro_def` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: identical args used in this `debug_assert_eq!` macro call
   --> $DIR/eq_op_macros.rs:38:22

--- a/src/tools/clippy/tests/ui/fallible_impl_from.stderr
+++ b/src/tools/clippy/tests/ui/fallible_impl_from.stderr
@@ -38,7 +38,7 @@ note: potential failure(s)
    |
 LL |             panic!();
    |             ^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
   --> $DIR/fallible_impl_from.rs:35:1
@@ -65,7 +65,7 @@ LL |         } else if s.parse::<u32>().unwrap() != 42 {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
    |             ^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: consider implementing `TryFrom` instead
   --> $DIR/fallible_impl_from.rs:53:1
@@ -87,7 +87,7 @@ LL |         if s.parse::<u32>().ok().unwrap() != 42 {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |             panic!("{:?}", s);
    |             ^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/implicit_hasher.stderr
+++ b/src/tools/clippy/tests/ui/implicit_hasher.stderr
@@ -109,7 +109,7 @@ LL |         impl<K: Hash + Eq, V> Foo<u8> for HashMap<K, V> {
 LL | gen!(impl);
    | ----------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding a type parameter
    |
 LL |         impl<K: Hash + Eq, V, S: ::std::hash::BuildHasher + Default> Foo<u8> for HashMap<K, V, S> {
@@ -128,7 +128,7 @@ LL |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>)
 LL | gen!(fn bar);
    | ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding a type parameter
    |
 LL |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32, S>, _set: &mut HashSet<i32>) {}
@@ -143,7 +143,7 @@ LL |         pub fn $name(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32>)
 LL | gen!(fn bar);
    | ------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding a type parameter
    |
 LL |         pub fn $name<S: ::std::hash::BuildHasher>(_map: &mut HashMap<i32, i32>, _set: &mut HashSet<i32, S>) {}

--- a/src/tools/clippy/tests/ui/item_after_statement.stderr
+++ b/src/tools/clippy/tests/ui/item_after_statement.stderr
@@ -27,7 +27,7 @@ LL | |             }
 LL |       b!();
    |       ----- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `b` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/clippy/tests/ui/match_same_arms2.stderr
+++ b/src/tools/clippy/tests/ui/match_same_arms2.stderr
@@ -121,7 +121,7 @@ help: consider refactoring into `(Ok(x), Some(_)) | (Ok(_), Some(x))`
    |
 LL |         (Ok(x), Some(_)) => println!("ok {}", x),
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms2.rs:117:18
@@ -139,7 +139,7 @@ help: consider refactoring into `Ok(3) | Ok(_)`
    |
 LL |         Ok(3) => println!("ok"),
    |         ^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this `match` has identical arm bodies
   --> $DIR/match_same_arms2.rs:144:14

--- a/src/tools/clippy/tests/ui/mem_discriminant.stderr
+++ b/src/tools/clippy/tests/ui/mem_discriminant.stderr
@@ -72,7 +72,7 @@ LL |     mem_discriminant_but_in_a_macro!(&rro);
    |     |                                help: try dereferencing: `*rro`
    |     in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mem_discriminant_but_in_a_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: calling `mem::discriminant` on non-enum type `&&&&&std::option::Option<i32>`
   --> $DIR/mem_discriminant.rs:34:5

--- a/src/tools/clippy/tests/ui/mem_replace_macro.stderr
+++ b/src/tools/clippy/tests/ui/mem_replace_macro.stderr
@@ -8,7 +8,7 @@ LL |     take!(s);
    |     --------- in this macro invocation
    |
    = note: `-D clippy::mem-replace-with-default` implied by `-D warnings`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `take` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui/missing_panics_doc.stderr
+++ b/src/tools/clippy/tests/ui/missing_panics_doc.stderr
@@ -27,7 +27,7 @@ note: first possible panic found here
    |
 LL |     panic!("This function panics")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:18:1
@@ -42,7 +42,7 @@ note: first possible panic found here
    |
 LL |     todo!()
    |     ^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:23:1
@@ -61,7 +61,7 @@ note: first possible panic found here
    |
 LL |             panic!()
    |             ^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:32:1
@@ -76,7 +76,7 @@ note: first possible panic found here
    |
 LL |     if true { unreachable!() } else { panic!() }
    |                                       ^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:37:1
@@ -92,7 +92,7 @@ note: first possible panic found here
    |
 LL |     assert_eq!(x, 0);
    |     ^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: docs for function which may panic missing `# Panics` section
   --> $DIR/missing_panics_doc.rs:43:1
@@ -108,7 +108,7 @@ note: first possible panic found here
    |
 LL |     assert_ne!(x, 0);
    |     ^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 7 previous errors
 

--- a/src/tools/clippy/tests/ui/mut_mut.stderr
+++ b/src/tools/clippy/tests/ui/mut_mut.stderr
@@ -21,7 +21,7 @@ LL |         &mut $p
 LL |     let mut z = mut_ptr!(&mut 3u32);
    |                 ------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `mut_ptr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this expression mutably borrows a mutable reference. Consider reborrowing
   --> $DIR/mut_mut.rs:22:21

--- a/src/tools/clippy/tests/ui/needless_question_mark.stderr
+++ b/src/tools/clippy/tests/ui/needless_question_mark.stderr
@@ -75,7 +75,7 @@ LL |         || -> Option<_> { Some(Some($expr)?) }()
 LL |     let _x = some_and_qmark_in_macro!(x?);
    |              ---------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `some_and_qmark_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 12 previous errors
 

--- a/src/tools/clippy/tests/ui/option_env_unwrap.stderr
+++ b/src/tools/clippy/tests/ui/option_env_unwrap.stderr
@@ -25,7 +25,7 @@ LL |     let _ = option_env_unwrap!("PATH");
    |             -------------------------- in this macro invocation
    |
    = help: consider using the `env!` macro instead
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `option_env_unwrap` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
   --> $DIR/option_env_unwrap.rs:12:9
@@ -37,7 +37,7 @@ LL |     let _ = option_env_unwrap!("PATH", "environment variable PATH isn't set
    |             ----------------------------------------------------------------- in this macro invocation
    |
    = help: consider using the `env!` macro instead
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `option_env_unwrap` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
   --> $DIR/option_env_unwrap.rs:21:13
@@ -46,7 +46,7 @@ LL |     let _ = option_env_unwrap_external!("PATH");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using the `env!` macro instead
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `option_env_unwrap_external` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: this will panic at run-time if the environment variable doesn't exist at compile-time
   --> $DIR/option_env_unwrap.rs:22:13
@@ -55,7 +55,7 @@ LL |     let _ = option_env_unwrap_external!("PATH", "environment variable PATH 
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using the `env!` macro instead
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `option_env_unwrap_external` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui/panic_in_result_fn.stderr
+++ b/src/tools/clippy/tests/ui/panic_in_result_fn.stderr
@@ -14,7 +14,7 @@ note: return Err() instead of panicking
    |
 LL |         panic!("error");
    |         ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
   --> $DIR/panic_in_result_fn.rs:12:5
@@ -31,7 +31,7 @@ note: return Err() instead of panicking
    |
 LL |         unimplemented!();
    |         ^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
   --> $DIR/panic_in_result_fn.rs:17:5
@@ -48,7 +48,7 @@ note: return Err() instead of panicking
    |
 LL |         unreachable!();
    |         ^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
   --> $DIR/panic_in_result_fn.rs:22:5
@@ -65,7 +65,7 @@ note: return Err() instead of panicking
    |
 LL |         todo!("Finish this");
    |         ^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
   --> $DIR/panic_in_result_fn.rs:53:1
@@ -82,7 +82,7 @@ note: return Err() instead of panicking
    |
 LL |     panic!("error");
    |     ^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
   --> $DIR/panic_in_result_fn.rs:68:1
@@ -99,7 +99,7 @@ note: return Err() instead of panicking
    |
 LL |     todo!("finish main method");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui/panic_in_result_fn_assertions.stderr
+++ b/src/tools/clippy/tests/ui/panic_in_result_fn_assertions.stderr
@@ -15,7 +15,7 @@ note: return Err() instead of panicking
    |
 LL |         assert!(x == 5, "wrong argument");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
   --> $DIR/panic_in_result_fn_assertions.rs:13:5
@@ -33,7 +33,7 @@ note: return Err() instead of panicking
    |
 LL |         assert_eq!(x, 5);
    |         ^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: used `unimplemented!()`, `unreachable!()`, `todo!()`, `panic!()` or assertion in a function that returns `Result`
   --> $DIR/panic_in_result_fn_assertions.rs:19:5
@@ -51,7 +51,7 @@ note: return Err() instead of panicking
    |
 LL |         assert_ne!(x, 1);
    |         ^^^^^^^^^^^^^^^^^
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/clippy/tests/ui/panicking_macros.stderr
+++ b/src/tools/clippy/tests/ui/panicking_macros.stderr
@@ -25,7 +25,7 @@ LL |     todo!();
    |     ^^^^^^^^
    |
    = note: `-D clippy::todo` implied by `-D warnings`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `todo` should not be present in production code
   --> $DIR/panicking_macros.rs:17:5
@@ -33,7 +33,7 @@ error: `todo` should not be present in production code
 LL |     todo!("message");
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `todo` should not be present in production code
   --> $DIR/panicking_macros.rs:18:5
@@ -41,7 +41,7 @@ error: `todo` should not be present in production code
 LL |     todo!("{} {}", "panic with", "multiple arguments");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:24:5
@@ -50,7 +50,7 @@ LL |     unimplemented!();
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unimplemented` implied by `-D warnings`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:25:5
@@ -58,7 +58,7 @@ error: `unimplemented` should not be present in production code
 LL |     unimplemented!("message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:26:5
@@ -66,7 +66,7 @@ error: `unimplemented` should not be present in production code
 LL |     unimplemented!("{} {}", "panic with", "multiple arguments");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:32:5
@@ -75,7 +75,7 @@ LL |     unreachable!();
    |     ^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::unreachable` implied by `-D warnings`
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:33:5
@@ -83,7 +83,7 @@ error: usage of the `unreachable!` macro
 LL |     unreachable!("message");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:34:5
@@ -91,7 +91,7 @@ error: usage of the `unreachable!` macro
 LL |     unreachable!("{} {}", "panic with", "multiple arguments");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `panic` should not be present in production code
   --> $DIR/panicking_macros.rs:40:5
@@ -105,7 +105,7 @@ error: `todo` should not be present in production code
 LL |     todo!();
    |     ^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `todo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `unimplemented` should not be present in production code
   --> $DIR/panicking_macros.rs:42:5
@@ -113,7 +113,7 @@ error: `unimplemented` should not be present in production code
 LL |     unimplemented!();
    |     ^^^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unimplemented` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: usage of the `unreachable!` macro
   --> $DIR/panicking_macros.rs:43:5
@@ -121,7 +121,7 @@ error: usage of the `unreachable!` macro
 LL |     unreachable!();
    |     ^^^^^^^^^^^^^^^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `unreachable` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 16 previous errors
 

--- a/src/tools/clippy/tests/ui/pattern_type_mismatch/syntax.stderr
+++ b/src/tools/clippy/tests/ui/pattern_type_mismatch/syntax.stderr
@@ -73,7 +73,7 @@ LL |     matching_macro!(value);
    |     ----------------------- in this macro invocation
    |
    = help: use `*` to dereference the match expression or explicitly match against a `&_` pattern and adjust the enclosed variable bindings
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `matching_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 9 previous errors
 

--- a/src/tools/clippy/tests/ui/toplevel_ref_arg.stderr
+++ b/src/tools/clippy/tests/ui/toplevel_ref_arg.stderr
@@ -39,7 +39,7 @@ LL |         let ref _y = 42;
 LL |         gen_binding!();
    |         --------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_binding` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui/toplevel_ref_arg_non_rustfix.stderr
+++ b/src/tools/clippy/tests/ui/toplevel_ref_arg_non_rustfix.stderr
@@ -15,7 +15,7 @@ LL |         fn fun_example(ref _x: usize) {}
 LL |         gen_function!();
    |         ---------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `gen_function` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/try_err.stderr
+++ b/src/tools/clippy/tests/ui/try_err.stderr
@@ -37,7 +37,7 @@ LL |             Err(_) => Err(1)?,
 LL |     try_validation!(Ok::<_, i32>(5));
    |     --------------------------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `try_validation` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:102:23
@@ -48,7 +48,7 @@ LL |             Err(_) => Err(ret_one!())?,
 LL |     try_validation_in_macro!(Ok::<_, i32>(5));
    |     ------------------------------------------ in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `try_validation_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: returning an `Err(_)` with the `?` operator
   --> $DIR/try_err.rs:141:9

--- a/src/tools/clippy/tests/ui/unit_cmp.stderr
+++ b/src/tools/clippy/tests/ui/unit_cmp.stderr
@@ -34,7 +34,7 @@ LL | |         }
 LL | |     );
    | |______^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `debug_assert_eq` of unit values detected. This will always succeed
   --> $DIR/unit_cmp.rs:32:5
@@ -48,7 +48,7 @@ LL | |         }
 LL | |     );
    | |______^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `assert_ne` of unit values detected. This will always fail
   --> $DIR/unit_cmp.rs:41:5
@@ -62,7 +62,7 @@ LL | |         }
 LL | |     );
    | |______^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `debug_assert_ne` of unit values detected. This will always fail
   --> $DIR/unit_cmp.rs:49:5
@@ -76,7 +76,7 @@ LL | |         }
 LL | |     );
    | |______^
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::assert_ne` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 6 previous errors
 

--- a/src/tools/clippy/tests/ui/unsafe_derive_deserialize.stderr
+++ b/src/tools/clippy/tests/ui/unsafe_derive_deserialize.stderr
@@ -6,7 +6,7 @@ LL | #[derive(Deserialize)]
    |
    = note: `-D clippy::unsafe-derive-deserialize` implied by `-D warnings`
    = help: consider implementing `serde::Deserialize` manually. See https://serde.rs/impl-deserialize.html
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
   --> $DIR/unsafe_derive_deserialize.rs:16:10
@@ -15,7 +15,7 @@ LL | #[derive(Deserialize)]
    |          ^^^^^^^^^^^
    |
    = help: consider implementing `serde::Deserialize` manually. See https://serde.rs/impl-deserialize.html
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
   --> $DIR/unsafe_derive_deserialize.rs:22:10
@@ -24,7 +24,7 @@ LL | #[derive(Deserialize)]
    |          ^^^^^^^^^^^
    |
    = help: consider implementing `serde::Deserialize` manually. See https://serde.rs/impl-deserialize.html
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: you are deriving `serde::Deserialize` on a type that has methods using `unsafe`
   --> $DIR/unsafe_derive_deserialize.rs:30:10
@@ -33,7 +33,7 @@ LL | #[derive(Deserialize)]
    |          ^^^^^^^^^^^
    |
    = help: consider implementing `serde::Deserialize` manually. See https://serde.rs/impl-deserialize.html
-   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/tools/clippy/tests/ui/unseparated_prefix_literals.stderr
+++ b/src/tools/clippy/tests/ui/unseparated_prefix_literals.stderr
@@ -51,7 +51,7 @@ LL |         42usize
 LL |     let _ = lit_from_macro!();
    |             ----------------- in this macro invocation
    |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `lit_from_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: integer type suffix should be separated by an underscore
   --> $DIR/unseparated_prefix_literals.rs:40:16


### PR DESCRIPTION
When there are multiple macros in use, it can be difficult to tell
which one was responsible for producing an error.