### PR TITLE
Update the bootstrap compiler

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -14,7 +14,6 @@
 #![feature(dropck_eyepatch)]
 #![feature(new_uninit)]
 #![feature(maybe_uninit_slice)]
-#![cfg_attr(bootstrap, feature(min_const_generics))]
 #![feature(min_specialization)]
 #![cfg_attr(test, feature(test))]
 

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -26,7 +26,6 @@
 #![feature(thread_id_value)]
 #![feature(extend_one)]
 #![feature(const_panic)]
-#![cfg_attr(bootstrap, feature(min_const_generics))]
 #![feature(new_uninit)]
 #![feature(once_cell)]
 #![feature(maybe_uninit_uninit_array)]

--- a/compiler/rustc_serialize/src/lib.rs
+++ b/compiler/rustc_serialize/src/lib.rs
@@ -13,7 +13,6 @@ Core encoding and decoding interfaces.
 #![feature(never_type)]
 #![feature(nll)]
 #![feature(associated_type_bounds)]
-#![cfg_attr(bootstrap, feature(min_const_generics))]
 #![feature(min_specialization)]
 #![feature(vec_spare_capacity)]
 #![feature(core_intrinsics)]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -118,7 +118,6 @@
 #![feature(range_bounds_assert_len)]
 #![feature(rustc_attrs)]
 #![feature(receiver_trait)]
-#![cfg_attr(bootstrap, feature(min_const_generics))]
 #![feature(min_specialization)]
 #![feature(set_ptr_value)]
 #![feature(slice_ptr_get)]

--- a/library/alloc/src/task.rs
+++ b/library/alloc/src/task.rs
@@ -85,8 +85,6 @@ pub trait Wake {
     }
 }
 
-#[cfg_attr(bootstrap, allow(rustc::ineffective_unstable_trait_impl))]
-#[cfg_attr(not(bootstrap), allow(ineffective_unstable_trait_impl))]
 #[stable(feature = "wake_trait", since = "1.51.0")]
 impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for Waker {
     fn from(waker: Arc<W>) -> Waker {
@@ -96,8 +94,6 @@ impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for Waker {
     }
 }
 
-#[cfg_attr(bootstrap, allow(rustc::ineffective_unstable_trait_impl))]
-#[cfg_attr(not(bootstrap), allow(ineffective_unstable_trait_impl))]
 #[stable(feature = "wake_trait", since = "1.51.0")]
 impl<W: Wake + Send + Sync + 'static> From<Arc<W>> for RawWaker {
     fn from(waker: Arc<W>) -> RawWaker {

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -1798,7 +1798,7 @@ fn subslice_patterns() {
 
     macro_rules! c {
         ($inp:expr, $typ:ty, $out:expr $(,)?) => {
-            assert_eq!($out, identity::<$typ>($inp));
+            assert_eq!($out, identity::<$typ>($inp))
         };
     }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -128,7 +128,6 @@
 #![feature(repr_simd, platform_intrinsics)]
 #![feature(rustc_attrs)]
 #![feature(simd_ffi)]
-#![cfg_attr(bootstrap, feature(min_const_generics))]
 #![feature(min_specialization)]
 #![feature(staged_api)]
 #![feature(std_internals)]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1,25 +1,3 @@
-#[cfg(bootstrap)]
-#[doc(include = "panic.md")]
-#[macro_export]
-#[allow_internal_unstable(core_panic)]
-#[stable(feature = "core", since = "1.6.0")]
-#[rustc_diagnostic_item = "core_panic_macro"]
-macro_rules! panic {
-    () => (
-        $crate::panic!("explicit panic")
-    );
-    ($msg:literal $(,)?) => (
-        $crate::panicking::panic($msg)
-    );
-    ($msg:expr $(,)?) => (
-        $crate::panicking::panic_str($msg)
-    );
-    ($fmt:expr, $($arg:tt)+) => (
-        $crate::panicking::panic_fmt($crate::format_args!($fmt, $($arg)+))
-    );
-}
-
-#[cfg(not(bootstrap))]
 #[doc(include = "panic.md")]
 #[macro_export]
 #[rustc_builtin_macro = "core_panic"]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -4,7 +4,6 @@
 //! types, initializing and manipulating memory.
 
 #![stable(feature = "rust1", since = "1.0.0")]
-#![cfg_attr(bootstrap, allow(unused_unsafe))]
 
 use crate::clone;
 use crate::cmp;
@@ -152,13 +151,6 @@ pub const fn forget<T>(t: T) {
 #[inline]
 #[unstable(feature = "forget_unsized", issue = "none")]
 pub fn forget_unsized<T: ?Sized>(t: T) {
-    #[cfg(bootstrap)]
-    // SAFETY: the forget intrinsic could be safe, but there's no point in making it safe since
-    // we'll be implementing this function soon via `ManuallyDrop`
-    unsafe {
-        intrinsics::forget(t)
-    }
-    #[cfg(not(bootstrap))]
     intrinsics::forget(t)
 }
 

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -94,10 +94,7 @@ mod cell;
 mod char;
 mod clone;
 mod cmp;
-
-#[cfg(not(bootstrap))]
 mod const_ptr;
-
 mod fmt;
 mod hash;
 mod intrinsics;

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -284,7 +284,6 @@ fn uninit_write_slice_cloned_no_drop() {
 }
 
 #[test]
-#[cfg(not(bootstrap))]
 fn uninit_const_assume_init_read() {
     const FOO: u32 = unsafe { MaybeUninit::new(42).assume_init_read() };
     assert_eq!(FOO, 42);

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -185,8 +185,8 @@
 //! [other]: #what-is-in-the-standard-library-documentation
 //! [primitive types]: ../book/ch03-02-data-types.html
 //! [rust-discord]: https://discord.gg/rust-lang
-#![cfg_attr(not(bootstrap), doc = "[array]: prim@array")]
-#![cfg_attr(not(bootstrap), doc = "[slice]: prim@slice")]
+//! [array]: prim@array
+//! [slice]: prim@slice
 #![cfg_attr(not(feature = "restricted-std"), stable(feature = "rust1", since = "1.0.0"))]
 #![cfg_attr(feature = "restricted-std", unstable(feature = "restricted_std", issue = "none"))]
 #![doc(

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -4,21 +4,6 @@
 //! library. Each macro is available for use when linking against the standard
 //! library.
 
-#[cfg(bootstrap)]
-#[doc(include = "../../core/src/macros/panic.md")]
-#[macro_export]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[allow_internal_unstable(libstd_sys_internals)]
-#[cfg_attr(not(test), rustc_diagnostic_item = "std_panic_macro")]
-macro_rules! panic {
-    () => ({ $crate::panic!("explicit panic") });
-    ($msg:expr $(,)?) => ({ $crate::rt::begin_panic($msg) });
-    ($fmt:expr, $($arg:tt)+) => ({
-        $crate::rt::begin_panic_fmt(&$crate::format_args!($fmt, $($arg)+))
-    });
-}
-
-#[cfg(not(bootstrap))]
 #[doc(include = "../../core/src/macros/panic.md")]
 #[macro_export]
 #[rustc_builtin_macro = "std_panic"]

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -877,7 +877,8 @@ class RustBuild(object):
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
             env["RUSTFLAGS"] += " -C linker=" + target_linker
-        env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes -Wsemicolon_in_expressions_from_macros"
+        # cfg(bootstrap): Add `-Wsemicolon_in_expressions_from_macros` after the next beta bump
+        env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
         if self.get_toml("deny-warnings", "rust") != "false":
             env["RUSTFLAGS"] += " -Dwarnings"
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -877,8 +877,7 @@ class RustBuild(object):
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
             env["RUSTFLAGS"] += " -C linker=" + target_linker
-        # cfg(bootstrap): Add `-Wsemicolon_in_expressions_from_macros` after the next beta bump
-        env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
+        env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes -Wsemicolon_in_expressions_from_macros"
         if self.get_toml("deny-warnings", "rust") != "false":
             env["RUSTFLAGS"] += " -Dwarnings"
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1279,7 +1279,12 @@ impl<'a> Builder<'a> {
             // some code doesn't go through this `rustc` wrapper.
             lint_flags.push("-Wrust_2018_idioms");
             lint_flags.push("-Wunused_lifetimes");
-            lint_flags.push("-Wsemicolon_in_expressions_from_macros");
+            // cfg(bootstrap): unconditionally enable this warning after the next beta bump
+            // This is currently disabled for the stage1 libstd, since build scripts
+            // will end up using the bootstrap compiler (which doesn't yet support this lint)
+            if compiler.stage != 0 && mode != Mode::Std {
+                lint_flags.push("-Wsemicolon_in_expressions_from_macros");
+            }
 
             if self.config.deny_warnings {
                 lint_flags.push("-Dwarnings");

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1279,12 +1279,7 @@ impl<'a> Builder<'a> {
             // some code doesn't go through this `rustc` wrapper.
             lint_flags.push("-Wrust_2018_idioms");
             lint_flags.push("-Wunused_lifetimes");
-            // cfg(bootstrap): unconditionally enable this warning after the next beta bump
-            // This is currently disabled for the stage1 libstd, since build scripts
-            // will end up using the bootstrap compiler (which doesn't yet support this lint)
-            if compiler.stage != 0 && mode != Mode::Std {
-                lint_flags.push("-Wsemicolon_in_expressions_from_macros");
-            }
+            lint_flags.push("-Wsemicolon_in_expressions_from_macros");
 
             if self.config.deny_warnings {
                 lint_flags.push("-Dwarnings");

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1160,18 +1160,10 @@ impl<'a> Builder<'a> {
         // itself, we skip it by default since we know it's safe to do so in that case.
         // See https://github.com/rust-lang/rust/issues/79361 for more info on this flag.
         if target.contains("apple") {
-            if stage == 0 {
-                if self.config.rust_run_dsymutil {
-                    rustflags.arg("-Zrun-dsymutil=yes");
-                } else {
-                    rustflags.arg("-Zrun-dsymutil=no");
-                }
+            if self.config.rust_run_dsymutil {
+                rustflags.arg("-Csplit-debuginfo=packed");
             } else {
-                if self.config.rust_run_dsymutil {
-                    rustflags.arg("-Csplit-debuginfo=packed");
-                } else {
-                    rustflags.arg("-Csplit-debuginfo=unpacked");
-                }
+                rustflags.arg("-Csplit-debuginfo=unpacked");
             }
         }
 

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # stable release's version number. `date` is the date where the release we're
 # bootstrapping off was released.
 
-date: 2020-12-30
+date: 2021-02-14
 rustc: beta
 
 # We use a nightly rustfmt to format the source because it solves some

--- a/src/test/run-make-fulldeps/coverage-spanview/expected_mir_dump.closure/closure.main-{closure#5}.-------.InstrumentCoverage.0.html
+++ b/src/test/run-make-fulldeps/coverage-spanview/expected_mir_dump.closure/closure.main-{closure#5}.-------.InstrumentCoverage.0.html
@@ -69,47 +69,47 @@ For revisions in Pull Requests (PR):
 </style>
 </head>
 <body>
-<div class="code" style="counter-reset: line 110"><span class="line">                      <span><span class="code even" style="--layer: 1" title="111:23-113:6: @0[5]: _15 = const main::{closure#5}::promoted[1]
-111:23-113:6: @0[6]: _7 = &amp;(*_15)
-111:23-113:6: @0[7]: _6 = &amp;(*_7)
-111:23-113:6: @0[8]: _5 = move _6 as &amp;[&amp;str] (Pointer(Unsize))
-112:28-112:61: @0[14]: _13 = ()
-112:28-112:61: @0[15]: FakeRead(ForMatchedPlace, _13)
-112:28-112:61: @0[16]: _14 = const main::{closure#5}::promoted[0]
-112:28-112:61: @0[17]: _11 = &amp;(*_14)
-112:28-112:61: @0[18]: _10 = &amp;(*_11)
-112:28-112:61: @0[19]: _9 = move _10 as &amp;[std::fmt::ArgumentV1] (Pointer(Unsize))
-112:28-112:61: @0.Call: _4 = std::fmt::Arguments::new_v1(move _5, move _9) -&gt; [return: bb1, unwind: bb3]
-112:9-112:62: @1.Call: _3 = std::io::_print(move _4) -&gt; [return: bb2, unwind: bb3]
-111:23-113:6: @2[5]: _0 = const ()
-111:23-113:6: @2.Return: return"><span class="annotation">@0,1,2⦊</span>{</span></span>
-<span class="line"><span class="code even" style="--layer: 1" title="111:23-113:6: @0[5]: _15 = const main::{closure#5}::promoted[1]
-111:23-113:6: @0[6]: _7 = &amp;(*_15)
-111:23-113:6: @0[7]: _6 = &amp;(*_7)
-111:23-113:6: @0[8]: _5 = move _6 as &amp;[&amp;str] (Pointer(Unsize))
-112:28-112:61: @0[14]: _13 = ()
-112:28-112:61: @0[15]: FakeRead(ForMatchedPlace, _13)
-112:28-112:61: @0[16]: _14 = const main::{closure#5}::promoted[0]
-112:28-112:61: @0[17]: _11 = &amp;(*_14)
-112:28-112:61: @0[18]: _10 = &amp;(*_11)
-112:28-112:61: @0[19]: _9 = move _10 as &amp;[std::fmt::ArgumentV1] (Pointer(Unsize))
-112:28-112:61: @0.Call: _4 = std::fmt::Arguments::new_v1(move _5, move _9) -&gt; [return: bb1, unwind: bb3]
-112:9-112:62: @1.Call: _3 = std::io::_print(move _4) -&gt; [return: bb2, unwind: bb3]
-111:23-113:6: @2[5]: _0 = const ()
-111:23-113:6: @2.Return: return">        $crate::io::_print($crate::format_args_nl!($($arg)*));</span></span>
-<span class="line"><span class="code even" style="--layer: 1" title="111:23-113:6: @0[5]: _15 = const main::{closure#5}::promoted[1]
-111:23-113:6: @0[6]: _7 = &amp;(*_15)
-111:23-113:6: @0[7]: _6 = &amp;(*_7)
-111:23-113:6: @0[8]: _5 = move _6 as &amp;[&amp;str] (Pointer(Unsize))
-112:28-112:61: @0[14]: _13 = ()
-112:28-112:61: @0[15]: FakeRead(ForMatchedPlace, _13)
-112:28-112:61: @0[16]: _14 = const main::{closure#5}::promoted[0]
-112:28-112:61: @0[17]: _11 = &amp;(*_14)
-112:28-112:61: @0[18]: _10 = &amp;(*_11)
-112:28-112:61: @0[19]: _9 = move _10 as &amp;[std::fmt::ArgumentV1] (Pointer(Unsize))
-112:28-112:61: @0.Call: _4 = std::fmt::Arguments::new_v1(move _5, move _9) -&gt; [return: bb1, unwind: bb3]
-112:9-112:62: @1.Call: _3 = std::io::_print(move _4) -&gt; [return: bb2, unwind: bb3]
-111:23-113:6: @2[5]: _0 = const ()
-111:23-113:6: @2.Return: return">    }<span class="annotation">⦉@0,1,2</span></span></span></span></div>
+<div class="code" style="counter-reset: line 95"><span class="line">                      <span><span class="code even" style="--layer: 1" title="96:23-98:6: @0[5]: _15 = const main::{closure#5}::promoted[1]
+96:23-98:6: @0[6]: _7 = &amp;(*_15)
+96:23-98:6: @0[7]: _6 = &amp;(*_7)
+96:23-98:6: @0[8]: _5 = move _6 as &amp;[&amp;str] (Pointer(Unsize))
+97:28-97:61: @0[14]: _13 = ()
+97:28-97:61: @0[15]: FakeRead(ForMatchedPlace, _13)
+97:28-97:61: @0[16]: _14 = const main::{closure#5}::promoted[0]
+97:28-97:61: @0[17]: _11 = &amp;(*_14)
+97:28-97:61: @0[18]: _10 = &amp;(*_11)
+97:28-97:61: @0[19]: _9 = move _10 as &amp;[std::fmt::ArgumentV1] (Pointer(Unsize))
+97:28-97:61: @0.Call: _4 = std::fmt::Arguments::new_v1(move _5, move _9) -&gt; [return: bb1, unwind: bb3]
+97:9-97:62: @1.Call: _3 = std::io::_print(move _4) -&gt; [return: bb2, unwind: bb3]
+96:23-98:6: @2[5]: _0 = const ()
+96:23-98:6: @2.Return: return"><span class="annotation">@0,1,2⦊</span>{</span></span>
+<span class="line"><span class="code even" style="--layer: 1" title="96:23-98:6: @0[5]: _15 = const main::{closure#5}::promoted[1]
+96:23-98:6: @0[6]: _7 = &amp;(*_15)
+96:23-98:6: @0[7]: _6 = &amp;(*_7)
+96:23-98:6: @0[8]: _5 = move _6 as &amp;[&amp;str] (Pointer(Unsize))
+97:28-97:61: @0[14]: _13 = ()
+97:28-97:61: @0[15]: FakeRead(ForMatchedPlace, _13)
+97:28-97:61: @0[16]: _14 = const main::{closure#5}::promoted[0]
+97:28-97:61: @0[17]: _11 = &amp;(*_14)
+97:28-97:61: @0[18]: _10 = &amp;(*_11)
+97:28-97:61: @0[19]: _9 = move _10 as &amp;[std::fmt::ArgumentV1] (Pointer(Unsize))
+97:28-97:61: @0.Call: _4 = std::fmt::Arguments::new_v1(move _5, move _9) -&gt; [return: bb1, unwind: bb3]
+97:9-97:62: @1.Call: _3 = std::io::_print(move _4) -&gt; [return: bb2, unwind: bb3]
+96:23-98:6: @2[5]: _0 = const ()
+96:23-98:6: @2.Return: return">        $crate::io::_print($crate::format_args_nl!($($arg)*));</span></span>
+<span class="line"><span class="code even" style="--layer: 1" title="96:23-98:6: @0[5]: _15 = const main::{closure#5}::promoted[1]
+96:23-98:6: @0[6]: _7 = &amp;(*_15)
+96:23-98:6: @0[7]: _6 = &amp;(*_7)
+96:23-98:6: @0[8]: _5 = move _6 as &amp;[&amp;str] (Pointer(Unsize))
+97:28-97:61: @0[14]: _13 = ()
+97:28-97:61: @0[15]: FakeRead(ForMatchedPlace, _13)
+97:28-97:61: @0[16]: _14 = const main::{closure#5}::promoted[0]
+97:28-97:61: @0[17]: _11 = &amp;(*_14)
+97:28-97:61: @0[18]: _10 = &amp;(*_11)
+97:28-97:61: @0[19]: _9 = move _10 as &amp;[std::fmt::ArgumentV1] (Pointer(Unsize))
+97:28-97:61: @0.Call: _4 = std::fmt::Arguments::new_v1(move _5, move _9) -&gt; [return: bb1, unwind: bb3]
+97:9-97:62: @1.Call: _3 = std::io::_print(move _4) -&gt; [return: bb2, unwind: bb3]
+96:23-98:6: @2[5]: _0 = const ()
+96:23-98:6: @2.Return: return">    }<span class="annotation">⦉@0,1,2</span></span></span></span></div>
 </body>
 </html>


### PR DESCRIPTION
This updates the bootstrap compiler, notably leaving out a change to enable semicolon in macro expressions lint, because stdarch still depends on the old behavior.