### PR TITLE
Fix ICE caused by suggestion with no code substitutions

### DIFF
--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -295,6 +295,7 @@ impl Diagnostic {
         suggestion: Vec<(Span, String)>,
         applicability: Applicability,
     ) -> &mut Self {
+        assert!(!suggestion.is_empty());
         self.suggestions.push(CodeSuggestion {
             substitutions: vec![Substitution {
                 parts: suggestion
@@ -318,6 +319,10 @@ impl Diagnostic {
         suggestions: Vec<Vec<(Span, String)>>,
         applicability: Applicability,
     ) -> &mut Self {
+        assert!(!suggestions.is_empty());
+        for s in &suggestions {
+            assert!(!s.is_empty());
+        }
         self.suggestions.push(CodeSuggestion {
             substitutions: suggestions
                 .into_iter()
@@ -348,6 +353,7 @@ impl Diagnostic {
         suggestion: Vec<(Span, String)>,
         applicability: Applicability,
     ) -> &mut Self {
+        assert!(!suggestion.is_empty());
         self.suggestions.push(CodeSuggestion {
             substitutions: vec![Substitution {
                 parts: suggestion

--- a/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.rs
+++ b/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.rs
@@ -1,0 +1,5 @@
+use std::result;
+impl result { //~ ERROR expected type, found module `result`
+    fn into_future() -> Err {} //~ ERROR expected type, found variant `Err`
+}
+fn main() {}

--- a/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
+++ b/src/test/ui/suggestions/do-not-attempt-to-add-suggestions-with-no-changes.stderr
@@ -1,0 +1,20 @@
+error[E0573]: expected type, found module `result`
+  --> $DIR/do-not-attempt-to-add-suggestions-with-no-changes.rs:2:6
+   |
+LL | impl result {
+   |      ^^^^^^ help: an enum with a similar name exists: `Result`
+   | 
+  ::: $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL | pub enum Result<T, E> {
+   | --------------------- similarly named enum `Result` defined here
+
+error[E0573]: expected type, found variant `Err`
+  --> $DIR/do-not-attempt-to-add-suggestions-with-no-changes.rs:3:25
+   |
+LL |     fn into_future() -> Err {}
+   |                         ^^^ not a type
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0573`.


### PR DESCRIPTION
Change suggestion logic to filter and checking _before_ creating
specific resolution suggestion.

Assert earlier that suggestions contain code substitions to make it
easier in the future to debug invalid uses. If we find this becomes too
noisy in the wild, we can always make the emitter resilient to these
cases and remove the assertions.

Fix #78651.