### PR TITLE
Do not consider using a semicolon inside of a different-crate macro

### DIFF
--- a/src/test/ui/typeck/auxiliary/issue-81943-lib.rs
+++ b/src/test/ui/typeck/auxiliary/issue-81943-lib.rs
@@ -1,0 +1,7 @@
+pub fn g(t: i32) -> i32 { t }
+// This function imitates `dbg!` so that future changes
+// to its macro definition won't make this test a dud.
+#[macro_export]
+macro_rules! d {
+  ($e:expr) => { match $e { x => { $crate::g(x) } } }
+}

--- a/src/test/ui/typeck/issue-81943.rs
+++ b/src/test/ui/typeck/issue-81943.rs
@@ -1,0 +1,13 @@
+// aux-build:issue-81943-lib.rs
+extern crate issue_81943_lib as lib;
+
+fn f<F: Fn(i32)>(f: F) { f(0); }
+fn g(t: i32) -> i32 { t }
+fn main() {
+  f(|x| lib::d!(x)); //~ERROR
+  f(|x| match x { tmp => { g(tmp) } }); //~ERROR
+  macro_rules! d {
+    ($e:expr) => { match $e { x => { g(x) } } } //~ERROR
+  }
+  f(|x| d!(x));
+}

--- a/src/test/ui/typeck/issue-81943.stderr
+++ b/src/test/ui/typeck/issue-81943.stderr
@@ -1,0 +1,51 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-81943.rs:7:9
+   |
+LL |   f(|x| lib::d!(x));
+   |         ^^^^^^^^^^ expected `()`, found `i32`
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0308]: mismatched types
+  --> $DIR/issue-81943.rs:8:28
+   |
+LL |   f(|x| match x { tmp => { g(tmp) } });
+   |         -------------------^^^^^^----
+   |         |                  |
+   |         |                  expected `()`, found `i32`
+   |         expected this to be `()`
+   |
+help: consider using a semicolon here
+   |
+LL |   f(|x| match x { tmp => { g(tmp); } });
+   |                                  ^
+help: consider using a semicolon here
+   |
+LL |   f(|x| match x { tmp => { g(tmp) } };);
+   |                                      ^
+
+error[E0308]: mismatched types
+  --> $DIR/issue-81943.rs:10:38
+   |
+LL |     ($e:expr) => { match $e { x => { g(x) } } }
+   |                    ------------------^^^^----
+   |                    |                 |
+   |                    |                 expected `()`, found `i32`
+   |                    expected this to be `()`
+LL |   }
+LL |   f(|x| d!(x));
+   |         ----- in this macro invocation
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using a semicolon here
+   |
+LL |     ($e:expr) => { match $e { x => { g(x); } } }
+   |                                          ^
+help: consider using a semicolon here
+   |
+LL |     ($e:expr) => { match $e { x => { g(x) } }; }
+   |                                              ^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #81943