### PR TITLE
use PlaceRef abstractions more consistently

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -199,7 +199,7 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
             }
 
             self.visit_local(&place_ref.local, context, location);
-            self.visit_projection(place_ref.local, place_ref.projection, context, location);
+            self.visit_projection(*place_ref, context, location);
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -962,8 +962,7 @@ impl<'tcx> LocalDecl<'tcx> {
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,
-                })
-                | BindingForm::ImplicitSelf(ImplicitSelfKind::Imm),
+                }) | BindingForm::ImplicitSelf(ImplicitSelfKind::Imm),
             )))
         )
     }
@@ -980,8 +979,7 @@ impl<'tcx> LocalDecl<'tcx> {
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,
-                })
-                | BindingForm::ImplicitSelf(_),
+                }) | BindingForm::ImplicitSelf(_),
             )))
         )
     }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -962,7 +962,8 @@ impl<'tcx> LocalDecl<'tcx> {
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,
-                }) | BindingForm::ImplicitSelf(ImplicitSelfKind::Imm),
+                })
+                | BindingForm::ImplicitSelf(ImplicitSelfKind::Imm),
             )))
         )
     }
@@ -979,7 +980,8 @@ impl<'tcx> LocalDecl<'tcx> {
                     opt_ty_info: _,
                     opt_match_place: _,
                     pat_span: _,
-                }) | BindingForm::ImplicitSelf(_),
+                })
+                | BindingForm::ImplicitSelf(_),
             )))
         )
     }

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -1002,7 +1002,7 @@ macro_rules! visit_place_fns {
             context: PlaceContext,
             location: Location,
         ) {
-            self.super_projection(place_ref.local, place_ref.projection, context, location);
+            self.super_projection(place_ref, context, location);
         }
 
         fn visit_projection_elem(
@@ -1037,15 +1037,15 @@ macro_rules! visit_place_fns {
 
         fn super_projection(
             &mut self,
-            local: Local,
-            projection: &[PlaceElem<'tcx>],
+            place_ref: PlaceRef<'tcx>,
             context: PlaceContext,
             location: Location,
         ) {
-            let mut cursor = projection;
+            // FIXME: Use PlaceRef::iter_projections, once that exists.
+            let mut cursor = place_ref.projection;
             while let &[ref proj_base @ .., elem] = cursor {
                 cursor = proj_base;
-                self.visit_projection_elem(local, cursor, elem, context, location);
+                self.visit_projection_elem(place_ref.local, cursor, elem, context, location);
             }
         }
 

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -998,12 +998,11 @@ macro_rules! visit_place_fns {
     () => {
         fn visit_projection(
             &mut self,
-            local: Local,
-            projection: &[PlaceElem<'tcx>],
+            place_ref: PlaceRef<'tcx>,
             context: PlaceContext,
             location: Location,
         ) {
-            self.super_projection(local, projection, context, location);
+            self.super_projection(place_ref.local, place_ref.projection, context, location);
         }
 
         fn visit_projection_elem(
@@ -1033,7 +1032,7 @@ macro_rules! visit_place_fns {
 
             self.visit_local(&place.local, context, location);
 
-            self.visit_projection(place.local, &place.projection, context, location);
+            self.visit_projection(place.as_ref(), context, location);
         }
 
         fn super_projection(

--- a/compiler/rustc_mir/src/dataflow/impls/liveness.rs
+++ b/compiler/rustc_mir/src/dataflow/impls/liveness.rs
@@ -95,7 +95,7 @@ where
 
         // We purposefully do not call `super_place` here to avoid calling `visit_local` for this
         // place with one of the `Projection` variants of `PlaceContext`.
-        self.visit_projection(local, projection, context, location);
+        self.visit_projection(place.as_ref(), context, location);
 
         match DefUse::for_place(context) {
             // Treat derefs as a use of the base local. `*p = 4` is not a def of `p` but a use.

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -508,12 +508,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                         }
                     };
                     self.visit_local(&reborrowed_place_ref.local, ctx, location);
-                    self.visit_projection(
-                        reborrowed_place_ref.local,
-                        reborrowed_place_ref.projection,
-                        ctx,
-                        location,
-                    );
+                    self.visit_projection(reborrowed_place_ref, ctx, location);
                     return;
                 }
             }
@@ -526,12 +521,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                         Mutability::Mut => PlaceContext::MutatingUse(MutatingUseContext::AddressOf),
                     };
                     self.visit_local(&reborrowed_place_ref.local, ctx, location);
-                    self.visit_projection(
-                        reborrowed_place_ref.local,
-                        reborrowed_place_ref.projection,
-                        ctx,
-                        location,
-                    );
+                    self.visit_projection(reborrowed_place_ref, ctx, location);
                     return;
                 }
             }

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -492,7 +492,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
         // Special-case reborrows to be more like a copy of a reference.
         match *rvalue {
             Rvalue::Ref(_, kind, place) => {
-                if let Some(reborrowed_proj) = place_as_reborrow(self.tcx, self.body, place) {
+                if let Some(place_ref) = place_as_reborrow(self.tcx, self.body, place) {
                     let ctx = match kind {
                         BorrowKind::Shared => {
                             PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow)
@@ -508,12 +508,12 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                         }
                     };
                     self.visit_local(&place.local, ctx, location);
-                    self.visit_projection(place.local, reborrowed_proj, ctx, location);
+                    self.visit_projection(place.local, place_ref.projection, ctx, location);
                     return;
                 }
             }
             Rvalue::AddressOf(mutbl, place) => {
-                if let Some(reborrowed_proj) = place_as_reborrow(self.tcx, self.body, place) {
+                if let Some(place_ref) = place_as_reborrow(self.tcx, self.body, place) {
                     let ctx = match mutbl {
                         Mutability::Not => {
                             PlaceContext::NonMutatingUse(NonMutatingUseContext::AddressOf)
@@ -521,7 +521,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
                         Mutability::Mut => PlaceContext::MutatingUse(MutatingUseContext::AddressOf),
                     };
                     self.visit_local(&place.local, ctx, location);
-                    self.visit_projection(place.local, reborrowed_proj, ctx, location);
+                    self.visit_projection(place.local, place_ref.projection, ctx, location);
                     return;
                 }
             }
@@ -1016,7 +1016,7 @@ fn place_as_reborrow(
     tcx: TyCtxt<'tcx>,
     body: &Body<'tcx>,
     place: Place<'tcx>,
-) -> Option<&'a [PlaceElem<'tcx>]> {
+) -> Option<PlaceRef<'tcx>> {
     match place.as_ref().last_projection() {
         Some((place_base, ProjectionElem::Deref)) => {
             // A borrow of a `static` also looks like `&(*_1)` in the MIR, but `_1` is a `const`
@@ -1025,13 +1025,14 @@ fn place_as_reborrow(
                 None
             } else {
                 // Ensure the type being derefed is a reference and not a raw pointer.
-                //
                 // This is sufficient to prevent an access to a `static mut` from being marked as a
                 // reborrow, even if the check above were to disappear.
                 let inner_ty = place_base.ty(body, tcx).ty;
-                match inner_ty.kind() {
-                    ty::Ref(..) => Some(place_base.projection),
-                    _ => None,
+
+                if let ty::Ref(..) = inner_ty.kind() {
+                    return Some(place_base);
+                } else {
+                    return None;
                 }
             }
         }

--- a/compiler/rustc_mir/src/transform/simplify.rs
+++ b/compiler/rustc_mir/src/transform/simplify.rs
@@ -414,8 +414,7 @@ impl UsedLocals {
         } else {
             // A definition. Although, it still might use other locals for indexing.
             self.super_projection(
-                place.local,
-                &place.projection,
+                place.as_ref(),
                 PlaceContext::MutatingUse(MutatingUseContext::Projection),
                 location,
             );


### PR DESCRIPTION
Addresses this [comment](https://github.com/rust-lang/rust/pull/80865/files#r558978715)
Associated issue: #80647

r? @RalfJung 