### PR TITLE
Add tests for Atomic*::fetch_{min,max}

### DIFF
--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -60,6 +60,24 @@ fn uint_xor() {
 }
 
 #[test]
+fn uint_min() {
+    let x = AtomicUsize::new(0xf731);
+    assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0x137f);
+    assert_eq!(x.fetch_min(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0x137f);
+}
+
+#[test]
+fn uint_max() {
+    let x = AtomicUsize::new(0x137f);
+    assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0xf731);
+    assert_eq!(x.fetch_max(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0xf731);
+}
+
+#[test]
 fn int_and() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_and(0x137f, SeqCst), 0xf731);
@@ -85,6 +103,24 @@ fn int_xor() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_xor(0x137f, SeqCst), 0xf731);
     assert_eq!(x.load(SeqCst), 0xf731 ^ 0x137f);
+}
+
+#[test]
+fn int_min() {
+    let x = AtomicIsize::new(0xf731);
+    assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0x137f);
+    assert_eq!(x.fetch_min(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0x137f);
+}
+
+#[test]
+fn int_max() {
+    let x = AtomicIsize::new(0x137f);
+    assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0xf731);
+    assert_eq!(x.fetch_max(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0xf731);
 }
 
 static S_FALSE: AtomicBool = AtomicBool::new(false);

--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -60,6 +60,7 @@ fn uint_xor() {
 }
 
 #[test]
+#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
 fn uint_min() {
     let x = AtomicUsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -69,6 +70,7 @@ fn uint_min() {
 }
 
 #[test]
+#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
 fn uint_max() {
     let x = AtomicUsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
@@ -106,6 +108,7 @@ fn int_xor() {
 }
 
 #[test]
+#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
 fn int_min() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -115,6 +118,7 @@ fn int_min() {
 }
 
 #[test]
+#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
 fn int_max() {
     let x = AtomicIsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);

--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -60,7 +60,7 @@ fn uint_xor() {
 }
 
 #[test]
-#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
+#[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
 fn uint_min() {
     let x = AtomicUsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -70,7 +70,7 @@ fn uint_min() {
 }
 
 #[test]
-#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
+#[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
 fn uint_max() {
     let x = AtomicUsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
@@ -108,7 +108,7 @@ fn int_xor() {
 }
 
 #[test]
-#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
+#[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
 fn int_min() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -118,7 +118,7 @@ fn int_min() {
 }
 
 #[test]
-#[cfg(not(target_arch = "arm"))] // Missing intrinsic in compiler-builtins
+#[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
 fn int_max() {
     let x = AtomicIsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);


### PR DESCRIPTION
This ensures that all atomic operations except for fences are tested. This has been useful to test my work on using atomic instructions for atomic operations in cg_clif instead of a global lock.