### PR TITLE
To digit simplification

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -330,8 +330,6 @@ impl char {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn to_digit(self, radix: u32) -> Option<u32> {
-        assert!(radix <= 36, "to_digit: radix is too high (maximum 36)");
-
         // the code is split up here to improve execution speed for cases where
         // the `radix` is constant and 10 or smaller
         let val = if radix <= 10 {
@@ -340,6 +338,8 @@ impl char {
                 _ => return None,
             }
         } else {
+            assert!(radix <= 36, "to_digit: radix is too high (maximum 36)");
+
             match self {
                 '0'..='9' => self as u32 - '0' as u32,
                 'a'..='z' => self as u32 - 'a' as u32 + 10,

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -337,7 +337,7 @@ impl char {
         // the `radix` is constant and 10 or smaller
         let val = if likely(radix <= 10) {
             // If not a digit, a number greater than radix will be created.
-            self as u32 ^ ASCII_DIGIT_MASK
+            (self as u32).wrapping_sub('0' as u32)
         } else {
             match self {
                 '0'..='9' => self as u32 - '0' as u32,

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1,5 +1,6 @@
 //! impl char {}
 
+use crate::intrinsics::likely;
 use crate::slice;
 use crate::str::from_utf8_unchecked_mut;
 use crate::unicode::printable::is_printable;
@@ -330,16 +331,14 @@ impl char {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn to_digit(self, radix: u32) -> Option<u32> {
+        assert!(radix <= 36, "to_digit: radix is too high (maximum 36)");
+        const ASCII_DIGIT_MASK: u32 = 0b11_0000;
         // the code is split up here to improve execution speed for cases where
         // the `radix` is constant and 10 or smaller
-        let val = if radix <= 10 {
-            match self {
-                '0'..='9' => self as u32 - '0' as u32,
-                _ => return None,
-            }
+        let val = if likely(radix <= 10) {
+            // If not a digit, a number greater than radix will be created.
+            self as u32 ^ ASCII_DIGIT_MASK
         } else {
-            assert!(radix <= 36, "to_digit: radix is too high (maximum 36)");
-
             match self {
                 '0'..='9' => self as u32 - '0' as u32,
                 'a'..='z' => self as u32 - 'a' as u32 + 10,

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -332,7 +332,6 @@ impl char {
     #[inline]
     pub fn to_digit(self, radix: u32) -> Option<u32> {
         assert!(radix <= 36, "to_digit: radix is too high (maximum 36)");
-        const ASCII_DIGIT_MASK: u32 = 0b11_0000;
         // the code is split up here to improve execution speed for cases where
         // the `radix` is constant and 10 or smaller
         let val = if likely(radix <= 10) {


### PR DESCRIPTION
I found out the other day that all the ascii digits have the first four bits as one would hope them to. (Eg. char `2` ends `0b0010`). There are two bits to indicate it's in the digit range ( `0b0011_0000`). If it is a true digit then all the higher bits aside from these two will be 0 (as ascii is the lowest part of the unicode u32 spectrum). So XORing with `0b11_0000` should mean we either get the number 0-9 or alternativly we get a larger number in the u32 space. If we get something that's not 0-9 then it will be discarded as it will be greater than the radix.

The code seems so fast though that there's quite a lot of noise in the benchmarks so it's not that easy to prove conclusively that it's faster as well as less instructions.

The non-fast path I was toying with as well wondering if we could do this as then we'd only have one return and less instructions still:
```
           match self {
                'a'..='z' => self as u32 - 'a' as u32 + 10,
                'A'..='Z' => self as u32 - 'A' as u32 + 10,
                _ => { radix = 10; self as u32 ^ ASCII_DIGIT_MASK},
            }
```

Here's the [godbolt](https://godbolt.org/z/883c9n). 

( H/T to @byteshadow for pointing out xor was what I needed)