### PR TITLE
work around auto_da_alloc heuristic in CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: collect CPU statistics
         run: src/ci/scripts/collect-cpu-stats.sh
         if: success() && !env.SKIP_JOB
+      - name: remount root filesystem
+        run: src/ci/scripts/tune-rootfs.sh
+        if: success() && !env.SKIP_JOB
       - name: show the current environment
         run: src/ci/scripts/dump-environment.sh
         if: success() && !env.SKIP_JOB
@@ -441,6 +444,9 @@ jobs:
       - name: collect CPU statistics
         run: src/ci/scripts/collect-cpu-stats.sh
         if: success() && !env.SKIP_JOB
+      - name: remount root filesystem
+        run: src/ci/scripts/tune-rootfs.sh
+        if: success() && !env.SKIP_JOB
       - name: show the current environment
         run: src/ci/scripts/dump-environment.sh
         if: success() && !env.SKIP_JOB
@@ -547,6 +553,9 @@ jobs:
         if: "success() && !env.SKIP_JOB && github.ref != 'refs/heads/try'"
       - name: collect CPU statistics
         run: src/ci/scripts/collect-cpu-stats.sh
+        if: success() && !env.SKIP_JOB
+      - name: remount root filesystem
+        run: src/ci/scripts/tune-rootfs.sh
         if: success() && !env.SKIP_JOB
       - name: show the current environment
         run: src/ci/scripts/dump-environment.sh

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -137,6 +137,10 @@ x--expand-yaml-anchors--remove:
         run: src/ci/scripts/collect-cpu-stats.sh
         <<: *step
 
+      - name: remount root filesystem
+        run: src/ci/scripts/tune-rootfs.sh
+        <<: *step
+
       - name: show the current environment
         run: src/ci/scripts/dump-environment.sh
         <<: *step

--- a/src/ci/scripts/tune-rootfs.sh
+++ b/src/ci/scripts/tune-rootfs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+if isLinux && [[ $(findmnt -n /) =~ "ext4" ]] ; then
+    # noauto_da_alloc since auto_da_alloc causes sync IO for some common file creation patters
+    # lazytime avoids sync IO when (rel)atime updates are applied
+    # nodiscard because the ext4 doesn't support async discard (unlike xfs or btrfs)
+    sudo mount -oremount,lazytime,nodiscard,noauto_da_alloc /
+
+    mount
+fi


### PR DESCRIPTION
Similar to #82047 except that it only applies in CI but catches more instances of the affected IO patterns.

The expected performance benefit is fairly small, at most a second per minute of compile time, so if it's too much for such a small win feel free to close it.