### PR TITLE
Remove unnecessary `Option` in `default_doc`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -561,8 +561,7 @@ impl<'a> Builder<'a> {
         self.run_step_descriptions(&Builder::get_step_descriptions(self.kind), &self.paths);
     }
 
-    pub fn default_doc(&self, paths: Option<&[PathBuf]>) {
-        let paths = paths.unwrap_or(&[]);
+    pub fn default_doc(&self, paths: &[PathBuf]) {
         self.run_step_descriptions(&Builder::get_step_descriptions(Kind::Doc), paths);
     }
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -68,7 +68,7 @@ impl Step for Docs {
         if !builder.config.docs {
             return None;
         }
-        builder.default_doc(None);
+        builder.default_doc(&[]);
 
         let dest = "share/doc/rust/html";
 
@@ -103,7 +103,7 @@ impl Step for RustcDocs {
         if !builder.config.compiler_docs {
             return None;
         }
-        builder.default_doc(None);
+        builder.default_doc(&[]);
 
         let mut tarball = Tarball::new(builder, "rustc-docs", &host.triple);
         tarball.set_product_name("Rustc Documentation");

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -111,7 +111,7 @@ impl Step for Linkcheck {
 
         builder.info(&format!("Linkcheck ({})", host));
 
-        builder.default_doc(None);
+        builder.default_doc(&[]);
 
         let _time = util::timeit(&builder);
         try_run(


### PR DESCRIPTION
Previously, there were two different ways to encode the same info: `None` or
`Some(&[])`. Now there is only one way, `&[]`.