### PR TITLE
Make some Option, Result methods unstably const

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -150,7 +150,7 @@
 use crate::iter::{FromIterator, FusedIterator, TrustedLen};
 use crate::pin::Pin;
 use crate::{
-    convert, fmt, hint, mem,
+    fmt, hint, mem,
     ops::{self, Deref, DerefMut},
 };
 
@@ -1275,7 +1275,8 @@ impl<T, E> Option<Result<T, E>> {
     /// ```
     #[inline]
     #[stable(feature = "transpose_result", since = "1.33.0")]
-    pub fn transpose(self) -> Result<Option<T>, E> {
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    pub const fn transpose(self) -> Result<Option<T>, E> {
         match self {
             Some(Ok(x)) => Ok(Some(x)),
             Some(Err(e)) => Err(e),
@@ -1750,7 +1751,11 @@ impl<T> Option<Option<T>> {
     /// ```
     #[inline]
     #[stable(feature = "option_flattening", since = "1.40.0")]
-    pub fn flatten(self) -> Option<T> {
-        self.and_then(convert::identity)
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    pub const fn flatten(self) -> Option<T> {
+        match self {
+            Some(inner) => inner,
+            None => None,
+        }
     }
 }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1233,7 +1233,8 @@ impl<T, E> Result<Option<T>, E> {
     /// ```
     #[inline]
     #[stable(feature = "transpose_result", since = "1.33.0")]
-    pub fn transpose(self) -> Option<Result<T, E>> {
+    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    pub const fn transpose(self) -> Option<Result<T, E>> {
         match self {
             Ok(Some(x)) => Some(Ok(x)),
             Ok(None) => None,


### PR DESCRIPTION
The following methods are now unstably const:

- Option::transpose
- Option::flatten
- Result::flatten

While some methods for could likely be made `const` in the future, nearly all of them require something to be dropped at compile-time, which isn't currently supported. The functions listed above should have a trivial path to stabilization.