### PR TITLE
32-bit ARM: Emit `lr` instead of `r14` when specified as an `asm!` output register.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -487,6 +487,9 @@ fn reg_to_llvm(reg: InlineAsmRegOrRegClass, layout: Option<&TyAndLayout<'tcx>>) 
             } else if reg == InlineAsmReg::AArch64(AArch64InlineAsmReg::x30) {
                 // LLVM doesn't recognize x30
                 "{lr}".to_string()
+            } else if reg == InlineAsmReg::Arm(ArmInlineAsmReg::r14) {
+                // LLVM doesn't recognize r14
+                "{lr}".to_string()
             } else {
                 format!("{{{}}}", reg.name())
             }

--- a/src/test/assembly/asm/arm-types.rs
+++ b/src/test/assembly/asm/arm-types.rs
@@ -91,6 +91,15 @@ pub unsafe fn sym_static() {
     asm!("adr r0, {}", sym extern_static);
 }
 
+// Regression test for #82052.
+// CHECK-LABEL: issue_82052
+// CHECK: push {{.*}}lr
+// CHECK: @APP
+// CHECK: @NO_APP
+pub unsafe fn issue_82052() {
+    asm!("", out("r14") _);
+}
+
 macro_rules! check {
     ($func:ident $ty:ident $class:ident $mov:literal) => {
         #[no_mangle]


### PR DESCRIPTION
On 32-bit ARM platforms, the register `r14` has the alias `lr`. When used as an output register in `asm!`, rustc canonicalizes the name to `r14`. LLVM only knows the register by the name `lr`, and rejects it. This changes rustc's LLVM code generation to output `lr` instead.

closes #82052 

r? @nagisa 