### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(decl_macro)]
 #![feature(or_patterns)]

--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -208,7 +208,7 @@ pub fn eval_to_const_value_raw_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc_middle::mir::interpret::EvalToConstValueResult<'tcx> {
-    // see comment in const_eval_raw_provider for what we're doing here
+    // see comment in eval_to_allocation_raw_provider for what we're doing here
     if key.param_env.reveal() == Reveal::All {
         let mut key = key;
         key.param_env = key.param_env.with_user_facing();

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -649,12 +649,12 @@ impl<T> BTreeSet<T> {
     /// #![feature(map_first_last)]
     /// use std::collections::BTreeSet;
     ///
-    /// let mut map = BTreeSet::new();
-    /// assert_eq!(map.first(), None);
-    /// map.insert(1);
-    /// assert_eq!(map.first(), Some(&1));
-    /// map.insert(2);
-    /// assert_eq!(map.first(), Some(&1));
+    /// let mut set = BTreeSet::new();
+    /// assert_eq!(set.first(), None);
+    /// set.insert(1);
+    /// assert_eq!(set.first(), Some(&1));
+    /// set.insert(2);
+    /// assert_eq!(set.first(), Some(&1));
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
     pub fn first(&self) -> Option<&T>
@@ -675,12 +675,12 @@ impl<T> BTreeSet<T> {
     /// #![feature(map_first_last)]
     /// use std::collections::BTreeSet;
     ///
-    /// let mut map = BTreeSet::new();
-    /// assert_eq!(map.last(), None);
-    /// map.insert(1);
-    /// assert_eq!(map.last(), Some(&1));
-    /// map.insert(2);
-    /// assert_eq!(map.last(), Some(&2));
+    /// let mut set = BTreeSet::new();
+    /// assert_eq!(set.last(), None);
+    /// set.insert(1);
+    /// assert_eq!(set.last(), Some(&1));
+    /// set.insert(2);
+    /// assert_eq!(set.last(), Some(&2));
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
     pub fn last(&self) -> Option<&T>

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -401,8 +401,6 @@ impl<'a> Arguments<'a> {
     /// # Examples
     ///
     /// ```rust
-    /// #![feature(fmt_as_str)]
-    ///
     /// use std::fmt::Arguments;
     ///
     /// fn write_str(_: &str) { /* ... */ }
@@ -417,13 +415,11 @@ impl<'a> Arguments<'a> {
     /// ```
     ///
     /// ```rust
-    /// #![feature(fmt_as_str)]
-    ///
     /// assert_eq!(format_args!("hello").as_str(), Some("hello"));
     /// assert_eq!(format_args!("").as_str(), Some(""));
     /// assert_eq!(format_args!("{}", 1).as_str(), None);
     /// ```
-    #[unstable(feature = "fmt_as_str", issue = "74442")]
+    #[stable(feature = "fmt_as_str", since = "1.52.0")]
     #[inline]
     pub fn as_str(&self) -> Option<&'static str> {
         match (self.pieces, self.args) {

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -816,6 +816,7 @@ pub(crate) mod builtin {
     #[macro_export]
     macro_rules! env {
         ($name:expr $(,)?) => {{ /* compiler built-in */ }};
+        ($name:expr, $error_msg:expr) => {{ /* compiler built-in */ }};
     }
 
     /// Optionally inspects an environment variable at compile time.

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -816,7 +816,7 @@ pub(crate) mod builtin {
     #[macro_export]
     macro_rules! env {
         ($name:expr $(,)?) => {{ /* compiler built-in */ }};
-        ($name:expr, $error_msg:expr) => {{ /* compiler built-in */ }};
+        ($name:expr, $error_msg:expr $(,)?) => {{ /* compiler built-in */ }};
     }
 
     /// Optionally inspects an environment variable at compile time.

--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -60,6 +60,24 @@ fn uint_xor() {
 }
 
 #[test]
+fn uint_min() {
+    let x = AtomicUsize::new(0xf731);
+    assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0x137f);
+    assert_eq!(x.fetch_min(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0x137f);
+}
+
+#[test]
+fn uint_max() {
+    let x = AtomicUsize::new(0x137f);
+    assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0xf731);
+    assert_eq!(x.fetch_max(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0xf731);
+}
+
+#[test]
 fn int_and() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_and(0x137f, SeqCst), 0xf731);
@@ -85,6 +103,24 @@ fn int_xor() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_xor(0x137f, SeqCst), 0xf731);
     assert_eq!(x.load(SeqCst), 0xf731 ^ 0x137f);
+}
+
+#[test]
+fn int_min() {
+    let x = AtomicIsize::new(0xf731);
+    assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0x137f);
+    assert_eq!(x.fetch_min(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0x137f);
+}
+
+#[test]
+fn int_max() {
+    let x = AtomicIsize::new(0x137f);
+    assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
+    assert_eq!(x.load(SeqCst), 0xf731);
+    assert_eq!(x.fetch_max(0x137f, SeqCst), 0xf731);
+    assert_eq!(x.load(SeqCst), 0xf731);
 }
 
 static S_FALSE: AtomicBool = AtomicBool::new(false);

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -264,7 +264,6 @@
 #![feature(exhaustive_patterns)]
 #![feature(extend_one)]
 #![feature(external_doc)]
-#![feature(fmt_as_str)]
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
 #![feature(gen_future)]

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -408,7 +408,7 @@ impl<S: Stream> Stream for AssertUnwindSafe<S> {
 /// aborting the process as well. This function *only* catches unwinding panics,
 /// not those that abort the process.
 ///
-/// Also note that unwinding into Rust code with a foreign exception (e.g. a
+/// Also note that unwinding into Rust code with a foreign exception (e.g.
 /// an exception thrown from C++ code) is undefined behavior.
 ///
 /// # Examples

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -1023,7 +1023,7 @@ extern "system" {
     pub fn HeapFree(hHeap: HANDLE, dwFlags: DWORD, lpMem: LPVOID) -> BOOL;
 
     // >= Vista / Server 2008
-    // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinka
+    // https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createsymboliclinkw
     pub fn CreateSymbolicLinkW(
         lpSymlinkFileName: LPCWSTR,
         lpTargetFileName: LPCWSTR,

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -561,8 +561,7 @@ impl<'a> Builder<'a> {
         self.run_step_descriptions(&Builder::get_step_descriptions(self.kind), &self.paths);
     }
 
-    pub fn default_doc(&self, paths: Option<&[PathBuf]>) {
-        let paths = paths.unwrap_or(&[]);
+    pub fn default_doc(&self, paths: &[PathBuf]) {
         self.run_step_descriptions(&Builder::get_step_descriptions(Kind::Doc), paths);
     }
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -68,7 +68,7 @@ impl Step for Docs {
         if !builder.config.docs {
             return None;
         }
-        builder.default_doc(None);
+        builder.default_doc(&[]);
 
         let dest = "share/doc/rust/html";
 
@@ -103,7 +103,7 @@ impl Step for RustcDocs {
         if !builder.config.compiler_docs {
             return None;
         }
-        builder.default_doc(None);
+        builder.default_doc(&[]);
 
         let mut tarball = Tarball::new(builder, "rustc-docs", &host.triple);
         tarball.set_product_name("Rustc Documentation");

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -111,7 +111,7 @@ impl Step for Linkcheck {
 
         builder.info(&format!("Linkcheck ({})", host));
 
-        builder.default_doc(None);
+        builder.default_doc(&[]);
 
         let _time = util::timeit(&builder);
         try_run(

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -300,7 +300,7 @@ flag][prefer-dynamic] may be used to influence which is used.
 If the same crate name is specified with and without a path, the one with the
 path is used and the pathless flag has no effect.
 
-[extern prelude]: ../reference/items/extern-crates.html#extern-prelude
+[extern prelude]: ../reference/names/preludes.html#extern-prelude
 [prefer-dynamic]: codegen-options/index.md#prefer-dynamic
 
 <a id="option-sysroot"></a>

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1269,7 +1269,7 @@ impl Clean<Item> for ty::AssocItem {
 
                     AssocTypeItem(bounds, ty.clean(cx))
                 } else {
-                    // FIXME: when could this happen? ASsociated items in inherent impls?
+                    // FIXME: when could this happen? Associated items in inherent impls?
                     let type_ = cx.tcx.type_of(self.def_id).clean(cx);
                     TypedefItem(
                         Typedef {

--- a/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.rs
+++ b/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.rs
@@ -1,0 +1,21 @@
+#![feature(const_generics, const_evaluatable_checked)]
+#![allow(incomplete_features)]
+
+// This test is a minimized reproduction for #79518 where
+// during error handling for the type mismatch we would try
+// to evaluate std::mem::size_of::<Self::Assoc> causing an ICE
+
+trait Foo {
+    type Assoc: PartialEq;
+    const AssocInstance: Self::Assoc;
+
+    fn foo()
+    where
+        [(); std::mem::size_of::<Self::Assoc>()]: ,
+    {
+        Self::AssocInstance == [(); std::mem::size_of::<Self::Assoc>()];
+        //~^ Error: mismatched types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.stderr
+++ b/src/test/ui/const-generics/issue-79518-default_trait_method_normalization.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-79518-default_trait_method_normalization.rs:16:32
+   |
+LL |         Self::AssocInstance == [(); std::mem::size_of::<Self::Assoc>()];
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found array `[(); _]`
+   |
+   = note: expected associated type `<Self as Foo>::Assoc`
+                        found array `[(); _]`
+   = help: consider constraining the associated type `<Self as Foo>::Assoc` to `[(); _]` or calling a method that returns `<Self as Foo>::Assoc`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/pattern/usefulness/issue-72377.rs
+++ b/src/test/ui/pattern/usefulness/issue-72377.rs
@@ -1,0 +1,17 @@
+#[derive(PartialEq, Eq)]
+enum X { A, B, C, }
+
+fn main() {
+    let x = X::A;
+    let y = Some(X::A);
+
+    match (x, y) {
+        //~^ ERROR non-exhaustive patterns: `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2
+        //~| more not covered
+        (_, None) => false,
+        (v, Some(w)) if v == w => true,
+        (X::B, Some(X::C)) => false,
+        (X::B, Some(X::A)) => false,
+        (X::A, Some(X::C)) | (X::C, Some(X::A)) => false,
+    };
+}

--- a/src/test/ui/pattern/usefulness/issue-72377.stderr
+++ b/src/test/ui/pattern/usefulness/issue-72377.stderr
@@ -1,0 +1,12 @@
+error[E0004]: non-exhaustive patterns: `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2 more not covered
+  --> $DIR/issue-72377.rs:8:11
+   |
+LL |     match (x, y) {
+   |           ^^^^^^ patterns `(A, Some(A))`, `(A, Some(B))`, `(B, Some(B))` and 2 more not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `(X, Option<X>)`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.


### PR DESCRIPTION
Successful merges:

 - #81897 (Add match pattern diagnostics regression test)
 - #82009 (const_generics: Dont evaluate array length const when handling errors)
 - #82060 (Fix typos in BTreeSet::{first, last} docs)
 - #82063 (Fixed minor typo in catch_unwind docs)
 - #82077 (Edit `rustc_arena::DropArena` docs)
 - #82093 (Add tests for Atomic*::fetch_{min,max})
 - #82096 (Fix a typo)
 - #82106 (Remove unnecessary `Option` in `default_doc`)
 - #82118 (Add missing env!-decl variant)
 - #82119 (Fix typo in link to CreateSymbolicLinkW documentation.)
 - #82120 (Stabilize Arguments::as_str)
 - #82129 (Remove redundant bool_to_option feature gate)
 - #82133 (Update link for extern prelude.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=81897,82009,82060,82063,82077,82093,82096,82106,82118,82119,82120,82129,82133)
<!-- homu-ignore:end -->