### PR TITLE
Implement `Allocator` for `!`

### DIFF
--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -404,3 +404,16 @@ where
         unsafe { (**self).shrink(ptr, old_layout, new_layout) }
     }
 }
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+unsafe impl Allocator for ! {
+    #[inline]
+    fn allocate(&self, _: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        *self
+    }
+
+    #[inline]
+    unsafe fn deallocate(&self, _: NonNull<u8>, _: Layout) {
+        *self
+    }
+}


### PR DESCRIPTION
Useful to represent situations where something will never actually allocate, such as immutable version of a copy-on-write type.

I know there's a *lot* of traits where `!` impls would make sense, and there's pros and cons of adding them. But this one has the advantage of being unstable, so adding it could help get more experience as to those pros and cons. Besides, I personally have an actual use-case for this impl in one of my projects. :)