### PR TITLE
fix consistency with is_ascii_whitespace

### DIFF
--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -299,10 +299,8 @@ where
 
     fn skip_ascii_whitespace(chars: &mut Chars<'_>) {
         let str = chars.as_str();
-        let first_non_space = str
-            .bytes()
-            .position(|b| b != b' ' && b != b'\t' && b != b'\n' && b != b'\r')
-            .unwrap_or(str.len());
+        let first_non_space =
+            str.bytes().position(|b| !b.is_ascii_whitespace()).unwrap_or(str.len());
         *chars = str[first_non_space..].chars()
     }
 }


### PR DESCRIPTION
Previously this method checked only 4 of 5 possible ascii whitespace byte variants (as defined in https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_whitespace).

Checked bytes:
before:
```
'\t' | '\n' | '\r' | ' '
```
after:
```
'\t' | '\n' | '\x0C' | '\r' | ' '
```