### PR TITLE
Reword labels on E0308 involving async fn return type

### DIFF
--- a/src/test/ui/async-await/dont-suggest-missing-await.stderr
+++ b/src/test/ui/async-await/dont-suggest-missing-await.stderr
@@ -2,11 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/dont-suggest-missing-await.rs:14:18
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- the `Output` of this `async fn`'s found opaque type
+   |                        --- checked the `Output` of this `async fn`, found opaque type
 ...
 LL |         take_u32(x)
    |                  ^ expected `u32`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note:     expected type `u32`
            found opaque type `impl Future`
 help: consider `await`ing on the `Future`

--- a/src/test/ui/async-await/generator-desc.stderr
+++ b/src/test/ui/async-await/generator-desc.stderr
@@ -13,13 +13,15 @@ error[E0308]: mismatched types
   --> $DIR/generator-desc.rs:12:16
    |
 LL | async fn one() {}
-   |                - the `Output` of this `async fn`'s expected opaque type
+   |                - checked the `Output` of this `async fn`, expected opaque type
 LL | async fn two() {}
-   |                - the `Output` of this `async fn`'s found opaque type
+   |                - checked the `Output` of this `async fn`, found opaque type
 ...
 LL |     fun(one(), two());
    |                ^^^^^ expected opaque type, found a different opaque type
    |
+   = note: while checking the return type of the `async fn`
+   = note: while checking the return type of the `async fn`
    = note: expected opaque type `impl Future` (opaque type at <$DIR/generator-desc.rs:5:16>)
               found opaque type `impl Future` (opaque type at <$DIR/generator-desc.rs:6:16>)
    = help: consider `await`ing on both `Future`s

--- a/src/test/ui/async-await/issue-61076.rs
+++ b/src/test/ui/async-await/issue-61076.rs
@@ -56,7 +56,7 @@ async fn struct_() -> Struct {
 }
 
 async fn tuple() -> Tuple {
-    //~^ NOTE the `Output` of this `async fn`'s expected opaque type
+    //~^ NOTE checked the `Output` of this `async fn`, expected opaque type
     Tuple(1i32)
 }
 
@@ -92,6 +92,7 @@ async fn match_() {
         Tuple(_) => {} //~ ERROR mismatched types
         //~^ NOTE expected opaque type, found struct `Tuple`
         //~| NOTE expected opaque type `impl Future`
+        //~| NOTE while checking the return type of the `async fn`
     }
 }
 

--- a/src/test/ui/async-await/issue-61076.stderr
+++ b/src/test/ui/async-await/issue-61076.stderr
@@ -61,11 +61,12 @@ error[E0308]: mismatched types
   --> $DIR/issue-61076.rs:92:9
    |
 LL | async fn tuple() -> Tuple {
-   |                     ----- the `Output` of this `async fn`'s expected opaque type
+   |                     ----- checked the `Output` of this `async fn`, expected opaque type
 ...
 LL |         Tuple(_) => {}
    |         ^^^^^^^^ expected opaque type, found struct `Tuple`
    |
+   = note: while checking the return type of the `async fn`
    = note: expected opaque type `impl Future`
                    found struct `Tuple`
 help: consider `await`ing on the `Future`

--- a/src/test/ui/async-await/suggest-missing-await-closure.stderr
+++ b/src/test/ui/async-await/suggest-missing-await-closure.stderr
@@ -2,11 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await-closure.rs:16:18
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- the `Output` of this `async fn`'s found opaque type
+   |                        --- checked the `Output` of this `async fn`, found opaque type
 ...
 LL |         take_u32(x)
    |                  ^ expected `u32`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note:     expected type `u32`
            found opaque type `impl Future`
 help: consider `await`ing on the `Future`

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -2,11 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await.rs:12:14
    |
 LL | async fn make_u32() -> u32 {
-   |                        --- the `Output` of this `async fn`'s found opaque type
+   |                        --- checked the `Output` of this `async fn`, found opaque type
 ...
 LL |     take_u32(x)
    |              ^ expected `u32`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note:     expected type `u32`
            found opaque type `impl Future`
 help: consider `await`ing on the `Future`
@@ -18,11 +19,12 @@ error[E0308]: mismatched types
   --> $DIR/suggest-missing-await.rs:22:5
    |
 LL | async fn dummy() {}
-   |                  - the `Output` of this `async fn`'s found opaque type
+   |                  - checked the `Output` of this `async fn`, found opaque type
 ...
 LL |     dummy()
    |     ^^^^^^^ expected `()`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note: expected unit type `()`
             found opaque type `impl Future`
 help: consider `await`ing on the `Future`

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -189,9 +189,10 @@ LL |         async fn ft1();
 LL |         async fn ft1() {}
    |                        ^
    |                        |
-   |                        the `Output` of this `async fn`'s found opaque type
+   |                        checked the `Output` of this `async fn`, found opaque type
    |                        expected `()`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note: expected fn pointer `fn()`
               found fn pointer `fn() -> impl Future`
 
@@ -204,9 +205,10 @@ LL |         const async unsafe extern "C" fn ft5();
 LL |         const async unsafe extern "C" fn ft5() {}
    |                                                ^
    |                                                |
-   |                                                the `Output` of this `async fn`'s found opaque type
+   |                                                checked the `Output` of this `async fn`, found opaque type
    |                                                expected `()`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note: expected fn pointer `unsafe extern "C" fn()`
               found fn pointer `unsafe extern "C" fn() -> impl Future`
 

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -53,9 +53,10 @@ LL |     async fn associated();
 LL |     async fn associated();
    |                          ^
    |                          |
-   |                          the `Output` of this `async fn`'s found opaque type
+   |                          checked the `Output` of this `async fn`, found opaque type
    |                          expected `()`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note: expected fn pointer `fn()`
               found fn pointer `fn() -> impl Future`
 

--- a/src/test/ui/suggestions/issue-81839.stderr
+++ b/src/test/ui/suggestions/issue-81839.stderr
@@ -17,8 +17,9 @@ LL | |     }
   ::: $DIR/auxiliary/issue-81839.rs:6:49
    |
 LL |       pub async fn answer_str(&self, _s: &str) -> Test {
-   |                                                   ---- the `Output` of this `async fn`'s found opaque type
+   |                                                   ---- checked the `Output` of this `async fn`, found opaque type
    |
+   = note: while checking the return type of the `async fn`
    = note:     expected type `()`
            found opaque type `impl Future`
 

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.rs
@@ -13,9 +13,9 @@ fn extra_semicolon() {
     };
 }
 
-async fn async_dummy() {} //~ NOTE the `Output` of this `async fn`'s found opaque type
-async fn async_dummy2() {} //~ NOTE the `Output` of this `async fn`'s found opaque type
-//~^ NOTE the `Output` of this `async fn`'s found opaque type
+async fn async_dummy() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
+async fn async_dummy2() {} //~ NOTE checked the `Output` of this `async fn`, found opaque type
+//~| NOTE checked the `Output` of this `async fn`, found opaque type
 
 async fn async_extra_semicolon_same() {
     let _ = match true { //~ NOTE `match` arms have incompatible types
@@ -26,6 +26,7 @@ async fn async_extra_semicolon_same() {
         false => async_dummy(), //~ ERROR `match` arms have incompatible types
         //~^ NOTE expected `()`, found opaque type
         //~| NOTE expected type `()`
+        //~| NOTE while checking the return type of the `async fn`
         //~| HELP consider `await`ing on the `Future`
     };
 }
@@ -39,6 +40,7 @@ async fn async_extra_semicolon_different() {
         false => async_dummy2(), //~ ERROR `match` arms have incompatible types
         //~^ NOTE expected `()`, found opaque type
         //~| NOTE expected type `()`
+        //~| NOTE while checking the return type of the `async fn`
         //~| HELP consider `await`ing on the `Future`
     };
 }
@@ -51,6 +53,7 @@ async fn async_different_futures() {
         //~^ NOTE expected opaque type, found a different opaque type
         //~| NOTE expected type `impl Future`
         //~| NOTE distinct uses of `impl Trait` result in different opaque types
+        //~| NOTE while checking the return type of the `async fn`
     };
 }
 

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -2,7 +2,7 @@ error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:26:18
    |
 LL |   async fn async_dummy() {}
-   |                          - the `Output` of this `async fn`'s found opaque type
+   |                          - checked the `Output` of this `async fn`, found opaque type
 ...
 LL |       let _ = match true {
    |  _____________-
@@ -18,6 +18,7 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
+   = note: while checking the return type of the `async fn`
    = note:     expected type `()`
            found opaque type `impl Future`
 help: consider `await`ing on the `Future`
@@ -30,10 +31,10 @@ LL |             async_dummy()
    |                         --
 
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/match-prev-arm-needing-semi.rs:39:18
+  --> $DIR/match-prev-arm-needing-semi.rs:40:18
    |
 LL |   async fn async_dummy2() {}
-   |                           - the `Output` of this `async fn`'s found opaque type
+   |                           - checked the `Output` of this `async fn`, found opaque type
 ...
 LL |       let _ = match true {
    |  _____________-
@@ -49,6 +50,7 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
+   = note: while checking the return type of the `async fn`
    = note:     expected type `()`
            found opaque type `impl Future`
 help: consider `await`ing on the `Future`
@@ -64,10 +66,10 @@ LL |         false => Box::new(async_dummy2()),
    |
 
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/match-prev-arm-needing-semi.rs:50:18
+  --> $DIR/match-prev-arm-needing-semi.rs:52:18
    |
 LL |   async fn async_dummy2() {}
-   |                           - the `Output` of this `async fn`'s found opaque type
+   |                           - checked the `Output` of this `async fn`, found opaque type
 ...
 LL |       let _ = match true {
    |  _____________-
@@ -81,6 +83,7 @@ LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
+   = note: while checking the return type of the `async fn`
    = note:     expected type `impl Future` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:16:24>)
            found opaque type `impl Future` (opaque type at <$DIR/match-prev-arm-needing-semi.rs:17:25>)
    = note: distinct uses of `impl Trait` result in different opaque types


### PR DESCRIPTION
Fix for #80658.

When someone writes code like this:

```rust
fn foo() -> u8 {
    async fn async_fn() -> () {}

    async_fn()
}
```

And they try to compile it, they will see an error that looks like this:

```bash
error[E0308]: mismatched types
 --> test.rs:4:5
  |
1 | fn foo() -> u8 {
  |             -- expected `u8` because of return type
2 |     async fn async_fn() -> () {}
  |                            -- checked the `Output` of this `async fn`, found opaque type
3 |
4 |     async_fn()
  |     ^^^^^^^^^^ expected `u8`, found opaque type
  |
  = note: while checking the return type of this `async fn`
  = note:     expected type `u8`
          found opaque type `impl Future`
```