### PR TITLE
Use binary search to find variants definitions

### DIFF
--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -48,6 +48,7 @@
 #![feature(associated_type_bounds)]
 #![feature(rustc_attrs)]
 #![feature(int_error_matching)]
+#![feature(is_sorted)]
 #![feature(half_open_range_patterns)]
 #![feature(exclusive_range_pattern)]
 #![feature(control_flow_enum)]


### PR DESCRIPTION
ADT variants are assigned increasing def ids. Use binary search to find
variant definition corresponding to a provided def id.