### PR TITLE
fix MIR fn-ptr pretty-printing

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1018,7 +1018,7 @@ pub trait PrettyPrinter<'tcx>:
                 p!(write("{:?}", char::try_from(int).unwrap()))
             }
             // Raw pointers
-            (Scalar::Int(int), ty::RawPtr(_)) => {
+            (Scalar::Int(int), ty::RawPtr(_) | ty::FnPtr(_)) => {
                 let data = int.assert_bits(self.tcx().data_layout.pointer_size);
                 self = self.typed_value(
                     |mut this| {
@@ -1040,8 +1040,7 @@ pub trait PrettyPrinter<'tcx>:
                             " as ",
                         )?;
                     }
-                    Some(_) => p!("<non-executable memory>"),
-                    None => p!("<dangling pointer>"),
+                    _ => self = self.pretty_print_const_pointer(ptr, ty, print_ty)?,
                 }
             }
             // For function type zsts just printing the path is enough

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -106,7 +106,7 @@ impl<Tag: Copy> std::fmt::Display for ImmTy<'tcx, Tag> {
                 }
                 ScalarMaybeUninit::Uninit => cx.typed_value(
                     |mut this| {
-                        this.write_str("{uninit ")?;
+                        this.write_str("uninit ")?;
                         Ok(this)
                     },
                     |this| this.print_type(ty),


### PR DESCRIPTION
An uninitialized function pointer would get printed as `{{uninit  fn()}` (notice the unbalanced parentheses), and a dangling fn ptr would ICE. This fixes both of that.

However, I have no idea how to add tests for this.

Also, I don't understand this MIR pretty-printing code. Somehow the print function `pretty_print_const_scalar` actually *returns* a transformed form of the const (but there is no doc comment explaining what is being returned); some match arms do `p!` while others do `self =`, and there's a wild mixture of `p!` and `write!`... all very mysterious and confusing.^^

r? @oli-obk 