### PR TITLE
Do not delete bootstrap.exe on Windows during clean

### DIFF
--- a/src/bootstrap/clean.rs
+++ b/src/bootstrap/clean.rs
@@ -21,6 +21,9 @@ pub fn clean(build: &Build, all: bool) {
     } else {
         rm_rf(&build.out.join("tmp"));
         rm_rf(&build.out.join("dist"));
+        // Only delete the bootstrap executable on non-Windows systems
+        // Windows does not allow deleting a currently running executable
+        #[cfg(not(windows))]
         rm_rf(&build.out.join("bootstrap"));
 
         for host in &build.hosts {


### PR DESCRIPTION
Windows does not allow deleting currently running executables.

This an addition to @jyn514's change in https://github.com/rust-lang/rust/pull/80574.