### PR TITLE
Specialize Iterator for &mut I where I: Sized

### DIFF
--- a/library/alloc/src/vec/drain.rs
+++ b/library/alloc/src/vec/drain.rs
@@ -1,7 +1,7 @@
 use crate::alloc::{Allocator, Global};
 use core::fmt;
 use core::iter::{FusedIterator, TrustedLen};
-use core::mem::{self};
+use core::mem::{self, MaybeUninit};
 use core::ptr::{self, NonNull};
 use core::slice::{self};
 
@@ -102,16 +102,11 @@ impl<T, A: Allocator> DoubleEndedIterator for Drain<'_, T, A> {
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> Drop for Drain<'_, T, A> {
     fn drop(&mut self) {
-        /// Continues dropping the remaining elements in the `Drain`, then moves back the
-        /// un-`Drain`ed elements to restore the original `Vec`.
+        /// Moves back the un-`Drain`ed elements to restore the original `Vec`.
         struct DropGuard<'r, 'a, T, A: Allocator>(&'r mut Drain<'a, T, A>);
 
         impl<'r, 'a, T, A: Allocator> Drop for DropGuard<'r, 'a, T, A> {
             fn drop(&mut self) {
-                // Continue the same loop we have below. If the loop already finished, this does
-                // nothing.
-                self.0.for_each(drop);
-
                 if self.0.tail_len > 0 {
                     unsafe {
                         let source_vec = self.0.vec.as_mut();
@@ -129,15 +124,43 @@ impl<T, A: Allocator> Drop for Drain<'_, T, A> {
             }
         }
 
-        // exhaust self first
-        while let Some(item) = self.next() {
-            let guard = DropGuard(self);
-            drop(item);
-            mem::forget(guard);
+        let iter = mem::replace(&mut self.iter, (&mut []).iter());
+        let drop_len = iter.len();
+        let drop_ptr = iter.as_slice().as_ptr();
+
+        // forget iter so there's no aliasing reference
+        drop(iter);
+
+        let mut vec = self.vec;
+
+        if mem::size_of::<T>() == 0 {
+            // ZSTs have no identity, so we don't need to move them around, we only need to drop the correct amount.
+            // this can be achieved by manipulating the Vec length instead of moving values out from `iter`.
+            unsafe {
+                let vec = vec.as_mut();
+                let old_len = vec.len();
+                vec.set_len(old_len + drop_len + self.tail_len);
+                vec.truncate(old_len + self.tail_len);
+            }
+
+            return;
         }
 
-        // Drop a `DropGuard` to move back the non-drained tail of `self`.
-        DropGuard(self);
+        // ensure elements are moved back into their appropriate places, even when drop_in_place panics
+        let _guard = DropGuard(self);
+
+        if drop_len == 0 {
+            return;
+        }
+
+        unsafe {
+            let vec = vec.as_mut();
+            let spare_capacity = vec.spare_capacity_mut();
+            let drop_offset = drop_ptr.offset_from(spare_capacity.as_ptr() as *const _) as usize;
+            let drop_range = drop_offset..(drop_offset + drop_len);
+            let to_drop = &mut spare_capacity[drop_range];
+            ptr::drop_in_place(MaybeUninit::slice_assume_init_mut(to_drop));
+        }
     }
 }
 

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1995,17 +1995,13 @@ pub trait Iterator {
     /// ```
     #[inline]
     #[stable(feature = "iterator_try_fold", since = "1.27.0")]
-    fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         Self: Sized,
         F: FnMut(B, Self::Item) -> R,
         R: Try<Ok = B>,
     {
-        let mut accum = init;
-        while let Some(x) = self.next() {
-            accum = f(accum, x)?;
-        }
-        try { accum }
+        default_try_fold(self, init, f)
     }
 
     /// An iterator method that applies a fallible function to each item in the
@@ -2136,16 +2132,12 @@ pub trait Iterator {
     #[doc(alias = "inject")]
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    fn fold<B, F>(self, init: B, f: F) -> B
     where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        let mut accum = init;
-        while let Some(x) = self.next() {
-            accum = f(accum, x);
-        }
-        accum
+        default_fold(self, init, f)
     }
 
     /// Reduces the elements to a single one, by repeatedly applying a reducing
@@ -3415,6 +3407,33 @@ pub trait Iterator {
     }
 }
 
+#[inline]
+fn default_try_fold<I, B, F, R>(iter: &mut I, init: B, mut f: F) -> R
+where
+    I: Iterator + ?Sized,
+    F: FnMut(B, I::Item) -> R,
+    R: Try<Ok = B>,
+{
+    let mut accum = init;
+    while let Some(x) = iter.next() {
+        accum = f(accum, x)?;
+    }
+    try { accum }
+}
+
+#[inline]
+fn default_fold<I, B, F>(mut iter: I, init: B, mut f: F) -> B
+where
+    I: Iterator,
+    F: FnMut(B, I::Item) -> B,
+{
+    let mut accum = init;
+    while let Some(x) = iter.next() {
+        accum = f(accum, x);
+    }
+    accum
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: Iterator + ?Sized> Iterator for &mut I {
     type Item = I::Item;
@@ -3459,27 +3478,19 @@ trait SpecSizedIterator: Iterator {
 
 impl<I: Iterator + ?Sized> SpecSizedIterator for &mut I {
     #[inline]
-    default fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R
+    default fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R
     where
         F: FnMut(B, Self::Item) -> R,
         R: Try<Ok = B>,
     {
-        let mut accum = init;
-        while let Some(x) = self.next() {
-            accum = f(accum, x)?;
-        }
-        try { accum }
+        default_try_fold(self, init, f)
     }
     #[inline]
-    default fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    default fn fold<B, F>(self, init: B, f: F) -> B
     where
         F: FnMut(B, Self::Item) -> B,
     {
-        let mut accum = init;
-        while let Some(x) = (&mut self).next() {
-            accum = f(accum, x);
-        }
-        accum
+        default_fold(self, init, f)
     }
 }
 

--- a/src/test/ui/issues/issue-3044.stderr
+++ b/src/test/ui/issues/issue-3044.stderr
@@ -11,7 +11,7 @@ LL | |     });
 note: associated function defined here
   --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
    |
-LL |     fn fold<B, F>(mut self, init: B, mut f: F) -> B
+LL |     fn fold<B, F>(self, init: B, f: F) -> B
    |        ^^^^
 
 error: aborting due to previous error


### PR DESCRIPTION
This PR aims to improve the implementation of `Iterator` and `DoubleEndedIterator` for `&mut I where I: Iterator`. This is accomplished by forwarding `try_fold` to the implementation for `I` (since it takes `&mut self`) and implementing `fold` in terms of `try_fold` (since `fold` takes `self`).

Since `try_fold` is not available if `I: !Sized` I needed to specialize the case `I: Sized` (that's also why I choose to keep the `+ Sized` bound, to be explicit about what I'm specializing). This means this optimization won't apply to `&mut dyn Iterator`.

While coding this pr I realized that it adds a considerable chunk of code for `&mut I where I: Iterator` and it may make sense to move it to a separate file just like other adapters. Tell me what you think about it.

Edit: Note that the following benchmark results are relatively old (they were done before the LLVM 12 update for instance) and should probably be updated. 

Here's a comparison (run with `cargo benchcmp master pr --threshold 2`) of the benchmark (run with `py x.py bench --stage 0 library/core --test-args iter::`):

```
 name                                         master.txt ns/iter  pr.txt ns/iter  diff ns/iter   diff %  speedup
 iter::bench_cycle_skip_take_ref_sum          2,702,500           1,037,230         -1,665,270  -61.62%   x 2.61
 iter::bench_cycle_take_ref_sum               950,040             738,915             -211,125  -22.22%   x 1.29
 iter::bench_cycle_take_skip_ref_sum          2,117,830           666,940           -1,450,890  -68.51%   x 3.18
 iter::bench_enumerate_chain_ref_sum          1,381,700           1,476,370             94,670    6.85%   x 0.94
 iter::bench_enumerate_ref_sum                459,605             436,760              -22,845   -4.97%   x 1.05
 iter::bench_filter_chain_ref_count           1,389,580           1,095,382           -294,198  -21.17%   x 1.27
 iter::bench_filter_chain_ref_sum             2,007,972           893,280           -1,114,692  -55.51%   x 2.25
 iter::bench_filter_map_chain_ref_sum         3,908,650           1,040,480         -2,868,170  -73.38%   x 3.76
 iter::bench_filter_map_ref_sum               806,280             469,225             -337,055  -41.80%   x 1.72
 iter::bench_filter_ref_sum                   604,827             566,450              -38,377   -6.35%   x 1.07
 iter::bench_flat_map_chain_ref_sum           4,467,065           1,641,630         -2,825,435  -63.25%   x 2.72
 iter::bench_flat_map_ref_sum                 1,849,160           474,605           -1,374,555  -74.33%   x 3.90
 iter::bench_flat_map_sum                     446,975             483,936               36,961    8.27%   x 0.92
 iter::bench_for_each_chain_ref_fold          1,608,805           1,378,055           -230,750  -14.34%   x 1.17
 iter::bench_fuse_chain_ref_sum               1,612,977           942,280             -670,697  -41.58%   x 1.71
 iter::bench_fuse_chain_sum                   461,980             707,125              245,145   53.06%   x 0.65
 iter::bench_fuse_ref_sum                     460,043             352,918             -107,125  -23.29%   x 1.30
 iter::bench_inspect_chain_ref_sum            1,612,792           941,940             -670,852  -41.60%   x 1.71
 iter::bench_inspect_chain_sum                460,000             706,720              246,720   53.63%   x 0.65
 iter::bench_inspect_ref_sum                  459,523             358,241             -101,282  -22.04%   x 1.28
 iter::bench_multiple_take                    63                  58                        -5   -7.94%   x 1.09
 iter::bench_peekable_chain_ref_sum           1,378,620           924,195             -454,425  -32.96%   x 1.49
 iter::bench_peekable_chain_sum               463,480             692,655              229,175   49.45%   x 0.67
 iter::bench_peekable_ref_sum                 459,677             346,225             -113,452  -24.68%   x 1.33
 iter::bench_rposition                        66                  74                         8   12.12%   x 0.89
 iter::bench_skip_chain_ref_sum               3,911,640           921,185           -2,990,455  -76.45%   x 4.25
 iter::bench_skip_cycle_skip_zip_add_ref_sum  4,439,160           3,252,870         -1,186,290  -26.72%   x 1.36
 iter::bench_skip_sum                         344,301             460,145              115,844   33.65%   x 0.75
 iter::bench_skip_while_chain_ref_sum         3,947,070           921,160           -3,025,910  -76.66%   x 4.28
 iter::bench_skip_while_ref_sum               344,387             460,540              116,153   33.73%   x 0.75
 iter::bench_take_while_chain_ref_sum         760,888             511,980             -248,908  -32.71%   x 1.49
```

There are a lot of promising improvements, but surprisingly there are also a couple of strange regressions:

```
 name                                         master.txt ns/iter  pr.txt ns/iter  diff ns/iter   diff %  speedup
 iter::bench_flat_map_sum                     446,975             483,936               36,961    8.27%   x 0.92
 iter::bench_fuse_chain_sum                   461,980             707,125              245,145   53.06%   x 0.65
 iter::bench_inspect_chain_sum                460,000             706,720              246,720   53.63%   x 0.65
 iter::bench_peekable_chain_sum               463,480             692,655              229,175   49.45%   x 0.67
 iter::bench_rposition                        66                  74                         8   12.12%   x 0.89
 iter::bench_skip_sum                         344,301             460,145              115,844   33.65%   x 0.75
```

These benchmarks shouldn't have be impacted by my changes because they never use `&mut impl Iterator` but somehow they were. My guess is that this is the result of some LLVM shenanigans because if I remove any benchmark containing `.by_ref()` then most of them don't regress anymore. Since these look like codegen problems and specific to the current benchmark I'm not too worried about them.

```
 name                                         master.txt ns/iter  pr.txt ns/iter  diff ns/iter   diff %  speedup
 iter::bench_enumerate_chain_ref_sum          1,381,700           1,476,370             94,670    6.85%   x 0.94
 iter::bench_skip_while_ref_sum               344,387             460,540              116,153   33.73%   x 0.75
```

These benchmarks however were directly impacted by my changes and the give the same results even if I remove all the other benchmarks, so I guess they're genuine regressions. 

All these regressions are present even if I copy the default `fold` implementation but directly call `I::next` instead of passing through `<&mut I>::next` (which should just call `I::next` anyway). This makes me think these are also codegen problem.

I would like to not have these regressions but the other improvements probably outweights them.