### PR TITLE
Include adjustments to allow unsizing coercions for raw slice pointers in receiver position

### DIFF
--- a/src/test/ui/raw-ref-op/raw-ref-unsize-coercion-receiver.rs
+++ b/src/test/ui/raw-ref-op/raw-ref-unsize-coercion-receiver.rs
@@ -1,0 +1,20 @@
+#![feature(raw_ref_op)]
+
+fn main() {
+  let a1 = [4,5,6];
+  let p1 = &raw const a1;
+  let _ = unsafe { p1.get_unchecked(1) };
+
+  let mut a2 = [4,5,6];
+  let p2 = &raw mut a2;
+  let _ = unsafe { p2.get_unchecked(1) };
+
+  let mut a3 = [4,5,6];
+  let p3 = &raw mut a3;
+  let _ = unsafe { p3.get_unchecked_mut(1) };
+
+  let a4 = [4,5,6];
+  let p4 = &raw const a4;
+  let _ = unsafe { p4.get_unchecked_mut(1) };
+  //~^ ERROR cannot borrow
+}

--- a/src/test/ui/raw-ref-op/raw-ref-unsize-coercion-receiver.stderr
+++ b/src/test/ui/raw-ref-op/raw-ref-unsize-coercion-receiver.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow `*p4` as mutable, as it is behind a `*const` pointer
+  --> $DIR/raw-ref-unsize-coercion-receiver.rs:18:20
+   |
+LL |   let p4 = &raw const a4;
+   |            ------------- help: consider changing this to be a mutable pointer: `&mut raw const a4`
+LL |   let _ = unsafe { p4.get_unchecked_mut(1) };
+   |                    ^^ `p4` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
Tries to fix https://github.com/rust-lang/rust/issues/74679

This change would allow calling methods defined for raw slice pointers directly on raw array pointers. The current implementation might have some problems, the idea is to insert adjustments for raw pointers in receiver position if the receiver type is a raw array pointer and a method candidate has a raw slice pointer as its self_ty. This could possibly be problematic, since we implicitly deref a raw pointer. However, currently the only methods that allow this type of unsizing coercion are unsafe, but we might need to only allow these types of coercions for unsafe methods in general. 

cc @RalfJung 