### PR TITLE
make `suggest_setup` help messages better

### DIFF
--- a/src/bootstrap/bin/main.rs
+++ b/src/bootstrap/bin/main.rs
@@ -15,14 +15,17 @@ fn main() {
 
     // check_version warnings are not printed during setup
     let changelog_suggestion =
-        if matches!(config.cmd, Subcommand::Setup {..}) { None } else { check_version(&config) };
+        if matches!(config.cmd, Subcommand::Setup { .. }) { None } else { check_version(&config) };
 
     // NOTE: Since `./configure` generates a `config.toml`, distro maintainers will see the
     // changelog warning, not the `x.py setup` message.
     let suggest_setup = !config.config.exists() && !matches!(config.cmd, Subcommand::Setup { .. });
     if suggest_setup {
         println!("warning: you have not made a `config.toml`");
-        println!("help: consider running `x.py setup` or copying `config.toml.example`");
+        println!(
+            "help: consider running `./x.py setup` or copying `config.toml.example` by running \
+            `cp config.toml.example config.toml`"
+        );
     } else if let Some(suggestion) = &changelog_suggestion {
         println!("{}", suggestion);
     }
@@ -31,7 +34,10 @@ fn main() {
 
     if suggest_setup {
         println!("warning: you have not made a `config.toml`");
-        println!("help: consider running `x.py setup` or copying `config.toml.example`");
+        println!(
+            "help: consider running `./x.py setup` or copying `config.toml.example` by running \
+            `cp config.toml.example config.toml`"
+        );
     } else if let Some(suggestion) = &changelog_suggestion {
         println!("{}", suggestion);
     }


### PR DESCRIPTION
When I first built the compiler and didn't create a `config.toml.example`, the following was emitted:

```
help: consider running `x.py setup` or copying `config.toml.example`
```

I ran `x.py setup` but got an error so in this PR I made the help messages a little clearer.