### PR TITLE
Replace if-let and while-let with `if let` and `while let`

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0162.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0162.md
@@ -1,6 +1,6 @@
 #### Note: this error code is no longer emitted by the compiler.
 
-An if-let pattern attempts to match the pattern, and enters the body if the
+An `if let` pattern attempts to match the pattern, and enters the body if the
 match was successful. If the match is irrefutable (when it cannot fail to
 match), use a regular `let`-binding instead. For instance:
 

--- a/compiler/rustc_error_codes/src/error_codes/E0165.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0165.md
@@ -1,6 +1,6 @@
 #### Note: this error code is no longer emitted by the compiler.
 
-A while-let pattern attempts to match the pattern, and enters the body if the
+A `while let` pattern attempts to match the pattern, and enters the body if the
 match was successful. If the match is irrefutable (when it cannot fail to
 match), use a regular `let`-binding inside a `loop` instead. For instance:
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1815,7 +1815,7 @@ declare_lint! {
 
 declare_lint! {
     /// The `irrefutable_let_patterns` lint detects detects [irrefutable
-    /// patterns] in [if-let] and [while-let] statements.
+    /// patterns] in [`if let`] and [`while let`] statements.
     ///
     ///
     ///
@@ -1832,7 +1832,7 @@ declare_lint! {
     /// ### Explanation
     ///
     /// There usually isn't a reason to have an irrefutable pattern in an
-    /// if-let or while-let statement, because the pattern will always match
+    /// `if let` or `while let` statement, because the pattern will always match
     /// successfully. A [`let`] or [`loop`] statement will suffice. However,
     /// when generating code with a macro, forbidding irrefutable patterns
     /// would require awkward workarounds in situations where the macro
@@ -1843,14 +1843,14 @@ declare_lint! {
     /// See [RFC 2086] for more details.
     ///
     /// [irrefutable patterns]: https://doc.rust-lang.org/reference/patterns.html#refutability
-    /// [if-let]: https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions
-    /// [while-let]: https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops
+    /// [`if let`]: https://doc.rust-lang.org/reference/expressions/if-expr.html#if-let-expressions
+    /// [`while let`]: https://doc.rust-lang.org/reference/expressions/loop-expr.html#predicate-pattern-loops
     /// [`let`]: https://doc.rust-lang.org/reference/statements.html#let-statements
     /// [`loop`]: https://doc.rust-lang.org/reference/expressions/loop-expr.html#infinite-loops
     /// [RFC 2086]: https://github.com/rust-lang/rfcs/blob/master/text/2086-allow-if-let-irrefutables.md
     pub IRREFUTABLE_LET_PATTERNS,
     Warn,
-    "detects irrefutable patterns in if-let and while-let statements"
+    "detects irrefutable patterns in `if let` and `while let` statements"
 }
 
 declare_lint! {

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -368,9 +368,9 @@ fn unreachable_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, catchall: Option<
 fn irrefutable_let_pattern(tcx: TyCtxt<'_>, span: Span, id: HirId, source: hir::MatchSource) {
     tcx.struct_span_lint_hir(IRREFUTABLE_LET_PATTERNS, id, span, |lint| {
         let msg = match source {
-            hir::MatchSource::IfLetDesugar { .. } => "irrefutable if-let pattern",
-            hir::MatchSource::WhileLetDesugar => "irrefutable while-let pattern",
-            hir::MatchSource::IfLetGuardDesugar => "irrefutable if-let guard",
+            hir::MatchSource::IfLetDesugar { .. } => "irrefutable `if let` pattern",
+            hir::MatchSource::WhileLetDesugar => "irrefutable `while let` pattern",
+            hir::MatchSource::IfLetGuardDesugar => "irrefutable `if let` guard",
             _ => bug!(),
         };
         lint.build(msg).emit()

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -45,7 +45,7 @@ impl NonConstExpr {
                 return None;
             }
 
-            Self::Match(IfLetGuardDesugar) => bug!("if-let guard outside a `match` expression"),
+            Self::Match(IfLetGuardDesugar) => bug!("`if let` guard outside a `match` expression"),
 
             // All other expressions are allowed.
             Self::Loop(Loop | While | WhileLet)

--- a/src/test/ui/binding/if-let.rs
+++ b/src/test/ui/binding/if-let.rs
@@ -6,7 +6,7 @@ pub fn main() {
     if let Some(y) = x {
         assert_eq!(y, 3);
     } else {
-        panic!("if-let panicked");
+        panic!("`if let` panicked");
     }
     let mut worked = false;
     if let Some(_) = x {
@@ -54,7 +54,7 @@ pub fn main() {
         if let Foo::Two(b) = a {
             assert_eq!(b, 42_usize);
         } else {
-            panic!("panic in nested if-let");
+            panic!("panic in nested `if let`");
         }
     }
 }

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.rs
@@ -16,7 +16,7 @@ fn main() {
         // FIXME(project-rfc-2229#24): Change this to be a destructure pattern
         // once this is fixed, to remove the warning.
         if let SingleVariant::Point(ref mut x, _) = point {
-            //~^ WARNING: irrefutable if-let pattern
+            //~^ WARNING: irrefutable `if let` pattern
             *x += 1;
         }
     };

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
@@ -7,7 +7,7 @@ LL | #![feature(capture_disjoint_fields)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
 
-warning: irrefutable if-let pattern
+warning: irrefutable `if let` pattern
   --> $DIR/closure-origin-single-variant-diagnostics.rs:18:9
    |
 LL | /         if let SingleVariant::Point(ref mut x, _) = point {

--- a/src/test/ui/expr/if/if-let.rs
+++ b/src/test/ui/expr/if/if-let.rs
@@ -4,8 +4,8 @@ fn macros() {
     macro_rules! foo{
         ($p:pat, $e:expr, $b:block) => {{
             if let $p = $e $b
-            //~^ WARN irrefutable if-let
-            //~| WARN irrefutable if-let
+            //~^ WARN irrefutable `if let`
+            //~| WARN irrefutable `if let`
         }}
     }
     macro_rules! bar{
@@ -23,27 +23,27 @@ fn macros() {
 }
 
 pub fn main() {
-    if let a = 1 { //~ WARN irrefutable if-let
+    if let a = 1 { //~ WARN irrefutable `if let`
         println!("irrefutable pattern");
     }
 
-    if let a = 1 { //~ WARN irrefutable if-let
+    if let a = 1 { //~ WARN irrefutable `if let`
         println!("irrefutable pattern");
     } else if true {
-        println!("else-if in irrefutable if-let");
+        println!("else-if in irrefutable `if let`");
     } else {
-        println!("else in irrefutable if-let");
+        println!("else in irrefutable `if let`");
     }
 
     if let 1 = 2 {
         println!("refutable pattern");
-    } else if let a = 1 { //~ WARN irrefutable if-let
+    } else if let a = 1 { //~ WARN irrefutable `if let`
         println!("irrefutable pattern");
     }
 
     if true {
         println!("if");
-    } else if let a = 1 { //~ WARN irrefutable if-let
+    } else if let a = 1 { //~ WARN irrefutable `if let`
         println!("irrefutable pattern");
     }
 }

--- a/src/test/ui/expr/if/if-let.stderr
+++ b/src/test/ui/expr/if/if-let.stderr
@@ -1,4 +1,4 @@
-warning: irrefutable if-let pattern
+warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:6:13
    |
 LL |               if let $p = $e $b
@@ -12,7 +12,7 @@ LL | |     });
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: irrefutable if-let pattern
+warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:6:13
    |
 LL |               if let $p = $e $b
@@ -25,7 +25,7 @@ LL | |     });
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: irrefutable if-let pattern
+warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:26:5
    |
 LL | /     if let a = 1 {
@@ -33,19 +33,19 @@ LL | |         println!("irrefutable pattern");
 LL | |     }
    | |_____^
 
-warning: irrefutable if-let pattern
+warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:30:5
    |
 LL | /     if let a = 1 {
 LL | |         println!("irrefutable pattern");
 LL | |     } else if true {
-LL | |         println!("else-if in irrefutable if-let");
+LL | |         println!("else-if in irrefutable `if let`");
 LL | |     } else {
-LL | |         println!("else in irrefutable if-let");
+LL | |         println!("else in irrefutable `if let`");
 LL | |     }
    | |_____^
 
-warning: irrefutable if-let pattern
+warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:40:12
    |
 LL |       } else if let a = 1 {
@@ -54,7 +54,7 @@ LL | |         println!("irrefutable pattern");
 LL | |     }
    | |_____^
 
-warning: irrefutable if-let pattern
+warning: irrefutable `if let` pattern
   --> $DIR/if-let.rs:46:12
    |
 LL |       } else if let a = 1 {

--- a/src/test/ui/issues/issue-19991.rs
+++ b/src/test/ui/issues/issue-19991.rs
@@ -1,4 +1,4 @@
-// Test if the sugared if-let construct correctly prints "missing an else clause" when an else
+// Test if the sugared `if let` construct correctly prints "missing an else clause" when an else
 // clause does not exist, instead of the unsympathetic "`match` arms have incompatible types"
 
 fn main() {

--- a/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.rs
+++ b/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.rs
@@ -1,9 +1,9 @@
 #![deny(irrefutable_let_patterns)]
 
 fn main() {
-    if let _ = 5 {} //~ ERROR irrefutable if-let pattern
+    if let _ = 5 {} //~ ERROR irrefutable `if let` pattern
 
-    while let _ = 5 { //~ ERROR irrefutable while-let pattern
+    while let _ = 5 { //~ ERROR irrefutable `while let` pattern
         break;
     }
 }

--- a/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
+++ b/src/test/ui/pattern/usefulness/deny-irrefutable-let-patterns.stderr
@@ -1,4 +1,4 @@
-error: irrefutable if-let pattern
+error: irrefutable `if let` pattern
   --> $DIR/deny-irrefutable-let-patterns.rs:4:5
    |
 LL |     if let _ = 5 {}
@@ -10,7 +10,7 @@ note: the lint level is defined here
 LL | #![deny(irrefutable_let_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: irrefutable while-let pattern
+error: irrefutable `while let` pattern
   --> $DIR/deny-irrefutable-let-patterns.rs:6:5
    |
 LL | /     while let _ = 5 {

--- a/src/test/ui/rfc-2294-if-let-guard/warns.rs
+++ b/src/test/ui/rfc-2294-if-let-guard/warns.rs
@@ -5,7 +5,7 @@
 fn irrefutable_let_guard() {
     match Some(()) {
         Some(x) if let () = x => {}
-        //~^ ERROR irrefutable if-let guard
+        //~^ ERROR irrefutable `if let` guard
         _ => {}
     }
 }

--- a/src/test/ui/rfc-2294-if-let-guard/warns.stderr
+++ b/src/test/ui/rfc-2294-if-let-guard/warns.stderr
@@ -1,4 +1,4 @@
-error: irrefutable if-let guard
+error: irrefutable `if let` guard
   --> $DIR/warns.rs:7:24
    |
 LL |         Some(x) if let () = x => {}

--- a/src/test/ui/while-let.rs
+++ b/src/test/ui/while-let.rs
@@ -5,8 +5,8 @@ fn macros() {
     macro_rules! foo{
         ($p:pat, $e:expr, $b:block) => {{
             while let $p = $e $b
-            //~^ WARN irrefutable while-let
-            //~| WARN irrefutable while-let
+            //~^ WARN irrefutable `while let`
+            //~| WARN irrefutable `while let`
         }}
     }
     macro_rules! bar{
@@ -24,7 +24,7 @@ fn macros() {
 }
 
 pub fn main() {
-    while let _a = 1 { //~ WARN irrefutable while-let
+    while let _a = 1 { //~ WARN irrefutable `while let`
         println!("irrefutable pattern");
         break;
     }

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -1,4 +1,4 @@
-warning: irrefutable while-let pattern
+warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:7:13
    |
 LL |               while let $p = $e $b
@@ -12,7 +12,7 @@ LL | |     });
    = note: `#[warn(irrefutable_let_patterns)]` on by default
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: irrefutable while-let pattern
+warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:7:13
    |
 LL |               while let $p = $e $b
@@ -25,7 +25,7 @@ LL | |     });
    |
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: irrefutable while-let pattern
+warning: irrefutable `while let` pattern
   --> $DIR/while-let.rs:27:5
    |
 LL | /     while let _a = 1 {

--- a/src/tools/clippy/clippy_lints/src/loops.rs
+++ b/src/tools/clippy/clippy_lints/src/loops.rs
@@ -341,7 +341,7 @@ declare_clippy_lint! {
     /// ```
     pub WHILE_LET_ON_ITERATOR,
     style,
-    "using a while-let loop instead of a for loop on an iterator"
+    "using a `while let` loop instead of a for loop on an iterator"
 }
 
 declare_clippy_lint! {


### PR DESCRIPTION
This pull request replaces if-let and while-let with `if let` and `while let`.

closes https://github.com/rust-lang/rust/issues/82205