### PR TITLE
fix the false 'defined here' messages

### DIFF
--- a/src/test/ui/consts/const-as-fn.rs
+++ b/src/test/ui/consts/const-as-fn.rs
@@ -1,0 +1,5 @@
+const FOO: usize = 0;
+
+fn main() {
+    FOO(); //~ ERROR expected function, found `usize`
+}

--- a/src/test/ui/consts/const-as-fn.stderr
+++ b/src/test/ui/consts/const-as-fn.stderr
@@ -1,0 +1,14 @@
+error[E0618]: expected function, found `usize`
+  --> $DIR/const-as-fn.rs:4:5
+   |
+LL | const FOO: usize = 0;
+   | --------------------- `FOO` defined here
+...
+LL |     FOO();
+   |     ^^^--
+   |     |
+   |     call expression requires function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.

--- a/src/test/ui/error-codes/E0618.stderr
+++ b/src/test/ui/error-codes/E0618.stderr
@@ -18,7 +18,7 @@ error[E0618]: expected function, found `i32`
   --> $DIR/E0618.rs:9:5
    |
 LL |     let x = 0i32;
-   |         - `i32` defined here
+   |         - `x` has type `i32`
 LL |     x();
    |     ^--
    |     |

--- a/src/test/ui/issues/issue-10969.stderr
+++ b/src/test/ui/issues/issue-10969.stderr
@@ -2,7 +2,7 @@ error[E0618]: expected function, found `i32`
   --> $DIR/issue-10969.rs:2:5
    |
 LL | fn func(i: i32) {
-   |         - `i32` defined here
+   |         - `i` has type `i32`
 LL |     i();
    |     ^--
    |     |
@@ -12,7 +12,7 @@ error[E0618]: expected function, found `i32`
   --> $DIR/issue-10969.rs:6:5
    |
 LL |     let i = 0i32;
-   |         - `i32` defined here
+   |         - `i` has type `i32`
 LL |     i();
    |     ^--
    |     |

--- a/src/test/ui/issues/issue-21701.stderr
+++ b/src/test/ui/issues/issue-21701.stderr
@@ -2,7 +2,7 @@ error[E0618]: expected function, found `U`
   --> $DIR/issue-21701.rs:2:13
    |
 LL | fn foo<U>(t: U) {
-   |           - `U` defined here
+   |           - `t` has type `U`
 LL |     let y = t();
    |             ^--
    |             |

--- a/src/test/ui/issues/issue-22468.stderr
+++ b/src/test/ui/issues/issue-22468.stderr
@@ -2,7 +2,7 @@ error[E0618]: expected function, found `&str`
   --> $DIR/issue-22468.rs:3:13
    |
 LL |     let foo = "bar";
-   |         --- `&str` defined here
+   |         --- `foo` has type `&str`
 LL |     let x = foo("baz");
    |             ^^^-------
    |             |

--- a/src/test/ui/issues/issue-26237.stderr
+++ b/src/test/ui/issues/issue-26237.stderr
@@ -5,7 +5,7 @@ LL |         $not_a_function($some_argument)
    |         ------------------------------- call expression requires function
 ...
 LL |     let mut value_a = 0;
-   |         ----------- `{integer}` defined here
+   |         ----------- `value_a` has type `{integer}`
 LL |     let mut value_b = 0;
 LL |     macro_panic!(value_a, value_b);
    |                  ^^^^^^^

--- a/src/test/ui/parser/parse-error-correct.stderr
+++ b/src/test/ui/parser/parse-error-correct.stderr
@@ -14,7 +14,7 @@ error[E0618]: expected function, found `{integer}`
   --> $DIR/parse-error-correct.rs:7:13
    |
 LL |     let y = 42;
-   |         - `{integer}` defined here
+   |         - `y` has type `{integer}`
 LL |     let x = y.;
 LL |     let x = y.();
    |             ^---

--- a/src/test/ui/structs/80853.rs
+++ b/src/test/ui/structs/80853.rs
@@ -1,0 +1,7 @@
+struct S;
+
+fn repro_ref(thing: S) {
+    thing(); //~ ERROR expected function, found `S`
+}
+
+fn main() {}

--- a/src/test/ui/structs/80853.stderr
+++ b/src/test/ui/structs/80853.stderr
@@ -1,0 +1,13 @@
+error[E0618]: expected function, found `S`
+  --> $DIR/80853.rs:4:5
+   |
+LL | fn repro_ref(thing: S) {
+   |              ----- `thing` has type `S`
+LL |     thing();
+   |     ^^^^^--
+   |     |
+   |     call expression requires function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0618`.


### PR DESCRIPTION
Closes #80853.

Take this code:

```rust
struct S;

fn repro_ref(thing: S) {
    thing();
}
```

Previously, the error message would be this:

```
error[E0618]: expected function, found `S`
 --> src/lib.rs:4:5
  |
3 | fn repro_ref(thing: S) {
  |              ----- `S` defined here
4 |     thing();
  |     ^^^^^--
  |     |
  |     call expression requires function

error: aborting due to previous error
```

This is incorrect as `S` is not defined in the function arguments, `thing` is defined there. With this change, the following is emitted:

```
error[E0618]: expected function, found `S`
  --> $DIR/80853.rs:4:5
   |
LL | fn repro_ref(thing: S) {
   |              ----- is of type `S`
LL |     thing();
   |     ^^^^^--
   |     |
   |     call expression requires function
   |
   = note: local variable `S` is not a function

error: aborting due to previous error
```

As you can see, this error message points out that `thing` is of type `S` and later in a note, that `S` is not a function. This change does seem like a downside for some error messages. Take this example:

```
LL | struct Empty2;
   | -------------- is of type `Empty2`
```

As you can see, the error message shows that the definition of `Empty2` is of type `Empty2`. Although this isn't wrong, it would be more helpful if it would say something like this (which was there previously):

```
LL | struct Empty2;
   | -------------- `Empty2` defined here
```

If there is a better way of doing this, where the `Empty2` example would stay the same as without this change, please inform me.

**Update: This is now fixed**

CC @camelid 