### PR TITLE
try-back-block-type test: Use TryFromSliceError for From test

### DIFF
--- a/src/test/ui/try-block/try-block-bad-type.rs
+++ b/src/test/ui/try-block/try-block-bad-type.rs
@@ -3,7 +3,7 @@
 #![feature(try_blocks)]
 
 pub fn main() {
-    let res: Result<u32, i32> = try {
+    let res: Result<u32, std::array::TryFromSliceError> = try {
         Err("")?; //~ ERROR `?` couldn't convert the error
         5
     };

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -1,16 +1,12 @@
-error[E0277]: `?` couldn't convert the error to `i32`
+error[E0277]: `?` couldn't convert the error to `TryFromSliceError`
   --> $DIR/try-block-bad-type.rs:7:16
    |
 LL |         Err("")?;
-   |                ^ the trait `From<&str>` is not implemented for `i32`
+   |                ^ the trait `From<&str>` is not implemented for `TryFromSliceError`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following implementations were found:
-             <i32 as From<NonZeroI32>>
-             <i32 as From<bool>>
-             <i32 as From<i16>>
-             <i32 as From<i8>>
-           and 2 others
+             <TryFromSliceError as From<Infallible>>
    = note: required by `from`
 
 error[E0271]: type mismatch resolving `<Result<i32, i32> as Try>::Ok == &str`


### PR DESCRIPTION
Using `i32` is rather fragile because it has many implementations.  Recently in an early draft of another MR (#82228) I did something that introduced a new `i32 as From<something>` impl and this test broke.

TryFromSliceError is nice because it doesn't seem likely to grow new conversions.  We still have one conversion, from Infallible.

My other MR is going to be reworked and won't need this any more but having done it I thought I would submit it rather than just throw it away.  Sorry for the tiny MR.