### PR TITLE
Remove query parameters when skipping search results

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -101,7 +101,7 @@ function focusSearchBar() {
     getSearchInput().focus();
 }
 
-// Removes the focus from the search bar
+// Removes the focus from the search bar.
 function defocusSearchBar() {
     getSearchInput().blur();
 }
@@ -220,6 +220,11 @@ function defocusSearchBar() {
         addClass(search, "hidden");
         removeClass(main, "hidden");
         document.title = titleBeforeSearch;
+        // We also remove the query parameter from the URL.
+        if (browserSupportsHistoryApi()) {
+            history.replaceState("", window.currentCrate + " - Rust",
+                getNakedUrl() + window.location.hash);
+        }
     }
 
     // used for special search precedence


### PR DESCRIPTION
Fixes #81330.

This PR changes the following: when pressing ESC and that no other "action" was performed (understand: no closing the search result, or hiding a menu or something along the line), then we discard the URL query parameters (the `?whatever=dsjfs`). What do you think about this change @rust-lang/rustdoc ?

EDIT: finally we're simply removing the query parameter when we're skipping the search results.

r? @Nemo157 