### PR TITLE
Do not ICE when evaluating locals' types of invalid `yield`

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -2081,6 +2081,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             _ => {
                 self.tcx.sess.emit_err(YieldExprOutsideOfGenerator { span: expr.span });
+                // Avoid expressions without types during writeback (#78653).
+                self.check_expr(value);
                 self.tcx.mk_unit()
             }
         }

--- a/src/test/ui/generator/yield-outside-generator-issue-78653.rs
+++ b/src/test/ui/generator/yield-outside-generator-issue-78653.rs
@@ -1,0 +1,7 @@
+#![feature(generators)]
+
+fn main() {
+    yield || for i in 0 { }
+    //~^ ERROR yield expression outside of generator literal
+    //~| ERROR `{integer}` is not an iterator
+}

--- a/src/test/ui/generator/yield-outside-generator-issue-78653.stderr
+++ b/src/test/ui/generator/yield-outside-generator-issue-78653.stderr
@@ -1,0 +1,21 @@
+error[E0627]: yield expression outside of generator literal
+  --> $DIR/yield-outside-generator-issue-78653.rs:4:5
+   |
+LL |     yield || for i in 0 { }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `{integer}` is not an iterator
+  --> $DIR/yield-outside-generator-issue-78653.rs:4:23
+   |
+LL |     yield || for i in 0 { }
+   |                       ^ `{integer}` is not an iterator
+   |
+   = help: the trait `Iterator` is not implemented for `{integer}`
+   = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
+   = note: required because of the requirements on the impl of `IntoIterator` for `{integer}`
+   = note: required by `into_iter`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0627.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
When a `yield` is outside of a generator, check its value regardless to
avoid an ICE while trying to get all locals' types in writeback.

Fix #78653.