### PR TITLE
Implement -Z hir-stats for nested foreign items

### DIFF
--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -114,6 +114,11 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
         self.visit_impl_item(nested_impl_item)
     }
 
+    fn visit_nested_foreign_item(&mut self, id: hir::ForeignItemId) {
+        let nested_foreign_item = self.krate.unwrap().foreign_item(id);
+        self.visit_foreign_item(nested_foreign_item);
+    }
+
     fn visit_nested_body(&mut self, body_id: hir::BodyId) {
         let nested_body = self.krate.unwrap().body(body_id);
         self.visit_body(nested_body)


### PR DESCRIPTION
An attempt to compute HIR stats for crates with nested foreign items results in an ICE.

```rust
fn main() {
    extern "C" { fn f(); }
}
```

```
thread 'rustc' panicked at 'visit_nested_xxx must be manually implemented in this visitor'
```

Provide required implementation of visitor method.