### PR TITLE
Emit error when trying to use assembler syntax directives in `asm!`

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -12,7 +12,6 @@ use rustc_span::{
     BytePos,
 };
 use rustc_span::{InnerSpan, Span};
-use rustc_target::asm::InlineAsmArch;
 
 struct AsmArgs {
     templates: Vec<P<ast::Expr>>,
@@ -403,6 +402,8 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, sp: Span, args: AsmArgs) -> P<ast
     let mut line_spans = Vec::with_capacity(args.templates.len());
     let mut curarg = 0;
 
+    let default_dialect = ecx.sess.inline_asm_dialect();
+
     for template_expr in args.templates.into_iter() {
         if !template.is_empty() {
             template.push(ast::InlineAsmTemplatePiece::String("\n".to_string()));
@@ -430,11 +431,6 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, sp: Span, args: AsmArgs) -> P<ast
         let template_snippet = ecx.source_map().span_to_snippet(template_sp).ok();
 
         if let Some(snippet) = &template_snippet {
-            let default_dialect = match ecx.sess.asm_arch {
-                Some(InlineAsmArch::X86 | InlineAsmArch::X86_64) => ast::LlvmAsmDialect::Intel,
-                _ => ast::LlvmAsmDialect::Att,
-            };
-
             let snippet = snippet.trim_matches('"');
             match default_dialect {
                 ast::LlvmAsmDialect::Intel => {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -784,6 +784,13 @@ impl Session {
         }
     }
 
+    pub fn inline_asm_dialect(&self) -> rustc_ast::LlvmAsmDialect {
+        match self.asm_arch {
+            Some(InlineAsmArch::X86 | InlineAsmArch::X86_64) => rustc_ast::LlvmAsmDialect::Intel,
+            _ => rustc_ast::LlvmAsmDialect::Att,
+        }
+    }
+
     pub fn relocation_model(&self) -> RelocModel {
         self.opts.cg.relocation_model.unwrap_or(self.target.relocation_model)
     }

--- a/src/test/ui/asm/inline-syntax.arm.stderr
+++ b/src/test/ui/asm/inline-syntax.arm.stderr
@@ -1,0 +1,14 @@
+error: att syntax is the default syntax on this target, and trying to use this directive may cause issues
+  --> $DIR/inline-syntax.rs:22:15
+   |
+LL |         asm!(".att_syntax noprefix", "nop");
+   |               ^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
+
+error: att syntax is the default syntax on this target, and trying to use this directive may cause issues
+  --> $DIR/inline-syntax.rs:25:15
+   |
+LL |         asm!(".att_syntax bbb noprefix", "nop");
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/asm/inline-syntax.rs
+++ b/src/test/ui/asm/inline-syntax.rs
@@ -1,23 +1,38 @@
-#![feature(asm, llvm_asm)]
+// revisions: x86_64 arm
+//[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
+//[arm] compile-flags: --target armv7-unknown-linux-gnueabihf
+
+#![feature(no_core, lang_items, rustc_attrs)]
+#![no_core]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+#[lang = "sized"]
+trait Sized {}
 
 fn main() {
     unsafe {
         asm!(".intel_syntax noprefix", "nop");
-        //~^ ERROR intel syntax is the default syntax on this target
+        //[x86_64]~^ ERROR intel syntax is the default syntax on this target
         asm!(".intel_syntax aaa noprefix", "nop");
-        //~^ ERROR intel syntax is the default syntax on this target
+        //[x86_64]~^ ERROR intel syntax is the default syntax on this target
         asm!(".att_syntax noprefix", "nop");
-        //~^ ERROR using the .att_syntax directive may cause issues
+        //[x86_64]~^ ERROR using the .att_syntax directive may cause issues
+        //[arm]~^^ att syntax is the default syntax on this target
         asm!(".att_syntax bbb noprefix", "nop");
-        //~^ ERROR using the .att_syntax directive may cause issues
+        //[x86_64]~^ ERROR using the .att_syntax directive may cause issues
+        //[arm]~^^ att syntax is the default syntax on this target
         asm!(".intel_syntax noprefix; nop");
-        //~^ ERROR intel syntax is the default syntax on this target
+        //[x86_64]~^ ERROR intel syntax is the default syntax on this target
 
         asm!(
             r"
             .intel_syntax noprefix
             nop"
         );
-        //~^^^ ERROR intel syntax is the default syntax on this target
+        //[x86_64]~^^^ ERROR intel syntax is the default syntax on this target
     }
 }

--- a/src/test/ui/asm/inline-syntax.rs
+++ b/src/test/ui/asm/inline-syntax.rs
@@ -1,0 +1,14 @@
+#![feature(asm, llvm_asm)]
+
+fn main() {
+    unsafe {
+        asm!(".intel_syntax noprefix", "nop");
+        //~^ ERROR intel sytnax is the default syntax
+        asm!(".intel_syntax aaa noprefix", "nop");
+        //~^ ERROR intel sytnax is the default syntax
+        asm!(".att_syntax noprefix", "nop");
+        //~^ ERROR using the .att_syntax directive may cause issues
+        asm!(".att_syntax bbb noprefix", "nop");
+        //~^ ERROR using the .att_syntax directive may cause issues
+    }
+}

--- a/src/test/ui/asm/inline-syntax.rs
+++ b/src/test/ui/asm/inline-syntax.rs
@@ -3,12 +3,21 @@
 fn main() {
     unsafe {
         asm!(".intel_syntax noprefix", "nop");
-        //~^ ERROR intel sytnax is the default syntax
+        //~^ ERROR intel syntax is the default syntax on this target
         asm!(".intel_syntax aaa noprefix", "nop");
-        //~^ ERROR intel sytnax is the default syntax
+        //~^ ERROR intel syntax is the default syntax on this target
         asm!(".att_syntax noprefix", "nop");
         //~^ ERROR using the .att_syntax directive may cause issues
         asm!(".att_syntax bbb noprefix", "nop");
         //~^ ERROR using the .att_syntax directive may cause issues
+        asm!(".intel_syntax noprefix; nop");
+        //~^ ERROR intel syntax is the default syntax on this target
+
+        asm!(
+            r"
+            .intel_syntax noprefix
+            nop"
+        );
+        //~^^^ ERROR intel syntax is the default syntax on this target
     }
 }

--- a/src/test/ui/asm/inline-syntax.stderr
+++ b/src/test/ui/asm/inline-syntax.stderr
@@ -1,14 +1,14 @@
-error: intel sytnax is the default syntax, and trying to use this directive may cause issues
+error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
   --> $DIR/inline-syntax.rs:5:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
-   |               ^^^^^^^^^^^^^^^^^^^^^^ help: Remove this assembler directive
+   |               ^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
-error: intel sytnax is the default syntax, and trying to use this directive may cause issues
+error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
   --> $DIR/inline-syntax.rs:7:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
-   |               ^^^^^^^^^^^^^ help: Remove this assembler directive: `aaa noprefix`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: using the .att_syntax directive may cause issues, use the att_syntax option instead
   --> $DIR/inline-syntax.rs:9:15
@@ -16,7 +16,7 @@ error: using the .att_syntax directive may cause issues, use the att_syntax opti
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
    |
-help: Remove the assembler directive and replace it with options(att_syntax)
+help: remove the assembler directive and replace it with options(att_syntax)
    |
 LL |         asm!("", "nop", options(att_syntax));
    |              --       ^^^^^^^^^^^^^^^^^^^^^
@@ -25,12 +25,26 @@ error: using the .att_syntax directive may cause issues, use the att_syntax opti
   --> $DIR/inline-syntax.rs:11:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
-   |               ^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: Remove the assembler directive and replace it with options(att_syntax)
+help: remove the assembler directive and replace it with options(att_syntax)
    |
-LL |         asm!(" bbb noprefix", "nop", options(att_syntax));
-   |              --                    ^^^^^^^^^^^^^^^^^^^^^
+LL |         asm!("", "nop", options(att_syntax));
+   |              --       ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
+  --> $DIR/inline-syntax.rs:13:15
+   |
+LL |         asm!(".intel_syntax noprefix; nop");
+   |               ^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
+
+error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
+  --> $DIR/inline-syntax.rs:18:14
+   |
+LL |               .intel_syntax noprefix
+   |  ______________^
+LL | |             nop"
+   | |_ help: remove this assembler directive
+
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/asm/inline-syntax.stderr
+++ b/src/test/ui/asm/inline-syntax.stderr
@@ -1,0 +1,36 @@
+error: intel sytnax is the default syntax, and trying to use this directive may cause issues
+  --> $DIR/inline-syntax.rs:5:15
+   |
+LL |         asm!(".intel_syntax noprefix", "nop");
+   |               ^^^^^^^^^^^^^^^^^^^^^^ help: Remove this assembler directive
+
+error: intel sytnax is the default syntax, and trying to use this directive may cause issues
+  --> $DIR/inline-syntax.rs:7:15
+   |
+LL |         asm!(".intel_syntax aaa noprefix", "nop");
+   |               ^^^^^^^^^^^^^ help: Remove this assembler directive: `aaa noprefix`
+
+error: using the .att_syntax directive may cause issues, use the att_syntax option instead
+  --> $DIR/inline-syntax.rs:9:15
+   |
+LL |         asm!(".att_syntax noprefix", "nop");
+   |               ^^^^^^^^^^^^^^^^^^^^
+   |
+help: Remove the assembler directive and replace it with options(att_syntax)
+   |
+LL |         asm!("", "nop", options(att_syntax));
+   |              --       ^^^^^^^^^^^^^^^^^^^^^
+
+error: using the .att_syntax directive may cause issues, use the att_syntax option instead
+  --> $DIR/inline-syntax.rs:11:15
+   |
+LL |         asm!(".att_syntax bbb noprefix", "nop");
+   |               ^^^^^^^^^^^
+   |
+help: Remove the assembler directive and replace it with options(att_syntax)
+   |
+LL |         asm!(" bbb noprefix", "nop", options(att_syntax));
+   |              --                    ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/asm/inline-syntax.x86_64.stderr
+++ b/src/test/ui/asm/inline-syntax.x86_64.stderr
@@ -1,17 +1,17 @@
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:5:15
+  --> $DIR/inline-syntax.rs:18:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:7:15
+  --> $DIR/inline-syntax.rs:20:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: using the .att_syntax directive may cause issues, use the att_syntax option instead
-  --> $DIR/inline-syntax.rs:9:15
+  --> $DIR/inline-syntax.rs:22:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |         asm!("", "nop", options(att_syntax));
    |              --       ^^^^^^^^^^^^^^^^^^^^^
 
 error: using the .att_syntax directive may cause issues, use the att_syntax option instead
-  --> $DIR/inline-syntax.rs:11:15
+  --> $DIR/inline-syntax.rs:25:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,13 +33,13 @@ LL |         asm!("", "nop", options(att_syntax));
    |              --       ^^^^^^^^^^^^^^^^^^^^^
 
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:13:15
+  --> $DIR/inline-syntax.rs:28:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:18:14
+  --> $DIR/inline-syntax.rs:33:14
    |
 LL |               .intel_syntax noprefix
    |  ______________^


### PR DESCRIPTION
The `.intel_syntax` and `.att_syntax` assembler directives should not be used, in favor of not specifying a syntax for intel, and in favor of the explicit `att_syntax` option using the inline assembly options.

Closes #79869