### PR TITLE
Add round_to_even to floating point types

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -497,6 +497,8 @@ pub(crate) fn codegen_intrinsic_call<'tcx>(
         truncf64(flt) -> f64 => trunc,
         roundf32(flt) -> f32 => roundf,
         roundf64(flt) -> f64 => round,
+        roundevenf32(flt) -> f32 => roundevenf,
+        roundevenf64(flt) -> f64 => roundeven,
 
         // trigonometry
         sinf32(flt) -> f32 => sinf,

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -573,6 +573,8 @@ impl CodegenCx<'b, 'tcx> {
         ifn!("llvm.copysign.f64", fn(t_f64, t_f64) -> t_f64);
         ifn!("llvm.round.f32", fn(t_f32) -> t_f32);
         ifn!("llvm.round.f64", fn(t_f64) -> t_f64);
+        ifn!("llvm.roundeven.f32", fn(t_f32) -> t_f32);
+        ifn!("llvm.roundeven.f64", fn(t_f64) -> t_f64);
 
         ifn!("llvm.rint.f32", fn(t_f32) -> t_f32);
         ifn!("llvm.rint.f64", fn(t_f64) -> t_f64);

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -68,6 +68,8 @@ fn get_simple_intrinsic(cx: &CodegenCx<'ll, '_>, name: Symbol) -> Option<&'ll Va
         sym::nearbyintf64 => "llvm.nearbyint.f64",
         sym::roundf32 => "llvm.round.f32",
         sym::roundf64 => "llvm.round.f64",
+        sym::roundevenf32 => "llvm.roundeven.f32",
+        sym::roundevenf64 => "llvm.roundeven.f64",
         _ => return None,
     };
     Some(cx.get_intrinsic(&llvm_name))

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -931,6 +931,8 @@ symbols! {
         rlib,
         rotate_left,
         rotate_right,
+        roundevenf32,
+        roundevenf64,
         roundf32,
         roundf64,
         rt,

--- a/compiler/rustc_typeck/src/check/intrinsic.rs
+++ b/compiler/rustc_typeck/src/check/intrinsic.rs
@@ -247,6 +247,8 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             sym::nearbyintf64 => (0, vec![tcx.types.f64], tcx.types.f64),
             sym::roundf32 => (0, vec![tcx.types.f32], tcx.types.f32),
             sym::roundf64 => (0, vec![tcx.types.f64], tcx.types.f64),
+            sym::roundevenf32 => (0, vec![tcx.types.f32], tcx.types.f32),
+            sym::roundevenf64 => (0, vec![tcx.types.f64], tcx.types.f64),
 
             sym::volatile_load | sym::unaligned_volatile_load => {
                 (1, vec![tcx.mk_imm_ptr(param(0))], param(0))

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1388,6 +1388,21 @@ extern "rust-intrinsic" {
     /// [`f64::round`](../../std/primitive.f64.html#method.round)
     pub fn roundf64(x: f64) -> f64;
 
+    /// Returns the nearest integer to an `f32`. Rounds half-way to the nearest even
+    /// integer.
+    ///
+    /// The version of this intrinsic in the standard libary is
+    /// [`f32::round`](../../std/primitive.f32.html#method.round_to_even)
+    #[cfg(not(bootstrap))]
+    pub fn roundevenf32(x: f32) -> f32;
+    /// Returns the nearest integer to an `f64`. Rounds half-way to the nearest even
+    /// integer.
+    ///
+    /// The version of this intrinsic in the standard libary is
+    /// [`f64::round`](../../std/primitive.f64.html#method.round_to_even)
+    #[cfg(not(bootstrap))]
+    pub fn roundevenf64(x: f64) -> f64;
+
     /// Float addition that allows optimizations based on algebraic rules.
     /// May assume inputs are finite.
     ///

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -87,6 +87,27 @@ impl f32 {
         unsafe { intrinsics::roundf32(self) }
     }
 
+    /// Returns the nearest integer to a number. Round half-way cases to the
+    /// nearest even integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![cfg_attr(not(bootstrap), feature(round_to_even))]
+    /// let f = 3.3_f32;
+    /// let g = -3.3_f32;
+    ///
+    /// assert_eq!(f.round_to_even(), 3.0);
+    /// assert_eq!(g.round_to_even(), -3.0);
+    /// ```
+    #[cfg(not(bootstrap))]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "round_to_even", issue = "none")]
+    #[inline]
+    pub fn round_to_even(self) -> f32 {
+        unsafe { intrinsics::roundevenf32(self) }
+    }
+
     /// Returns the integer part of a number.
     ///
     /// # Examples

--- a/library/std/src/f32/tests.rs
+++ b/library/std/src/f32/tests.rs
@@ -201,12 +201,31 @@ fn test_round() {
     assert_approx_eq!(1.3f32.round(), 1.0f32);
     assert_approx_eq!(1.5f32.round(), 2.0f32);
     assert_approx_eq!(1.7f32.round(), 2.0f32);
+    assert_approx_eq!(2.5f32.round(), 3.0f32);
     assert_approx_eq!(0.0f32.round(), 0.0f32);
     assert_approx_eq!((-0.0f32).round(), -0.0f32);
     assert_approx_eq!((-1.0f32).round(), -1.0f32);
     assert_approx_eq!((-1.3f32).round(), -1.0f32);
     assert_approx_eq!((-1.5f32).round(), -2.0f32);
     assert_approx_eq!((-1.7f32).round(), -2.0f32);
+    assert_approx_eq!((-2.5f32).round(), -3.0f32);
+}
+
+#[test]
+#[cfg(not(bootstrap))]
+fn test_round_to_even() {
+    assert_approx_eq!(1.0f32.round_to_even(), 1.0f32);
+    assert_approx_eq!(1.3f32.round_to_even(), 1.0f32);
+    assert_approx_eq!(1.5f32.round_to_even(), 2.0f32);
+    assert_approx_eq!(1.7f32.round_to_even(), 2.0f32);
+    assert_approx_eq!(2.5f32.round_to_even(), 2.0f32);
+    assert_approx_eq!(0.0f32.round_to_even(), 0.0f32);
+    assert_approx_eq!((-0.0f32).round_to_even(), -0.0f32);
+    assert_approx_eq!((-1.0f32).round_to_even(), -1.0f32);
+    assert_approx_eq!((-1.3f32).round_to_even(), -1.0f32);
+    assert_approx_eq!((-1.5f32).round_to_even(), -2.0f32);
+    assert_approx_eq!((-1.7f32).round_to_even(), -2.0f32);
+    assert_approx_eq!((-2.5f32).round_to_even(), -2.0f32);
 }
 
 #[test]

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -87,6 +87,27 @@ impl f64 {
         unsafe { intrinsics::roundf64(self) }
     }
 
+    /// Returns the nearest integer to a number. Round half-way cases to the
+    /// nearest even integer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![cfg_attr(not(bootstrap), feature(round_to_even))]
+    /// let f = 3.3_f64;
+    /// let g = -3.3_f64;
+    ///
+    /// assert_eq!(f.round_to_even(), 3.0);
+    /// assert_eq!(g.round_to_even(), -3.0);
+    /// ```
+    #[cfg(not(bootstrap))]
+    #[must_use = "method returns a new number and does not mutate the original value"]
+    #[unstable(feature = "round_to_even", issue = "none")]
+    #[inline]
+    pub fn round_to_even(self) -> f64 {
+        unsafe { intrinsics::roundevenf64(self) }
+    }
+
     /// Returns the integer part of a number.
     ///
     /// # Examples

--- a/library/std/src/f64/tests.rs
+++ b/library/std/src/f64/tests.rs
@@ -203,12 +203,31 @@ fn test_round() {
     assert_approx_eq!(1.3f64.round(), 1.0f64);
     assert_approx_eq!(1.5f64.round(), 2.0f64);
     assert_approx_eq!(1.7f64.round(), 2.0f64);
+    assert_approx_eq!(2.5f64.round(), 3.0f64);
     assert_approx_eq!(0.0f64.round(), 0.0f64);
     assert_approx_eq!((-0.0f64).round(), -0.0f64);
     assert_approx_eq!((-1.0f64).round(), -1.0f64);
     assert_approx_eq!((-1.3f64).round(), -1.0f64);
     assert_approx_eq!((-1.5f64).round(), -2.0f64);
     assert_approx_eq!((-1.7f64).round(), -2.0f64);
+    assert_approx_eq!((-2.5f64).round(), -3.0f64);
+}
+
+#[test]
+#[cfg(not(bootstrap))]
+fn test_round_to_even() {
+    assert_approx_eq!(1.0f64.round_to_even(), 1.0f64);
+    assert_approx_eq!(1.3f64.round_to_even(), 1.0f64);
+    assert_approx_eq!(1.5f64.round_to_even(), 2.0f64);
+    assert_approx_eq!(1.7f64.round_to_even(), 2.0f64);
+    assert_approx_eq!(2.5f64.round_to_even(), 2.0f64);
+    assert_approx_eq!(0.0f64.round_to_even(), 0.0f64);
+    assert_approx_eq!((-0.0f64).round_to_even(), -0.0f64);
+    assert_approx_eq!((-1.0f64).round_to_even(), -1.0f64);
+    assert_approx_eq!((-1.3f64).round_to_even(), -1.0f64);
+    assert_approx_eq!((-1.5f64).round_to_even(), -2.0f64);
+    assert_approx_eq!((-1.7f64).round_to_even(), -2.0f64);
+    assert_approx_eq!((-2.5f64).round_to_even(), -2.0f64);
 }
 
 #[test]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -302,6 +302,7 @@
 #![feature(ptr_internals)]
 #![feature(raw)]
 #![feature(ready_macro)]
+#![cfg_attr(not(bootstrap), feature(round_to_even))]
 #![feature(rustc_attrs)]
 #![feature(rustc_private)]
 #![feature(shrink_to)]


### PR DESCRIPTION
When rounding floats that lie exactly inbetween two integers (i.e., every float that ends with `.5`), The default rounding behaviour in Rust is rounding away from `0`. Sometimes however, it is desired to round to the closest even number instead (banker's rounding).
It is currently not very easy to use rounding to even numbers in Rust, although LLVM has an intrinsic that supports this.

This patch adds support for rounding using the round-to-even mode.

### When does this matter?

It is often not very relevant how this edge case is handled. However, one example of how it could matter is when you are rounding floats in a list, and afterward computing the sum or average. For example:

```rust
0.5f64 + 1.5f64 + 2.5f64 + 3.5f64 // (real value) = 8.0
0.5f64.round() + 1.5f64.round() + 2.5f64.round() + 3.5f64.round() // = 10.0
0.5f64.round_to_even() + 1.5f64.round_to_even() + 2.5f64.round_to_even() + 3.5f64.round_to_even() // = 8.0
```

In this example you see how an unintended statistical bias was introduced, just because of how we handled the rounding of half-integral numbers.

### Other langagues

Here is an overview of the default behaviour in some other languages.

|            | Tie away from 0 | Tie to even | Tie towards +Inf |
|------------|-------------------|---------------|---------------|
| *Rust*       | ***X***                 |               |               |
| C/C++      | **X**                 |               |               |
| JavaScript |                   |               | **X**             |
| Python     |                   | **X**             |               |
| Go         | **X**                 | **X** [*]            |               |
| Julia         |              | **X**           |               | <!-- Link: https://docs.julialang.org/en/v1/base/math/#Base.round-Tuple{Type,Any} -->
| Java       |                   |               | **X**             |
| Haskell    |                   | **X**             |               |
| C#         |                   | **X**            |               |
| Matlab     | **X**                 |               |               |

[*] Go has a separate `Math.RoundToEven` function which does rounding-to-even.
See https://github.com/JuliaLang/julia/issues/8750 for a more complete (albeit somewhat outdated) survey.

### Alternatives

- Let the user implement this function themselves.
- Change the default rounding behaviour of Rust to from tie-away-from-zero to tie-to-even, and add a `.round_from_zero()` function instead. This may actually not be a very weird idea. I myself was surprised that the default rounding behaviour in Rust was _not_ tie-to-even, and when I look for example at the discussion in https://github.com/rust-lang/rust/issues/55107 it seems that I'm not the only one that expected it to behave differently. Obviously, because the documentation currently states promises that the behaviour is tie-away-from-zero, that would probably be a breaking change.

### Related discussions

- https://github.com/rust-lang/rust/issues/55107
- https://github.com/rust-lang/rust/issues/70336
- https://github.com/rust-lang/rust/issues/77745
- https://github.com/JuliaLang/julia/issues/8750


r? @m-ou-se 