### PR TITLE
libtest: Fix unwrap panic on duplicate TestDesc

### DIFF
--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -353,12 +353,13 @@ where
             }
 
             let mut completed_test = res.unwrap();
-            let running_test = running_tests.remove(&completed_test.desc).unwrap();
-            if let Some(join_handle) = running_test.join_handle {
-                if let Err(_) = join_handle.join() {
-                    if let TrOk = completed_test.result {
-                        completed_test.result =
-                            TrFailedMsg("panicked after reporting success".to_string());
+            if let Some(running_test) = running_tests.remove(&completed_test.desc) {
+                if let Some(join_handle) = running_test.join_handle {
+                    if let Err(_) = join_handle.join() {
+                        if let TrOk = completed_test.result {
+                            completed_test.result =
+                                TrFailedMsg("panicked after reporting success".to_string());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It is possible for different tests to collide to the same `TestDesc` when macros are involved. That is a bug, but it didn’t cause a panic until #81367. For now, change the code to ignore this problem.

Fixes #81852.

This will need to be applied to `beta` too.