### PR TITLE
[intra-doc links] Don't check feature gates of items re-exported across crates

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1207,7 +1207,10 @@ impl LinkCollector<'_, '_> {
                     // for discussion on the matter.
                     verify(kind, id)?;
 
+                    // FIXME: it would be nice to check that the feature gate was enabled in the original crate, not just ignore it altogether.
+                    // However I'm not sure how to check that across crates.
                     if prim == PrimitiveType::RawPointer
+                        && item.def_id.is_local()
                         && !self.cx.tcx.features().intra_doc_pointers
                     {
                         let span = super::source_span_for_markdown_range(

--- a/src/test/rustdoc-ui/intra-doc/auxiliary/pointer-reexports-allowed.rs
+++ b/src/test/rustdoc-ui/intra-doc/auxiliary/pointer-reexports-allowed.rs
@@ -1,0 +1,4 @@
+#![feature(intra_doc_pointers)]
+#![crate_name = "inner"]
+/// Link to [some pointer](*const::to_raw_parts)
+pub fn foo() {}

--- a/src/test/rustdoc-ui/intra-doc/pointer-reexports-allowed.rs
+++ b/src/test/rustdoc-ui/intra-doc/pointer-reexports-allowed.rs
@@ -1,0 +1,4 @@
+// aux-build:pointer-reexports-allowed.rs
+// check-pass
+extern crate inner;
+pub use inner::foo;


### PR DESCRIPTION
It should be never break another crate to re-export a public item.

Note that this doesn't check the feature gate at
*all* for other crates:

- Feature-gates aren't currently serialized, so the only way to check
  the gate is with ad-hoc attribute checking.
- Checking the feature gate twice (once when documenting the original
  crate and one when documenting the current crate) seems not great.

This should still catch using the feature most of the time though, since
people tend to document their own crates.

Closes https://github.com/rust-lang/rust/issues/82284.

r? @Manishearth 