### PR TITLE
Consider auto derefs before warning about write only fields

### DIFF
--- a/src/test/ui/lint/dead-code/write-only-field.rs
+++ b/src/test/ui/lint/dead-code/write-only-field.rs
@@ -17,4 +17,53 @@ fn field_write(s: &mut S) {
 fn main() {
     let mut s = S { f: 0, sub: Sub { f: 0 } };
     field_write(&mut s);
+
+    auto_deref();
+    nested_boxes();
+}
+
+fn auto_deref() {
+    struct E {
+        x: bool,
+        y: bool, //~ ERROR: field is never read
+    }
+
+    struct P<'a> {
+        e: &'a mut E
+    }
+
+    impl P<'_> {
+        fn f(&mut self) {
+            self.e.x = true;
+            self.e.y = true;
+        }
+    }
+
+    let mut e = E { x: false, y: false };
+    let mut p = P { e: &mut e };
+    p.f();
+    assert!(e.x);
+}
+
+fn nested_boxes() {
+    struct A {
+        b: Box<B>,
+    }
+
+    struct B {
+        c: Box<C>,
+    }
+
+    struct C {
+        u: u32, //~ ERROR: field is never read
+        v: u32, //~ ERROR: field is never read
+    }
+
+    let mut a = A {
+        b: Box::new(B {
+            c: Box::new(C { u: 0, v: 0 }),
+        }),
+    };
+    a.b.c.v = 10;
+    a.b.c = Box::new(C { u: 1, v: 2 });
 }

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -22,5 +22,23 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^
 
-error: aborting due to 3 previous errors
+error: field is never read: `y`
+  --> $DIR/write-only-field.rs:28:9
+   |
+LL |         y: bool,
+   |         ^^^^^^^
+
+error: field is never read: `u`
+  --> $DIR/write-only-field.rs:58:9
+   |
+LL |         u: u32,
+   |         ^^^^^^
+
+error: field is never read: `v`
+  --> $DIR/write-only-field.rs:59:9
+   |
+LL |         v: u32,
+   |         ^^^^^^
+
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Changes from #81473 extended the dead code lint with an ability to detect
fields that are written to but never read from. The implementation skips
over fields on the left hand side of an assignment, without marking them
as live.

A field access might involve an automatic dereference and de-facto read
the field. Conservatively mark expressions with deref adjustments as
live to avoid generating false positive warnings.

Closes #81626.