### PR TITLE
Remove many RefCells from DocContext

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -41,7 +41,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
     ) -> Option<Item> {
         let tcx = self.cx.tcx;
         let trait_ref = ty::TraitRef { def_id: trait_def_id, substs: tcx.mk_substs_trait(ty, &[]) };
-        if !self.cx.generated_synthetics.borrow_mut().insert((ty, trait_def_id)) {
+        if !self.cx.generated_synthetics.insert((ty, trait_def_id)) {
             debug!("get_auto_trait_impl_for({:?}): already generated, aborting", trait_ref);
             return None;
         }

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -22,8 +22,8 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
         debug!("get_blanket_impls({:?})", ty);
         let mut impls = Vec::new();
         for &trait_def_id in self.cx.tcx.all_traits(LOCAL_CRATE).iter() {
-            if !self.cx.renderinfo.borrow().access_levels.is_public(trait_def_id)
-                || self.cx.generated_synthetics.borrow_mut().get(&(ty, trait_def_id)).is_some()
+            if !self.cx.renderinfo.access_levels.is_public(trait_def_id)
+                || self.cx.generated_synthetics.get(&(ty, trait_def_id)).is_some()
             {
                 continue;
             }
@@ -94,7 +94,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                     return;
                 }
 
-                self.cx.generated_synthetics.borrow_mut().insert((ty, trait_def_id));
+                self.cx.generated_synthetics.insert((ty, trait_def_id));
                 let provided_trait_methods = self
                     .cx
                     .tcx

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -23,10 +23,9 @@ crate fn krate(mut cx: &mut DocContext<'_>) -> Crate {
     let krate = cx.tcx.hir().krate();
     let module = crate::visit_ast::RustdocVisitor::new(&mut cx).visit(krate);
 
-    let mut r = cx.renderinfo.get_mut();
-    r.deref_trait_did = cx.tcx.lang_items().deref_trait();
-    r.deref_mut_trait_did = cx.tcx.lang_items().deref_mut_trait();
-    r.owned_box_did = cx.tcx.lang_items().owned_box();
+    cx.renderinfo.deref_trait_did = cx.tcx.lang_items().deref_trait();
+    cx.renderinfo.deref_mut_trait_did = cx.tcx.lang_items().deref_mut_trait();
+    cx.renderinfo.owned_box_did = cx.tcx.lang_items().owned_box();
 
     let mut externs = Vec::new();
     for &cnum in cx.tcx.crates().iter() {
@@ -494,10 +493,10 @@ crate fn enter_impl_trait<F, R>(cx: &mut DocContext<'_>, f: F) -> R
 where
     F: FnOnce(&mut DocContext<'_>) -> R,
 {
-    let old_bounds = mem::take(&mut *cx.impl_trait_bounds.get_mut());
+    let old_bounds = mem::take(&mut cx.impl_trait_bounds);
     let r = f(cx);
-    assert!(cx.impl_trait_bounds.borrow().is_empty());
-    *cx.impl_trait_bounds.get_mut() = old_bounds;
+    assert!(cx.impl_trait_bounds.is_empty());
+    cx.impl_trait_bounds = old_bounds;
     r
 }
 

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -127,7 +127,7 @@ impl<'a, 'b> CoverageCalculator<'a, 'b> {
     }
 
     fn print_results(&self) {
-        let output_format = self.ctx.renderinfo.borrow().output_format;
+        let output_format = self.ctx.renderinfo.output_format;
         if output_format.is_json() {
             println!("{}", self.to_json());
             return;

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -48,11 +48,10 @@ crate fn collect_trait_impls(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
                 if !cx.tcx.get_attrs(def_id).lists(sym::doc).has_word(sym::hidden) {
                     let self_ty = cx.tcx.type_of(def_id);
                     let impls = get_auto_trait_and_blanket_impls(cx, self_ty, def_id);
-                    let mut renderinfo = cx.renderinfo.borrow_mut();
 
-                    new_items.extend(impls.filter(|i| renderinfo.inlined.insert(i.def_id)));
+                    new_items.extend(impls.filter(|i| cx.renderinfo.inlined.insert(i.def_id)));
                 }
-            })
+            });
         }
     }
 

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -97,8 +97,7 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
                 |lint| lint.build("missing code example in this documentation").emit(),
             );
         }
-    } else if tests.found_tests > 0 && !cx.renderinfo.borrow().access_levels.is_public(item.def_id)
-    {
+    } else if tests.found_tests > 0 && !cx.renderinfo.access_levels.is_public(item.def_id) {
         cx.tcx.struct_span_lint_hir(
             lint::builtin::PRIVATE_DOC_TESTS,
             hir_id,

--- a/src/librustdoc/passes/strip_private.rs
+++ b/src/librustdoc/passes/strip_private.rs
@@ -17,7 +17,7 @@ crate const STRIP_PRIVATE: Pass = Pass {
 crate fn strip_private(mut krate: clean::Crate, cx: &mut DocContext<'_>) -> clean::Crate {
     // This stripper collects all *retained* nodes.
     let mut retained = DefIdSet::default();
-    let access_levels = cx.renderinfo.borrow().access_levels.clone();
+    let access_levels = cx.renderinfo.access_levels.clone();
 
     // strip all private items
     {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -113,7 +113,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             assert_eq!(cur_mod_def_id, macro_parent_def_id);
             cur_mod.macros.push((def, None));
         }
-        self.cx.renderinfo.get_mut().exact_paths = self.exact_paths;
+        self.cx.renderinfo.exact_paths = self.exact_paths;
         top_level_module
     }
 
@@ -199,12 +199,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     } else {
                         // All items need to be handled here in case someone wishes to link
                         // to them with intra-doc links
-                        self.cx
-                            .renderinfo
-                            .get_mut()
-                            .access_levels
-                            .map
-                            .insert(did, AccessLevel::Public);
+                        self.cx.renderinfo.access_levels.map.insert(did, AccessLevel::Public);
                     }
                 }
             }
@@ -216,7 +211,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             None => return false,
         };
 
-        let is_private = !self.cx.renderinfo.borrow().access_levels.is_public(res_did);
+        let is_private = !self.cx.renderinfo.access_levels.is_public(res_did);
         let is_hidden = inherits_doc_hidden(self.cx, res_hir_id);
 
         // Only inline if requested or if the item would otherwise be stripped.

--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -25,7 +25,7 @@ impl<'a, 'tcx> LibEmbargoVisitor<'a, 'tcx> {
     crate fn new(cx: &'a mut crate::core::DocContext<'tcx>) -> LibEmbargoVisitor<'a, 'tcx> {
         LibEmbargoVisitor {
             tcx: cx.tcx,
-            access_levels: &mut cx.renderinfo.get_mut().access_levels,
+            access_levels: &mut cx.renderinfo.access_levels,
             prev_level: Some(AccessLevel::Public),
             visited_mods: FxHashSet::default(),
         }


### PR DESCRIPTION
I left some of them so this change doesn't balloon in size and because
removing the RefCell in `DocContext.resolver` would require compiler
changes.

Thanks to @jyn514 for making this a lot easier with #82020!

r? @jyn514
