### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -821,7 +821,7 @@ fn usage(verbose: bool, include_unstable_options: bool, nightly_build: bool) {
     } else {
         "\n    --help -v           Print the full set of options rustc accepts"
     };
-    let at_path = if verbose && nightly_build {
+    let at_path = if verbose {
         "    @path               Read newline separated options from `path`\n"
     } else {
         ""

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1078,8 +1078,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     "both opaque, likely future {:?} {:?} {:?} {:?}",
                     last_def_id, last_bounds, exp_def_id, exp_bounds
                 );
-                let last_hir_id = self.tcx.hir().local_def_id_to_hir_id(last_def_id.expect_local());
-                let exp_hir_id = self.tcx.hir().local_def_id_to_hir_id(exp_def_id.expect_local());
+
+                let (last_local_id, exp_local_id) =
+                    match (last_def_id.as_local(), exp_def_id.as_local()) {
+                        (Some(last_hir_id), Some(exp_hir_id)) => (last_hir_id, exp_hir_id),
+                        (_, _) => return None,
+                    };
+
+                let last_hir_id = self.tcx.hir().local_def_id_to_hir_id(last_local_id);
+                let exp_hir_id = self.tcx.hir().local_def_id_to_hir_id(exp_local_id);
+
                 match (
                     &self.tcx.hir().expect_item(last_hir_id).kind,
                     &self.tcx.hir().expect_item(exp_hir_id).kind,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1073,6 +1073,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         let last_expr_ty = self.node_ty(last_expr.hir_id);
         let needs_box = match (last_expr_ty.kind(), expected_ty.kind()) {
+            (ty::Opaque(last_def_id, _), ty::Opaque(exp_def_id, _))
+                if last_def_id == exp_def_id =>
+            {
+                StatementAsExpression::CorrectType
+            }
             (ty::Opaque(last_def_id, last_bounds), ty::Opaque(exp_def_id, exp_bounds)) => {
                 debug!(
                     "both opaque, likely future {:?} {:?} {:?} {:?}",

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -251,8 +251,8 @@ pub struct Stdin {
 ///     let mut buffer = String::new();
 ///     let stdin = io::stdin(); // We get `Stdin` here.
 ///     {
-///         let mut stdin_lock = stdin.lock(); // We get `StdinLock` here.
-///         stdin_lock.read_to_string(&mut buffer)?;
+///         let mut handle = stdin.lock(); // We get `StdinLock` here.
+///         handle.read_to_string(&mut buffer)?;
 ///     } // `StdinLock` is dropped here.
 ///     Ok(())
 /// }

--- a/src/test/rustdoc/sized_trait.rs
+++ b/src/test/rustdoc/sized_trait.rs
@@ -1,0 +1,17 @@
+#![crate_name = "foo"]
+
+// @has foo/struct.Bar.html
+// @!has - '//h3[@id="impl-Sized"]'
+pub struct Bar {
+    a: u16,
+}
+
+// @has foo/struct.Foo.html
+// @!has - '//h3[@id="impl-Sized"]'
+pub struct Foo<T: ?Sized>(T);
+
+// @has foo/struct.Unsized.html
+// @has - '//h3[@id="impl-Sized"]/code' 'impl !Sized for Unsized'
+pub struct Unsized {
+    data: [u8],
+}

--- a/src/test/ui/suggestions/auxiliary/issue-81839.rs
+++ b/src/test/ui/suggestions/auxiliary/issue-81839.rs
@@ -1,0 +1,9 @@
+// edition:2018
+
+pub struct Test {}
+
+impl Test {
+    pub async fn answer_str(&self, _s: &str) -> Test {
+        Test {}
+    }
+}

--- a/src/test/ui/suggestions/issue-81839.rs
+++ b/src/test/ui/suggestions/issue-81839.rs
@@ -1,0 +1,17 @@
+// aux-build:issue-81839.rs
+// edition:2018
+
+extern crate issue_81839;
+
+async fn test(ans: &str, num: i32, cx: &issue_81839::Test) -> u32 {
+    match num {
+        1 => {
+            cx.answer_str("hi");
+        }
+        _ => cx.answer_str("hi"), //~ `match` arms have incompatible types
+    }
+
+    1
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-81839.stderr
+++ b/src/test/ui/suggestions/issue-81839.stderr
@@ -1,0 +1,27 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/issue-81839.rs:11:14
+   |
+LL | /     match num {
+LL | |         1 => {
+LL | |             cx.answer_str("hi");
+   | |             --------------------
+   | |             |                  |
+   | |             |                  help: consider removing this semicolon
+   | |             this is found to be of type `()`
+LL | |         }
+LL | |         _ => cx.answer_str("hi"),
+   | |              ^^^^^^^^^^^^^^^^^^^ expected `()`, found opaque type
+LL | |     }
+   | |_____- `match` arms have incompatible types
+   | 
+  ::: $DIR/auxiliary/issue-81839.rs:6:49
+   |
+LL |       pub async fn answer_str(&self, _s: &str) -> Test {
+   |                                                   ---- the `Output` of this `async fn`'s found opaque type
+   |
+   = note:     expected type `()`
+           found opaque type `impl Future`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -24,13 +24,10 @@ help: consider `await`ing on the `Future`
    |
 LL |         false => async_dummy().await,
    |                               ^^^^^^
-help: consider removing this semicolon and boxing the expressions
+help: consider removing this semicolon
    |
-LL |             Box::new(async_dummy())
-LL |
-LL |         }
-LL |         false => Box::new(async_dummy()),
-   |
+LL |             async_dummy()
+   |                         --
 
 error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:39:18


### PR DESCRIPTION
Successful merges:

 - #78181 (Add Sized trait display when implemented on type)
 - #81991 (Fix panic in 'remove semicolon' when types are not local)
 - #82244 (Keep consistency in example for Stdin StdinLock)
 - #82260 (rustc: Show `@path` usage in stable)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=78181,81991,82244,82260)
<!-- homu-ignore:end -->