### PR TITLE
Lower condition of `if` expression before it's "then" block

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -347,8 +347,9 @@ impl<'hir> LoweringContext<'_, 'hir> {
     ) -> hir::ExprKind<'hir> {
         macro_rules! make_if {
             ($opt:expr) => {{
+                let cond = self.lower_expr(cond);
                 let then_expr = self.lower_block_expr(then);
-                hir::ExprKind::If(self.lower_expr(cond), self.arena.alloc(then_expr), $opt)
+                hir::ExprKind::If(cond, self.arena.alloc(then_expr), $opt)
             }};
         }
         if let Some(rslt) = else_opt {

--- a/src/test/ui/pattern/issue-82290.rs
+++ b/src/test/ui/pattern/issue-82290.rs
@@ -1,0 +1,7 @@
+#![feature(let_chains)] //~ WARN the feature `let_chains` is incomplete
+
+fn main() {
+    if true && let x = 1 { //~ ERROR `let` expressions are not supported here
+        let _ = x;
+    }
+}

--- a/src/test/ui/pattern/issue-82290.stderr
+++ b/src/test/ui/pattern/issue-82290.stderr
@@ -1,0 +1,20 @@
+error: `let` expressions are not supported here
+  --> $DIR/issue-82290.rs:4:16
+   |
+LL |     if true && let x = 1 {
+   |                ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if`- and `while`-expressions
+   = note: as well as when nested within `&&` and parenthesis in those conditions
+
+warning: the feature `let_chains` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/issue-82290.rs:1:12
+   |
+LL | #![feature(let_chains)]
+   |            ^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+
+error: aborting due to previous error; 1 warning emitted
+


### PR DESCRIPTION
Fix #82290, fix #82250.