### PR TITLE
Jsondocck improvements

### DIFF
--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -1,24 +1,24 @@
 // edition:2018
 
-// @has nested.json "$.index[*][?(@.name=='nested')].kind" \"module\"
-// @has - "$.index[*][?(@.name=='nested')].inner.is_crate" true
+// @is nested.json "$.index[*][?(@.name=='nested')].kind" \"module\"
+// @is - "$.index[*][?(@.name=='nested')].inner.is_crate" true
 // @count - "$.index[*][?(@.name=='nested')].inner.items[*]" 1
 
-// @has nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
-// @has - "$.index[*][?(@.name=='l1')].inner.is_crate" false
+// @is nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
+// @is - "$.index[*][?(@.name=='l1')].inner.is_crate" false
 // @count - "$.index[*][?(@.name=='l1')].inner.items[*]" 2
 pub mod l1 {
 
-    // @has nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
-    // @has - "$.index[*][?(@.name=='l3')].inner.is_crate" false
+    // @is nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
+    // @is - "$.index[*][?(@.name=='l3')].inner.is_crate" false
     // @count - "$.index[*][?(@.name=='l3')].inner.items[*]" 1
     pub mod l3 {
 
-        // @has nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
-        // @has - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
+        // @is nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
+        // @is - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
         pub struct L4;
     }
-    // @has nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"
-    // @has - "$.index[*][?(@.inner.span=='l3::L4')].inner.glob" false
+    // @is nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"
+    // @is - "$.index[*][?(@.inner.span=='l3::L4')].inner.glob" false
     pub use l3::L4;
 }

--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -7,15 +7,18 @@
 // @is nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
 // @is - "$.index[*][?(@.name=='l1')].inner.is_crate" false
 // @count - "$.index[*][?(@.name=='l1')].inner.items[*]" 2
+// @set l1_id = - "$.index[*][?(@.name=='l1')].id"
 pub mod l1 {
 
     // @is nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
     // @is - "$.index[*][?(@.name=='l3')].inner.is_crate" false
     // @count - "$.index[*][?(@.name=='l3')].inner.items[*]" 1
+    // @set l3_id = - "$.index[*][?(@.name=='l3')].id"
     pub mod l3 {
 
         // @is nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
         // @is - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
+        // @set l4_id = - "$.index[*][?(@.name=='L4')].id"
         pub struct L4;
     }
     // @is nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"

--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -7,18 +7,19 @@
 // @is nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
 // @is - "$.index[*][?(@.name=='l1')].inner.is_crate" false
 // @count - "$.index[*][?(@.name=='l1')].inner.items[*]" 2
-// @set l1_id = - "$.index[*][?(@.name=='l1')].id"
 pub mod l1 {
 
     // @is nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
     // @is - "$.index[*][?(@.name=='l3')].inner.is_crate" false
     // @count - "$.index[*][?(@.name=='l3')].inner.items[*]" 1
     // @set l3_id = - "$.index[*][?(@.name=='l3')].id"
+    // @has - "$.index[*][?(@.name=='l1')].inner.items[*]" $l3_id
     pub mod l3 {
 
         // @is nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
         // @is - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
         // @set l4_id = - "$.index[*][?(@.name=='L4')].id"
+        // @has - "$.index[*][?(@.name=='l3')].inner.items[*]" $l4_id
         pub struct L4;
     }
     // @is nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"

--- a/src/tools/jsondocck/src/cache.rs
+++ b/src/tools/jsondocck/src/cache.rs
@@ -9,6 +9,7 @@ pub struct Cache {
     root: PathBuf,
     files: HashMap<PathBuf, String>,
     values: HashMap<PathBuf, Value>,
+    pub variables: HashMap<String, Value>,
     last_path: Option<PathBuf>,
 }
 
@@ -19,6 +20,7 @@ impl Cache {
             root: Path::new(doc_dir).to_owned(),
             files: HashMap::new(),
             values: HashMap::new(),
+            variables: HashMap::new(),
             last_path: None,
         }
     }

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -207,9 +207,15 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                     let val = cache.get_value(&command.args[0])?;
                     match select(&val, &command.args[1]) {
                         Ok(results) => {
-                            let pat: Value = serde_json::from_str(&command.args[2]).unwrap();
-
-                            !results.is_empty() && results.into_iter().any(|val| *val == pat)
+                            // FIXME: Share the pat getting code with the `Is` branch.
+                            let v_holder;
+                            let pat: &Value = if command.args[2].starts_with("$") {
+                                &cache.variables[&command.args[2][1..]]
+                            } else {
+                                v_holder = serde_json::from_str(&command.args[2]).unwrap();
+                                &v_holder
+                            };
+                            !results.is_empty() && results.into_iter().any(|val| val == pat)
                         }
                         Err(_) => false,
                     }
@@ -234,8 +240,14 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
             let val = cache.get_value(&command.args[0])?;
             match select(&val, &command.args[1]) {
                 Ok(results) => {
-                    let pat: Value = serde_json::from_str(&command.args[2]).unwrap();
-                    results.len() == 1 && *results[0] == pat
+                    let v_holder;
+                    let pat: &Value = if command.args[2].starts_with("$") {
+                        &cache.variables[&command.args[2][1..]]
+                    } else {
+                        v_holder = serde_json::from_str(&command.args[2]).unwrap();
+                        &v_holder
+                    };
+                    results.len() == 1 && results[0] == pat
                 }
                 Err(_) => false,
             }

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -187,7 +187,7 @@ fn get_commands(template: &str) -> Result<Vec<Command>, ()> {
 /// Performs the actual work of ensuring a command passes. Generally assumes the command
 /// is syntactically valid.
 fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
-    // FIXME: Be more granular about why, (eg syntax error, count not equal)
+    // FIXME: Be more granular about why, (e.g. syntax error, count not equal)
     let result = match command.kind {
         CommandKind::Has => {
             match command.args.len() {
@@ -215,7 +215,7 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                                 v_holder = serde_json::from_str(&command.args[2]).unwrap();
                                 &v_holder
                             };
-                            !results.is_empty() && results.into_iter().any(|val| val == pat)
+                            results.contains(pat)
                         }
                         Err(_) => false,
                     }
@@ -263,7 +263,7 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                 Ok(results) => {
                     assert_eq!(results.len(), 1);
                     let r = cache.variables.insert(command.args[0].clone(), results[0].clone());
-                    assert!(r.is_none(), "Name collision");
+                    assert!(r.is_none(), "Name collision: {} is duplicated", command.args[0]);
                     true
                 }
                 Err(_) => false,


### PR DESCRIPTION
Adds 2 new commands, `@is` and `@set`.

`@is` works like `@has`, except instead of checking if any value matches, it checks that there is exactly one value, and it matches. This allows more precise testing.

`@set` gets a value, and saves it to be used later. This makes it possible to check that an item appears in the correct module.

Once this lands, the rest of the test suite can be upgraded to use these.

cc @CraftSpider 

 @rustbot modify labels: +T-rustdoc +A-rustdoc-json +A-testsuite 