### PR TITLE
Don't generate src link on dummy spans

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1852,6 +1852,10 @@ impl Span {
         self.0
     }
 
+    crate fn is_dummy(&self) -> bool {
+        self.0.is_dummy()
+    }
+
     crate fn filename(&self, sess: &Session) -> FileName {
         sess.source_map().span_to_filename(self.0)
     }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1638,6 +1638,9 @@ impl Context<'_> {
     /// may happen, for example, with externally inlined items where the source
     /// of their crate documentation isn't known.
     fn src_href(&self, item: &clean::Item) -> Option<String> {
+        if item.source.is_dummy() {
+            return None;
+        }
         let mut root = self.root_path();
         let mut path = String::new();
         let cnum = item.source.cnum(self.sess());

--- a/src/test/rustdoc/src-links-auto-impls.rs
+++ b/src/test/rustdoc/src-links-auto-impls.rs
@@ -1,0 +1,12 @@
+#![crate_name = "foo"]
+
+// @has foo/struct.Unsized.html
+// @has - '//h3[@id="impl-Sized"]/code' 'impl !Sized for Unsized'
+// @!has - '//h3[@id="impl-Sized"]/a[@class="srclink"]' '[src]'
+// @has - '//h3[@id="impl-Sync"]/code' 'impl Sync for Unsized'
+// @!has - '//h3[@id="impl-Sync"]/a[@class="srclink"]' '[src]'
+// @has - '//h3[@id="impl-Any"]/code' 'impl<T> Any for T'
+// @has - '//h3[@id="impl-Any"]/a[@class="srclink"]' '[src]'
+pub struct Unsized {
+    data: [u8],
+}


### PR DESCRIPTION
Just realized that the "auto trait impls" had `[src]` links were leading to the crate root because they were dummy spans. This PR fixes this issue.

cc @jyn514 
r? @camelid 