### PR TITLE
WIP: use trait object for io::Error representation

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -752,7 +752,8 @@ impl<T: ?Sized> Box<T> {
     /// [`Layout`]: crate::Layout
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
-    pub unsafe fn from_raw(raw: *mut T) -> Self {
+    #[rustc_const_unstable(feature = "const_box_from_raw", issue = "none")]
+    pub const unsafe fn from_raw(raw: *mut T) -> Self {
         unsafe { Self::from_raw_in(raw, Global) }
     }
 }
@@ -807,7 +808,8 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// [`Layout`]: crate::Layout
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[inline]
-    pub unsafe fn from_raw_in(raw: *mut T, alloc: A) -> Self {
+    #[rustc_const_unstable(feature = "const_box_from_raw", issue = "none")]
+    pub const unsafe fn from_raw_in(raw: *mut T, alloc: A) -> Self {
         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
     }
 

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -90,6 +90,7 @@
 #![feature(coerce_unsized)]
 #![feature(const_btree_new)]
 #![feature(const_fn)]
+#![feature(const_box_from_raw)]
 #![feature(cow_is_borrowed)]
 #![feature(const_cow_is_borrowed)]
 #![feature(destructuring_assignment)]

--- a/library/std/src/io/error/tests.rs
+++ b/library/std/src/io/error/tests.rs
@@ -1,4 +1,4 @@
-use super::{Custom, Error, ErrorKind, Repr};
+use super::{Custom, Error, ErrorKind};
 use crate::error;
 use crate::fmt;
 use crate::mem::size_of;
@@ -16,10 +16,10 @@ fn test_debug_error() {
     let msg = error_string(code);
     let kind = decode_error_kind(code);
     let err = Error {
-        repr: Repr::Custom(box Custom {
+        repr: box Custom {
             kind: ErrorKind::InvalidInput,
-            error: box Error { repr: super::Repr::Os(code) },
-        }),
+            error: box Error::from_raw_os_error(code),
+        },
     };
     let expected = format!(
         "Custom {{ \

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -241,6 +241,7 @@
 #![feature(char_internals)]
 #![feature(concat_idents)]
 #![feature(const_cstr_unchecked)]
+#![feature(const_box_from_raw)]
 #![feature(const_fn_floating_point_arithmetic)]
 #![feature(const_fn_transmute)]
 #![feature(const_fn)]


### PR DESCRIPTION
This is a little experiment in the hopes that `io::Error` could box some user types without allocating.

I want to do a perf run on these changes, but there are a couple things to fix up first:

- I'm using `i32::MIN` as a sentinel value for os errors at the moment, which is a bit of a shame. This shouldn't ever be returned from libc or windows APIs, but there was nothing stopping users from passing it to the API before.
  - On 64 bit targets, we can simply store a flag in the higher order bytes
  - For 32 bit, we could technically store the data as a `(ptr::NonNull<VTable>, *mut ())` to allow zero.
    - Checking this condition manually may have performance problems
- Will those `as_error_*` calls be much of a performance hit?
- Can we `repr(u8)` `ErrorKind` without a stability problem?