### PR TITLE
Replace for...insert-style loops with extend/collect

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -988,9 +988,11 @@ fn start_executing_work<B: ExtraBackendMethods>(
                 Some(Arc::new(exported_symbols))
             }
             Lto::Fat | Lto::Thin => {
+                exported_symbols.reserve(tcx.crates().len() + 1);
                 exported_symbols.insert(LOCAL_CRATE, copy_symbols(LOCAL_CRATE));
-                exported_symbols
-                    .extend(tcx.crates().iter().map(|&cnum| (cnum, copy_symbols(cnum))));
+                for &cnum in tcx.crates() {
+                    exported_symbols.insert(cnum, copy_symbols(cnum));
+                }
                 Some(Arc::new(exported_symbols))
             }
         }

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -989,9 +989,8 @@ fn start_executing_work<B: ExtraBackendMethods>(
             }
             Lto::Fat | Lto::Thin => {
                 exported_symbols.insert(LOCAL_CRATE, copy_symbols(LOCAL_CRATE));
-                for &cnum in tcx.crates().iter() {
-                    exported_symbols.insert(cnum, copy_symbols(cnum));
-                }
+                exported_symbols
+                    .extend(tcx.crates().iter().map(|&cnum| (cnum, copy_symbols(cnum))));
                 Some(Arc::new(exported_symbols))
             }
         }

--- a/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
@@ -208,12 +208,10 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
             // can internalize all candidates, since there is nowhere else they
             // could be accessed from.
             for cgu in &mut partitioning.codegen_units {
-                cgu.items_mut().extend(
-                    partitioning
-                        .internalization_candidates
-                        .iter()
-                        .map(|&candidate| (candidate, (Linkage::Internal, Visibility::Default))),
-                );
+                cgu.items_mut().reserve(partitioning.internalization_candidates.len());
+                for candidate in &partitioning.internalization_candidates {
+                    cgu.items_mut().insert(*candidate, (Linkage::Internal, Visibility::Default));
+                }
             }
 
             return;

--- a/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/default.rs
@@ -208,9 +208,12 @@ impl<'tcx> Partitioner<'tcx> for DefaultPartitioning {
             // can internalize all candidates, since there is nowhere else they
             // could be accessed from.
             for cgu in &mut partitioning.codegen_units {
-                for candidate in &partitioning.internalization_candidates {
-                    cgu.items_mut().insert(*candidate, (Linkage::Internal, Visibility::Default));
-                }
+                cgu.items_mut().extend(
+                    partitioning
+                        .internalization_candidates
+                        .iter()
+                        .map(|&candidate| (candidate, (Linkage::Internal, Visibility::Default))),
+                );
             }
 
             return;

--- a/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
@@ -39,7 +39,11 @@ pub fn merge_codegen_units<'tcx>(
 
         // Move the mono-items from `smallest` to `second_smallest`
         second_smallest.modify_size_estimate(smallest.size_estimate());
-        second_smallest.items_mut().extend(smallest.items_mut().drain());
+
+        second_smallest.items_mut().reserve(smallest.items().len());
+        for (k, v) in smallest.items_mut().drain() {
+            second_smallest.items_mut().insert(k, v);
+        }
 
         // Record that `second_smallest` now contains all the stuff that was in
         // `smallest` before.

--- a/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
+++ b/compiler/rustc_mir/src/monomorphize/partitioning/merging.rs
@@ -39,9 +39,7 @@ pub fn merge_codegen_units<'tcx>(
 
         // Move the mono-items from `smallest` to `second_smallest`
         second_smallest.modify_size_estimate(smallest.size_estimate());
-        for (k, v) in smallest.items_mut().drain() {
-            second_smallest.items_mut().insert(k, v);
-        }
+        second_smallest.items_mut().extend(smallest.items_mut().drain());
 
         // Record that `second_smallest` now contains all the stuff that was in
         // `smallest` before.

--- a/compiler/rustc_query_system/src/dep_graph/query.rs
+++ b/compiler/rustc_query_system/src/dep_graph/query.rs
@@ -15,10 +15,10 @@ impl<K: DepKind> DepGraphQuery<K> {
         edge_list_data: &[usize],
     ) -> DepGraphQuery<K> {
         let mut graph = Graph::with_capacity(nodes.len(), edge_list_data.len());
-        let mut indices = FxHashMap::default();
-        for node in nodes {
-            indices.insert(*node, graph.add_node(*node));
-        }
+        let indices = nodes
+            .iter()
+            .map(|&node| (node, graph.add_node(node)))
+            .collect::<FxHashMap<DepNode<K>, NodeIndex>>();
 
         for (source, &(start, end)) in edge_list_indices.iter().enumerate() {
             for &target in &edge_list_data[start..end] {

--- a/compiler/rustc_serialize/src/json.rs
+++ b/compiler/rustc_serialize/src/json.rs
@@ -2668,21 +2668,13 @@ impl<A: ToJson> ToJson for Vec<A> {
 
 impl<T: ToString, A: ToJson> ToJson for BTreeMap<T, A> {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
-        for (key, value) in self {
-            d.insert(key.to_string(), value.to_json());
-        }
-        Json::Object(d)
+        Json::Object(self.iter().map(|(k, v)| (k.to_string(), v.to_json())).collect())
     }
 }
 
 impl<A: ToJson> ToJson for HashMap<string::String, A> {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
-        for (key, value) in self {
-            d.insert((*key).clone(), value.to_json());
-        }
-        Json::Object(d)
+        Json::Object(self.iter().map(|(k, v)| (k.clone(), v.to_json())).collect())
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -271,12 +271,10 @@ impl AutoTraitFinder<'tcx> {
         // Don't try to proess any nested obligations involving predicates
         // that are already in the `ParamEnv` (modulo regions): we already
         // know that they must hold.
-        fresh_preds.extend(
-            param_env
-                .caller_bounds()
-                .into_iter()
-                .map(|predicate| self.clean_pred(infcx, predicate)),
-        );
+        fresh_preds.reserve(param_env.caller_bounds().len());
+        for predicate in param_env.caller_bounds() {
+            fresh_preds.insert(self.clean_pred(infcx, predicate));
+        }
 
         let mut select = SelectionContext::with_negative(&infcx, true);
 

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -271,9 +271,12 @@ impl AutoTraitFinder<'tcx> {
         // Don't try to proess any nested obligations involving predicates
         // that are already in the `ParamEnv` (modulo regions): we already
         // know that they must hold.
-        for predicate in param_env.caller_bounds() {
-            fresh_preds.insert(self.clean_pred(infcx, predicate));
-        }
+        fresh_preds.extend(
+            param_env
+                .caller_bounds()
+                .into_iter()
+                .map(|predicate| self.clean_pred(infcx, predicate)),
+        );
 
         let mut select = SelectionContext::with_negative(&infcx, true);
 

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -343,11 +343,10 @@ impl GraphExt for Graph {
                     }
 
                     // Set G's parent to N and N's parent to P.
-                    self.parent.extend(
-                        grand_children_to_be
-                            .iter()
-                            .map(|&grand_child_to_be| (grand_child_to_be, impl_def_id)),
-                    );
+                    self.parent.reserve(grand_children_to_be.len() + 1);
+                    for &grand_child_to_be in &grand_children_to_be {
+                        self.parent.insert(grand_child_to_be, impl_def_id);
+                    }
                     self.parent.insert(impl_def_id, parent);
 
                     // Add G as N's child.

--- a/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/specialization_graph.rs
@@ -343,9 +343,11 @@ impl GraphExt for Graph {
                     }
 
                     // Set G's parent to N and N's parent to P.
-                    for &grand_child_to_be in &grand_children_to_be {
-                        self.parent.insert(grand_child_to_be, impl_def_id);
-                    }
+                    self.parent.extend(
+                        grand_children_to_be
+                            .iter()
+                            .map(|&grand_child_to_be| (grand_child_to_be, impl_def_id)),
+                    );
                     self.parent.insert(impl_def_id, parent);
 
                     // Add G as N's child.

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -816,8 +816,9 @@ crate fn collect_bound_vars<'tcx, T: TypeFoldable<'tcx>>(
     let mut bound_var_substitutor = NamedBoundVarSubstitutor::new(tcx, &named_parameters);
     let new_ty = ty.skip_binder().fold_with(&mut bound_var_substitutor);
 
-    parameters
-        .extend(named_parameters.values().map(|&var| (var, chalk_ir::VariableKind::Lifetime)));
+    for var in named_parameters.values() {
+        parameters.insert(*var, chalk_ir::VariableKind::Lifetime);
+    }
 
     (0..parameters.len()).for_each(|i| {
         parameters

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -816,9 +816,8 @@ crate fn collect_bound_vars<'tcx, T: TypeFoldable<'tcx>>(
     let mut bound_var_substitutor = NamedBoundVarSubstitutor::new(tcx, &named_parameters);
     let new_ty = ty.skip_binder().fold_with(&mut bound_var_substitutor);
 
-    for var in named_parameters.values() {
-        parameters.insert(*var, chalk_ir::VariableKind::Lifetime);
-    }
+    parameters
+        .extend(named_parameters.values().map(|&var| (var, chalk_ir::VariableKind::Lifetime)));
 
     (0..parameters.len()).for_each(|i| {
         parameters

--- a/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
@@ -207,8 +207,11 @@ impl ItemLikeVisitor<'v> for InherentOverlapChecker<'tcx> {
                                 };
                                 let (_id, region) = connected_regions.iter().next().unwrap();
                                 // Update the connected region ids
-                                connected_region_ids
-                                    .extend(region.idents.iter().map(|&ident| (ident, id_to_set)));
+
+                                connected_region_ids.reserve(region.idents.len());
+                                for ident in region.idents.iter() {
+                                    connected_region_ids.insert(*ident, id_to_set);
+                                }
                             }
                             _ => {
                                 // We have multiple connected regions to merge.
@@ -235,8 +238,10 @@ impl ItemLikeVisitor<'v> for InherentOverlapChecker<'tcx> {
                                     }
                                     let r = connected_regions.remove(&id).unwrap();
                                     // Update the connected region ids
-                                    connected_region_ids
-                                        .extend(r.idents.iter().map(|&ident| (ident, id_to_set)));
+                                    connected_region_ids.reserve(r.idents.len());
+                                    for ident in r.idents.iter() {
+                                        connected_region_ids.insert(*ident, id_to_set);
+                                    }
                                     region.idents.extend_from_slice(&r.idents);
                                     region.impl_blocks.extend(r.impl_blocks);
                                 }

--- a/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
@@ -207,9 +207,8 @@ impl ItemLikeVisitor<'v> for InherentOverlapChecker<'tcx> {
                                 };
                                 let (_id, region) = connected_regions.iter().next().unwrap();
                                 // Update the connected region ids
-                                for ident in region.idents.iter() {
-                                    connected_region_ids.insert(*ident, id_to_set);
-                                }
+                                connected_region_ids
+                                    .extend(region.idents.iter().map(|&ident| (ident, id_to_set)));
                             }
                             _ => {
                                 // We have multiple connected regions to merge.
@@ -236,9 +235,8 @@ impl ItemLikeVisitor<'v> for InherentOverlapChecker<'tcx> {
                                     }
                                     let r = connected_regions.remove(&id).unwrap();
                                     // Update the connected region ids
-                                    for ident in r.idents.iter() {
-                                        connected_region_ids.insert(*ident, id_to_set);
-                                    }
+                                    connected_region_ids
+                                        .extend(r.idents.iter().map(|&ident| (ident, id_to_set)));
                                     region.idents.extend_from_slice(&r.idents);
                                     region.impl_blocks.extend(r.impl_blocks);
                                 }


### PR DESCRIPTION
This PR does some general cleanup around the compiler by replacing repeated insertions into collections like `HashMap` and `HashSet` with calls to `extend()` or `collect()`.

Hopefully, this will help avoid reallocation in places where we can avoid it, so I'd like to do a perf run to see if we get some improvements (or regressions).