### PR TITLE
Use the first paragraph, instead of cookie-cutter text, for rustdoc descriptions

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1124,6 +1124,7 @@ crate fn plain_text_summary(md: &str) -> String {
             Event::HardBreak | Event::SoftBreak => s.push(' '),
             Event::Start(Tag::CodeBlock(..)) => break,
             Event::End(Tag::Paragraph) => break,
+            Event::End(Tag::Heading(..)) => break,
             _ => (),
         }
     }

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -230,6 +230,7 @@ fn test_plain_text_summary() {
     t("code `let x = i32;` ...", "code `let x = i32;` ...");
     t("type `Type<'static>` ...", "type `Type<'static>` ...");
     t("# top header", "top header");
+    t("# top header\n\nfollowed by some text", "top header");
     t("## header", "header");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
     t("```\nfn main() {}\n```", "");

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -534,17 +534,12 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         if !root_path.ends_with('/') {
             root_path.push('/');
         }
-        let description = krate
-            .module
-            .as_ref()
-            .and_then(|item| Some(plain_text_summary(item.doc_value()?.as_str())))
-            .unwrap_or_else(|| String::from("List of all items in this crate"));
         let mut page = layout::Page {
             title: "List of all items in this crate",
             css_class: "mod",
             root_path: "../",
             static_root_path: self.shared.static_root_path.as_deref(),
-            description: description.as_str(),
+            description: "List of all items in this crate",
             keywords: BASIC_KEYWORDS,
             resource_suffix: &self.shared.resource_suffix,
             extra_scripts: &[],

--- a/src/test/rustdoc/description.rs
+++ b/src/test/rustdoc/description.rs
@@ -1,11 +1,14 @@
 #![crate_name = "foo"]
 //! # Description test crate
 //!
-//! This is the contents of the test crate docstring. It should not show up in the description.
+//! This is the contents of the test crate docstring.
+//! It should not show up in the description.
 
-// @matches 'foo/index.html' '//meta[@name="description"]/@content' 'Description test crate'
+// @matches 'foo/index.html' '//meta[@name="description"]/@content' \
+//   'Description test crate'
 
-// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' 'First paragraph description.'
+// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
+//   'First paragraph description.'
 /// First paragraph description.
 ///
 /// Second paragraph should not show up.
@@ -13,7 +16,7 @@ pub mod foo_mod {
     pub struct __Thing {}
 }
 
-// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' 'Only paragraph.'
+// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' \
+//   'Only paragraph.'
 /// Only paragraph.
 pub fn foo_fn() {}
-

--- a/src/test/rustdoc/description.rs
+++ b/src/test/rustdoc/description.rs
@@ -1,0 +1,19 @@
+#![crate_name = "foo"]
+//! # Description test crate
+//!
+//! This is the contents of the test crate docstring. It should not show up in the description.
+
+// @matches 'foo/index.html' '//meta[@name="description"]/@content' 'Description test crate'
+
+// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' 'First paragraph description.'
+/// First paragraph description.
+///
+/// Second paragraph should not show up.
+pub mod foo_mod {
+    pub struct __Thing {}
+}
+
+// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' 'Only paragraph.'
+/// Only paragraph.
+pub fn foo_fn() {}
+

--- a/src/test/rustdoc/description.rs
+++ b/src/test/rustdoc/description.rs
@@ -4,10 +4,10 @@
 //! This is the contents of the test crate docstring.
 //! It should not show up in the description.
 
-// @matches 'foo/index.html' '//meta[@name="description"]/@content' \
+// @has 'foo/index.html' '//meta[@name="description"]/@content' \
 //   'Description test crate'
 
-// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
+// @has 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
 //   'First paragraph description.'
 /// First paragraph description.
 ///
@@ -16,7 +16,7 @@ pub mod foo_mod {
     pub struct __Thing {}
 }
 
-// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' \
+// @has 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' \
 //   'Only paragraph.'
 /// Only paragraph.
 pub fn foo_fn() {}

--- a/src/test/rustdoc/description.rs
+++ b/src/test/rustdoc/description.rs
@@ -6,6 +6,7 @@
 
 // @has 'foo/index.html' '//meta[@name="description"]/@content' \
 //   'Description test crate'
+// @!has - '//meta[@name="description"]/@content' 'should not show up'
 
 // @has 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
 //   'First paragraph description.'

--- a/src/test/rustdoc/description.rs
+++ b/src/test/rustdoc/description.rs
@@ -9,6 +9,7 @@
 
 // @has 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
 //   'First paragraph description.'
+// @!has - '//meta[@name="description"]/@content' 'Second paragraph'
 /// First paragraph description.
 ///
 /// Second paragraph should not show up.

--- a/src/test/rustdoc/description_default.rs
+++ b/src/test/rustdoc/description_default.rs
@@ -1,12 +1,14 @@
 #![crate_name = "foo"]
 
-// @matches 'foo/index.html' '//meta[@name="description"]/@content' 'API documentation for the Rust `foo` crate.'
+// @matches 'foo/index.html' '//meta[@name="description"]/@content' \
+//   'API documentation for the Rust `foo` crate.'
 
-// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' 'API documentation for the Rust `foo_mod` mod in crate `foo`.'
+// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
+//   'API documentation for the Rust `foo_mod` mod in crate `foo`.'
 pub mod foo_mod {
     pub struct __Thing {}
 }
 
-// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' 'API documentation for the Rust `foo_fn` fn in crate `foo`.'
+// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' \
+//   'API documentation for the Rust `foo_fn` fn in crate `foo`.'
 pub fn foo_fn() {}
-

--- a/src/test/rustdoc/description_default.rs
+++ b/src/test/rustdoc/description_default.rs
@@ -1,0 +1,12 @@
+#![crate_name = "foo"]
+
+// @matches 'foo/index.html' '//meta[@name="description"]/@content' 'API documentation for the Rust `foo` crate.'
+
+// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' 'API documentation for the Rust `foo_mod` mod in crate `foo`.'
+pub mod foo_mod {
+    pub struct __Thing {}
+}
+
+// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' 'API documentation for the Rust `foo_fn` fn in crate `foo`.'
+pub fn foo_fn() {}
+

--- a/src/test/rustdoc/description_default.rs
+++ b/src/test/rustdoc/description_default.rs
@@ -1,14 +1,14 @@
 #![crate_name = "foo"]
 
-// @matches 'foo/index.html' '//meta[@name="description"]/@content' \
+// @has 'foo/index.html' '//meta[@name="description"]/@content' \
 //   'API documentation for the Rust `foo` crate.'
 
-// @matches 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
+// @has 'foo/foo_mod/index.html' '//meta[@name="description"]/@content' \
 //   'API documentation for the Rust `foo_mod` mod in crate `foo`.'
 pub mod foo_mod {
     pub struct __Thing {}
 }
 
-// @matches 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' \
+// @has 'foo/fn.foo_fn.html' '//meta[@name="description"]/@content' \
 //   'API documentation for the Rust `foo_fn` fn in crate `foo`.'
 pub fn foo_fn() {}


### PR DESCRIPTION
Partially addresses #82283.