### PR TITLE
rustdoc: Cleanup `html::render::Context`

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1373,10 +1373,6 @@ impl IdMap {
         }
     }
 
-    crate fn reset(&mut self) {
-        self.map = init_id_map();
-    }
-
     crate fn derive<S: AsRef<str> + ToString>(&mut self, candidate: S) -> String {
         let id = match self.map.get_mut(candidate.as_ref()) {
             None => candidate.to_string(),

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -38,15 +38,9 @@ fn test_unique_id() {
         "assoc_type.Item-1",
     ];
 
-    let map = RefCell::new(IdMap::new());
-    let test = || {
-        let mut map = map.borrow_mut();
-        let actual: Vec<String> = input.iter().map(|s| map.derive(s.to_string())).collect();
-        assert_eq!(&actual[..], expected);
-    };
-    test();
-    map.borrow_mut().reset();
-    test();
+    let mut map = IdMap::new();
+    let actual: Vec<String> = input.iter().map(|s| map.derive(s.to_string())).collect();
+    assert_eq!(&actual[..], expected);
 }
 
 #[test]

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -1,7 +1,6 @@
 use super::{plain_text_summary, short_markdown_summary};
 use super::{ErrorCodes, IdMap, Ignore, LangString, Markdown, MarkdownHtml};
 use rustc_span::edition::{Edition, DEFAULT_EDITION};
-use std::cell::RefCell;
 
 #[test]
 fn test_unique_id() {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -52,10 +52,10 @@ crate struct Context<'tcx> {
     /// publicly reused items to redirect to the right location.
     pub(super) render_redirect_pages: bool,
     /// The map used to ensure all generated 'id=' attributes are unique.
-    pub(super) id_map: Box<RefCell<IdMap>>,
+    pub(super) id_map: RefCell<IdMap>,
     /// Tracks section IDs for `Deref` targets so they match in both the main
     /// body and the sidebar.
-    pub(super) deref_id_map: Box<RefCell<FxHashMap<DefId, String>>>,
+    pub(super) deref_id_map: RefCell<FxHashMap<DefId, String>>,
     /// Shared mutable state.
     ///
     /// Issue for improving the situation: [#82381][]
@@ -76,7 +76,7 @@ crate struct Context<'tcx> {
 
 // `Context` is cloned a lot, so we don't want the size to grow unexpectedly.
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(Context<'_>, 88);
+rustc_data_structures::static_assert_size!(Context<'_>, 152);
 
 impl<'tcx> Context<'tcx> {
     pub(super) fn path(&self, filename: &str) -> PathBuf {
@@ -415,8 +415,8 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             current: Vec::new(),
             dst,
             render_redirect_pages: false,
-            id_map: Box::new(RefCell::new(id_map)),
-            deref_id_map: Box::new(RefCell::new(FxHashMap::default())),
+            id_map: RefCell::new(id_map),
+            deref_id_map: RefCell::new(FxHashMap::default()),
             shared: Rc::new(scx),
             cache: Rc::new(cache),
         };
@@ -438,8 +438,8 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             current: self.current.clone(),
             dst: self.dst.clone(),
             render_redirect_pages: self.render_redirect_pages,
-            id_map: Box::new(RefCell::new(id_map)),
-            deref_id_map: Box::new(RefCell::new(FxHashMap::default())),
+            id_map: RefCell::new(id_map),
+            deref_id_map: RefCell::new(FxHashMap::default()),
             shared: Rc::clone(&self.shared),
             cache: Rc::clone(&self.cache),
         }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -53,10 +53,10 @@ crate struct Context<'tcx> {
     /// publicly reused items to redirect to the right location.
     pub(super) render_redirect_pages: bool,
     /// The map used to ensure all generated 'id=' attributes are unique.
-    pub(super) id_map: RefCell<IdMap>,
+    pub(super) id_map: Box<RefCell<IdMap>>,
     /// Tracks section IDs for `Deref` targets so they match in both the main
     /// body and the sidebar.
-    pub(super) deref_id_map: RefCell<FxHashMap<DefId, String>>,
+    pub(super) deref_id_map: Box<RefCell<FxHashMap<DefId, String>>>,
     /// Shared mutable state.
     ///
     /// Issue for improving the situation: [#82381][]
@@ -77,7 +77,7 @@ crate struct Context<'tcx> {
 
 // `Context` is cloned a lot, so we don't want the size to grow unexpectedly.
 #[cfg(target_arch = "x86_64")]
-rustc_data_structures::static_assert_size!(Context<'_>, 152);
+rustc_data_structures::static_assert_size!(Context<'_>, 88);
 
 impl<'tcx> Context<'tcx> {
     pub(super) fn path(&self, filename: &str) -> PathBuf {
@@ -421,8 +421,8 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             current: Vec::new(),
             dst,
             render_redirect_pages: false,
-            id_map: RefCell::new(id_map),
-            deref_id_map: RefCell::new(FxHashMap::default()),
+            id_map: Box::new(RefCell::new(id_map)),
+            deref_id_map: Box::new(RefCell::new(FxHashMap::default())),
             shared: Rc::new(scx),
             cache: Rc::new(cache),
         };

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -44,15 +44,20 @@ use crate::html::{layout, sources};
 crate struct Context<'tcx> {
     /// Current hierarchy of components leading down to what's currently being
     /// rendered
-    crate current: Vec<String>,
+    pub(super) current: Vec<String>,
     /// The current destination folder of where HTML artifacts should be placed.
     /// This changes as the context descends into the module hierarchy.
-    crate dst: PathBuf,
+    pub(super) dst: PathBuf,
     /// A flag, which when `true`, will render pages which redirect to the
     /// real location of an item. This is used to allow external links to
     /// publicly reused items to redirect to the right location.
-    crate render_redirect_pages: bool,
-    crate shared: Rc<SharedContext<'tcx>>,
+    pub(super) render_redirect_pages: bool,
+    /// Shared mutable state.
+    ///
+    /// Issue for improving the situation: [#82381][]
+    ///
+    /// [#82381]: https://github.com/rust-lang/rust/issues/82381
+    pub(super) shared: Rc<SharedContext<'tcx>>,
     /// The [`Cache`] used during rendering.
     ///
     /// Ideally the cache would be in [`SharedContext`], but it's mutated
@@ -62,7 +67,7 @@ crate struct Context<'tcx> {
     /// It's immutable once in `Context`, so it's not as bad that it's not in
     /// `SharedContext`.
     // FIXME: move `cache` to `SharedContext`
-    crate cache: Rc<Cache>,
+    pub(super) cache: Rc<Cache>,
 }
 
 impl<'tcx> Context<'tcx> {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -70,6 +70,10 @@ crate struct Context<'tcx> {
     pub(super) cache: Rc<Cache>,
 }
 
+// `Context` is cloned a lot, so we don't want the size to grow unexpectedly.
+#[cfg(target_arch = "x86_64")]
+rustc_data_structures::static_assert_size!(Context<'_>, 72);
+
 impl<'tcx> Context<'tcx> {
     pub(super) fn path(&self, filename: &str) -> PathBuf {
         // We use splitn vs Path::extension here because we might get a filename

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -81,6 +81,7 @@ crate fn ensure_trailing_slash(v: &str) -> impl fmt::Display + '_ {
     })
 }
 
+/// Shared mutable state used in [`Context`] and elsewhere.
 crate struct SharedContext<'tcx> {
     crate tcx: TyCtxt<'tcx>,
     /// The path to the crate root source minus the file name.
@@ -96,16 +97,16 @@ crate struct SharedContext<'tcx> {
     /// The local file sources we've emitted and their respective url-paths.
     crate local_sources: FxHashMap<PathBuf, String>,
     /// Whether the collapsed pass ran
-    crate collapsed: bool,
+    collapsed: bool,
     /// The base-URL of the issue tracker for when an item has been tagged with
     /// an issue number.
-    crate issue_tracker_base_url: Option<String>,
+    issue_tracker_base_url: Option<String>,
     /// The directories that have already been created in this doc run. Used to reduce the number
     /// of spurious `create_dir_all` calls.
-    crate created_dirs: RefCell<FxHashSet<PathBuf>>,
+    created_dirs: RefCell<FxHashSet<PathBuf>>,
     /// This flag indicates whether listings of modules (in the side bar and documentation itself)
     /// should be ordered alphabetically or in order of appearance (in the source code).
-    crate sort_modules_alphabetically: bool,
+    sort_modules_alphabetically: bool,
     /// Additional CSS files to be added to the generated docs.
     crate style_files: Vec<StylePath>,
     /// Suffix to be added on resource files (if suffix is "-v2" then "light.css" becomes
@@ -118,7 +119,7 @@ crate struct SharedContext<'tcx> {
     crate fs: DocFS,
     /// The default edition used to parse doctests.
     crate edition: Edition,
-    crate codes: ErrorCodes,
+    codes: ErrorCodes,
     playground: Option<markdown::Playground>,
     /// The map used to ensure all generated 'id=' attributes are unique.
     id_map: RefCell<IdMap>,
@@ -128,11 +129,11 @@ crate struct SharedContext<'tcx> {
     all: RefCell<AllTypes>,
     /// Storage for the errors produced while generating documentation so they
     /// can be printed together at the end.
-    crate errors: Receiver<String>,
+    errors: Receiver<String>,
     /// `None` by default, depends on the `generate-redirect-map` option flag. If this field is set
     /// to `Some(...)`, it'll store redirections and then generate a JSON file at the top level of
     /// the crate.
-    crate redirections: Option<RefCell<FxHashMap<String, String>>>,
+    redirections: Option<RefCell<FxHashMap<String, String>>>,
 }
 
 impl SharedContext<'_> {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -70,7 +70,7 @@ use crate::html::format::{
     PrintWithSpace, WhereClause,
 };
 use crate::html::layout;
-use crate::html::markdown::{self, ErrorCodes, IdMap, Markdown, MarkdownHtml, MarkdownSummaryLine};
+use crate::html::markdown::{self, ErrorCodes, Markdown, MarkdownHtml, MarkdownSummaryLine};
 
 /// A pair of name and its optional document.
 crate type NameDoc = (String, Option<String>);
@@ -121,11 +121,6 @@ crate struct SharedContext<'tcx> {
     crate edition: Edition,
     codes: ErrorCodes,
     playground: Option<markdown::Playground>,
-    /// The map used to ensure all generated 'id=' attributes are unique.
-    id_map: RefCell<IdMap>,
-    /// Tracks section IDs for `Deref` targets so they match in both the main
-    /// body and the sidebar.
-    deref_id_map: RefCell<FxHashMap<DefId, String>>,
     all: RefCell<AllTypes>,
     /// Storage for the errors produced while generating documentation so they
     /// can be printed together at the end.
@@ -650,7 +645,7 @@ fn render_markdown(
     prefix: &str,
     is_hidden: bool,
 ) {
-    let mut ids = cx.shared.id_map.borrow_mut();
+    let mut ids = cx.id_map.borrow_mut();
     write!(
         w,
         "<div class=\"docblock{}\">{}{}</div>",
@@ -810,7 +805,7 @@ fn short_item_info(
 
         if let Some(note) = note {
             let note = note.as_str();
-            let mut ids = cx.shared.id_map.borrow_mut();
+            let mut ids = cx.id_map.borrow_mut();
             let html = MarkdownHtml(
                 &note,
                 &mut ids,
@@ -849,7 +844,7 @@ fn short_item_info(
         message.push_str(&format!(" ({})", feature));
 
         if let Some(unstable_reason) = reason {
-            let mut ids = cx.shared.id_map.borrow_mut();
+            let mut ids = cx.id_map.borrow_mut();
             message = format!(
                 "<details><summary>{}</summary>{}</details>",
                 message,
@@ -1189,8 +1184,7 @@ fn render_assoc_items(
                     type_.print(cx.cache())
                 )));
                 debug!("Adding {} to deref id map", type_.print(cx.cache()));
-                cx.shared
-                    .deref_id_map
+                cx.deref_id_map
                     .borrow_mut()
                     .insert(type_.def_id_full(cx.cache()).unwrap(), id.clone());
                 write!(
@@ -1497,7 +1491,7 @@ fn render_impl(
         }
 
         if let Some(ref dox) = cx.shared.maybe_collapsed_doc_value(&i.impl_item) {
-            let mut ids = cx.shared.id_map.borrow_mut();
+            let mut ids = cx.id_map.borrow_mut();
             write!(
                 w,
                 "<div class=\"docblock\">{}</div>",
@@ -2046,7 +2040,7 @@ fn sidebar_deref_methods(cx: &Context<'_>, out: &mut Buffer, impl_: &Impl, v: &V
                 .flat_map(|i| get_methods(i.inner_impl(), true, &mut used_links, deref_mut, c))
                 .collect::<Vec<_>>();
             if !ret.is_empty() {
-                let deref_id_map = cx.shared.deref_id_map.borrow();
+                let deref_id_map = cx.deref_id_map.borrow();
                 let id = deref_id_map
                     .get(&real_target.def_id_full(cx.cache()).unwrap())
                     .expect("Deref section without derived id");

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -149,6 +149,10 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         ))
     }
 
+    fn make_child_renderer(&self) -> Self {
+        self.clone()
+    }
+
     /// Inserts an item into the index. This should be used rather than directly calling insert on
     /// the hashmap because certain items (traits and types) need to have their mappings for trait
     /// implementations filled out before they're inserted.


### PR DESCRIPTION
- Move most shared fields to `SharedContext` (except for `cache`, which
  isn't mutated anyway)
- Replace a use of `Arc` with `Rc`
- Make a bunch of fields private
- Add static size assertion for `Context`
- Don't share `id_map` and `deref_id_map`
