### PR TITLE
config.toml parsing error improvements

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -631,7 +631,9 @@ changelog-seen = 2
 # The full path to the musl libdir.
 #musl-libdir = musl-root/lib
 
-# The root location of the `wasm32-wasi` sysroot.
+# The root location of the `wasm32-wasi` sysroot. Only used for the
+# `wasm32-wasi` target. If you are building wasm32-wasi target, make sure to
+# create a `[target.wasm32-wasi]` section and move this field there.
 #wasi-root = "..."
 
 # Used in testing for configuring where the QEMU images are located, you

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -178,7 +178,9 @@ fn copy_self_contained_objects(
     // To do that we have to distribute musl startup objects as a part of Rust toolchain
     // and link with them manually in the self-contained mode.
     if target.contains("musl") {
-        let srcdir = builder.musl_libdir(target).unwrap();
+        let srcdir = builder.musl_libdir(target).unwrap_or_else(|| {
+            panic!("Target {:?} does not have a \"musl-libdir\" key", target.triple)
+        });
         for &obj in &["crt1.o", "Scrt1.o", "rcrt1.o", "crti.o", "crtn.o"] {
             copy_and_stamp(
                 builder,
@@ -196,7 +198,12 @@ fn copy_self_contained_objects(
             target_deps.push((target, DependencyType::TargetSelfContained));
         }
     } else if target.ends_with("-wasi") {
-        let srcdir = builder.wasi_root(target).unwrap().join("lib/wasm32-wasi");
+        let srcdir = builder
+            .wasi_root(target)
+            .unwrap_or_else(|| {
+                panic!("Target {:?} does not have a \"wasi-root\" key", target.triple)
+            })
+            .join("lib/wasm32-wasi");
         for &obj in &["crt1.o", "crt1-reactor.o"] {
             copy_and_stamp(
                 builder,


### PR DESCRIPTION
Improve error messages for musl-libdir and wasi-root keys. Previously
the parser would panic with `unwrap()`. Now it prints

      Target "wasm32-wasi" does not have a "wasi-root" key

(and similar for the `musl-libdir` field, which is used in target that
use musl)

Also update comments around wasi-root field to make it clear that the
field is only valid in wasm32-wasi target and needs to be moved to a
`[target.wasm32-wasi]` section to be valid.

Fixes #82317

---

r? @Mark-Simulacrum 