### PR TITLE
Add WrappingAdd and WrappingAddAssign trait for integer types only

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -102,6 +102,7 @@
 #![feature(const_unreachable_unchecked)]
 #![feature(const_maybe_uninit_assume_init)]
 #![feature(const_maybe_uninit_as_ptr)]
+#![feature(core_sealed)]
 #![feature(custom_inner_attributes)]
 #![feature(decl_macro)]
 #![feature(doc_cfg)]
@@ -304,3 +305,11 @@ mod core_arch;
 
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub use core_arch::arch;
+
+mod sealed {
+    /// This trait being unreachable from outside the crate
+    /// prevents outside implementations of our extension traits.
+    /// This allows adding more trait methods in the future.
+    #[unstable(feature = "core_sealed", issue = "none")]
+    pub trait Sealed {}
+}

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -276,9 +276,9 @@ pub mod alloc;
 
 // note: does not need to be public
 mod bool;
+mod sealed;
 mod tuple;
 mod unit;
-mod sealed;
 
 #[stable(feature = "core_primitive", since = "1.43.0")]
 pub mod primitive;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -278,6 +278,7 @@ pub mod alloc;
 mod bool;
 mod tuple;
 mod unit;
+mod sealed;
 
 #[stable(feature = "core_primitive", since = "1.43.0")]
 pub mod primitive;
@@ -305,11 +306,3 @@ mod core_arch;
 
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub use core_arch::arch;
-
-mod sealed {
-    /// This trait being unreachable from outside the crate
-    /// prevents outside implementations of our extension traits.
-    /// This allows adding more trait methods in the future.
-    #[unstable(feature = "core_sealed", issue = "none")]
-    pub trait Sealed {}
-}

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -1,3 +1,5 @@
+pub mod wrapping;
+
 /// The addition operator `+`.
 ///
 /// Note that `Rhs` is `Self` by default, but this is not mandatory. For

--- a/library/core/src/ops/arith/wrapping.rs
+++ b/library/core/src/ops/arith/wrapping.rs
@@ -1,0 +1,98 @@
+use crate::sealed::Sealed;
+
+macro_rules! sealed_impl {
+    ($($T:ty)+) => {
+        $(
+            #[unstable(feature = "core_sealed", issue = "none")]
+            impl Sealed for $T {}
+
+            #[unstable(feature = "core_sealed", issue = "none")]
+            impl Sealed for &'_ $T {}
+        )+
+    };
+}
+
+sealed_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+
+/// The trait corresponds to wrapping add arithmetics.
+///
+/// # Notes
+///
+/// This trait is sealed, you cannot implement this trait outside the standard library.
+/// This trait doesn't correspond to any operator.
+#[unstable(feature = "wrapping_add", issue = "none")]
+pub trait WrappingAdd<Rhs = Self>: Sealed + Copy {
+    /// The resulting type after applying the `wrapping_add` operator.
+    type Output;
+
+    /// Performs the add and wrapping operation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ops::WrappingAdd;
+    /// assert_eq!(<u16 as WrappingAdd>::wrapping_add(100, 27), 127);
+    /// assert_eq!(<u16 as WrappingAdd>::wrapping_add(u16::MAX, 2), 1);
+    /// ```
+    #[must_use]
+    fn wrapping_add(self, rhs: Rhs) -> Self::Output;
+}
+
+macro_rules! add_impl {
+    ($($T:ty)+) => {
+        $(
+            #[unstable(feature = "wrapping_add", issue = "none")]
+            impl WrappingAdd for $T {
+                type Output = $T;
+
+                #[inline]
+                fn wrapping_add(self, other: $T) -> $T {
+                    <$T>::wrapping_add(self, other)
+                }
+            }
+
+            forward_ref_binop! { impl WrappingAdd, wrapping_add for $T, $T }
+        )+
+    };
+}
+
+add_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+
+/// The trait for assignment result of `wrapping_add` operation.
+//
+/// # Notes
+///
+/// This trait is sealed, you cannot implement this trait outside the standard library.
+/// This trait doesn't correspond to any operator.
+#[unstable(feature = "wrapping_add", issue = "none")]
+pub trait WrappingAddAssign<Rhs = Self>: Sealed + Copy {
+    /// Assign result of `wrapping_add` to `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ops::WrappingAddAssign;
+    /// let mut x = 42u16;
+    /// assert_eq!(x.wrapping_add_assign(1), 43);
+    /// assert_eq!(x.wrapping_add_assign(u16::MAX), 42);
+    /// ```
+    fn wrapping_add_assign(&mut self, rhs: Rhs);
+}
+
+macro_rules! add_assign_impl {
+    ($($T:ty)+) => {
+        $(
+            #[unstable(feature = "wrapping_add", issue = "none")]
+            impl WrappingAddAssign for $T {
+                #[inline]
+                fn wrapping_add_assign(&mut self, other: $T) {
+                    *self = <$T>::wrapping_add(*self, other);
+                }
+            }
+
+            forward_ref_op_assign! { impl WrappingAddAssign, wrapping_add_assign for $T, $T }
+        )+
+    };
+}
+
+add_assign_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }

--- a/library/core/src/ops/arith/wrapping.rs
+++ b/library/core/src/ops/arith/wrapping.rs
@@ -37,7 +37,12 @@ macro_rules! add_impl {
                 }
             }
 
-            forward_ref_binop! { impl WrappingAdd, wrapping_add for $T, $T }
+            forward_ref_binop! {
+                impl WrappingAdd,
+                wrapping_add for $T,
+                $T,
+                #[unstable(feature = "wrapping_add", issue = "none")]
+            }
         )+
     };
 }
@@ -76,7 +81,12 @@ macro_rules! add_assign_impl {
                 }
             }
 
-            forward_ref_op_assign! { impl WrappingAddAssign, wrapping_add_assign for $T, $T }
+            forward_ref_op_assign! {
+                impl WrappingAddAssign,
+                wrapping_add_assign for $T,
+                $T,
+                #[unstable(feature = "wrapping_add", issue = "none")]
+            }
         )+
     };
 }

--- a/library/core/src/ops/arith/wrapping.rs
+++ b/library/core/src/ops/arith/wrapping.rs
@@ -1,19 +1,5 @@
 use crate::sealed::Sealed;
 
-macro_rules! sealed_impl {
-    ($($T:ty)+) => {
-        $(
-            #[unstable(feature = "core_sealed", issue = "none")]
-            impl Sealed for $T {}
-
-            #[unstable(feature = "core_sealed", issue = "none")]
-            impl Sealed for &'_ $T {}
-        )+
-    };
-}
-
-sealed_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
-
 /// The trait corresponds to wrapping add arithmetics.
 ///
 /// # Notes

--- a/library/core/src/ops/mod.rs
+++ b/library/core/src/ops/mod.rs
@@ -155,6 +155,9 @@ pub use self::arith::{Add, Div, Mul, Neg, Rem, Sub};
 #[stable(feature = "op_assign_traits", since = "1.8.0")]
 pub use self::arith::{AddAssign, DivAssign, MulAssign, RemAssign, SubAssign};
 
+#[unstable(feature = "op_wrapping_assign_traits", issue = "none")]
+pub use self::arith::wrapping::{WrappingAdd, WrappingAddAssign};
+
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::bit::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
 #[stable(feature = "op_assign_traits", since = "1.8.0")]

--- a/library/core/src/sealed.rs
+++ b/library/core/src/sealed.rs
@@ -1,0 +1,20 @@
+/// This trait being unreachable from outside the crate
+/// prevents outside implementations of our extension traits.
+/// This allows adding more trait methods in the future.
+#[unstable(feature = "core_sealed", issue = "none")]
+pub trait Sealed {}
+
+macro_rules! integers_sealed_impl {
+    ($($T:ty)+) => {
+        $(
+            #[unstable(feature = "core_sealed", issue = "none")]
+            impl Sealed for $T {}
+
+            #[unstable(feature = "core_sealed", issue = "none")]
+            impl Sealed for &'_ $T {}
+        )+
+    };
+}
+
+// Used by sealed `WrappingAdd` trait.
+integers_sealed_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }

--- a/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
+++ b/src/test/mir-opt/lower_intrinsics.wrapping.LowerIntrinsics.diff
@@ -30,7 +30,7 @@
           _4 = _1;                         // scope 0 at $DIR/lower_intrinsics.rs:7:45: 7:46
           StorageLive(_5);                 // scope 0 at $DIR/lower_intrinsics.rs:7:48: 7:49
           _5 = _2;                         // scope 0 at $DIR/lower_intrinsics.rs:7:48: 7:49
--         _3 = wrapping_add::<T>(move _4, move _5) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:7:14: 7:50
+-         _3 = std::intrinsics::wrapping_add::<T>(move _4, move _5) -> bb1; // scope 0 at $DIR/lower_intrinsics.rs:7:14: 7:50
 -                                          // mir::Constant
 -                                          // + span: $DIR/lower_intrinsics.rs:7:14: 7:44
 -                                          // + literal: Const { ty: extern "rust-intrinsic" fn(T, T) -> T {std::intrinsics::wrapping_add::<T>}, val: Value(Scalar(<ZST>)) }


### PR DESCRIPTION
The wrapping add assignment operation is used quite a lot in cryptography, hashing algorithm, and emulator implementations, etc.

Edit: After a few more thoughts, I think we should just use std::num::Wrapping.
