### PR TITLE
Improve anonymous lifetime note to indicate the target span

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -1,6 +1,7 @@
 //! Error Reporting for Anonymous Region Lifetime Errors
 //! where both the regions are anonymous.
 
+use crate::infer::error_reporting::nice_region_error::find_anon_type::find_anon_type;
 use crate::infer::error_reporting::nice_region_error::util::AnonymousParamInfo;
 use crate::infer::error_reporting::nice_region_error::NiceRegionError;
 use crate::infer::lexical_region_resolve::RegionResolutionError;
@@ -66,9 +67,9 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let scope_def_id_sub = anon_reg_sub.def_id;
         let bregion_sub = anon_reg_sub.boundregion;
 
-        let ty_sup = self.find_anon_type(sup, &bregion_sup)?;
+        let ty_sup = find_anon_type(self.tcx(), sup, &bregion_sup)?;
 
-        let ty_sub = self.find_anon_type(sub, &bregion_sub)?;
+        let ty_sub = find_anon_type(self.tcx(), sub, &bregion_sub)?;
 
         debug!(
             "try_report_anon_anon_conflict: found_param1={:?} sup={:?} br1={:?}",

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -1,4 +1,3 @@
-use crate::infer::error_reporting::nice_region_error::NiceRegionError;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc_hir::Node;
@@ -6,67 +5,64 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::middle::resolve_lifetime as rl;
 use rustc_middle::ty::{self, Region, TyCtxt};
 
-impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
-    /// This function calls the `visit_ty` method for the parameters
-    /// corresponding to the anonymous regions. The `nested_visitor.found_type`
-    /// contains the anonymous type.
-    ///
-    /// # Arguments
-    /// region - the anonymous region corresponding to the anon_anon conflict
-    /// br - the bound region corresponding to the above region which is of type `BrAnon(_)`
-    ///
-    /// # Example
-    /// ```
-    /// fn foo(x: &mut Vec<&u8>, y: &u8)
-    ///    { x.push(y); }
-    /// ```
-    /// The function returns the nested type corresponding to the anonymous region
-    /// for e.g., `&u8` and Vec<`&u8`.
-    pub(super) fn find_anon_type(
-        &self,
-        region: Region<'tcx>,
-        br: &ty::BoundRegionKind,
-    ) -> Option<(&hir::Ty<'tcx>, &hir::FnDecl<'tcx>)> {
-        if let Some(anon_reg) = self.tcx().is_suitable_region(region) {
-            let hir_id = self.tcx().hir().local_def_id_to_hir_id(anon_reg.def_id);
-            let fndecl = match self.tcx().hir().get(hir_id) {
-                Node::Item(&hir::Item { kind: hir::ItemKind::Fn(ref m, ..), .. })
-                | Node::TraitItem(&hir::TraitItem {
-                    kind: hir::TraitItemKind::Fn(ref m, ..),
-                    ..
-                })
-                | Node::ImplItem(&hir::ImplItem {
-                    kind: hir::ImplItemKind::Fn(ref m, ..), ..
-                }) => &m.decl,
-                _ => return None,
-            };
-
-            fndecl
-                .inputs
-                .iter()
-                .find_map(|arg| self.find_component_for_bound_region(arg, br))
-                .map(|ty| (ty, &**fndecl))
-        } else {
-            None
-        }
-    }
-
-    // This method creates a FindNestedTypeVisitor which returns the type corresponding
-    // to the anonymous region.
-    fn find_component_for_bound_region(
-        &self,
-        arg: &'tcx hir::Ty<'tcx>,
-        br: &ty::BoundRegionKind,
-    ) -> Option<&'tcx hir::Ty<'tcx>> {
-        let mut nested_visitor = FindNestedTypeVisitor {
-            tcx: self.tcx(),
-            bound_region: *br,
-            found_type: None,
-            current_index: ty::INNERMOST,
+/// This function calls the `visit_ty` method for the parameters
+/// corresponding to the anonymous regions. The `nested_visitor.found_type`
+/// contains the anonymous type.
+///
+/// # Arguments
+/// region - the anonymous region corresponding to the anon_anon conflict
+/// br - the bound region corresponding to the above region which is of type `BrAnon(_)`
+///
+/// # Example
+/// ```
+/// fn foo(x: &mut Vec<&u8>, y: &u8)
+///    { x.push(y); }
+/// ```
+/// The function returns the nested type corresponding to the anonymous region
+/// for e.g., `&u8` and Vec<`&u8`.
+pub(crate) fn find_anon_type(
+    tcx: TyCtxt<'tcx>,
+    region: Region<'tcx>,
+    br: &ty::BoundRegionKind,
+) -> Option<(&'tcx hir::Ty<'tcx>, &'tcx hir::FnDecl<'tcx>)> {
+    if let Some(anon_reg) = tcx.is_suitable_region(region) {
+        let hir_id = tcx.hir().local_def_id_to_hir_id(anon_reg.def_id);
+        let fndecl = match tcx.hir().get(hir_id) {
+            Node::Item(&hir::Item { kind: hir::ItemKind::Fn(ref m, ..), .. })
+            | Node::TraitItem(&hir::TraitItem {
+                kind: hir::TraitItemKind::Fn(ref m, ..), ..
+            })
+            | Node::ImplItem(&hir::ImplItem { kind: hir::ImplItemKind::Fn(ref m, ..), .. }) => {
+                &m.decl
+            }
+            _ => return None,
         };
-        nested_visitor.visit_ty(arg);
-        nested_visitor.found_type
+
+        fndecl
+            .inputs
+            .iter()
+            .find_map(|arg| find_component_for_bound_region(tcx, arg, br))
+            .map(|ty| (ty, &**fndecl))
+    } else {
+        None
     }
+}
+
+// This method creates a FindNestedTypeVisitor which returns the type corresponding
+// to the anonymous region.
+fn find_component_for_bound_region(
+    tcx: TyCtxt<'tcx>,
+    arg: &'tcx hir::Ty<'tcx>,
+    br: &ty::BoundRegionKind,
+) -> Option<&'tcx hir::Ty<'tcx>> {
+    let mut nested_visitor = FindNestedTypeVisitor {
+        tcx,
+        bound_region: *br,
+        found_type: None,
+        current_index: ty::INNERMOST,
+    };
+    nested_visitor.visit_ty(arg);
+    nested_visitor.found_type
 }
 
 // The FindNestedTypeVisitor captures the corresponding `hir::Ty` of the

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
@@ -5,8 +5,8 @@ use rustc_errors::{DiagnosticBuilder, ErrorReported};
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::source_map::Span;
 
-pub mod find_anon_type;
 mod different_lifetimes;
+pub mod find_anon_type;
 mod named_anon_conflict;
 mod placeholder_error;
 mod static_impl_trait;

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/mod.rs
@@ -5,8 +5,8 @@ use rustc_errors::{DiagnosticBuilder, ErrorReported};
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::source_map::Span;
 
+pub mod find_anon_type;
 mod different_lifetimes;
-mod find_anon_type;
 mod named_anon_conflict;
 mod placeholder_error;
 mod static_impl_trait;

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -1,5 +1,6 @@
 //! Error Reporting for Anonymous Region Lifetime Errors
 //! where one region is named and the other is anonymous.
+use crate::infer::error_reporting::nice_region_error::find_anon_type::find_anon_type;
 use crate::infer::error_reporting::nice_region_error::NiceRegionError;
 use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir::intravisit::Visitor;
@@ -74,7 +75,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             return None;
         }
 
-        if let Some((_, fndecl)) = self.find_anon_type(anon, &br) {
+        if let Some((_, fndecl)) = find_anon_type(self.tcx(), anon, &br) {
             if self.is_self_anon(is_first, scope_def_id) {
                 return None;
             }

--- a/src/test/ui/issues/issue-16683.stderr
+++ b/src/test/ui/issues/issue-16683.stderr
@@ -4,11 +4,11 @@ error[E0495]: cannot infer an appropriate lifetime for autoref due to conflictin
 LL |         self.a();
    |              ^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 3:5...
-  --> $DIR/issue-16683.rs:3:5
+note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 3:10...
+  --> $DIR/issue-16683.rs:3:10
    |
 LL |     fn b(&self) {
-   |     ^^^^^^^^^^^
+   |          ^^^^^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/issue-16683.rs:4:9
    |

--- a/src/test/ui/issues/issue-17740.stderr
+++ b/src/test/ui/issues/issue-17740.stderr
@@ -6,11 +6,11 @@ LL |     fn bar(self: &mut Foo) {
    |
    = note: expected struct `Foo<'a>`
               found struct `Foo<'_>`
-note: the anonymous lifetime #2 defined on the method body at 6:5...
-  --> $DIR/issue-17740.rs:6:5
+note: the anonymous lifetime defined on the method body at 6:23...
+  --> $DIR/issue-17740.rs:6:23
    |
 LL |     fn bar(self: &mut Foo) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 5:7
   --> $DIR/issue-17740.rs:5:7
    |
@@ -30,11 +30,11 @@ note: the lifetime `'a` as defined on the impl at 5:7...
    |
 LL | impl <'a> Foo<'a>{
    |       ^^
-note: ...does not necessarily outlive the anonymous lifetime #2 defined on the method body at 6:5
-  --> $DIR/issue-17740.rs:6:5
+note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 6:23
+  --> $DIR/issue-17740.rs:6:23
    |
 LL |     fn bar(self: &mut Foo) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-17758.stderr
+++ b/src/test/ui/issues/issue-17758.stderr
@@ -4,11 +4,11 @@ error[E0495]: cannot infer an appropriate lifetime for autoref due to conflictin
 LL |         self.foo();
    |              ^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 6:5...
-  --> $DIR/issue-17758.rs:6:5
+note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 6:12...
+  --> $DIR/issue-17758.rs:6:12
    |
 LL |     fn bar(&self) {
-   |     ^^^^^^^^^^^^^
+   |            ^^^^^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/issue-17758.rs:7:9
    |

--- a/src/test/ui/issues/issue-17905-2.stderr
+++ b/src/test/ui/issues/issue-17905-2.stderr
@@ -6,11 +6,11 @@ LL |     fn say(self: &Pair<&str, isize>) {
    |
    = note: expected struct `Pair<&str, _>`
               found struct `Pair<&str, _>`
-note: the anonymous lifetime #2 defined on the method body at 8:5...
-  --> $DIR/issue-17905-2.rs:8:5
+note: the anonymous lifetime defined on the method body at 8:24...
+  --> $DIR/issue-17905-2.rs:8:24
    |
 LL |     fn say(self: &Pair<&str, isize>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^
 note: ...does not necessarily outlive the lifetime `'_` as defined on the impl at 5:5
   --> $DIR/issue-17905-2.rs:5:5
    |
@@ -30,11 +30,11 @@ note: the lifetime `'_` as defined on the impl at 5:5...
    |
 LL |     &str,
    |     ^
-note: ...does not necessarily outlive the anonymous lifetime #2 defined on the method body at 8:5
-  --> $DIR/issue-17905-2.rs:8:5
+note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 8:24
+  --> $DIR/issue-17905-2.rs:8:24
    |
 LL |     fn say(self: &Pair<&str, isize>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -4,11 +4,11 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 28:5...
-  --> $DIR/issue-20831-debruijn.rs:28:5
+note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 28:58...
+  --> $DIR/issue-20831-debruijn.rs:28:58
    |
 LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...but the lifetime must also be valid for the lifetime `'a` as defined on the impl at 26:6...
   --> $DIR/issue-20831-debruijn.rs:26:6
    |

--- a/src/test/ui/issues/issue-27942.stderr
+++ b/src/test/ui/issues/issue-27942.stderr
@@ -6,11 +6,11 @@ LL |     fn select(&self) -> BufferViewHandle<R>;
    |
    = note: expected type `Resources<'_>`
               found type `Resources<'a>`
-note: the anonymous lifetime #1 defined on the method body at 5:5...
-  --> $DIR/issue-27942.rs:5:5
+note: the anonymous lifetime defined on the method body at 5:15...
+  --> $DIR/issue-27942.rs:5:15
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the trait at 3:18
   --> $DIR/issue-27942.rs:3:18
    |
@@ -30,11 +30,11 @@ note: the lifetime `'a` as defined on the trait at 3:18...
    |
 LL | pub trait Buffer<'a, R: Resources<'a>> {
    |                  ^^
-note: ...does not necessarily outlive the anonymous lifetime #1 defined on the method body at 5:5
-  --> $DIR/issue-27942.rs:5:5
+note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 5:15
+  --> $DIR/issue-27942.rs:5:15
    |
 LL |     fn select(&self) -> BufferViewHandle<R>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/issue-52742.stderr
+++ b/src/test/ui/nll/issue-52742.stderr
@@ -9,11 +9,11 @@ note: ...the reference is valid for the lifetime `'_` as defined on the impl at 
    |
 LL | impl Foo<'_, '_> {
    |          ^^
-note: ...but the borrowed content is only valid for the anonymous lifetime #2 defined on the method body at 13:5
-  --> $DIR/issue-52742.rs:13:5
+note: ...but the borrowed content is only valid for the anonymous lifetime defined on the method body at 13:31
+  --> $DIR/issue-52742.rs:13:31
    |
 LL |     fn take_bar(&mut self, b: Bar<'_>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                               ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-55394.stderr
+++ b/src/test/ui/nll/issue-55394.stderr
@@ -4,11 +4,11 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'s` d
 LL |         Foo { bar }
    |         ^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 8:5...
-  --> $DIR/issue-55394.rs:8:5
+note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 8:17...
+  --> $DIR/issue-55394.rs:8:17
    |
 LL |     fn new(bar: &mut Bar) -> Self {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 ^^^^^^^^
 note: ...so that reference does not outlive borrowed content
   --> $DIR/issue-55394.rs:9:15
    |

--- a/src/test/ui/nll/type-alias-free-regions.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.stderr
@@ -4,11 +4,11 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
 LL |         C { f: b }
    |         ^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 16:5...
-  --> $DIR/type-alias-free-regions.rs:16:5
+note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 16:24...
+  --> $DIR/type-alias-free-regions.rs:16:24
    |
 LL |     fn from_box(b: Box<B>) -> Self {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^
 note: ...so that the expression is assignable
   --> $DIR/type-alias-free-regions.rs:17:16
    |
@@ -35,11 +35,11 @@ error[E0495]: cannot infer an appropriate lifetime due to conflicting requiremen
 LL |         C { f: Box::new(b.0) }
    |                ^^^^^^^^^^^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 26:5...
-  --> $DIR/type-alias-free-regions.rs:26:5
+note: first, the lifetime cannot outlive the anonymous lifetime defined on the method body at 26:23...
+  --> $DIR/type-alias-free-regions.rs:26:23
    |
 LL |     fn from_tuple(b: (B,)) -> Self {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^
 note: ...so that the expression is assignable
   --> $DIR/type-alias-free-regions.rs:27:25
    |

--- a/src/test/ui/regions/regions-infer-paramd-indirect.stderr
+++ b/src/test/ui/regions/regions-infer-paramd-indirect.stderr
@@ -6,11 +6,11 @@ LL |         self.f = b;
    |
    = note: expected struct `Box<Box<&'a isize>>`
               found struct `Box<Box<&isize>>`
-note: the anonymous lifetime #2 defined on the method body at 21:5...
-  --> $DIR/regions-infer-paramd-indirect.rs:21:5
+note: the anonymous lifetime defined on the method body at 21:36...
+  --> $DIR/regions-infer-paramd-indirect.rs:21:36
    |
 LL |     fn set_f_bad(&mut self, b: Box<B>) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    ^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 16:6
   --> $DIR/regions-infer-paramd-indirect.rs:16:6
    |

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.nll.stderr
@@ -7,11 +7,11 @@ LL | |         t.test();
 LL | |     });
    | |______^
    |
-note: the parameter type `T` must be valid for the anonymous lifetime #2 defined on the function body at 19:1...
-  --> $DIR/missing-lifetimes-in-signature-2.rs:19:1
+note: the parameter type `T` must be valid for the anonymous lifetime defined on the function body at 19:24...
+  --> $DIR/missing-lifetimes-in-signature-2.rs:19:24
    |
 LL | fn func<T: Test>(foo: &Foo, t: T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-2.stderr
@@ -6,11 +6,11 @@ LL | fn func<T: Test>(foo: &Foo, t: T) {
 LL |     foo.bar(move |_| {
    |         ^^^
    |
-note: the parameter type `T` must be valid for the anonymous lifetime #2 defined on the function body at 19:1...
-  --> $DIR/missing-lifetimes-in-signature-2.rs:19:1
+note: the parameter type `T` must be valid for the anonymous lifetime defined on the function body at 19:24...
+  --> $DIR/missing-lifetimes-in-signature-2.rs:19:24
    |
 LL | fn func<T: Test>(foo: &Foo, t: T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^
 note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature-2.rs:20:13: 23:6]` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature-2.rs:20:9
    |

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
@@ -25,14 +25,11 @@ error[E0311]: the parameter type `G` may not live long enough
 LL | fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
    |                                     ^^^^^^^^^^^^^^^^^^
    |
-note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the function body at 25:1...
-  --> $DIR/missing-lifetimes-in-signature.rs:25:1
+note: the parameter type `G` must be valid for the anonymous lifetime defined on the function body at 25:26...
+  --> $DIR/missing-lifetimes-in-signature.rs:25:26
    |
-LL | / fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-LL | |
-LL | | where
-LL | |     G: Get<T>
-   | |_____________^
+LL | fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |                          ^^^^^^
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:47:45
@@ -40,14 +37,11 @@ error[E0311]: the parameter type `G` may not live long enough
 LL | fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
    |                                             ^^^^^^^^^^^^^^^^^^
    |
-note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the function body at 47:1...
-  --> $DIR/missing-lifetimes-in-signature.rs:47:1
+note: the parameter type `G` must be valid for the anonymous lifetime defined on the function body at 47:34...
+  --> $DIR/missing-lifetimes-in-signature.rs:47:34
    |
-LL | / fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-LL | |
-LL | | where
-LL | |     G: Get<T>
-   | |_____________^
+LL | fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |                                  ^^^^^^
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:59:58
@@ -55,11 +49,11 @@ error[E0311]: the parameter type `G` may not live long enough
 LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
    |                                                          ^^^^^^^^^^^^^^^^^^
    |
-note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the method body at 59:5...
-  --> $DIR/missing-lifetimes-in-signature.rs:59:5
+note: the parameter type `G` must be valid for the anonymous lifetime defined on the method body at 59:47...
+  --> $DIR/missing-lifetimes-in-signature.rs:59:47
    |
 LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^
 
 error[E0311]: the parameter type `G` may not live long enough
   --> $DIR/missing-lifetimes-in-signature.rs:68:45
@@ -67,14 +61,11 @@ error[E0311]: the parameter type `G` may not live long enough
 LL | fn bat<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the function body at 68:1...
-  --> $DIR/missing-lifetimes-in-signature.rs:68:1
+note: the parameter type `G` must be valid for the anonymous lifetime defined on the function body at 68:34...
+  --> $DIR/missing-lifetimes-in-signature.rs:68:34
    |
-LL | / fn bat<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
-LL | |
-LL | | where
-LL | |     G: Get<T>
-   | |_____________^
+LL | fn bat<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ + 'a
+   |                                  ^^^^^^
 
 error[E0621]: explicit lifetime required in the type of `dest`
   --> $DIR/missing-lifetimes-in-signature.rs:73:5

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -33,14 +33,11 @@ error[E0311]: the parameter type `G` may not live long enough
 LL | fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
    |                                     ^^^^^^^^^^^^^^^^^^
    |
-note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the function body at 25:1...
-  --> $DIR/missing-lifetimes-in-signature.rs:25:1
+note: the parameter type `G` must be valid for the anonymous lifetime defined on the function body at 25:26...
+  --> $DIR/missing-lifetimes-in-signature.rs:25:26
    |
-LL | / fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-LL | |
-LL | | where
-LL | |     G: Get<T>
-   | |_____________^
+LL | fn bar<G, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |                          ^^^^^^
 note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature.rs:30:5: 32:6]` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature.rs:25:37
    |
@@ -57,14 +54,11 @@ error[E0311]: the parameter type `G` may not live long enough
 LL | fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
    |                                             ^^^^^^^^^^^^^^^^^^
    |
-note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the function body at 47:1...
-  --> $DIR/missing-lifetimes-in-signature.rs:47:1
+note: the parameter type `G` must be valid for the anonymous lifetime defined on the function body at 47:34...
+  --> $DIR/missing-lifetimes-in-signature.rs:47:34
    |
-LL | / fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
-LL | |
-LL | | where
-LL | |     G: Get<T>
-   | |_____________^
+LL | fn qux<'a, G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |                                  ^^^^^^
 note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature.rs:52:5: 54:6]` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature.rs:47:45
    |
@@ -81,11 +75,11 @@ error[E0311]: the parameter type `G` may not live long enough
 LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
    |                                                          ^^^^^^^^^^^^^^^^^^
    |
-note: the parameter type `G` must be valid for the anonymous lifetime #1 defined on the method body at 59:5...
-  --> $DIR/missing-lifetimes-in-signature.rs:59:5
+note: the parameter type `G` must be valid for the anonymous lifetime defined on the method body at 59:47...
+  --> $DIR/missing-lifetimes-in-signature.rs:59:47
    |
 LL |     fn qux<'b, G: Get<T> + 'b, T>(g: G, dest: &mut T) -> impl FnOnce() + '_ {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^
 note: ...so that the type `[closure@$DIR/missing-lifetimes-in-signature.rs:61:9: 63:10]` will meet its required lifetime bounds
   --> $DIR/missing-lifetimes-in-signature.rs:59:58
    |

--- a/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
+++ b/src/test/ui/ufcs/ufcs-explicit-self-bad.stderr
@@ -33,11 +33,11 @@ LL |     fn dummy2(self: &Bar<T>) {}
    |
    = note: expected reference `&'a Bar<T>`
               found reference `&Bar<T>`
-note: the anonymous lifetime #1 defined on the method body at 37:5...
-  --> $DIR/ufcs-explicit-self-bad.rs:37:5
+note: the anonymous lifetime defined on the method body at 37:21...
+  --> $DIR/ufcs-explicit-self-bad.rs:37:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 35:6
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
@@ -57,11 +57,11 @@ note: the lifetime `'a` as defined on the impl at 35:6...
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
-note: ...does not necessarily outlive the anonymous lifetime #1 defined on the method body at 37:5
-  --> $DIR/ufcs-explicit-self-bad.rs:37:5
+note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 37:21
+  --> $DIR/ufcs-explicit-self-bad.rs:37:21
    |
 LL |     fn dummy2(self: &Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
 
 error[E0308]: mismatched `self` parameter type
   --> $DIR/ufcs-explicit-self-bad.rs:39:21
@@ -71,11 +71,11 @@ LL |     fn dummy3(self: &&Bar<T>) {}
    |
    = note: expected reference `&'a Bar<T>`
               found reference `&Bar<T>`
-note: the anonymous lifetime #2 defined on the method body at 39:5...
-  --> $DIR/ufcs-explicit-self-bad.rs:39:5
+note: the anonymous lifetime defined on the method body at 39:22...
+  --> $DIR/ufcs-explicit-self-bad.rs:39:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^
 note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 35:6
   --> $DIR/ufcs-explicit-self-bad.rs:35:6
    |
@@ -95,11 +95,11 @@ note: the lifetime `'a` as defined on the impl at 35:6...
    |
 LL | impl<'a, T> SomeTrait for &'a Bar<T> {
    |      ^^
-note: ...does not necessarily outlive the anonymous lifetime #2 defined on the method body at 39:5
-  --> $DIR/ufcs-explicit-self-bad.rs:39:5
+note: ...does not necessarily outlive the anonymous lifetime defined on the method body at 39:22
+  --> $DIR/ufcs-explicit-self-bad.rs:39:22
    |
 LL |     fn dummy3(self: &&Bar<T>) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                      ^^^^^^^
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Improvement for  #81650
Cc #81995

Message after this improvement:
(Improve note in the middle)

```
error[E0311]: the parameter type `T` may not live long enough
  --> src/main.rs:25:11
   |
24 | fn play_with<T: Animal + Send>(scope: &Scope, animal: T) {
   |              -- help: consider adding an explicit lifetime bound...: `T: 'a +`
25 |     scope.spawn(move |_| {
   |           ^^^^^
   |
note: the parameter type `T` must be valid for the anonymous lifetime defined on the function body at 24:40...
  --> src/main.rs:24:40
   |
24 | fn play_with<T: Animal + Send>(scope: &Scope, animal: T) {
   |                                        ^^^^^
note: ...so that the type `[closure@src/main.rs:25:17: 27:6]` will meet its required lifetime bounds
  --> src/main.rs:25:11
   |
25 |     scope.spawn(move |_| {
   |           ^^^^^
```

r? @estebank 