### PR TITLE
Fix sizes of repr(C) enums on hexagon

### DIFF
--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -130,6 +130,7 @@ impl IntegerExt for Integer {
 
         if repr.c() {
             match &tcx.sess.target.arch[..] {
+                "hexagon" => min_from_extern = Some(I8),
                 // WARNING: the ARM EABI has two variants; the one corresponding
                 // to `at_least == I32` appears to be used on Linux and NetBSD,
                 // but some systems may use the variant corresponding to no

--- a/src/test/ui/layout/hexagon-enum.rs
+++ b/src/test/ui/layout/hexagon-enum.rs
@@ -1,0 +1,33 @@
+// compile-flags: --target hexagon-unknown-linux-musl
+//
+// Verify that the hexagon targets implement the repr(C) for enums correctly.
+//
+// See #82100
+#![feature(never_type, rustc_attrs, type_alias_impl_trait, no_core, lang_items)]
+#![crate_type = "lib"]
+#![no_core]
+
+#[lang="sized"]
+trait Sized {}
+
+#[rustc_layout(debug)]
+#[repr(C)]
+enum A { Apple } //~ ERROR: layout_of
+
+#[rustc_layout(debug)]
+#[repr(C)]
+enum B { Banana = 255, } //~ ERROR: layout_of
+
+#[rustc_layout(debug)]
+#[repr(C)]
+enum C { Chaenomeles = 256, } //~ ERROR: layout_of
+
+#[rustc_layout(debug)]
+#[repr(C)]
+enum P { Peach = 0x1000_0000isize, } //~ ERROR: layout_of
+
+const TANGERINE: usize = 0x8100_0000; // hack to get negative numbers without negation operator!
+
+#[rustc_layout(debug)]
+#[repr(C)]
+enum T { Tangerine = TANGERINE as isize } //~ ERROR: layout_of

--- a/src/test/ui/layout/hexagon-enum.stderr
+++ b/src/test/ui/layout/hexagon-enum.stderr
@@ -1,0 +1,442 @@
+error: layout_of(A) = Layout {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+        ],
+        memory_index: [
+            0,
+        ],
+    },
+    variants: Multiple {
+        tag: Scalar {
+            value: Int(
+                I8,
+                false,
+            ),
+            valid_range: 0..=0,
+        },
+        tag_encoding: Direct,
+        tag_field: 0,
+        variants: [
+            Layout {
+                fields: Arbitrary {
+                    offsets: [],
+                    memory_index: [],
+                },
+                variants: Single {
+                    index: 0,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 0,
+                    },
+                    pref: Align {
+                        pow2: 0,
+                    },
+                },
+                size: Size {
+                    raw: 1,
+                },
+            },
+        ],
+    },
+    abi: Scalar(
+        Scalar {
+            value: Int(
+                I8,
+                false,
+            ),
+            valid_range: 0..=0,
+        },
+    ),
+    largest_niche: Some(
+        Niche {
+            offset: Size {
+                raw: 0,
+            },
+            scalar: Scalar {
+                value: Int(
+                    I8,
+                    false,
+                ),
+                valid_range: 0..=0,
+            },
+        },
+    ),
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 0,
+        },
+        pref: Align {
+            pow2: 0,
+        },
+    },
+    size: Size {
+        raw: 1,
+    },
+}
+  --> $DIR/hexagon-enum.rs:15:1
+   |
+LL | enum A { Apple }
+   | ^^^^^^^^^^^^^^^^
+
+error: layout_of(B) = Layout {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+        ],
+        memory_index: [
+            0,
+        ],
+    },
+    variants: Multiple {
+        tag: Scalar {
+            value: Int(
+                I8,
+                false,
+            ),
+            valid_range: 255..=255,
+        },
+        tag_encoding: Direct,
+        tag_field: 0,
+        variants: [
+            Layout {
+                fields: Arbitrary {
+                    offsets: [],
+                    memory_index: [],
+                },
+                variants: Single {
+                    index: 0,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 0,
+                    },
+                    pref: Align {
+                        pow2: 0,
+                    },
+                },
+                size: Size {
+                    raw: 1,
+                },
+            },
+        ],
+    },
+    abi: Scalar(
+        Scalar {
+            value: Int(
+                I8,
+                false,
+            ),
+            valid_range: 255..=255,
+        },
+    ),
+    largest_niche: Some(
+        Niche {
+            offset: Size {
+                raw: 0,
+            },
+            scalar: Scalar {
+                value: Int(
+                    I8,
+                    false,
+                ),
+                valid_range: 255..=255,
+            },
+        },
+    ),
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 0,
+        },
+        pref: Align {
+            pow2: 0,
+        },
+    },
+    size: Size {
+        raw: 1,
+    },
+}
+  --> $DIR/hexagon-enum.rs:19:1
+   |
+LL | enum B { Banana = 255, }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: layout_of(C) = Layout {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+        ],
+        memory_index: [
+            0,
+        ],
+    },
+    variants: Multiple {
+        tag: Scalar {
+            value: Int(
+                I16,
+                false,
+            ),
+            valid_range: 256..=256,
+        },
+        tag_encoding: Direct,
+        tag_field: 0,
+        variants: [
+            Layout {
+                fields: Arbitrary {
+                    offsets: [],
+                    memory_index: [],
+                },
+                variants: Single {
+                    index: 0,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 1,
+                    },
+                    pref: Align {
+                        pow2: 1,
+                    },
+                },
+                size: Size {
+                    raw: 2,
+                },
+            },
+        ],
+    },
+    abi: Scalar(
+        Scalar {
+            value: Int(
+                I16,
+                false,
+            ),
+            valid_range: 256..=256,
+        },
+    ),
+    largest_niche: Some(
+        Niche {
+            offset: Size {
+                raw: 0,
+            },
+            scalar: Scalar {
+                value: Int(
+                    I16,
+                    false,
+                ),
+                valid_range: 256..=256,
+            },
+        },
+    ),
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 1,
+        },
+        pref: Align {
+            pow2: 1,
+        },
+    },
+    size: Size {
+        raw: 2,
+    },
+}
+  --> $DIR/hexagon-enum.rs:23:1
+   |
+LL | enum C { Chaenomeles = 256, }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: layout_of(P) = Layout {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+        ],
+        memory_index: [
+            0,
+        ],
+    },
+    variants: Multiple {
+        tag: Scalar {
+            value: Int(
+                I32,
+                false,
+            ),
+            valid_range: 268435456..=268435456,
+        },
+        tag_encoding: Direct,
+        tag_field: 0,
+        variants: [
+            Layout {
+                fields: Arbitrary {
+                    offsets: [],
+                    memory_index: [],
+                },
+                variants: Single {
+                    index: 0,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 2,
+                    },
+                    pref: Align {
+                        pow2: 2,
+                    },
+                },
+                size: Size {
+                    raw: 4,
+                },
+            },
+        ],
+    },
+    abi: Scalar(
+        Scalar {
+            value: Int(
+                I32,
+                false,
+            ),
+            valid_range: 268435456..=268435456,
+        },
+    ),
+    largest_niche: Some(
+        Niche {
+            offset: Size {
+                raw: 0,
+            },
+            scalar: Scalar {
+                value: Int(
+                    I32,
+                    false,
+                ),
+                valid_range: 268435456..=268435456,
+            },
+        },
+    ),
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 2,
+        },
+        pref: Align {
+            pow2: 2,
+        },
+    },
+    size: Size {
+        raw: 4,
+    },
+}
+  --> $DIR/hexagon-enum.rs:27:1
+   |
+LL | enum P { Peach = 0x1000_0000isize, }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: layout_of(T) = Layout {
+    fields: Arbitrary {
+        offsets: [
+            Size {
+                raw: 0,
+            },
+        ],
+        memory_index: [
+            0,
+        ],
+    },
+    variants: Multiple {
+        tag: Scalar {
+            value: Int(
+                I32,
+                true,
+            ),
+            valid_range: 2164260864..=2164260864,
+        },
+        tag_encoding: Direct,
+        tag_field: 0,
+        variants: [
+            Layout {
+                fields: Arbitrary {
+                    offsets: [],
+                    memory_index: [],
+                },
+                variants: Single {
+                    index: 0,
+                },
+                abi: Aggregate {
+                    sized: true,
+                },
+                largest_niche: None,
+                align: AbiAndPrefAlign {
+                    abi: Align {
+                        pow2: 2,
+                    },
+                    pref: Align {
+                        pow2: 2,
+                    },
+                },
+                size: Size {
+                    raw: 4,
+                },
+            },
+        ],
+    },
+    abi: Scalar(
+        Scalar {
+            value: Int(
+                I32,
+                true,
+            ),
+            valid_range: 2164260864..=2164260864,
+        },
+    ),
+    largest_niche: Some(
+        Niche {
+            offset: Size {
+                raw: 0,
+            },
+            scalar: Scalar {
+                value: Int(
+                    I32,
+                    true,
+                ),
+                valid_range: 2164260864..=2164260864,
+            },
+        },
+    ),
+    align: AbiAndPrefAlign {
+        abi: Align {
+            pow2: 2,
+        },
+        pref: Align {
+            pow2: 2,
+        },
+    },
+    size: Size {
+        raw: 4,
+    },
+}
+  --> $DIR/hexagon-enum.rs:33:1
+   |
+LL | enum T { Tangerine = TANGERINE as isize }
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Enums on hexagon use a smallest size (but at least 1 byte) that fits all
the enumeration values. This is unlike many other ABIs where enums are
at least 32 bits.

Fixes #82100