### PR TITLE
disable atomic_max/min tests in Miri

### DIFF
--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -61,6 +61,7 @@ fn uint_xor() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_min
 fn uint_min() {
     let x = AtomicUsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -71,6 +72,7 @@ fn uint_min() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_max
 fn uint_max() {
     let x = AtomicUsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
@@ -109,6 +111,7 @@ fn int_xor() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_min
 fn int_min() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -119,6 +122,7 @@ fn int_min() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_max
 fn int_max() {
     let x = AtomicIsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);


### PR DESCRIPTION
Disable some tests that currently [fail in Miri](https://travis-ci.com/github/RalfJung/miri-test-libstd/builds/217788631).