### PR TITLE
Less allocations in rustdoc

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::path::PathBuf;
 
 use rustc_data_structures::fx::FxHashMap;
@@ -42,7 +43,9 @@ crate fn render<T: Print, S: Print>(
     style_files: &[StylePath],
 ) -> String {
     let static_root_path = page.static_root_path.unwrap_or(page.root_path);
-    format!(
+    let mut result = String::with_capacity(4096);
+    write!(
+        &mut result,
         "<!DOCTYPE html>\
 <html lang=\"en\">\
 <head>\
@@ -55,13 +58,76 @@ crate fn render<T: Print, S: Print>(
     <link rel=\"stylesheet\" type=\"text/css\" href=\"{static_root_path}normalize{suffix}.css\">\
     <link rel=\"stylesheet\" type=\"text/css\" href=\"{static_root_path}rustdoc{suffix}.css\" \
           id=\"mainThemeStyle\">\
-    {style_files}\
-    <script id=\"default-settings\"{default_settings}></script>\
+    ",
+        description = page.description,
+        keywords = page.keywords,
+        title = page.title,
+        static_root_path = static_root_path,
+        suffix = page.resource_suffix,
+    )
+    .unwrap();
+
+    for e in style_files
+        .iter()
+        .filter_map(|t| {
+            if let Some(stem) = t.path.file_stem() { Some((stem, t.disabled)) } else { None }
+        })
+        .filter_map(|t| if let Some(path) = t.0.to_str() { Some((path, t.1)) } else { None })
+        .map(|t| {
+            format!(
+                r#"<link rel="stylesheet" type="text/css" href="{}.css" {} {}>"#,
+                Escape(&format!("{}{}{}", static_root_path, t.0, page.resource_suffix)),
+                if t.1 { "disabled" } else { "" },
+                if t.0 == "light" { "id=\"themeStyle\"" } else { "" }
+            )
+        })
+    {
+        write!(&mut result, "{}<script id=\"default-settings\"", e).unwrap();
+    }
+
+    for (k, v) in layout.default_settings.iter() {
+        write!(&mut result, r#" data-{}="{}""#, k.replace('-', "_"), Escape(v)).unwrap();
+    }
+
+    write!(
+        &mut result,
+        "></script>\
     <script src=\"{static_root_path}storage{suffix}.js\"></script>\
-    <noscript><link rel=\"stylesheet\" href=\"{static_root_path}noscript{suffix}.css\"></noscript>\
-    {css_extension}\
-    {favicon}\
-    {in_header}\
+    <noscript><link rel=\"stylesheet\" href=\"{static_root_path}noscript{suffix}.css\"></noscript>",
+        static_root_path = static_root_path,
+        suffix = page.resource_suffix,
+    )
+    .unwrap();
+
+    if layout.css_file_extension.is_some() {
+        write!(
+            &mut result,
+            "<link rel=\"stylesheet\" \
+                       type=\"text/css\" \
+                       href=\"{static_root_path}theme{suffix}.css\">",
+            static_root_path = static_root_path,
+            suffix = page.resource_suffix
+        )
+        .unwrap();
+    }
+
+    if layout.favicon.is_empty() {
+        write!(
+            &mut result,
+            r##"<link rel="icon" type="image/svg+xml" href="{static_root_path}favicon{suffix}.svg">
+<link rel="alternate icon" type="image/png" href="{static_root_path}favicon-16x16{suffix}.png">
+<link rel="alternate icon" type="image/png" href="{static_root_path}favicon-32x32{suffix}.png">"##,
+            static_root_path = static_root_path,
+            suffix = page.resource_suffix
+        )
+        .unwrap();
+    } else {
+        write!(&mut result, r#"<link rel="shortcut icon" href="{}">"#, layout.favicon).unwrap();
+    }
+
+    write!(
+        &mut result,
+        "{in_header}\
     <style type=\"text/css\">\
     #crate-search{{background-image:url(\"{static_root_path}down-arrow{suffix}.svg\");}}\
     </style>\
@@ -76,8 +142,42 @@ crate fn render<T: Print, S: Print>(
     {before_content}\
     <nav class=\"sidebar\">\
         <div class=\"sidebar-menu\">&#9776;</div>\
-        {logo}\
-        {sidebar}\
+    ",
+        static_root_path = static_root_path,
+        suffix = page.resource_suffix,
+        css_class = page.css_class,
+        in_header = layout.external_html.in_header,
+        before_content = layout.external_html.before_content,
+    )
+    .unwrap();
+
+    if layout.logo.is_empty() {
+        write!(
+            &mut result,
+            "<a href='{root}{path}index.html'>\
+                     <div class='logo-container rust-logo'>\
+                     <img src='{static_root_path}rust-logo{suffix}.png' alt='logo'></div></a>",
+            root = page.root_path,
+            path = ensure_trailing_slash(&layout.krate),
+            static_root_path = static_root_path,
+            suffix = page.resource_suffix
+        )
+        .unwrap();
+    } else {
+        write!(
+            &mut result,
+            "<a href='{root}{path}index.html'>\
+                     <div class='logo-container'><img src='{logo}' alt='logo'></div></a>",
+            root = page.root_path,
+            path = ensure_trailing_slash(&layout.krate),
+            logo = layout.logo
+        )
+        .unwrap();
+    }
+
+    write!(
+        &mut result,
+        "{sidebar}\
     </nav>\
     <div class=\"theme-picker\">\
         <button id=\"theme-picker\" aria-label=\"Pick another theme!\" aria-haspopup=\"menu\">\
@@ -91,8 +191,27 @@ crate fn render<T: Print, S: Print>(
     <nav class=\"sub\">\
         <form class=\"search-form\">\
             <div class=\"search-container\">\
-                <div>{filter_crates}\
-                    <input class=\"search-input\" name=\"search\" \
+                <div>",
+        static_root_path = static_root_path,
+        suffix = page.resource_suffix,
+        sidebar = Buffer::html().to_display(sidebar),
+    )
+    .unwrap();
+
+    if layout.generate_search_filter {
+        write!(
+            &mut result,
+            "<select id=\"crate-search\">\
+                 <option value=\"All crates\">All crates</option>\
+             </select>\
+             "
+        )
+        .unwrap();
+    }
+
+    write!(
+        &mut result,
+        "<input class=\"search-input\" name=\"search\" \
                            disabled \
                            autocomplete=\"off\" \
                            spellcheck=\"false\" \
@@ -114,112 +233,45 @@ crate fn render<T: Print, S: Print>(
     {after_content}\
     <div id=\"rustdoc-vars\" data-root-path=\"{root_path}\" data-current-crate=\"{krate}\"></div>
     <script src=\"{static_root_path}main{suffix}.js\"></script>\
-    {extra_scripts}\
+    ",
+        static_root_path = static_root_path,
+        suffix = page.resource_suffix,
+        root_path = page.root_path,
+        after_content = layout.external_html.after_content,
+        content = Buffer::html().to_display(t),
+        krate = layout.krate,
+    )
+    .unwrap();
+    for e in page.static_extra_scripts.iter() {
+        write!(
+            &mut result,
+            "<script src=\"{static_root_path}{extra_script}.js\"></script>",
+            static_root_path = static_root_path,
+            extra_script = e
+        )
+        .unwrap();
+    }
+    for e in page.extra_scripts.iter() {
+        write!(
+            &mut result,
+            "<script src=\"{root_path}{extra_script}.js\"></script>",
+            root_path = page.root_path,
+            extra_script = e
+        )
+        .unwrap();
+    }
+
+    write!(
+        &mut result,
+        "\
     <script defer src=\"{root_path}search-index{suffix}.js\"></script>\
 </body>\
 </html>",
-        css_extension = if layout.css_file_extension.is_some() {
-            format!(
-                "<link rel=\"stylesheet\" \
-                       type=\"text/css\" \
-                       href=\"{static_root_path}theme{suffix}.css\">",
-                static_root_path = static_root_path,
-                suffix = page.resource_suffix
-            )
-        } else {
-            String::new()
-        },
-        content = Buffer::html().to_display(t),
-        static_root_path = static_root_path,
-        root_path = page.root_path,
-        css_class = page.css_class,
-        logo = {
-            if layout.logo.is_empty() {
-                format!(
-                    "<a href='{root}{path}index.html'>\
-                     <div class='logo-container rust-logo'>\
-                     <img src='{static_root_path}rust-logo{suffix}.png' alt='logo'></div></a>",
-                    root = page.root_path,
-                    path = ensure_trailing_slash(&layout.krate),
-                    static_root_path = static_root_path,
-                    suffix = page.resource_suffix
-                )
-            } else {
-                format!(
-                    "<a href='{root}{path}index.html'>\
-                     <div class='logo-container'><img src='{logo}' alt='logo'></div></a>",
-                    root = page.root_path,
-                    path = ensure_trailing_slash(&layout.krate),
-                    logo = layout.logo
-                )
-            }
-        },
-        title = page.title,
-        description = page.description,
-        keywords = page.keywords,
-        favicon = if layout.favicon.is_empty() {
-            format!(
-                r##"<link rel="icon" type="image/svg+xml" href="{static_root_path}favicon{suffix}.svg">
-<link rel="alternate icon" type="image/png" href="{static_root_path}favicon-16x16{suffix}.png">
-<link rel="alternate icon" type="image/png" href="{static_root_path}favicon-32x32{suffix}.png">"##,
-                static_root_path = static_root_path,
-                suffix = page.resource_suffix
-            )
-        } else {
-            format!(r#"<link rel="shortcut icon" href="{}">"#, layout.favicon)
-        },
-        in_header = layout.external_html.in_header,
-        before_content = layout.external_html.before_content,
-        after_content = layout.external_html.after_content,
-        sidebar = Buffer::html().to_display(sidebar),
-        krate = layout.krate,
-        default_settings = layout
-            .default_settings
-            .iter()
-            .map(|(k, v)| format!(r#" data-{}="{}""#, k.replace('-', "_"), Escape(v)))
-            .collect::<String>(),
-        style_files = style_files
-            .iter()
-            .filter_map(|t| {
-                if let Some(stem) = t.path.file_stem() { Some((stem, t.disabled)) } else { None }
-            })
-            .filter_map(|t| {
-                if let Some(path) = t.0.to_str() { Some((path, t.1)) } else { None }
-            })
-            .map(|t| format!(
-                r#"<link rel="stylesheet" type="text/css" href="{}.css" {} {}>"#,
-                Escape(&format!("{}{}{}", static_root_path, t.0, page.resource_suffix)),
-                if t.1 { "disabled" } else { "" },
-                if t.0 == "light" { "id=\"themeStyle\"" } else { "" }
-            ))
-            .collect::<String>(),
         suffix = page.resource_suffix,
-        extra_scripts = page
-            .static_extra_scripts
-            .iter()
-            .map(|e| {
-                format!(
-                    "<script src=\"{static_root_path}{extra_script}.js\"></script>",
-                    static_root_path = static_root_path,
-                    extra_script = e
-                )
-            })
-            .chain(page.extra_scripts.iter().map(|e| {
-                format!(
-                    "<script src=\"{root_path}{extra_script}.js\"></script>",
-                    root_path = page.root_path,
-                    extra_script = e
-                )
-            }))
-            .collect::<String>(),
-        filter_crates = if layout.generate_search_filter {
-            "<select id=\"crate-search\">\
-                 <option value=\"All crates\">All crates</option>\
-             </select>"
-        } else {
-            ""
-        },
+        root_path = page.root_path
     )
+    .unwrap();
+    result
 }
 
 crate fn redirect(url: &str) -> String {

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -82,8 +82,9 @@ crate fn render<T: Print, S: Print>(
             )
         })
     {
-        write!(&mut result, "{}<script id=\"default-settings\"", e).unwrap();
+        write!(&mut result, "{}", e).unwrap();
     }
+    writeln!(&mut result, "<script id=\"default-settings\"").unwrap();
 
     for (k, v) in layout.default_settings.iter() {
         write!(&mut result, r#" data-{}="{}""#, k.replace('-', "_"), Escape(v)).unwrap();

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -562,7 +562,8 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             sidebar,
             |buf: &mut Buffer| all.print(buf),
             &self.shared.style_files,
-        );
+        )
+        .expect("Failed to render layout");
         self.shared.fs.write(&final_file, v.as_bytes())?;
 
         // Generating settings page.
@@ -583,7 +584,8 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 &self.shared.style_files,
             )?,
             &style_files,
-        );
+        )
+        .expect("Failed to render layout");
         self.shared.fs.write(&settings_file, v.as_bytes())?;
 
         // Flush pending errors.
@@ -1090,7 +1092,8 @@ themePicker.onblur = handleThemeButtonsBlur;
                     })
                     .collect::<String>()
             );
-            let v = layout::render(&cx.shared.layout, &page, "", content, &cx.shared.style_files);
+            let v = layout::render(&cx.shared.layout, &page, "", content, &cx.shared.style_files)
+                .expect("Failed to render layout");
             cx.shared.fs.write(&dst, v.as_bytes())?;
         }
     }
@@ -1615,6 +1618,7 @@ impl Context<'_> {
                 |buf: &mut _| print_item(self, it, buf),
                 &self.shared.style_files,
             )
+            .expect("Failed to render layout")
         } else {
             let mut url = self.root_path();
             if let Some(&(ref names, ty)) = self.cache.paths.get(&it.def_id) {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -4263,8 +4263,8 @@ fn get_next_url(buffer: &mut String, used_links: &mut FxHashSet<String>, mut url
     let mut add = 1;
     url.push_str("-0");
     while {
-        let mut number = add;
-        let mut num_digits = 0;
+        let mut number = (add - 1) / 10;
+        let mut num_digits = 1;
         while number != 0 {
             number = number / 10;
             num_digits += 1;

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -134,7 +134,8 @@ impl SourceCollector<'_, '_> {
             "",
             |buf: &mut _| print_src(buf, contents, self.scx.edition),
             &self.scx.style_files,
-        );
+        )
+        .expect("Failed to render layout");
         self.scx.fs.write(&cur, v.as_bytes())?;
         self.scx.local_sources.insert(p, href);
         Ok(())

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -20,7 +20,8 @@ crate fn render(
     krate: clean::Crate,
 ) -> Result<clean::Crate, Error> {
     info!("emitting source files");
-    let dst = dst.join("src").join(&*krate.name.as_str());
+    let mut dst = dst.join("src");
+    dst.push(&*krate.name.as_str());
     scx.ensure_dir(&dst)?;
     let mut folder = SourceCollector { dst, scx };
     Ok(folder.fold_crate(krate))


### PR DESCRIPTION
This change removes many temporary allocations when rendering items in rustdoc. Unfortunately this doesn't seem to have a big impact on speed performance when I test locally (rendering items remains at a comparable percentage of total time). This should help memory utilization a bit, but I've not been able to confirm this yet.

r? @jyn514 