### PR TITLE
rustbuild: print out env vars on verbose rustc invocations

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -139,6 +139,12 @@ fn main() {
     }
 
     if verbose > 1 {
+        let rust_env_vars =
+            env::vars().filter(|(k, _)| k.starts_with("RUST") || k.starts_with("CARGO"));
+        for (i, (k, v)) in rust_env_vars.enumerate() {
+            eprintln!("rustc env[{}]: {:?}={:?}", i, k, v);
+        }
+        eprintln!("rustc working directory: {}", env::current_dir().unwrap().display());
         eprintln!(
             "rustc command: {:?}={:?} {:?}",
             bootstrap::util::dylib_path_var(),


### PR DESCRIPTION
Print out environment variables related to Rust on sufficiently verbose rustc invocations.

Output is filtered via heuristic of only printing environment variables whose keys start with "RUST" or "CARGO." This filtering is mostly motivated by my not caring to see e.g. "PATH" in my own output, though it is also motivated as a way to try to avoid printing out personal secrets like github keys that people might have stored in their environments for better or for worse, especially since build output is often pasted into bug reports or gists.

Fix #38686.

<details>

<summary>Click here to see sample output</summary>

Sample output looks like:

```
...
      Fresh core v0.0.0 (/home/pnkfelix/Dev/Rust/rust.git/library/core)
rustc env[0]: "CARGO"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/bin/cargo"
rustc env[1]: "CARGO_CRATE_NAME"="core"
rustc env[2]: "CARGO_INCREMENTAL"="0"
rustc env[3]: "CARGO_MAKEFLAGS"="--jobserver-fds=5,6 -j --jobserver-auth=5,6 -j"
rustc env[4]: "CARGO_MANIFEST_DIR"="/home/pnkfelix/Dev/Rust/rust.git/library/core"
rustc env[5]: "CARGO_PKG_AUTHORS"="The Rust Project Developers"
rustc env[6]: "CARGO_PKG_DESCRIPTION"=""
rustc env[7]: "CARGO_PKG_HOMEPAGE"=""
rustc env[8]: "CARGO_PKG_LICENSE"=""
rustc env[9]: "CARGO_PKG_LICENSE_FILE"=""
rustc env[10]: "CARGO_PKG_NAME"="core"
rustc env[11]: "CARGO_PKG_REPOSITORY"=""
rustc env[12]: "CARGO_PKG_VERSION"="0.0.0"
rustc env[13]: "CARGO_PKG_VERSION_MAJOR"="0"
rustc env[14]: "CARGO_PKG_VERSION_MINOR"="0"
rustc env[15]: "CARGO_PKG_VERSION_PATCH"="0"
rustc env[16]: "CARGO_PKG_VERSION_PRE"=""
rustc env[17]: "CARGO_PROFILE_RELEASE_CODEGEN_UNITS"="256"
rustc env[18]: "CARGO_PROFILE_RELEASE_DEBUG"="0"
rustc env[19]: "CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS"="false"
rustc env[20]: "CARGO_TARGET_DIR"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0-std"
rustc env[21]: "RUSTBUILD_NATIVE_DIR"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/native"
rustc env[22]: "RUSTC"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/bootstrap/debug/rustc"
rustc env[23]: "RUSTC_BOOTSTRAP"="1"
rustc env[24]: "RUSTC_BREAK_ON_ICE"="1"
rustc env[25]: "RUSTC_ERROR_METADATA_DST"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/tmp/extended-error-metadata"
rustc env[26]: "RUSTC_FORCE_UNSTABLE"="1"
rustc env[27]: "RUSTC_INSTALL_BINDIR"="bin"
rustc env[28]: "RUSTC_LIBDIR"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/lib"
rustc env[29]: "RUSTC_LINT_FLAGS"="-Wrust_2018_idioms -Wunused_lifetimes -Dwarnings"
rustc env[30]: "RUSTC_PRINT_STEP_TIMINGS"="1"
rustc env[31]: "RUSTC_REAL"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/bin/rustc"
rustc env[32]: "RUSTC_SNAPSHOT"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/bin/rustc"
rustc env[33]: "RUSTC_SNAPSHOT_LIBDIR"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/lib"
rustc env[34]: "RUSTC_STAGE"="0"
rustc env[35]: "RUSTC_SYSROOT"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0-sysroot"
rustc env[36]: "RUSTC_VERBOSE"="2"
rustc env[37]: "RUSTDOC"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/bootstrap/debug/rustdoc"
rustc env[38]: "RUSTDOCFLAGS"="--cfg=bootstrap -Dwarnings -Winvalid_codeblock_attributes --crate-version 1.52.0-dev"
rustc env[39]: "RUSTDOC_REAL"="/path/to/nowhere/rustdoc/not/required"
rustc env[40]: "RUSTFLAGS"="--cfg=bootstrap -Zmacro-backtrace -Clink-args=-Wl,-rpath,$ORIGIN/../lib -Cprefer-dynamic"
rustc env[41]: "RUST_COMPILER_RT_ROOT"="/home/pnkfelix/Dev/Rust/rust.git/src/llvm-project/compiler-rt"
rustc env[42]: "RUST_TEST_THREADS"="128"
rustc working directory: /home/pnkfelix/Dev/Rust/rust.git
rustc command: "LD_LIBRARY_PATH"="/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/lib:/home/pnkfelix/Dev/Rust/rust.git/objdi\
r-default/build/x86_64-unknown-linux-gnu/stage0-std/release/deps:/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/lib" "/home\
/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0/bin/rustc" "--crate-name" "core" "--edition=2018" "library/core/src/lib.rs" "--er\
ror-format=json" "--json=diagnostic-rendered-ansi,artifacts" "--crate-type" "lib" "--emit=dep-info,metadata,link" "-C" "opt-level=3" "-C" "embed-bitcode=no" "-C" \
"codegen-units=256" "-C" "debuginfo=0" "-C" "metadata=6748933694d8be19" "-C" "extra-filename=-6748933694d8be19" "--out-dir" "/home/pnkfelix/Dev/Rust/rust.git/objd\
ir-default/build/x86_64-unknown-linux-gnu/stage0-std/x86_64-unknown-linux-gnu/release/deps" "--target" "x86_64-unknown-linux-gnu" "-L" "dependency=/home/pnkfelix/\
Dev/Rust/rust.git/objdir-default/build/x86_64-unknown-linux-gnu/stage0-std/x86_64-unknown-linux-gnu/release/deps" "-L" "dependency=/home/pnkfelix/Dev/Rust/rust.gi\
t/objdir-default/build/x86_64-unknown-linux-gnu/stage0-std/release/deps" "--cfg=bootstrap" "-Zmacro-backtrace" "-Clink-args=-Wl,-rpath,$ORIGIN/../lib" "-Cprefer-d\
ynamic" "-Z" "binary-dep-depinfo" "-Wrust_2018_idioms" "-Wunused_lifetimes" "-Dwarnings" "--sysroot" "/home/pnkfelix/Dev/Rust/rust.git/objdir-default/build/x86_64\
-unknown-linux-gnu/stage0-sysroot" "-Z" "force-unstable-if-unmarked"
...
```