### PR TITLE
Fixes to ExitStatus and its docs

### DIFF
--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -186,12 +186,20 @@ impl CommandExt for process::Command {
 
 /// Unix-specific extensions to [`process::ExitStatus`].
 ///
+/// On Unix, `ExitStatus` **does not necessarily represent an exit status**, as passed to the
+/// `exit` system call or returned by [`ExitStatus::code()`](crate::process::ExitStatus::code).
+/// It represents **any wait status**, as returned by one of the `wait` family of system calls.
+///
+/// This is because a Unix wait status (a Rust `ExitStatus`) can represent a Unix exit status, but
+/// can also represent other kinds of process event.
+///
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait ExitStatusExt: Sealed {
-    /// Creates a new `ExitStatus` from the raw underlying `i32` return value of
-    /// a process.
+    /// Creates a new `ExitStatus` from the raw underlying integer status value from `wait`
+    ///
+    /// The value should be a **wait status, not an exit status**.
     #[stable(feature = "exit_status_from", since = "1.12.0")]
     fn from_raw(raw: i32) -> Self;
 
@@ -220,6 +228,8 @@ pub trait ExitStatusExt: Sealed {
     fn continued(&self) -> bool;
 
     /// Returns the underlying raw `wait` status.
+    ///
+    /// The returned integer is a **wait status, not an exit status**.
     #[unstable(feature = "unix_process_wait_more", issue = "80695")]
     fn into_raw(self) -> i32;
 }

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -527,9 +527,18 @@ impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(code) = self.code() {
             write!(f, "exit code: {}", code)
+        } else if let Some(signal) = self.signal() {
+            if self.core_dumped() {
+                write!(f, "signal: {} (core dumped)", signal)
+            } else {
+                write!(f, "signal: {}", signal)
+            }
+        } else if let Some(signal) = self.stopped_signal() {
+            write!(f, "stopped (not terminated) by signal: {}", signal)
+        } else if self.continued() {
+            write!(f, "continued (WIFCONTINUED)")
         } else {
-            let signal = self.signal().unwrap();
-            write!(f, "signal: {}", signal)
+            write!(f, "unrecognised wait status: {} {:#x}", self.0, self.0)
         }
     }
 }

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -542,3 +542,7 @@ impl fmt::Display for ExitStatus {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "process_unix/tests.rs"]
+mod tests;

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -1,0 +1,22 @@
+#[test]
+fn exitstatus_display_tests() {
+    // In practice this is the same on every Unix.
+    // If some weird platform turns out to be different, and this test fails, use #[cfg].
+    use crate::os::unix::process::ExitStatusExt;
+    use crate::process::ExitStatus;
+
+    let t = |v, s| assert_eq!(s, format!("{}", <ExitStatus as ExitStatusExt>::from_raw(v)));
+
+    t(0x0000f, "signal: 15");
+    t(0x0008b, "signal: 11 (core dumped)");
+    t(0x00000, "exit code: 0");
+    t(0x0ff00, "exit code: 255");
+    t(0x0137f, "stopped (not terminated) by signal: 19");
+    t(0x0ffff, "continued (WIFCONTINUED)");
+
+    // Testing "unrecognised wait status" is hard because the wait.h macros typically
+    // assume that the value came from wait and isn't mad.  With the glibc I have here
+    // this works:
+    #[cfg(target_env = "gnu")]
+    t(0x000ff, "unrecognised wait status: 255 0xff");
+}

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -22,6 +22,6 @@ fn exitstatus_display_tests() {
     // Testing "unrecognised wait status" is hard because the wait.h macros typically
     // assume that the value came from wait and isn't mad.  With the glibc I have here
     // this works:
-    #[cfg(target_env = "gnu")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     t(0x000ff, "unrecognised wait status: 255 0xff");
 }

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -16,8 +16,10 @@ fn exitstatus_display_tests() {
     //   https://github.com/rust-lang/rust/pull/82749#issuecomment-790525956
     // The purpose of this test is to test our string formatting, not our understanding of the wait
     // status magic numbers.  So restrict these to Linux.
-    #[cfg(target_os = "linux")] t(0x0137f, "stopped (not terminated) by signal: 19");
-    #[cfg(target_os = "linux")] t(0x0ffff, "continued (WIFCONTINUED)");
+    #[cfg(target_os = "linux")]
+    t(0x0137f, "stopped (not terminated) by signal: 19");
+    #[cfg(target_os = "linux")]
+    t(0x0ffff, "continued (WIFCONTINUED)");
 
     // Testing "unrecognised wait status" is hard because the wait.h macros typically
     // assume that the value came from wait and isn't mad.  With the glibc I have here

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -16,14 +16,15 @@ fn exitstatus_display_tests() {
     //   https://github.com/rust-lang/rust/pull/82749#issuecomment-790525956
     // The purpose of this test is to test our string formatting, not our understanding of the wait
     // status magic numbers.  So restrict these to Linux.
-    #[cfg(target_os = "linux")]
-    t(0x0137f, "stopped (not terminated) by signal: 19");
-    #[cfg(target_os = "linux")]
-    t(0x0ffff, "continued (WIFCONTINUED)");
+    if cfg!(target_os = "linux") {
+        t(0x0137f, "stopped (not terminated) by signal: 19");
+        t(0x0ffff, "continued (WIFCONTINUED)");
+    }
 
     // Testing "unrecognised wait status" is hard because the wait.h macros typically
     // assume that the value came from wait and isn't mad.  With the glibc I have here
     // this works:
-    #[cfg(all(target_os = "linux", target_env = "gnu"))]
-    t(0x000ff, "unrecognised wait status: 255 0xff");
+    if cfg!(all(target_os = "linux", target_env = "gnu")) {
+        t(0x000ff, "unrecognised wait status: 255 0xff");
+    }
 }

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -11,8 +11,13 @@ fn exitstatus_display_tests() {
     t(0x0008b, "signal: 11 (core dumped)");
     t(0x00000, "exit code: 0");
     t(0x0ff00, "exit code: 255");
-    t(0x0137f, "stopped (not terminated) by signal: 19");
-    t(0x0ffff, "continued (WIFCONTINUED)");
+
+    // On MacOS, 0x0137f is WIFCONTINUED, not WIFSTOPPED.  Probably *BSD is similar.
+    //   https://github.com/rust-lang/rust/pull/82749#issuecomment-790525956
+    // The purpose of this test is to test our string formatting, not our understanding of the wait
+    // status magic numbers.  So restrict these to Linux.
+    #[cfg(target_os = "linux")] t(0x0137f, "stopped (not terminated) by signal: 19");
+    #[cfg(target_os = "linux")] t(0x0ffff, "continued (WIFCONTINUED)");
 
     // Testing "unrecognised wait status" is hard because the wait.h macros typically
     // assume that the value came from wait and isn't mad.  With the glibc I have here


### PR DESCRIPTION
* On Unix, properly display every possible wait status (and don't panic on weird values)
* In the documentation, be clear and consistent about "exit status" vs "wait status".