### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -61,6 +61,7 @@ fn uint_xor() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_min
 fn uint_min() {
     let x = AtomicUsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -71,6 +72,7 @@ fn uint_min() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_max
 fn uint_max() {
     let x = AtomicUsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);
@@ -109,6 +111,7 @@ fn int_xor() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_min
 fn int_min() {
     let x = AtomicIsize::new(0xf731);
     assert_eq!(x.fetch_min(0x137f, SeqCst), 0xf731);
@@ -119,6 +122,7 @@ fn int_min() {
 
 #[test]
 #[cfg(any(not(target_arch = "arm"), target_os = "linux"))] // Missing intrinsic in compiler-builtins
+#[cfg_attr(miri, ignore)] // FIXME: Miri does not support atomic_max
 fn int_max() {
     let x = AtomicIsize::new(0x137f);
     assert_eq!(x.fetch_max(0xf731, SeqCst), 0x137f);

--- a/src/doc/rustdoc/src/how-to-write-documentation.md
+++ b/src/doc/rustdoc/src/how-to-write-documentation.md
@@ -101,7 +101,7 @@ what an item is, how it is used, and for what purpose it exists.
 Let's see an example coming from the [standard library] by taking a look at the
 [`std::env::args()`][env::args] function:
 
-``````text
+``````markdown
 Returns the arguments which this program was started with (normally passed
 via the command line).
 
@@ -135,7 +135,7 @@ for argument in env::args() {
 
 Everything before the first empty line will be reused to describe the component
 in searches and module overviews.  For example, the function `std::env::args()`
-above will be shown on the [`std::env`] module documentation.  It is good
+above will be shown on the [`std::env`] module documentation. It is good
 practice to keep the summary to one line: concise writing is a goal of good
 documentation.
 
@@ -153,9 +153,10 @@ and finally provides a code example.
 
 ## Markdown
 
-`rustdoc` uses the [CommonMark markdown specification]. You might be
-interested into taking a look at their website to see what's possible to do.
- - [commonmark quick reference]
+`rustdoc` uses the [CommonMark Markdown specification]. You might be
+interested in taking a look at their website to see what's possible:
+
+ - [CommonMark quick reference]
  - [current spec]
 
 In addition to the standard CommonMark syntax, `rustdoc` supports several
@@ -239,6 +240,21 @@ This will render as
 </ul>
 
 See the specification for the [task list extension] for more details.
+
+### Smart punctuation
+
+Some ASCII punctuation sequences will be automatically turned into fancy Unicode
+characters:
+
+| ASCII sequence | Unicode |
+|----------------|---------|
+| `--`           | –       |
+| `---`          | —       |
+| `...`          | …       |
+| `"`            | “ or ”, depending on context |
+| `'`            | ‘ or ’, depending on context |
+
+So, no need to manually enter those Unicode characters!
 
 [`backtrace`]: https://docs.rs/backtrace/0.3.50/backtrace/
 [commonmark markdown specification]: https://commonmark.org/

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -52,11 +52,12 @@ pub(crate) fn opts() -> Options {
         | Options::ENABLE_FOOTNOTES
         | Options::ENABLE_STRIKETHROUGH
         | Options::ENABLE_TASKLISTS
+        | Options::ENABLE_SMART_PUNCTUATION
 }
 
 /// A subset of [`opts()`] used for rendering summaries.
 pub(crate) fn summary_opts() -> Options {
-    Options::ENABLE_STRIKETHROUGH
+    Options::ENABLE_STRIKETHROUGH | Options::ENABLE_SMART_PUNCTUATION
 }
 
 /// When `to_string` is called, this struct will emit the HTML corresponding to

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -201,8 +201,8 @@ fn test_short_markdown_summary() {
     t("Hard-break  \nsummary", "Hard-break summary");
     t("hello [Rust] :)\n\n[Rust]: https://www.rust-lang.org", "hello Rust :)");
     t("hello [Rust](https://www.rust-lang.org \"Rust\") :)", "hello Rust :)");
-    t("code `let x = i32;` ...", "code <code>let x = i32;</code> ...");
-    t("type `Type<'static>` ...", "type <code>Type<'static></code> ...");
+    t("code `let x = i32;` ...", "code <code>let x = i32;</code> …");
+    t("type `Type<'static>` ...", "type <code>Type<'static></code> …");
     t("# top header", "top header");
     t("## header", "header");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
@@ -227,8 +227,8 @@ fn test_plain_text_summary() {
     t("Hard-break  \nsummary", "Hard-break summary");
     t("hello [Rust] :)\n\n[Rust]: https://www.rust-lang.org", "hello Rust :)");
     t("hello [Rust](https://www.rust-lang.org \"Rust\") :)", "hello Rust :)");
-    t("code `let x = i32;` ...", "code `let x = i32;` ...");
-    t("type `Type<'static>` ...", "type `Type<'static>` ...");
+    t("code `let x = i32;` ...", "code `let x = i32;` …");
+    t("type `Type<'static>` ...", "type `Type<'static>` …");
     t("# top header", "top header");
     t("## header", "header");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
@@ -250,6 +250,6 @@ fn test_markdown_html_escape() {
     }
 
     t("`Struct<'a, T>`", "<p><code>Struct&lt;'a, T&gt;</code></p>\n");
-    t("Struct<'a, T>", "<p>Struct&lt;'a, T&gt;</p>\n");
+    t("Struct<'a, T>", "<p>Struct&lt;’a, T&gt;</p>\n");
     t("Struct<br>", "<p>Struct&lt;br&gt;</p>\n");
 }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -101,7 +101,7 @@ function focusSearchBar() {
     getSearchInput().focus();
 }
 
-// Removes the focus from the search bar
+// Removes the focus from the search bar.
 function defocusSearchBar() {
     getSearchInput().blur();
 }
@@ -220,6 +220,11 @@ function defocusSearchBar() {
         addClass(search, "hidden");
         removeClass(main, "hidden");
         document.title = titleBeforeSearch;
+        // We also remove the query parameter from the URL.
+        if (browserSupportsHistoryApi()) {
+            history.replaceState("", window.currentCrate + " - Rust",
+                getNakedUrl() + window.location.hash);
+        }
     }
 
     // used for special search precedence

--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -1,24 +1,24 @@
 // edition:2018
 
-// @has nested.json "$.index[*][?(@.name=='nested')].kind" \"module\"
-// @has - "$.index[*][?(@.name=='nested')].inner.is_crate" true
+// @is nested.json "$.index[*][?(@.name=='nested')].kind" \"module\"
+// @is - "$.index[*][?(@.name=='nested')].inner.is_crate" true
 // @count - "$.index[*][?(@.name=='nested')].inner.items[*]" 1
 
-// @has nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
-// @has - "$.index[*][?(@.name=='l1')].inner.is_crate" false
+// @is nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
+// @is - "$.index[*][?(@.name=='l1')].inner.is_crate" false
 // @count - "$.index[*][?(@.name=='l1')].inner.items[*]" 2
 pub mod l1 {
 
-    // @has nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
-    // @has - "$.index[*][?(@.name=='l3')].inner.is_crate" false
+    // @is nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
+    // @is - "$.index[*][?(@.name=='l3')].inner.is_crate" false
     // @count - "$.index[*][?(@.name=='l3')].inner.items[*]" 1
     pub mod l3 {
 
-        // @has nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
-        // @has - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
+        // @is nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
+        // @is - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
         pub struct L4;
     }
-    // @has nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"
-    // @has - "$.index[*][?(@.inner.span=='l3::L4')].inner.glob" false
+    // @is nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"
+    // @is - "$.index[*][?(@.inner.span=='l3::L4')].inner.glob" false
     pub use l3::L4;
 }

--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -7,15 +7,18 @@
 // @is nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
 // @is - "$.index[*][?(@.name=='l1')].inner.is_crate" false
 // @count - "$.index[*][?(@.name=='l1')].inner.items[*]" 2
+// @set l1_id = - "$.index[*][?(@.name=='l1')].id"
 pub mod l1 {
 
     // @is nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
     // @is - "$.index[*][?(@.name=='l3')].inner.is_crate" false
     // @count - "$.index[*][?(@.name=='l3')].inner.items[*]" 1
+    // @set l3_id = - "$.index[*][?(@.name=='l3')].id"
     pub mod l3 {
 
         // @is nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
         // @is - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
+        // @set l4_id = - "$.index[*][?(@.name=='L4')].id"
         pub struct L4;
     }
     // @is nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"

--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -7,18 +7,19 @@
 // @is nested.json "$.index[*][?(@.name=='l1')].kind" \"module\"
 // @is - "$.index[*][?(@.name=='l1')].inner.is_crate" false
 // @count - "$.index[*][?(@.name=='l1')].inner.items[*]" 2
-// @set l1_id = - "$.index[*][?(@.name=='l1')].id"
 pub mod l1 {
 
     // @is nested.json "$.index[*][?(@.name=='l3')].kind" \"module\"
     // @is - "$.index[*][?(@.name=='l3')].inner.is_crate" false
     // @count - "$.index[*][?(@.name=='l3')].inner.items[*]" 1
     // @set l3_id = - "$.index[*][?(@.name=='l3')].id"
+    // @has - "$.index[*][?(@.name=='l1')].inner.items[*]" $l3_id
     pub mod l3 {
 
         // @is nested.json "$.index[*][?(@.name=='L4')].kind" \"struct\"
         // @is - "$.index[*][?(@.name=='L4')].inner.struct_type" \"unit\"
         // @set l4_id = - "$.index[*][?(@.name=='L4')].id"
+        // @has - "$.index[*][?(@.name=='l3')].inner.items[*]" $l4_id
         pub struct L4;
     }
     // @is nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"

--- a/src/test/rustdoc/inline_cross/add-docs.rs
+++ b/src/test/rustdoc/inline_cross/add-docs.rs
@@ -4,6 +4,6 @@ extern crate inner;
 
 
 // @has add_docs/struct.MyStruct.html
-// @has add_docs/struct.MyStruct.html "Doc comment from 'pub use', Doc comment from definition"
+// @has add_docs/struct.MyStruct.html "Doc comment from ‘pub use’, Doc comment from definition"
 /// Doc comment from 'pub use',
 pub use inner::MyStruct;

--- a/src/test/rustdoc/smart-punct.rs
+++ b/src/test/rustdoc/smart-punct.rs
@@ -1,0 +1,13 @@
+#![crate_name = "foo"]
+
+//! This is the "start" of the 'document'! How'd you know that "it's" the start?
+//!
+//! # Header with "smart punct'"
+//!
+//! [link with "smart punct'" -- yessiree!][]
+//!
+//! [link with "smart punct'" -- yessiree!]: https://www.rust-lang.org
+
+// @has "foo/index.html" "//p" "This is the “start” of the ‘document’! How’d you know that “it’s” the start?"
+// @has "foo/index.html" "//h1" "Header with “smart punct’”"
+// @has "foo/index.html" '//a[@href="https://www.rust-lang.org"]' "link with “smart punct’” – yessiree!"

--- a/src/test/rustdoc/smart-punct.rs
+++ b/src/test/rustdoc/smart-punct.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-linelength
+
 #![crate_name = "foo"]
 
 //! This is the "start" of the 'document'! How'd you know that "it's" the start?
@@ -7,7 +9,22 @@
 //! [link with "smart punct'" -- yessiree!][]
 //!
 //! [link with "smart punct'" -- yessiree!]: https://www.rust-lang.org
+//!
+//! # Code should not be smart-punct'd
+//!
+//! `this inline code -- it shouldn't have "smart punct"`
+//!
+//! ```
+//! let x = "don't smart-punct me -- please!";
+//! ```
+//!
+//! ```text
+//! I say "don't smart-punct me -- please!"
+//! ```
 
 // @has "foo/index.html" "//p" "This is the “start” of the ‘document’! How’d you know that “it’s” the start?"
 // @has "foo/index.html" "//h1" "Header with “smart punct’”"
 // @has "foo/index.html" '//a[@href="https://www.rust-lang.org"]' "link with “smart punct’” – yessiree!"
+// @has "foo/index.html" '//code' 'this inline code -- it shouldn\'t have "smart punct"'
+// @has "foo/index.html" '//pre' 'let x = "don\'t smart-punct me -- please!";'
+// @has "foo/index.html" '//pre' 'I say "don\'t smart-punct me -- please!"'

--- a/src/test/rustdoc/smart-punct.rs
+++ b/src/test/rustdoc/smart-punct.rs
@@ -25,6 +25,6 @@
 // @has "foo/index.html" "//p" "This is the “start” of the ‘document’! How’d you know that “it’s” the start?"
 // @has "foo/index.html" "//h1" "Header with “smart punct’”"
 // @has "foo/index.html" '//a[@href="https://www.rust-lang.org"]' "link with “smart punct’” – yessiree!"
-// @has "foo/index.html" '//code' 'this inline code -- it shouldn\'t have "smart punct"'
-// @has "foo/index.html" '//pre' 'let x = "don\'t smart-punct me -- please!";'
-// @has "foo/index.html" '//pre' 'I say "don\'t smart-punct me -- please!"'
+// @has "foo/index.html" '//code' "this inline code -- it shouldn't have \"smart punct\""
+// @has "foo/index.html" '//pre' "let x = \"don't smart-punct me -- please!\";"
+// @has "foo/index.html" '//pre' "I say \"don't smart-punct me -- please!\""

--- a/src/test/ui/issues/issue-81918.rs
+++ b/src/test/ui/issues/issue-81918.rs
@@ -1,0 +1,11 @@
+// check-pass
+// dont-check-compiler-stdout
+// compile-flags: -Z unpretty=mir-cfg
+
+// This checks that unpretty=mir-cfg does not panic. See #81918.
+
+const TAG: &'static str = "ABCD";
+
+fn main() {
+    if TAG == "" {}
+}

--- a/src/test/ui/lint/dead-code/write-only-field.rs
+++ b/src/test/ui/lint/dead-code/write-only-field.rs
@@ -17,4 +17,53 @@ fn field_write(s: &mut S) {
 fn main() {
     let mut s = S { f: 0, sub: Sub { f: 0 } };
     field_write(&mut s);
+
+    auto_deref();
+    nested_boxes();
+}
+
+fn auto_deref() {
+    struct E {
+        x: bool,
+        y: bool, //~ ERROR: field is never read
+    }
+
+    struct P<'a> {
+        e: &'a mut E
+    }
+
+    impl P<'_> {
+        fn f(&mut self) {
+            self.e.x = true;
+            self.e.y = true;
+        }
+    }
+
+    let mut e = E { x: false, y: false };
+    let mut p = P { e: &mut e };
+    p.f();
+    assert!(e.x);
+}
+
+fn nested_boxes() {
+    struct A {
+        b: Box<B>,
+    }
+
+    struct B {
+        c: Box<C>,
+    }
+
+    struct C {
+        u: u32, //~ ERROR: field is never read
+        v: u32, //~ ERROR: field is never read
+    }
+
+    let mut a = A {
+        b: Box::new(B {
+            c: Box::new(C { u: 0, v: 0 }),
+        }),
+    };
+    a.b.c.v = 10;
+    a.b.c = Box::new(C { u: 1, v: 2 });
 }

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -22,5 +22,23 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^
 
-error: aborting due to 3 previous errors
+error: field is never read: `y`
+  --> $DIR/write-only-field.rs:28:9
+   |
+LL |         y: bool,
+   |         ^^^^^^^
+
+error: field is never read: `u`
+  --> $DIR/write-only-field.rs:58:9
+   |
+LL |         u: u32,
+   |         ^^^^^^
+
+error: field is never read: `v`
+  --> $DIR/write-only-field.rs:59:9
+   |
+LL |         v: u32,
+   |         ^^^^^^
+
+error: aborting due to 6 previous errors
 

--- a/src/tools/jsondocck/src/cache.rs
+++ b/src/tools/jsondocck/src/cache.rs
@@ -9,6 +9,7 @@ pub struct Cache {
     root: PathBuf,
     files: HashMap<PathBuf, String>,
     values: HashMap<PathBuf, Value>,
+    pub variables: HashMap<String, Value>,
     last_path: Option<PathBuf>,
 }
 
@@ -19,6 +20,7 @@ impl Cache {
             root: Path::new(doc_dir).to_owned(),
             files: HashMap::new(),
             values: HashMap::new(),
+            variables: HashMap::new(),
             last_path: None,
         }
     }

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -207,9 +207,15 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                     let val = cache.get_value(&command.args[0])?;
                     match select(&val, &command.args[1]) {
                         Ok(results) => {
-                            let pat: Value = serde_json::from_str(&command.args[2]).unwrap();
-
-                            !results.is_empty() && results.into_iter().any(|val| *val == pat)
+                            // FIXME: Share the pat getting code with the `Is` branch.
+                            let v_holder;
+                            let pat: &Value = if command.args[2].starts_with("$") {
+                                &cache.variables[&command.args[2][1..]]
+                            } else {
+                                v_holder = serde_json::from_str(&command.args[2]).unwrap();
+                                &v_holder
+                            };
+                            !results.is_empty() && results.into_iter().any(|val| val == pat)
                         }
                         Err(_) => false,
                     }
@@ -234,8 +240,14 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
             let val = cache.get_value(&command.args[0])?;
             match select(&val, &command.args[1]) {
                 Ok(results) => {
-                    let pat: Value = serde_json::from_str(&command.args[2]).unwrap();
-                    results.len() == 1 && *results[0] == pat
+                    let v_holder;
+                    let pat: &Value = if command.args[2].starts_with("$") {
+                        &cache.variables[&command.args[2][1..]]
+                    } else {
+                        v_holder = serde_json::from_str(&command.args[2]).unwrap();
+                        &v_holder
+                    };
+                    results.len() == 1 && results[0] == pat
                 }
                 Err(_) => false,
             }

--- a/src/tools/jsondocck/src/main.rs
+++ b/src/tools/jsondocck/src/main.rs
@@ -187,7 +187,7 @@ fn get_commands(template: &str) -> Result<Vec<Command>, ()> {
 /// Performs the actual work of ensuring a command passes. Generally assumes the command
 /// is syntactically valid.
 fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
-    // FIXME: Be more granular about why, (eg syntax error, count not equal)
+    // FIXME: Be more granular about why, (e.g. syntax error, count not equal)
     let result = match command.kind {
         CommandKind::Has => {
             match command.args.len() {
@@ -215,7 +215,7 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                                 v_holder = serde_json::from_str(&command.args[2]).unwrap();
                                 &v_holder
                             };
-                            !results.is_empty() && results.into_iter().any(|val| val == pat)
+                            results.contains(pat)
                         }
                         Err(_) => false,
                     }
@@ -263,7 +263,7 @@ fn check_command(command: Command, cache: &mut Cache) -> Result<(), CkError> {
                 Ok(results) => {
                     assert_eq!(results.len(), 1);
                     let r = cache.variables.insert(command.args[0].clone(), results[0].clone());
-                    assert!(r.is_none(), "Name collision");
+                    assert!(r.is_none(), "Name collision: {} is duplicated", command.args[0]);
                     true
                 }
                 Err(_) => false,


### PR DESCRIPTION
Successful merges:

 - #79423 (Enable smart punctuation)
 - #82234 (Remove query parameters when skipping search results)
 - #82297 (Consider auto derefs before warning about write only fields)
 - #82311 (Jsondocck improvements)
 - #82362 (Fix mir-cfg dumps)
 - #82391 (disable atomic_max/min tests in Miri)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=79423,82234,82297,82311,82362,82391)
<!-- homu-ignore:end -->