### PR TITLE
Stop leaking implementation detail in `Debug` impls of opaque types

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -435,7 +435,7 @@ impl dyn Any + Send + Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
     t: u64,
@@ -461,6 +461,13 @@ impl TypeId {
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         TypeId { t: intrinsics::type_id::<T>() }
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl fmt::Debug for TypeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("TypeId(_)")
     }
 }
 

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -988,7 +988,7 @@ impl<T> hash::Hash for Discriminant<T> {
 #[stable(feature = "discriminant_value", since = "1.21.0")]
 impl<T> fmt::Debug for Discriminant<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_tuple("Discriminant").field(&self.0).finish()
+        fmt.pad("Discriminant(_)")
     }
 }
 

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -985,7 +985,7 @@ pub fn park_timeout(dur: Duration) {
 ///
 /// [`id`]: Thread::id
 #[stable(feature = "thread_id", since = "1.19.0")]
-#[derive(Eq, PartialEq, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Hash)]
 pub struct ThreadId(NonZeroU64);
 
 impl ThreadId {
@@ -1022,6 +1022,13 @@ impl ThreadId {
     #[unstable(feature = "thread_id_value", issue = "67939")]
     pub fn as_u64(&self) -> NonZeroU64 {
         self.0
+    }
+}
+
+#[stable(feature = "thread_id", since = "1.19.0")]
+impl fmt::Debug for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("ThreadId(_)")
     }
 }
 

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -410,7 +410,9 @@ impl Sub<Instant> for Instant {
 #[stable(feature = "time2", since = "1.8.0")]
 impl fmt::Debug for Instant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        // Instant is an opaque type and only useful with `Duration`. So it
+        // would be misleading to show implementation detail in the output.
+        f.pad("Instant(_)")
     }
 }
 


### PR DESCRIPTION
This changes the `Debug` impl of:
- `core::any::TypeId`
- `core::mem::Discriminant`
- `std::thread::ThreadId`
- `std::time::Instant`

All these types are explicitly described as "opaque" in the documentation, so they shouldn't print implementation details in their `Debug` implementation IMO.

The change for `ThreadId` can possibly be reverted in the future, when the method `thread_id_value` is stabilized: https://github.com/rust-lang/rust/issues/67939. The same goes for `Discriminant` once/if the `DiscriminantKind` trait gets stabilized. But until then, these are opaque types.

No one should rely on the output of `Debug` impls, so this shouldn't break anything. However, just to be sure, crater was used before for changes like this.

Curious to hear what you think about this change. 