### PR TITLE
Add a `size()` function to WASI's `MetadataExt`.

### DIFF
--- a/library/std/src/sys/wasi/ext/fs.rs
+++ b/library/std/src/sys/wasi/ext/fs.rs
@@ -397,6 +397,8 @@ pub trait MetadataExt {
     fn ino(&self) -> u64;
     /// Returns the `st_nlink` field of the internal `filestat_t`
     fn nlink(&self) -> u64;
+    /// Returns the `st_size` field of the internal `filestat_t`
+    fn size(&self) -> u64;
     /// Returns the `st_atim` field of the internal `filestat_t`
     fn atim(&self) -> u64;
     /// Returns the `st_mtim` field of the internal `filestat_t`
@@ -414,6 +416,9 @@ impl MetadataExt for fs::Metadata {
     }
     fn nlink(&self) -> u64 {
         self.as_inner().as_wasi().nlink
+    }
+    fn size(&self) -> u64 {
+        self.as_inner().as_wasi().size
     }
     fn atim(&self) -> u64 {
         self.as_inner().as_wasi().atim


### PR DESCRIPTION
WASI's `filestat` type includes a size field, so expose it in
`MetadataExt` via a `size()` function, similar to the corresponding Unix
function.

r? @alexcrichton 