### PR TITLE
Don't share `id_map` and `deref_id_map`

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -110,7 +110,11 @@ crate struct Context<'tcx> {
     /// real location of an item. This is used to allow external links to
     /// publicly reused items to redirect to the right location.
     render_redirect_pages: bool,
-    /// Shared mutable state. We should probably redesign this.
+    /// Shared mutable state.
+    ///
+    /// Issue for improving the situation: [#82381][]
+    ///
+    /// [#82381]: https://github.com/rust-lang/rust/issues/82381
     shared: Rc<SharedContext<'tcx>>,
     /// The [`Cache`] used during rendering.
     ///
@@ -127,7 +131,7 @@ crate struct Context<'tcx> {
 // `Context` is cloned a lot, so we don't want the size to grow unexpectedly.
 rustc_data_structures::static_assert_size!(Context<'_>, 72);
 
-/// Shared mutable state in [`Context`]. We should probably redesign this.
+/// Shared mutable state used in [`Context`] and elsewhere.
 crate struct SharedContext<'tcx> {
     crate tcx: TyCtxt<'tcx>,
     /// The path to the crate root source minus the file name.

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -129,6 +129,7 @@ crate struct Context<'tcx> {
 }
 
 // `Context` is cloned a lot, so we don't want the size to grow unexpectedly.
+#[cfg(target_arch = "x86_64")]
 rustc_data_structures::static_assert_size!(Context<'_>, 72);
 
 /// Shared mutable state used in [`Context`] and elsewhere.

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -124,6 +124,9 @@ crate struct Context<'tcx> {
     cache: Rc<Cache>,
 }
 
+// `Context` is cloned a lot, so we don't want the size to grow unexpectedly.
+rustc_data_structures::static_assert_size!(Context<'_>, 72);
+
 /// Shared mutable state in [`Context`]. We should probably redesign this.
 crate struct SharedContext<'tcx> {
     crate tcx: TyCtxt<'tcx>,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -44,7 +44,6 @@ use std::rc::Rc;
 use std::str;
 use std::string::ToString;
 use std::sync::mpsc::{channel, Receiver};
-use std::sync::Arc;
 
 use itertools::Itertools;
 use rustc_ast_pretty::pprust;
@@ -111,7 +110,7 @@ crate struct Context<'tcx> {
     /// real location of an item. This is used to allow external links to
     /// publicly reused items to redirect to the right location.
     crate render_redirect_pages: bool,
-    crate shared: Arc<SharedContext<'tcx>>,
+    crate shared: Rc<SharedContext<'tcx>>,
     /// The [`Cache`] used during rendering.
     ///
     /// Ideally the cache would be in [`SharedContext`], but it's mutated
@@ -517,16 +516,16 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             current: Vec::new(),
             dst,
             render_redirect_pages: false,
-            shared: Arc::new(scx),
+            shared: Rc::new(scx),
             cache: Rc::new(cache),
         };
 
         CURRENT_DEPTH.with(|s| s.set(0));
 
         // Write shared runs within a flock; disable thread dispatching of IO temporarily.
-        Arc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);
+        Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);
         write_shared(&cx, &krate, index, &md_opts)?;
-        Arc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(false);
+        Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(false);
         Ok((cx, krate))
     }
 
@@ -599,7 +598,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         self.shared.fs.write(&settings_file, v.as_bytes())?;
 
         // Flush pending errors.
-        Arc::get_mut(&mut self.shared).unwrap().fs.close();
+        Rc::get_mut(&mut self.shared).unwrap().fs.close();
         let nb_errors = self.shared.errors.iter().map(|err| diag.struct_err(&err).emit()).count();
         if nb_errors > 0 {
             Err(Error::new(io::Error::new(io::ErrorKind::Other, "I/O error"), ""))

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -102,15 +102,16 @@ crate fn ensure_trailing_slash(v: &str) -> impl fmt::Display + '_ {
 crate struct Context<'tcx> {
     /// Current hierarchy of components leading down to what's currently being
     /// rendered
-    crate current: Vec<String>,
+    current: Vec<String>,
     /// The current destination folder of where HTML artifacts should be placed.
     /// This changes as the context descends into the module hierarchy.
-    crate dst: PathBuf,
+    dst: PathBuf,
     /// A flag, which when `true`, will render pages which redirect to the
     /// real location of an item. This is used to allow external links to
     /// publicly reused items to redirect to the right location.
-    crate render_redirect_pages: bool,
-    crate shared: Rc<SharedContext<'tcx>>,
+    render_redirect_pages: bool,
+    /// Shared mutable state. We should probably redesign this.
+    shared: Rc<SharedContext<'tcx>>,
     /// The [`Cache`] used during rendering.
     ///
     /// Ideally the cache would be in [`SharedContext`], but it's mutated
@@ -120,9 +121,10 @@ crate struct Context<'tcx> {
     /// It's immutable once in `Context`, so it's not as bad that it's not in
     /// `SharedContext`.
     // FIXME: move `cache` to `SharedContext`
-    crate cache: Rc<Cache>,
+    cache: Rc<Cache>,
 }
 
+/// Shared mutable state in [`Context`]. We should probably redesign this.
 crate struct SharedContext<'tcx> {
     crate tcx: TyCtxt<'tcx>,
     /// The path to the crate root source minus the file name.
@@ -138,16 +140,16 @@ crate struct SharedContext<'tcx> {
     /// The local file sources we've emitted and their respective url-paths.
     crate local_sources: FxHashMap<PathBuf, String>,
     /// Whether the collapsed pass ran
-    crate collapsed: bool,
+    collapsed: bool,
     /// The base-URL of the issue tracker for when an item has been tagged with
     /// an issue number.
-    crate issue_tracker_base_url: Option<String>,
+    issue_tracker_base_url: Option<String>,
     /// The directories that have already been created in this doc run. Used to reduce the number
     /// of spurious `create_dir_all` calls.
-    crate created_dirs: RefCell<FxHashSet<PathBuf>>,
+    created_dirs: RefCell<FxHashSet<PathBuf>>,
     /// This flag indicates whether listings of modules (in the side bar and documentation itself)
     /// should be ordered alphabetically or in order of appearance (in the source code).
-    crate sort_modules_alphabetically: bool,
+    sort_modules_alphabetically: bool,
     /// Additional CSS files to be added to the generated docs.
     crate style_files: Vec<StylePath>,
     /// Suffix to be added on resource files (if suffix is "-v2" then "light.css" becomes
@@ -160,7 +162,7 @@ crate struct SharedContext<'tcx> {
     crate fs: DocFS,
     /// The default edition used to parse doctests.
     crate edition: Edition,
-    crate codes: ErrorCodes,
+    codes: ErrorCodes,
     playground: Option<markdown::Playground>,
     /// The map used to ensure all generated 'id=' attributes are unique.
     id_map: RefCell<IdMap>,
@@ -170,7 +172,7 @@ crate struct SharedContext<'tcx> {
     all: RefCell<AllTypes>,
     /// Storage for the errors produced while generating documentation so they
     /// can be printed together at the end.
-    crate errors: Receiver<String>,
+    errors: Receiver<String>,
 }
 
 impl<'tcx> Context<'tcx> {


### PR DESCRIPTION
All the tests passed, so it doesn't seem they need to be shared.
Plus they should be item/page-specific.

I'm not sure why they were shared before. I think the reason `id_map`
worked as a shared value before is that it is cleared before rendering
each item (in `render_item`). And then I'm guessing `deref_id_map`
worked because it's a hashmap keyed by `DefId`, so there was no overlap
(though I'm guessing we could have had issues in the future).

Note that `id_map` currently still has to be cleared because otherwise
child items would inherit the `id_map` of their parent. I'm hoping to
figure out a way to stop cloning `Context`, but until then we have to
reset `id_map`.

**Builds on top of #82356 (otherwise we'd have merge conflicts), so this is
blocked on that PR.**
