### PR TITLE
Set RUST_BACKTRACE=0 when running `treat-err-as-bug` tests

### DIFF
--- a/src/test/ui/treat-err-as-bug/delay_span_bug.rs
+++ b/src/test/ui/treat-err-as-bug/delay_span_bug.rs
@@ -4,6 +4,7 @@
 // error-pattern: [trigger_delay_span_bug] trigger a delay span bug
 // normalize-stderr-test "note: .*\n\n" -> ""
 // normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
 
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/treat-err-as-bug/delay_span_bug.stderr
+++ b/src/test/ui/treat-err-as-bug/delay_span_bug.stderr
@@ -1,5 +1,5 @@
 error: internal compiler error: delayed span bug triggered by #[rustc_error(delay_span_bug_from_inside_query)]
-  --> $DIR/delay_span_bug.rs:11:1
+  --> $DIR/delay_span_bug.rs:12:1
    |
 LL | fn main() {}
    | ^^^^^^^^^

--- a/src/test/ui/treat-err-as-bug/err.rs
+++ b/src/test/ui/treat-err-as-bug/err.rs
@@ -4,6 +4,7 @@
 // error-pattern: [eval_to_allocation_raw] const-evaluating + checking `C`
 // normalize-stderr-test "note: .*\n\n" -> ""
 // normalize-stderr-test "thread 'rustc' panicked.*\n" -> ""
+// rustc-env:RUST_BACKTRACE=0
 
 #![crate_type = "rlib"]
 

--- a/src/test/ui/treat-err-as-bug/err.stderr
+++ b/src/test/ui/treat-err-as-bug/err.stderr
@@ -1,5 +1,5 @@
 error[E0080]: could not evaluate static initializer
-  --> $DIR/err.rs:10:21
+  --> $DIR/err.rs:11:21
    |
 LL | pub static C: u32 = 0 - 1;
    |                     ^^^^^ attempt to compute `0_u32 - 1_u32`, which would overflow


### PR DESCRIPTION
These ensure that these tests pass regardless of what RUST_BACKTRACE is
set to in the user's shell.