### PR TITLE
Refactor deprecation attributes

### DIFF
--- a/compiler/rustc_attr/src/lib.rs
+++ b/compiler/rustc_attr/src/lib.rs
@@ -12,6 +12,7 @@ extern crate rustc_macros;
 mod builtin;
 
 pub use builtin::*;
+pub use DeprKind::*;
 pub use IntType::*;
 pub use ReprAttr::*;
 pub use StabilityLevel::*;

--- a/compiler/rustc_error_codes/src/error_codes/E0542.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0542.md
@@ -1,42 +1,48 @@
-The `since` value is missing in a stability attribute.
+The `since` value in a stability attribute is either missing
+or does not parse to a version string.
 
 Erroneous code example:
 
 ```compile_fail,E0542
 #![feature(staged_api)]
-#![stable(since = "1.0.0", feature = "test")]
+#![stable(since = "1.0.0", feature = "foo")]
 
-#[stable(feature = "_stable_fn")] // invalid
-fn _stable_fn() {}
+#[stable(feature = "foo")] // missing
+fn _stable1() {}
 
-#[rustc_const_stable(feature = "_stable_const_fn")] // invalid
-fn _stable_const_fn() {}
+#[stable(feature = "foo", since = "bar")] // invalid
+fn _stable2() {}
 
-#[stable(feature = "_deprecated_fn", since = "0.1.0")]
-#[rustc_deprecated(
-    reason = "explanation for deprecation"
-)] // invalid
-fn _deprecated_fn() {}
+#[rustc_const_stable(feature = "foo")] // missing
+fn _const1() {}
+
+#[rustc_const_stable(feature = "foo", since = "bar")] // invalid
+fn _const2() {}
+
+#[stable(feature = "foo", since = "1.0.0")]
+#[rustc_deprecated(reason = "bar")] // missing
+fn _deprecated1() {}
+
+#[stable(feature = "foo", since = "1.0.0")]
+#[rustc_deprecated(reason = "qux", since = "bar")] // invalid
+fn _deprecated2() {}
 ```
 
 To fix this issue, you need to provide the `since` field. Example:
 
 ```
 #![feature(staged_api)]
-#![stable(since = "1.0.0", feature = "test")]
+#![stable(since = "1.0.0", feature = "foo")]
 
-#[stable(feature = "_stable_fn", since = "1.0.0")] // ok!
-fn _stable_fn() {}
+#[stable(feature = "foo", since = "1.0.0")] // ok!
+fn _stable() {}
 
-#[rustc_const_stable(feature = "_stable_const_fn", since = "1.0.0")] // ok!
-fn _stable_const_fn() {}
+#[rustc_const_stable(feature = "foo", since = "1.0.0")] // ok!
+fn _const() {}
 
-#[stable(feature = "_deprecated_fn", since = "0.1.0")]
-#[rustc_deprecated(
-    since = "1.0.0",
-    reason = "explanation for deprecation"
-)] // ok!
-fn _deprecated_fn() {}
+#[stable(feature = "foo", since = "1.0.0")]
+#[rustc_deprecated(reason = "qux", since = "1.0.0")] // ok!
+fn _deprecated() {}
 ```
 
 See the [How Rust is Made and “Nightly Rust”][how-rust-made-nightly] appendix

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -6,7 +6,7 @@ use rustc_ast::token::{self, Nonterminal};
 use rustc_ast::tokenstream::{CanSynthesizeMissingTokens, TokenStream};
 use rustc_ast::visit::{AssocCtxt, Visitor};
 use rustc_ast::{self as ast, Attribute, NodeId, PatKind};
-use rustc_attr::{self as attr, Deprecation, HasAttrs, Stability};
+use rustc_attr::{self as attr, DeprKind, HasAttrs, Stability};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::{self, Lrc};
 use rustc_errors::{DiagnosticBuilder, ErrorReported};
@@ -705,7 +705,7 @@ pub struct SyntaxExtension {
     /// The macro's stability info.
     pub stability: Option<Stability>,
     /// The macro's deprecation info.
-    pub deprecation: Option<Deprecation>,
+    pub deprecation: Option<DeprKind>,
     /// Names of helper attributes registered by this macro.
     pub helper_attrs: Vec<Symbol>,
     /// Edition of the crate in which this macro is defined.

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -917,7 +917,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         self.root.tables.const_stability.get(self, id).map(|stab| stab.decode(self))
     }
 
-    fn get_deprecation(&self, id: DefIndex) -> Option<attr::Deprecation> {
+    fn get_deprecation(&self, id: DefIndex) -> Option<attr::DeprKind> {
         self.root.tables.deprecation.get(self, id).map(|depr| depr.decode(self))
     }
 

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -288,7 +288,7 @@ define_tables! {
     children: Table<DefIndex, Lazy<[DefIndex]>>,
     stability: Table<DefIndex, Lazy<attr::Stability>>,
     const_stability: Table<DefIndex, Lazy<attr::ConstStability>>,
-    deprecation: Table<DefIndex, Lazy<attr::Deprecation>>,
+    deprecation: Table<DefIndex, Lazy<attr::DeprKind>>,
     ty: Table<DefIndex, Lazy!(Ty<'tcx>)>,
     fn_sig: Table<DefIndex, Lazy!(ty::PolyFnSig<'tcx>)>,
     impl_trait_ref: Table<DefIndex, Lazy!(ty::TraitRef<'tcx>)>,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1089,11 +1089,12 @@ impl<'a> Resolver<'a> {
         }
         if let Some(depr) = &ext.deprecation {
             let path = pprust::path_to_string(&path);
-            let (message, lint) = stability::deprecation_message(depr, "macro", &path);
+            let message = stability::deprecation_message(depr, "macro", &path);
+            let lint = stability::deprecation_lint(depr);
             stability::early_report_deprecation(
                 &mut self.lint_buffer,
                 &message,
-                depr.suggestion,
+                depr.suggestion(),
                 lint,
                 span,
                 node_id,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -197,6 +197,7 @@ symbols! {
         StructuralEq,
         StructuralPartialEq,
         Sync,
+        TBD,
         Target,
         Try,
         Ty,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -12,7 +12,7 @@ use arrayvec::ArrayVec;
 use rustc_ast::attr;
 use rustc_ast::util::comments::beautify_doc_string;
 use rustc_ast::{self as ast, AttrStyle};
-use rustc_attr::{ConstStability, Deprecation, Stability, StabilityLevel};
+use rustc_attr::{ConstStability, DeprKind, Stability, StabilityLevel, Version};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_feature::UnstableFeatures;
 use rustc_hir as hir;
@@ -114,7 +114,7 @@ impl Item {
         if self.is_fake() { None } else { tcx.lookup_const_stability(self.def_id) }
     }
 
-    crate fn deprecation(&self, tcx: TyCtxt<'_>) -> Option<Deprecation> {
+    crate fn deprecation(&self, tcx: TyCtxt<'_>) -> Option<DeprKind> {
         if self.is_fake() { None } else { tcx.lookup_deprecation(self.def_id) }
     }
 
@@ -257,16 +257,16 @@ impl Item {
         })
     }
 
-    crate fn stable_since(&self, tcx: TyCtxt<'_>) -> Option<SymbolStr> {
+    crate fn stable_since(&self, tcx: TyCtxt<'_>) -> Option<Version> {
         match self.stability(tcx)?.level {
-            StabilityLevel::Stable { since, .. } => Some(since.as_str()),
+            StabilityLevel::Stable { since, .. } => Some(since),
             StabilityLevel::Unstable { .. } => None,
         }
     }
 
-    crate fn const_stable_since(&self, tcx: TyCtxt<'_>) -> Option<SymbolStr> {
+    crate fn const_stable_since(&self, tcx: TyCtxt<'_>) -> Option<Version> {
         match self.const_stability(tcx)?.level {
-            StabilityLevel::Stable { since, .. } => Some(since.as_str()),
+            StabilityLevel::Stable { since, .. } => Some(since),
             StabilityLevel::Unstable { .. } => None,
         }
     }

--- a/src/test/rustdoc/implementor-stable-version.rs
+++ b/src/test/rustdoc/implementor-stable-version.rs
@@ -2,18 +2,18 @@
 
 #![feature(staged_api)]
 
-#[stable(feature = "bar", since = "OLD 1.0")]
+#[stable(feature = "bar", since = "1.0.0")]
 pub trait Bar {}
 
-#[stable(feature = "baz", since = "OLD 1.0")]
+#[stable(feature = "baz", since = "1.0.0")]
 pub trait Baz {}
 
 pub struct Foo;
 
-// @has foo/trait.Bar.html '//div[@id="implementors-list"]//span[@class="since"]' 'NEW 2.0'
-#[stable(feature = "foobar", since = "NEW 2.0")]
+// @has foo/trait.Bar.html '//div[@id="implementors-list"]//span[@class="since"]' '2.0.0'
+#[stable(feature = "foobar", since = "2.0.0")]
 impl Bar for Foo {}
 
-// @!has foo/trait.Baz.html '//div[@id="implementors-list"]//span[@class="since"]' 'OLD 1.0'
-#[stable(feature = "foobaz", since = "OLD 1.0")]
+// @!has foo/trait.Baz.html '//div[@id="implementors-list"]//span[@class="since"]' '1.0.0'
+#[stable(feature = "foobaz", since = "1.0.0")]
 impl Baz for Foo {}

--- a/src/test/ui/reachable-unnameable-type-alias.rs
+++ b/src/test/ui/reachable-unnameable-type-alias.rs
@@ -1,14 +1,14 @@
 // run-pass
 
 #![feature(staged_api)]
-#![stable(feature = "a", since = "b")]
+#![stable(feature = "a", since = "1.0.0")]
 
 mod inner_private_module {
     // UnnameableTypeAlias isn't marked as reachable, so no stability annotation is required here
     pub type UnnameableTypeAlias = u8;
 }
 
-#[stable(feature = "a", since = "b")]
+#[stable(feature = "a", since = "1.0.0")]
 pub fn f() -> inner_private_module::UnnameableTypeAlias {
     0
 }

--- a/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-issue-43027.rs
@@ -1,7 +1,7 @@
 #![feature(staged_api)]
-#![stable(feature = "test", since = "0")]
+#![stable(feature = "test", since = "1.0.0")]
 
-#[stable(feature = "test", since = "0")]
+#[stable(feature = "test", since = "1.0.0")]
 pub struct Reverse<T>(pub T); //~ ERROR field has missing stability attribute
 
 fn main() {

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.rs
@@ -5,19 +5,19 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 mod bogus_attribute_types_1 {
-    #[stable(feature = "a", since = "b", reason)] //~ ERROR unknown meta item 'reason' [E0541]
+    #[stable(feature = "a", since = "1.0.0", reason)] //~ ERROR unknown meta item 'reason' [E0541]
     fn f1() { }
 
     #[stable(feature = "a", since)] //~ ERROR incorrect meta item [E0539]
     fn f2() { }
 
-    #[stable(feature, since = "a")] //~ ERROR incorrect meta item [E0539]
+    #[stable(feature, since = "1.0.0")] //~ ERROR incorrect meta item [E0539]
     fn f3() { }
 
     #[stable(feature = "a", since(b))] //~ ERROR incorrect meta item [E0539]
     fn f5() { }
 
-    #[stable(feature(b), since = "a")] //~ ERROR incorrect meta item [E0539]
+    #[stable(feature(b), since = "1.0.0")] //~ ERROR incorrect meta item [E0539]
     fn f6() { }
 }
 
@@ -28,49 +28,55 @@ mod missing_feature_names {
     #[unstable(feature = "b")] //~ ERROR missing 'issue' [E0547]
     fn f2() { }
 
-    #[stable(since = "a")] //~ ERROR missing 'feature' [E0546]
+    #[stable(since = "1.0.0")] //~ ERROR missing 'feature' [E0546]
     fn f3() { }
 }
 
 mod missing_version {
-    #[stable(feature = "a")] //~ ERROR missing 'since' [E0542]
+    #[stable(feature = "a")] //~ ERROR invalid 'since' [E0542]
     fn f1() { }
 
-    #[stable(feature = "a", since = "b")]
-    #[rustc_deprecated(reason = "a")] //~ ERROR missing 'since' [E0542]
+    #[stable(feature = "a", since = "1.0.0")]
+    #[rustc_deprecated(reason = "a")] //~ ERROR invalid 'since' [E0542]
     fn f2() { }
 
-    #[stable(feature = "a", since = "b")]
-    #[rustc_deprecated(since = "a")] //~ ERROR missing 'reason' [E0543]
+    #[stable(feature = "a", since = "1.0.0")]
+    #[rustc_deprecated(since = "1.0.0")] //~ ERROR missing 'reason' [E0543]
     fn f3() { }
 }
 
 #[unstable(feature = "b", issue = "none")]
-#[stable(feature = "a", since = "b")] //~ ERROR multiple stability levels [E0544]
+#[stable(feature = "a", since = "1.0.0")] //~ ERROR multiple stability levels [E0544]
 fn multiple1() { }
 
 #[unstable(feature = "b", issue = "none")]
 #[unstable(feature = "b", issue = "none")] //~ ERROR multiple stability levels [E0544]
 fn multiple2() { }
 
-#[stable(feature = "a", since = "b")]
-#[stable(feature = "a", since = "b")] //~ ERROR multiple stability levels [E0544]
+#[stable(feature = "a", since = "1.0.0")]
+#[stable(feature = "a", since = "1.0.0")] //~ ERROR multiple stability levels [E0544]
 fn multiple3() { }
 
-#[stable(feature = "a", since = "b")]
-#[rustc_deprecated(since = "b", reason = "text")]
-#[rustc_deprecated(since = "b", reason = "text")] //~ ERROR multiple deprecated attributes
+#[stable(feature = "a", since = "1.0.0")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")] //~ ERROR multiple deprecated attributes
 #[rustc_const_unstable(feature = "c", issue = "none")]
 #[rustc_const_unstable(feature = "d", issue = "none")] //~ ERROR multiple stability levels
 pub const fn multiple4() { }
-//~^ ERROR Invalid stability version found
+
+#[stable(feature = "a", since = "invalid")] //~ ERROR invalid 'since' [E0542]
+fn invalid_stability_version() {}
 
 #[stable(feature = "a", since = "1.0.0")]
-#[rustc_deprecated(since = "invalid", reason = "text")]
-fn invalid_deprecation_version() {} //~ ERROR Invalid deprecation version found
+#[rustc_deprecated(since = "invalid", reason = "text")] //~ ERROR invalid 'since' [E0542]
+fn invalid_deprecation_version() {}
 
-#[rustc_deprecated(since = "a", reason = "text")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
 fn deprecated_without_unstable_or_stable() { }
 //~^^ ERROR rustc_deprecated attribute must be paired with either stable or unstable attribute
+
+#[stable(feature = "a", since = "2.0.0")]
+#[rustc_deprecated(since = "1.0.0", reason = "text")]
+fn deprecated_before_stabilized() {} //~ ERROR An API can't be stabilized after it is deprecated
 
 fn main() { }

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -1,8 +1,8 @@
 error[E0541]: unknown meta item 'reason'
-  --> $DIR/stability-attribute-sanity.rs:8:42
+  --> $DIR/stability-attribute-sanity.rs:8:46
    |
-LL |     #[stable(feature = "a", since = "b", reason)]
-   |                                          ^^^^^^ expected one of `since`, `note`
+LL |     #[stable(feature = "a", since = "1.0.0", reason)]
+   |                                              ^^^^^^ expected one of `since`, `note`
 
 error[E0539]: incorrect meta item
   --> $DIR/stability-attribute-sanity.rs:11:29
@@ -13,7 +13,7 @@ LL |     #[stable(feature = "a", since)]
 error[E0539]: incorrect meta item
   --> $DIR/stability-attribute-sanity.rs:14:14
    |
-LL |     #[stable(feature, since = "a")]
+LL |     #[stable(feature, since = "1.0.0")]
    |              ^^^^^^^
 
 error[E0539]: incorrect meta item
@@ -25,7 +25,7 @@ LL |     #[stable(feature = "a", since(b))]
 error[E0539]: incorrect meta item
   --> $DIR/stability-attribute-sanity.rs:20:14
    |
-LL |     #[stable(feature(b), since = "a")]
+LL |     #[stable(feature(b), since = "1.0.0")]
    |              ^^^^^^^^^^
 
 error[E0546]: missing 'feature'
@@ -43,16 +43,16 @@ LL |     #[unstable(feature = "b")]
 error[E0546]: missing 'feature'
   --> $DIR/stability-attribute-sanity.rs:31:5
    |
-LL |     #[stable(since = "a")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[stable(since = "1.0.0")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0542]: missing 'since'
+error[E0542]: invalid 'since'
   --> $DIR/stability-attribute-sanity.rs:36:5
    |
 LL |     #[stable(feature = "a")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0542]: missing 'since'
+error[E0542]: invalid 'since'
   --> $DIR/stability-attribute-sanity.rs:40:5
    |
 LL |     #[rustc_deprecated(reason = "a")]
@@ -61,14 +61,14 @@ LL |     #[rustc_deprecated(reason = "a")]
 error[E0543]: missing 'reason'
   --> $DIR/stability-attribute-sanity.rs:44:5
    |
-LL |     #[rustc_deprecated(since = "a")]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     #[rustc_deprecated(since = "1.0.0")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0544]: multiple stability levels
   --> $DIR/stability-attribute-sanity.rs:49:1
    |
-LL | #[stable(feature = "a", since = "b")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[stable(feature = "a", since = "1.0.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0544]: multiple stability levels
   --> $DIR/stability-attribute-sanity.rs:53:1
@@ -79,16 +79,16 @@ LL | #[unstable(feature = "b", issue = "none")]
 error[E0544]: multiple stability levels
   --> $DIR/stability-attribute-sanity.rs:57:1
    |
-LL | #[stable(feature = "a", since = "b")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[stable(feature = "a", since = "1.0.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0550]: multiple deprecated attributes
   --> $DIR/stability-attribute-sanity.rs:62:1
    |
-LL | #[rustc_deprecated(since = "b", reason = "text")]
-   | ------------------------------------------------- first deprecation attribute
-LL | #[rustc_deprecated(since = "b", reason = "text")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ repeated deprecation attribute
+LL | #[rustc_deprecated(since = "1.0.0", reason = "text")]
+   | ----------------------------------------------------- first deprecation attribute
+LL | #[rustc_deprecated(since = "1.0.0", reason = "text")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ repeated deprecation attribute
 
 error[E0544]: multiple stability levels
   --> $DIR/stability-attribute-sanity.rs:64:1
@@ -96,25 +96,31 @@ error[E0544]: multiple stability levels
 LL | #[rustc_const_unstable(feature = "d", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Invalid stability version found
-  --> $DIR/stability-attribute-sanity.rs:65:1
+error[E0542]: invalid 'since'
+  --> $DIR/stability-attribute-sanity.rs:67:1
    |
-LL | pub const fn multiple4() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[stable(feature = "a", since = "invalid")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Invalid deprecation version found
-  --> $DIR/stability-attribute-sanity.rs:70:1
+error[E0542]: invalid 'since'
+  --> $DIR/stability-attribute-sanity.rs:71:1
    |
-LL | fn invalid_deprecation_version() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[rustc_deprecated(since = "invalid", reason = "text")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0549]: rustc_deprecated attribute must be paired with either stable or unstable attribute
-  --> $DIR/stability-attribute-sanity.rs:72:1
+  --> $DIR/stability-attribute-sanity.rs:74:1
    |
-LL | #[rustc_deprecated(since = "a", reason = "text")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | #[rustc_deprecated(since = "1.0.0", reason = "text")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 19 previous errors
+error: An API can't be stabilized after it is deprecated
+  --> $DIR/stability-attribute-sanity.rs:80:1
+   |
+LL | fn deprecated_before_stabilized() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0539, E0541, E0542, E0543, E0546, E0547, E0549, E0550.
 For more information about an error, try `rustc --explain E0539`.

--- a/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-trait-impl.rs
@@ -1,12 +1,12 @@
 #![feature(staged_api)]
 
-#[stable(feature = "x", since = "1")]
+#[stable(feature = "x", since = "1.0.0")]
 struct StableType;
 
 #[unstable(feature = "x", issue = "none")]
 struct UnstableType;
 
-#[stable(feature = "x", since = "1")]
+#[stable(feature = "x", since = "1.0.0")]
 trait StableTrait {}
 
 #[unstable(feature = "x", issue = "none")]


### PR DESCRIPTION
The existing handling of deprecation attributes has grown organically to encompass three different meanings over two distinct attributes, and has become pretty messy as a result. This PR cleans up the handling of deprecated attributes:

* Inspired by the existing `rustc_attr::StabilityLevel`, replace the `Deprecated` struct with a `DeprKind` enum for the two deprecated attributes: the stable `deprecated` and the unstable `rustc_deprecated`. This allows us to eliminate some unnecessary defensive checks regarding the fields present in the stable attribute.
* The `RustcDeprecated` variant contains a boolean field to indicate whether or not this will trigger the `deprecated` lint or the `deprecated_in_future` lint. The logic for determining this is moved from `rustc_middle` to `rustc_attr`. This also allows us to use the pre-existing `parse_version` logic that is private to `rustc_attr`.
* While `Deprecated` still stores an opaque `Symbol` as its `since` field, `RustcDeprecated` now stores a `Version`. Because the `StabilityLevel` enum is closely related to `DeprKind`, the `StabilityLevel::Stable` variant now also stores a `Version`. Storing `Version` allows us to remove the custom comparison logic for a sanity check in rustc_passes (a test for this sanity check is also added). As a bonus, errors related to passing in invalid version strings now point to the offending attribute rather than to the decorated item.
* Because `Version` is now being widely-used, it is exported as a public item. The sizes of its fields are also reduced from `u16` to `u8`. [Yes, I am aware of the irony.](https://lwn.net/Articles/845120/)