### PR TITLE
Enforce python3 and deprecate the use of python2

### DIFF
--- a/configure
+++ b/configure
@@ -12,7 +12,4 @@ try() {
 }
 
 try python3 "$@"
-try python2.7 "$@"
-try python27 "$@"
-try python2 "$@"
 exec python $script "$@"

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import argparse
 import contextlib
 import datetime
@@ -14,6 +13,7 @@ import tempfile
 
 from time import time
 
+
 def support_xz():
     try:
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
@@ -23,6 +23,7 @@ def support_xz():
         return True
     except tarfile.CompressionError:
         return False
+
 
 def get(url, path, verbose=False, do_verify=True):
     suffix = '.sha256'
@@ -43,7 +44,7 @@ def get(url, path, verbose=False, do_verify=True):
                 else:
                     if verbose:
                         print("ignoring already-download file",
-                            path, "due to failed verification")
+                              path, "due to failed verification")
                     os.unlink(path)
         download(temp_path, url, True, verbose)
         if do_verify and not verify(temp_path, sha_path, verbose):
@@ -274,7 +275,7 @@ def default_build_triple(verbose):
 
     if cputype == 'powerpc' and ostype == 'unknown-freebsd':
         cputype = subprocess.check_output(
-              ['uname', '-p']).strip().decode(default_encoding)
+            ['uname', '-p']).strip().decode(default_encoding)
     cputype_mapper = {
         'BePC': 'i686',
         'aarch64': 'aarch64',
@@ -362,6 +363,7 @@ def output(filepath):
 
 class RustBuild(object):
     """Provide all the methods required to build Rust"""
+
     def __init__(self):
         self.date = ''
         self._download_url = ''
@@ -413,7 +415,8 @@ class RustBuild(object):
             lib_dir = "{}/lib".format(self.bin_root())
             for lib in os.listdir(lib_dir):
                 if lib.endswith(".so"):
-                    self.fix_bin_or_dylib(os.path.join(lib_dir, lib), rpath_libz=True)
+                    self.fix_bin_or_dylib(os.path.join(
+                        lib_dir, lib), rpath_libz=True)
             with output(self.rustc_stamp()) as rust_stamp:
                 rust_stamp.write(self.date)
 
@@ -424,10 +427,13 @@ class RustBuild(object):
             if rustfmt_channel:
                 tarball_suffix = '.tar.xz' if support_xz() else '.tar.gz'
                 [channel, date] = rustfmt_channel.split('-', 1)
-                filename = "rustfmt-{}-{}{}".format(channel, self.build, tarball_suffix)
-                self._download_stage0_helper(filename, "rustfmt-preview", tarball_suffix, date)
+                filename = "rustfmt-{}-{}{}".format(
+                    channel, self.build, tarball_suffix)
+                self._download_stage0_helper(
+                    filename, "rustfmt-preview", tarball_suffix, date)
                 self.fix_bin_or_dylib("{}/bin/rustfmt".format(self.bin_root()))
-                self.fix_bin_or_dylib("{}/bin/cargo-fmt".format(self.bin_root()))
+                self.fix_bin_or_dylib(
+                    "{}/bin/cargo-fmt".format(self.bin_root()))
                 with output(self.rustfmt_stamp()) as rustfmt_stamp:
                     rustfmt_stamp.write(self.rustfmt_channel)
 
@@ -456,10 +462,12 @@ class RustBuild(object):
             if self.program_out_of_date(self.llvm_stamp(), llvm_sha + str(llvm_assertions)):
                 self._download_ci_llvm(llvm_sha, llvm_assertions)
                 for binary in ["llvm-config", "FileCheck"]:
-                    self.fix_bin_or_dylib(os.path.join(llvm_root, "bin", binary), rpath_libz=True)
+                    self.fix_bin_or_dylib(os.path.join(
+                        llvm_root, "bin", binary), rpath_libz=True)
                 for lib in os.listdir(llvm_lib):
                     if lib.endswith(".so"):
-                        self.fix_bin_or_dylib(os.path.join(llvm_lib, lib), rpath_libz=True)
+                        self.fix_bin_or_dylib(os.path.join(
+                            llvm_lib, lib), rpath_libz=True)
                 with output(self.llvm_stamp()) as llvm_stamp:
                     llvm_stamp.write(llvm_sha + str(llvm_assertions))
 
@@ -493,7 +501,8 @@ class RustBuild(object):
         tarball = os.path.join(rustc_cache, filename)
         if not os.path.exists(tarball):
             get("{}/{}".format(url, filename), tarball, verbose=self.verbose)
-        unpack(tarball, tarball_suffix, self.bin_root(), match=pattern, verbose=self.verbose)
+        unpack(tarball, tarball_suffix, self.bin_root(),
+               match=pattern, verbose=self.verbose)
 
     def _download_ci_llvm(self, llvm_sha, llvm_assertions):
         cache_prefix = "llvm-{}-{}".format(llvm_sha, llvm_assertions)
@@ -502,7 +511,8 @@ class RustBuild(object):
         if not os.path.exists(rustc_cache):
             os.makedirs(rustc_cache)
 
-        url = "https://ci-artifacts.rust-lang.org/rustc-builds/{}".format(llvm_sha)
+        url = "https://ci-artifacts.rust-lang.org/rustc-builds/{}".format(
+            llvm_sha)
         if llvm_assertions:
             url = url.replace('rustc-builds', 'rustc-builds-alt')
         # ci-artifacts are only stored as .xz, not .gz
@@ -514,10 +524,11 @@ class RustBuild(object):
         filename = "rust-dev-nightly-" + self.build + tarball_suffix
         tarball = os.path.join(rustc_cache, filename)
         if not os.path.exists(tarball):
-            get("{}/{}".format(url, filename), tarball, verbose=self.verbose, do_verify=False)
+            get("{}/{}".format(url, filename), tarball,
+                verbose=self.verbose, do_verify=False)
         unpack(tarball, tarball_suffix, self.llvm_root(),
-                match="rust-dev",
-                verbose=self.verbose)
+               match="rust-dev",
+               verbose=self.verbose)
 
     def fix_bin_or_dylib(self, fname, rpath_libz=False):
         """Modifies the interpreter section of 'fname' to fix the dynamic linker,
@@ -604,7 +615,8 @@ class RustBuild(object):
             # Finally, set the corret .interp for binaries
             bintools_dir = "{}/stdenv.cc.bintools".format(nix_deps_dir)
             with open("{}/nix-support/dynamic-linker".format(bintools_dir)) as dynamic_linker:
-                patchelf_args += ["--set-interpreter", dynamic_linker.read().rstrip()]
+                patchelf_args += ["--set-interpreter",
+                                  dynamic_linker.read().rstrip()]
 
         try:
             subprocess.check_output([patchelf] + patchelf_args + [fname])
@@ -641,7 +653,6 @@ class RustBuild(object):
         True
         """
         return os.path.join(self.llvm_root(), '.llvm-stamp')
-
 
     def program_out_of_date(self, stamp_path, key):
         """Check if the given program stamp is out of date"""
@@ -829,7 +840,8 @@ class RustBuild(object):
         elif self.get_toml("crt-static", build_section) == "false":
             target_features += ["-crt-static"]
         if target_features:
-            env["RUSTFLAGS"] += " -C target-feature=" + (",".join(target_features))
+            env["RUSTFLAGS"] += " -C target-feature=" + \
+                (",".join(target_features))
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
             env["RUSTFLAGS"] += " -C linker=" + target_linker
@@ -866,7 +878,8 @@ class RustBuild(object):
     def check_submodule(self, module, slow_submodules):
         if not slow_submodules:
             checked_out = subprocess.Popen(["git", "rev-parse", "HEAD"],
-                                           cwd=os.path.join(self.rust_root, module),
+                                           cwd=os.path.join(
+                                               self.rust_root, module),
                                            stdout=subprocess.PIPE)
             return checked_out
         else:
@@ -877,7 +890,8 @@ class RustBuild(object):
 
         if checked_out is not None:
             default_encoding = sys.getdefaultencoding()
-            checked_out = checked_out.communicate()[0].decode(default_encoding).strip()
+            checked_out = checked_out.communicate(
+            )[0].decode(default_encoding).strip()
             if recorded_submodules[module] == checked_out:
                 return
 
@@ -890,7 +904,8 @@ class RustBuild(object):
         if self.git_version >= distutils.version.LooseVersion("2.11.0"):
             update_args.append("--progress")
         update_args.append(module)
-        run(update_args, cwd=self.rust_root, verbose=self.verbose, exception=True)
+        run(update_args, cwd=self.rust_root,
+            verbose=self.verbose, exception=True)
 
         run(["git", "reset", "-q", "--hard"],
             cwd=module_path, verbose=self.verbose)
@@ -906,7 +921,8 @@ class RustBuild(object):
         default_encoding = sys.getdefaultencoding()
 
         # check the existence and version of 'git' command
-        git_version_str = require(['git', '--version']).split()[2].decode(default_encoding)
+        git_version_str = require(
+            ['git', '--version']).split()[2].decode(default_encoding)
         self.git_version = distutils.version.LooseVersion(git_version_str)
 
         slow_submodules = self.get_toml('fast-submodules') == "false"
@@ -923,8 +939,10 @@ class RustBuild(object):
         ).decode(default_encoding).splitlines()]
         filtered_submodules = []
         submodules_names = []
-        llvm_checked_out = os.path.exists(os.path.join(self.rust_root, "src/llvm-project/.git"))
-        external_llvm_provided = self.get_toml('llvm-config') or self.downloading_llvm()
+        llvm_checked_out = os.path.exists(os.path.join(
+            self.rust_root, "src/llvm-project/.git"))
+        external_llvm_provided = self.get_toml(
+            'llvm-config') or self.downloading_llvm()
         llvm_needed = not self.get_toml('codegen-backends', 'rust') \
             or "llvm" in self.get_toml('codegen-backends', 'rust')
         for module in submodules:
@@ -942,7 +960,8 @@ class RustBuild(object):
             submodules_names.append(module)
         recorded = subprocess.Popen(["git", "ls-tree", "HEAD"] + submodules_names,
                                     cwd=self.rust_root, stdout=subprocess.PIPE)
-        recorded = recorded.communicate()[0].decode(default_encoding).strip().splitlines()
+        recorded = recorded.communicate()[0].decode(
+            default_encoding).strip().splitlines()
         recorded_submodules = {}
         for data in recorded:
             data = data.split()
@@ -975,7 +994,8 @@ class RustBuild(object):
                 print('      and so in order to preserve your $HOME this will now')
                 print('      use vendored sources by default.')
                 if not os.path.exists(vendor_dir):
-                    print('error: vendoring required, but vendor directory does not exist.')
+                    print(
+                        'error: vendoring required, but vendor directory does not exist.')
                     print('       Run `cargo vendor` without sudo to initialize the '
                           'vendor directory.')
                     raise Exception("{} not found".format(vendor_dir))
@@ -1052,7 +1072,8 @@ def bootstrap(help_triggered):
     profile = build.get_toml('profile')
     if profile is not None:
         include_file = 'config.{}.toml'.format(profile)
-        include_dir = os.path.join(build.rust_root, 'src', 'bootstrap', 'defaults')
+        include_dir = os.path.join(
+            build.rust_root, 'src', 'bootstrap', 'defaults')
         include_path = os.path.join(include_dir, include_file)
         # HACK: This works because `build.get_toml()` returns the first match it finds for a
         # specific key, so appending our defaults at the end allows the user to override them
@@ -1070,7 +1091,8 @@ def bootstrap(help_triggered):
     build.check_vendored_status()
 
     build_dir = build.get_toml('build-dir', 'build') or 'build'
-    build.build_dir = os.path.abspath(build_dir.replace("$ROOT", build.rust_root))
+    build.build_dir = os.path.abspath(
+        build_dir.replace("$ROOT", build.rust_root))
 
     data = stage0_data(build.rust_root)
     build.date = data['date']

--- a/src/bootstrap/bootstrap_test.py
+++ b/src/bootstrap/bootstrap_test.py
@@ -1,6 +1,5 @@
 """Bootstrap tests"""
 
-from __future__ import absolute_import, division, print_function
 import os
 import doctest
 import unittest
@@ -15,25 +14,29 @@ import bootstrap
 
 class Stage0DataTestCase(unittest.TestCase):
     """Test Case for stage0_data"""
+
     def setUp(self):
         self.rust_root = tempfile.mkdtemp()
         os.mkdir(os.path.join(self.rust_root, "src"))
         with open(os.path.join(self.rust_root, "src",
                                "stage0.txt"), "w") as stage0:
-            stage0.write("#ignore\n\ndate: 2017-06-15\nrustc: beta\ncargo: beta\nrustfmt: beta")
+            stage0.write(
+                "#ignore\n\ndate: 2017-06-15\nrustc: beta\ncargo: beta\nrustfmt: beta")
 
     def tearDown(self):
         rmtree(self.rust_root)
 
     def test_stage0_data(self):
         """Extract data from stage0.txt"""
-        expected = {"date": "2017-06-15", "rustc": "beta", "cargo": "beta", "rustfmt": "beta"}
+        expected = {"date": "2017-06-15", "rustc": "beta",
+                    "cargo": "beta", "rustfmt": "beta"}
         data = bootstrap.stage0_data(self.rust_root)
         self.assertDictEqual(data, expected)
 
 
 class VerifyTestCase(unittest.TestCase):
     """Test Case for verify"""
+
     def setUp(self):
         self.container = tempfile.mkdtemp()
         self.src = os.path.join(self.container, "src.txt")
@@ -62,6 +65,7 @@ class VerifyTestCase(unittest.TestCase):
 
 class ProgramOutOfDate(unittest.TestCase):
     """Test if a program is out of date"""
+
     def setUp(self):
         self.container = tempfile.mkdtemp()
         os.mkdir(os.path.join(self.container, "stage0"))
@@ -79,19 +83,22 @@ class ProgramOutOfDate(unittest.TestCase):
         """Return True when the stamp file does not exists"""
         if os.path.exists(self.rustc_stamp_path):
             os.unlink(self.rustc_stamp_path)
-        self.assertTrue(self.build.program_out_of_date(self.rustc_stamp_path, self.key))
+        self.assertTrue(self.build.program_out_of_date(
+            self.rustc_stamp_path, self.key))
 
     def test_dates_are_different(self):
         """Return True when the dates are different"""
         with open(self.rustc_stamp_path, "w") as rustc_stamp:
             rustc_stamp.write("2017-06-14None")
-        self.assertTrue(self.build.program_out_of_date(self.rustc_stamp_path, self.key))
+        self.assertTrue(self.build.program_out_of_date(
+            self.rustc_stamp_path, self.key))
 
     def test_same_dates(self):
         """Return False both dates match"""
         with open(self.rustc_stamp_path, "w") as rustc_stamp:
             rustc_stamp.write("2017-06-15None")
-        self.assertFalse(self.build.program_out_of_date(self.rustc_stamp_path, self.key))
+        self.assertFalse(self.build.program_out_of_date(
+            self.rustc_stamp_path, self.key))
 
 
 if __name__ == '__main__':

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -2,14 +2,13 @@
 
 # ignore-tidy-linelength
 
-from __future__ import absolute_import, division, print_function
+import bootstrap
 import sys
 import os
 rust_dir = os.path.dirname(os.path.abspath(__file__))
 rust_dir = os.path.dirname(rust_dir)
 rust_dir = os.path.dirname(rust_dir)
 sys.path.append(os.path.join(rust_dir, "src", "bootstrap"))
-import bootstrap
 
 
 class Option(object):
@@ -36,24 +35,34 @@ o("docs", "build.docs", "build standard library documentation")
 o("compiler-docs", "build.compiler-docs", "build compiler documentation")
 o("optimize-tests", "rust.optimize-tests", "build tests with optimizations")
 o("parallel-compiler", "rust.parallel-compiler", "build a multi-threaded rustc")
-o("verbose-tests", "rust.verbose-tests", "enable verbose output when running tests")
-o("ccache", "llvm.ccache", "invoke gcc/clang via ccache to reuse object files between builds")
+o("verbose-tests", "rust.verbose-tests",
+  "enable verbose output when running tests")
+o("ccache", "llvm.ccache",
+  "invoke gcc/clang via ccache to reuse object files between builds")
 o("sccache", None, "invoke gcc/clang via sccache to reuse object files between builds")
 o("local-rust", None, "use an installed rustc rather than downloading a snapshot")
 v("local-rust-root", None, "set prefix for local rust binary")
-o("local-rebuild", "build.local-rebuild", "assume local-rust matches the current version, for rebuilds; implies local-rust, and is implied if local-rust already matches the current version")
-o("llvm-static-stdcpp", "llvm.static-libstdcpp", "statically link to libstdc++ for LLVM")
-o("llvm-link-shared", "llvm.link-shared", "prefer shared linking to LLVM (llvm-config --link-shared)")
+o("local-rebuild", "build.local-rebuild",
+  "assume local-rust matches the current version, for rebuilds; implies local-rust, and is implied if local-rust already matches the current version")
+o("llvm-static-stdcpp", "llvm.static-libstdcpp",
+  "statically link to libstdc++ for LLVM")
+o("llvm-link-shared", "llvm.link-shared",
+  "prefer shared linking to LLVM (llvm-config --link-shared)")
 o("rpath", "rust.rpath", "build rpaths into rustc itself")
-o("llvm-version-check", "llvm.version-check", "check if the LLVM version is supported, build anyway")
+o("llvm-version-check", "llvm.version-check",
+  "check if the LLVM version is supported, build anyway")
 o("codegen-tests", "rust.codegen-tests", "run the src/test/codegen tests")
 o("option-checking", None, "complain about unrecognized options in this configure script")
-o("ninja", "llvm.ninja", "build LLVM using the Ninja generator (for MSVC, requires building in the correct environment)")
+o("ninja", "llvm.ninja",
+  "build LLVM using the Ninja generator (for MSVC, requires building in the correct environment)")
 o("locked-deps", "build.locked-deps", "force Cargo.lock to be up to date")
 o("vendor", "build.vendor", "enable usage of vendored Rust crates")
-o("sanitizers", "build.sanitizers", "build the sanitizer runtimes (asan, lsan, msan, tsan)")
-o("dist-src", "rust.dist-src", "when building tarballs enables building a source tarball")
-o("cargo-native-static", "build.cargo-native-static", "static native libraries in cargo")
+o("sanitizers", "build.sanitizers",
+  "build the sanitizer runtimes (asan, lsan, msan, tsan)")
+o("dist-src", "rust.dist-src",
+  "when building tarballs enables building a source tarball")
+o("cargo-native-static", "build.cargo-native-static",
+  "static native libraries in cargo")
 o("profiler", "build.profiler", "build the profiler runtime")
 o("full-tools", None, "enable all tools")
 o("lld", "rust.lld", "build lld")
@@ -73,13 +82,19 @@ o("optimize", "rust.optimize", "build optimized rust code")
 o("optimize-llvm", "llvm.optimize", "build optimized LLVM")
 o("llvm-assertions", "llvm.assertions", "build LLVM with assertions")
 o("debug-assertions", "rust.debug-assertions", "build with debugging assertions")
-o("llvm-release-debuginfo", "llvm.release-debuginfo", "build LLVM with debugger metadata")
+o("llvm-release-debuginfo", "llvm.release-debuginfo",
+  "build LLVM with debugger metadata")
 v("debuginfo-level", "rust.debuginfo-level", "debuginfo level for Rust code")
-v("debuginfo-level-rustc", "rust.debuginfo-level-rustc", "debuginfo level for the compiler")
-v("debuginfo-level-std", "rust.debuginfo-level-std", "debuginfo level for the standard library")
-v("debuginfo-level-tools", "rust.debuginfo-level-tools", "debuginfo level for the tools")
-v("debuginfo-level-tests", "rust.debuginfo-level-tests", "debuginfo level for the test suites run with compiletest")
-v("save-toolstates", "rust.save-toolstates", "save build and test status of external tools into this file")
+v("debuginfo-level-rustc", "rust.debuginfo-level-rustc",
+  "debuginfo level for the compiler")
+v("debuginfo-level-std", "rust.debuginfo-level-std",
+  "debuginfo level for the standard library")
+v("debuginfo-level-tools", "rust.debuginfo-level-tools",
+  "debuginfo level for the tools")
+v("debuginfo-level-tests", "rust.debuginfo-level-tests",
+  "debuginfo level for the test suites run with compiletest")
+v("save-toolstates", "rust.save-toolstates",
+  "save build and test status of external tools into this file")
 
 v("prefix", "install.prefix", "set installation prefix")
 v("localstatedir", "install.localstatedir", "local state directory")
@@ -146,7 +161,8 @@ v("qemu-riscv64-rootfs", "target.riscv64gc-unknown-linux-gnu.qemu-rootfs",
 v("experimental-targets", "llvm.experimental-targets",
   "experimental LLVM targets to build")
 v("release-channel", "rust.channel", "the name of the release channel to build")
-v("release-description", "rust.description", "optional descriptive string for version output")
+v("release-description", "rust.description",
+  "optional descriptive string for version output")
 v("dist-compression-formats", None,
   "comma-separated list of compression formats to use")
 
@@ -155,8 +171,10 @@ v("default-linker", "rust.default-linker", "the default linker")
 
 # Many of these are saved below during the "writing configuration" step
 # (others are conditionally saved).
-o("manage-submodules", "build.submodules", "let the build manage the git submodules")
-o("full-bootstrap", "build.full-bootstrap", "build three compilers instead of two")
+o("manage-submodules", "build.submodules",
+  "let the build manage the git submodules")
+o("full-bootstrap", "build.full-bootstrap",
+  "build three compilers instead of two")
 o("extended", "build.extended", "build an extended rust tool set")
 
 v("tools", None, "List of extended tools will be installed")
@@ -185,9 +203,11 @@ if '--help' in sys.argv or '-h' in sys.argv:
             # no one needs to know about these obscure options
             continue
         if option.value:
-            print('\t{:30} {}'.format('--{}=VAL'.format(option.name), option.desc))
+            print('\t{:30} {}'.format(
+                '--{}=VAL'.format(option.name), option.desc))
         else:
-            print('\t{:30} {}'.format('--enable-{}'.format(option.name), option.desc))
+            print('\t{:30} {}'.format(
+                '--enable-{}'.format(option.name), option.desc))
     print('')
     print('This configure script is a thin configuration shim over the true')
     print('configuration system, `config.toml`. You can explore the comments')
@@ -376,7 +396,8 @@ for line in open(rust_dir + '/config.toml.example').read().split("\n"):
         if cur_section.startswith('target'):
             cur_section = 'target'
         elif '.' in cur_section:
-            raise RuntimeError("don't know how to deal with section: {}".format(cur_section))
+            raise RuntimeError(
+                "don't know how to deal with section: {}".format(cur_section))
         sections[cur_section] = [line]
         section_order.append(cur_section)
     else:
@@ -395,7 +416,8 @@ if 'target' in config:
         configured_targets.append(target)
 for target in configured_targets:
     targets[target] = sections['target'][:]
-    targets[target][0] = targets[target][0].replace("x86_64-unknown-linux-gnu", target)
+    targets[target][0] = targets[target][0].replace(
+        "x86_64-unknown-linux-gnu", target)
 
 
 def is_number(value):

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -40,7 +40,8 @@ if command -v python > /dev/null; then
 elif command -v python3 > /dev/null; then
     PYTHON="python3"
 else
-    PYTHON="python2"
+    echo "Python3 is required to run rustc" 1>&2
+    exit 1
 fi
 
 if ! isCI || isCiBranch auto || isCiBranch beta; then

--- a/src/etc/dec2flt_table.py
+++ b/src/etc/dec2flt_table.py
@@ -13,7 +13,6 @@ The representation ([u64], [i16]) instead of the more natural [(u64, i16)]
 is used because (u64, i16) has a ton of padding which would make the table
 even larger, and it's already uncomfortably large (6 KiB).
 """
-from __future__ import print_function
 from math import ceil, log
 from fractions import Fraction
 from collections import namedtuple

--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -101,8 +101,6 @@ checks if the given file does not exist, for example.
 
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
-
 import codecs
 import io
 import sys
@@ -126,7 +124,7 @@ except ImportError:
 
 # "void elements" (no closing tag) from the HTML Standard section 12.1.2
 VOID_ELEMENTS = {'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'keygen',
-                     'link', 'menuitem', 'meta', 'param', 'source', 'track', 'wbr'}
+                 'link', 'menuitem', 'meta', 'param', 'source', 'track', 'wbr'}
 
 # Python 2 -> 3 compatibility
 try:
@@ -141,6 +139,7 @@ class CustomHTMLParser(HTMLParser):
     this is possible because we are dealing with very regular HTML from
     rustdoc; we only have to deal with i) void elements and ii) empty
     attributes."""
+
     def __init__(self, target=None):
         HTMLParser.__init__(self)
         self.__builder = target or ET.TreeBuilder()
@@ -166,7 +165,8 @@ class CustomHTMLParser(HTMLParser):
         self.__builder.data(unichr(name2codepoint[name]))
 
     def handle_charref(self, name):
-        code = int(name[1:], 16) if name.startswith(('x', 'X')) else int(name, 10)
+        code = int(name[1:], 16) if name.startswith(
+            ('x', 'X')) else int(name, 10)
         self.__builder.data(unichr(code))
 
     def close(self):
@@ -250,7 +250,8 @@ def get_commands(template):
             try:
                 args = shlex.split(args)
             except UnicodeEncodeError:
-                args = [arg.decode('utf-8') for arg in shlex.split(args.encode('utf-8'))]
+                args = [arg.decode('utf-8')
+                        for arg in shlex.split(args.encode('utf-8'))]
             yield Command(negated=negated, cmd=cmd, args=args, lineno=lineno+1, context=line)
 
 
@@ -275,7 +276,8 @@ def normalize_xpath(path):
     elif path.startswith('.//'):
         return path
     else:
-        raise InvalidCheck('Non-absolute XPath is not supported due to implementation issues')
+        raise InvalidCheck(
+            'Non-absolute XPath is not supported due to implementation issues')
 
 
 class CachedFiles(object):
@@ -291,7 +293,8 @@ class CachedFiles(object):
             self.last_path = path
             return path
         elif self.last_path is None:
-            raise InvalidCheck('Tried to use the previous path in the first command')
+            raise InvalidCheck(
+                'Tried to use the previous path in the first command')
         else:
             return self.last_path
 
@@ -322,7 +325,8 @@ class CachedFiles(object):
             try:
                 tree = ET.fromstringlist(f.readlines(), CustomHTMLParser())
             except Exception as e:
-                raise RuntimeError('Cannot parse an HTML file {!r}: {}'.format(path, e))
+                raise RuntimeError(
+                    'Cannot parse an HTML file {!r}: {}'.format(path, e))
             self.trees[path] = tree
             return self.trees[path]
 
@@ -420,7 +424,8 @@ def check_command(c, cache):
                     ret = False
             elif len(c.args) == 2:  # @has/matches <path> <pat> = string test
                 cerr = "`PATTERN` did not match"
-                ret = check_string(cache.get_file(c.args[0]), c.args[1], regexp)
+                ret = check_string(cache.get_file(
+                    c.args[0]), c.args[1], regexp)
             elif len(c.args) == 3:  # @has/matches <path> <pat> <match> = XML tree test
                 cerr = "`XPATH PATTERN` did not match"
                 tree = cache.get_tree(c.args[0])
@@ -432,18 +437,22 @@ def check_command(c, cache):
                     pat = c.args[1]
                     if pat.endswith('/text()'):
                         pat = pat[:-7]
-                    ret = check_tree_text(cache.get_tree(c.args[0]), pat, c.args[2], regexp)
+                    ret = check_tree_text(cache.get_tree(
+                        c.args[0]), pat, c.args[2], regexp)
             else:
-                raise InvalidCheck('Invalid number of @{} arguments'.format(c.cmd))
+                raise InvalidCheck(
+                    'Invalid number of @{} arguments'.format(c.cmd))
 
         elif c.cmd == 'count':  # count test
             if len(c.args) == 3:  # @count <path> <pat> <count> = count test
                 expected = int(c.args[2])
                 found = get_tree_count(cache.get_tree(c.args[0]), c.args[1])
-                cerr = "Expected {} occurrences but found {}".format(expected, found)
+                cerr = "Expected {} occurrences but found {}".format(
+                    expected, found)
                 ret = expected == found
             else:
-                raise InvalidCheck('Invalid number of @{} arguments'.format(c.cmd))
+                raise InvalidCheck(
+                    'Invalid number of @{} arguments'.format(c.cmd))
         elif c.cmd == 'has-dir':  # has-dir test
             if len(c.args) == 1:  # @has-dir <path> = has-dir test
                 try:
@@ -453,7 +462,8 @@ def check_command(c, cache):
                     cerr = str(err)
                     ret = False
             else:
-                raise InvalidCheck('Invalid number of @{} arguments'.format(c.cmd))
+                raise InvalidCheck(
+                    'Invalid number of @{} arguments'.format(c.cmd))
         elif c.cmd == 'valid-html':
             raise InvalidCheck('Unimplemented @valid-html')
 

--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -13,7 +13,6 @@
 # Most of the time the `print` command will be executed while the program is still running will thus
 # fail. Using this Python script, the above will work as expected.
 
-from __future__ import print_function
 import lldb
 import os
 import sys
@@ -92,7 +91,8 @@ def execute_command(command_interpreter, command):
                 print_debug("breakpoint with id %s is already registered. Ignoring." %
                             str(breakpoint_id))
             else:
-                print_debug("registering breakpoint callback, id = " + str(breakpoint_id))
+                print_debug(
+                    "registering breakpoint callback, id = " + str(breakpoint_id))
                 callback_command = ("breakpoint command add -F breakpoint_callback " +
                                     str(breakpoint_id))
                 command_interpreter.HandleCommand(callback_command, res)
@@ -121,8 +121,10 @@ def start_breakpoint_listener(target):
                             lldb.SBBreakpoint.GetBreakpointEventTypeFromEvent(event) == \
                             lldb.eBreakpointEventTypeAdded:
                         global new_breakpoints
-                        breakpoint = lldb.SBBreakpoint.GetBreakpointFromEvent(event)
-                        print_debug("breakpoint added, id = " + str(breakpoint.id))
+                        breakpoint = lldb.SBBreakpoint.GetBreakpointFromEvent(
+                            event)
+                        print_debug("breakpoint added, id = " +
+                                    str(breakpoint.id))
                         new_breakpoints.append(breakpoint.id)
         except:
             print_debug("breakpoint listener shutting down")
@@ -133,7 +135,8 @@ def start_breakpoint_listener(target):
     listener_thread.start()
 
     # Register the listener with the target
-    target.GetBroadcaster().AddListener(listener, lldb.SBTarget.eBroadcastBitBreakpointChanged)
+    target.GetBroadcaster().AddListener(
+        listener, lldb.SBTarget.eBroadcastBitBreakpointChanged)
 
 
 def start_watchdog():
@@ -216,7 +219,8 @@ try:
             execute_command(command_interpreter, command)
 
 except IOError as e:
-    print("Could not read debugging script '%s'." % script_path, file=sys.stderr)
+    print("Could not read debugging script '%s'." %
+          script_path, file=sys.stderr)
     print(e, file=sys.stderr)
     print("Aborting.", file=sys.stderr)
     sys.exit(1)

--- a/src/etc/test-float-parse/runtests.py
+++ b/src/etc/test-float-parse/runtests.py
@@ -77,7 +77,7 @@ Windows) the worker processes are leaked and stick around forever.
 They're only a few megabytes each, but still, this script should not be run
 if you aren't prepared to manually kill a lot of orphaned processes.
 """
-from __future__ import print_function
+
 import sys
 import os.path
 import time

--- a/src/test/run-make-fulldeps/coverage-reports/normalize_paths.py
+++ b/src/test/run-make-fulldeps/coverage-reports/normalize_paths.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import sys
 
 # Normalize file paths in output

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -6,8 +6,6 @@
 # It gets called from `src/ci/publish_toolstate.sh` when a new commit lands on `master`
 # (i.e., after it passed all checks on `auto`).
 
-from __future__ import print_function
-
 import sys
 import re
 import os
@@ -62,6 +60,7 @@ REPOS = {
     'rustc-dev-guide': 'https://github.com/rust-lang/rustc-dev-guide',
 }
 
+
 def load_json_from_response(resp):
     content = resp.read()
     if isinstance(content, bytes):
@@ -69,6 +68,7 @@ def load_json_from_response(resp):
     else:
         print("Refusing to decode " + str(type(content)) + " to str")
     return json.loads(content)
+
 
 def validate_maintainers(repo, github_token):
     '''Ensure all maintainers are assignable on a GitHub repo'''
@@ -83,7 +83,8 @@ def validate_maintainers(repo, github_token):
             # Properly load nested teams.
             'Accept': 'application/vnd.github.hellcat-preview+json',
         }))
-        assignable.extend(user['login'] for user in load_json_from_response(response))
+        assignable.extend(user['login']
+                          for user in load_json_from_response(response))
         # Load the next page if available
         url = None
         link_header = response.headers.get('Link')
@@ -213,7 +214,8 @@ def update_latest(
                 old = status[os]
                 new = s.get(tool, old)
                 status[os] = new
-                maintainers = ' '.join('@'+name for name in MAINTAINERS.get(tool, ()))
+                maintainers = ' '.join(
+                    '@'+name for name in MAINTAINERS.get(tool, ()))
                 # comparing the strings, but they are ordered appropriately:
                 # "test-pass" > "test-fail" > "build-fail"
                 if new > old:
@@ -243,8 +245,10 @@ def update_latest(
             if create_issue_for_status is not None:
                 try:
                     issue(
-                        tool, create_issue_for_status, MAINTAINERS.get(tool, ''),
-                        relevant_pr_number, relevant_pr_user, LABELS.get(tool, ''),
+                        tool, create_issue_for_status, MAINTAINERS.get(
+                            tool, ''),
+                        relevant_pr_number, relevant_pr_user, LABELS.get(
+                            tool, ''),
                     )
                 except urllib2.HTTPError as e:
                     # network errors will simply end up not creating an issue, but that's better
@@ -252,7 +256,8 @@ def update_latest(
                     print("HTTPError when creating issue for status regression: {0}\n{1}"
                           .format(e, e.read()))
                 except IOError as e:
-                    print("I/O error when creating issue for status regression: {0}".format(e))
+                    print(
+                        "I/O error when creating issue for status regression: {0}".format(e))
                 except:
                     print("Unexpected error when creating issue for status regression: {0}"
                           .format(sys.exc_info()[0]))
@@ -284,7 +289,8 @@ try:
         if github_token:
             validate_maintainers(repo, github_token)
         else:
-            print('skipping toolstate maintainers validation since no GitHub token is present')
+            print(
+                'skipping toolstate maintainers validation since no GitHub token is present')
         # When validating maintainers don't run the full script.
         exit(0)
 

--- a/src/tools/x/src/main.rs
+++ b/src/tools/x/src/main.rs
@@ -4,7 +4,7 @@
 //! However, since `exec` isn't available on Windows, we indirect through
 //! `exec_or_status`, which will call `exec` on unix and `status` on Windows.
 //!
-//! We use `python`, `python3`, or `python2` as the python interpreter to run
+//! We use `python` or `python3` as the python interpreter to run
 //! `x.py`, in that order of preference.
 
 use std::{
@@ -13,7 +13,6 @@ use std::{
 };
 
 const PYTHON: &str = "python";
-const PYTHON2: &str = "python2";
 const PYTHON3: &str = "python3";
 
 fn python() -> &'static str {
@@ -22,7 +21,6 @@ fn python() -> &'static str {
         None => return PYTHON,
     };
 
-    let mut python2 = false;
     let mut python3 = false;
 
     for dir in env::split_paths(&val) {
@@ -30,16 +28,16 @@ fn python() -> &'static str {
             return PYTHON;
         }
 
-        python2 |= dir.join(PYTHON2).exists();
         python3 |= dir.join(PYTHON3).exists();
     }
 
     if python3 {
         PYTHON3
-    } else if python2 {
-        PYTHON2
-    } else {
+    } else if PYTHON {
         PYTHON
+    } else {
+        eprintln!("Python3 is required to build rustc");
+        process::exit(1);
     }
 }
 

--- a/x.py
+++ b/x.py
@@ -2,6 +2,7 @@
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 
+import bootstrap
 import os
 import sys
 
@@ -17,11 +18,10 @@ if sys.version_info.major < 3:
         try:
             os.execvp("python3", ["python3"] + sys.argv)
         except OSError:
-            # Python 3 isn't available, fall back to python 2
-            pass
+            # If Python3 isn't available, raise an error
+            raise OSError("Python3 is required in order to build rustc")
 
 rust_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(rust_dir, "src", "bootstrap"))
 
-import bootstrap
 bootstrap.main()

--- a/x.py
+++ b/x.py
@@ -2,7 +2,6 @@
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 
-import bootstrap
 import os
 import sys
 
@@ -24,4 +23,5 @@ if sys.version_info.major < 3:
 rust_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(rust_dir, "src", "bootstrap"))
 
+import bootstrap
 bootstrap.main()


### PR DESCRIPTION
This PR enforces python3 and depreciates the use of python2 to build the Rust compiler. As python2 is [no longer supported](https://www.python.org/doc/sunset-python-2/) and we are approaching python4, we should move towards python3. Python2 is no longer maintained and could bring bugs to rustc if used. Even though Rust is about compatibility, the Python team highly recommends deprecating python2 since it's no longer maintained and security/general bug reports will not be looked at. Additionally, if rustc wanted to use python3 only features/python3 only packages, this would break when using python2.

Note: this PR also formats the Python code

From the Python ["Sunset Python 2"](https://www.python.org/doc/sunset-python-2/) blog post:

> **What will happen if I did not upgrade by January 1st, 2020?**
>
> If people find catastrophic security problems in Python 2, or in software written in Python 2, then most volunteers will not help fix them. If you need help with Python 2 software, then many volunteers will not help you, and over time fewer and fewer volunteers will be able to help you. You will lose chances to use good tools because they will only run on Python 3, and you will slow down people who depend on you and work with you.
> Some of these problems started on January 1. Other problems will grow over time.
