### PR TITLE
Skip emitting closure diagnostic when closure_kind_origins has no entry

### DIFF
--- a/src/test/ui/closures/issue-82438-mut-without-upvar.rs
+++ b/src/test/ui/closures/issue-82438-mut-without-upvar.rs
@@ -1,0 +1,28 @@
+use std::error::Error;
+struct A {
+}
+
+impl A {
+    pub fn new() -> A {
+        A {
+        }
+    }
+
+    pub fn f<'a>(
+        &'a self,
+        team_name: &'a str,
+        c: &'a mut dyn FnMut(String, String, u64, u64)
+    ) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
+}
+
+
+fn main() {
+    let A = A::new();
+    let participant_name = "A";
+
+    let c = |a, b, c, d| {};
+
+    A.f(participant_name, &mut c); //~ ERROR cannot borrow
+}

--- a/src/test/ui/closures/issue-82438-mut-without-upvar.stderr
+++ b/src/test/ui/closures/issue-82438-mut-without-upvar.stderr
@@ -1,0 +1,12 @@
+error[E0596]: cannot borrow `c` as mutable, as it is not declared as mutable
+  --> $DIR/issue-82438-mut-without-upvar.rs:27:27
+   |
+LL |     let c = |a, b, c, d| {};
+   |         - help: consider changing this to be mutable: `mut c`
+LL | 
+LL |     A.f(participant_name, &mut c);
+   |                           ^^^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
Fixes #82438

This map is not guarnateed to have an entry for a closure.