### PR TITLE
Cleanup option parsing and config.toml.example

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -112,6 +112,7 @@ changelog-seen = 2
 
 # When invoking `llvm-config` this configures whether the `--shared` argument is
 # passed to prefer linking to shared libraries.
+# NOTE: `thin-lto = true` requires this to be `true` and will give an error otherwise.
 #link-shared = false
 
 # When building llvm, this configures what is being appended to the version.
@@ -120,22 +121,23 @@ changelog-seen = 2
 #version-suffix = "-rust-dev"
 
 # On MSVC you can compile LLVM with clang-cl, but the test suite doesn't pass
-# with clang-cl, so this is special in that it only compiles LLVM with clang-cl
-#clang-cl = '/path/to/clang-cl.exe'
+# with clang-cl, so this is special in that it only compiles LLVM with clang-cl.
+# Note that this takes a /path/to/clang-cl, not a boolean.
+#clang-cl = cc
 
 # Pass extra compiler and linker flags to the LLVM CMake build.
-#cflags = "-fextra-flag"
-#cxxflags = "-fextra-flag"
-#ldflags = "-Wl,extra-flag"
+#cflags = ""
+#cxxflags = ""
+#ldflags = ""
 
 # Use libc++ when building LLVM instead of libstdc++. This is the default on
 # platforms already use libc++ as the default C++ library, but this option
 # allows you to use libc++ even on platforms when it's not. You need to ensure
 # that your host compiler ships with libc++.
-#use-libcxx = true
+#use-libcxx = false
 
 # The value specified here will be passed as `-DLLVM_USE_LINKER` to CMake.
-#use-linker = "lld"
+#use-linker = <none> (path)
 
 # Whether or not to specify `-DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=YES`
 #allow-old-toolchain = false
@@ -147,6 +149,9 @@ changelog-seen = 2
 # General build configuration options
 # =============================================================================
 [build]
+# The default stage to use for the `check` subcommand
+#check-stage = 0
+
 # The default stage to use for the `doc` subcommand
 #doc-stage = 0
 
@@ -170,14 +175,14 @@ changelog-seen = 2
 # binaries of this build triple and the nightly will be used to bootstrap the
 # first compiler.
 #
-# Defaults to host platform
-#build = "x86_64-unknown-linux-gnu"
+# Defaults to platform where `x.py` is run.
+#build = "x86_64-unknown-linux-gnu" (as an example)
 
 # Which triples to produce a compiler toolchain for. Each of these triples will
 # be bootstrapped from the build triple themselves.
 #
-# Defaults to just the build triple
-#host = ["x86_64-unknown-linux-gnu"]
+# Defaults to just the build triple.
+#host = ["x86_64-unknown-linux-gnu"] (as an example)
 
 # Which triples to build libraries (core/alloc/std/test/proc_macro) for. Each of
 # these triples will be bootstrapped from the build triple themselves.
@@ -185,7 +190,7 @@ changelog-seen = 2
 # Defaults to `host`. If you set this explicitly, you likely want to add all
 # host triples to this list as well in order for those host toolchains to be
 # able to compile programs for their native target.
-#target = ["x86_64-unknown-linux-gnu"]
+#target = ["x86_64-unknown-linux-gnu"] (as an example)
 
 # Use this directory to store build artifacts.
 # You can use "$ROOT" to indicate the root of the git repository.
@@ -193,15 +198,15 @@ changelog-seen = 2
 
 # Instead of downloading the src/stage0.txt version of Cargo specified, use
 # this Cargo binary instead to build all Rust code
-#cargo = "/path/to/bin/cargo"
+#cargo = "/path/to/cargo"
 
 # Instead of downloading the src/stage0.txt version of the compiler
 # specified, use this rustc binary instead as the stage0 snapshot compiler.
-#rustc = "/path/to/bin/rustc"
+#rustc = "/path/to/rustc"
 
 # Instead of download the src/stage0.txt version of rustfmt specified,
 # use this rustfmt binary instead as the stage0 snapshot rustfmt.
-#rustfmt = "/path/to/bin/rustfmt"
+#rustfmt = "/path/to/rustfmt"
 
 # Flag to specify whether any documentation is built. If false, rustdoc and
 # friends will still be compiled but they will not be used to generate any
@@ -325,15 +330,8 @@ changelog-seen = 2
 # Where to install man pages in `prefix` above
 #mandir = "share/man"
 
-# Where to install data in `prefix` above (currently unused)
+# Where to install data in `prefix` above
 #datadir = "share"
-
-# Where to install additional info in `prefix` above (currently unused)
-#infodir = "share/info"
-
-# Where to install local state (currently unused)
-# If this is a relative path, it will get installed in `prefix` above
-#localstatedir = "/var/lib"
 
 # =============================================================================
 # Options for compiling Rust code itself
@@ -384,7 +382,9 @@ changelog-seen = 2
 
 # Sets the number of codegen units to build the standard library with,
 # regardless of what the codegen-unit setting for the rest of the compiler is.
-#codegen-units-std = 1
+# NOTE: building with anything other than 1 is known to occasionally have bugs.
+# See https://github.com/rust-lang/rust/issues/83600.
+#codegen-units-std = codegen-units
 
 # Whether or not debug assertions are enabled for the compiler and standard
 # library. Debug assertions control the maximum log level used by rustc. When
@@ -427,19 +427,13 @@ changelog-seen = 2
 #debuginfo-level = 0
 
 # Debuginfo level for the compiler.
-#
-# Defaults to rust.debuginfo-level value
-#debuginfo-level-rustc = 0
+#debuginfo-level-rustc = debuginfo-level
 
 # Debuginfo level for the standard library.
-#
-# Defaults to rust.debuginfo-level value
-#debuginfo-level-std = 0
+#debuginfo-level-std = debuginfo-level
 
 # Debuginfo level for the tools.
-#
-# Defaults to rust.debuginfo-level value
-#debuginfo-level-tools = 0
+#debuginfo-level-tools = debuginfo-level
 
 # Debuginfo level for the test suites run with compiletest.
 # FIXME(#61117): Some tests fail when this option is enabled.
@@ -466,7 +460,9 @@ changelog-seen = 2
 # The default linker that will be hard-coded into the generated compiler for
 # targets that don't specify linker explicitly in their target specifications.
 # Note that this is not the linker used to link said compiler.
-#default-linker = "cc"
+#
+# See https://doc.rust-lang.org/rustc/codegen-options/index.html#linker for more information.
+#default-linker = <none> (path)
 
 # The "channel" for the Rust build to produce. The stable/beta channels only
 # allow using stable features, whereas the nightly and dev channels allow using
@@ -476,10 +472,15 @@ changelog-seen = 2
 # A descriptive string to be appended to `rustc --version` output, which is
 # also used in places like debuginfo `DW_AT_producer`. This may be useful for
 # supplementary build information, like distro-specific package versions.
-#description = ""
+#description = <none> (string)
 
-# The root location of the musl installation directory.
-#musl-root = "..."
+# The root location of the musl installation directory. The library directory
+# will also need to contain libunwind.a for an unwinding implementation. Note
+# that this option only makes sense for musl targets that produce statically
+# linked binaries.
+#
+# Defaults to /usr on musl hosts. Has no default otherwise.
+#musl-root = <platform specific> (path)
 
 # By default the `rustc` executable is built with `-Wl,-rpath` flags on Unix
 # platforms to ensure that the compiler is usable by default from the build
@@ -502,14 +503,14 @@ changelog-seen = 2
 # Having the git information can cause a lot of rebuilds during development.
 # Note: If this attribute is not explicitly set (e.g. if left commented out) it
 # will default to true if channel = "dev", but will default to false otherwise.
-#ignore-git = true
+#ignore-git = if channel == "dev" { true } else { false }
 
 # When creating source tarballs whether or not to create a source tarball.
-#dist-src = false
+#dist-src = true
 
 # After building or testing extended tools (e.g. clippy and rustfmt), append the
 # result (broken, compiling, testing) into this JSON file.
-#save-toolstates = "/path/to/toolstates.json"
+#save-toolstates = <none> (path)
 
 # This is an array of the codegen backends that will be compiled for the rustc
 # that's being compiled. The default is to only build the LLVM codegen backend,
@@ -545,9 +546,7 @@ changelog-seen = 2
 # Compile the compiler with a non-default ThinLTO import limit. This import
 # limit controls the maximum size of functions imported by ThinLTO. Decreasing
 # will make code compile faster at the expense of lower runtime performance.
-# If `incremental` is set to true above, the import limit will default to 10
-# instead of LLVM's default of 100.
-#thin-lto-import-instr-limit = 100
+#thin-lto-import-instr-limit = if incremental { 10 } else { LLVM default (currently 100) }
 
 # Map debuginfo paths to `/rust/$sha/...`, generally only set for releases
 #remap-debuginfo = false
@@ -581,63 +580,66 @@ changelog-seen = 2
 # =============================================================================
 [target.x86_64-unknown-linux-gnu]
 
-# C compiler to be used to compiler C code. Note that the
+# C compiler to be used to compile C code. Note that the
 # default value is platform specific, and if not specified it may also depend on
 # what platform is crossing to what platform.
-#cc = "cc"
+# See `src/bootstrap/cc_detect.rs` for details.
+#cc = "cc" (path)
 
-# C++ compiler to be used to compiler C++ code (e.g. LLVM and our LLVM shims).
+# C++ compiler to be used to compile C++ code (e.g. LLVM and our LLVM shims).
 # This is only used for host targets.
-#cxx = "c++"
+# See `src/bootstrap/cc_detect.rs` for details.
+#cxx = "c++" (path)
 
 # Archiver to be used to assemble static libraries compiled from C/C++ code.
 # Note: an absolute path should be used, otherwise LLVM build will break.
-#ar = "ar"
+#ar = "ar" (path)
 
 # Ranlib to be used to assemble static libraries compiled from C/C++ code.
 # Note: an absolute path should be used, otherwise LLVM build will break.
-#ranlib = "ranlib"
+#ranlib = "ranlib" (path)
 
-# Linker to be used to link Rust code. Note that the
+# Linker to be used to bootstrap Rust code. Note that the
 # default value is platform specific, and if not specified it may also depend on
 # what platform is crossing to what platform.
 # Setting this will override the `use-lld` option for Rust code when targeting MSVC.
-#linker = "cc"
+#linker = "cc" (path)
 
 # Path to the `llvm-config` binary of the installation of a custom LLVM to link
 # against. Note that if this is specified we don't compile LLVM at all for this
 # target.
-#llvm-config = "../path/to/llvm/root/bin/llvm-config"
+#llvm-config = <none> (path)
 
 # Normally the build system can find LLVM's FileCheck utility, but if
 # not, you can specify an explicit file name for it.
-#llvm-filecheck = "/path/to/FileCheck"
+#llvm-filecheck = "/path/to/llvm-version/bin/FileCheck"
 
 # If this target is for Android, this option will be required to specify where
 # the NDK for the target lives. This is used to find the C compiler to link and
 # build native code.
-#android-ndk = "/path/to/ndk"
+# See `src/bootstrap/cc_detect.rs` for details.
+#android-ndk = <none> (path)
 
 # Build the sanitizer runtimes for this target.
 # This option will override the same option under [build] section.
-#sanitizers = false
+#sanitizers = build.sanitizers (bool)
 
 # Build the profiler runtime for this target(required when compiling with options that depend
 # on this runtime, such as `-C profile-generate` or `-Z instrument-coverage`).
 # This option will override the same option under [build] section.
-#profiler = false
+#profiler = build.profiler (bool)
 
 # Force static or dynamic linkage of the standard library for this target. If
 # this target is a host for rustc, this will also affect the linkage of the
 # compiler itself. This is useful for building rustc on targets that normally
 # only use static libraries. If unset, the target's default linkage is used.
-#crt-static = false
+#crt-static = <platform-specific> (bool)
 
 # The root location of the musl installation directory. The library directory
 # will also need to contain libunwind.a for an unwinding implementation. Note
 # that this option only makes sense for musl targets that produce statically
-# linked binaries
-#musl-root = "..."
+# linked binaries.
+#musl-root = build.musl-root (path)
 
 # The full path to the musl libdir.
 #musl-libdir = musl-root/lib
@@ -645,11 +647,11 @@ changelog-seen = 2
 # The root location of the `wasm32-wasi` sysroot. Only used for the
 # `wasm32-wasi` target. If you are building wasm32-wasi target, make sure to
 # create a `[target.wasm32-wasi]` section and move this field there.
-#wasi-root = "..."
+#wasi-root = <none> (path)
 
 # Used in testing for configuring where the QEMU images are located, you
 # probably don't want to use this.
-#qemu-rootfs = "..."
+#qemu-rootfs = <none> (path)
 
 # =============================================================================
 # Distribution options
@@ -666,12 +668,7 @@ changelog-seen = 2
 #
 # This folder should be populated ahead of time before the build system is
 # invoked.
-#sign-folder = "path/to/folder/to/sign"
-
-# This is a file which contains the password of the default gpg key. This will
-# be passed to `gpg` down the road when signing all files in `sign-folder`
-# above. This should be stored in plaintext.
-#gpg-password-file = "path/to/gpg/password"
+#sign-folder = <none> (path)
 
 # The remote address that all artifacts will eventually be uploaded to. The
 # build system generates manifests which will point to these urls, and for the
@@ -679,18 +676,19 @@ changelog-seen = 2
 #
 # Note that this address should not contain a trailing slash as file names will
 # be appended to it.
-#upload-addr = "https://example.com/folder"
+#upload-addr = <none> (URL)
 
 # Whether to build a plain source tarball to upload
 # We disable that on Windows not to override the one already uploaded on S3
 # as the one built on Windows will contain backslashes in paths causing problems
 # on linux
 #src-tarball = true
-#
 
 # Whether to allow failures when building tools
 #missing-tools = false
 
 # List of compression formats to use when generating dist tarballs. The list of
 # formats is provided to rust-installer, which must support all of them.
+#
+# This list must be non-empty.
 #compression-formats = ["gz", "xz"]

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Changes since the last major version]
 
 - `llvm-libunwind` now accepts `in-tree` (formerly true), `system` or `no` (formerly false) [#77703](https://github.com/rust-lang/rust/pull/77703)
+- The options `infodir`, `localstatedir`, and `gpg-password-file` are no longer allowed in config.toml. Previously, they were ignored without warning. Note that `infodir` and `localstatedir` are still accepted by `./configure`, with a warning. [#82451](https://github.com/rust-lang/rust/pull/82451)
 
 ### Non-breaking changes
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -67,7 +67,7 @@ pub struct Config {
     pub rustc_error_format: Option<String>,
     pub json_output: bool,
     pub test_compare_mode: bool,
-    pub llvm_libunwind: Option<LlvmLibunwind>,
+    pub llvm_libunwind: LlvmLibunwind,
     pub color: Color,
 
     pub on_fail: Option<String>,
@@ -101,8 +101,8 @@ pub struct Config {
     pub llvm_link_jobs: Option<u32>,
     pub llvm_version_suffix: Option<String>,
     pub llvm_use_linker: Option<String>,
-    pub llvm_allow_old_toolchain: Option<bool>,
-    pub llvm_polly: Option<bool>,
+    pub llvm_allow_old_toolchain: bool,
+    pub llvm_polly: bool,
     pub llvm_from_ci: bool,
 
     pub use_lld: bool,
@@ -149,7 +149,6 @@ pub struct Config {
     // dist misc
     pub dist_sign_folder: Option<PathBuf>,
     pub dist_upload_addr: Option<String>,
-    pub dist_gpg_password_file: Option<PathBuf>,
     pub dist_compression_formats: Option<Vec<String>>,
 
     // libstd features
@@ -404,10 +403,6 @@ struct Install {
     libdir: Option<String>,
     mandir: Option<String>,
     datadir: Option<String>,
-
-    // standard paths, currently unused
-    infodir: Option<String>,
-    localstatedir: Option<String>,
 }
 
 /// TOML representation of how the LLVM build is configured.
@@ -563,11 +558,10 @@ impl Config {
         config.rust_rpath = true;
         config.channel = "dev".to_string();
         config.codegen_tests = true;
-        config.ignore_git = false;
         config.rust_dist_src = true;
         config.rust_codegen_backends = vec![INTERNER.intern_str("llvm")];
         config.deny_warnings = true;
-        config.missing_tools = false;
+        config.bindir = "bin".into();
 
         // set by build.rs
         config.build = TargetSelection::from_user(&env!("BUILD_TRIPLE"));
@@ -597,7 +591,6 @@ impl Config {
         config.dry_run = flags.dry_run;
         config.keep_stage = flags.keep_stage;
         config.keep_stage_std = flags.keep_stage_std;
-        config.bindir = "bin".into(); // default
         config.color = flags.color;
         if let Some(value) = flags.deny_warnings {
             config.deny_warnings = value;
@@ -792,12 +785,25 @@ impl Config {
             config.llvm_ldflags = llvm.ldflags.clone();
             set(&mut config.llvm_use_libcxx, llvm.use_libcxx);
             config.llvm_use_linker = llvm.use_linker.clone();
-            config.llvm_allow_old_toolchain = llvm.allow_old_toolchain;
-            config.llvm_polly = llvm.polly;
+            config.llvm_allow_old_toolchain = llvm.allow_old_toolchain.unwrap_or(false);
+            config.llvm_polly = llvm.polly.unwrap_or(false);
             config.llvm_from_ci = match llvm.download_ci_llvm {
                 Some(StringOrBool::String(s)) => {
                     assert!(s == "if-available", "unknown option `{}` for download-ci-llvm", s);
-                    config.build.triple == "x86_64-unknown-linux-gnu"
+                    // This is currently all tier 1 targets (since others may not have CI artifacts)
+                    // https://doc.rust-lang.org/rustc/platform-support.html#tier-1
+                    // FIXME: this is duplicated in bootstrap.py
+                    let supported_platforms = [
+                        "aarch64-unknown-linux-gnu",
+                        "i686-pc-windows-gnu",
+                        "i686-pc-windows-msvc",
+                        "i686-unknown-linux-gnu",
+                        "x86_64-unknown-linux-gnu",
+                        "x86_64-apple-darwin",
+                        "x86_64-pc-windows-gnu",
+                        "x86_64-pc-windows-msvc",
+                    ];
+                    supported_platforms.contains(&&*config.build.triple)
                 }
                 Some(StringOrBool::Bool(b)) => b,
                 None => false,
@@ -818,7 +824,6 @@ impl Config {
                 check_ci_llvm!(llvm.targets);
                 check_ci_llvm!(llvm.experimental_targets);
                 check_ci_llvm!(llvm.link_jobs);
-                check_ci_llvm!(llvm.link_shared);
                 check_ci_llvm!(llvm.clang_cl);
                 check_ci_llvm!(llvm.version_suffix);
                 check_ci_llvm!(llvm.cflags);
@@ -839,6 +844,11 @@ impl Config {
                 // If we're building with ThinLTO on, we want to link to LLVM
                 // shared, to avoid re-doing ThinLTO (which happens in the link
                 // step) with each stage.
+                assert_ne!(
+                    llvm.link_shared,
+                    Some(false),
+                    "setting link-shared=false is incompatible with thin-lto=true"
+                );
                 config.llvm_link_shared = true;
             }
         }
@@ -864,7 +874,8 @@ impl Config {
             set(&mut config.test_compare_mode, rust.test_compare_mode);
             config.llvm_libunwind = rust
                 .llvm_libunwind
-                .map(|v| v.parse().expect("failed to parse rust.llvm-libunwind"));
+                .map(|v| v.parse().expect("failed to parse rust.llvm-libunwind"))
+                .unwrap_or_default();
             set(&mut config.backtrace, rust.backtrace);
             set(&mut config.channel, rust.channel);
             config.description = rust.description;
@@ -952,7 +963,6 @@ impl Config {
 
         if let Some(t) = toml.dist {
             config.dist_sign_folder = t.sign_folder.map(PathBuf::from);
-            config.dist_gpg_password_file = t.gpg_password_file.map(PathBuf::from);
             config.dist_upload_addr = t.upload_addr;
             config.dist_compression_formats = t.compression_formats;
             set(&mut config.rust_dist_src, t.src_tarball);
@@ -976,12 +986,8 @@ impl Config {
         // default values for all options that we haven't otherwise stored yet.
 
         config.llvm_skip_rebuild = llvm_skip_rebuild.unwrap_or(false);
-
-        let default = false;
-        config.llvm_assertions = llvm_assertions.unwrap_or(default);
-
-        let default = true;
-        config.rust_optimize = optimize.unwrap_or(default);
+        config.llvm_assertions = llvm_assertions.unwrap_or(false);
+        config.rust_optimize = optimize.unwrap_or(true);
 
         let default = debug == Some(true);
         config.rust_debug_assertions = debug_assertions.unwrap_or(default);

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -439,7 +439,12 @@ def configure_section(lines, config):
             lines[i] = "{} = {}".format(key, to_toml(value))
             break
         if not found:
-            raise RuntimeError("failed to find config line for {}".format(key))
+            # These are used by rpm, but aren't accepted by x.py.
+            # Give a warning that they're ignored, but not a hard error.
+            if key in ["infodir", "localstatedir"]:
+                print("warning: {} will be ignored".format(key))
+            else:
+                raise RuntimeError("failed to find config line for {}".format(key))
 
 
 for section_key in config:

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -547,7 +547,7 @@ impl Build {
     fn std_features(&self, target: TargetSelection) -> String {
         let mut features = "panic-unwind".to_string();
 
-        match self.config.llvm_libunwind.unwrap_or_default() {
+        match self.config.llvm_libunwind {
             LlvmLibunwind::InTree => features.push_str(" llvm-libunwind"),
             LlvmLibunwind::System => features.push_str(" system-llvm-libunwind"),
             LlvmLibunwind::No => {}

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -256,7 +256,7 @@ impl Step for Llvm {
             enabled_llvm_projects.push("compiler-rt");
         }
 
-        if let Some(true) = builder.config.llvm_polly {
+        if builder.config.llvm_polly {
             enabled_llvm_projects.push("polly");
         }
 
@@ -311,7 +311,7 @@ impl Step for Llvm {
             cfg.define("LLVM_USE_LINKER", linker);
         }
 
-        if let Some(true) = builder.config.llvm_allow_old_toolchain {
+        if builder.config.llvm_allow_old_toolchain {
             cfg.define("LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN", "YES");
         }
 


### PR DESCRIPTION
- Add an assertion that `link-shared = true` when `thin-lto = true`.
  Previously, link-shared would be silently overwritten.

- Get rid of `Option<bool>` in bootstrap/config.rs. Set defaults
  immediately instead of delaying until later in bootstrap. This makes
  it easier to find what the default value is.

- Remove redundant `config.x = false` when the default was already false
- Set defaults for `bindir` in `default_opts()` instead of `parse()`
- Update `download-ci-llvm = if-supported` option to match bootstrap.py
- Remove redundant check for link_shared. Previously, it was checked twice.

- Update various options in config.toml.example to their defaults.
  Previously, some options showed an example value instead of the
  default value.

- Fix incorrect defaults in config.toml.example
  + `use-libcxx` defaults to false
  + Add missing `check-stage = 0`
  + Update several defaults to be conditional (e.g. `if incremental { 10 } else { 100 }`)

- Remove redundant defaults in prose
- Use the same comment for the default and target-dependent `musl-root`
- Fix typos
- Link to `cc_detect` for `cc` and `cxx`, since the logic is ... complicated.
- Update more defaults to better reflect how they actually get set
- Remove ignored `gpg-password-file` option

  This stopped being used in
  7704d35,
  but was never removed from config.toml.

- Remove unused flags from `config.toml`
    + Disallow `infodir` and `localstatedir` in `config.toml`
    + Allow the flags in `./configure`, but give a warning that they will be
      ignored.
    + Fix incorrect comment that `datadir` will be ignored.

    Example output:

    ```
    $ ./configure --set install.infodir=xxx
    configure: processing command line
    configure:
    configure: install.infodir      := xxx
    configure: build.configure-args := ['--set', 'install.infodir=xxx']
    warning: infodir will be ignored
    configure:
    configure: writing `config.toml` in current directory
    configure:
    configure: run `python /home/joshua/rustc3/x.py --help`
    configure:
    ```

- Update CHANGELOG

cc https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/bootstrap.20defaults