### PR TITLE
Use libc::accept4 on Android instead of raw syscall.

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.79", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { version = "0.2.85", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.39" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -195,6 +195,7 @@ impl Socket {
         // glibc 2.10 and musl 0.9.5.
         cfg_if::cfg_if! {
             if #[cfg(any(
+                target_os = "android",
                 target_os = "dragonfly",
                 target_os = "freebsd",
                 target_os = "illumos",
@@ -206,13 +207,6 @@ impl Socket {
                     libc::accept4(self.0.raw(), storage, len, libc::SOCK_CLOEXEC)
                 })?;
                 Ok(Socket(FileDesc::new(fd)))
-            // While the Android kernel supports the syscall,
-            // it is not included in all versions of Android's libc.
-            } else if #[cfg(target_os = "android")] {
-                let fd = cvt_r(|| unsafe {
-                    libc::syscall(libc::SYS_accept4, self.0.raw(), storage, len, libc::SOCK_CLOEXEC)
-                })?;
-                Ok(Socket(FileDesc::new(fd as c_int)))
             } else {
                 let fd = cvt_r(|| unsafe { libc::accept(self.0.raw(), storage, len) })?;
                 let fd = FileDesc::new(fd);


### PR DESCRIPTION
This PR replaces the use of a raw `accept4` syscall with `libc::accept4`. This was originally added (by me) because `std` couldn't update to the latest `libc` with `accept4` support for android. By now, libc is already on 0.2.85, so the workaround can be removed.

@rustbot label +O-android +T-libs-impl