### PR TITLE
[stable] Fix TcpListener::accept() on x86 Android on stable by disabling the use of accept4.

### DIFF
--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -208,7 +208,7 @@ impl Socket {
                 Ok(Socket(FileDesc::new(fd)))
             // While the Android kernel supports the syscall,
             // it is not included in all versions of Android's libc.
-            } else if #[cfg(target_os = "android")] {
+            } else if #[cfg(all(target_os = "android", not(target_arch = "x86")))] {
                 let fd = cvt_r(|| unsafe {
                     libc::syscall(libc::SYS_accept4, self.0.raw(), storage, len, libc::SOCK_CLOEXEC)
                 })?;


### PR DESCRIPTION
`TcpListener::accept` is broken on Android x86 on stable and beta because it performs a raw `accept4` syscall, which doesn't exist on that platform. This was originally reported in #82400, so you can find more details there.

This PR fixes it by simply falling back to `accept` on x86 Android platforms.

Note that for the main branch it would be nice to fix the issue with https://github.com/rust-lang/rust/pull/82473, https://github.com/rust-lang/libc/pull/2079 and another libc bump. However, if that can't happen before the next beta release, then a similar fix as this PR should be applied on the main branch too.

@rustbot label +O-android
r? @Mark-Simulacrum