### PR TITLE
[beta] Fix TcpListener::accept() on x86 Android on beta by disabling the use of accept4.

### DIFF
--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -208,7 +208,7 @@ impl Socket {
                 Ok(Socket(FileDesc::new(fd)))
             // While the Android kernel supports the syscall,
             // it is not included in all versions of Android's libc.
-            } else if #[cfg(target_os = "android")] {
+            } else if #[cfg(all(target_os = "android", not(target_arch = "x86")))] {
                 let fd = cvt_r(|| unsafe {
                     libc::syscall(libc::SYS_accept4, self.0.raw(), storage, len, libc::SOCK_CLOEXEC)
                 })?;


### PR DESCRIPTION
This is the same as #82475, but for beta.

In a nutshell: `TcpListener::accept` is broken on Android x86 on stable and beta because it performs a raw `accept4` syscall, which doesn't exist on that platform. This was originally reported in #82400, so you can find more details there.

@rustbot label +O-android
r? @Mark-Simulacrum