### PR TITLE
Constify methods of `std::net::SocketAddr`, `SocketAddrV4` and `SocketAddrV6`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -247,6 +247,7 @@
 #![feature(const_ip)]
 #![feature(const_ipv6)]
 #![feature(const_raw_ptr_deref)]
+#![feature(const_socketaddr)]
 #![feature(const_ipv4)]
 #![feature(container_error_extra)]
 #![feature(core_intrinsics)]

--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -143,7 +143,8 @@ impl SocketAddr {
     /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
     /// ```
     #[stable(feature = "ip_addr", since = "1.7.0")]
-    pub fn ip(&self) -> IpAddr {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn ip(&self) -> IpAddr {
         match *self {
             SocketAddr::V4(ref a) => IpAddr::V4(*a.ip()),
             SocketAddr::V6(ref a) => IpAddr::V6(*a.ip()),
@@ -182,7 +183,8 @@ impl SocketAddr {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn port(&self) -> u16 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn port(&self) -> u16 {
         match *self {
             SocketAddr::V4(ref a) => a.port(),
             SocketAddr::V6(ref a) => a.port(),
@@ -224,7 +226,8 @@ impl SocketAddr {
     /// assert_eq!(socket.is_ipv6(), false);
     /// ```
     #[stable(feature = "sockaddr_checker", since = "1.16.0")]
-    pub fn is_ipv4(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn is_ipv4(&self) -> bool {
         matches!(*self, SocketAddr::V4(_))
     }
 
@@ -244,7 +247,8 @@ impl SocketAddr {
     /// assert_eq!(socket.is_ipv6(), true);
     /// ```
     #[stable(feature = "sockaddr_checker", since = "1.16.0")]
-    pub fn is_ipv6(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn is_ipv6(&self) -> bool {
         matches!(*self, SocketAddr::V6(_))
     }
 }
@@ -284,7 +288,8 @@ impl SocketAddrV4 {
     /// assert_eq!(socket.ip(), &Ipv4Addr::new(127, 0, 0, 1));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn ip(&self) -> &Ipv4Addr {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn ip(&self) -> &Ipv4Addr {
         // SAFETY: `Ipv4Addr` is `#[repr(C)] struct { _: in_addr; }`.
         // It is safe to cast from `&in_addr` to `&Ipv4Addr`.
         unsafe { &*(&self.inner.sin_addr as *const c::in_addr as *const Ipv4Addr) }
@@ -317,7 +322,8 @@ impl SocketAddrV4 {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn port(&self) -> u16 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn port(&self) -> u16 {
         ntohs(self.inner.sin_port)
     }
 
@@ -380,7 +386,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.ip(), &Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn ip(&self) -> &Ipv6Addr {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn ip(&self) -> &Ipv6Addr {
         unsafe { &*(&self.inner.sin6_addr as *const c::in6_addr as *const Ipv6Addr) }
     }
 
@@ -411,7 +418,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn port(&self) -> u16 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn port(&self) -> u16 {
         ntohs(self.inner.sin6_port)
     }
 
@@ -452,7 +460,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.flowinfo(), 10);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn flowinfo(&self) -> u32 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn flowinfo(&self) -> u32 {
         self.inner.sin6_flowinfo
     }
 
@@ -490,7 +499,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.scope_id(), 78);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn scope_id(&self) -> u32 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn scope_id(&self) -> u32 {
         self.inner.sin6_scope_id
     }
 


### PR DESCRIPTION
The following methods are made unstable const under the `const_socketaddr` feature (https://github.com/rust-lang/rust/issues/82485):


```rust
// std::net

impl SocketAddr {
    pub const fn ip(&self) -> IpAddr;
    pub const fn port(&self) -> u16;
    pub const fn is_ipv4(&self) -> bool;
    pub const fn is_ipv6(&self) -> bool;
}

impl SocketAddrV4 {
    pub const fn ip(&self) -> IpAddr;
    pub const fn port(&self) -> u16;
}

impl SocketAddrV6 {
    pub const fn ip(&self) -> IpAddr;
    pub const fn port(&self) -> u16;
    pub const fn flowinfo(&self) -> u32;
    pub const fn scope_id(&self) -> u32;
}
```

Note: `SocketAddrV4::ip` and `SocketAddrV6::ip` use pointer casting and depend on the unstable feature `const_raw_ptr_deref`