### PR TITLE
Fix impl being removed excessively

### DIFF
--- a/src/test/rustdoc/impl-on-foreign.rs
+++ b/src/test/rustdoc/impl-on-foreign.rs
@@ -1,0 +1,26 @@
+#![crate_name = "foo"]
+
+use std::convert::AsRef;
+pub struct Gus;
+
+// @has 'foo/struct.Gus.html'
+// @has - '//h3[@class="impl"]/code' 'impl AsRef<str> for Gus'
+impl AsRef<str> for Gus {
+    fn as_ref(&self) -> &str {
+        todo!()
+    }
+}
+
+// @has - '//h3[@class="impl"]/code' 'impl AsRef<Gus> for str'
+impl AsRef<Gus> for str {
+    fn as_ref(&self) -> &Gus {
+        todo!()
+    }
+}
+
+// @has - '//h3[@class="impl"]/code' 'impl AsRef<Gus> for String'
+impl AsRef<Gus> for String {
+    fn as_ref(&self) -> &Gus {
+        todo!()
+    }
+}


### PR DESCRIPTION
Fixes #82465.

To prevent some impls to get removed, the type has to be "registered". This is because of the change from https://github.com/rust-lang/rust/pull/80653/commits/8eaf68f92c213358dda59dc3eb648036ab62e18d , before that commit, the impls were filtered before we added the multiple `Deref` "go down".

cc @jryans
r? @jyn514 