### PR TITLE
Properly account for non-shorthand pattern field in unused variable lint

### DIFF
--- a/src/test/ui/lint/unused_variables-issue-82488.fixed
+++ b/src/test/ui/lint/unused_variables-issue-82488.fixed
@@ -1,0 +1,16 @@
+// run-rustfix
+#![deny(unused_variables)]
+
+struct Point {
+    x: u32,
+    y: u32
+}
+
+fn process_point(Point { x, y: _renamed }: Point) {
+//~^ ERROR unused variable: `renamed`
+    let _ = x;
+}
+
+fn main() {
+    process_point(Point { x: 0, y: 0 });
+}

--- a/src/test/ui/lint/unused_variables-issue-82488.rs
+++ b/src/test/ui/lint/unused_variables-issue-82488.rs
@@ -1,0 +1,16 @@
+// run-rustfix
+#![deny(unused_variables)]
+
+struct Point {
+    x: u32,
+    y: u32
+}
+
+fn process_point(Point { x, y: renamed }: Point) {
+//~^ ERROR unused variable: `renamed`
+    let _ = x;
+}
+
+fn main() {
+    process_point(Point { x: 0, y: 0 });
+}

--- a/src/test/ui/lint/unused_variables-issue-82488.stderr
+++ b/src/test/ui/lint/unused_variables-issue-82488.stderr
@@ -1,0 +1,14 @@
+error: unused variable: `renamed`
+  --> $DIR/unused_variables-issue-82488.rs:9:32
+   |
+LL | fn process_point(Point { x, y: renamed }: Point) {
+   |                                ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_renamed`
+   |
+note: the lint level is defined here
+  --> $DIR/unused_variables-issue-82488.rs:2:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #82488