### PR TITLE
Rename the `tidy` binary to `rust-tidy`

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -47,7 +47,7 @@ impl Step for ToolBuild {
     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let compiler = self.compiler;
         let target = self.target;
-        let tool = self.tool;
+        let mut tool = self.tool;
         let path = self.path;
         let is_optional_tool = self.is_optional_tool;
 
@@ -208,6 +208,12 @@ impl Step for ToolBuild {
                 None
             }
         } else {
+            // HACK(#82501): on Windows, the tools directory gets added to PATH when running tests, and
+            // compiletest confuses HTML tidy with the in-tree tidy. Name the in-tree tidy something
+            // different so the problem doesn't come up.
+            if tool == "tidy" {
+                tool = "rust-tidy";
+            }
             let cargo_out =
                 builder.cargo_out(compiler, self.mode, target).join(exe(tool, compiler.host));
             let bin = builder.tools_dir(compiler).join(exe(tool, compiler.host));

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -3,9 +3,14 @@ name = "tidy"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
+autobins = false
 
 [dependencies]
 cargo_metadata = "0.11"
 regex = "1"
 lazy_static = "1"
 walkdir = "2"
+
+[[bin]]
+name = "rust-tidy"
+path = "src/main.rs"


### PR DESCRIPTION
This avoids naming collisions, particularly on Windows where the
dynamic library variable is PATH and setting it causes the in-tree
`tidy` to take precedence over the HTML tidy used by compiletest.

This doesn't change the x.py interface in any way, it still accepts `x.py test tidy` and prints error messages about `tidy`. It only changes the name of the file on disk.

Fixes https://github.com/rust-lang/rust/issues/82501.