### PR TITLE
Fix back-forward cache in rustdoc frontend

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1995,6 +1995,20 @@ function defocusSearchBar() {
                 });
             }
             search();
+
+            // This is required in firefox to avoid this problem: Navigating to a search result
+            // with the keyboard, hitting enter, and then hitting back would take you back to
+            // the doc page, rather than the search that should overlay it.
+            // This was an interaction between the back-forward cache and our handlers
+            // that try to sync state between the URL and the search input. To work around it,
+            // do a small amount of re-init on page show.
+            window.onpageshow = function(){
+                var qSearch = getQueryStringParams().search;
+                if (search_input.value === "" && qSearch) {
+                    search_input.value = qSearch;
+                }
+                search();
+            };
         }
 
         index = buildIndex(rawSearchIndex);
@@ -2953,9 +2967,3 @@ function defocusSearchBar() {
     onHashChange(null);
     window.onhashchange = onHashChange;
 }());
-
-// This is required in firefox. Explanations: when going back in the history, firefox doesn't re-run
-// the JS, therefore preventing rustdoc from setting a few things required to be able to reload the
-// previous search results (if you navigated to a search result with the keyboard, pressed enter on
-// it to navigate to that result, and then came back to this page).
-window.onunload = function(){};


### PR DESCRIPTION
Rustdoc's frontend set a no-op unload handler, specifically to disable
Firefox's back-forward cache because it caused a bug. It's nice to
allow the back-forward cache because it permits faster navigations.

This change addresses the issues that were caused by back-forward cache.

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/1.5/Using_Firefox_1.5_caching
https://web.dev/bfcache/

Demo: https://jacob.hoffman-andrews.com/rust/fix-bfcache/std/string/struct.String.html

Related: #72272