### PR TITLE
Add GUI tests

### DIFF
--- a/src/test/rustdoc-gui/search-input-mobile.goml
+++ b/src/test/rustdoc-gui/search-input-mobile.goml
@@ -1,0 +1,11 @@
+// Test to ensure that you can click on the search input, whatever the width.
+// The PR which fixed it is: https://github.com/rust-lang/rust/pull/81592
+goto: file://|DOC_PATH|/index.html
+size: (463, 700)
+// We first check that the search input isn't already focused.
+assert-false: ("input.search-input:focus")
+click: "input.search-input"
+reload:
+size: (750, 700)
+click: "input.search-input"
+assert: ("input.search-input:focus")

--- a/src/test/rustdoc-gui/shortcuts.goml
+++ b/src/test/rustdoc-gui/shortcuts.goml
@@ -1,0 +1,26 @@
+// Check that the various shortcuts are working.
+goto: file://|DOC_PATH|/index.html
+// We first check that the search input isn't already focused.
+assert-false: "input.search-input:focus"
+press-key: "s"
+assert: "input.search-input:focus"
+press-key: "Escape"
+assert-false: "input.search-input:focus"
+// We now check for the help popup.
+press-key: "?"
+assert: ("#help", {"display": "flex"})
+assert-false: "#help.hidden"
+press-key: "Escape"
+assert: ("#help.hidden", {"display": "none"})
+// Check for the themes list.
+assert: ("#theme-choices", {"display": "none"})
+press-key: "t"
+assert: ("#theme-choices", {"display": "block"})
+press-key: "t"
+// We ensure that 't' hides back the menu.
+assert: ("#theme-choices", {"display": "none"})
+press-key: "t"
+assert: ("#theme-choices", {"display": "block"})
+press-key: "Escape"
+// We ensure that 'Escape' hides the menu too.
+assert: ("#theme-choices", {"display": "none"})


### PR DESCRIPTION
The start of a lot more of GUI tests! \o/

One test is to ensure that the search input can always be selected in all rustdoc "modes" (mobile, tablet mostly) whereas the second checks the shortcuts.

r? @jyn514 