### PR TITLE
Deprecate `doc(include)`

### DIFF
--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -448,17 +448,24 @@ macro_rules! declare_tool_lint {
         $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level: ident, $desc: expr
         $(, @future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
     ) => (
-        $crate::declare_tool_lint!{$(#[$attr])* $vis $tool::$NAME, $Level, $desc, false}
+        $crate::declare_tool_lint!{
+            $(#[$attr])* $vis $tool::$NAME, $Level, $desc, false
+            $(, @future_incompatible = FutureIncompatibleInfo { $($field : $val),* };)?
+        }
     );
     (
         $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level:ident, $desc:expr,
         report_in_external_macro: $rep:expr
+        $(, @future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
     ) => (
-         $crate::declare_tool_lint!{$(#[$attr])* $vis $tool::$NAME, $Level, $desc, $rep}
+         $crate::declare_tool_lint!{$(#[$attr])* $vis $tool::$NAME, $Level, $desc, $rep
+         $(, @future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
+         }
     );
     (
         $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level:ident, $desc:expr,
         $external:expr
+         $(, @future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
     ) => (
         $(#[$attr])*
         $vis static $NAME: &$crate::Lint = &$crate::Lint {
@@ -467,10 +474,14 @@ macro_rules! declare_tool_lint {
             desc: $desc,
             edition_lint_opts: None,
             report_in_external_macro: $external,
-            future_incompatible: None,
+            $(future_incompatible: Some($crate::FutureIncompatibleInfo {
+                $($field: $val,)*
+                ..$crate::FutureIncompatibleInfo::default_fields_for_macro()
+            }),)?
             is_plugin: true,
             feature_gate: None,
             crate_level_only: false,
+            ..$crate::Lint::default_fields_for_macro()
         };
     );
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -446,6 +446,7 @@ macro_rules! declare_lint {
 macro_rules! declare_tool_lint {
     (
         $(#[$attr:meta])* $vis:vis $tool:ident ::$NAME:ident, $Level: ident, $desc: expr
+        $(, @future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
     ) => (
         $crate::declare_tool_lint!{$(#[$attr])* $vis $tool::$NAME, $Level, $desc, false}
     );

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -340,6 +340,22 @@ error in a future release.
 
 ```rust
 #![feature(external_doc)]
-#[doc(include = "README.md")]
-pub fn foo() {}
+#![doc(include = "./external-doc.rs")]
+```
+
+Which will give:
+
+```text
+warning: `#[doc(include)]` is deprecated and will be removed in a future release
+ --> external-doc.rs:2:1
+  |
+2 | #![doc(include = "./external-doc.rs")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(rustdoc::doc_include)]` on by default
+  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+  = note: for more information, see issue #44732 <https://github.com/rust-lang/rust/issues/44732>
+help: use `#![feature(extended_key_value_attributes)]` instead
+  |
+2 | #![doc = include_str!("./external-doc.rs")]
 ```

--- a/src/doc/rustdoc/src/lints.md
+++ b/src/doc/rustdoc/src/lints.md
@@ -331,3 +331,15 @@ warning: this URL is not a hyperlink
 3 | /// [http://example.net]
   |      ^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<http://example.net>`
 ```
+
+## external_doc
+
+This lint is **nightly-only** and **warns by default**. It detects when
+`#![feature(external_doc)]` is used. This feature is scheduled for removal and will give a hard
+error in a future release.
+
+```rust
+#![feature(external_doc)]
+#[doc(include = "README.md")]
+pub fn foo() {}
+```

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -298,8 +298,7 @@ fn merge_attrs(
     // when we render them.
     if let Some(inner) = new_attrs {
         if let Some(new_id) = parent_module {
-            let diag = cx.sess().diagnostic();
-            Attributes::from_ast(diag, old_attrs, Some((inner, new_id)), local)
+            Attributes::from_ast(cx.tcx, old_attrs, Some((inner, new_id)), local)
         } else {
             let mut both = inner.to_vec();
             both.extend_from_slice(old_attrs);

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -241,7 +241,7 @@ impl Clean<Item> for doctree::Module<'_> {
 }
 
 fn clean_attrs(attrs: &[ast::Attribute], local: bool, cx: &mut DocContext<'_>) -> Attributes {
-    Attributes::from_ast(cx.sess().diagnostic(), attrs, None, local)
+    Attributes::from_ast(cx.tcx, attrs, None, local)
 }
 
 impl Clean<GenericBound> for hir::GenericBound<'_> {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -739,7 +739,7 @@ impl Attributes {
     }
 
     crate fn from_ast(
-        handler: &::rustc_errors::Handler,
+        tcx: TyCtxt<'_>,
         attrs: &[ast::Attribute],
         additional_attrs: Option<(&[ast::Attribute], DefId)>,
         local: bool,
@@ -801,7 +801,7 @@ impl Attributes {
                             // Extracted #[doc(cfg(...))]
                             match Cfg::parse(cfg_mi) {
                                 Ok(new_cfg) => cfg &= new_cfg,
-                                Err(e) => handler.span_err(e.span, e.msg),
+                                Err(e) => tcx.sess.span_err(e.span, e.msg),
                             }
                         } else if let Some((filename, contents)) = Attributes::extract_include(&mi)
                         {

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1093,7 +1093,7 @@ impl<'a, 'hir, 'tcx> HirCollector<'a, 'hir, 'tcx> {
         nested: F,
     ) {
         let attrs = self.tcx.hir().attrs(hir_id);
-        let mut attrs = Attributes::from_ast(self.sess.diagnostic(), attrs, None, true);
+        let mut attrs = Attributes::from_ast(self.tcx, attrs, None, true);
         if let Some(ref cfg) = attrs.cfg {
             if !cfg.matches(&self.sess.parse_sess, Some(&self.sess.features_untracked())) {
                 return;

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1093,7 +1093,7 @@ impl<'a, 'hir, 'tcx> HirCollector<'a, 'hir, 'tcx> {
         nested: F,
     ) {
         let attrs = self.tcx.hir().attrs(hir_id);
-        let mut attrs = Attributes::from_ast(self.sess.diagnostic(), attrs, None);
+        let mut attrs = Attributes::from_ast(self.sess.diagnostic(), attrs, None, true);
         if let Some(ref cfg) = attrs.cfg {
             if !cfg.matches(&self.sess.parse_sess, Some(&self.sess.features_untracked())) {
                 return;

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1093,7 +1093,7 @@ impl<'a, 'hir, 'tcx> HirCollector<'a, 'hir, 'tcx> {
         nested: F,
     ) {
         let attrs = self.tcx.hir().attrs(hir_id);
-        let mut attrs = Attributes::from_ast(self.tcx, attrs, None, true);
+        let mut attrs = Attributes::from_ast(self.tcx, attrs, None, Some(hir_id));
         if let Some(ref cfg) = attrs.cfg {
             if !cfg.matches(&self.sess.parse_sess, Some(&self.sess.features_untracked())) {
                 return;

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -64,9 +64,12 @@ where
 }
 
 macro_rules! declare_rustdoc_lint {
-    ($(#[$attr:meta])* $name: ident, $level: ident, $descr: literal $(,)?) => {
+    ($(#[$attr:meta])* $name: ident, $level: ident, $descr: literal
+    $(, @future_incompatible = FutureIncompatibleInfo { $($field:ident : $val:expr),* $(,)*  }; )?
+    $(,)?) => {
         declare_tool_lint! {
             $(#[$attr])* pub rustdoc::$name, $level, $descr
+            $(, @future_incompatible = FutureIncompatibleInfo { $($field : $val),* };)?
         }
     }
 }
@@ -156,6 +159,22 @@ declare_rustdoc_lint! {
     NON_AUTOLINKS,
     Warn,
     "detects URLs that could be written using only angle brackets"
+}
+
+declare_rustdoc_lint! {
+    /// The `doc_include` lint detects when `#[doc(include = ...)]` is used.
+    /// This feature is scheduled for removal and will give a hard error in a future release.
+    ///
+    /// This is a `rustdoc` only lint, see the documentation in the [rustdoc book].
+    ///
+    /// [rustdoc book]: ../../../rustdoc/lints.html#non_autolinks
+    DOC_INCLUDE,
+    Warn,
+    "detects using `#[doc(include = ...)]`",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #44732 <https://github.com/rust-lang/rust/issues/44732>",
+        edition: None,
+    };
 }
 
 crate static RUSTDOC_LINTS: Lazy<Vec<&'static Lint>> = Lazy::new(|| {

--- a/src/test/rustdoc-ui/auxiliary/doc-include-deprecated.rs
+++ b/src/test/rustdoc-ui/auxiliary/doc-include-deprecated.rs
@@ -1,0 +1,5 @@
+#![crate_name = "inner"]
+#![feature(external_doc)]
+#[doc(include = "docs.md")]
+pub struct HasDocInclude {}
+pub struct NoDocs {}

--- a/src/test/rustdoc-ui/auxiliary/docs.md
+++ b/src/test/rustdoc-ui/auxiliary/docs.md
@@ -1,0 +1,1 @@
+Here have some docs

--- a/src/test/rustdoc-ui/doc-include-deprecated.rs
+++ b/src/test/rustdoc-ui/doc-include-deprecated.rs
@@ -1,0 +1,14 @@
+// aux-build:doc-include-deprecated.rs
+// check-pass
+#![feature(external_doc)]
+#![doc(include = "auxiliary/docs.md")] //~ WARNING deprecated
+
+extern crate inner;
+
+pub use inner::HasDocInclude;
+
+#[doc(include = "auxiliary/docs.md")] //~ WARNING deprecated
+pub use inner::HasDocInclude as _;
+
+#[doc(include = "auxiliary/docs.md")] //~ WARNING deprecated
+pub use inner::NoDocs;

--- a/src/test/rustdoc-ui/doc-include-deprecated.rs
+++ b/src/test/rustdoc-ui/doc-include-deprecated.rs
@@ -1,14 +1,20 @@
 // aux-build:doc-include-deprecated.rs
 // check-pass
 #![feature(external_doc)]
-#![doc(include = "auxiliary/docs.md")] //~ WARNING deprecated
+#![doc(include = "auxiliary/docs.md")]
+//~^ WARNING deprecated
+//~| WARNING hard error in a future release
 
 extern crate inner;
 
 pub use inner::HasDocInclude;
 
-#[doc(include = "auxiliary/docs.md")] //~ WARNING deprecated
+#[doc(include = "auxiliary/docs.md")]
+//~^ WARNING deprecated
+//~| WARNING hard error in a future release
 pub use inner::HasDocInclude as _;
 
-#[doc(include = "auxiliary/docs.md")] //~ WARNING deprecated
+#[doc(include = "auxiliary/docs.md")]
+//~^ WARNING deprecated
+//~| WARNING hard error in a future release
 pub use inner::NoDocs;

--- a/src/test/rustdoc-ui/doc-include-deprecated.stderr
+++ b/src/test/rustdoc-ui/doc-include-deprecated.stderr
@@ -1,0 +1,35 @@
+warning: `doc(include)` is deprecated
+  --> $DIR/doc-include-deprecated.rs:10:1
+   |
+LL | #[doc(include = "auxiliary/docs.md")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `#![feature(extended_key_value_attributes)]` instead
+   |
+LL | #[doc = include_str!("auxiliary/docs.md")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `doc(include)` is deprecated
+  --> $DIR/doc-include-deprecated.rs:13:1
+   |
+LL | #[doc(include = "auxiliary/docs.md")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `#![feature(extended_key_value_attributes)]` instead
+   |
+LL | #[doc = include_str!("auxiliary/docs.md")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `doc(include)` is deprecated
+  --> $DIR/doc-include-deprecated.rs:4:1
+   |
+LL | #![doc(include = "auxiliary/docs.md")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `#![feature(extended_key_value_attributes)]` instead
+   |
+LL | #![doc = include_str!("auxiliary/docs.md")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: 3 warnings emitted
+

--- a/src/test/rustdoc-ui/doc-include-deprecated.stderr
+++ b/src/test/rustdoc-ui/doc-include-deprecated.stderr
@@ -1,35 +1,42 @@
-warning: `doc(include)` is deprecated
-  --> $DIR/doc-include-deprecated.rs:10:1
+warning: `#[doc(include)]` is deprecated and will be removed in a future release
+  --> $DIR/doc-include-deprecated.rs:12:1
    |
 LL | #[doc(include = "auxiliary/docs.md")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: `#[warn(rustdoc::doc_include)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #44732 <https://github.com/rust-lang/rust/issues/44732>
 help: use `#![feature(extended_key_value_attributes)]` instead
    |
 LL | #[doc = include_str!("auxiliary/docs.md")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 
-warning: `doc(include)` is deprecated
-  --> $DIR/doc-include-deprecated.rs:13:1
+warning: `#[doc(include)]` is deprecated and will be removed in a future release
+  --> $DIR/doc-include-deprecated.rs:17:1
    |
 LL | #[doc(include = "auxiliary/docs.md")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #44732 <https://github.com/rust-lang/rust/issues/44732>
 help: use `#![feature(extended_key_value_attributes)]` instead
    |
 LL | #[doc = include_str!("auxiliary/docs.md")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 
-warning: `doc(include)` is deprecated
+warning: `#[doc(include)]` is deprecated and will be removed in a future release
   --> $DIR/doc-include-deprecated.rs:4:1
    |
 LL | #![doc(include = "auxiliary/docs.md")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #44732 <https://github.com/rust-lang/rust/issues/44732>
 help: use `#![feature(extended_key_value_attributes)]` instead
    |
 LL | #![doc = include_str!("auxiliary/docs.md")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 
 warning: 3 warnings emitted
 


### PR DESCRIPTION
 ## Why deprecate doc(include)?

This nightly feature is a strictly less general version of
`extended_key_value_attributes` (https://github.com/rust-lang/rust/issues/78835), which looks like this:

 ```
 #[doc = include_str!("docs.md")]
 ```

In particular, that feature allows manipulating the filename and
included docs in a way that `doc(include)` cannot, due to eager
evaluation:

 ```
 #[doc = concat!(
    "These are my docs: ",
    include_str!(concat!(env!("OUT_DIR"), "/generated_docs.md"))
  )]
 ```

For more about eager evaluation and how it impacts macro parsing,
see petrochenkov's excellent writeup: https://internals.rust-lang.org/t/macro-expansion-points-in-attributes/11455

Given that `#[doc(include)]` offers no features that
`extended_key_value_attributes` cannot, it makes no sense for the
language and rustdoc to maintain it indefinitely. This deprecates
`doc(include)` and adds a structured suggestion to switch to switch to
`doc = include_str!` instead.

 ## Implementation

This now adds a `DOC_INCLUDE` lint, which is marked as `future_incompatible`. To make that possible, it also extends `declare_tool_lint!` and `declare_rustdoc_lint!` to allow future-incompat lints. Finally, it changes `Attributes::from_ast` to require an `Option<HirId>` instead of just whether the item is local or not.

cc https://github.com/rust-lang/rust/issues/44732. I plan to remove the feature gate altogether eventually, but I want to have at least a month or two when it's deprecated so people have time to switch.

r? @GuillaumeGomez cc @petrochenkov 