### PR TITLE
-Zunpretty: allow passing several printing modes as comma-separated list

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -350,9 +350,11 @@ fn configure_and_expand_inner<'a>(
         rustc_builtin_macros::test_harness::inject(&sess, &mut resolver, &mut krate)
     });
 
-    if let Some(PpMode::Source(PpSourceMode::EveryBodyLoops)) = sess.opts.pretty {
-        tracing::debug!("replacing bodies with loop {{}}");
-        util::ReplaceBodyWithLoop::new(&mut resolver).visit_crate(&mut krate);
+    if let Some(ppmodes) = &sess.opts.pretty {
+        if ppmodes.contains(&PpMode::Source(PpSourceMode::EveryBodyLoops)) {
+            tracing::debug!("replacing bodies with loop {{}}");
+            util::ReplaceBodyWithLoop::new(&mut resolver).visit_crate(&mut krate);
+        }
     }
 
     let has_proc_macro_decls = sess.time("AST_validation", || {

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -147,7 +147,7 @@ top_level_options!(
         // by the compiler.
         json_artifact_notifications: bool [TRACKED],
 
-        pretty: Option<PpMode> [UNTRACKED],
+        pretty: Option<Vec<PpMode>> [UNTRACKED],
     }
 );
 
@@ -1153,11 +1153,11 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
     unpretty: Option<String> = (None, parse_unpretty, [UNTRACKED],
         "present the input source, unstable (and less-pretty) variants;
         valid types are any of the types for `--pretty`, as well as:
-        `expanded`, `expanded,identified`,
-        `expanded,hygiene` (with internal representations),
+        `expanded`, `expanded+identified`,
+        `expanded+hygiene` (with internal representations),
         `everybody_loops` (all function bodies replaced with `loop {}`),
-        `hir` (the HIR), `hir,identified`,
-        `hir,typed` (HIR with types for each node),
+        `hir` (the HIR), `hir+identified`,
+        `hir+typed` (HIR with types for each node),
         `hir-tree` (dump the raw HIR),
         `mir` (the MIR), or `mir-cfg` (graphviz formatted MIR)"),
     unsound_mir_opts: bool = (false, parse_bool, [TRACKED],

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -3,7 +3,7 @@ use ::std::prelude::v1::*;
 #[macro_use]
 extern crate std;
 // pretty-compare-only
-// pretty-mode:hir,typed
+// pretty-mode:hir+typed
 // pp-exact:issue-4264.pp
 
 // #4264 fixed-length vector types

--- a/src/test/pretty/issue-4264.rs
+++ b/src/test/pretty/issue-4264.rs
@@ -1,5 +1,5 @@
 // pretty-compare-only
-// pretty-mode:hir,typed
+// pretty-mode:hir+typed
 // pp-exact:issue-4264.pp
 
 // #4264 fixed-length vector types

--- a/src/test/ui/hygiene/unpretty-debug.rs
+++ b/src/test/ui/hygiene/unpretty-debug.rs
@@ -1,5 +1,5 @@
 // check-pass
-// compile-flags: -Zunpretty=expanded,hygiene
+// compile-flags: -Zunpretty=expanded+hygiene
 
 // Don't break whenever Symbol numbering changes
 // normalize-stdout-test "\d+#" -> "0#"

--- a/src/test/ui/hygiene/unpretty-debug.stdout
+++ b/src/test/ui/hygiene/unpretty-debug.stdout
@@ -1,5 +1,5 @@
 // check-pass
-// compile-flags: -Zunpretty=expanded,hygiene
+// compile-flags: -Zunpretty=expanded+hygiene
 
 // Don't break whenever Symbol numbering changes
 // normalize-stdout-test "\d+#" -> "0#"

--- a/src/test/ui/proc-macro/meta-macro-hygiene.rs
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.rs
@@ -2,7 +2,7 @@
 // aux-build:make-macro.rs
 // aux-build:meta-macro.rs
 // edition:2018
-// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene -Z trim-diagnostic-paths=no
+// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded+hygiene -Z trim-diagnostic-paths=no
 // check-pass
 // normalize-stdout-test "\d+#" -> "0#"
 //

--- a/src/test/ui/proc-macro/meta-macro-hygiene.stdout
+++ b/src/test/ui/proc-macro/meta-macro-hygiene.stdout
@@ -6,7 +6,7 @@ Respanned: TokenStream [Ident { ident: "$crate", span: $DIR/auxiliary/make-macro
 // aux-build:make-macro.rs
 // aux-build:meta-macro.rs
 // edition:2018
-// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene -Z trim-diagnostic-paths=no
+// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded+hygiene -Z trim-diagnostic-paths=no
 // check-pass
 // normalize-stdout-test "\d+#" -> "0#"
 //

--- a/src/test/ui/proc-macro/nonterminal-token-hygiene.rs
+++ b/src/test/ui/proc-macro/nonterminal-token-hygiene.rs
@@ -1,7 +1,7 @@
 // Make sure that marks from declarative macros are applied to tokens in nonterminal.
 
 // check-pass
-// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene
+// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded+hygiene
 // compile-flags: -Z trim-diagnostic-paths=no
 // normalize-stdout-test "\d+#" -> "0#"
 // aux-build:test-macros.rs

--- a/src/test/ui/proc-macro/nonterminal-token-hygiene.stdout
+++ b/src/test/ui/proc-macro/nonterminal-token-hygiene.stdout
@@ -26,7 +26,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
 // Make sure that marks from declarative macros are applied to tokens in nonterminal.
 
 // check-pass
-// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded,hygiene
+// compile-flags: -Z span-debug -Z macro-backtrace -Z unpretty=expanded+hygiene
 // compile-flags: -Z trim-diagnostic-paths=no
 // normalize-stdout-test "\d+#" -> "0#"
 // aux-build:test-macros.rs


### PR DESCRIPTION
Modes that had a comma in them use "+" now:
`-Zunpretty=expanded,hygiene` =>` -Zunpretty=expanded+hygiene`

You can now print several modes back to back like this:
`-Zunpretty=expanded+hygiene,mir,hir,everybody_loops`

Note: `everybody_loops` modifies the IR which can influence output of other printing modes.