### PR TITLE
More Into<Cow> methods.

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2358,11 +2358,27 @@ impl<'a> From<&'a str> for Cow<'a, str> {
     }
 }
 
+#[stable(feature = "cow_u8_slice_from_str", since = "1.52.0")]
+impl<'a> From<&'a str> for Cow<'a, [u8]> {
+    #[inline]
+    fn from(s: &'a str) -> Cow<'a, [u8]> {
+        Cow::Borrowed(s.as_bytes())
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> From<String> for Cow<'a, str> {
     #[inline]
     fn from(s: String) -> Cow<'a, str> {
         Cow::Owned(s)
+    }
+}
+
+#[stable(feature = "cow_u8_slice_from_str", since = "1.52.0")]
+impl<'a> From<String> for Cow<'a, [u8]> {
+    #[inline]
+    fn from(s: String) -> Cow<'a, [u8]> {
+        Cow::Owned(s.into_bytes())
     }
 }
 

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1681,8 +1681,20 @@ fn test_box_slice_clone() {
 fn test_cow_from() {
     let borrowed = "borrowed";
     let owned = String::from("owned");
-    match (Cow::from(owned.clone()), Cow::from(borrowed)) {
+
+    let cow_owned: Cow<'_, str> = Cow::from(owned.clone());
+    let cow_borrowed: Cow<'_, str> = Cow::from(borrowed);
+    match (cow_owned, cow_borrowed) {
         (Cow::Owned(o), Cow::Borrowed(b)) => assert!(o == owned && b == borrowed),
+        _ => panic!("invalid `Cow::from`"),
+    }
+
+    let cow_owned: Cow<'_, [u8]> = Cow::from(owned.clone());
+    let cow_borrowed: Cow<'_, [u8]> = Cow::from(borrowed);
+    match (cow_owned, cow_borrowed) {
+        (Cow::Owned(o), Cow::Borrowed(b)) => {
+            assert!(o == owned.into_bytes() && b == borrowed.as_bytes())
+        }
         _ => panic!("invalid `Cow::from`"),
     }
 }


### PR DESCRIPTION
Provide methods for converting `&str` and `String` into `Cow<'_, [u8]>`.

This PR adds 2 convenience conversion trait impls for using a `str` in place of a `[u8]`, since `str` is effectively a subtype of `[u8]` (although of course the compiler does not know this).

There might be times when the type inference now fails where it would pass before (see the modified test case).