### PR TITLE
Add natvis for Result, NonNull, CString, CStr, and Cow

### DIFF
--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -75,4 +75,11 @@
       <ExpandedItem>ptr.pointer->data</ExpandedItem>
     </Expand>
   </Type>
+  <Type Name="alloc::borrow::Cow&lt;*&gt;">
+    <DisplayString Condition="RUST$ENUM$DISR == 0x0">Borrowed({__0})</DisplayString>
+    <DisplayString Condition="RUST$ENUM$DISR == 0x1">Owned({__0})</DisplayString>
+    <Expand>
+      <Item Name="[value]" ExcludeView="simple">__0</Item>
+    </Expand>
+  </Type>
 </AutoVisualizer>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -30,4 +30,19 @@
     </Expand>
   </Type>
 
+  <Type Name="core::result::Result&lt;*&gt;">
+    <DisplayString Condition="RUST$ENUM$DISR == 0x0">Ok({__0})</DisplayString>
+    <DisplayString Condition="RUST$ENUM$DISR == 0x1">Err({(*($T2*) &amp;__0)})</DisplayString>
+    <Expand>
+      <Item Name="[value]" Condition="RUST$ENUM$DISR == 0x0">__0</Item>
+      <Item Name="[value]" Condition="RUST$ENUM$DISR == 0x1">(*($T2*) &amp;__0)</Item>
+    </Expand>
+  </Type>
+
+  <Type Name="core::ptr::non_null::NonNull&lt;*&gt;">
+    <DisplayString>{(void*) pointer}</DisplayString>
+    <Expand>
+      <Item Name="[value]">*pointer</Item>
+    </Expand>
+  </Type>
 </AutoVisualizer>

--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -72,4 +72,33 @@
       </CustomListItems>
     </Expand>
   </Type>
+
+  <Type Name="std::ffi::c_str::CString">
+    <DisplayString>{inner.data_ptr,s}</DisplayString>
+    <Expand>
+      <Synthetic Name="[chars]">
+        <Expand>
+          <ArrayItems>
+            <Size>inner.length</Size>
+            <ValuePointer>(char*)inner.data_ptr</ValuePointer>
+          </ArrayItems>
+        </Expand>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="std::ffi::c_str::CStr">
+    <DisplayString>{(char*) inner}</DisplayString>
+    <Expand>
+      <Synthetic Name="[chars]">
+        <DisplayString>{(char*) inner}</DisplayString>
+        <Expand>
+          <ArrayItems>
+            <Size>strlen((char *) inner) + 1</Size>
+            <ValuePointer>(char*)inner</ValuePointer>
+          </ArrayItems>
+        </Expand>
+      </Synthetic>
+    </Expand>
+  </Type>
 </AutoVisualizer>


### PR DESCRIPTION
This adds natvis support (used for Windows debugging) to the following types: `Result`, `NonNull`, `CString`, `CStr`, and `Cow`. 