### PR TITLE
Fix soundness bug with type alias impl trait

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/mod.rs
@@ -1307,7 +1307,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                         };
                         debug!("opaque_defn_ty = {:?}", opaque_defn_ty);
                         let subst_opaque_defn_ty =
-                            opaque_defn_ty.concrete_type.subst(tcx, opaque_decl.substs);
+                            opaque_defn_ty.concrete_type.subst(tcx, opaque_decl.substs[0]);
                         let renumbered_opaque_defn_ty =
                             renumber::renumber_regions(infcx, subst_opaque_defn_ty);
 
@@ -1328,7 +1328,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                                 opaque_def_id,
                                 ty::ResolvedOpaqueTy {
                                     concrete_type: renumbered_opaque_defn_ty,
-                                    substs: opaque_decl.substs,
+                                    substs: opaque_decl.substs[0],
                                 },
                             ));
                         } else {

--- a/compiler/rustc_trait_selection/src/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/opaque_types.rs
@@ -21,7 +21,7 @@ pub type OpaqueTypeMap<'tcx> = DefIdMap<OpaqueTypeDecl<'tcx>>;
 /// Information about the opaque types whose values we
 /// are inferring in this function (these are the `impl Trait` that
 /// appear in the return type).
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct OpaqueTypeDecl<'tcx> {
     /// The opaque type (`ty::Opaque`) for this declaration.
     pub opaque_type: Ty<'tcx>,

--- a/compiler/rustc_trait_selection/src/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/opaque_types.rs
@@ -1109,22 +1109,26 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
             } else {
                 // Don't emit multiple errors for the same set of substs
                 opaque_defn.substs.push(substs);
+                /*opaque_defn.concrete_ty = tcx.ty_error_with_message(
+                    self.value_span,
+                    "defining use generics differ from previous defining use",
+                );*/
                 tcx.sess
                     .struct_span_err(
                         self.value_span,
                         &format!(
-                            "defining use generics {:?} differ from previous defining use",
+                            "defining use generics `{:?}` differ from previous defining use",
                             substs
                         ),
                     )
                     .span_note(
                         opaque_defn.definition_span,
                         &format!(
-                            "previous defining use with different generics {:?} found here",
+                            "previous defining use with different generics `{:?}` found here",
                             opaque_defn.substs[0]
                         ),
                     )
-                    .delay_as_bug();
+                    .emit();
             }
         }
         let span = tcx.def_span(def_id);
@@ -1161,7 +1165,7 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
         let definition_span = self.value_span;
 
         // We only keep the first concrete type var, as we will already error
-        // out if there are multiple due to the conflicting obligations 
+        // out if there are multiple due to the conflicting obligations
         if !self.opaque_types.contains_key(&def_id) {
             self.opaque_types.insert(
                 def_id,

--- a/compiler/rustc_trait_selection/src/opaque_types.rs
+++ b/compiler/rustc_trait_selection/src/opaque_types.rs
@@ -1109,10 +1109,10 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
             } else {
                 // Don't emit multiple errors for the same set of substs
                 opaque_defn.substs.push(substs);
-                /*opaque_defn.concrete_ty = tcx.ty_error_with_message(
+                opaque_defn.concrete_ty = tcx.ty_error_with_message(
                     self.value_span,
                     "defining use generics differ from previous defining use",
-                );*/
+                );
                 tcx.sess
                     .struct_span_err(
                         self.value_span,

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -741,7 +741,7 @@ fn check_opaque_meets_bounds<'tcx>(
         for (def_id, opaque_defn) in opaque_type_map {
             match infcx
                 .at(&misc_cause, param_env)
-                .eq(opaque_defn.concrete_ty, tcx.type_of(def_id).subst(tcx, opaque_defn.substs))
+                .eq(opaque_defn.concrete_ty, tcx.type_of(def_id).subst(tcx, opaque_defn.substs[0]))
             {
                 Ok(infer_ok) => inh.register_infer_ok_obligations(infer_ok),
                 Err(ty_err) => tcx.sess.delay_span_bug(

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -399,8 +399,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }
             }
-            let _ = opaque_types.insert(ty, decl);
             let _ = opaque_types_vars.insert(decl.concrete_ty, decl.opaque_type);
+            let _ = opaque_types.insert(ty, decl);
         }
 
         value

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -915,6 +915,7 @@ fn check_fn_or_method<'fcx, 'tcx>(
 /// fn b<T>() -> Foo<T, u32> { .. }
 /// ```
 ///
+#[instrument(level = "debug", skip(tcx, fcx))]
 fn check_opaque_types<'fcx, 'tcx>(
     tcx: TyCtxt<'tcx>,
     fcx: &FnCtxt<'fcx, 'tcx>,
@@ -922,12 +923,11 @@ fn check_opaque_types<'fcx, 'tcx>(
     span: Span,
     ty: Ty<'tcx>,
 ) {
-    trace!("check_opaque_types(ty={:?})", ty);
     ty.fold_with(&mut ty::fold::BottomUpFolder {
         tcx: fcx.tcx,
         ty_op: |ty| {
             if let ty::Opaque(def_id, substs) = *ty.kind() {
-                trace!("check_opaque_types: opaque_ty, {:?}, {:?}", def_id, substs);
+                trace!(?def_id, ?substs, "opaque type");
                 let generics = tcx.generics_of(def_id);
 
                 let opaque_hir_id = if let Some(local_id) = def_id.as_local() {
@@ -965,7 +965,7 @@ fn check_opaque_types<'fcx, 'tcx>(
                 if !may_define_opaque_type(tcx, fn_def_id, opaque_hir_id) {
                     return ty;
                 }
-                trace!("check_opaque_types: may define, generics={:#?}", generics);
+                trace!(?generics, "may define");
                 let mut seen_params: FxHashMap<_, Vec<_>> = FxHashMap::default();
                 for (i, arg) in substs.iter().enumerate() {
                     let arg_is_param = match arg.unpack() {

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -540,7 +540,10 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
                 }
 
                 if let Some((prev_span, prev_ty)) = self.found {
-                    if *concrete_type != prev_ty {
+                    if *concrete_type != prev_ty
+                        && !concrete_type.references_error()
+                        && !prev_ty.references_error()
+                    {
                         debug!("find_opaque_ty_constraints: span={:?}", span);
                         // Found different concrete types for the opaque type.
                         let mut err = self.tcx.sess.struct_span_err(

--- a/src/test/ui/generator/layout-error.min_tait.stderr
+++ b/src/test/ui/generator/layout-error.min_tait.stderr
@@ -22,19 +22,7 @@ LL |     static POOL: Task<F> = Task::new();
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/layout-error.rs:31:24
-   |
-LL |     Task::spawn(&POOL, || cb());
-   |                        ^^^^^^^ expected `[type error]`, got `impl Future`
-   |
-note: previous use here
-  --> $DIR/layout-error.rs:30:5
-   |
-LL |     static POOL: Task<F> = Task::new();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0425, E0658.
 For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/generator/layout-error.rs
+++ b/src/test/ui/generator/layout-error.rs
@@ -29,5 +29,4 @@ fn main() {
     // Check that statics are inhabited computes they layout.
     static POOL: Task<F> = Task::new(); //[min_tait]~ ERROR not permitted here
     Task::spawn(&POOL, || cb()); //[min_tait]~ ERROR type alias impl trait is not permitted here
-    //[min_tait]~^ ERROR concrete type differs from previous
 }

--- a/src/test/ui/generator/metadata-sufficient-for-layout.full_tait.stderr
+++ b/src/test/ui/generator/metadata-sufficient-for-layout.full_tait.stderr
@@ -16,7 +16,7 @@ LL | #![cfg_attr(full_tait, feature(type_alias_impl_trait, impl_trait_in_binding
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
 error: fatal error triggered by #[rustc_error]
-  --> $DIR/metadata-sufficient-for-layout.rs:29:1
+  --> $DIR/metadata-sufficient-for-layout.rs:28:1
    |
 LL | fn main() {}
    | ^^^^^^^^^

--- a/src/test/ui/generator/metadata-sufficient-for-layout.min_tait.stderr
+++ b/src/test/ui/generator/metadata-sufficient-for-layout.min_tait.stderr
@@ -7,18 +7,6 @@ LL | static A: Option<F> = None;
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/metadata-sufficient-for-layout.rs:25:1
-   |
-LL | fn f() -> F { metadata_sufficient_for_layout::g() }
-   | ^^^^^^^^^^^ expected `[type error]`, got `impl Generator`
-   |
-note: previous use here
-  --> $DIR/metadata-sufficient-for-layout.rs:22:1
-   |
-LL | static A: Option<F> = None;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/generator/metadata-sufficient-for-layout.rs
+++ b/src/test/ui/generator/metadata-sufficient-for-layout.rs
@@ -23,7 +23,6 @@ static A: Option<F> = None;
 //[min_tait]~^ ERROR not permitted here
 
 fn f() -> F { metadata_sufficient_for_layout::g() }
-//[min_tait]~^ ERROR concrete type differs
 
 #[rustc_error]
 fn main() {} //[full_tait]~ ERROR

--- a/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.min_tait.stderr
@@ -7,18 +7,6 @@ LL |     let null = || -> Opaque { 0 };
    = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
    = help: add `#![feature(type_alias_impl_trait)]` to the crate attributes to enable
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/issue-52843-closure-constrain.rs:13:16
-   |
-LL |     let null = || -> Opaque { 0 };
-   |                ^^^^^^^^^^^^^^^^^^ expected `String`, got `[type error]`
-   |
-note: previous use here
-  --> $DIR/issue-52843-closure-constrain.rs:12:5
-   |
-LL |     fn _unused() -> Opaque { String::new() }
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.rs
@@ -11,6 +11,6 @@ fn main() {
     type Opaque = impl Debug;
     fn _unused() -> Opaque { String::new() }
     let null = || -> Opaque { 0 }; //[min_tait]~ ERROR: not permitted here
-    //~^ ERROR: concrete type differs from previous defining opaque type use
+    //[full_tait]~^ ERROR: concrete type differs from previous defining opaque type use
     println!("{:?}", null());
 }

--- a/src/test/ui/type-alias-impl-trait/issue-60407.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-60407.min_tait.stderr
@@ -7,18 +7,6 @@ LL | static mut TEST: Option<Debuggable> = None;
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/issue-60407.rs:16:1
-   |
-LL | fn foo() -> Debuggable {
-   | ^^^^^^^^^^^^^^^^^^^^^^ expected `[type error]`, got `u32`
-   |
-note: previous use here
-  --> $DIR/issue-60407.rs:9:1
-   |
-LL | static mut TEST: Option<Debuggable> = None;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/type-alias-impl-trait/issue-60407.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-60407.rs
@@ -13,6 +13,6 @@ fn main() { //[full_tait]~ ERROR
     unsafe { TEST = Some(foo()) }
 }
 
-fn foo() -> Debuggable { //[min_tait]~ ERROR concrete type differs
+fn foo() -> Debuggable {
     0u32
 }

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-pass.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-pass.rs
@@ -1,0 +1,12 @@
+// check-pass
+#![feature(min_type_alias_impl_trait)]
+
+type X<A: ToString + Clone, B: ToString + Clone> = impl ToString;
+
+fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
+    (a.clone(), a)
+}
+
+fn main() {
+    println!("{}", <X<_, _> as ToString>::to_string(&f(42_i32, String::new()).1));
+}

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.rs
@@ -1,0 +1,16 @@
+// https://github.com/rust-lang/rust/issues/73481
+// This test used to cause unsoundness, since one of the two possible
+// resolutions was chosen at random instead of erroring due to conflicts.
+
+#![feature(min_type_alias_impl_trait)]
+
+type X<A, B> = impl Into<&'static A>;
+//~^ the trait bound `&'static B: From<&A>` is not satisfied
+
+fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
+    (a, a)
+}
+
+fn main() {
+    println!("{}", <X<_, _> as Into<&String>>::into(f(&[1isize, 2, 3], String::new()).1));
+}

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.rs
@@ -5,7 +5,6 @@
 #![feature(min_type_alias_impl_trait)]
 
 type X<A, B> = impl Into<&'static A>;
-//~^ ERROR the trait bound `&'static B: From<&A>` is not satisfied
 
 fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
     //~^ ERROR defining use generics `[B, A]` differ from previous defining use

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `&'static B: From<&A>` is not satisfied
+  --> $DIR/multiple-def-uses-in-one-fn.rs:7:16
+   |
+LL | type X<A, B> = impl Into<&'static A>;
+   |                ^^^^^^^^^^^^^^^^^^^^^ the trait `From<&A>` is not implemented for `&'static B`
+   |
+   = note: required because of the requirements on the impl of `Into<&'static B>` for `&A`
+help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
+   |
+LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) where &'static B: From<&A> {
+   |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
@@ -1,39 +1,26 @@
 error: defining use generics `[B, A]` differ from previous defining use
-  --> $DIR/multiple-def-uses-in-one-fn.rs:10:45
+  --> $DIR/multiple-def-uses-in-one-fn.rs:9:45
    |
 LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
    |                                             ^^^^^^^^^^^^^^^^^^
    |
 note: previous defining use with different generics `[A, B]` found here
-  --> $DIR/multiple-def-uses-in-one-fn.rs:10:45
+  --> $DIR/multiple-def-uses-in-one-fn.rs:9:45
    |
 LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
    |                                             ^^^^^^^^^^^^^^^^^^
-
-error[E0277]: the trait bound `&'static B: From<&A>` is not satisfied
-  --> $DIR/multiple-def-uses-in-one-fn.rs:7:16
-   |
-LL | type X<A, B> = impl Into<&'static A>;
-   |                ^^^^^^^^^^^^^^^^^^^^^ the trait `From<&A>` is not implemented for `&'static B`
-   |
-   = note: required because of the requirements on the impl of `Into<&'static B>` for `&A`
-help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
-   |
-LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) where &'static B: From<&A> {
-   |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: defining use generics `[B, A]` differ from previous defining use
-  --> $DIR/multiple-def-uses-in-one-fn.rs:10:1
+  --> $DIR/multiple-def-uses-in-one-fn.rs:9:1
    |
 LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: previous defining use with different generics `[A, B]` found here
-  --> $DIR/multiple-def-uses-in-one-fn.rs:10:1
+  --> $DIR/multiple-def-uses-in-one-fn.rs:9:1
    |
 LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn.stderr
@@ -1,3 +1,15 @@
+error: defining use generics `[B, A]` differ from previous defining use
+  --> $DIR/multiple-def-uses-in-one-fn.rs:10:45
+   |
+LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
+   |                                             ^^^^^^^^^^^^^^^^^^
+   |
+note: previous defining use with different generics `[A, B]` found here
+  --> $DIR/multiple-def-uses-in-one-fn.rs:10:45
+   |
+LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
+   |                                             ^^^^^^^^^^^^^^^^^^
+
 error[E0277]: the trait bound `&'static B: From<&A>` is not satisfied
   --> $DIR/multiple-def-uses-in-one-fn.rs:7:16
    |
@@ -10,6 +22,18 @@ help: consider introducing a `where` bound, but there might be an alternative be
 LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) where &'static B: From<&A> {
    |                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: defining use generics `[B, A]` differ from previous defining use
+  --> $DIR/multiple-def-uses-in-one-fn.rs:10:1
+   |
+LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous defining use with different generics `[A, B]` found here
+  --> $DIR/multiple-def-uses-in-one-fn.rs:10:1
+   |
+LL | fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.rs
@@ -4,15 +4,14 @@
 
 #![feature(min_type_alias_impl_trait)]
 
-type X<A, B> = impl Into<&'static A>;
-//~^ ERROR the trait bound `&'static B: From<&A>` is not satisfied
+type X<A: ToString + Clone, B: ToString + Clone> = impl ToString;
 
-fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
+fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
     //~^ ERROR defining use generics `[B, A]` differ from previous defining use
     //~| ERROR defining use generics `[B, A]` differ from previous defining use
-    (a, a)
+    (a.clone(), a)
 }
 
 fn main() {
-    println!("{}", <X<_, _> as Into<&String>>::into(f(&[1isize, 2, 3], String::new()).1));
+    println!("{}", <X<_, _> as ToString>::to_string(&f(42_i32, String::new()).1));
 }

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.stderr
@@ -1,0 +1,26 @@
+error: defining use generics `[B, A]` differ from previous defining use
+  --> $DIR/multiple-def-uses-in-one-fn2.rs:9:63
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   |                                                               ^^^^^^^^^^^^^^^^^^
+   |
+note: previous defining use with different generics `[A, B]` found here
+  --> $DIR/multiple-def-uses-in-one-fn2.rs:9:63
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   |                                                               ^^^^^^^^^^^^^^^^^^
+
+error: defining use generics `[B, A]` differ from previous defining use
+  --> $DIR/multiple-def-uses-in-one-fn2.rs:9:1
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous defining use with different generics `[A, B]` found here
+  --> $DIR/multiple-def-uses-in-one-fn2.rs:9:1
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.rs
@@ -13,7 +13,6 @@ fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>)
 }
 
 fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
-    //~^ ERROR concrete type differs from previous defining opaque type use
     (a, b) //~ ERROR mismatched types
 }
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.rs
@@ -13,6 +13,7 @@ fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>)
 }
 
 fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
+    //~^ ERROR concrete type differs from previous defining opaque type use
     (a, b) //~ ERROR mismatched types
 }
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.rs
@@ -4,15 +4,16 @@
 
 #![feature(min_type_alias_impl_trait)]
 
-type X<A, B> = impl Into<&'static A>;
-//~^ ERROR the trait bound `&'static B: From<&A>` is not satisfied
+type X<A: ToString + Clone, B: ToString + Clone> = impl ToString;
 
-fn f<A, B: 'static>(a: &'static A, b: B) -> (X<A, B>, X<B, A>) {
+fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
     //~^ ERROR defining use generics `[B, A]` differ from previous defining use
     //~| ERROR defining use generics `[B, A]` differ from previous defining use
-    (a, a)
+    (a, b)
 }
 
-fn main() {
-    println!("{}", <X<_, _> as Into<&String>>::into(f(&[1isize, 2, 3], String::new()).1));
+fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
+    (a, b) //~ ERROR mismatched types
 }
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.stderr
@@ -23,13 +23,12 @@ LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/multiple-def-uses-in-one-fn3.rs:17:9
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:16:9
    |
 LL | fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
    |      -                    - found type parameter
    |      |
    |      expected type parameter
-LL |
 LL |     (a, b)
    |         ^ expected type parameter `A`, found type parameter `B`
    |
@@ -38,18 +37,6 @@ LL |     (a, b)
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/multiple-def-uses-in-one-fn3.rs:15:1
-   |
-LL | fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[type error]`, got `A`
-   |
-note: previous use here
-  --> $DIR/multiple-def-uses-in-one-fn3.rs:9:1
-   |
-LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.stderr
@@ -23,12 +23,13 @@ LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/multiple-def-uses-in-one-fn3.rs:16:9
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:17:9
    |
 LL | fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
    |      -                    - found type parameter
    |      |
    |      expected type parameter
+LL |
 LL |     (a, b)
    |         ^ expected type parameter `A`, found type parameter `B`
    |
@@ -37,6 +38,18 @@ LL |     (a, b)
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 
-error: aborting due to 3 previous errors
+error: concrete type differs from previous defining opaque type use
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:15:1
+   |
+LL | fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[type error]`, got `A`
+   |
+note: previous use here
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:9:1
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn3.stderr
@@ -1,0 +1,42 @@
+error: defining use generics `[B, A]` differ from previous defining use
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:9:63
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   |                                                               ^^^^^^^^^^^^^^^^^^
+   |
+note: previous defining use with different generics `[A, B]` found here
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:9:63
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   |                                                               ^^^^^^^^^^^^^^^^^^
+
+error: defining use generics `[B, A]` differ from previous defining use
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:9:1
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: previous defining use with different generics `[A, B]` found here
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:9:1
+   |
+LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/multiple-def-uses-in-one-fn3.rs:16:9
+   |
+LL | fn g<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<A, B>) {
+   |      -                    - found type parameter
+   |      |
+   |      expected type parameter
+LL |     (a, b)
+   |         ^ expected type parameter `A`, found type parameter `B`
+   |
+   = note: expected type parameter `A`
+              found type parameter `B`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
cc @jackh726 

fixes https://github.com/rust-lang/rust/issues/73481 (only the first defining for a specific TAIT use within a function is handled at all, all others are not looked at at all)

r? @matthewjasper 

I am fully aware the diagnostics aren't great, but they are ungreat in general around type alias impl trait, which is tracked in https://github.com/rust-lang/rust/issues/63205