### PR TITLE
Rustdoc Json: Add tests for Reexports, and improve jsondocck

### DIFF
--- a/src/test/rustdoc-json/reexport/glob_extern.rs
+++ b/src/test/rustdoc-json/reexport/glob_extern.rs
@@ -1,0 +1,17 @@
+// edition:2018
+
+#![no_core]
+#![feature(no_core)]
+
+// @!has glob_extern.json "$.index[*][?(@.name=='mod1')]"
+mod mod1 {
+    extern "C" {
+        // @set public_fn_id = - "$.index[*][?(@.name=='public_fn')].id"
+        pub fn public_fn();
+        // @!has - "$.index[*][?(@.name=='private_fn')]"
+        fn private_fn();
+    }
+}
+
+// @has - "$.index[*][?(@.name=='glob_extern')].inner.items[*]" $public_fn_id
+pub use mod1::*;

--- a/src/test/rustdoc-json/reexport/glob_private.rs
+++ b/src/test/rustdoc-json/reexport/glob_private.rs
@@ -1,0 +1,27 @@
+// edition:2018
+
+#![no_core]
+#![feature(no_core)]
+
+// @!has glob_private.json "$.index[*][?(@.name=='mod1')]"
+mod mod1 {
+    // @!has - "$.index[*][?(@.name=='mod2')]"
+    mod mod2 {
+        // @set m2pub_id = - "$.index[*][?(@.name=='Mod2Public')].id"
+        pub struct Mod2Public;
+
+        // @!has - "$.index[*][?(@.name=='Mod2Private')]"
+        struct Mod2Private;
+    }
+    pub use self::mod2::*;
+
+    // @set m1pub_id = - "$.index[*][?(@.name=='Mod1Public')].id"
+    pub struct Mod1Public;
+
+    // @!has - "$.index[*][?(@.name=='Mod1Private')]"
+    struct Mod1Private;
+}
+pub use mod1::*;
+
+// @has - "$.index[*][?(@.name=='glob_private')].inner.items[*]" $m2pub_id
+// @has - "$.index[*][?(@.name=='glob_private')].inner.items[*]" $m1pub_id

--- a/src/test/rustdoc-json/reexport/rename_public.rs
+++ b/src/test/rustdoc-json/reexport/rename_public.rs
@@ -1,0 +1,17 @@
+// edition:2018
+
+#![no_core]
+#![feature(no_core)]
+
+// @set inner_id = rename_public.json "$.index[*][?(@.name=='inner')].id"
+// @has - "$.index[*][?(@.name=='rename_public')].inner.items[*]" $inner_id
+pub mod inner {
+    // @set public_id = - "$.index[*][?(@.name=='Public')].id"
+    // @has - "$.index[*][?(@.name=='inner')].inner.items[*]" $public_id
+    pub struct Public;
+}
+// @set import_id = - "$.index[*][?(@.inner.name=='NewName')].id"
+// @!has - "$.index[*][?(@.inner.name=='Public')]"
+// @has - "$.index[*][?(@.name=='rename_public')].inner.items[*]" $import_id
+// @is - "$.index[*][?(@.inner.name=='NewName')].inner.span" \"inner::Public\"
+pub use inner::Public as NewName;

--- a/src/test/rustdoc-json/reexport/simple_private.rs
+++ b/src/test/rustdoc-json/reexport/simple_private.rs
@@ -1,0 +1,13 @@
+// edition:2018
+
+#![no_core]
+#![feature(no_core)]
+
+// @!has simple_private.json "$.index[*][?(@.name=='inner')]"
+mod inner {
+    // @set pub_id = - "$.index[*][?(@.name=='Public')].id"
+    pub struct Public;
+}
+
+// @has - "$.index[*][?(@.name=='simple_private')].inner.items[*]" $pub_id
+pub use inner::Public;

--- a/src/test/rustdoc-json/reexport/simple_public.rs
+++ b/src/test/rustdoc-json/reexport/simple_public.rs
@@ -1,0 +1,18 @@
+// edition:2018
+
+#![no_core]
+#![feature(no_core)]
+
+// @set inner_id = simple_public.json "$.index[*][?(@.name=='inner')].id"
+// @has - "$.index[*][?(@.name=='simple_public')].inner.items[*]" $inner_id
+pub mod inner {
+
+    // @set public_id = - "$.index[*][?(@.name=='Public')].id"
+    // @has - "$.index[*][?(@.name=='inner')].inner.items[*]" $public_id
+    pub struct Public;
+}
+
+// @set import_id = - "$.index[*][?(@.inner.name=='Public')].id"
+// @has - "$.index[*][?(@.name=='simple_public')].inner.items[*]" $import_id
+// @is - "$.index[*][?(@.inner.name=='Public')].inner.span" \"inner::Public\"
+pub use inner::Public;


### PR DESCRIPTION
The two changes are orthognal, so you can land just one if you want, but the improved errors realy helped write the tests.

Notably does not have the case from #80664, but I want to have all the ajacent cases tested before starting work on that to ensure I dont break anything.

Improves #81359

cc @CraftSpider 

r? @jyn514 

@rustbot modify labels: +A-testsuite +T-rustdoc +A-rustdoc-json
