### PR TITLE
u8::to_string() specialisation (far less asm).

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2224,6 +2224,15 @@ impl ToString for char {
     }
 }
 
+#[stable(feature = "u8_to_string_specialization", since="1.999.0")]
+impl ToString for u8 {
+    #[inline]
+    fn to_string(&self) -> String {
+        // Encode utf8 panics if not valid utf8.
+        String::from((*self as char).encode_utf8(&mut [0; 1]))
+    }
+}
+
 #[stable(feature = "str_to_string_specialization", since = "1.9.0")]
 impl ToString for str {
     #[inline]


### PR DESCRIPTION
#73533 pointed out that u8::to_string() was heavy on the codegen: https://rust.godbolt.org/z/1MnhWY

Interestingly whether we use `[0;1]` or `[0;4]` (the latter is used for the char specialisation) it seems to make no difference to the generated code.

(I tried putting an unstable attribute but apparently it's not effective there so I put a high since value for now. Please point me in the right direction as to how I should put that attribute on?)