### PR TITLE
i8 and u8::to_string() specialisation (far less asm).

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2248,15 +2248,12 @@ impl ToString for i8 {
     #[inline]
     fn to_string(&self) -> String {
         let mut vec = vec![0; 4];
-        let n = *self;
         let mut free = 0;
-        let mut n: u8 = if n.is_negative() {
+        if self.is_negative() {
             vec[free] = b'-';
             free += 1;
-            i8::unsigned_abs(n)
-        } else {
-            n as u8
-        };
+        }
+        let mut n = self.unsigned_abs();
         if n >= 10 {
             if n >= 100 {
                 n -= 100;

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2254,14 +2254,18 @@ static DEC_DIGITS_LUT: &[u8; 200] = b"0001020304050607080910111213141516171819\
 impl ToString for i8 {
     #[inline]
     fn to_string(&self) -> String {
-        let mut vec: Vec<u8> = if *self < 0 {
+        let mut n = *self;
+        let mut vec: Vec<u8> = if n < 0 {
+            // convert the negative num to positive by summing 1 to it's 2 complement
+            // ( -128u8.abs() would panic )
+            n = (!n).wrapping_add(1);
             let mut v = Vec::with_capacity(4);
             v.push(b'-');
             v
         } else {
             Vec::with_capacity(3)
         };
-        let mut n = self.abs();
+        let mut n = n as u8;
         if n >= 10 {
             if n >= 100 {
                 n -= 100;

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2224,7 +2224,7 @@ impl ToString for char {
     }
 }
 
-#[stable(feature = "u8_to_string_specialization", since="1.999.0")]
+#[stable(feature = "u8_to_string_specialization", since = "1.999.0")]
 impl ToString for u8 {
     #[inline]
     fn to_string(&self) -> String {
@@ -2240,6 +2240,39 @@ impl ToString for u8 {
         };
         result.push((b'0' + n) as char);
         result
+    }
+}
+
+// 2 digit decimal look up table
+static DEC_DIGITS_LUT: &[u8; 200] = b"0001020304050607080910111213141516171819\
+      2021222324252627282930313233343536373839\
+      4041424344454647484950515253545556575859\
+      6061626364656667686970717273747576777879\
+      8081828384858687888990919293949596979899";
+
+#[stable(feature = "i8_to_string_specialization", since = "1.999.0")]
+impl ToString for i8 {
+    #[inline]
+    fn to_string(&self) -> String {
+        let mut vec: Vec<u8> = if *self < 0 {
+            let mut v = Vec::with_capacity(4);
+            v.push(b'-');
+            v
+        } else {
+            Vec::with_capacity(3)
+        };
+        let mut n = self.abs();
+        if n >= 10 {
+            if n >= 100 {
+                n -= 100;
+                vec.push(b'1');
+            }
+            let nn = n * 2;
+            vec.extend_from_slice(&DEC_DIGITS_LUT[nn as usize..=nn as usize + 1]);
+        } else {
+            vec.push(b'0' + (n as u8));
+        }
+        unsafe { String::from_utf8_unchecked(vec) }
     }
 }
 

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2228,18 +2228,18 @@ impl ToString for char {
 impl ToString for u8 {
     #[inline]
     fn to_string(&self) -> String {
-        let mut result = String::with_capacity(3);
+        let mut buf = String::with_capacity(3);
         let mut n = *self;
-        if n >= 100 {
-            result.push((b'0' + n / 100) as char);
-            n %= 100;
-        }
-        if !result.is_empty() || n >= 10 {
-            result.push((b'0' + n / 10) as char);
+        if n >= 10 {
+            if n >= 100 {
+                buf.push((b'0' + n / 100) as char);
+                n %= 100;
+            }
+            buf.push((b'0' + n / 10) as char);
             n %= 10;
-        };
-        result.push((b'0' + n) as char);
-        result
+        }
+        buf.push((b'0' + n) as char);
+        buf
     }
 }
 
@@ -2247,31 +2247,21 @@ impl ToString for u8 {
 impl ToString for i8 {
     #[inline]
     fn to_string(&self) -> String {
-        let mut vec = vec![0; 4];
-        let mut free = 0;
+        let mut buf = String::with_capacity(4);
         if self.is_negative() {
-            vec[free] = b'-';
-            free += 1;
+            buf.push('-');
         }
         let mut n = self.unsigned_abs();
         if n >= 10 {
             if n >= 100 {
+                buf.push('1');
                 n -= 100;
-                vec[free] = b'1';
-                free += 1;
             }
-            debug_assert!(n < 100);
-            vec[free] = b'0' + n / 10;
-            free += 1;
+            buf.push((b'0' + n / 10) as char);
             n %= 10;
         }
-        debug_assert!(n < 10);
-        vec[free] = b'0' + n;
-        free += 1;
-        vec.truncate(free);
-
-        // SAFETY: Vec only contains ascii so valid utf8
-        unsafe { String::from_utf8_unchecked(vec) }
+        buf.push((b'0' + n) as char);
+        buf
     }
 }
 

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2224,6 +2224,25 @@ impl ToString for char {
     }
 }
 
+#[stable(feature = "u8_to_string_specialization", since="1.999.0")]
+impl ToString for u8 {
+    #[inline]
+    fn to_string(&self) -> String {
+        let mut result = String::with_capacity(3);
+        let mut n = *self;
+        if n >= 100 {
+            result.push((b'0' + n / 100) as char);
+            n %= 100;
+        }
+        if !result.is_empty() || n >= 10 {
+            result.push((b'0' + n / 10) as char);
+            n %= 10;
+        };
+        result.push((b'0' + n) as char);
+        result
+    }
+}
+
 #[stable(feature = "str_to_string_specialization", since = "1.9.0")]
 impl ToString for str {
     #[inline]


### PR DESCRIPTION
Take 2. Around 1/6th of the assembly to without specialisation.

https://godbolt.org/z/bzz8Mq

(partially fixes #73533 )
