### PR TITLE
Add ARIA role to sidebar toggle in Rustdoc

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -75,7 +75,7 @@ crate fn render<T: Print, S: Print>(
     <![endif]-->\
     {before_content}\
     <nav class=\"sidebar\">\
-        <div class=\"sidebar-menu\">&#9776;</div>\
+        <div class=\"sidebar-menu\" role=\"button\">&#9776;</div>\
         {logo}\
         {sidebar}\
     </nav>\


### PR DESCRIPTION
This indicates that the div is an interactive element, and makes the sidebar toggle "clickable" in assistive technologies.

Example of Vimium after this change has been applied (see the issue mentioned below for a screenshot of before):

![Screenshot of Vimium link hints on a Rustdoc page, indicating that the sidebar toggle is clickable](https://user-images.githubusercontent.com/1552853/109384961-ff935400-78f8-11eb-8199-1d35181aeff0.png)

Fixes #82582