### PR TITLE
Added CharIndices::offset function

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -137,6 +137,7 @@
 #![feature(stmt_expr_attributes)]
 #![feature(str_split_as_str)]
 #![feature(str_split_inclusive_as_str)]
+#![feature(char_indices_offset)]
 #![feature(trait_alias)]
 #![feature(transparent_unions)]
 #![feature(try_blocks)]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -209,7 +209,7 @@ impl<'a> CharIndices<'a> {
     /// assert_eq!(chars.next(), None);
     /// ```
     #[inline]
-    #[unstable(feature = "char_indices_offset", issue = "none")]
+    #[unstable(feature = "char_indices_offset", issue = "83871")]
     pub fn offset(&self) -> usize {
         self.front_offset
     }

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -189,6 +189,29 @@ impl<'a> CharIndices<'a> {
     pub fn as_str(&self) -> &'a str {
         self.iter.as_str()
     }
+
+    /// Returns the byte position of the next character, or the length 
+    /// of the underlying string if there are no more characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut chars = "a楽".char_indices();
+    ///
+    /// assert_eq!(chars.offset(), 0);
+    /// assert_eq!(chars.next(), Some((0, 'a')));
+    ///
+    /// assert_eq!(chars.offset(), 1);
+    /// assert_eq!(chars.next(), Some((1, '楽')));
+    ///
+    /// assert_eq!(chars.offset(), 4);
+    /// assert_eq!(chars.next(), None);
+    /// ```
+    #[inline]
+    #[unstable(feature = "char_indices_offset", issue = "none")]
+    pub fn offset(&self) -> usize {
+        self.front_offset
+    }
 }
 
 /// An iterator over the bytes of a string slice.

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -196,6 +196,7 @@ impl<'a> CharIndices<'a> {
     /// # Examples
     ///
     /// ```
+    /// #![feature(char_indices_offset)]
     /// let mut chars = "a楽".char_indices();
     ///
     /// assert_eq!(chars.offset(), 0);

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -190,7 +190,7 @@ impl<'a> CharIndices<'a> {
         self.iter.as_str()
     }
 
-    /// Returns the byte position of the next character, or the length 
+    /// Returns the byte position of the next character, or the length
     /// of the underlying string if there are no more characters.
     ///
     /// # Examples


### PR DESCRIPTION
The CharIndices iterator has a field internally called front_offset, that I think would be very useful to have access to.

You can already do something like ``char_indices.next().map(|(offset, _)| offset)``, but that is wordy, in addition to not handling the case where the iterator has ended, where you'd want the offset to be equal to the length.

I'm very new to the open source world and the rust repository, so I'm sorry if I missed a step or did something weird.