### PR TITLE
Teach rustdoc how to display WASI.

### DIFF
--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -483,6 +483,7 @@ impl<'a> fmt::Display for Display<'a> {
                         "openbsd" => "OpenBSD",
                         "redox" => "Redox",
                         "solaris" => "Solaris",
+                        "wasi" => "WASI",
                         "windows" => "Windows",
                         _ => "",
                     },

--- a/src/librustdoc/clean/cfg/tests.rs
+++ b/src/librustdoc/clean/cfg/tests.rs
@@ -368,6 +368,10 @@ fn test_render_long_html() {
             "This is supported on <strong>macOS</strong> only."
         );
         assert_eq!(
+            name_value_cfg("target_os", "wasi").render_long_html(),
+            "This is supported on <strong>WASI</strong> only."
+        );
+        assert_eq!(
             name_value_cfg("target_pointer_width", "16").render_long_html(),
             "This is supported on <strong>16-bit</strong> only."
         );

--- a/src/test/rustdoc/doc-cfg.rs
+++ b/src/test/rustdoc/doc-cfg.rs
@@ -5,6 +5,8 @@
 // @!has - '//*[@id="main"]/*[@class="item-info"]/*[@class="stab portability"]' ''
 // @has - '//*[@id="method.unix_and_arm_only_function"]' 'fn unix_and_arm_only_function()'
 // @has - '//*[@class="stab portability"]' 'This is supported on Unix and ARM only.'
+// @has - '//*[@id="method.wasi_and_wasm32_only_function"]' 'fn wasi_and_wasm32_only_function()'
+// @has - '//*[@class="stab portability"]' 'This is supported on WASI and WebAssembly only.'
 pub struct Portable;
 
 // @has doc_cfg/unix_only/index.html \
@@ -34,6 +36,36 @@ pub mod unix_only {
     #[doc(cfg(target_arch = "arm"))]
     impl ArmOnly for super::Portable {
         fn unix_and_arm_only_function() {}
+    }
+}
+
+// @has doc_cfg/wasi_only/index.html \
+//  '//*[@id="main"]/*[@class="item-info"]/*[@class="stab portability"]' \
+//  'This is supported on WASI only.'
+// @matches - '//*[@class="module-item"]//*[@class="stab portability"]' '\AWebAssembly\Z'
+// @count - '//*[@class="stab portability"]' 2
+#[doc(cfg(target_os = "wasi"))]
+pub mod wasi_only {
+    // @has doc_cfg/wasi_only/fn.wasi_only_function.html \
+    //  '//*[@id="main"]/*[@class="item-info"]/*[@class="stab portability"]' \
+    //  'This is supported on WASI only.'
+    // @count - '//*[@class="stab portability"]' 1
+    pub fn wasi_only_function() {
+        content::should::be::irrelevant();
+    }
+
+    // @has doc_cfg/wasi_only/trait.Wasm32Only.html \
+    //  '//*[@id="main"]/*[@class="item-info"]/*[@class="stab portability"]' \
+    //  'This is supported on WASI and WebAssembly only.'
+    // @count - '//*[@class="stab portability"]' 1
+    #[doc(cfg(target_arch = "wasm32"))]
+    pub trait Wasm32Only {
+        fn wasi_and_wasm32_only_function();
+    }
+
+    #[doc(cfg(target_arch = "wasm32"))]
+    impl Wasm32Only for super::Portable {
+        fn wasi_and_wasm32_only_function() {}
     }
 }
 


### PR DESCRIPTION
As a followup to [this comment] in #82420, this patch teaches rustdoc
how to display WASI.

[this comment]: https://github.com/rust-lang/rust/pull/82420#issuecomment-784523826

r? @alexcrichton 