### PR TITLE
Fixed support for macOS Catalyst on ARM64

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/aarch64_apple_ios_macabi.rs
@@ -4,12 +4,12 @@ use crate::spec::{Target, TargetOptions};
 pub fn target() -> Target {
     let base = opts("ios", Arch::Arm64_macabi);
     Target {
-        llvm_target: "arm64-apple-ios-macabi".to_string(),
+        llvm_target: "arm64-apple-ios14.0-macabi".to_string(),
         pointer_width: 64,
         data_layout: "e-m:o-i64:64-i128:128-n32:64-S128".to_string(),
         arch: "aarch64".to_string(),
         options: TargetOptions {
-            features: "+neon,+fp-armv8,+apple-a7".to_string(),
+            features: "+neon,+fp-armv8,+apple-a12".to_string(),
             eliminate_frame_pointer: false,
             max_atomic_width: Some(128),
             unsupported_abis: super::arm_base::unsupported_abis(),
@@ -18,11 +18,9 @@ pub fn target() -> Target {
             // These arguments are not actually invoked - they just have
             // to look right to pass App Store validation.
             bitcode_llvm_cmdline: "-triple\0\
-                arm64-apple-ios-macabi\0\
+                arm64-apple-ios14.0-macabi\0\
                 -emit-obj\0\
                 -disable-llvm-passes\0\
-                -target-abi\0\
-                darwinpcs\0\
                 -Os\0"
                 .to_string(),
             ..base


### PR DESCRIPTION
When I initially added Arm64 Catalyst support in https://github.com/rust-lang/rust/pull/77484 I had access to a DTK. However, while waiting to merge the PR some other changes were merged which caused conflicts in the branch. When fixing those conflicts I had no access to the DTK anymore and didn't try out if the resulting binaries did indeed work on Apple Silicon. I finally have a M1 and I realized that some small changes were necessary to support Apple Silicon. This PR adds the required changes. I've been running binaries generated with this branch for some time now and they work without issues.