### PR TITLE
Apply lint restrictions from renamed lints

### DIFF
--- a/src/test/ui/lint/renamed-lints-still-apply.rs
+++ b/src/test/ui/lint/renamed-lints-still-apply.rs
@@ -1,0 +1,9 @@
+// compile-flags: --crate-type lib
+#![deny(single_use_lifetime)]
+//~^ WARNING renamed
+//~| NOTE `#[warn(renamed_and_removed_lints)]` on by default
+//~| NOTE defined here
+fn _foo<'a>(_x: &'a u32) {}
+//~^ ERROR only used once
+//~| NOTE this lifetime
+//~| NOTE is used only here

--- a/src/test/ui/lint/renamed-lints-still-apply.stderr
+++ b/src/test/ui/lint/renamed-lints-still-apply.stderr
@@ -1,0 +1,28 @@
+warning: lint `single_use_lifetime` has been renamed to `single_use_lifetimes`
+  --> $DIR/renamed-lints-still-apply.rs:2:9
+   |
+LL | #![deny(single_use_lifetime)]
+   |         ^^^^^^^^^^^^^^^^^^^ help: use the new name: `single_use_lifetimes`
+   |
+   = note: `#[warn(renamed_and_removed_lints)]` on by default
+
+error: lifetime parameter `'a` only used once
+  --> $DIR/renamed-lints-still-apply.rs:6:9
+   |
+LL | fn _foo<'a>(_x: &'a u32) {}
+   |         ^^       -- ...is used only here
+   |         |
+   |         this lifetime...
+   |
+note: the lint level is defined here
+  --> $DIR/renamed-lints-still-apply.rs:2:9
+   |
+LL | #![deny(single_use_lifetime)]
+   |         ^^^^^^^^^^^^^^^^^^^
+help: elide the single-use lifetime
+   |
+LL | fn _foo(_x: &u32) {}
+   |       --    --
+
+error: aborting due to previous error; 1 warning emitted
+


### PR DESCRIPTION
Previously, if you denied the old name of a renamed lint, it would warn
about using the new name, but otherwise do nothing. Now, it will behave
the same as if you'd used the new name.

Fixes https://github.com/rust-lang/rust/issues/82615.

r? @ehuss 