### PR TITLE
Propagate `--test-args` for `x.py test src/tools/cargo`

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -212,6 +212,7 @@ impl Step for Cargo {
         if !builder.fail_fast {
             cargo.arg("--no-fail-fast");
         }
+        cargo.arg("--").args(builder.config.cmd.test_args());
 
         // Don't run cross-compile tests, we may not have cross-compiled libstd libs
         // available.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/82621.