### PR TITLE
ci: musl: upgrade to 1.2.2

### DIFF
--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -4,7 +4,7 @@
 #
 # Versions of the toolchain components are configurable in `musl-cross-make/Makefile` and
 # musl unlike GLIBC is forward compatible so upgrading it shouldn't break old distributions.
-# Right now we have: Binutils 2.31.1, GCC 9.2.0, musl 1.1.24.
+# Right now we have: Binutils 2.31.1, GCC 9.2.0, musl 1.2.2.
 
 # ignore-tidy-linelength
 
@@ -45,8 +45,8 @@ cd musl-cross-make
 # A few commits ahead of v0.9.9 to include the cowpatch fix:
 git checkout a54eb56f33f255dfca60be045f12a5cfaf5a72a9
 
-hide_output make -j$(nproc) TARGET=$TARGET MUSL_VER=1.1.24 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE
-hide_output make install TARGET=$TARGET MUSL_VER=1.1.24 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE OUTPUT=$OUTPUT
+hide_output make -j$(nproc) TARGET=$TARGET MUSL_VER=1.2.2 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE
+hide_output make install TARGET=$TARGET MUSL_VER=1.2.2 LINUX_HEADERS_SITE=$LINUX_HEADERS_SITE OUTPUT=$OUTPUT
 
 cd -
 

--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -25,7 +25,7 @@ shift
 # Apparently applying `-fPIC` everywhere allows them to link successfully.
 export CFLAGS="-fPIC $CFLAGS"
 
-MUSL=musl-1.1.24
+MUSL=musl-1.2.2
 
 # may have been downloaded in a previous run
 if [ ! -d $MUSL ]; then


### PR DESCRIPTION
Upgrade musl components in CI to 1.2.2.

This probably should not land until rust-lang/libc#2088 is merged.

musl 1.1 is for all practical purposes no longer receiving maintenance.