### PR TITLE
Remove an old FIXME comment and inline attribute

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -455,7 +455,6 @@ fn subst_and_check_impossible_predicates<'tcx>(
 
 /// Given a trait `trait_ref`, iterates the vtable entries
 /// that come from `trait_ref`, including its supertraits.
-#[inline] // FIXME(#35870): avoid closures being unexported due to `impl Trait`.
 fn vtable_methods<'tcx>(
     tcx: TyCtxt<'tcx>,
     trait_ref: ty::PolyTraitRef<'tcx>,


### PR DESCRIPTION
Apparently #35870 caused a problem in this code (which originally
returned an impl trait) and `#[inline]` was added as a workaround, in
ade79d76090.

The issue is now fixed and the comment and `#[inline]` can now be
removed.