### PR TITLE
Set focus on the search input if a query is set.

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2859,6 +2859,10 @@ function defocusSearchBar() {
     function enableSearchInput() {
         if (search_input) {
             search_input.removeAttribute('disabled');
+            var params = getQueryStringParams();
+            if (search_input.value !== "" || (params && params.search)) {
+                search_input.focus();
+            }
         }
     }
 


### PR DESCRIPTION
This addresses #78824 by manually focusing the element after it's enabled.

I tried autofocus as well, but I think that doesn't work because the element is marked disabled in the HTML on load. I added the input value conditional to make sure there's actually a search term set, otherwise we'd focus whenever any page was loaded.