### PR TITLE
Cleanup rustdoc warnings

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -559,7 +559,8 @@ impl CheckAttrVisitor<'tcx> {
                             sym::masked,
                             sym::no_default_passes, // deprecated
                             sym::no_inline,
-                            sym::passes, // deprecated
+                            sym::passes,  // deprecated
+                            sym::plugins, // removed, but rustdoc warns about it itself
                             sym::primitive,
                             sym::spotlight,
                             sym::test,

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -654,9 +654,8 @@ fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Han
             {
                 continue;
             }
-            let mut err =
-                diag.struct_warn(&format!("the '{}' flag is considered deprecated", flag));
-            err.warn(
+            let mut err = diag.struct_warn(&format!("the `{}` flag is deprecated", flag));
+            err.note(
                 "see issue #44136 <https://github.com/rust-lang/rust/issues/44136> \
                  for more information",
             );

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -572,6 +572,8 @@ crate fn run_global_ctxt(
 
         if name == "no_default_passes" {
             msg.help("you may want to use `#![doc(document_private_items)]`");
+        } else if name.starts_with("plugins") {
+            msg.warn("`#![doc(plugins = \"...\")]` no longer functions; see CVE-2018-1000622 <https://nvd.nist.gov/vuln/detail/CVE-2018-1000622>");
         }
 
         msg.emit();
@@ -618,10 +620,6 @@ crate fn run_global_ctxt(
                 }
                 sym::plugins => {
                     report_deprecated_attr("plugins = \"...\"", diag, attr.span());
-                    eprintln!(
-                        "WARNING: `#![doc(plugins = \"...\")]` \
-                         no longer functions; see CVE-2018-1000622"
-                    );
                     continue;
                 }
                 _ => continue,

--- a/src/test/rustdoc-ui/deprecated-attrs.rs
+++ b/src/test/rustdoc-ui/deprecated-attrs.rs
@@ -11,3 +11,7 @@
 //~| NOTE see issue #44136
 //~| WARNING ignoring unknown pass
 //~| NOTE `collapse-docs` pass was removed
+#![doc(plugins = "xxx")]
+//~^ WARNING attribute is deprecated
+//~| NOTE see issue #44136
+//~| WARNING no longer functions; see CVE

--- a/src/test/rustdoc-ui/deprecated-attrs.rs
+++ b/src/test/rustdoc-ui/deprecated-attrs.rs
@@ -1,7 +1,13 @@
 // check-pass
+// compile-flags: --passes unknown-pass
+// error-pattern: ignoring unknown pass `unknown-pass`
 
-#![doc(no_default_passes, passes = "unindent-comments")]
-
-struct SomeStruct;
-
-pub struct OtherStruct;
+#![doc(no_default_passes)]
+//~^ WARNING attribute is deprecated
+//~| NOTE see issue #44136
+//~| HELP use `#![doc(document_private_items)]`
+#![doc(passes = "collapse-docs unindent-comments")]
+//~^ WARNING attribute is deprecated
+//~| NOTE see issue #44136
+//~| WARNING ignoring unknown pass
+//~| NOTE `collapse-docs` pass was removed

--- a/src/test/rustdoc-ui/deprecated-attrs.stderr
+++ b/src/test/rustdoc-ui/deprecated-attrs.stderr
@@ -1,11 +1,33 @@
-warning: the `#![doc(no_default_passes)]` attribute is considered deprecated
+warning: the `passes` flag is deprecated
    |
-   = warning: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+   = note: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+
+warning: ignoring unknown pass `unknown-pass`
+
+warning: the `#![doc(no_default_passes)]` attribute is deprecated
+  --> $DIR/deprecated-attrs.rs:5:8
+   |
+LL | #![doc(no_default_passes)]
+   |        ^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
    = help: you may want to use `#![doc(document_private_items)]`
 
-warning: the `#![doc(passes = "...")]` attribute is considered deprecated
+warning: the `#![doc(passes = "...")]` attribute is deprecated
+  --> $DIR/deprecated-attrs.rs:9:8
    |
-   = warning: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+LL | #![doc(passes = "collapse-docs unindent-comments")]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
 
-warning: 2 warnings emitted
+warning: ignoring unknown pass `collapse-docs`
+  --> $DIR/deprecated-attrs.rs:9:17
+   |
+LL | #![doc(passes = "collapse-docs unindent-comments")]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the `collapse-docs` pass was removed in #80261 <https://github.com/rust-lang/rust/pull/80261>
+
+warning: 4 warnings emitted
 

--- a/src/test/rustdoc-ui/deprecated-attrs.stderr
+++ b/src/test/rustdoc-ui/deprecated-attrs.stderr
@@ -29,5 +29,14 @@ LL | #![doc(passes = "collapse-docs unindent-comments")]
    |
    = note: the `collapse-docs` pass was removed in #80261 <https://github.com/rust-lang/rust/pull/80261>
 
-warning: 4 warnings emitted
+warning: the `#![doc(plugins = "...")]` attribute is deprecated
+  --> $DIR/deprecated-attrs.rs:14:8
+   |
+LL | #![doc(plugins = "xxx")]
+   |        ^^^^^^^^^^^^^^^
+   |
+   = note: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+   = warning: `#![doc(plugins = "...")]` no longer functions; see CVE-2018-1000622 <https://nvd.nist.gov/vuln/detail/CVE-2018-1000622>
+
+warning: 5 warnings emitted
 


### PR DESCRIPTION
## Clean up error reporting for deprecated passes

Using `error!` here goes all the way back to the original commit, https://github.com/rust-lang/rust/pull/8540. I don't see any reason to use logging; rustdoc should use diagnostics wherever possible. See https://github.com/rust-lang/rust/pull/81932#issuecomment-785291244 for further context.

- Use spans for deprecated attributes
- Use a proper diagnostic for unknown passes, instead of error logging
- Add tests for unknown passes
- Improve some wording in diagnostics

##  Report that `doc(plugins)` doesn't work using diagnostics instead of `eprintln!`

This also adds a test for the output.

This was added in https://github.com/rust-lang/rust/pull/52194. I don't see any particular reason not to use diagnostics here, I think it was just missed in https://github.com/rust-lang/rust/pull/50541.