### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: "echo \"[CI_PR_NUMBER=$num]\""
         env:
           num: "${{ github.event.number }}"
-        if: "success() && !env.SKIP_JOBS && github.event_name == 'pull_request'"
+        if: "success() && !env.SKIP_JOB && github.event_name == 'pull_request'"
       - name: add extra environment variables
         run: src/ci/scripts/setup-environment.sh
         env:
@@ -425,7 +425,7 @@ jobs:
         run: "echo \"[CI_PR_NUMBER=$num]\""
         env:
           num: "${{ github.event.number }}"
-        if: "success() && !env.SKIP_JOBS && github.event_name == 'pull_request'"
+        if: "success() && !env.SKIP_JOB && github.event_name == 'pull_request'"
       - name: add extra environment variables
         run: src/ci/scripts/setup-environment.sh
         env:
@@ -532,7 +532,7 @@ jobs:
         run: "echo \"[CI_PR_NUMBER=$num]\""
         env:
           num: "${{ github.event.number }}"
-        if: "success() && !env.SKIP_JOBS && github.event_name == 'pull_request'"
+        if: "success() && !env.SKIP_JOB && github.event_name == 'pull_request'"
       - name: add extra environment variables
         run: src/ci/scripts/setup-environment.sh
         env:

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -19,7 +19,7 @@ use rustc_middle::ty::{self, Region, TyCtxt};
 ///    { x.push(y); }
 /// ```
 /// The function returns the nested type corresponding to the anonymous region
-/// for e.g., `&u8` and Vec<`&u8`.
+/// for e.g., `&u8` and `Vec<&u8>`.
 pub(crate) fn find_anon_type(
     tcx: TyCtxt<'tcx>,
     region: Region<'tcx>,

--- a/config.toml.example
+++ b/config.toml.example
@@ -290,6 +290,12 @@ changelog-seen = 2
 # tracking over time)
 #print-step-timings = false
 
+# Print out resource usage data for each rustbuild step, as defined by the Unix
+# struct rusage. (Note that this setting is completely unstable: the data it
+# captures, what platforms it supports, the format of its associated output, and
+# this setting's very existence, are all subject to change.)
+#print-step-rusage = false
+
 # =============================================================================
 # General install configuration options
 # =============================================================================

--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -122,7 +122,7 @@ pub unsafe trait GlobalAlloc {
     ///   this allocator,
     ///
     /// * `layout` must be the same layout that was used
-    ///   to allocate that block of memory,
+    ///   to allocate that block of memory.
     #[stable(feature = "global_alloc", since = "1.28.0")]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout);
 
@@ -167,7 +167,10 @@ pub unsafe trait GlobalAlloc {
     /// and should be considered unusable (unless of course it was
     /// transferred back to the caller again via the return value of
     /// this method). The new memory block is allocated with `layout`, but
-    /// with the `size` updated to `new_size`.
+    /// with the `size` updated to `new_size`. This new layout should be
+    /// used when deallocating the new memory block with `dealloc`. The range
+    /// `0..min(layout.size(), new_size)` of the new memory block is
+    /// guaranteed to have the same values as the original block.
     ///
     /// If this method returns null, then ownership of the memory
     /// block has not been transferred to this allocator, and the

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -139,6 +139,12 @@ fn main() {
     }
 
     if verbose > 1 {
+        let rust_env_vars =
+            env::vars().filter(|(k, _)| k.starts_with("RUST") || k.starts_with("CARGO"));
+        for (i, (k, v)) in rust_env_vars.enumerate() {
+            eprintln!("rustc env[{}]: {:?}={:?}", i, k, v);
+        }
+        eprintln!("rustc working directory: {}", env::current_dir().unwrap().display());
         eprintln!(
             "rustc command: {:?}={:?} {:?}",
             bootstrap::util::dylib_path_var(),

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -155,16 +155,24 @@ fn main() {
         cmd.status().expect(&errmsg)
     };
 
-    if env::var_os("RUSTC_PRINT_STEP_TIMINGS").is_some() {
+    if env::var_os("RUSTC_PRINT_STEP_TIMINGS").is_some()
+        || env::var_os("RUSTC_PRINT_STEP_RUSAGE").is_some()
+    {
         if let Some(crate_name) = crate_name {
             let dur = start.elapsed();
             let is_test = args.iter().any(|a| a == "--test");
+            // If the user requested resource usage data, then
+            // include that in addition to the timing output.
+            let rusage_data =
+                env::var_os("RUSTC_PRINT_STEP_RUSAGE").and_then(|_| format_rusage_data());
             eprintln!(
-                "[RUSTC-TIMING] {} test:{} {}.{:03}",
+                "[RUSTC-TIMING] {} test:{} {}.{:03}{}{}",
                 crate_name,
                 is_test,
                 dur.as_secs(),
-                dur.subsec_millis()
+                dur.subsec_millis(),
+                if rusage_data.is_some() { " " } else { "" },
+                rusage_data.unwrap_or(String::new()),
             );
         }
     }
@@ -191,4 +199,72 @@ fn main() {
             std::process::exit(0xfe);
         }
     }
+}
+
+#[cfg(not(unix))]
+/// getrusage is not available on non-unix platforms. So for now, we do not
+/// bother trying to make a shim for it.
+fn format_rusage_data() -> Option<String> {
+    None
+}
+
+#[cfg(unix)]
+/// Tries to build a string with human readable data for several of the rusage
+/// fields. Note that we are focusing mainly on data that we believe to be
+/// supplied on Linux (the `rusage` struct has other fields in it but they are
+/// currently unsupported by Linux).
+fn format_rusage_data() -> Option<String> {
+    let rusage: libc::rusage = unsafe {
+        let mut recv = std::mem::zeroed();
+        // -1 is RUSAGE_CHILDREN, which means to get the rusage for all children
+        // (and grandchildren, etc) processes that have respectively terminated
+        // and been waited for.
+        let retval = libc::getrusage(-1, &mut recv);
+        if retval != 0 {
+            return None;
+        }
+        recv
+    };
+    // Mac OS X reports the maxrss in bytes, not kb.
+    let divisor = if env::consts::OS == "macos" { 1024 } else { 1 };
+    let maxrss = rusage.ru_maxrss + (divisor - 1) / divisor;
+
+    let mut init_str = format!(
+        "user: {USER_SEC}.{USER_USEC:03} \
+         sys: {SYS_SEC}.{SYS_USEC:03} \
+         max rss (kb): {MAXRSS}",
+        USER_SEC = rusage.ru_utime.tv_sec,
+        USER_USEC = rusage.ru_utime.tv_usec,
+        SYS_SEC = rusage.ru_stime.tv_sec,
+        SYS_USEC = rusage.ru_stime.tv_usec,
+        MAXRSS = maxrss
+    );
+
+    // The remaining rusage stats vary in platform support. So we treat
+    // uniformly zero values in each category as "not worth printing", since it
+    // either means no events of that type occurred, or that the platform
+    // does not support it.
+
+    let minflt = rusage.ru_minflt;
+    let majflt = rusage.ru_majflt;
+    if minflt != 0 || majflt != 0 {
+        init_str.push_str(&format!(" page reclaims: {} page faults: {}", minflt, majflt));
+    }
+
+    let inblock = rusage.ru_inblock;
+    let oublock = rusage.ru_oublock;
+    if inblock != 0 || oublock != 0 {
+        init_str.push_str(&format!(" fs block inputs: {} fs block outputs: {}", inblock, oublock));
+    }
+
+    let nvcsw = rusage.ru_nvcsw;
+    let nivcsw = rusage.ru_nivcsw;
+    if nvcsw != 0 || nivcsw != 0 {
+        init_str.push_str(&format!(
+            " voluntary ctxt switches: {} involuntary ctxt switches: {}",
+            nvcsw, nivcsw
+        ));
+    }
+
+    return Some(init_str);
 }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -938,6 +938,12 @@ impl<'a> Builder<'a> {
         // but this breaks CI. At the very least, stage0 `rustdoc` needs `--cfg bootstrap`. See
         // #71458.
         let mut rustdocflags = rustflags.clone();
+        rustdocflags.propagate_cargo_env("RUSTDOCFLAGS");
+        if stage == 0 {
+            rustdocflags.env("RUSTDOCFLAGS_BOOTSTRAP");
+        } else {
+            rustdocflags.env("RUSTDOCFLAGS_NOT_BOOTSTRAP");
+        }
 
         if let Ok(s) = env::var("CARGOFLAGS") {
             cargo.args(s.split_whitespace());
@@ -1551,21 +1557,27 @@ impl<'a> Builder<'a> {
 mod tests;
 
 #[derive(Debug, Clone)]
-struct Rustflags(String);
+struct Rustflags(String, TargetSelection);
 
 impl Rustflags {
     fn new(target: TargetSelection) -> Rustflags {
-        let mut ret = Rustflags(String::new());
-
-        // Inherit `RUSTFLAGS` by default ...
-        ret.env("RUSTFLAGS");
-
-        // ... and also handle target-specific env RUSTFLAGS if they're
-        // configured.
-        let target_specific = format!("CARGO_TARGET_{}_RUSTFLAGS", crate::envify(&target.triple));
-        ret.env(&target_specific);
-
+        let mut ret = Rustflags(String::new(), target);
+        ret.propagate_cargo_env("RUSTFLAGS");
         ret
+    }
+
+    /// By default, cargo will pick up on various variables in the environment. However, bootstrap
+    /// reuses those variables to pass additional flags to rustdoc, so by default they get overriden.
+    /// Explicitly add back any previous value in the environment.
+    ///
+    /// `prefix` is usually `RUSTFLAGS` or `RUSTDOCFLAGS`.
+    fn propagate_cargo_env(&mut self, prefix: &str) {
+        // Inherit `RUSTFLAGS` by default ...
+        self.env(prefix);
+
+        // ... and also handle target-specific env RUSTFLAGS if they're configured.
+        let target_specific = format!("CARGO_TARGET_{}_{}", crate::envify(&self.1.triple), prefix);
+        self.env(&target_specific);
     }
 
     fn env(&mut self, env: &str) {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1259,6 +1259,10 @@ impl<'a> Builder<'a> {
             cargo.env("RUSTC_PRINT_STEP_TIMINGS", "1");
         }
 
+        if self.config.print_step_rusage {
+            cargo.env("RUSTC_PRINT_STEP_RUSAGE", "1");
+        }
+
         if self.config.backtrace_on_ice {
             cargo.env("RUSTC_BACKTRACE_ON_ICE", "1");
         }

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -161,6 +161,7 @@ pub struct Config {
     pub verbose_tests: bool,
     pub save_toolstates: Option<PathBuf>,
     pub print_step_timings: bool,
+    pub print_step_rusage: bool,
     pub missing_tools: bool,
 
     // Fallback musl-root for all targets
@@ -380,6 +381,7 @@ struct Build {
     configure_args: Option<Vec<String>>,
     local_rebuild: Option<bool>,
     print_step_timings: Option<bool>,
+    print_step_rusage: Option<bool>,
     check_stage: Option<u32>,
     doc_stage: Option<u32>,
     build_stage: Option<u32>,
@@ -679,6 +681,7 @@ impl Config {
         set(&mut config.configure_args, build.configure_args);
         set(&mut config.local_rebuild, build.local_rebuild);
         set(&mut config.print_step_timings, build.print_step_timings);
+        set(&mut config.print_step_rusage, build.print_step_rusage);
 
         // See https://github.com/rust-lang/compiler-team/issues/326
         config.stage = match config.cmd {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -212,6 +212,7 @@ impl Step for Cargo {
         if !builder.fail_fast {
             cargo.arg("--no-fail-fast");
         }
+        cargo.arg("--").args(builder.config.cmd.test_args());
 
         // Don't run cross-compile tests, we may not have cross-compiled libstd libs
         // available.

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -47,7 +47,7 @@ impl Step for ToolBuild {
     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
         let compiler = self.compiler;
         let target = self.target;
-        let tool = self.tool;
+        let mut tool = self.tool;
         let path = self.path;
         let is_optional_tool = self.is_optional_tool;
 
@@ -208,6 +208,12 @@ impl Step for ToolBuild {
                 None
             }
         } else {
+            // HACK(#82501): on Windows, the tools directory gets added to PATH when running tests, and
+            // compiletest confuses HTML tidy with the in-tree tidy. Name the in-tree tidy something
+            // different so the problem doesn't come up.
+            if tool == "tidy" {
+                tool = "rust-tidy";
+            }
             let cargo_out =
                 builder.cargo_out(compiler, self.mode, target).join(exe(tool, compiler.host));
             let bin = builder.tools_dir(compiler).join(exe(tool, compiler.host));

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -110,7 +110,7 @@ x--expand-yaml-anchors--remove:
         run: echo "[CI_PR_NUMBER=$num]"
         env:
           num: ${{ github.event.number }}
-        if: success() && !env.SKIP_JOBS && github.event_name == 'pull_request'
+        if: success() && !env.SKIP_JOB && github.event_name == 'pull_request'
 
       - name: add extra environment variables
         run: src/ci/scripts/setup-environment.sh

--- a/src/test/rustdoc-gui/search-input-mobile.goml
+++ b/src/test/rustdoc-gui/search-input-mobile.goml
@@ -1,0 +1,11 @@
+// Test to ensure that you can click on the search input, whatever the width.
+// The PR which fixed it is: https://github.com/rust-lang/rust/pull/81592
+goto: file://|DOC_PATH|/index.html
+size: (463, 700)
+// We first check that the search input isn't already focused.
+assert-false: ("input.search-input:focus")
+click: "input.search-input"
+reload:
+size: (750, 700)
+click: "input.search-input"
+assert: ("input.search-input:focus")

--- a/src/test/rustdoc-gui/shortcuts.goml
+++ b/src/test/rustdoc-gui/shortcuts.goml
@@ -1,0 +1,26 @@
+// Check that the various shortcuts are working.
+goto: file://|DOC_PATH|/index.html
+// We first check that the search input isn't already focused.
+assert-false: "input.search-input:focus"
+press-key: "s"
+assert: "input.search-input:focus"
+press-key: "Escape"
+assert-false: "input.search-input:focus"
+// We now check for the help popup.
+press-key: "?"
+assert: ("#help", {"display": "flex"})
+assert-false: "#help.hidden"
+press-key: "Escape"
+assert: ("#help.hidden", {"display": "none"})
+// Check for the themes list.
+assert: ("#theme-choices", {"display": "none"})
+press-key: "t"
+assert: ("#theme-choices", {"display": "block"})
+press-key: "t"
+// We ensure that 't' hides back the menu.
+assert: ("#theme-choices", {"display": "none"})
+press-key: "t"
+assert: ("#theme-choices", {"display": "block"})
+press-key: "Escape"
+// We ensure that 'Escape' hides the menu too.
+assert: ("#theme-choices", {"display": "none"})

--- a/src/test/ui/proc-macro/attr-complex-fn.rs
+++ b/src/test/ui/proc-macro/attr-complex-fn.rs
@@ -1,0 +1,26 @@
+// check-pass
+// compile-flags: -Z span-debug --error-format human
+// aux-build:test-macros.rs
+
+#![feature(stmt_expr_attributes)]
+#![feature(custom_inner_attributes)]
+#![feature(rustc_attrs)]
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+trait MyTrait<T> {}
+struct MyStruct<const N: bool>;
+
+#[print_attr]
+fn foo<T: MyTrait<MyStruct<{ true }>>>() {}
+
+impl<T> MyTrait<T> for MyStruct<{true}> {
+    #![print_attr]
+    #![rustc_dummy]
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/attr-complex-fn.stdout
+++ b/src/test/ui/proc-macro/attr-complex-fn.stdout
@@ -1,0 +1,171 @@
+PRINT-ATTR INPUT (DISPLAY): fn foo < T : MyTrait < MyStruct < { true } >> > () { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fn",
+        span: $DIR/attr-complex-fn.rs:19:1: 19:3 (#0),
+    },
+    Ident {
+        ident: "foo",
+        span: $DIR/attr-complex-fn.rs:19:4: 19:7 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:19:7: 19:8 (#0),
+    },
+    Ident {
+        ident: "T",
+        span: $DIR/attr-complex-fn.rs:19:8: 19:9 (#0),
+    },
+    Punct {
+        ch: ':',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:19:9: 19:10 (#0),
+    },
+    Ident {
+        ident: "MyTrait",
+        span: $DIR/attr-complex-fn.rs:19:11: 19:18 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:19:18: 19:19 (#0),
+    },
+    Ident {
+        ident: "MyStruct",
+        span: $DIR/attr-complex-fn.rs:19:19: 19:27 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:19:27: 19:28 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "true",
+                span: $DIR/attr-complex-fn.rs:19:30: 19:34 (#0),
+            },
+        ],
+        span: $DIR/attr-complex-fn.rs:19:28: 19:36 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Joint,
+        span: $DIR/attr-complex-fn.rs:19:36: 19:38 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Joint,
+        span: $DIR/attr-complex-fn.rs:19:36: 19:38 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:19:38: 19:39 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/attr-complex-fn.rs:19:39: 19:41 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/attr-complex-fn.rs:19:42: 19:44 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): impl < T > MyTrait < T > for MyStruct < { true } > { # ! [rustc_dummy] }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "impl",
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Ident {
+        ident: "T",
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Ident {
+        ident: "MyTrait",
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Ident {
+        ident: "T",
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Ident {
+        ident: "for",
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Ident {
+        ident: "MyStruct",
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "true",
+                span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+            },
+        ],
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "rustc_dummy",
+                        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+                    },
+                ],
+                span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+            },
+        ],
+        span: $DIR/attr-complex-fn.rs:21:1: 24:2 (#0),
+    },
+]

--- a/src/test/ui/proc-macro/auxiliary/test-macros.rs
+++ b/src/test/ui/proc-macro/auxiliary/test-macros.rs
@@ -128,6 +128,20 @@ pub fn print_attr_args(args: TokenStream, input: TokenStream) -> TokenStream {
     input
 }
 
+#[proc_macro_attribute]
+pub fn print_target_and_args(args: TokenStream, input: TokenStream) -> TokenStream {
+    print_helper(args, "ATTR_ARGS");
+    print_helper(input.clone(), "ATTR");
+    input
+}
+
+#[proc_macro_attribute]
+pub fn print_target_and_args_consume(args: TokenStream, input: TokenStream) -> TokenStream {
+    print_helper(args, "ATTR_ARGS");
+    print_helper(input.clone(), "ATTR");
+    TokenStream::new()
+}
+
 #[proc_macro_derive(Print, attributes(print_helper))]
 pub fn print_derive(input: TokenStream) -> TokenStream {
     print_helper(input, "DERIVE");

--- a/src/test/ui/proc-macro/expand-to-derive.rs
+++ b/src/test/ui/proc-macro/expand-to-derive.rs
@@ -1,0 +1,34 @@
+// check-pass
+// compile-flags: -Z span-debug --error-format human
+// aux-build:test-macros.rs
+
+#![feature(rustc_attrs)]
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+macro_rules! expand_to_derive {
+    ($item:item) => {
+        #[derive(Print)]
+        struct Foo {
+            #[cfg(FALSE)] removed: bool,
+            field: [bool; {
+                $item
+                0
+            }]
+        }
+    };
+}
+
+expand_to_derive! {
+    #[cfg_attr(not(FALSE), rustc_dummy)]
+    struct Inner {
+        #[cfg(FALSE)] removed_inner_field: bool,
+        other_inner_field: u8,
+    }
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/expand-to-derive.stdout
+++ b/src/test/ui/proc-macro/expand-to-derive.stdout
@@ -1,0 +1,109 @@
+PRINT-DERIVE INPUT (DISPLAY): struct Foo
+{
+    field :
+    [bool ; { #[rustc_dummy] struct Inner { other_inner_field : u8, } 0 }],
+}
+PRINT-DERIVE INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "struct",
+        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "field",
+                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "bool",
+                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                    },
+                    Punct {
+                        ch: ';',
+                        spacing: Alone,
+                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "rustc_dummy",
+                                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                                    },
+                                ],
+                                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                            },
+                            Ident {
+                                ident: "struct",
+                                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                            },
+                            Ident {
+                                ident: "Inner",
+                                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "other_inner_field",
+                                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                                    },
+                                    Punct {
+                                        ch: ':',
+                                        spacing: Alone,
+                                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                                    },
+                                    Ident {
+                                        ident: "u8",
+                                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                                    },
+                                ],
+                                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                            },
+                            Literal {
+                                kind: Integer,
+                                symbol: "0",
+                                suffix: None,
+                                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                            },
+                        ],
+                        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+                    },
+                ],
+                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+            },
+        ],
+        span: $DIR/expand-to-derive.rs:16:9: 22:10 (#4),
+    },
+]

--- a/src/test/ui/proc-macro/inner-attrs.rs
+++ b/src/test/ui/proc-macro/inner-attrs.rs
@@ -1,0 +1,47 @@
+// check-pass
+// compile-flags: -Z span-debug --error-format human
+// aux-build:test-macros.rs
+
+#![feature(custom_inner_attributes)]
+#![feature(proc_macro_hygiene)]
+#![feature(stmt_expr_attributes)]
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+#[print_target_and_args(first)]
+#[print_target_and_args(second)]
+fn foo() {
+    #![print_target_and_args(third)]
+    #![print_target_and_args(fourth)]
+}
+
+struct MyStruct {
+    field: bool
+}
+
+fn bar() {
+    (#![print_target_and_args(fifth)] 1, 2);
+
+    [#![print_target_and_args(sixth)] 1 , 2];
+    [#![print_target_and_args(seventh)] true ; 5];
+
+
+    match 0 {
+        #![print_target_and_args(eighth)]
+        _ => {}
+    }
+
+    MyStruct { #![print_target_and_args(ninth)] field: true };
+}
+
+extern {
+    fn weird_extern() {
+        #![print_target_and_args_consume(tenth)]
+    }
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/inner-attrs.stdout
+++ b/src/test/ui/proc-macro/inner-attrs.stdout
@@ -1,0 +1,520 @@
+PRINT-ATTR_ARGS INPUT (DISPLAY): first
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "first",
+        span: $DIR/inner-attrs.rs:15:25: 15:30 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(second)] fn foo()
+{ # ! [print_target_and_args(third)] # ! [print_target_and_args(fourth)] }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "print_target_and_args",
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "second",
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                ],
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Ident {
+        ident: "fn",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Ident {
+        ident: "foo",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "third",
+                                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                            },
+                        ],
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                ],
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "fourth",
+                                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                            },
+                        ],
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                ],
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): second
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "second",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): fn foo()
+{ # ! [print_target_and_args(third)] # ! [print_target_and_args(fourth)] }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fn",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Ident {
+        ident: "foo",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "third",
+                                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                            },
+                        ],
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                ],
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "fourth",
+                                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                            },
+                        ],
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                ],
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): third
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "third",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): fn foo() { # ! [print_target_and_args(fourth)] }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fn",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Ident {
+        ident: "foo",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "fourth",
+                                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                            },
+                        ],
+                        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+                    },
+                ],
+                span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): fourth
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fourth",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): fn foo() { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fn",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Ident {
+        ident: "foo",
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/inner-attrs.rs:17:1: 20:2 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): fifth
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fifth",
+        span: $DIR/inner-attrs.rs:27:31: 27:36 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): (1, 2) ;
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Literal {
+                kind: Integer,
+                symbol: "1",
+                suffix: None,
+                span: $DIR/inner-attrs.rs:27:5: 27:45 (#0),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:27:5: 27:45 (#0),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "2",
+                suffix: None,
+                span: $DIR/inner-attrs.rs:27:5: 27:45 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:27:5: 27:45 (#0),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: $DIR/inner-attrs.rs:27:5: 27:45 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): sixth
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "sixth",
+        span: $DIR/inner-attrs.rs:29:31: 29:36 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): [1, 2] ;
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Literal {
+                kind: Integer,
+                symbol: "1",
+                suffix: None,
+                span: $DIR/inner-attrs.rs:29:5: 29:46 (#0),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:29:5: 29:46 (#0),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "2",
+                suffix: None,
+                span: $DIR/inner-attrs.rs:29:5: 29:46 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:29:5: 29:46 (#0),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: $DIR/inner-attrs.rs:29:5: 29:46 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): seventh
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "seventh",
+        span: $DIR/inner-attrs.rs:30:31: 30:38 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): [true ; 5] ;
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "true",
+                span: $DIR/inner-attrs.rs:30:5: 30:51 (#0),
+            },
+            Punct {
+                ch: ';',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:30:5: 30:51 (#0),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "5",
+                suffix: None,
+                span: $DIR/inner-attrs.rs:30:5: 30:51 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:30:5: 30:51 (#0),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: $DIR/inner-attrs.rs:30:5: 30:51 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): eighth
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "eighth",
+        span: $DIR/inner-attrs.rs:34:34: 34:40 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): match 0 { _ => { } }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "match",
+        span: $DIR/inner-attrs.rs:33:5: 36:6 (#0),
+    },
+    Literal {
+        kind: Integer,
+        symbol: "0",
+        suffix: None,
+        span: $DIR/inner-attrs.rs:33:5: 36:6 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "_",
+                span: $DIR/inner-attrs.rs:33:5: 36:6 (#0),
+            },
+            Punct {
+                ch: '=',
+                spacing: Joint,
+                span: $DIR/inner-attrs.rs:33:5: 36:6 (#0),
+            },
+            Punct {
+                ch: '>',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:33:5: 36:6 (#0),
+            },
+            Group {
+                delimiter: Brace,
+                stream: TokenStream [],
+                span: $DIR/inner-attrs.rs:33:5: 36:6 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:33:5: 36:6 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): ninth
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "ninth",
+        span: $DIR/inner-attrs.rs:38:41: 38:46 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): MyStruct { field : true, } ;
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "MyStruct",
+        span: $DIR/inner-attrs.rs:38:5: 38:63 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "field",
+                span: $DIR/inner-attrs.rs:38:5: 38:63 (#0),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:38:5: 38:63 (#0),
+            },
+            Ident {
+                ident: "true",
+                span: $DIR/inner-attrs.rs:38:5: 38:63 (#0),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/inner-attrs.rs:38:5: 38:63 (#0),
+            },
+        ],
+        span: $DIR/inner-attrs.rs:38:5: 38:63 (#0),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: $DIR/inner-attrs.rs:38:5: 38:63 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): tenth
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "tenth",
+        span: $DIR/inner-attrs.rs:43:42: 43:47 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): fn weird_extern() { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "fn",
+        span: $DIR/inner-attrs.rs:42:5: 44:6 (#0),
+    },
+    Ident {
+        ident: "weird_extern",
+        span: $DIR/inner-attrs.rs:42:5: 44:6 (#0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [],
+        span: $DIR/inner-attrs.rs:42:5: 44:6 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/inner-attrs.rs:42:5: 44:6 (#0),
+    },
+]

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.rs
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.rs
@@ -10,6 +10,9 @@
 // (a pretty-printed struct may cause a line to start with '{' )
 // FIXME: We currently lose spans here (see issue #43081)
 
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
 #[macro_use]
 extern crate test_macros;
 
@@ -57,6 +60,10 @@ struct Foo<#[cfg(FALSE)] A, B> {
             #[cfg(FALSE)] bool,
             u8
         );
+
+        fn plain_removed_fn() {
+            #![cfg_attr(not(FALSE), cfg(FALSE))]
+        }
 
         0
     }],

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.stderr
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.stderr
@@ -1,5 +1,5 @@
 warning: derive helper attribute is used before it is introduced
-  --> $DIR/issue-75930-derive-cfg.rs:16:3
+  --> $DIR/issue-75930-derive-cfg.rs:19:3
    |
 LL | #[print_helper(a)]
    |   ^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -19,84 +19,35 @@ struct Foo < #[cfg(FALSE)] A, B >
                  #[cfg(FALSE)] String, u8)
          } struct
          TupleStruct(#[cfg(FALSE)] String, #[cfg(not(FALSE))] i32,
-                     #[cfg(FALSE)] bool, u8) ; 0
+                     #[cfg(FALSE)] bool, u8) ; fn plain_removed_fn()
+         { # ! [cfg_attr(not(FALSE), cfg(FALSE))] } 0
      }], #[print_helper(d)] fourth : B
 }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:16:1: 16:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:19:1: 19:2 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "print_helper",
-                span: $DIR/issue-75930-derive-cfg.rs:16:3: 16:15 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:19:3: 19:15 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "a",
-                        span: $DIR/issue-75930-derive-cfg.rs:16:16: 16:17 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:19:16: 19:17 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:16:15: 16:18 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:19:15: 19:18 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:16:2: 16:19 (#0),
-    },
-    Punct {
-        ch: '#',
-        spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:18:1: 18:2 (#0),
-    },
-    Group {
-        delimiter: Bracket,
-        stream: TokenStream [
-            Ident {
-                ident: "allow",
-                span: $DIR/issue-75930-derive-cfg.rs:18:24: 18:29 (#0),
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [
-                    Ident {
-                        ident: "dead_code",
-                        span: $DIR/issue-75930-derive-cfg.rs:18:30: 18:39 (#0),
-                    },
-                ],
-                span: $DIR/issue-75930-derive-cfg.rs:18:29: 18:40 (#0),
-            },
-        ],
-        span: $DIR/issue-75930-derive-cfg.rs:18:1: 18:2 (#0),
-    },
-    Punct {
-        ch: '#',
-        spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:20:1: 20:2 (#0),
-    },
-    Group {
-        delimiter: Bracket,
-        stream: TokenStream [
-            Ident {
-                ident: "derive",
-                span: $DIR/issue-75930-derive-cfg.rs:20:3: 20:9 (#0),
-            },
-            Group {
-                delimiter: Parenthesis,
-                stream: TokenStream [
-                    Ident {
-                        ident: "Print",
-                        span: $DIR/issue-75930-derive-cfg.rs:20:10: 20:15 (#0),
-                    },
-                ],
-                span: $DIR/issue-75930-derive-cfg.rs:20:9: 20:16 (#0),
-            },
-        ],
-        span: $DIR/issue-75930-derive-cfg.rs:20:2: 20:17 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:19:2: 19:19 (#0),
     },
     Punct {
         ch: '#',
@@ -107,77 +58,127 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
+                ident: "allow",
+                span: $DIR/issue-75930-derive-cfg.rs:21:24: 21:29 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "dead_code",
+                        span: $DIR/issue-75930-derive-cfg.rs:21:30: 21:39 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:21:29: 21:40 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:21:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:23:1: 23:2 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "derive",
+                span: $DIR/issue-75930-derive-cfg.rs:23:3: 23:9 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "Print",
+                        span: $DIR/issue-75930-derive-cfg.rs:23:10: 23:15 (#0),
+                    },
+                ],
+                span: $DIR/issue-75930-derive-cfg.rs:23:9: 23:16 (#0),
+            },
+        ],
+        span: $DIR/issue-75930-derive-cfg.rs:23:2: 23:17 (#0),
+    },
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/issue-75930-derive-cfg.rs:24:1: 24:2 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
                 ident: "print_helper",
-                span: $DIR/issue-75930-derive-cfg.rs:21:3: 21:15 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:24:3: 24:15 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "b",
-                        span: $DIR/issue-75930-derive-cfg.rs:21:16: 21:17 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:24:16: 24:17 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:21:15: 21:18 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:24:15: 24:18 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:21:2: 21:19 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:24:2: 24:19 (#0),
     },
     Ident {
         ident: "struct",
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 22:7 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 25:7 (#0),
     },
     Ident {
         ident: "Foo",
-        span: $DIR/issue-75930-derive-cfg.rs:22:8: 22:11 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:8: 25:11 (#0),
     },
     Punct {
         ch: '<',
         spacing: Joint,
-        span: $DIR/issue-75930-derive-cfg.rs:22:11: 22:12 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:11: 25:12 (#0),
     },
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:12: 22:13 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:12: 25:13 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "cfg",
-                span: $DIR/issue-75930-derive-cfg.rs:22:14: 22:17 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:14: 25:17 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "FALSE",
-                        span: $DIR/issue-75930-derive-cfg.rs:22:18: 22:23 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:18: 25:23 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:22:17: 22:24 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:17: 25:24 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:22:13: 22:25 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:13: 25:25 (#0),
     },
     Ident {
         ident: "A",
-        span: $DIR/issue-75930-derive-cfg.rs:22:26: 22:27 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:26: 25:27 (#0),
     },
     Punct {
         ch: ',',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:27: 22:28 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:27: 25:28 (#0),
     },
     Ident {
         ident: "B",
-        span: $DIR/issue-75930-derive-cfg.rs:22:29: 22:30 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:29: 25:30 (#0),
     },
     Punct {
         ch: '>',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:30: 22:31 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:30: 25:31 (#0),
     },
     Group {
         delimiter: Brace,
@@ -185,128 +186,128 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:23:5: 23:6 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:26:5: 26:6 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "cfg",
-                        span: $DIR/issue-75930-derive-cfg.rs:23:7: 23:10 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:26:7: 26:10 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 ident: "FALSE",
-                                span: $DIR/issue-75930-derive-cfg.rs:23:11: 23:16 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:26:11: 26:16 (#0),
                             },
                         ],
-                        span: $DIR/issue-75930-derive-cfg.rs:23:10: 23:17 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:26:10: 26:17 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:23:6: 23:18 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:26:6: 26:18 (#0),
             },
             Ident {
                 ident: "first",
-                span: $DIR/issue-75930-derive-cfg.rs:23:19: 23:24 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:26:19: 26:24 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:23:24: 23:25 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:26:24: 26:25 (#0),
             },
             Ident {
                 ident: "String",
-                span: $DIR/issue-75930-derive-cfg.rs:23:26: 23:32 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:26:26: 26:32 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:23:32: 23:33 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:26:32: 26:33 (#0),
             },
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:24:5: 24:6 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:27:5: 27:6 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "cfg_attr",
-                        span: $DIR/issue-75930-derive-cfg.rs:24:7: 24:15 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:27:7: 27:15 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 ident: "FALSE",
-                                span: $DIR/issue-75930-derive-cfg.rs:24:16: 24:21 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:27:16: 27:21 (#0),
                             },
                             Punct {
                                 ch: ',',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:24:21: 24:22 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:27:21: 27:22 (#0),
                             },
                             Ident {
                                 ident: "deny",
-                                span: $DIR/issue-75930-derive-cfg.rs:24:23: 24:27 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:27:23: 27:27 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "warnings",
-                                        span: $DIR/issue-75930-derive-cfg.rs:24:28: 24:36 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:27:28: 27:36 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:24:27: 24:37 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:27:27: 27:37 (#0),
                             },
                         ],
-                        span: $DIR/issue-75930-derive-cfg.rs:24:15: 24:38 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:27:15: 27:38 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:24:6: 24:39 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:27:6: 27:39 (#0),
             },
             Ident {
                 ident: "second",
-                span: $DIR/issue-75930-derive-cfg.rs:24:40: 24:46 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:27:40: 27:46 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:24:46: 24:47 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:27:46: 27:47 (#0),
             },
             Ident {
                 ident: "bool",
-                span: $DIR/issue-75930-derive-cfg.rs:24:48: 24:52 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:27:48: 27:52 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:24:52: 24:53 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:27:52: 27:53 (#0),
             },
             Ident {
                 ident: "third",
-                span: $DIR/issue-75930-derive-cfg.rs:25:5: 25:10 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:28:5: 28:10 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:25:10: 25:11 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:28:10: 28:11 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "u8",
-                        span: $DIR/issue-75930-derive-cfg.rs:25:13: 25:15 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:28:13: 28:15 (#0),
                     },
                     Punct {
                         ch: ';',
                         spacing: Alone,
-                        span: $DIR/issue-75930-derive-cfg.rs:25:15: 25:16 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:28:15: 28:16 (#0),
                     },
                     Group {
                         delimiter: Brace,
@@ -314,159 +315,58 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                             Punct {
                                 ch: '#',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:26:9: 26:10 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:29:9: 29:10 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:26:11: 26:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:11: 29:14 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "FALSE",
-                                                span: $DIR/issue-75930-derive-cfg.rs:26:15: 26:20 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:29:15: 29:20 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:26:14: 26:21 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:29:14: 29:21 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:26:10: 26:22 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:29:10: 29:22 (#0),
                             },
                             Ident {
                                 ident: "struct",
-                                span: $DIR/issue-75930-derive-cfg.rs:26:23: 26:29 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:29:23: 29:29 (#0),
                             },
                             Ident {
                                 ident: "Bar",
-                                span: $DIR/issue-75930-derive-cfg.rs:26:30: 26:33 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:29:30: 29:33 (#0),
                             },
                             Punct {
                                 ch: ';',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:26:33: 26:34 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:29:33: 29:34 (#0),
                             },
                             Punct {
                                 ch: '#',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:27:9: 27:10 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:30:9: 30:10 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:27:11: 27:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:30:11: 30:14 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "not",
-                                                span: $DIR/issue-75930-derive-cfg.rs:27:15: 27:18 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:27:19: 27:24 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:27:18: 27:25 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:27:14: 27:26 (#0),
-                                    },
-                                ],
-                                span: $DIR/issue-75930-derive-cfg.rs:27:10: 27:27 (#0),
-                            },
-                            Ident {
-                                ident: "struct",
-                                span: $DIR/issue-75930-derive-cfg.rs:27:28: 27:34 (#0),
-                            },
-                            Ident {
-                                ident: "Inner",
-                                span: $DIR/issue-75930-derive-cfg.rs:27:35: 27:40 (#0),
-                            },
-                            Punct {
-                                ch: ';',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:27:40: 27:41 (#0),
-                            },
-                            Punct {
-                                ch: '#',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:28:9: 28:10 (#0),
-                            },
-                            Group {
-                                delimiter: Bracket,
-                                stream: TokenStream [
-                                    Ident {
-                                        ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:28:11: 28:14 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "FALSE",
-                                                span: $DIR/issue-75930-derive-cfg.rs:28:15: 28:20 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:28:14: 28:21 (#0),
-                                    },
-                                ],
-                                span: $DIR/issue-75930-derive-cfg.rs:28:10: 28:22 (#0),
-                            },
-                            Ident {
-                                ident: "let",
-                                span: $DIR/issue-75930-derive-cfg.rs:28:23: 28:26 (#0),
-                            },
-                            Ident {
-                                ident: "a",
-                                span: $DIR/issue-75930-derive-cfg.rs:28:27: 28:28 (#0),
-                            },
-                            Punct {
-                                ch: '=',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:28:29: 28:30 (#0),
-                            },
-                            Literal {
-                                kind: Integer,
-                                symbol: "25",
-                                suffix: None,
-                                span: $DIR/issue-75930-derive-cfg.rs:28:31: 28:33 (#0),
-                            },
-                            Punct {
-                                ch: ';',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:28:33: 28:34 (#0),
-                            },
-                            Ident {
-                                ident: "match",
-                                span: $DIR/issue-75930-derive-cfg.rs:29:9: 29:14 (#0),
-                            },
-                            Ident {
-                                ident: "true",
-                                span: $DIR/issue-75930-derive-cfg.rs:29:15: 29:19 (#0),
-                            },
-                            Group {
-                                delimiter: Brace,
-                                stream: TokenStream [
-                                    Punct {
-                                        ch: '#',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:13: 30:14 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Bracket,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "cfg",
                                                 span: $DIR/issue-75930-derive-cfg.rs:30:15: 30:18 (#0),
                                             },
                                             Group {
@@ -482,281 +382,273 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                         ],
                                         span: $DIR/issue-75930-derive-cfg.rs:30:14: 30:26 (#0),
                                     },
-                                    Ident {
-                                        ident: "true",
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:27: 30:31 (#0),
-                                    },
-                                    Punct {
-                                        ch: '=',
-                                        spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:32: 30:34 (#0),
-                                    },
-                                    Punct {
-                                        ch: '>',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:32: 30:34 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Brace,
-                                        stream: TokenStream [],
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:35: 30:37 (#0),
-                                    },
-                                    Punct {
-                                        ch: ',',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:37: 30:38 (#0),
-                                    },
-                                    Punct {
-                                        ch: '#',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:31:13: 31:14 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Bracket,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "cfg_attr",
-                                                span: $DIR/issue-75930-derive-cfg.rs:31:15: 31:23 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "not",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:31:24: 31:27 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:31:28: 31:33 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:31:27: 31:34 (#0),
-                                                    },
-                                                    Punct {
-                                                        ch: ',',
-                                                        spacing: Alone,
-                                                        span: $DIR/issue-75930-derive-cfg.rs:31:34: 31:35 (#0),
-                                                    },
-                                                    Ident {
-                                                        ident: "allow",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:31:36: 31:41 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "warnings",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:31:42: 31:50 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:31:41: 31:51 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:31:23: 31:52 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:31:14: 31:53 (#0),
-                                    },
-                                    Ident {
-                                        ident: "false",
-                                        span: $DIR/issue-75930-derive-cfg.rs:31:54: 31:59 (#0),
-                                    },
-                                    Punct {
-                                        ch: '=',
-                                        spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:31:60: 31:62 (#0),
-                                    },
-                                    Punct {
-                                        ch: '>',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:31:60: 31:62 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Brace,
-                                        stream: TokenStream [],
-                                        span: $DIR/issue-75930-derive-cfg.rs:31:63: 31:65 (#0),
-                                    },
-                                    Punct {
-                                        ch: ',',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:31:65: 31:66 (#0),
-                                    },
-                                    Ident {
-                                        ident: "_",
-                                        span: $DIR/issue-75930-derive-cfg.rs:32:13: 32:14 (#0),
-                                    },
-                                    Punct {
-                                        ch: '=',
-                                        spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:32:15: 32:17 (#0),
-                                    },
-                                    Punct {
-                                        ch: '>',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:32:15: 32:17 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Brace,
-                                        stream: TokenStream [],
-                                        span: $DIR/issue-75930-derive-cfg.rs:32:18: 32:20 (#0),
-                                    },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:29:20: 33:10 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:30:10: 30:27 (#0),
+                            },
+                            Ident {
+                                ident: "struct",
+                                span: $DIR/issue-75930-derive-cfg.rs:30:28: 30:34 (#0),
+                            },
+                            Ident {
+                                ident: "Inner",
+                                span: $DIR/issue-75930-derive-cfg.rs:30:35: 30:40 (#0),
                             },
                             Punct {
                                 ch: ';',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:33:10: 33:11 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:30:40: 30:41 (#0),
                             },
                             Punct {
                                 ch: '#',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:35:9: 35:10 (#0),
-                            },
-                            Group {
-                                delimiter: Bracket,
-                                stream: TokenStream [
-                                    Ident {
-                                        ident: "print_helper",
-                                        span: $DIR/issue-75930-derive-cfg.rs:35:11: 35:23 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "should_be_removed",
-                                                span: $DIR/issue-75930-derive-cfg.rs:35:24: 35:41 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:35:23: 35:42 (#0),
-                                    },
-                                ],
-                                span: $DIR/issue-75930-derive-cfg.rs:35:10: 35:43 (#0),
-                            },
-                            Ident {
-                                ident: "fn",
-                                span: $DIR/issue-75930-derive-cfg.rs:36:9: 36:11 (#0),
-                            },
-                            Ident {
-                                ident: "removed_fn",
-                                span: $DIR/issue-75930-derive-cfg.rs:36:12: 36:22 (#0),
-                            },
-                            Group {
-                                delimiter: Parenthesis,
-                                stream: TokenStream [],
-                                span: $DIR/issue-75930-derive-cfg.rs:36:22: 36:24 (#0),
-                            },
-                            Group {
-                                delimiter: Brace,
-                                stream: TokenStream [
-                                    Punct {
-                                        ch: '#',
-                                        spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:37:13: 37:14 (#0),
-                                    },
-                                    Punct {
-                                        ch: '!',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:37:14: 37:15 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Bracket,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:37:16: 37:19 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:37:20: 37:25 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:37:19: 37:26 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:37:15: 37:27 (#0),
-                                    },
-                                ],
-                                span: $DIR/issue-75930-derive-cfg.rs:36:25: 38:10 (#0),
-                            },
-                            Punct {
-                                ch: '#',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:40:9: 40:10 (#0),
-                            },
-                            Group {
-                                delimiter: Bracket,
-                                stream: TokenStream [
-                                    Ident {
-                                        ident: "print_helper",
-                                        span: $DIR/issue-75930-derive-cfg.rs:40:11: 40:23 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "c",
-                                                span: $DIR/issue-75930-derive-cfg.rs:40:24: 40:25 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:40:23: 40:26 (#0),
-                                    },
-                                ],
-                                span: $DIR/issue-75930-derive-cfg.rs:40:10: 40:27 (#0),
-                            },
-                            Punct {
-                                ch: '#',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:40:28: 40:29 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:31:9: 31:10 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:40:30: 40:33 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:31:11: 31:14 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
-                                                ident: "not",
-                                                span: $DIR/issue-75930-derive-cfg.rs:40:34: 40:37 (#0),
+                                                ident: "FALSE",
+                                                span: $DIR/issue-75930-derive-cfg.rs:31:15: 31:20 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:31:14: 31:21 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:31:10: 31:22 (#0),
+                            },
+                            Ident {
+                                ident: "let",
+                                span: $DIR/issue-75930-derive-cfg.rs:31:23: 31:26 (#0),
+                            },
+                            Ident {
+                                ident: "a",
+                                span: $DIR/issue-75930-derive-cfg.rs:31:27: 31:28 (#0),
+                            },
+                            Punct {
+                                ch: '=',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:31:29: 31:30 (#0),
+                            },
+                            Literal {
+                                kind: Integer,
+                                symbol: "25",
+                                suffix: None,
+                                span: $DIR/issue-75930-derive-cfg.rs:31:31: 31:33 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:31:33: 31:34 (#0),
+                            },
+                            Ident {
+                                ident: "match",
+                                span: $DIR/issue-75930-derive-cfg.rs:32:9: 32:14 (#0),
+                            },
+                            Ident {
+                                ident: "true",
+                                span: $DIR/issue-75930-derive-cfg.rs:32:15: 32:19 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:33:13: 33:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:33:15: 33:18 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:40:38: 40:43 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:33:19: 33:24 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:40:37: 40:44 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:33:18: 33:25 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:40:33: 40:45 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:33:14: 33:26 (#0),
+                                    },
+                                    Ident {
+                                        ident: "true",
+                                        span: $DIR/issue-75930-derive-cfg.rs:33:27: 33:31 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:33:32: 33:34 (#0),
+                                    },
+                                    Punct {
+                                        ch: '>',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:33:32: 33:34 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [],
+                                        span: $DIR/issue-75930-derive-cfg.rs:33:35: 33:37 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:33:37: 33:38 (#0),
+                                    },
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:13: 34:14 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg_attr",
+                                                span: $DIR/issue-75930-derive-cfg.rs:34:15: 34:23 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "not",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:34:24: 34:27 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:34:28: 34:33 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:34:27: 34:34 (#0),
+                                                    },
+                                                    Punct {
+                                                        ch: ',',
+                                                        spacing: Alone,
+                                                        span: $DIR/issue-75930-derive-cfg.rs:34:34: 34:35 (#0),
+                                                    },
+                                                    Ident {
+                                                        ident: "allow",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:34:36: 34:41 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "warnings",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:34:42: 34:50 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:34:41: 34:51 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:34:23: 34:52 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:14: 34:53 (#0),
+                                    },
+                                    Ident {
+                                        ident: "false",
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:54: 34:59 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:60: 34:62 (#0),
+                                    },
+                                    Punct {
+                                        ch: '>',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:60: 34:62 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [],
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:63: 34:65 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:34:65: 34:66 (#0),
+                                    },
+                                    Ident {
+                                        ident: "_",
+                                        span: $DIR/issue-75930-derive-cfg.rs:35:13: 35:14 (#0),
+                                    },
+                                    Punct {
+                                        ch: '=',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:35:15: 35:17 (#0),
+                                    },
+                                    Punct {
+                                        ch: '>',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:35:15: 35:17 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Brace,
+                                        stream: TokenStream [],
+                                        span: $DIR/issue-75930-derive-cfg.rs:35:18: 35:20 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:40:29: 40:46 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:32:20: 36:10 (#0),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:36:10: 36:11 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:38:9: 38:10 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "print_helper",
+                                        span: $DIR/issue-75930-derive-cfg.rs:38:11: 38:23 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "should_be_removed",
+                                                span: $DIR/issue-75930-derive-cfg.rs:38:24: 38:41 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:38:23: 38:42 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:38:10: 38:43 (#0),
                             },
                             Ident {
                                 ident: "fn",
-                                span: $DIR/issue-75930-derive-cfg.rs:40:47: 40:49 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:39:9: 39:11 (#0),
                             },
                             Ident {
-                                ident: "kept_fn",
-                                span: $DIR/issue-75930-derive-cfg.rs:40:50: 40:57 (#0),
+                                ident: "removed_fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:39:12: 39:22 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [],
-                                span: $DIR/issue-75930-derive-cfg.rs:40:57: 40:59 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:39:22: 39:24 (#0),
                             },
                             Group {
                                 delimiter: Brace,
@@ -764,198 +656,195 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                     Punct {
                                         ch: '#',
                                         spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:41:13: 41:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:40:13: 40:14 (#0),
                                     },
                                     Punct {
                                         ch: '!',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:41:14: 41:15 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:40:14: 40:15 (#0),
                                     },
                                     Group {
                                         delimiter: Bracket,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:41:16: 41:19 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:40:16: 40:19 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:40:20: 40:25 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:40:19: 40:26 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:40:15: 40:27 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:39:25: 41:10 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:43:9: 43:10 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "print_helper",
+                                        span: $DIR/issue-75930-derive-cfg.rs:43:11: 43:23 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "c",
+                                                span: $DIR/issue-75930-derive-cfg.rs:43:24: 43:25 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:43:23: 43:26 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:43:10: 43:27 (#0),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/issue-75930-derive-cfg.rs:43:28: 43:29 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "cfg",
+                                        span: $DIR/issue-75930-derive-cfg.rs:43:30: 43:33 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "not",
+                                                span: $DIR/issue-75930-derive-cfg.rs:43:34: 43:37 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "FALSE",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:43:38: 43:43 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:43:37: 43:44 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:43:33: 43:45 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:43:29: 43:46 (#0),
+                            },
+                            Ident {
+                                ident: "fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:43:47: 43:49 (#0),
+                            },
+                            Ident {
+                                ident: "kept_fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:43:50: 43:57 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                                span: $DIR/issue-75930-derive-cfg.rs:43:57: 43:59 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:44:13: 44:14 (#0),
+                                    },
+                                    Punct {
+                                        ch: '!',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:44:14: 44:15 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg",
+                                                span: $DIR/issue-75930-derive-cfg.rs:44:16: 44:19 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "not",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:41:20: 41:23 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:44:20: 44:23 (#0),
                                                     },
                                                     Group {
                                                         delimiter: Parenthesis,
                                                         stream: TokenStream [
                                                             Ident {
                                                                 ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:41:24: 41:29 (#0),
+                                                                span: $DIR/issue-75930-derive-cfg.rs:44:24: 44:29 (#0),
                                                             },
                                                         ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:41:23: 41:30 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:44:23: 44:30 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:41:19: 41:31 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:44:19: 44:31 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:41:15: 41:32 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:44:15: 44:32 (#0),
                                     },
                                     Ident {
                                         ident: "let",
-                                        span: $DIR/issue-75930-derive-cfg.rs:42:13: 42:16 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:45:13: 45:16 (#0),
                                     },
                                     Ident {
                                         ident: "my_val",
-                                        span: $DIR/issue-75930-derive-cfg.rs:42:17: 42:23 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:45:17: 45:23 (#0),
                                     },
                                     Punct {
                                         ch: '=',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:42:24: 42:25 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:45:24: 45:25 (#0),
                                     },
                                     Ident {
                                         ident: "true",
-                                        span: $DIR/issue-75930-derive-cfg.rs:42:26: 42:30 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:45:26: 45:30 (#0),
                                     },
                                     Punct {
                                         ch: ';',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:42:30: 42:31 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:45:30: 45:31 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:40:60: 43:10 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:43:60: 46:10 (#0),
                             },
                             Ident {
                                 ident: "enum",
-                                span: $DIR/issue-75930-derive-cfg.rs:45:9: 45:13 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:48:9: 48:13 (#0),
                             },
                             Ident {
                                 ident: "TupleEnum",
-                                span: $DIR/issue-75930-derive-cfg.rs:45:14: 45:23 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:48:14: 48:23 (#0),
                             },
                             Group {
                                 delimiter: Brace,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "Foo",
-                                        span: $DIR/issue-75930-derive-cfg.rs:46:13: 46:16 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:49:13: 49:16 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
-                                            Punct {
-                                                ch: '#',
-                                                spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:47:17: 47:18 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Bracket,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "cfg",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:47:19: 47:22 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:47:23: 47:28 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:47:22: 47:29 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:47:18: 47:30 (#0),
-                                            },
-                                            Ident {
-                                                ident: "u8",
-                                                span: $DIR/issue-75930-derive-cfg.rs:47:31: 47:33 (#0),
-                                            },
-                                            Punct {
-                                                ch: ',',
-                                                spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:47:33: 47:34 (#0),
-                                            },
-                                            Punct {
-                                                ch: '#',
-                                                spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:48:17: 48:18 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Bracket,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "cfg",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:48:19: 48:22 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:48:23: 48:28 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:48:22: 48:29 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:48:18: 48:30 (#0),
-                                            },
-                                            Ident {
-                                                ident: "bool",
-                                                span: $DIR/issue-75930-derive-cfg.rs:48:31: 48:35 (#0),
-                                            },
-                                            Punct {
-                                                ch: ',',
-                                                spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:48:35: 48:36 (#0),
-                                            },
-                                            Punct {
-                                                ch: '#',
-                                                spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:49:17: 49:18 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Bracket,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "cfg",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:49:19: 49:22 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "not",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:49:23: 49:26 (#0),
-                                                            },
-                                                            Group {
-                                                                delimiter: Parenthesis,
-                                                                stream: TokenStream [
-                                                                    Ident {
-                                                                        ident: "FALSE",
-                                                                        span: $DIR/issue-75930-derive-cfg.rs:49:27: 49:32 (#0),
-                                                                    },
-                                                                ],
-                                                                span: $DIR/issue-75930-derive-cfg.rs:49:26: 49:33 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:49:22: 49:34 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:49:18: 49:35 (#0),
-                                            },
-                                            Ident {
-                                                ident: "i32",
-                                                span: $DIR/issue-75930-derive-cfg.rs:49:36: 49:39 (#0),
-                                            },
-                                            Punct {
-                                                ch: ',',
-                                                spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:49:39: 49:40 (#0),
-                                            },
                                             Punct {
                                                 ch: '#',
                                                 spacing: Alone,
@@ -982,31 +871,143 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                                 span: $DIR/issue-75930-derive-cfg.rs:50:18: 50:30 (#0),
                                             },
                                             Ident {
-                                                ident: "String",
-                                                span: $DIR/issue-75930-derive-cfg.rs:50:31: 50:37 (#0),
+                                                ident: "u8",
+                                                span: $DIR/issue-75930-derive-cfg.rs:50:31: 50:33 (#0),
                                             },
                                             Punct {
                                                 ch: ',',
                                                 spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:50:37: 50:38 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:50:33: 50:34 (#0),
+                                            },
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:51:17: 51:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:51:19: 51:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:51:23: 51:28 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:51:22: 51:29 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:51:18: 51:30 (#0),
+                                            },
+                                            Ident {
+                                                ident: "bool",
+                                                span: $DIR/issue-75930-derive-cfg.rs:51:31: 51:35 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:51:35: 51:36 (#0),
+                                            },
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:52:17: 52:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:52:19: 52:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "not",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:52:23: 52:26 (#0),
+                                                            },
+                                                            Group {
+                                                                delimiter: Parenthesis,
+                                                                stream: TokenStream [
+                                                                    Ident {
+                                                                        ident: "FALSE",
+                                                                        span: $DIR/issue-75930-derive-cfg.rs:52:27: 52:32 (#0),
+                                                                    },
+                                                                ],
+                                                                span: $DIR/issue-75930-derive-cfg.rs:52:26: 52:33 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:52:22: 52:34 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:52:18: 52:35 (#0),
+                                            },
+                                            Ident {
+                                                ident: "i32",
+                                                span: $DIR/issue-75930-derive-cfg.rs:52:36: 52:39 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:52:39: 52:40 (#0),
+                                            },
+                                            Punct {
+                                                ch: '#',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:53:17: 53:18 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Bracket,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:53:19: 53:22 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:53:23: 53:28 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:53:22: 53:29 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:53:18: 53:30 (#0),
+                                            },
+                                            Ident {
+                                                ident: "String",
+                                                span: $DIR/issue-75930-derive-cfg.rs:53:31: 53:37 (#0),
+                                            },
+                                            Punct {
+                                                ch: ',',
+                                                spacing: Alone,
+                                                span: $DIR/issue-75930-derive-cfg.rs:53:37: 53:38 (#0),
                                             },
                                             Ident {
                                                 ident: "u8",
-                                                span: $DIR/issue-75930-derive-cfg.rs:50:39: 50:41 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:53:39: 53:41 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:46:16: 51:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:49:16: 54:14 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:45:24: 52:10 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:48:24: 55:10 (#0),
                             },
                             Ident {
                                 ident: "struct",
-                                span: $DIR/issue-75930-derive-cfg.rs:54:9: 54:15 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:57:9: 57:15 (#0),
                             },
                             Ident {
                                 ident: "TupleStruct",
-                                span: $DIR/issue-75930-derive-cfg.rs:54:16: 54:27 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:57:16: 57:27 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
@@ -1014,184 +1015,262 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                     Punct {
                                         ch: '#',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:55:13: 55:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:58:13: 58:14 (#0),
                                     },
                                     Group {
                                         delimiter: Bracket,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:55:15: 55:18 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:58:15: 58:18 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:55:19: 55:24 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:58:19: 58:24 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:55:18: 55:25 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:58:18: 58:25 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:55:14: 55:26 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:58:14: 58:26 (#0),
                                     },
                                     Ident {
                                         ident: "String",
-                                        span: $DIR/issue-75930-derive-cfg.rs:55:27: 55:33 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:58:27: 58:33 (#0),
                                     },
                                     Punct {
                                         ch: ',',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:55:33: 55:34 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:58:33: 58:34 (#0),
                                     },
                                     Punct {
                                         ch: '#',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:56:13: 56:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:59:13: 59:14 (#0),
                                     },
                                     Group {
                                         delimiter: Bracket,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:56:15: 56:18 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:59:15: 59:18 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "not",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:56:19: 56:22 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:59:19: 59:22 (#0),
                                                     },
                                                     Group {
                                                         delimiter: Parenthesis,
                                                         stream: TokenStream [
                                                             Ident {
                                                                 ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:56:23: 56:28 (#0),
+                                                                span: $DIR/issue-75930-derive-cfg.rs:59:23: 59:28 (#0),
                                                             },
                                                         ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:56:22: 56:29 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:59:22: 59:29 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:56:18: 56:30 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:59:18: 59:30 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:56:14: 56:31 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:59:14: 59:31 (#0),
                                     },
                                     Ident {
                                         ident: "i32",
-                                        span: $DIR/issue-75930-derive-cfg.rs:56:32: 56:35 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:59:32: 59:35 (#0),
                                     },
                                     Punct {
                                         ch: ',',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:56:35: 56:36 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:59:35: 59:36 (#0),
                                     },
                                     Punct {
                                         ch: '#',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:57:13: 57:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:60:13: 60:14 (#0),
                                     },
                                     Group {
                                         delimiter: Bracket,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:57:15: 57:18 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:60:15: 60:18 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:57:19: 57:24 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:60:19: 60:24 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:57:18: 57:25 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:60:18: 60:25 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:57:14: 57:26 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:60:14: 60:26 (#0),
                                     },
                                     Ident {
                                         ident: "bool",
-                                        span: $DIR/issue-75930-derive-cfg.rs:57:27: 57:31 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:60:27: 60:31 (#0),
                                     },
                                     Punct {
                                         ch: ',',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:57:31: 57:32 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:60:31: 60:32 (#0),
                                     },
                                     Ident {
                                         ident: "u8",
-                                        span: $DIR/issue-75930-derive-cfg.rs:58:13: 58:15 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:61:13: 61:15 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:54:27: 59:10 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:57:27: 62:10 (#0),
                             },
                             Punct {
                                 ch: ';',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:59:10: 59:11 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:62:10: 62:11 (#0),
+                            },
+                            Ident {
+                                ident: "fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:64:9: 64:11 (#0),
+                            },
+                            Ident {
+                                ident: "plain_removed_fn",
+                                span: $DIR/issue-75930-derive-cfg.rs:64:12: 64:28 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [],
+                                span: $DIR/issue-75930-derive-cfg.rs:64:28: 64:30 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Joint,
+                                        span: $DIR/issue-75930-derive-cfg.rs:65:13: 65:14 (#0),
+                                    },
+                                    Punct {
+                                        ch: '!',
+                                        spacing: Alone,
+                                        span: $DIR/issue-75930-derive-cfg.rs:65:14: 65:15 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "cfg_attr",
+                                                span: $DIR/issue-75930-derive-cfg.rs:65:16: 65:24 (#0),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "not",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:65:25: 65:28 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:65:29: 65:34 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:65:28: 65:35 (#0),
+                                                    },
+                                                    Punct {
+                                                        ch: ',',
+                                                        spacing: Alone,
+                                                        span: $DIR/issue-75930-derive-cfg.rs:65:35: 65:36 (#0),
+                                                    },
+                                                    Ident {
+                                                        ident: "cfg",
+                                                        span: $DIR/issue-75930-derive-cfg.rs:65:37: 65:40 (#0),
+                                                    },
+                                                    Group {
+                                                        delimiter: Parenthesis,
+                                                        stream: TokenStream [
+                                                            Ident {
+                                                                ident: "FALSE",
+                                                                span: $DIR/issue-75930-derive-cfg.rs:65:41: 65:46 (#0),
+                                                            },
+                                                        ],
+                                                        span: $DIR/issue-75930-derive-cfg.rs:65:40: 65:47 (#0),
+                                                    },
+                                                ],
+                                                span: $DIR/issue-75930-derive-cfg.rs:65:24: 65:48 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/issue-75930-derive-cfg.rs:65:15: 65:49 (#0),
+                                    },
+                                ],
+                                span: $DIR/issue-75930-derive-cfg.rs:64:31: 66:10 (#0),
                             },
                             Literal {
                                 kind: Integer,
                                 symbol: "0",
                                 suffix: None,
-                                span: $DIR/issue-75930-derive-cfg.rs:61:9: 61:10 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:68:9: 68:10 (#0),
                             },
                         ],
-                        span: $DIR/issue-75930-derive-cfg.rs:25:17: 62:6 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:28:17: 69:6 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:25:12: 62:7 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:28:12: 69:7 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:62:7: 62:8 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:69:7: 69:8 (#0),
             },
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:63:5: 63:6 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:70:5: 70:6 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "print_helper",
-                        span: $DIR/issue-75930-derive-cfg.rs:63:7: 63:19 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:70:7: 70:19 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 ident: "d",
-                                span: $DIR/issue-75930-derive-cfg.rs:63:20: 63:21 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:70:20: 70:21 (#0),
                             },
                         ],
-                        span: $DIR/issue-75930-derive-cfg.rs:63:19: 63:22 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:70:19: 70:22 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:63:6: 63:23 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:70:6: 70:23 (#0),
             },
             Ident {
                 ident: "fourth",
-                span: $DIR/issue-75930-derive-cfg.rs:64:5: 64:11 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:71:5: 71:11 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:64:11: 64:12 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:71:11: 71:12 (#0),
             },
             Ident {
                 ident: "B",
-                span: $DIR/issue-75930-derive-cfg.rs:64:13: 64:14 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:71:13: 71:14 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:22:32: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:32: 72:2 (#0),
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[print_helper(b)] struct Foo < B >
@@ -1211,141 +1290,141 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "print_helper",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "a",
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "allow",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "dead_code",
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "print_helper",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "b",
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Ident {
         ident: "struct",
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Ident {
         ident: "Foo",
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Punct {
         ch: '<',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Ident {
         ident: "B",
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Punct {
         ch: '>',
         spacing: Alone,
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
     Group {
         delimiter: Brace,
         stream: TokenStream [
             Ident {
                 ident: "second",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Ident {
                 ident: "bool",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Ident {
                 ident: "third",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "u8",
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                     Punct {
                         ch: ';',
                         spacing: Alone,
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                     Group {
                         delimiter: Brace,
@@ -1353,58 +1432,58 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                             Punct {
                                 ch: '#',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "not",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "struct",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "Inner",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Punct {
                                 ch: ';',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "match",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "true",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Brace,
@@ -1412,146 +1491,146 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                     Punct {
                                         ch: '#',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Bracket,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "allow",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "warnings",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Ident {
                                         ident: "false",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: '=',
                                         spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: '>',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Brace,
                                         stream: TokenStream [],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Ident {
                                         ident: "_",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: '=',
                                         spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: '>',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Brace,
                                         stream: TokenStream [],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Punct {
                                 ch: ';',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Punct {
                                 ch: '#',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "print_helper",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "c",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Punct {
                                 ch: '#',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "not",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "fn",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "kept_fn",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Brace,
@@ -1559,82 +1638,82 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                     Punct {
                                         ch: '#',
                                         spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: '!',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Bracket,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "not",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                     Group {
                                                         delimiter: Parenthesis,
                                                         stream: TokenStream [
                                                             Ident {
                                                                 ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                             },
                                                         ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Ident {
                                         ident: "let",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Ident {
                                         ident: "my_val",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: '=',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Ident {
                                         ident: "true",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: ';',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "enum",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "TupleEnum",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Brace,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "Foo",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
@@ -1642,69 +1721,69 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                             Punct {
                                                 ch: '#',
                                                 spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Group {
                                                 delimiter: Bracket,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "cfg",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                     Group {
                                                         delimiter: Parenthesis,
                                                         stream: TokenStream [
                                                             Ident {
                                                                 ident: "not",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                             },
                                                             Group {
                                                                 delimiter: Parenthesis,
                                                                 stream: TokenStream [
                                                                     Ident {
                                                                         ident: "FALSE",
-                                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                                     },
                                                                 ],
-                                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                             },
                                                         ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Ident {
                                                 ident: "i32",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Punct {
                                                 ch: ',',
                                                 spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Ident {
                                                 ident: "u8",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: ',',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "struct",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Ident {
                                 ident: "TupleStruct",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Group {
                                 delimiter: Parenthesis,
@@ -1712,120 +1791,120 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                     Punct {
                                         ch: '#',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Group {
                                         delimiter: Bracket,
                                         stream: TokenStream [
                                             Ident {
                                                 ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                             Group {
                                                 delimiter: Parenthesis,
                                                 stream: TokenStream [
                                                     Ident {
                                                         ident: "not",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                     Group {
                                                         delimiter: Parenthesis,
                                                         stream: TokenStream [
                                                             Ident {
                                                                 ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                             },
                                                         ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Ident {
                                         ident: "i32",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Punct {
                                         ch: ',',
                                         spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                     Ident {
                                         ident: "u8",
-                                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                                     },
                                 ],
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Punct {
                                 ch: ';',
                                 spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                             Literal {
                                 kind: Integer,
                                 symbol: "0",
                                 suffix: None,
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                         ],
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Punct {
                 ch: '#',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "print_helper",
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                     Group {
                         delimiter: Parenthesis,
                         stream: TokenStream [
                             Ident {
                                 ident: "d",
-                                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                             },
                         ],
-                        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
                     },
                 ],
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Ident {
                 ident: "fourth",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Punct {
                 ch: ':',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Ident {
                 ident: "B",
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
             Punct {
                 ch: ',',
                 spacing: Alone,
-                span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+                span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:22:1: 65:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:25:1: 72:2 (#0),
     },
 ]

--- a/src/test/ui/proc-macro/macro-rules-derive-cfg.rs
+++ b/src/test/ui/proc-macro/macro-rules-derive-cfg.rs
@@ -1,0 +1,31 @@
+// check-pass
+// compile-flags: -Z span-debug --error-format human
+// aux-build:test-macros.rs
+
+#![feature(rustc_attrs)]
+#![feature(stmt_expr_attributes)]
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+macro_rules! produce_it {
+    ($expr:expr) => {
+        #[derive(Print)]
+        struct Foo {
+            val: [bool; {
+                let a = #[cfg_attr(not(FALSE), rustc_dummy(first))] $expr;
+                0
+            }]
+        }
+    }
+}
+
+produce_it!(#[cfg_attr(not(FALSE), rustc_dummy(second))] {
+    #![cfg_attr(not(FALSE), allow(unused))]
+    30
+});
+
+fn main() {}

--- a/src/test/ui/proc-macro/macro-rules-derive-cfg.stdout
+++ b/src/test/ui/proc-macro/macro-rules-derive-cfg.stdout
@@ -1,0 +1,176 @@
+PRINT-DERIVE INPUT (DISPLAY): struct Foo
+{
+    val :
+    [bool ;
+     {
+         let a = #[rustc_dummy(first)] #[rustc_dummy(second)]
+         { # ! [allow(unused)] 30 } ; 0
+     }],
+}
+PRINT-DERIVE INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "struct",
+        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "val",
+                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "bool",
+                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                    },
+                    Punct {
+                        ch: ';',
+                        spacing: Alone,
+                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "let",
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Ident {
+                                ident: "a",
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Punct {
+                                ch: '=',
+                                spacing: Alone,
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "rustc_dummy",
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "first",
+                                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                            },
+                                        ],
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                ],
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Punct {
+                                ch: '#',
+                                spacing: Alone,
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "rustc_dummy",
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "second",
+                                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                            },
+                                        ],
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                ],
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Punct {
+                                        ch: '#',
+                                        spacing: Joint,
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                    Punct {
+                                        ch: '!',
+                                        spacing: Alone,
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                    Group {
+                                        delimiter: Bracket,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "allow",
+                                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                            },
+                                            Group {
+                                                delimiter: Parenthesis,
+                                                stream: TokenStream [
+                                                    Ident {
+                                                        ident: "unused",
+                                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                                    },
+                                                ],
+                                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                            },
+                                        ],
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                    Literal {
+                                        kind: Integer,
+                                        symbol: "30",
+                                        suffix: None,
+                                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                                    },
+                                ],
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Punct {
+                                ch: ';',
+                                spacing: Alone,
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                            Literal {
+                                kind: Integer,
+                                symbol: "0",
+                                suffix: None,
+                                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                            },
+                        ],
+                        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+                    },
+                ],
+                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+            },
+        ],
+        span: $DIR/macro-rules-derive-cfg.rs:17:9: 22:10 (#4),
+    },
+]

--- a/src/test/ui/proc-macro/nested-derive-cfg.rs
+++ b/src/test/ui/proc-macro/nested-derive-cfg.rs
@@ -1,0 +1,23 @@
+// compile-flags: -Z span-debug --error-format human
+// aux-build:test-macros.rs
+// check-pass
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+#[derive(Print)]
+struct Foo {
+    #[cfg(FALSE)] removed: bool,
+    my_array: [bool; {
+        struct Inner {
+            #[cfg(FALSE)] removed_inner_field: u8,
+            non_removed_inner_field: usize
+        }
+        0
+    }]
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/nested-derive-cfg.stdout
+++ b/src/test/ui/proc-macro/nested-derive-cfg.stdout
@@ -1,0 +1,94 @@
+PRINT-DERIVE INPUT (DISPLAY): struct Foo
+{
+    my_array :
+    [bool ; { struct Inner { non_removed_inner_field : usize, } 0 }],
+}
+PRINT-DERIVE INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "struct",
+        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "my_array",
+                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+            },
+            Punct {
+                ch: ':',
+                spacing: Alone,
+                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "bool",
+                        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                    },
+                    Punct {
+                        ch: ';',
+                        spacing: Alone,
+                        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                    },
+                    Group {
+                        delimiter: Brace,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "struct",
+                                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                            },
+                            Ident {
+                                ident: "Inner",
+                                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                            },
+                            Group {
+                                delimiter: Brace,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "non_removed_inner_field",
+                                        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                                    },
+                                    Punct {
+                                        ch: ':',
+                                        spacing: Alone,
+                                        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                                    },
+                                    Ident {
+                                        ident: "usize",
+                                        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                                    },
+                                    Punct {
+                                        ch: ',',
+                                        spacing: Alone,
+                                        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                                    },
+                                ],
+                                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                            },
+                            Literal {
+                                kind: Integer,
+                                symbol: "0",
+                                suffix: None,
+                                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                            },
+                        ],
+                        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+                    },
+                ],
+                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+            },
+            Punct {
+                ch: ',',
+                spacing: Alone,
+                span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/nested-derive-cfg.rs:12:1: 21:2 (#0),
+    },
+]

--- a/src/test/ui/proc-macro/weird-braces.rs
+++ b/src/test/ui/proc-macro/weird-braces.rs
@@ -1,0 +1,23 @@
+// aux-build:test-macros.rs
+// check-pass
+// compile-flags: -Z span-debug
+
+#![feature(custom_inner_attributes)]
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+extern crate test_macros;
+use test_macros::{print_target_and_args};
+
+struct Foo<const V: bool>;
+trait Bar<const V: bool> {}
+
+#[print_target_and_args(first_outer)]
+#[print_target_and_args(second_outer)]
+impl Bar<{1 > 0}> for Foo<{true}> {
+    #![print_target_and_args(first_inner)]
+    #![print_target_and_args(second_inner)]
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/weird-braces.stdout
+++ b/src/test/ui/proc-macro/weird-braces.stdout
@@ -1,0 +1,524 @@
+PRINT-ATTR_ARGS INPUT (DISPLAY): first_outer
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "first_outer",
+        span: $DIR/weird-braces.rs:16:25: 16:36 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): #[print_target_and_args(second_outer)] impl Bar < { 1 > 0 } > for Foo <
+{ true } >
+{
+    # ! [print_target_and_args(first_inner)] # !
+    [print_target_and_args(second_inner)]
+}
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "print_target_and_args",
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "second_outer",
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                ],
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "impl",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Bar",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Literal {
+                kind: Integer,
+                symbol: "1",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '>',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "0",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "for",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "true",
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "first_inner",
+                                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                            },
+                        ],
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                ],
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "second_inner",
+                                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                            },
+                        ],
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                ],
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): second_outer
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "second_outer",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
+{
+    # ! [print_target_and_args(first_inner)] # !
+    [print_target_and_args(second_inner)]
+}
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "impl",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Bar",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Literal {
+                kind: Integer,
+                symbol: "1",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '>',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "0",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "for",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "true",
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "first_inner",
+                                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                            },
+                        ],
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                ],
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "second_inner",
+                                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                            },
+                        ],
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                ],
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): first_inner
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "first_inner",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } >
+{ # ! [print_target_and_args(second_inner)] }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "impl",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Bar",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Literal {
+                kind: Integer,
+                symbol: "1",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '>',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "0",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "for",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "true",
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "print_target_and_args",
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                    Group {
+                        delimiter: Parenthesis,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "second_inner",
+                                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                            },
+                        ],
+                        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+                    },
+                ],
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+]
+PRINT-ATTR_ARGS INPUT (DISPLAY): second_inner
+PRINT-ATTR_ARGS INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "second_inner",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): impl Bar < { 1 > 0 } > for Foo < { true } > { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "impl",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Bar",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Literal {
+                kind: Integer,
+                symbol: "1",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Punct {
+                ch: '>',
+                spacing: Alone,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+            Literal {
+                kind: Integer,
+                symbol: "0",
+                suffix: None,
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "for",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Ident {
+        ident: "Foo",
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '<',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "true",
+                span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+            },
+        ],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Punct {
+        ch: '>',
+        spacing: Alone,
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/weird-braces.rs:18:1: 21:2 (#0),
+    },
+]

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -3,9 +3,14 @@ name = "tidy"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
+autobins = false
 
 [dependencies]
 cargo_metadata = "0.11"
 regex = "1"
 lazy_static = "1"
 walkdir = "2"
+
+[[bin]]
+name = "rust-tidy"
+path = "src/main.rs"


### PR DESCRIPTION
Successful merges:

 - #82309 (Propagate RUSTDOCFLAGS in the environment when documenting)
 - #82403 (rustbuild: print out env vars on verbose rustc invocations)
 - #82507 (Rename the `tidy` binary to `rust-tidy`)
 - #82531 (Add GUI tests)
 - #82532 (Add `build.print_step_rusage` to config.toml)
 - #82543 (fix env var name in CI)
 - #82622 (Propagate `--test-args` for `x.py test src/tools/cargo`)
 - #82628 (Try to clarify GlobalAlloc::realloc documentation comment.)
 - #82630 (Fix a typo in the `find_anon_type` doc)
 - #82643 (Add more proc-macro attribute tests)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=82309,82403,82507,82531,82532,82543,82622,82628,82630,82643)
<!-- homu-ignore:end -->