### PR TITLE
Highlight identifier span instead of whole pattern span in `unused` lint

### DIFF
--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -12,16 +12,16 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
 
 warning: unused variable: `mut_unused_var`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:33:13
    |
 LL |     let mut mut_unused_var = 1;
-   |         ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_mut_unused_var`
+   |             ^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_mut_unused_var`
 
 warning: unused variable: `var`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:10
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:14
    |
 LL |     let (mut var, unused_var) = (1, 2);
-   |          ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_var`
+   |              ^^^ help: if this is intentional, prefix it with an underscore: `_var`
 
 warning: unused variable: `unused_var`
   --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:19
@@ -36,10 +36,10 @@ LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:46:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:46:30
    |
 LL |                          mut hours_are_suns,
-   |                          ^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^^^^^^^^^^
    |
    = note: consider using `_hours_are_suns` instead
 

--- a/src/test/ui/lint/issue-81314-unused-span-ident.fixed
+++ b/src/test/ui/lint/issue-81314-unused-span-ident.fixed
@@ -1,0 +1,12 @@
+// run-rustfix
+// Regression test for #81314: Unused variable lint should
+// span only the identifier and not the rest of the pattern
+
+#![deny(unused)]
+
+fn main() {
+    let [_rest @ ..] = [1, 2, 3]; //~ ERROR unused variable
+}
+
+pub fn foo([_rest @ ..]: &[i32]) { //~ ERROR unused variable
+}

--- a/src/test/ui/lint/issue-81314-unused-span-ident.rs
+++ b/src/test/ui/lint/issue-81314-unused-span-ident.rs
@@ -1,0 +1,12 @@
+// run-rustfix
+// Regression test for #81314: Unused variable lint should
+// span only the identifier and not the rest of the pattern
+
+#![deny(unused)]
+
+fn main() {
+    let [rest @ ..] = [1, 2, 3]; //~ ERROR unused variable
+}
+
+pub fn foo([rest @ ..]: &[i32]) { //~ ERROR unused variable
+}

--- a/src/test/ui/lint/issue-81314-unused-span-ident.stderr
+++ b/src/test/ui/lint/issue-81314-unused-span-ident.stderr
@@ -1,0 +1,21 @@
+error: unused variable: `rest`
+  --> $DIR/issue-81314-unused-span-ident.rs:8:10
+   |
+LL |     let [rest @ ..] = [1, 2, 3];
+   |          ^^^^ help: if this is intentional, prefix it with an underscore: `_rest`
+   |
+note: the lint level is defined here
+  --> $DIR/issue-81314-unused-span-ident.rs:5:9
+   |
+LL | #![deny(unused)]
+   |         ^^^^^^
+   = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
+
+error: unused variable: `rest`
+  --> $DIR/issue-81314-unused-span-ident.rs:11:13
+   |
+LL | pub fn foo([rest @ ..]: &[i32]) {
+   |             ^^^^ help: if this is intentional, prefix it with an underscore: `_rest`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/liveness/liveness-consts.stderr
+++ b/src/test/ui/liveness/liveness-consts.stderr
@@ -1,8 +1,8 @@
 warning: variable `a` is assigned to, but never used
-  --> $DIR/liveness-consts.rs:7:9
+  --> $DIR/liveness-consts.rs:7:13
    |
 LL |     let mut a = 0;
-   |         ^^^^^
+   |             ^
    |
 note: the lint level is defined here
   --> $DIR/liveness-consts.rs:2:9

--- a/src/test/ui/liveness/liveness-dead.stderr
+++ b/src/test/ui/liveness/liveness-dead.stderr
@@ -1,8 +1,8 @@
 error: value assigned to `x` is never read
-  --> $DIR/liveness-dead.rs:9:9
+  --> $DIR/liveness-dead.rs:9:13
    |
 LL |     let mut x: isize = 3;
-   |         ^^^^^
+   |             ^
    |
 note: the lint level is defined here
   --> $DIR/liveness-dead.rs:2:9
@@ -20,10 +20,10 @@ LL |     x = 4;
    = help: maybe it is overwritten before being read?
 
 error: value passed to `x` is never read
-  --> $DIR/liveness-dead.rs:20:7
+  --> $DIR/liveness-dead.rs:20:11
    |
 LL | fn f4(mut x: i32) {
-   |       ^^^^^
+   |           ^
    |
    = help: maybe it is overwritten before being read?
 

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -44,10 +44,10 @@ LL |     let x = 3;
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`
 
 error: variable `x` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:30:9
+  --> $DIR/liveness-unused.rs:30:13
    |
 LL |     let mut x = 3;
-   |         ^^^^^
+   |             ^
    |
    = note: consider using `_x` instead
 
@@ -65,10 +65,10 @@ LL | #![deny(unused_assignments)]
    = help: maybe it is overwritten before being read?
 
 error: variable `z` is assigned to, but never used
-  --> $DIR/liveness-unused.rs:37:9
+  --> $DIR/liveness-unused.rs:37:13
    |
 LL |     let mut z = 3;
-   |         ^^^^^
+   |             ^
    |
    = note: consider using `_z` instead
 


### PR DESCRIPTION
Fixes #81314

This pretty much just changes the span highlighted in the lint from `pat_sp` to `ident.span`. There's however an exception, which is in patterns with shorthands like `Point { y, ref mut x }`, where a suggestion to change just `x` would be invalid; in those cases I had to keep the pattern span. Another option would be suggesting something like `Point { y, x: ref mut _x }`.

I also added a new test since there weren't any test that checked the `unused` lint with optional patterns.