### PR TITLE
Added fetch methods to signed and unsigned integers

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2001,9 +2001,11 @@ macro_rules! int_impl {
             Self::MAX
         }
 
-        /// Adds to the current value, returning the previous value.
+        /// [Adds](crate::ops::Add) to the current value, returning the previous value.
         ///
         /// This operation wraps around on overflow.
+        ///
+        /// **Note:** This operation is not atomic. If atomicity is desired, use the types in [`sync::atomic`](crate::sync::atomic).
         ///
         /// # Examples
         ///
@@ -2021,7 +2023,7 @@ macro_rules! int_impl {
             old
         }
 
-        /// Subtracts from the current value, returning the previous value.
+        /// [Subtracts](crate::ops::Sub) from the current value, returning the previous value.
         ///
         /// This operation wraps around on overflow.
         ///
@@ -2041,7 +2043,7 @@ macro_rules! int_impl {
             old
         }
 
-        /// Bitwise "and" with the current value, returning the previous value.
+        /// Bitwise ["and"](crate::ops::BitAnd) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -2077,7 +2079,7 @@ macro_rules! int_impl {
             old
         }
 
-        /// Bitwise "or" with the current value, returning the previous value.
+        /// Bitwise ["or"](crate::ops::BitOr) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -2095,7 +2097,7 @@ macro_rules! int_impl {
             old
         }
 
-        /// Bitwise "xor" with the current value, returning the previous value.
+        /// Bitwise ["xor"](crate::ops::BitXor) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -2134,7 +2136,7 @@ macro_rules! int_impl {
             old
         }
 
-        /// Maximum with the current value, returning the previous value.
+        /// [Maximum](crate::cmp::max) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -2152,7 +2154,7 @@ macro_rules! int_impl {
             old
         }
 
-        /// Minimum with the current value, returning the previous value.
+        /// [Minimum](crate::cmp::min) with the current value, returning the previous value.
         ///
         /// # Examples
         ///

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2000,5 +2000,176 @@ macro_rules! int_impl {
         pub const fn max_value() -> Self {
             Self::MAX
         }
+
+        /// Adds to the current value, returning the previous value.
+        ///
+        /// This operation wraps around on overflow.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0;")]
+        /// assert_eq!(foo.fetch_add(10), 0);
+        /// assert_eq!(foo, 10);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_add(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = self.wrapping_add(val);
+            old
+        }
+
+        /// Subtracts from the current value, returning the previous value.
+        ///
+        /// This operation wraps around on overflow.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 20;")]
+        /// assert_eq!(foo.fetch_sub(10), 20);
+        /// assert_eq!(foo, 10);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_sub(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = self.wrapping_sub(val);
+            old
+        }
+
+        /// Bitwise "and" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0b101101;")]
+        /// assert_eq!(foo.fetch_and(0b110011), 0b101101);
+        /// assert_eq!(foo, 0b100001);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_and(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = *self & val;
+            old
+        }
+
+        /// Bitwise "nand" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0x13;")]
+        /// assert_eq!(foo.fetch_nand(0x31), 0x13);
+        /// assert_eq!(foo, !(0x13 & 0x31));
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_nand(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = !(*self & val);
+            old
+        }
+
+        /// Bitwise "or" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0b101101;")]
+        /// assert_eq!(foo.fetch_or(0b110011), 0b101101);
+        /// assert_eq!(foo, 0b111111);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_or(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = *self | val;
+            old
+        }
+
+        /// Bitwise "xor" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0b101101;")]
+        /// assert_eq!(foo.fetch_xor(0b110011), 0b101101);
+        /// assert_eq!(foo, 0b011110);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_xor(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = *self ^ val;
+            old
+        }
+
+        /// Fetches the value, and applies a function to it, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 7;")]
+        /// assert_eq!(foo.fetch_update(|foo| foo + 1), 7);
+        /// assert_eq!(foo.fetch_update(|foo| foo + 1), 8);
+        /// assert_eq!(foo, 9);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_update<F>(&mut self, f: F) -> Self
+            where F: FnOnce($SelfT) -> $SelfT
+        {
+            let old = *self;
+            *self = f(*self);
+            old
+        }
+
+        /// Maximum with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 23;")]
+        /// assert_eq!(foo.fetch_max(42), 23);
+        /// assert_eq!(foo, 42);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_max(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = (*self).max(val);
+            old
+        }
+
+        /// Minimum with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 23;")]
+        /// assert_eq!(foo.fetch_min(42), 23);
+        /// assert_eq!(foo, 23);
+        /// assert_eq!(foo.fetch_min(22), 23);
+        /// assert_eq!(foo, 22);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_min(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = (*self).min(val);
+            old
+        }
     }
 }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1827,7 +1827,7 @@ macro_rules! uint_impl {
         #[rustc_deprecated(since = "TBD", reason = "replaced by the `MAX` associated constant on this type")]
         pub const fn max_value() -> Self { Self::MAX }
 
-        /// Adds to the current value, returning the previous value.
+        /// [Adds](crate::ops::Add) to the current value, returning the previous value.
         ///
         /// This operation wraps around on overflow.
         ///
@@ -1847,7 +1847,7 @@ macro_rules! uint_impl {
             old
         }
 
-        /// Subtracts from the current value, returning the previous value.
+        /// [Subtracts](crate::ops::Sub) from the current value, returning the previous value.
         ///
         /// This operation wraps around on overflow.
         ///
@@ -1867,7 +1867,7 @@ macro_rules! uint_impl {
             old
         }
 
-        /// Bitwise "and" with the current value, returning the previous value.
+        /// Bitwise ["and"](crate::ops::BitAnd) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -1903,7 +1903,7 @@ macro_rules! uint_impl {
             old
         }
 
-        /// Bitwise "or" with the current value, returning the previous value.
+        /// Bitwise ["or"](crate::ops::BitOr) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -1921,7 +1921,7 @@ macro_rules! uint_impl {
             old
         }
 
-        /// Bitwise "xor" with the current value, returning the previous value.
+        /// Bitwise ["xor"](crate::ops::BitXor) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -1960,7 +1960,7 @@ macro_rules! uint_impl {
             old
         }
 
-        /// Maximum with the current value, returning the previous value.
+        /// [Maximum](crate::cmp::max) with the current value, returning the previous value.
         ///
         /// # Examples
         ///
@@ -1978,7 +1978,7 @@ macro_rules! uint_impl {
             old
         }
 
-        /// Minimum with the current value, returning the previous value.
+        /// [Minimum](crate::cmp::min) with the current value, returning the previous value.
         ///
         /// # Examples
         ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1826,5 +1826,176 @@ macro_rules! uint_impl {
         #[rustc_const_stable(feature = "const_max_value", since = "1.32.0")]
         #[rustc_deprecated(since = "TBD", reason = "replaced by the `MAX` associated constant on this type")]
         pub const fn max_value() -> Self { Self::MAX }
+
+        /// Adds to the current value, returning the previous value.
+        ///
+        /// This operation wraps around on overflow.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0;")]
+        /// assert_eq!(foo.fetch_add(10), 0);
+        /// assert_eq!(foo, 10);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_add(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = self.wrapping_add(val);
+            old
+        }
+
+        /// Subtracts from the current value, returning the previous value.
+        ///
+        /// This operation wraps around on overflow.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 20;")]
+        /// assert_eq!(foo.fetch_sub(10), 20);
+        /// assert_eq!(foo, 10);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_sub(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = self.wrapping_sub(val);
+            old
+        }
+
+        /// Bitwise "and" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0b101101;")]
+        /// assert_eq!(foo.fetch_and(0b110011), 0b101101);
+        /// assert_eq!(foo, 0b100001);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_and(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = *self & val;
+            old
+        }
+
+        /// Bitwise "nand" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0x13;")]
+        /// assert_eq!(foo.fetch_nand(0x31), 0x13);
+        /// assert_eq!(foo, !(0x13 & 0x31));
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_nand(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = !(*self & val);
+            old
+        }
+
+        /// Bitwise "or" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0b101101;")]
+        /// assert_eq!(foo.fetch_or(0b110011), 0b101101);
+        /// assert_eq!(foo, 0b111111);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_or(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = *self | val;
+            old
+        }
+
+        /// Bitwise "xor" with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 0b101101;")]
+        /// assert_eq!(foo.fetch_xor(0b110011), 0b101101);
+        /// assert_eq!(foo, 0b011110);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_xor(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = *self ^ val;
+            old
+        }
+
+        /// Fetches the value, and applies a function to it, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 7;")]
+        /// assert_eq!(foo.fetch_update(|foo| foo + 1), 7);
+        /// assert_eq!(foo.fetch_update(|foo| foo + 1), 8);
+        /// assert_eq!(foo, 9);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_update<F>(&mut self, f: F) -> Self
+            where F: FnOnce($SelfT) -> $SelfT
+        {
+            let old = *self;
+            *self = f(*self);
+            old
+        }
+
+        /// Maximum with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 23;")]
+        /// assert_eq!(foo.fetch_max(42), 23);
+        /// assert_eq!(foo, 42);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_max(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = (*self).max(val);
+            old
+        }
+
+        /// Minimum with the current value, returning the previous value.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #![feature(int_fetch_ops)]
+        #[doc = concat!("let mut foo: ", stringify!($SelfT), " = 23;")]
+        /// assert_eq!(foo.fetch_min(42), 23);
+        /// assert_eq!(foo, 23);
+        /// assert_eq!(foo.fetch_min(22), 23);
+        /// assert_eq!(foo, 22);
+        /// ```
+        #[inline]
+        #[unstable(feature = "int_fetch_ops", issue = "none")]
+        pub fn fetch_min(&mut self, val: Self) -> Self {
+            let old = *self;
+            *self = (*self).min(val);
+            old
+        }
     }
 }


### PR DESCRIPTION
I've frequently found myself needing to fetch and increment the value of an integer inline for several reasons, such as generating new IDs. The API of atomic integers is really nice and I felt it very unfortunate and unexpected that non-atomic integers did not have a similar API. Sadly, the traditional imperative approach is unwieldy, not least because methods like `max` require dereferencing the receiver to actually do the correct thing.

This PR implements methods akin to those on the atomic integer types for regular integers.

Obviously, it's still very much a draft (there is no tracking issue and the docs link to the wrong tracking issue). I'm also rather ambivalent about `fetch_update` since it's an API that has a purpose that's rather unique to atomics. I included it for completeness, but the API differs from that of atomic integers.

I've not gone through the RFC process because this is a rather trivial library change.

Before:

```rust
let old = *my_integer;
*my_integer = (*my_integer).max(val);
make_use_of(old);
```

After:

```rust
make_use_of(my_integer.fetch_max(val));
```

I hope you'll agree that the latter is significantly cleaner and in line with the precedent set by the atomic integers.

As a point of interest, these operations mirror C's post-increment operators. `x.fetch_add(1)` is equivalent to `x++` in C.