### PR TITLE
Warn about unknown doc attributes

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -544,6 +544,41 @@ impl CheckAttrVisitor<'tcx> {
                         {
                             return false;
                         }
+                    } else if let Some(i_meta) = meta.meta_item() {
+                        if ![
+                            sym::cfg,
+                            sym::hidden,
+                            sym::html_favicon_url,
+                            sym::html_logo_url,
+                            sym::html_no_source,
+                            sym::html_playground_url,
+                            sym::html_root_url,
+                            sym::include,
+                            sym::inline,
+                            sym::issue_tracker_base_url,
+                            sym::masked,
+                            sym::no_default_passes, // deprecated
+                            sym::no_inline,
+                            sym::passes, // deprecated
+                            sym::primitive,
+                            sym::spotlight,
+                            sym::test,
+                        ]
+                        .iter()
+                        .any(|m| i_meta.has_name(*m))
+                        {
+                            self.tcx
+                                .sess
+                                .struct_span_err(
+                                    meta.span(),
+                                    &format!(
+                                        "unknown `doc` attribute `{}`",
+                                        i_meta.name_or_empty(),
+                                    ),
+                                )
+                                .emit();
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/test/rustdoc-ui/doc-attr.rs
+++ b/src/test/rustdoc-ui/doc-attr.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+#![doc(as_ptr)] //~ ERROR
+
+#[doc(as_ptr)] //~ ERROR
+pub fn foo() {}

--- a/src/test/rustdoc-ui/doc-attr.stderr
+++ b/src/test/rustdoc-ui/doc-attr.stderr
@@ -1,0 +1,14 @@
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr.rs:4:7
+   |
+LL | #[doc(as_ptr)]
+   |       ^^^^^^
+
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr.rs:2:8
+   |
+LL | #![doc(as_ptr)]
+   |        ^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/attributes/doc-attr.rs
+++ b/src/test/ui/attributes/doc-attr.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+#![doc(as_ptr)] //~ ERROR
+
+#[doc(as_ptr)] //~ ERROR
+pub fn foo() {}

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -1,0 +1,14 @@
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr.rs:4:7
+   |
+LL | #[doc(as_ptr)]
+   |       ^^^^^^
+
+error: unknown `doc` attribute `as_ptr`
+  --> $DIR/doc-attr.rs:2:8
+   |
+LL | #![doc(as_ptr)]
+   |        ^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #82652.

For the text error, I decided to go for "invalid" instead of "unknown". What do you think?

r? @jyn514 