### PR TITLE
Change twice used large const table to static

### DIFF
--- a/library/core/src/num/dec2flt/table.rs
+++ b/library/core/src/num/dec2flt/table.rs
@@ -5,7 +5,7 @@ pub const MIN_E: i16 = -305;
 pub const MAX_E: i16 = 305;
 
 #[rustfmt::skip]
-pub const POWERS: ([u64; 611], [i16; 611]) = (
+pub static POWERS: ([u64; 611], [i16; 611]) = (
     [
         0xe0b62e2929aba83c,
         0x8c71dcd9ba0b4926,

--- a/src/etc/dec2flt_table.py
+++ b/src/etc/dec2flt_table.py
@@ -113,7 +113,7 @@ def print_proper_powers():
     print()
     print("#[rustfmt::skip]")
     typ = "([u64; {0}], [i16; {0}])".format(len(powers))
-    print("pub const POWERS: ", typ, " = (", sep='')
+    print("pub static POWERS: ", typ, " = (", sep='')
     print("    [")
     for z in powers:
         print("        0x{:x},".format(z.sig))


### PR DESCRIPTION
This table is used twice in core::num::dec2flt::algorithm::power_of_ten. According to the semantics of const, a separate huge definition of the table is inlined at both places.

https://github.com/rust-lang/rust/blob/5233edcf1c7ee70ac25e4ec1115c3546f53d8a2d/library/core/src/num/dec2flt/algorithm.rs#L16-L22

Theoretically this gets cleaned up by optimization passes, but in practice I am experiencing a miscompile from LTO on this code. Making the table a static, which would only be defined a single time and not require attention from LTO, eliminates the miscompile and seems semantically more appropriate anyway. A separate bug report on the LTO bug is forthcoming.

Original addition of `const` is from #27307.