### PR TITLE
Document panicking cases for integer division and remainder

### DIFF
--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -456,9 +456,13 @@ pub trait Div<Rhs = Self> {
 }
 
 macro_rules! div_impl_integer {
-    ($($t:ty)*) => ($(
+    ($(($($t:ty)*) => $panic:expr),*) => ($($(
         /// This operation rounds towards zero, truncating any
         /// fractional part of the exact result.
+        ///
+        /// # Panics
+        ///
+        #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Div for $t {
             type Output = $t;
@@ -468,10 +472,13 @@ macro_rules! div_impl_integer {
         }
 
         forward_ref_binop! { impl Div, div for $t, $t }
-    )*)
+    )*)*)
 }
 
-div_impl_integer! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+div_impl_integer! {
+    (usize u8 u16 u32 u64 u128) => "This operation will panic if `other == 0`.",
+    (isize i8 i16 i32 i64 i128) => "This operation will panic if `other == 0` or the division results in overflow."
+}
 
 macro_rules! div_impl_float {
     ($($t:ty)*) => ($(

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -556,9 +556,13 @@ pub trait Rem<Rhs = Self> {
 }
 
 macro_rules! rem_impl_integer {
-    ($($t:ty)*) => ($(
+    ($(($($t:ty)*) => $panic:expr),*) => ($($(
         /// This operation satisfies `n % d == n - (n / d) * d`. The
         /// result has the same sign as the left operand.
+        ///
+        /// # Panics
+        ///
+        #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Rem for $t {
             type Output = $t;
@@ -568,10 +572,13 @@ macro_rules! rem_impl_integer {
         }
 
         forward_ref_binop! { impl Rem, rem for $t, $t }
-    )*)
+    )*)*)
 }
 
-rem_impl_integer! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+rem_impl_integer! {
+    (usize u8 u16 u32 u64 u128) => "This operation will panic if `other == 0`.",
+    (isize i8 i16 i32 i64 i128) => "This operation will panic if `other == 0` or if `self / other` results in overflow."
+}
 
 macro_rules! rem_impl_float {
     ($($t:ty)*) => ($(


### PR DESCRIPTION
This PR documents the cases when integer division and remainder operations panic. These operations panic in two cases: division by zero and overflow.

It's surprising that these operations always panic on overflow, unlike most other arithmetic operations, which panic on overflow only when `debug_assertions` is enabled. The panic on overflow for the remainder is also surprising because a return value of `0` would be reasonable in this case. ("Overflow" occurs only for `MIN % -1`.) Since the panics on overflow are somewhat surprising, they should be documented.

I guess it's worth asking: is panic on overflow (even when `debug_assertions` is disabled) the intended behavior? If not, what's the best way forward?