### PR TITLE
Move `std::sys::unix::platform` to `std::sys::unix::ext`

### DIFF
--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -70,8 +70,6 @@ cfg_if::cfg_if! {
         #[allow(missing_docs)]
         pub mod unix_ext {}
     } else {
-        // On other platforms like Windows document the bare bones of unix
-        use crate::os::linux as platform;
         #[path = "unix/ext/mod.rs"]
         pub mod unix_ext;
     }

--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -2,11 +2,11 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use super::platform::fs::MetadataExt as _;
 use crate::fs::{self, OpenOptions, Permissions};
 use crate::io;
 use crate::path::Path;
 use crate::sys;
-use crate::sys::platform::fs::MetadataExt as UnixMetadataExt;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
 // Used for `File::read` on intra-doc links
 #[allow(unused_imports)]

--- a/library/std/src/sys/unix/ext/mod.rs
+++ b/library/std/src/sys/unix/ext/mod.rs
@@ -29,6 +29,42 @@
 #![doc(cfg(unix))]
 #![allow(missing_docs)]
 
+cfg_if::cfg_if! {
+    if #[cfg(doc)] {
+        // Use linux as the default platform when documenting on other platforms like Windows
+        use crate::os::linux as platform;
+    } else {
+        #[cfg(target_os = "android")]
+        use crate::os::android as platform;
+        #[cfg(target_os = "dragonfly")]
+        use crate::os::dragonfly as platform;
+        #[cfg(target_os = "emscripten")]
+        use crate::os::emscripten as platform;
+        #[cfg(target_os = "freebsd")]
+        use crate::os::freebsd as platform;
+        #[cfg(target_os = "fuchsia")]
+        use crate::os::fuchsia as platform;
+        #[cfg(target_os = "haiku")]
+        use crate::os::haiku as platform;
+        #[cfg(target_os = "illumos")]
+        use crate::os::illumos as platform;
+        #[cfg(target_os = "ios")]
+        use crate::os::ios as platform;
+        #[cfg(any(target_os = "linux", target_os = "l4re"))]
+        use crate::os::linux as platform;
+        #[cfg(target_os = "macos")]
+        use crate::os::macos as platform;
+        #[cfg(target_os = "netbsd")]
+        use crate::os::netbsd as platform;
+        #[cfg(target_os = "openbsd")]
+        use crate::os::openbsd as platform;
+        #[cfg(target_os = "redox")]
+        use crate::os::redox as platform;
+        #[cfg(target_os = "solaris")]
+        use crate::os::solaris as platform;
+    }
+}
+
 pub mod ffi;
 pub mod fs;
 pub mod io;

--- a/library/std/src/sys/unix/ext/raw.rs
+++ b/library/std/src/sys/unix/ext/raw.rs
@@ -24,10 +24,10 @@ pub type pid_t = i32;
 
 #[doc(inline)]
 #[stable(feature = "pthread_t", since = "1.8.0")]
-pub use crate::sys::platform::raw::pthread_t;
+pub use super::platform::raw::pthread_t;
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use crate::sys::platform::raw::{blkcnt_t, time_t};
+pub use super::platform::raw::{blkcnt_t, time_t};
 #[doc(inline)]
 #[stable(feature = "raw_ext", since = "1.1.0")]
-pub use crate::sys::platform::raw::{blksize_t, dev_t, ino_t, mode_t, nlink_t, off_t};
+pub use super::platform::raw::{blksize_t, dev_t, ino_t, mode_t, nlink_t, off_t};

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -2,38 +2,6 @@
 
 use crate::io::ErrorKind;
 
-#[cfg(any(doc, target_os = "linux"))]
-pub use crate::os::linux as platform;
-
-#[cfg(all(not(doc), target_os = "android"))]
-pub use crate::os::android as platform;
-#[cfg(all(not(doc), target_os = "dragonfly"))]
-pub use crate::os::dragonfly as platform;
-#[cfg(all(not(doc), target_os = "emscripten"))]
-pub use crate::os::emscripten as platform;
-#[cfg(all(not(doc), target_os = "freebsd"))]
-pub use crate::os::freebsd as platform;
-#[cfg(all(not(doc), target_os = "fuchsia"))]
-pub use crate::os::fuchsia as platform;
-#[cfg(all(not(doc), target_os = "haiku"))]
-pub use crate::os::haiku as platform;
-#[cfg(all(not(doc), target_os = "illumos"))]
-pub use crate::os::illumos as platform;
-#[cfg(all(not(doc), target_os = "ios"))]
-pub use crate::os::ios as platform;
-#[cfg(all(not(doc), target_os = "l4re"))]
-pub use crate::os::linux as platform;
-#[cfg(all(not(doc), target_os = "macos"))]
-pub use crate::os::macos as platform;
-#[cfg(all(not(doc), target_os = "netbsd"))]
-pub use crate::os::netbsd as platform;
-#[cfg(all(not(doc), target_os = "openbsd"))]
-pub use crate::os::openbsd as platform;
-#[cfg(all(not(doc), target_os = "redox"))]
-pub use crate::os::redox as platform;
-#[cfg(all(not(doc), target_os = "solaris"))]
-pub use crate::os::solaris as platform;
-
 pub use self::rand::hashmap_random_keys;
 pub use libc::strlen;
 


### PR DESCRIPTION
This moves the operating system dependent alias `platform` (`std::os::{linux, android, ...}`) from `std::sys::unix` to `std::sys::unix::ext` (a.k.a. `std::os::unix`), removing the need for compatibility code in `unix_ext` when documenting on another platform.

This is also a step in making it possible to properly move `std::sys::unix::ext` to `std::os::unix`, as ideally `std::sys` should not depend on the rest of `std`.