### PR TITLE
meta: Notify Zulip for rustdoc nominated issues

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -102,6 +102,15 @@ message_on_add = """\
 """
 message_on_remove = "Issue #{number}'s prioritization request has been removed."
 
+[notify-zulip."T-rustdoc"]
+required_labels = ["I-nominated"]
+zulip_stream = 266220 # #rustdoc
+topic = "nominated: #{number}"
+message_on_add = """\
+@*T-rustdoc* issue #{number} "{title}" has been nominated for `T-rustdoc` discussion.
+"""
+message_on_remove = "Issue #{number}'s nomination request has been removed."
+
 [github-releases]
 format = "rustc"
 project-name = "Rust"


### PR DESCRIPTION
The rustdoc team does not currently use the `I-nominated` label, unlike
the libs and compiler teams (and maybe others). One reason for this is
that the other teams discuss their nominated issues in meetings, while
rustdoc is an async-only team.

However, it might be helpful to start using the `I-nominated` label for
rustdoc. The team currently uses a `cc @rust-lang/rustdoc` ping as the
equivalent, but it's easier to track issues when they use `I-nominated`.
Also we'd be more consistent with the other teams' procedures.

Since rustdoc doesn't have meetings, I propose we instead use the
triagebot notify Zulip functionality to create a topic in `#rustdoc` on
Zulip and ping the team. So it would look a bit like the procedure for
WG-prioritization when an issue acquires the `I-prioritize` label.

cc @rust-lang/rustdoc for approval of the change
r? @Mark-Simulacrum to make sure I configured triagebot correctly
