### PR TITLE
Fix stabilization version of move_ref_pattern

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -272,7 +272,7 @@ declare_features! (
     (accepted, doc_alias, "1.48.0", Some(50146), None),
     /// Allows patterns with concurrent by-move and by-ref bindings.
     /// For example, you can write `Foo(a, ref b)` where `a` is by-move and `b` is by-ref.
-    (accepted, move_ref_pattern, "1.48.0", Some(68354), None),
+    (accepted, move_ref_pattern, "1.49.0", Some(68354), None),
     /// The smallest useful subset of `const_generics`.
     (accepted, min_const_generics, "1.51.0", Some(74878), None),
 


### PR DESCRIPTION
Both the [changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1490-2020-12-31) and the milestone of the [stabilization PR](https://github.com/rust-lang/rust/pull/76119) say 1.49.0, but the source says 1.48.0. I think the former is correct.