### PR TITLE
Do not hard error on broken constants in type aliases

### DIFF
--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.full.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.full.stderr
@@ -1,14 +1,18 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/simple_fail.rs:9:48
+  --> $DIR/simple_fail.rs:12:10
    |
-LL | fn test<const N: usize>() -> Arr<N> where [u8; N - 1]: Sized {
-   |                                                ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+LL |     [u8; N - 1]: Sized,
+   |          ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
 
-error[E0080]: evaluation of constant value failed
+error: any use of this value will cause an error
   --> $DIR/simple_fail.rs:6:33
    |
 LL | type Arr<const N: usize> = [u8; N - 1];
    |                                 ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.min.stderr
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.min.stderr
@@ -8,10 +8,10 @@ LL | type Arr<const N: usize> = [u8; N - 1];
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/simple_fail.rs:9:48
+  --> $DIR/simple_fail.rs:12:10
    |
-LL | fn test<const N: usize>() -> Arr<N> where [u8; N - 1]: Sized {
-   |                                                ^ cannot perform const operation using `N`
+LL |     [u8; N - 1]: Sized,
+   |          ^ cannot perform const operation using `N`
    |
    = help: const parameters may only be used as standalone arguments, i.e. `N`
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions

--- a/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.rs
+++ b/src/test/ui/const-generics/const_evaluatable_checked/simple_fail.rs
@@ -3,12 +3,16 @@
 #![cfg_attr(full, feature(const_evaluatable_checked))]
 #![allow(incomplete_features)]
 
-type Arr<const N: usize> = [u8; N - 1]; //[full]~ ERROR evaluation of constant
+type Arr<const N: usize> = [u8; N - 1]; //[full]~ ERROR any use of this value will cause an error
 //[min]~^ ERROR generic parameters may not be used in const operations
+//[full]~^^ WARN this was previously accepted by the compiler but is being phased out
 
-fn test<const N: usize>() -> Arr<N> where [u8; N - 1]: Sized {
-//[min]~^ ERROR generic parameters may not be used in const operations
-//[full]~^^ ERROR evaluation of constant
+fn test<const N: usize>() -> Arr<N>
+where
+    [u8; N - 1]: Sized,
+    //[min]~^ ERROR generic parameters may not be used in const operations
+    //[full]~^^ ERROR evaluation of constant
+{
     todo!()
 }
 

--- a/src/test/ui/type-alias/erroneous_const.rs
+++ b/src/test/ui/type-alias/erroneous_const.rs
@@ -1,0 +1,19 @@
+type Foo = [u8; 0 - 1];
+//~^ ERROR any use of this value will cause an error
+//~| WARN will become a hard error
+
+fn foo() -> Foo {
+    todo!()
+}
+struct Q<const N: usize>;
+type Bar = Q<{ 0 - 1 }>;
+//~^ ERROR any use of this value will cause an error
+//~| WARN will become a hard error
+
+impl Default for Bar {
+    fn default() -> Self {
+        Q
+    }
+}
+
+fn main() {}

--- a/src/test/ui/type-alias/erroneous_const.stderr
+++ b/src/test/ui/type-alias/erroneous_const.stderr
@@ -1,0 +1,23 @@
+error: any use of this value will cause an error
+  --> $DIR/erroneous_const.rs:1:17
+   |
+LL | type Foo = [u8; 0 - 1];
+   |                 ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $DIR/erroneous_const.rs:9:16
+   |
+LL | type Bar = Q<{ 0 - 1 }>;
+   |              --^^^^^--
+   |                |
+   |                attempt to compute `0_usize - 1_usize`, which would overflow
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
In #69741 @estebank was adding WF checks to type aliases. This will evaluate all constants in a type alias, which wasn't happening before, so that would be a breaking change. Thus I proactively excluded these constants from the hard error list, and we instead emit the future incompat lint. More context: https://github.com/rust-lang/rust/pull/69741#issuecomment-783395624

r? @lcnr 

cc @rust-lang/wg-const-eval 