### PR TITLE
Change error about unknown attributes to a warning

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -567,16 +567,23 @@ impl CheckAttrVisitor<'tcx> {
                         .iter()
                         .any(|m| i_meta.has_name(*m))
                         {
-                            self.tcx
-                                .sess
-                                .struct_span_err(
-                                    meta.span(),
-                                    &format!(
+                            self.tcx.struct_span_lint_hir(
+                                UNUSED_ATTRIBUTES,
+                                hir_id,
+                                i_meta.span,
+                                |lint| {
+                                    lint.build(&format!(
                                         "unknown `doc` attribute `{}`",
-                                        i_meta.name_or_empty(),
-                                    ),
-                                )
-                                .emit();
+                                        i_meta.name_or_empty()
+                                    ))
+                                    .warn(
+                                        "this was previously accepted by the compiler but is \
+                                        being phased out; it will become a hard error in \
+                                        a future release!",
+                                    )
+                                    .emit();
+                                },
+                            );
                             return false;
                         }
                     }

--- a/src/test/rustdoc-ui/doc-attr.rs
+++ b/src/test/rustdoc-ui/doc-attr.rs
@@ -1,5 +1,11 @@
 #![crate_type = "lib"]
-#![doc(as_ptr)] //~ ERROR
+#![deny(unused_attributes)]
+//~^ NOTE lint level is defined here
+#![doc(as_ptr)]
+//~^ ERROR unknown `doc` attribute
+//~| WARNING will become a hard error in a future release
 
-#[doc(as_ptr)] //~ ERROR
+#[doc(as_ptr)]
+//~^ ERROR unknown `doc` attribute
+//~| WARNING will become a hard error in a future release
 pub fn foo() {}

--- a/src/test/rustdoc-ui/doc-attr.stderr
+++ b/src/test/rustdoc-ui/doc-attr.stderr
@@ -1,14 +1,23 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:4:7
+  --> $DIR/doc-attr.rs:8:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/doc-attr.rs:2:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:2:8
+  --> $DIR/doc-attr.rs:4:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/attributes/doc-attr.rs
+++ b/src/test/ui/attributes/doc-attr.rs
@@ -1,5 +1,11 @@
 #![crate_type = "lib"]
-#![doc(as_ptr)] //~ ERROR
+#![deny(unused_attributes)]
+//~^ NOTE lint level is defined here
+#![doc(as_ptr)]
+//~^ ERROR unknown `doc` attribute
+//~| WARNING will become a hard error in a future release
 
-#[doc(as_ptr)] //~ ERROR
+#[doc(as_ptr)]
+//~^ ERROR unknown `doc` attribute
+//~| WARNING will become a hard error in a future release
 pub fn foo() {}

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -1,14 +1,23 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:4:7
+  --> $DIR/doc-attr.rs:8:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/doc-attr.rs:2:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:2:8
+  --> $DIR/doc-attr.rs:4:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Hard errors should go through a future-compatibility phase first, especially since these attributes only have no effect and don't actively cause bugs.

Follow-up to https://github.com/rust-lang/rust/pull/82662. Fixes ecosystem breakage like https://github.com/rust-lang/rust-clippy/issues/6832.

r? @GuillaumeGomez 