### PR TITLE
Implement nonzero arithmetics for NonZero types.

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -641,6 +641,64 @@ nonzero_signed_operations! {
     NonZeroIsize(isize) -> NonZeroUsize(usize);
 }
 
+// A bunch of methods for both signed and unsigned nonzero types.
+macro_rules! nonzero_unsigned_signed_operations {
+    ( $( $Ty: ident($Int: ty); )+ ) => {
+        $(
+            impl $Ty {
+                /// Multiply two non-zero integers together.
+                /// Return [`None`] on overflow.
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
+                #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(Some(four), two.checked_mul(two));
+                /// assert_eq!(None, max.checked_mul(two));
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn checked_mul(self, other: $Ty) -> Option<$Ty> {
+                    if let Some(result) = self.get().checked_mul(other.get()) {
+                        // SAFETY: checked_mul returns None on overflow
+                        // and `other` is also non-null
+                        // so the result cannot be zero.
+                        Some(unsafe { $Ty::new_unchecked(result) })
+                    } else {
+                        None
+                    }
+                }
+            }
+        )+
+    }
+}
+
+nonzero_unsigned_signed_operations! {
+    NonZeroU8(u8);
+    NonZeroU16(u16);
+    NonZeroU32(u32);
+    NonZeroU64(u64);
+    NonZeroU128(u128);
+    NonZeroUsize(usize);
+    NonZeroI8(i8);
+    NonZeroI16(i16);
+    NonZeroI32(i32);
+    NonZeroI64(i64);
+    NonZeroI128(i128);
+    NonZeroIsize(isize);
+}
+
 macro_rules! nonzero_unsigned_is_power_of_two {
     ( $( $Ty: ident )+ ) => {
         $(

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -770,6 +770,35 @@ macro_rules! nonzero_unsigned_signed_operations {
                         None
                     }
                 }
+
+                /// Raise non-zero value to an integer power.
+                #[doc = concat!("Return [`", stringify!($Int), "::MAX`] on overflow.")]
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
+                #[doc = concat!("let twenty_seven = ", stringify!($Ty), "::new(27)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(twenty_seven, three.saturating_pow(3));
+                /// assert_eq!(max, max.saturating_pow(3));
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn saturating_pow(self, other: u32) -> $Ty {
+                    // SAFETY: saturating_pow returns u*::MAX on overflow
+                    // so the result cannot be zero.
+                    unsafe { $Ty::new_unchecked(self.get().saturating_pow(other)) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -322,6 +322,35 @@ macro_rules! nonzero_unsigned_operations {
                         None
                     }
                 }
+
+                /// Add an unsigned integer to a non-zero value.
+                #[doc = concat!("Return [`", stringify!($Int), "::MAX`] on overflow.")]
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(two, one.saturating_add(1));
+                /// assert_eq!(max, max.saturating_add(1));
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn saturating_add(self, other: $Int) -> $Ty {
+                    // SAFETY: $Int::saturating_add returns $Int::MAX on overflow
+                    // so the result cannot be zero.
+                    unsafe { $Ty::new_unchecked(self.get().saturating_add(other)) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -679,6 +679,36 @@ macro_rules! nonzero_unsigned_signed_operations {
                         None
                     }
                 }
+
+                /// Multiply two non-zero integers together.
+                #[doc = concat!("Return [`", stringify!($Int), "::MAX`] on overflow.")]
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
+                #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(four, two.saturating_mul(two));
+                /// assert_eq!(max, four.saturating_mul(max));
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn saturating_mul(self, other: $Ty) -> $Ty {
+                    // SAFETY: saturating_mul returns u*::MAX on overflow
+                    // and `other` is also non-null
+                    // so the result cannot be zero.
+                    unsafe { $Ty::new_unchecked(self.get().saturating_mul(other.get())) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -594,6 +594,39 @@ macro_rules! nonzero_signed_operations {
                     // SAFETY: absolute value of nonzero cannot yield zero values.
                     unsafe { $Ty::new_unchecked(self.get().wrapping_abs()) }
                 }
+
+                /// Computes the absolute value of self
+                /// without any wrapping or panicking.
+                ///
+                /// # Example
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                #[doc = concat!("# use std::num::", stringify!($Uty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let u_pos = ", stringify!($Uty), "::new(1)?;")]
+                #[doc = concat!("let i_pos = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let i_neg = ", stringify!($Ty), "::new(-1)?;")]
+                #[doc = concat!("let i_min = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MIN)?;")]
+                #[doc = concat!("let u_max = ", stringify!($Uty), "::new(",
+                                stringify!($Uint), "::MAX / 2 + 1)?;")]
+                ///
+                /// assert_eq!(u_pos, i_pos.unsigned_abs());
+                /// assert_eq!(u_pos, i_neg.unsigned_abs());
+                /// assert_eq!(u_max, i_min.unsigned_abs());
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn unsigned_abs(self) -> $Uty {
+                    // SAFETY: absolute value of nonzero cannot yield zero values.
+                    unsafe { $Uty::new_unchecked(self.get().unsigned_abs()) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -709,6 +709,34 @@ macro_rules! nonzero_unsigned_signed_operations {
                     // so the result cannot be zero.
                     unsafe { $Ty::new_unchecked(self.get().saturating_mul(other.get())) }
                 }
+
+                /// Multiply two non-zero integers together,
+                /// assuming overflow cannot occur.
+                /// This results in undefined behavior when
+                #[doc = concat!("`self * rhs > ", stringify!($Int), "::MAX`, ")]
+                #[doc = concat!("or `self * rhs < ", stringify!($Int), "::MIN`.")]
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
+                #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
+                ///
+                /// assert_eq!(four, unsafe { two.unchecked_mul(two) });
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub unsafe fn unchecked_mul(self, other: $Ty) -> $Ty {
+                    // SAFETY: The caller ensures there is no overflow.
+                    unsafe { $Ty::new_unchecked(self.get().unchecked_mul(other.get())) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -42,7 +42,8 @@ macro_rules! nonzero_integers {
             pub struct $Ty($Int);
 
             impl $Ty {
-                /// Creates a non-zero without checking the value.
+                /// Creates a non-zero without checking whether the value is non-zero.
+                /// This results in undefined behaviour if the value is zero.
                 ///
                 /// # Safety
                 ///
@@ -291,7 +292,9 @@ macro_rules! nonzero_unsigned_operations {
         $(
             impl $Ty {
                 /// Add an unsigned integer to a non-zero value.
-                /// Return [`None`] on overflow.
+                /// Check for overflow and return [`None`] on overflow
+                /// As a consequence, the result cannot wrap to zero.
+                ///
                 ///
                 /// # Examples
                 ///
@@ -354,7 +357,9 @@ macro_rules! nonzero_unsigned_operations {
 
                 /// Add an unsigned integer to a non-zero value,
                 /// assuming overflow cannot occur.
-                /// This results in undefined behaviour when
+                /// Overflow is unchecked, and it is undefined behaviour to overflow
+                /// *even if the result would wrap to a non-zero value*.
+                /// The behaviour is undefined as soon as
                 #[doc = concat!("`self + rhs > ", stringify!($Int), "::MAX`")]
                 #[doc = concat!(" or `self + rhs < ", stringify!($Int), "::MIN`.")]
                 ///
@@ -381,8 +386,9 @@ macro_rules! nonzero_unsigned_operations {
                 }
 
                 /// Returns the smallest power of two greater than or equal to n.
-                /// If the next power of two is greater than the type’s maximum value,
-                /// [`None`] is returned, otherwise the power of two is wrapped in [`Some`].
+                /// Check for overflow and return [`None`]
+                /// if the next power of two is greater than the type’s maximum value.
+                /// As a consequence, the result cannot wrap to zero.
                 ///
                 /// # Examples
                 ///
@@ -462,8 +468,9 @@ macro_rules! nonzero_signed_operations {
                 }
 
                 /// Checked absolute value.
-                /// Returns [`None`] if
+                /// Check for overflow and returns [`None`] if
                 #[doc = concat!("`self == ", stringify!($Int), "::MIN`.")]
+                /// The result cannot be zero.
                 ///
                 /// # Example
                 ///
@@ -647,7 +654,8 @@ macro_rules! nonzero_unsigned_signed_operations {
         $(
             impl $Ty {
                 /// Multiply two non-zero integers together.
-                /// Return [`None`] on overflow.
+                /// Check for overflow and return [`None`] on overflow.
+                /// As a consequence, the result cannot wrap to zero.
                 ///
                 /// # Examples
                 ///
@@ -712,7 +720,9 @@ macro_rules! nonzero_unsigned_signed_operations {
 
                 /// Multiply two non-zero integers together,
                 /// assuming overflow cannot occur.
-                /// This results in undefined behavior when
+                /// Overflow is unchecked, and it is undefined behaviour to overflow
+                /// *even if the result would wrap to a non-zero value*.
+                /// The behaviour is undefined as soon as
                 #[doc = concat!("`self * rhs > ", stringify!($Int), "::MAX`, ")]
                 #[doc = concat!("or `self * rhs < ", stringify!($Int), "::MIN`.")]
                 ///
@@ -739,7 +749,8 @@ macro_rules! nonzero_unsigned_signed_operations {
                 }
 
                 /// Raise non-zero value to an integer power.
-                /// Return [`None`] on overflow.
+                /// Check for overflow and return [`None`] on overflow.
+                /// As a consequence, the result cannot wrap to zero.
                 ///
                 /// # Examples
                 ///

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -429,6 +429,51 @@ nonzero_unsigned_operations! {
     NonZeroUsize(usize);
 }
 
+// A bunch of methods for signed nonzero types only.
+macro_rules! nonzero_signed_operations {
+    ( $( $Ty: ident($Int: ty) -> $Uty: ident($Uint: ty); )+ ) => {
+        $(
+            impl $Ty {
+                /// Computes the absolute value of self.
+                #[doc = concat!("See [`", stringify!($Int), "::abs`]")]
+                /// for documentation on overflow behaviour.
+                ///
+                /// # Example
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
+                ///
+                /// assert_eq!(pos, pos.abs());
+                /// assert_eq!(pos, neg.abs());
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn abs(self) -> $Ty {
+                    // SAFETY: This cannot overflow to zero.
+                    unsafe { $Ty::new_unchecked(self.get().abs()) }
+                }
+            }
+        )+
+    }
+}
+
+nonzero_signed_operations! {
+    NonZeroI8(i8) -> NonZeroU8(u8);
+    NonZeroI16(i16) -> NonZeroU16(u16);
+    NonZeroI32(i32) -> NonZeroU32(u32);
+    NonZeroI64(i64) -> NonZeroU64(u64);
+    NonZeroI128(i128) -> NonZeroU128(u128);
+    NonZeroIsize(isize) -> NonZeroUsize(usize);
+}
+
 macro_rules! nonzero_unsigned_is_power_of_two {
     ( $( $Ty: ident )+ ) => {
         $(

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -493,6 +493,40 @@ macro_rules! nonzero_signed_operations {
                         None
                     }
                 }
+
+                /// Computes the absolute value of self,
+                /// with overflow information, see
+                #[doc = concat!("[`", stringify!($Int), "::overflowing_abs`].")]
+                ///
+                /// # Example
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
+                #[doc = concat!("let min = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MIN)?;")]
+                ///
+                /// assert_eq!((pos, false), pos.overflowing_abs());
+                /// assert_eq!((pos, false), neg.overflowing_abs());
+                /// assert_eq!((min, true), min.overflowing_abs());
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn overflowing_abs(self) -> ($Ty, bool) {
+                    let (nz, flag) = self.get().overflowing_abs();
+                    (
+                        // SAFETY: absolute value of nonzero cannot yield zero values.
+                        unsafe { $Ty::new_unchecked(nz) },
+                        flag,
+                    )
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -737,6 +737,39 @@ macro_rules! nonzero_unsigned_signed_operations {
                     // SAFETY: The caller ensures there is no overflow.
                     unsafe { $Ty::new_unchecked(self.get().unchecked_mul(other.get())) }
                 }
+
+                /// Raise non-zero value to an integer power.
+                /// Return [`None`] on overflow.
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
+                #[doc = concat!("let twenty_seven = ", stringify!($Ty), "::new(27)?;")]
+                #[doc = concat!("let half_max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX / 2)?;")]
+                ///
+                /// assert_eq!(Some(twenty_seven), three.checked_pow(3));
+                /// assert_eq!(None, half_max.checked_pow(3));
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn checked_pow(self, other: u32) -> Option<$Ty> {
+                    if let Some(result) = self.get().checked_pow(other) {
+                        // SAFETY: checked_pow returns None on overflow
+                        // so the result cannot be zero.
+                        Some(unsafe { $Ty::new_unchecked(result) })
+                    } else {
+                        None
+                    }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -351,6 +351,34 @@ macro_rules! nonzero_unsigned_operations {
                     // so the result cannot be zero.
                     unsafe { $Ty::new_unchecked(self.get().saturating_add(other)) }
                 }
+
+                /// Add an unsigned integer to a non-zero value,
+                /// assuming overflow cannot occur.
+                /// This results in undefined behaviour when
+                #[doc = concat!("`self + rhs > ", stringify!($Int), "::MAX`")]
+                #[doc = concat!(" or `self + rhs < ", stringify!($Int), "::MIN`.")]
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
+                ///
+                /// assert_eq!(two, unsafe { one.unchecked_add(1) });
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub unsafe fn unchecked_add(self, other: $Int) -> $Ty {
+                    // SAFETY: The caller ensures there is no overflow.
+                    unsafe { $Ty::new_unchecked(self.get().unchecked_add(other)) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -285,6 +285,57 @@ nonzero_integers_div! {
     NonZeroUsize(usize);
 }
 
+// A bunch of methods for unsigned nonzero types only.
+macro_rules! nonzero_unsigned_operations {
+    ( $( $Ty: ident($Int: ty); )+ ) => {
+        $(
+            impl $Ty {
+                /// Add an unsigned integer to a non-zero value.
+                /// Return [`None`] on overflow.
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(Some(two), one.checked_add(1));
+                /// assert_eq!(None, max.checked_add(1));
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn checked_add(self, other: $Int) -> Option<$Ty> {
+                    if let Some(result) = self.get().checked_add(other) {
+                        // SAFETY: $Int::checked_add returns None on overflow
+                        // so the result cannot be zero.
+                        Some(unsafe { $Ty::new_unchecked(result) })
+                    } else {
+                        None
+                    }
+                }
+            }
+        )+
+    }
+}
+
+nonzero_unsigned_operations! {
+    NonZeroU8(u8);
+    NonZeroU16(u16);
+    NonZeroU32(u32);
+    NonZeroU64(u64);
+    NonZeroU128(u128);
+    NonZeroUsize(usize);
+}
+
 macro_rules! nonzero_unsigned_is_power_of_two {
     ( $( $Ty: ident )+ ) => {
         $(

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -460,6 +460,39 @@ macro_rules! nonzero_signed_operations {
                     // SAFETY: This cannot overflow to zero.
                     unsafe { $Ty::new_unchecked(self.get().abs()) }
                 }
+
+                /// Checked absolute value.
+                /// Returns [`None`] if
+                #[doc = concat!("`self == ", stringify!($Int), "::MIN`.")]
+                ///
+                /// # Example
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
+                #[doc = concat!("let min = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MIN)?;")]
+                ///
+                /// assert_eq!(Some(pos), neg.checked_abs());
+                /// assert_eq!(None, min.checked_abs());
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn checked_abs(self) -> Option<$Ty> {
+                    if let Some(nz) = self.get().checked_abs() {
+                        // SAFETY: absolute value of nonzero cannot yield zero values.
+                        Some(unsafe { $Ty::new_unchecked(nz) })
+                    } else {
+                        None
+                    }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -527,6 +527,40 @@ macro_rules! nonzero_signed_operations {
                         flag,
                     )
                 }
+
+                /// Saturating absolute value, see
+                #[doc = concat!("[`", stringify!($Int), "::saturating_abs`].")]
+                ///
+                /// # Example
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
+                #[doc = concat!("let min = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MIN)?;")]
+                #[doc = concat!("let min_plus = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MIN + 1)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(pos, pos.saturating_abs());
+                /// assert_eq!(pos, neg.saturating_abs());
+                /// assert_eq!(max, min.saturating_abs());
+                /// assert_eq!(max, min_plus.saturating_abs());
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn saturating_abs(self) -> $Ty {
+                    // SAFETY: absolute value of nonzero cannot yield zero values.
+                    unsafe { $Ty::new_unchecked(self.get().saturating_abs()) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -561,6 +561,39 @@ macro_rules! nonzero_signed_operations {
                     // SAFETY: absolute value of nonzero cannot yield zero values.
                     unsafe { $Ty::new_unchecked(self.get().saturating_abs()) }
                 }
+
+                /// Wrapping absolute value, see
+                #[doc = concat!("[`", stringify!($Int), "::wrapping_abs`].")]
+                ///
+                /// # Example
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
+                #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
+                #[doc = concat!("let min = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MIN)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(pos, pos.wrapping_abs());
+                /// assert_eq!(pos, neg.wrapping_abs());
+                /// assert_eq!(min, min.wrapping_abs());
+                /// # // FIXME: add once Neg is implemented?
+                /// # // assert_eq!(max, (-max).wrapping_abs());
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn wrapping_abs(self) -> $Ty {
+                    // SAFETY: absolute value of nonzero cannot yield zero values.
+                    unsafe { $Ty::new_unchecked(self.get().wrapping_abs()) }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -379,6 +379,42 @@ macro_rules! nonzero_unsigned_operations {
                     // SAFETY: The caller ensures there is no overflow.
                     unsafe { $Ty::new_unchecked(self.get().unchecked_add(other)) }
                 }
+
+                /// Returns the smallest power of two greater than or equal to n.
+                /// If the next power of two is greater than the type’s maximum value,
+                /// [`None`] is returned, otherwise the power of two is wrapped in [`Some`].
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #![feature(nonzero_ops)]
+                /// # #![feature(try_trait)]
+                #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
+                ///
+                /// # fn main() -> Result<(), std::option::NoneError> {
+                #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
+                #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
+                #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
+                #[doc = concat!("let max = ", stringify!($Ty), "::new(",
+                                stringify!($Int), "::MAX)?;")]
+                ///
+                /// assert_eq!(Some(two), two.checked_next_power_of_two() );
+                /// assert_eq!(Some(four), three.checked_next_power_of_two() );
+                /// assert_eq!(None, max.checked_next_power_of_two() );
+                /// # Ok(())
+                /// # }
+                /// ```
+                #[unstable(feature = "nonzero_ops", issue = "84186")]
+                #[inline]
+                pub const fn checked_next_power_of_two(self) -> Option<$Ty> {
+                    if let Some(nz) = self.get().checked_next_power_of_two() {
+                        // SAFETY: The next power of two is positive
+                        // and overflow is checked.
+                        Some(unsafe { $Ty::new_unchecked(nz) })
+                    } else {
+                        None
+                    }
+                }
             }
         )+
     }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -300,10 +300,10 @@ macro_rules! nonzero_unsigned_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
                 #[doc = concat!("let max = ", stringify!($Ty), "::new(",
@@ -311,7 +311,7 @@ macro_rules! nonzero_unsigned_operations {
                 ///
                 /// assert_eq!(Some(two), one.checked_add(1));
                 /// assert_eq!(None, max.checked_add(1));
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -333,10 +333,10 @@ macro_rules! nonzero_unsigned_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
                 #[doc = concat!("let max = ", stringify!($Ty), "::new(",
@@ -344,7 +344,7 @@ macro_rules! nonzero_unsigned_operations {
                 ///
                 /// assert_eq!(two, one.saturating_add(1));
                 /// assert_eq!(max, max.saturating_add(1));
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -366,15 +366,15 @@ macro_rules! nonzero_unsigned_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let one = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
                 ///
                 /// assert_eq!(two, unsafe { one.unchecked_add(1) });
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -393,10 +393,10 @@ macro_rules! nonzero_unsigned_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
                 #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
                 #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
@@ -406,7 +406,7 @@ macro_rules! nonzero_unsigned_operations {
                 /// assert_eq!(Some(two), two.checked_next_power_of_two() );
                 /// assert_eq!(Some(four), three.checked_next_power_of_two() );
                 /// assert_eq!(None, max.checked_next_power_of_two() );
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -447,16 +447,16 @@ macro_rules! nonzero_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
                 ///
                 /// assert_eq!(pos, pos.abs());
                 /// assert_eq!(pos, neg.abs());
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -475,10 +475,10 @@ macro_rules! nonzero_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
                 #[doc = concat!("let min = ", stringify!($Ty), "::new(",
@@ -486,7 +486,7 @@ macro_rules! nonzero_signed_operations {
                 ///
                 /// assert_eq!(Some(pos), neg.checked_abs());
                 /// assert_eq!(None, min.checked_abs());
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -508,10 +508,10 @@ macro_rules! nonzero_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
                 #[doc = concat!("let min = ", stringify!($Ty), "::new(",
@@ -520,7 +520,7 @@ macro_rules! nonzero_signed_operations {
                 /// assert_eq!((pos, false), pos.overflowing_abs());
                 /// assert_eq!((pos, false), neg.overflowing_abs());
                 /// assert_eq!((min, true), min.overflowing_abs());
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -541,10 +541,10 @@ macro_rules! nonzero_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
                 #[doc = concat!("let min = ", stringify!($Ty), "::new(",
@@ -558,7 +558,7 @@ macro_rules! nonzero_signed_operations {
                 /// assert_eq!(pos, neg.saturating_abs());
                 /// assert_eq!(max, min.saturating_abs());
                 /// assert_eq!(max, min_plus.saturating_abs());
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -575,10 +575,10 @@ macro_rules! nonzero_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let pos = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let neg = ", stringify!($Ty), "::new(-1)?;")]
                 #[doc = concat!("let min = ", stringify!($Ty), "::new(",
@@ -591,7 +591,7 @@ macro_rules! nonzero_signed_operations {
                 /// assert_eq!(min, min.wrapping_abs());
                 /// # // FIXME: add once Neg is implemented?
                 /// # // assert_eq!(max, (-max).wrapping_abs());
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -608,11 +608,11 @@ macro_rules! nonzero_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 #[doc = concat!("# use std::num::", stringify!($Uty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let u_pos = ", stringify!($Uty), "::new(1)?;")]
                 #[doc = concat!("let i_pos = ", stringify!($Ty), "::new(1)?;")]
                 #[doc = concat!("let i_neg = ", stringify!($Ty), "::new(-1)?;")]
@@ -624,7 +624,7 @@ macro_rules! nonzero_signed_operations {
                 /// assert_eq!(u_pos, i_pos.unsigned_abs());
                 /// assert_eq!(u_pos, i_neg.unsigned_abs());
                 /// assert_eq!(u_max, i_min.unsigned_abs());
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -660,10 +660,10 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
                 #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
                 #[doc = concat!("let max = ", stringify!($Ty), "::new(",
@@ -671,7 +671,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// assert_eq!(Some(four), two.checked_mul(two));
                 /// assert_eq!(None, max.checked_mul(two));
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -694,10 +694,10 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
                 #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
                 #[doc = concat!("let max = ", stringify!($Ty), "::new(",
@@ -705,7 +705,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// assert_eq!(four, two.saturating_mul(two));
                 /// assert_eq!(max, four.saturating_mul(max));
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -737,15 +737,15 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let two = ", stringify!($Ty), "::new(2)?;")]
                 #[doc = concat!("let four = ", stringify!($Ty), "::new(4)?;")]
                 ///
                 /// assert_eq!(four, unsafe { two.unchecked_mul(two) });
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -763,10 +763,10 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
                 #[doc = concat!("let twenty_seven = ", stringify!($Ty), "::new(27)?;")]
                 #[doc = concat!("let half_max = ", stringify!($Ty), "::new(",
@@ -774,7 +774,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// assert_eq!(Some(twenty_seven), three.checked_pow(3));
                 /// assert_eq!(None, half_max.checked_pow(3));
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]
@@ -805,10 +805,10 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// ```
                 /// #![feature(nonzero_ops)]
-                /// # #![feature(try_trait)]
                 #[doc = concat!("# use std::num::", stringify!($Ty), ";")]
                 ///
-                /// # fn main() -> Result<(), std::option::NoneError> {
+                /// # fn main() { test().unwrap(); }
+                /// # fn test() -> Option<()> {
                 #[doc = concat!("let three = ", stringify!($Ty), "::new(3)?;")]
                 #[doc = concat!("let twenty_seven = ", stringify!($Ty), "::new(27)?;")]
                 #[doc = concat!("let max = ", stringify!($Ty), "::new(",
@@ -816,7 +816,7 @@ macro_rules! nonzero_unsigned_signed_operations {
                 ///
                 /// assert_eq!(twenty_seven, three.saturating_pow(3));
                 /// assert_eq!(max, max.saturating_pow(3));
-                /// # Ok(())
+                /// # Some(())
                 /// # }
                 /// ```
                 #[unstable(feature = "nonzero_ops", issue = "84186")]


### PR DESCRIPTION
Hello'all, this is my first PR to this repo.

Non-zero natural numbers are stable by addition/multiplication/exponentiation, so it makes sense to make this arithmetic possible with `NonZeroU*`.

The major pitfall is that overflowing underlying `u*` types possibly lead to underlying `0` values, which break the major invariant of `NonZeroU*`. To accommodate it, only `checked_` and `saturating_` operations are implemented.

Other variants allowing wrapped results like `wrapping_` or `overflowing_` are ruled out *de facto*.

`impl Add<u*> for NonZeroU* { .. }` was considered, as it panics on overflow which enforces the invariant, but it does not so in release mode. I considered forcing `NonZeroU*::add` to panic in release mode by deferring the check to `u*::checked_add`, but this is less explicit for the user than directly using `NonZeroU*::checked_add`.
Following @Lokathor's advice on zulip, I have dropped the idea.

@poliorcetics on Discord also suggested implementing `_sub` operations, but I'd postpone this to another PR if there is a need for it. My opinion is that it could be useful in some cases, but that it makes less sense because non-null natural numbers are not stable by subtraction even in theory, while the overflowing problem is just about technical implementation.

One thing I don't like is that the type of the `other` arg differs in every implementation: `_add` methods accept any raw positive integer, `_mul` methods only accept non-zero values otherwise the invariant is also broken, and `_pow` only seems to accept `u32` for a reason I ignore but that seems consistent throughout `std`. Maybe there is a better way to harmonize this?

This is it, Iope I haven't forgotten anything and I'll be happy to read your feedback.