### PR TITLE
use outer_expn_data() instead of outer_expn().expn_data()

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1422,7 +1422,7 @@ impl<'a> Resolver<'a> {
 
     fn macro_def(&self, mut ctxt: SyntaxContext) -> DefId {
         loop {
-            match ctxt.outer_expn().expn_data().macro_def_id {
+            match ctxt.outer_expn_data().macro_def_id {
                 Some(def_id) => return def_id,
                 None => ctxt.remove_mark(),
             };


### PR DESCRIPTION
From the comment in hygiene.rs, so use it:
https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/hygiene.rs#L627-L632