### PR TITLE
Warn on `#![doc(test(...))]` on items other than the crate root and use future incompatible lint

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3061,14 +3061,17 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `invalid_doc_attributes` lint detects when the `#[doc(...)]` is
+    /// The `invalid_doc_attribute` lint detects when the `#[doc(...)]` is
     /// misused.
     ///
     /// ### Example
     ///
     /// ```rust,compile_fail
     /// #![deny(warnings)]
-    /// #[doc(test(no_crate_inject))]
+    ///
+    /// pub mod submodule {
+    ///     #![doc(test(no_crate_inject))]
+    /// }
     /// ```
     ///
     /// {{produces}}
@@ -3083,6 +3086,6 @@ declare_lint! {
     "detects invalid `#[doc(...)]` attributes",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #82730 <https://github.com/rust-lang/rust/issues/82730>",
-        edition: Some(Edition::Edition2021),
+        edition: None,
     };
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3061,7 +3061,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `invalid_doc_attribute` lint detects when the `#[doc(...)]` is
+    /// The `invalid_doc_attributes` lint detects when the `#[doc(...)]` is
     /// misused.
     ///
     /// ### Example
@@ -3081,7 +3081,7 @@ declare_lint! {
     /// Previously, there were very like checks being performed on `#[doc(..)]`
     /// unlike the other attributes. It'll now catch all the issues that it
     /// silently ignored previously.
-    pub INVALID_DOC_ATTRIBUTE,
+    pub INVALID_DOC_ATTRIBUTES,
     Warn,
     "detects invalid `#[doc(...)]` attributes",
     @future_incompatible = FutureIncompatibleInfo {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3059,3 +3059,30 @@ declare_lint! {
     Allow,
     "No declared ABI for extern declaration"
 }
+
+declare_lint! {
+    /// The `invalid_doc_attributes` lint detects when the `#[doc(...)]` is
+    /// misused.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(warnings)]
+    /// #[doc(test(no_crate_inject))]
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Previously, there were very like checks being performed on `#[doc(..)]`
+    /// unlike the other attributes. It'll now catch all the issues that it
+    /// silently ignored previously.
+    pub INVALID_DOC_ATTRIBUTE,
+    Warn,
+    "detects invalid `#[doc(...)]` attributes",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #82730 <https://github.com/rust-lang/rust/issues/82730>",
+        edition: Some(Edition::Edition2021),
+    };
+}

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -585,7 +585,7 @@ impl CheckAttrVisitor<'tcx> {
                         .any(|m| i_meta.has_name(*m))
                         {
                             self.tcx.struct_span_lint_hir(
-                                UNUSED_ATTRIBUTES,
+                                INVALID_DOC_ATTRIBUTE,
                                 hir_id,
                                 i_meta.span,
                                 |lint| {
@@ -593,11 +593,6 @@ impl CheckAttrVisitor<'tcx> {
                                         "unknown `doc` attribute `{}`",
                                         i_meta.name_or_empty()
                                     ))
-                                    .warn(
-                                        "this was previously accepted by the compiler but is \
-                                        being phased out; it will become a hard error in \
-                                        a future release!",
-                                    )
                                     .emit();
                                 },
                             );

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -18,7 +18,7 @@ use rustc_hir::{
 };
 use rustc_hir::{MethodKind, Target};
 use rustc_session::lint::builtin::{
-    CONFLICTING_REPR_HINTS, INVALID_DOC_ATTRIBUTE, UNUSED_ATTRIBUTES,
+    CONFLICTING_REPR_HINTS, INVALID_DOC_ATTRIBUTES, UNUSED_ATTRIBUTES,
 };
 use rustc_session::parse::feature_err;
 use rustc_span::symbol::{sym, Symbol};
@@ -549,7 +549,7 @@ impl CheckAttrVisitor<'tcx> {
                     } else if meta.has_name(sym::test) {
                         if CRATE_HIR_ID != hir_id {
                             self.tcx.struct_span_lint_hir(
-                                INVALID_DOC_ATTRIBUTE,
+                                INVALID_DOC_ATTRIBUTES,
                                 hir_id,
                                 meta.span(),
                                 |lint| {
@@ -585,7 +585,7 @@ impl CheckAttrVisitor<'tcx> {
                         .any(|m| i_meta.has_name(*m))
                         {
                             self.tcx.struct_span_lint_hir(
-                                INVALID_DOC_ATTRIBUTE,
+                                INVALID_DOC_ATTRIBUTES,
                                 hir_id,
                                 i_meta.span,
                                 |lint| {

--- a/src/test/rustdoc-ui/doc-attr.rs
+++ b/src/test/rustdoc-ui/doc-attr.rs
@@ -1,11 +1,10 @@
 #![crate_type = "lib"]
-#![deny(unused_attributes)]
-//~^ NOTE lint level is defined here
+#![deny(warnings)]
 #![doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~| WARNING will become a hard error in a future release
+//~^^ WARN
 
 #[doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~| WARNING will become a hard error in a future release
+//~^^ WARN
 pub fn foo() {}

--- a/src/test/rustdoc-ui/doc-attr.stderr
+++ b/src/test/rustdoc-ui/doc-attr.stderr
@@ -1,5 +1,5 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:8:7
+  --> $DIR/doc-attr.rs:7:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
@@ -7,17 +7,20 @@ LL | #[doc(as_ptr)]
 note: the lint level is defined here
   --> $DIR/doc-attr.rs:2:9
    |
-LL | #![deny(unused_attributes)]
-   |         ^^^^^^^^^^^^^^^^^
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:4:8
+  --> $DIR/doc-attr.rs:3:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/rustdoc-ui/doc-attr.stderr
+++ b/src/test/rustdoc-ui/doc-attr.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 

--- a/src/test/rustdoc-ui/doc-attr2.rs
+++ b/src/test/rustdoc-ui/doc-attr2.rs
@@ -1,0 +1,11 @@
+#![crate_type = "lib"]
+#![deny(warnings)]
+
+#[doc(test(no_crate_inject))] //~ ERROR
+//~^ WARN
+pub fn foo() {}
+
+pub mod bar {
+    #![doc(test(no_crate_inject))] //~ ERROR
+    //~^ WARN
+}

--- a/src/test/rustdoc-ui/doc-attr2.stderr
+++ b/src/test/rustdoc-ui/doc-attr2.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 

--- a/src/test/rustdoc-ui/doc-attr2.stderr
+++ b/src/test/rustdoc-ui/doc-attr2.stderr
@@ -1,0 +1,26 @@
+error: `#![doc(test(...)]` is only allowed as a crate level attribute
+  --> $DIR/doc-attr2.rs:4:7
+   |
+LL | #[doc(test(no_crate_inject))]
+   |       ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/doc-attr2.rs:2:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: `#![doc(test(...)]` is only allowed as a crate level attribute
+  --> $DIR/doc-attr2.rs:9:12
+   |
+LL |     #![doc(test(no_crate_inject))]
+   |            ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/attributes/doc-attr.rs
+++ b/src/test/ui/attributes/doc-attr.rs
@@ -1,11 +1,10 @@
 #![crate_type = "lib"]
-#![deny(unused_attributes)]
-//~^ NOTE lint level is defined here
+#![deny(warnings)]
 #![doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~| WARNING will become a hard error in a future release
+//~^^ WARN
 
 #[doc(as_ptr)]
 //~^ ERROR unknown `doc` attribute
-//~| WARNING will become a hard error in a future release
+//~^^ WARN
 pub fn foo() {}

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -1,5 +1,5 @@
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:8:7
+  --> $DIR/doc-attr.rs:7:7
    |
 LL | #[doc(as_ptr)]
    |       ^^^^^^
@@ -7,17 +7,20 @@ LL | #[doc(as_ptr)]
 note: the lint level is defined here
   --> $DIR/doc-attr.rs:2:9
    |
-LL | #![deny(unused_attributes)]
-   |         ^^^^^^^^^^^^^^^^^
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: unknown `doc` attribute `as_ptr`
-  --> $DIR/doc-attr.rs:4:8
+  --> $DIR/doc-attr.rs:3:8
    |
 LL | #![doc(as_ptr)]
    |        ^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 

--- a/src/test/ui/attributes/doc-attr2.rs
+++ b/src/test/ui/attributes/doc-attr2.rs
@@ -1,0 +1,11 @@
+#![crate_type = "lib"]
+#![deny(warnings)]
+
+#[doc(test(no_crate_inject))] //~ ERROR
+//~^ WARN
+pub fn foo() {}
+
+pub mod bar {
+    #![doc(test(no_crate_inject))] //~ ERROR
+    //~^ WARN
+}

--- a/src/test/ui/attributes/doc-attr2.stderr
+++ b/src/test/ui/attributes/doc-attr2.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
-   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
+   = note: `#[deny(invalid_doc_attributes)]` implied by `#[deny(warnings)]`
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 

--- a/src/test/ui/attributes/doc-attr2.stderr
+++ b/src/test/ui/attributes/doc-attr2.stderr
@@ -1,0 +1,26 @@
+error: `#![doc(test(...)]` is only allowed as a crate level attribute
+  --> $DIR/doc-attr2.rs:4:7
+   |
+LL | #[doc(test(no_crate_inject))]
+   |       ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/doc-attr2.rs:2:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(invalid_doc_attribute)]` implied by `#[deny(warnings)]`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: `#![doc(test(...)]` is only allowed as a crate level attribute
+  --> $DIR/doc-attr2.rs:9:12
+   |
+LL |     #![doc(test(no_crate_inject))]
+   |            ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Part of #82672.

This PR does multiple things:
 * Create a new `INVALID_DOC_ATTRIBUTE` lint which is also "future incompatible", allowing us to use it as a warning for the moment until it turns (eventually) into a hard error.
 * Use this link when `#![doc(test(...))]` isn't used at the crate level.
 * Make #82702 use this new lint as well.

r? @jyn514 