### PR TITLE
Remove unnecessary conditional `cfg(target_os)` for `redox` and `vxworks`

### DIFF
--- a/library/std/src/os/mod.rs
+++ b/library/std/src/os/mod.rs
@@ -28,7 +28,7 @@ pub use crate::sys::wasi_ext as wasi;
 // If we're not documenting libstd then we just expose the main modules as we otherwise would.
 
 #[cfg(not(doc))]
-#[cfg(any(target_os = "redox", unix, target_os = "vxworks", target_os = "hermit"))]
+#[cfg(any(unix, target_os = "hermit"))]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use crate::sys::ext as unix;
 


### PR DESCRIPTION
`redox` and `vxworks` are now part of target_family `unix`, thus `cfg(unix)` already implies `cfg(target_os="redox")` and `cfg(target_os="vxworks")`

https://github.com/rust-lang/rust/blob/35dbef235048f9a2939dc20effe083ca483c37ff/compiler/rustc_target/src/spec/redox_base.rs#L26

https://github.com/rust-lang/rust/blob/35dbef235048f9a2939dc20effe083ca483c37ff/compiler/rustc_target/src/spec/vxworks_base.rs#L27

