### PR TITLE
rustdoc: Don't use `CURRENT_DEPTH` in `clean/types.rs`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -190,8 +190,8 @@ impl Item {
         self.attrs.collapsed_doc_value()
     }
 
-    crate fn links(&self, cache: &Cache) -> Vec<RenderedLink> {
-        self.attrs.links(&self.def_id.krate, cache)
+    crate fn links(&self, cache: &Cache, depth: usize) -> Vec<RenderedLink> {
+        self.attrs.links(&self.def_id.krate, cache, depth)
     }
 
     crate fn is_crate(&self) -> bool {
@@ -844,9 +844,8 @@ impl Attributes {
     /// Gets links as a vector
     ///
     /// Cache must be populated before call
-    crate fn links(&self, krate: &CrateNum, cache: &Cache) -> Vec<RenderedLink> {
+    crate fn links(&self, krate: &CrateNum, cache: &Cache, depth: usize) -> Vec<RenderedLink> {
         use crate::html::format::href;
-        use crate::html::render::CURRENT_DEPTH;
 
         self.links
             .iter()
@@ -871,7 +870,6 @@ impl Attributes {
                         if let Some(ref fragment) = *fragment {
                             let url = match cache.extern_locations.get(krate) {
                                 Some(&(_, _, ExternalLocation::Local)) => {
-                                    let depth = CURRENT_DEPTH.with(|l| l.get());
                                     "../".repeat(depth)
                                 }
                                 Some(&(_, _, ExternalLocation::Remote(ref s))) => s.to_string(),


### PR DESCRIPTION
Helps with #82742.

This part actually wasn't that hard. Ending the use of it in
`html/format.rs` is probably going to be *a lot* harder.

r? @jyn514
