### PR TITLE
Tell cargo to track logging environment variables

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1350,11 +1350,16 @@ pub fn build_session(
 
     let mut parse_sess = ParseSess::with_span_handler(span_diagnostic, source_map);
     parse_sess.assume_incomplete_release = sopts.debugging_opts.assume_incomplete_release;
+    let dep_info = parse_sess.env_depinfo.get_mut();
+    for log_var in &["RUSTC_LOG", "RUSTC_LOG_COLOR"] {
+        let val = std::env::var(log_var).as_deref().ok().map(Symbol::intern);
+        dep_info.insert((Symbol::intern(log_var), val));
+    }
+
     let sysroot = match &sopts.maybe_sysroot {
         Some(sysroot) => sysroot.clone(),
         None => filesearch::get_or_default_sysroot(),
     };
-
     let host_triple = config::host_triple();
     let target_triple = sopts.target_triple.triple();
     let host_tlib_path = SearchPath::from_sysroot_and_triple(&sysroot, host_triple);


### PR DESCRIPTION
Previously, changing the value of `RUSTC_LOG` would not rebuild, and,
because cargo caches output, show exactly the same logging as before.
This was confusing. Emit `RUSTC_LOG` with other `depinfo` dependencies
so cargo knows to rebuild when it's changed.

Note that this only adds RUSTC_LOG to depinfo.  Unfortunately, adding
RUSTDOC_LOG only when running as rustdoc doesn't help because rustdoc
doesn't emit depinfo at all. Unconditionally emitting RUSTDOC_LOG in the
depinfo doesn't help because cargo ignores it for everything except
rustc itself. I am not yet sure how to fix this; see
https://github.com/rust-lang/cargo/issues/8374 for more info.