### PR TITLE
Update minifier dependency version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.0.33"
+version = "0.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bf0db2475f5e627787da77ca52fe33c294063f49f4134b8bc662eedb5e7332"
+checksum = "6cdf618de5c9c98d4a7b2e0d1f1e44f82a19196cfd94040bb203621c25d28d98"
 dependencies = [
  "macro-utils",
 ]

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 [dependencies]
 arrayvec = { version = "0.5.1", default-features = false }
 pulldown-cmark = { version = "0.8", default-features = false }
-minifier = "0.0.33"
+minifier = "0.0.39"
 rayon = { version = "0.3.0", package = "rustc-rayon" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Very small PR simply upgrading the minifier-rs version we use in rustdoc.

Some details might be useful: there were a few bug fixes and a lot of cleanup/code improvements.

r? @camelid 