### PR TITLE
Add diagnostic item to `Default` trait

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -18,7 +18,7 @@ use crate::{Edition, Span, DUMMY_SP, SESSION_GLOBALS};
 #[cfg(test)]
 mod tests;
 
-// The proc macro code for this is in `src/librustc_macros/src/symbols.rs`.
+// The proc macro code for this is in `compiler/rustc_macros/src/symbols.rs`.
 symbols! {
     // After modifying this list adjust `is_special`, `is_used_keyword`/`is_unused_keyword`,
     // this should be rarely necessary though if the keywords are kept in alphabetic order.

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -80,6 +80,7 @@
 ///     bar: f32,
 /// }
 /// ```
+#[cfg_attr(not(test), rustc_diagnostic_item = "Default")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Default: Sized {
     /// Returns the "default value" for a type.


### PR DESCRIPTION
This PR adds diagnostic item to `Default` trait to be used by rust-lang/rust-clippy#6562 issue. 
Also fixes the obsolete path to the `symbols.rs` file in the comment.