### PR TITLE
Fix bad diagnostics for anon params with ref and/or qualified paths

### DIFF
--- a/src/test/ui/anon-params/anon-params-denied-2018.rs
+++ b/src/test/ui/anon-params/anon-params-denied-2018.rs
@@ -9,6 +9,12 @@ trait T {
     fn foo_with_ref(&mut i32);
     //~^ ERROR expected one of `:`, `@`, or `|`, found `)`
 
+    fn foo_with_qualified_path(<Bar as T>::Baz);
+    //~^ ERROR expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
+
+    fn foo_with_qualified_path_and_ref(&<Bar as T>::Baz);
+    //~^ ERROR expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
+
     fn bar_with_default_impl(String, String) {}
     //~^ ERROR expected one of `:`
     //~| ERROR expected one of `:`

--- a/src/test/ui/anon-params/anon-params-denied-2018.rs
+++ b/src/test/ui/anon-params/anon-params-denied-2018.rs
@@ -5,6 +5,10 @@
 trait T {
     fn foo(i32); //~ expected one of `:`, `@`, or `|`, found `)`
 
+    // Also checks with `&`
+    fn foo_with_ref(&mut i32);
+    //~^ ERROR expected one of `:`, `@`, or `|`, found `)`
+
     fn bar_with_default_impl(String, String) {}
     //~^ ERROR expected one of `:`
     //~| ERROR expected one of `:`

--- a/src/test/ui/anon-params/anon-params-denied-2018.rs
+++ b/src/test/ui/anon-params/anon-params-denied-2018.rs
@@ -15,6 +15,10 @@ trait T {
     fn foo_with_qualified_path_and_ref(&<Bar as T>::Baz);
     //~^ ERROR expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
 
+    fn foo_with_multiple_qualified_paths(<Bar as T>::Baz, <Bar as T>::Baz);
+    //~^ ERROR expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `,`
+    //~| ERROR expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
+
     fn bar_with_default_impl(String, String) {}
     //~^ ERROR expected one of `:`
     //~| ERROR expected one of `:`

--- a/src/test/ui/anon-params/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params/anon-params-denied-2018.stderr
@@ -18,8 +18,28 @@ help: if this is a type, explicitly ignore the parameter name
 LL |     fn foo(_: i32);
    |            ^^^^^^
 
+error: expected one of `:`, `@`, or `|`, found `)`
+  --> $DIR/anon-params-denied-2018.rs:9:29
+   |
+LL |     fn foo_with_ref(&mut i32);
+   |                             ^ expected one of `:`, `@`, or `|`
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn foo_with_ref(self: &mut i32);
+   |                     ^^^^^^^^^^^^^^
+help: if this is a parameter name, give it a type
+   |
+LL |     fn foo_with_ref(i32: &mut TypeName);
+   |                     ^^^^^^^^^^^^^^^^^^
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn foo_with_ref(_: &mut i32);
+   |                     ^^^^^^^^^^^
+
 error: expected one of `:`, `@`, or `|`, found `,`
-  --> $DIR/anon-params-denied-2018.rs:8:36
+  --> $DIR/anon-params-denied-2018.rs:12:36
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                    ^ expected one of `:`, `@`, or `|`
@@ -39,7 +59,7 @@ LL |     fn bar_with_default_impl(_: String, String) {}
    |                              ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `)`
-  --> $DIR/anon-params-denied-2018.rs:8:44
+  --> $DIR/anon-params-denied-2018.rs:12:44
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                            ^ expected one of `:`, `@`, or `|`
@@ -55,7 +75,7 @@ LL |     fn bar_with_default_impl(String, _: String) {}
    |                                      ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `,`
-  --> $DIR/anon-params-denied-2018.rs:13:22
+  --> $DIR/anon-params-denied-2018.rs:17:22
    |
 LL |     fn baz(a:usize, b, c: usize) -> usize {
    |                      ^ expected one of `:`, `@`, or `|`
@@ -70,5 +90,5 @@ help: if this is a type, explicitly ignore the parameter name
 LL |     fn baz(a:usize, _: b, c: usize) -> usize {
    |                     ^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/anon-params/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params/anon-params-denied-2018.stderr
@@ -38,8 +38,24 @@ help: if this is a type, explicitly ignore the parameter name
 LL |     fn foo_with_ref(_: &mut i32);
    |                     ^^^^^^^^^^^
 
+error: expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
+  --> $DIR/anon-params-denied-2018.rs:12:47
+   |
+LL |     fn foo_with_qualified_path(<Bar as T>::Baz);
+   |                                               ^ expected one of 8 possible tokens
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+
+error: expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
+  --> $DIR/anon-params-denied-2018.rs:15:56
+   |
+LL |     fn foo_with_qualified_path_and_ref(&<Bar as T>::Baz);
+   |                                                        ^ expected one of 8 possible tokens
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+
 error: expected one of `:`, `@`, or `|`, found `,`
-  --> $DIR/anon-params-denied-2018.rs:12:36
+  --> $DIR/anon-params-denied-2018.rs:18:36
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                    ^ expected one of `:`, `@`, or `|`
@@ -59,7 +75,7 @@ LL |     fn bar_with_default_impl(_: String, String) {}
    |                              ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `)`
-  --> $DIR/anon-params-denied-2018.rs:12:44
+  --> $DIR/anon-params-denied-2018.rs:18:44
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                            ^ expected one of `:`, `@`, or `|`
@@ -75,7 +91,7 @@ LL |     fn bar_with_default_impl(String, _: String) {}
    |                                      ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `,`
-  --> $DIR/anon-params-denied-2018.rs:17:22
+  --> $DIR/anon-params-denied-2018.rs:23:22
    |
 LL |     fn baz(a:usize, b, c: usize) -> usize {
    |                      ^ expected one of `:`, `@`, or `|`
@@ -90,5 +106,5 @@ help: if this is a type, explicitly ignore the parameter name
 LL |     fn baz(a:usize, _: b, c: usize) -> usize {
    |                     ^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/anon-params/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params/anon-params-denied-2018.stderr
@@ -45,6 +45,10 @@ LL |     fn foo_with_qualified_path(<Bar as T>::Baz);
    |                                               ^ expected one of 8 possible tokens
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: explicitly ignore the parameter name
+   |
+LL |     fn foo_with_qualified_path(_: <Bar as T>::Baz);
+   |                                ^^^^^^^^^^^^^^^^^^
 
 error: expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
   --> $DIR/anon-params-denied-2018.rs:15:56
@@ -53,6 +57,10 @@ LL |     fn foo_with_qualified_path_and_ref(&<Bar as T>::Baz);
    |                                                        ^ expected one of 8 possible tokens
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: explicitly ignore the parameter name
+   |
+LL |     fn foo_with_qualified_path_and_ref(_: &<Bar as T>::Baz);
+   |                                        ^^^^^^^^^^^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `,`
   --> $DIR/anon-params-denied-2018.rs:18:36

--- a/src/test/ui/anon-params/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params/anon-params-denied-2018.stderr
@@ -62,8 +62,32 @@ help: explicitly ignore the parameter name
 LL |     fn foo_with_qualified_path_and_ref(_: &<Bar as T>::Baz);
    |                                        ^^^^^^^^^^^^^^^^^^^
 
+error: expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `,`
+  --> $DIR/anon-params-denied-2018.rs:18:57
+   |
+LL |     fn foo_with_multiple_qualified_paths(<Bar as T>::Baz, <Bar as T>::Baz);
+   |                                                         ^ expected one of 8 possible tokens
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: explicitly ignore the parameter name
+   |
+LL |     fn foo_with_multiple_qualified_paths(_: <Bar as T>::Baz, <Bar as T>::Baz);
+   |                                          ^^^^^^^^^^^^^^^^^^
+
+error: expected one of `(`, `...`, `..=`, `..`, `::`, `:`, `{`, or `|`, found `)`
+  --> $DIR/anon-params-denied-2018.rs:18:74
+   |
+LL |     fn foo_with_multiple_qualified_paths(<Bar as T>::Baz, <Bar as T>::Baz);
+   |                                                                          ^ expected one of 8 possible tokens
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: explicitly ignore the parameter name
+   |
+LL |     fn foo_with_multiple_qualified_paths(<Bar as T>::Baz, _: <Bar as T>::Baz);
+   |                                                           ^^^^^^^^^^^^^^^^^^
+
 error: expected one of `:`, `@`, or `|`, found `,`
-  --> $DIR/anon-params-denied-2018.rs:18:36
+  --> $DIR/anon-params-denied-2018.rs:22:36
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                    ^ expected one of `:`, `@`, or `|`
@@ -83,7 +107,7 @@ LL |     fn bar_with_default_impl(_: String, String) {}
    |                              ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `)`
-  --> $DIR/anon-params-denied-2018.rs:18:44
+  --> $DIR/anon-params-denied-2018.rs:22:44
    |
 LL |     fn bar_with_default_impl(String, String) {}
    |                                            ^ expected one of `:`, `@`, or `|`
@@ -99,7 +123,7 @@ LL |     fn bar_with_default_impl(String, _: String) {}
    |                                      ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `,`
-  --> $DIR/anon-params-denied-2018.rs:23:22
+  --> $DIR/anon-params-denied-2018.rs:27:22
    |
 LL |     fn baz(a:usize, b, c: usize) -> usize {
    |                      ^ expected one of `:`, `@`, or `|`
@@ -114,5 +138,5 @@ help: if this is a type, explicitly ignore the parameter name
 LL |     fn baz(a:usize, _: b, c: usize) -> usize {
    |                     ^^^^
 
-error: aborting due to 7 previous errors
+error: aborting due to 9 previous errors
 

--- a/src/test/ui/parser/lifetime-in-pattern.stderr
+++ b/src/test/ui/parser/lifetime-in-pattern.stderr
@@ -9,6 +9,20 @@ error: expected one of `:`, `@`, or `|`, found `)`
    |
 LL | fn test(&'a str) {
    |                ^ expected one of `:`, `@`, or `|`
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL | fn test(self: &str) {
+   |         ^^^^^^^^^^
+help: if this is a parameter name, give it a type
+   |
+LL | fn test(str: &TypeName) {
+   |         ^^^^^^^^^^^^^^
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn test(_: &str) {
+   |         ^^^^^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fixes #82729
It's easier to review with hiding whitespace changes.