### PR TITLE
Make rustc shim's verbose output include crate_name being compiled.

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -141,18 +141,23 @@ fn main() {
     if verbose > 1 {
         let rust_env_vars =
             env::vars().filter(|(k, _)| k.starts_with("RUST") || k.starts_with("CARGO"));
+        let prefix = match crate_name {
+            Some(crate_name) => format!("rustc {}", crate_name),
+            None => "rustc".to_string(),
+        };
         for (i, (k, v)) in rust_env_vars.enumerate() {
-            eprintln!("rustc env[{}]: {:?}={:?}", i, k, v);
+            eprintln!("{} env[{}]: {:?}={:?}", prefix, i, k, v);
         }
-        eprintln!("rustc working directory: {}", env::current_dir().unwrap().display());
+        eprintln!("{} working directory: {}", prefix, env::current_dir().unwrap().display());
         eprintln!(
-            "rustc command: {:?}={:?} {:?}",
+            "{} command: {:?}={:?} {:?}",
+            prefix,
             bootstrap::util::dylib_path_var(),
             env::join_paths(&dylib_path).unwrap(),
             cmd,
         );
-        eprintln!("sysroot: {:?}", sysroot);
-        eprintln!("libdir: {:?}", libdir);
+        eprintln!("{} sysroot: {:?}", prefix, sysroot);
+        eprintln!("{} libdir: {:?}", prefix, libdir);
     }
 
     let start = Instant::now();

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -138,12 +138,14 @@ fn main() {
         cmd.arg("-Z").arg("force-unstable-if-unmarked");
     }
 
+    let is_test = args.iter().any(|a| a == "--test");
     if verbose > 1 {
         let rust_env_vars =
             env::vars().filter(|(k, _)| k.starts_with("RUST") || k.starts_with("CARGO"));
+        let prefix = if is_test { "[RUSTC-SHIM] rustc --test" } else { "[RUSTC-SHIM] rustc" };
         let prefix = match crate_name {
-            Some(crate_name) => format!("rustc {}", crate_name),
-            None => "rustc".to_string(),
+            Some(crate_name) => format!("{} {}", prefix, crate_name),
+            None => prefix.to_string(),
         };
         for (i, (k, v)) in rust_env_vars.enumerate() {
             eprintln!("{} env[{}]: {:?}={:?}", prefix, i, k, v);
@@ -171,7 +173,6 @@ fn main() {
     {
         if let Some(crate_name) = crate_name {
             let dur = start.elapsed();
-            let is_test = args.iter().any(|a| a == "--test");
             // If the user requested resource usage data, then
             // include that in addition to the timing output.
             let rusage_data =


### PR DESCRIPTION
This change is mainly motivated by an issue with the environment printing I added in PR 82403: multiple rustc invocations progress in parallel, and the environment output, spanning multiple lines, gets interleaved in ways make it difficult to extra the enviroment settings.

(This aforementioned difficulty is more of a hiccup than an outright show-stopper, because the environment variables tend to be the same for all of the rustc invocations, so it doesn't matter too much if one mixes up which lines one is looking at. But still: Better to fix it.)