### PR TITLE
add the bool::not method.

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -644,9 +644,6 @@ declare_features! (
     /// Allows associated types in inherent impls.
     (active, inherent_associated_types, "1.52.0", Some(8995), None),
 
-    /// Adds the `bool::not` method so that you don't need `core::ops::Not` imported.
-    (active, bool_not_method, "1.52.0", None, None),
-
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -644,6 +644,9 @@ declare_features! (
     /// Allows associated types in inherent impls.
     (active, inherent_associated_types, "1.52.0", Some(8995), None),
 
+    /// Adds the `bool::not` method so that you don't need `core::ops::Not` imported.
+    (active, bool_not_method, "1.52.0", None, None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -31,4 +31,9 @@ impl bool {
     pub fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
         if self { Some(f()) } else { None }
     }
+
+    #[unstable(feature = "bool_not_method", issue = "none")]
+    pub fn not(self) -> Self {
+        !self
+    }
 }

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -41,7 +41,8 @@ impl bool {
     /// assert_eq!(true.not(), false);
     /// ```
     #[unstable(feature = "bool_not_method", issue = "none")]
-    pub fn not(self) -> Self {
+    #[inline]
+    pub const fn not(self) -> Self {
         !self
     }
 }

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -32,6 +32,14 @@ impl bool {
         if self { Some(f()) } else { None }
     }
 
+    /// Returns the opposite value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// assert_eq!(false.not(), true);
+    /// assert_eq!(true.not(), false);
+    /// ```
     #[unstable(feature = "bool_not_method", issue = "none")]
     pub fn not(self) -> Self {
         !self

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -34,11 +34,16 @@ impl bool {
 
     /// Returns the opposite value.
     ///
+    /// This is identical in functionality to usage of the `!` operator, it's
+    /// simply an alternate way to write it. Because it's post-fix instead of
+    /// pre-fix, it is often more readable within chained function call
+    /// expressions.
+    ///
     /// # Examples
     ///
     /// ```
-    /// assert_eq!(false.not(), true);
-    /// assert_eq!(true.not(), false);
+    /// assert_eq!(!true, true.not());
+    /// assert_eq!(!false, false.not());
     /// ```
     #[unstable(feature = "bool_not_method", issue = "none")]
     #[inline]


### PR DESCRIPTION
This adds a `not` method to the `bool` type so that you can call `b.not()` without having to have `core::ops::Not` in scope. Also, a feature gate for the method.

This is a much smaller overall change compared to placing `core::opt::Not` into the 2021 prelude (as some have proposed).

(@jyn514 gave mild mentor advice on how to get started here and wanted a ping when it was posted)