### PR TITLE
Get with field index from pattern slice instead of directly indexing

### DIFF
--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -1343,7 +1343,9 @@ impl<'p, 'tcx> Fields<'p, 'tcx> {
         match &mut fields {
             Fields::Vec(pats) => {
                 for (i, pat) in new_pats {
-                    pats[i] = pat
+                    if let Some(p) = pats.get_mut(i) {
+                        *p = pat;
+                    }
                 }
             }
             Fields::Filtered { fields, .. } => {

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1176,7 +1176,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut no_field_errors = true;
 
         let mut inexistent_fields = vec![];
-        let mut invisible_fields = vec![];
         // Typecheck each field.
         for field in fields {
             let span = field.span;
@@ -1192,12 +1191,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     field_map
                         .get(&ident)
                         .map(|(i, f)| {
-                            if !f
-                                .vis
-                                .is_accessible_from(tcx.parent_module(pat.hir_id).to_def_id(), tcx)
-                            {
-                                invisible_fields.push(field.ident);
-                            }
                             self.write_field_index(field.hir_id, *i);
                             self.tcx.check_stability(f.did, Some(pat.hir_id), span);
                             self.field_ty(span, f, substs)
@@ -1288,13 +1281,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.error_tuple_variant_index_shorthand(variant, pat, fields)
                 {
                     err.emit();
-                } else if !invisible_fields.is_empty() {
-                    let mut err = self.error_invisible_fields(
-                        adt.variant_descr(),
-                        &invisible_fields,
-                        variant,
-                    );
-                    err.emit();
                 }
             }
         }
@@ -1371,41 +1357,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         .span_label(span, format!("multiple uses of `{}` in pattern", ident))
         .span_label(other_field, format!("first use of `{}`", ident))
         .emit();
-    }
-
-    fn error_invisible_fields(
-        &self,
-        kind_name: &str,
-        invisible_fields: &[Ident],
-        variant: &ty::VariantDef,
-    ) -> DiagnosticBuilder<'tcx> {
-        let spans = invisible_fields.iter().map(|ident| ident.span).collect::<Vec<_>>();
-        let (field_names, t) = if invisible_fields.len() == 1 {
-            (format!("a field named `{}`", invisible_fields[0]), "is")
-        } else {
-            (
-                format!(
-                    "fields named {}",
-                    invisible_fields
-                        .iter()
-                        .map(|ident| format!("`{}`", ident))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ),
-                "are",
-            )
-        };
-        let err = struct_span_err!(
-            self.tcx.sess,
-            spans,
-            E0603,
-            "cannot match on {} of {} `{}`, which {} not accessible in current scope",
-            field_names,
-            kind_name,
-            self.tcx.def_path_str(variant.def_id),
-            t
-        );
-        err
     }
 
     fn error_inexistent_fields(

--- a/src/test/ui/structs/struct-variant-privacy-xc.rs
+++ b/src/test/ui/structs/struct-variant-privacy-xc.rs
@@ -4,8 +4,7 @@ extern crate struct_variant_privacy;
 fn f(b: struct_variant_privacy::Bar) {
     //~^ ERROR enum `Bar` is private
     match b {
-        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR cannot match on
-                                                         //~^ ERROR enum `Bar` is private
+        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.rs
+++ b/src/test/ui/structs/struct-variant-privacy-xc.rs
@@ -1,9 +1,11 @@
 // aux-build:struct_variant_privacy.rs
 extern crate struct_variant_privacy;
 
-fn f(b: struct_variant_privacy::Bar) { //~ ERROR enum `Bar` is private
+fn f(b: struct_variant_privacy::Bar) {
+    //~^ ERROR enum `Bar` is private
     match b {
-        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
+        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR cannot match on
+                                                         //~^ ERROR enum `Bar` is private
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -22,12 +22,6 @@ note: the enum `Bar` is defined here
 LL | enum Bar {
    | ^^^^^^^^
 
-error[E0603]: cannot match on a field named `a` of variant `struct_variant_privacy::Bar::Baz`, which is not accessible in current scope
-  --> $DIR/struct-variant-privacy-xc.rs:7:44
-   |
-LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
-   |                                            ^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -11,7 +11,7 @@ LL | enum Bar {
    | ^^^^^^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy-xc.rs:6:33
+  --> $DIR/struct-variant-privacy-xc.rs:7:33
    |
 LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
    |                                 ^^^ private enum
@@ -22,6 +22,12 @@ note: the enum `Bar` is defined here
 LL | enum Bar {
    | ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0603]: cannot match on a field named `a` of variant `struct_variant_privacy::Bar::Baz`, which is not accessible in current scope
+  --> $DIR/struct-variant-privacy-xc.rs:7:44
+   |
+LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
+   |                                            ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy.rs
+++ b/src/test/ui/structs/struct-variant-privacy.rs
@@ -1,12 +1,14 @@
 mod foo {
     enum Bar {
-        Baz { a: isize }
+        Baz { a: isize },
     }
 }
 
-fn f(b: foo::Bar) { //~ ERROR enum `Bar` is private
+fn f(b: foo::Bar) {
+    //~^ ERROR enum `Bar` is private
     match b {
         foo::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
+                                      //~^ ERROR cannot match on
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy.rs
+++ b/src/test/ui/structs/struct-variant-privacy.rs
@@ -8,7 +8,6 @@ fn f(b: foo::Bar) {
     //~^ ERROR enum `Bar` is private
     match b {
         foo::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
-                                      //~^ ERROR cannot match on
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -22,12 +22,6 @@ note: the enum `Bar` is defined here
 LL |     enum Bar {
    |     ^^^^^^^^
 
-error[E0603]: cannot match on a field named `a` of variant `Bar::Baz`, which is not accessible in current scope
-  --> $DIR/struct-variant-privacy.rs:10:25
-   |
-LL |         foo::Bar::Baz { a: _a } => {}
-   |                         ^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -11,7 +11,7 @@ LL |     enum Bar {
    |     ^^^^^^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy.rs:9:14
+  --> $DIR/struct-variant-privacy.rs:10:14
    |
 LL |         foo::Bar::Baz { a: _a } => {}
    |              ^^^ private enum
@@ -22,6 +22,12 @@ note: the enum `Bar` is defined here
 LL |     enum Bar {
    |     ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0603]: cannot match on a field named `a` of variant `Bar::Baz`, which is not accessible in current scope
+  --> $DIR/struct-variant-privacy.rs:10:25
+   |
+LL |         foo::Bar::Baz { a: _a } => {}
+   |                         ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/typeck/issue-82772.rs
+++ b/src/test/ui/typeck/issue-82772.rs
@@ -1,13 +1,13 @@
 // edition:2018
 
 fn main() {
-    use a::LocalModPrivateStruct;
-    let Box { 1: _, .. }: Box<()>; //~ ERROR cannot match on
-    let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
-    //~^ ERROR cannot match on
+    use a::ModPrivateStruct;
+    let Box { 0: _, .. }: Box<()>; //~ ERROR field `0` of
+    let Box { 1: _, .. }: Box<()>; //~ ERROR field `1` of
+    let ModPrivateStruct { 1: _, .. } = ModPrivateStruct::default(); //~ ERROR field `1` of
 }
 
 mod a {
     #[derive(Default)]
-    pub struct LocalModPrivateStruct(u8, u8);
+    pub struct ModPrivateStruct(u8, u8);
 }

--- a/src/test/ui/typeck/issue-82772.rs
+++ b/src/test/ui/typeck/issue-82772.rs
@@ -1,0 +1,13 @@
+// edition:2018
+
+fn main() {
+    use a::LocalModPrivateStruct;
+    let Box { 1: _, .. }: Box<()>; //~ ERROR cannot match on
+    let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
+    //~^ ERROR cannot match on
+}
+
+mod a {
+    #[derive(Default)]
+    pub struct LocalModPrivateStruct(u8, u8);
+}

--- a/src/test/ui/typeck/issue-82772.stderr
+++ b/src/test/ui/typeck/issue-82772.stderr
@@ -1,15 +1,21 @@
-error[E0603]: cannot match on a field named `1` of struct `Box`, which is not accessible in current scope
+error[E0451]: field `0` of struct `Box` is private
   --> $DIR/issue-82772.rs:5:15
    |
-LL |     let Box { 1: _, .. }: Box<()>;
-   |               ^
+LL |     let Box { 0: _, .. }: Box<()>;
+   |               ^^^^ private field
 
-error[E0603]: cannot match on a field named `1` of struct `LocalModPrivateStruct`, which is not accessible in current scope
-  --> $DIR/issue-82772.rs:6:33
+error[E0451]: field `1` of struct `Box` is private
+  --> $DIR/issue-82772.rs:6:15
    |
-LL |     let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
-   |                                 ^
+LL |     let Box { 1: _, .. }: Box<()>;
+   |               ^^^^ private field
 
-error: aborting due to 2 previous errors
+error[E0451]: field `1` of struct `ModPrivateStruct` is private
+  --> $DIR/issue-82772.rs:7:28
+   |
+LL |     let ModPrivateStruct { 1: _, .. } = ModPrivateStruct::default();
+   |                            ^^^^ private field
 
-For more information about this error, try `rustc --explain E0603`.
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/src/test/ui/typeck/issue-82772.stderr
+++ b/src/test/ui/typeck/issue-82772.stderr
@@ -1,0 +1,15 @@
+error[E0603]: cannot match on a field named `1` of struct `Box`, which is not accessible in current scope
+  --> $DIR/issue-82772.rs:5:15
+   |
+LL |     let Box { 1: _, .. }: Box<()>;
+   |               ^
+
+error[E0603]: cannot match on a field named `1` of struct `LocalModPrivateStruct`, which is not accessible in current scope
+  --> $DIR/issue-82772.rs:6:33
+   |
+LL |     let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
+   |                                 ^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0603`.


### PR DESCRIPTION
Closes #82772 
r? @estebank 

https://github.com/rust-lang/rust/pull/82789#issuecomment-796921977
> @estebank So the real cause is we only generate single pattern for Box here
https://github.com/csmoe/rust/blob/615b03aeaa8ce9819de7828740ab3cd7def4fa76/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs#L1130-L1132
But in the replacing function, it tries to index on the 1-length pattern slice with field 1, thus out of bounds.
https://github.com/csmoe/rust/blob/615b03aeaa8ce9819de7828740ab3cd7def4fa76/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs#L1346