### PR TITLE
Rename `rustdoc` to `rustdoc::all`

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -343,6 +343,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         "intra_doc_link_resolution_failure",
         "use `rustdoc::broken_intra_doc_links` instead",
     );
+    store.register_removed("rustdoc", "use `rustdoc::all` instead");
 
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -175,8 +175,8 @@ crate fn register_lints(_sess: &Session, lint_store: &mut LintStore) {
     lint_store.register_lints(&**RUSTDOC_LINTS);
     lint_store.register_group(
         true,
-        "rustdoc",
-        None,
+        "rustdoc::all",
+        Some("rustdoc"),
         RUSTDOC_LINTS.iter().map(|&lint| LintId::of(lint)).collect(),
     );
     for lint in &*RUSTDOC_LINTS {

--- a/src/test/rustdoc-ui/check-fail.rs
+++ b/src/test/rustdoc-ui/check-fail.rs
@@ -1,7 +1,7 @@
 // compile-flags: -Z unstable-options --check
 
 #![deny(missing_docs)]
-#![deny(rustdoc)]
+#![deny(rustdoc::all)]
 
 //! ```rust,testharness
 //~^ ERROR

--- a/src/test/rustdoc-ui/check-fail.stderr
+++ b/src/test/rustdoc-ui/check-fail.stderr
@@ -19,9 +19,9 @@ LL | pub fn foo() {}
 note: the lint level is defined here
   --> $DIR/check-fail.rs:4:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?
   --> $DIR/check-fail.rs:6:1
@@ -35,9 +35,9 @@ LL | | //! ```
 note: the lint level is defined here
   --> $DIR/check-fail.rs:4:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc::all)]`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?

--- a/src/test/rustdoc-ui/check.rs
+++ b/src/test/rustdoc-ui/check.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs)]
 //~^ WARN
 //~^^ WARN
-#![warn(rustdoc)]
+#![warn(rustdoc::all)]
 
 pub fn foo() {}
 //~^ WARN

--- a/src/test/rustdoc-ui/check.stderr
+++ b/src/test/rustdoc-ui/check.stderr
@@ -4,7 +4,7 @@ warning: missing documentation for the crate
 LL | / #![warn(missing_docs)]
 LL | |
 LL | |
-LL | | #![warn(rustdoc)]
+LL | | #![warn(rustdoc::all)]
 LL | |
 LL | | pub fn foo() {}
    | |_______________^
@@ -26,9 +26,9 @@ warning: no documentation found for this crate's top-level module
 note: the lint level is defined here
   --> $DIR/check.rs:7:9
    |
-LL | #![warn(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[warn(rustdoc::missing_crate_level_docs)]` implied by `#[warn(rustdoc)]`
+LL | #![warn(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[warn(rustdoc::missing_crate_level_docs)]` implied by `#[warn(rustdoc::all)]`
    = help: The following guide may be of use:
            https://doc.rust-lang.org/nightly/rustdoc/how-to-write-documentation.html
 
@@ -38,7 +38,7 @@ warning: missing code example in this documentation
 LL | / #![warn(missing_docs)]
 LL | |
 LL | |
-LL | | #![warn(rustdoc)]
+LL | | #![warn(rustdoc::all)]
 LL | |
 LL | | pub fn foo() {}
    | |_______________^
@@ -46,9 +46,9 @@ LL | | pub fn foo() {}
 note: the lint level is defined here
   --> $DIR/check.rs:7:9
    |
-LL | #![warn(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[warn(rustdoc::missing_doc_code_examples)]` implied by `#[warn(rustdoc)]`
+LL | #![warn(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[warn(rustdoc::missing_doc_code_examples)]` implied by `#[warn(rustdoc::all)]`
 
 warning: missing code example in this documentation
   --> $DIR/check.rs:9:1

--- a/src/test/rustdoc-ui/lint-group.rs
+++ b/src/test/rustdoc-ui/lint-group.rs
@@ -4,7 +4,7 @@
 //! println!("sup");
 //! ```
 
-#![deny(rustdoc)]
+#![deny(rustdoc::all)]
 
 /// what up, let's make an [error]
 ///

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -7,9 +7,9 @@ LL | /// wait, this doesn't have a doctest?
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
 
 error: documentation test in private item
   --> $DIR/lint-group.rs:19:1
@@ -24,9 +24,9 @@ LL | | /// ```
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::private_doc_tests)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::private_doc_tests)]` implied by `#[deny(rustdoc::all)]`
 
 error: missing code example in this documentation
   --> $DIR/lint-group.rs:26:1
@@ -43,9 +43,9 @@ LL | /// what up, let's make an [error]
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc::all)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unclosed HTML tag `unknown`
@@ -57,9 +57,9 @@ LL | /// <unknown>
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc::all)]`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/rustdoc-ui/unknown-renamed-lints.rs
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.rs
@@ -12,6 +12,9 @@
 #![deny(non_autolinks)]
 //~^ ERROR renamed to `rustdoc::non_autolinks`
 
+#![deny(rustdoc)]
+//~^ ERROR removed: use `rustdoc::all` instead
+
 // Explicitly don't try to handle this case, it was never valid
 #![deny(rustdoc::intra_doc_link_resolution_failure)]
 //~^ ERROR unknown lint

--- a/src/test/rustdoc-ui/unknown-renamed-lints.stderr
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.stderr
@@ -34,13 +34,19 @@ error: lint `non_autolinks` has been renamed to `rustdoc::non_autolinks`
 LL | #![deny(non_autolinks)]
    |         ^^^^^^^^^^^^^ help: use the new name: `rustdoc::non_autolinks`
 
+error: lint `rustdoc` has been removed: use `rustdoc::all` instead
+  --> $DIR/unknown-renamed-lints.rs:15:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+
 error: unknown lint: `rustdoc::intra_doc_link_resolution_failure`
-  --> $DIR/unknown-renamed-lints.rs:16:9
+  --> $DIR/unknown-renamed-lints.rs:19:9
    |
 LL | #![deny(rustdoc::intra_doc_link_resolution_failure)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Compilation failed, aborting rustdoc
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/lint/rustdoc-group.rs
+++ b/src/test/ui/lint/rustdoc-group.rs
@@ -1,0 +1,5 @@
+// check-pass
+// compile-flags: --crate-type lib
+#![deny(rustdoc)]
+//~^ WARNING removed: use `rustdoc::all`
+#![deny(rustdoc::all)] // has no effect when run with rustc directly

--- a/src/test/ui/lint/rustdoc-group.stderr
+++ b/src/test/ui/lint/rustdoc-group.stderr
@@ -1,0 +1,10 @@
+warning: lint `rustdoc` has been removed: use `rustdoc::all` instead
+  --> $DIR/rustdoc-group.rs:3:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+   |
+   = note: `#[warn(renamed_and_removed_lints)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
When rustdoc lints were changed to be tool lints, the `rustdoc` group was removed, leading to spurious warnings like

```
warning: unknown lint: `rustdoc`
```

The lint group still worked when rustdoc ran, since rustdoc added the group itself.

This renames the group to `rustdoc::all` for consistency with `clippy::all` and the rest of the rustdoc lints.

Follow-up to #80527.
r? @Manishearth 