### PR TITLE
Build rustdoc for run-make tests, not just run-make-fulldeps

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1076,7 +1076,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         // Avoid depending on rustdoc when we don't need it.
         if mode == "rustdoc"
-            || (mode == "run-make" && suite.ends_with("fulldeps"))
+            || mode == "run-make"
             || (mode == "ui" && is_rustdoc)
             || mode == "js-doc-test"
             || mode == "rustdoc-json"


### PR DESCRIPTION
Rustdoc almost never needs a full stage 2 compiler, and requiring
rustdoc tests to be in run-make-fulldeps adds a lot of compile time for
no reason.

This is the same change from https://github.com/rust-lang/rust/pull/81197, but separated into its own PR. I ran into this again today while working on https://github.com/rust-lang/docs.rs/issues/1302.
r? @Mark-Simulacrum 