### PR TITLE
rustdoc: Add an unstable option to print all unversioned files

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1612,24 +1612,6 @@ impl PrimitiveType {
         CELL.get_or_init(move || {
             use self::PrimitiveType::*;
 
-            /// A macro to create a FxHashMap.
-            ///
-            /// Example:
-            ///
-            /// ```
-            /// let letters = map!{"a" => "b", "c" => "d"};
-            /// ```
-            ///
-            /// Trailing commas are allowed.
-            /// Commas between elements are required (even if the expression is a block).
-            macro_rules! map {
-                ($( $key: expr => $val: expr ),* $(,)*) => {{
-                    let mut map = ::rustc_data_structures::fx::FxHashMap::default();
-                    $( map.insert($key, $val); )*
-                    map
-                }}
-            }
-
             let single = |a: Option<DefId>| a.into_iter().collect();
             let both = |a: Option<DefId>, b: Option<DefId>| -> ArrayVec<_> {
                 a.into_iter().chain(b).collect()

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -315,6 +315,13 @@ impl Options {
             return Err(0);
         }
 
+        if matches.opt_strs("print").iter().any(|opt| opt == "unversioned-files") {
+            for file in crate::html::render::FILES_UNVERSIONED.keys() {
+                println!("{}", file);
+            }
+            return Err(0);
+        }
+
         let color = config::parse_color(&matches);
         let (json_rendered, _artifacts) = config::parse_json(&matches);
         let error_format = config::parse_error_format(&matches, color, json_rendered);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -33,6 +33,7 @@ mod print_item;
 mod write_shared;
 
 crate use context::*;
+crate use write_shared::FILES_UNVERSIONED;
 
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -4,6 +4,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::path::{Component, Path, PathBuf};
+use std::lazy::SyncLazy as Lazy;
 
 use itertools::Itertools;
 use rustc_data_structures::flock;
@@ -212,21 +213,26 @@ themePicker.onblur = handleThemeButtonsBlur;
         static_files::NORMALIZE_CSS,
         options.enable_minification,
     )?;
-    write(cx.dst.join("FiraSans-Regular.woff2"), static_files::fira_sans::REGULAR2)?;
-    write(cx.dst.join("FiraSans-Medium.woff2"), static_files::fira_sans::MEDIUM2)?;
-    write(cx.dst.join("FiraSans-Regular.woff"), static_files::fira_sans::REGULAR)?;
-    write(cx.dst.join("FiraSans-Medium.woff"), static_files::fira_sans::MEDIUM)?;
-    write(cx.dst.join("FiraSans-LICENSE.txt"), static_files::fira_sans::LICENSE)?;
-    write(cx.dst.join("SourceSerifPro-Regular.ttf.woff"), static_files::source_serif_pro::REGULAR)?;
-    write(cx.dst.join("SourceSerifPro-Bold.ttf.woff"), static_files::source_serif_pro::BOLD)?;
-    write(cx.dst.join("SourceSerifPro-It.ttf.woff"), static_files::source_serif_pro::ITALIC)?;
-    write(cx.dst.join("SourceSerifPro-LICENSE.md"), static_files::source_serif_pro::LICENSE)?;
-    write(cx.dst.join("SourceCodePro-Regular.woff"), static_files::source_code_pro::REGULAR)?;
-    write(cx.dst.join("SourceCodePro-Semibold.woff"), static_files::source_code_pro::SEMIBOLD)?;
-    write(cx.dst.join("SourceCodePro-LICENSE.txt"), static_files::source_code_pro::LICENSE)?;
-    write(cx.dst.join("LICENSE-MIT.txt"), static_files::LICENSE_MIT)?;
-    write(cx.dst.join("LICENSE-APACHE.txt"), static_files::LICENSE_APACHE)?;
-    write(cx.dst.join("COPYRIGHT.txt"), static_files::COPYRIGHT)?;
+    static FILES_UNVERSIONED: Lazy<FxHashMap<&str, &[u8]>> = Lazy::new(|| map! {
+        "FiraSans-Regular.woff2" => static_files::fira_sans::REGULAR2,
+        "FiraSans-Medium.woff2" => static_files::fira_sans::MEDIUM2,
+        "FiraSans-Regular.woff" => static_files::fira_sans::REGULAR,
+        "FiraSans-Medium.woff" => static_files::fira_sans::MEDIUM,
+        "FiraSans-LICENSE.txt" => static_files::fira_sans::LICENSE,
+        "SourceSerifPro-Regular.ttf.woff" => static_files::source_serif_pro::REGULAR,
+        "SourceSerifPro-Bold.ttf.woff" => static_files::source_serif_pro::BOLD,
+        "SourceSerifPro-It.ttf.woff" => static_files::source_serif_pro::ITALIC,
+        "SourceSerifPro-LICENSE.md" => static_files::source_serif_pro::LICENSE,
+        "SourceCodePro-Regular.woff" => static_files::source_code_pro::REGULAR,
+        "SourceCodePro-Semibold.woff" => static_files::source_code_pro::SEMIBOLD,
+        "SourceCodePro-LICENSE.txt" => static_files::source_code_pro::LICENSE,
+        "LICENSE-MIT.txt" => static_files::LICENSE_MIT,
+        "LICENSE-APACHE.txt" => static_files::LICENSE_APACHE,
+        "COPYRIGHT.txt" => static_files::COPYRIGHT,
+    });
+    for (file, contents) in &*FILES_UNVERSIONED {
+        write(cx.dst.join(file), contents)?;
+    }
 
     fn collect(path: &Path, krate: &str, key: &str) -> io::Result<(Vec<String>, Vec<String>)> {
         let mut ret = Vec::new();

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -3,8 +3,8 @@ use std::fmt::Write;
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io::{self, BufReader};
-use std::path::{Component, Path, PathBuf};
 use std::lazy::SyncLazy as Lazy;
+use std::path::{Component, Path, PathBuf};
 
 use itertools::Itertools;
 use rustc_data_structures::flock;
@@ -18,6 +18,26 @@ use crate::docfs::{DocFS, PathError};
 use crate::error::Error;
 use crate::formats::FormatRenderer;
 use crate::html::{layout, static_files};
+
+crate static FILES_UNVERSIONED: Lazy<FxHashMap<&str, &[u8]>> = Lazy::new(|| {
+    map! {
+        "FiraSans-Regular.woff2" => static_files::fira_sans::REGULAR2,
+        "FiraSans-Medium.woff2" => static_files::fira_sans::MEDIUM2,
+        "FiraSans-Regular.woff" => static_files::fira_sans::REGULAR,
+        "FiraSans-Medium.woff" => static_files::fira_sans::MEDIUM,
+        "FiraSans-LICENSE.txt" => static_files::fira_sans::LICENSE,
+        "SourceSerifPro-Regular.ttf.woff" => static_files::source_serif_pro::REGULAR,
+        "SourceSerifPro-Bold.ttf.woff" => static_files::source_serif_pro::BOLD,
+        "SourceSerifPro-It.ttf.woff" => static_files::source_serif_pro::ITALIC,
+        "SourceSerifPro-LICENSE.md" => static_files::source_serif_pro::LICENSE,
+        "SourceCodePro-Regular.woff" => static_files::source_code_pro::REGULAR,
+        "SourceCodePro-Semibold.woff" => static_files::source_code_pro::SEMIBOLD,
+        "SourceCodePro-LICENSE.txt" => static_files::source_code_pro::LICENSE,
+        "LICENSE-MIT.txt" => static_files::LICENSE_MIT,
+        "LICENSE-APACHE.txt" => static_files::LICENSE_APACHE,
+        "COPYRIGHT.txt" => static_files::COPYRIGHT,
+    }
+});
 
 pub(super) fn write_shared(
     cx: &Context<'_>,
@@ -213,23 +233,6 @@ themePicker.onblur = handleThemeButtonsBlur;
         static_files::NORMALIZE_CSS,
         options.enable_minification,
     )?;
-    static FILES_UNVERSIONED: Lazy<FxHashMap<&str, &[u8]>> = Lazy::new(|| map! {
-        "FiraSans-Regular.woff2" => static_files::fira_sans::REGULAR2,
-        "FiraSans-Medium.woff2" => static_files::fira_sans::MEDIUM2,
-        "FiraSans-Regular.woff" => static_files::fira_sans::REGULAR,
-        "FiraSans-Medium.woff" => static_files::fira_sans::MEDIUM,
-        "FiraSans-LICENSE.txt" => static_files::fira_sans::LICENSE,
-        "SourceSerifPro-Regular.ttf.woff" => static_files::source_serif_pro::REGULAR,
-        "SourceSerifPro-Bold.ttf.woff" => static_files::source_serif_pro::BOLD,
-        "SourceSerifPro-It.ttf.woff" => static_files::source_serif_pro::ITALIC,
-        "SourceSerifPro-LICENSE.md" => static_files::source_serif_pro::LICENSE,
-        "SourceCodePro-Regular.woff" => static_files::source_code_pro::REGULAR,
-        "SourceCodePro-Semibold.woff" => static_files::source_code_pro::SEMIBOLD,
-        "SourceCodePro-LICENSE.txt" => static_files::source_code_pro::LICENSE,
-        "LICENSE-MIT.txt" => static_files::LICENSE_MIT,
-        "LICENSE-APACHE.txt" => static_files::LICENSE_APACHE,
-        "COPYRIGHT.txt" => static_files::COPYRIGHT,
-    });
     for (file, contents) in &*FILES_UNVERSIONED {
         write(cx.dst.join(file), contents)?;
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -524,6 +524,9 @@ fn opts() -> Vec<RustcOptGroup> {
                 "Generate JSON file at the top level instead of generating HTML redirection files",
             )
         }),
+        unstable("print", |o| {
+            o.optmulti("", "print", "Rustdoc information to print on stdout", "[unversioned-files]")
+        }),
     ]
 }
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -71,6 +71,24 @@ use rustc_session::config::{make_crate_type_option, ErrorOutputType, RustcOptGro
 use rustc_session::getopts;
 use rustc_session::{early_error, early_warn};
 
+/// A macro to create a FxHashMap.
+///
+/// Example:
+///
+/// ```
+/// let letters = map!{"a" => "b", "c" => "d"};
+/// ```
+///
+/// Trailing commas are allowed.
+/// Commas between elements are required (even if the expression is a block).
+macro_rules! map {
+    ($( $key: expr => $val: expr ),* $(,)*) => {{
+        let mut map = ::rustc_data_structures::fx::FxHashMap::default();
+        $( map.insert($key, $val); )*
+        map
+    }}
+}
+
 #[macro_use]
 mod externalfiles;
 

--- a/src/test/run-make-fulldeps/print-unversioned-files/Makefile
+++ b/src/test/run-make-fulldeps/print-unversioned-files/Makefile
@@ -1,0 +1,4 @@
+-include ../tools.mk
+
+all:
+	$(RUSTDOC) -Z unstable-options --print unversioned-files | sort | diff - unversioned-files.txt

--- a/src/test/run-make-fulldeps/print-unversioned-files/unversioned-files.txt
+++ b/src/test/run-make-fulldeps/print-unversioned-files/unversioned-files.txt
@@ -1,0 +1,15 @@
+COPYRIGHT.txt
+FiraSans-LICENSE.txt
+FiraSans-Medium.woff
+FiraSans-Medium.woff2
+FiraSans-Regular.woff
+FiraSans-Regular.woff2
+LICENSE-APACHE.txt
+LICENSE-MIT.txt
+SourceCodePro-LICENSE.txt
+SourceCodePro-Regular.woff
+SourceCodePro-Semibold.woff
+SourceSerifPro-Bold.ttf.woff
+SourceSerifPro-It.ttf.woff
+SourceSerifPro-LICENSE.md
+SourceSerifPro-Regular.ttf.woff


### PR DESCRIPTION
This allows sharing those files between different doc invocations
without having to know their names ahead of time.

Helps with https://github.com/rust-lang/docs.rs/issues/1302.
r? @GuillaumeGomez cc @pietroalbini @Nemo157