### PR TITLE
rustdoc: CSS: show the `<details>` "triangle" in all cases

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -148,6 +148,7 @@ p {
 }
 
 summary {
+	display: list-item;
 	outline: none;
 }
 
@@ -832,10 +833,6 @@ body.blur > :not(#help) {
 }
 .stab p {
 	display: inline;
-}
-
-.stab summary {
-	display: list-item;
 }
 
 .stab .emoji {


### PR DESCRIPTION
Currently we use `<details>` and `<summary>` for the unstable
info box, under class `.stab`. However, they can also be useful
to add detailed documentation like lengthy detailed examples
that would be too much to show by default, e.g.:

    /// <details><summary>Time-threads diagram</summary>
    ///
    /// ```text
    /// // Thread 1             |  // Thread 2
    /// let _rg = lock.read();  |
    ///                         |  // will block
    ///                         |  let _wg = lock.write();
    /// // may deadlock         |
    /// let _rg = lock.read();  |
    /// ```
    /// </details>

See https://github.com/rust-lang/rust/pull/82624 for an example
where we could use this functionality.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>