### PR TITLE
rustdoc: Remove redundant enableSearchInput function

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2208,7 +2208,7 @@ function defocusSearchBar() {
             return "+";
         }
         // button will collapse the section
-        // note that this text is also set in the HTML template in render.rs
+        // note that this text is also set in the HTML template in ../render/mod.rs
         return "\u2212"; // "\u2212" is "−" minus sign
     }
 
@@ -2851,17 +2851,10 @@ function defocusSearchBar() {
         });
     }
 
-    function enableSearchInput() {
-        if (search_input) {
-            search_input.removeAttribute('disabled');
-        }
-    }
-
     function addSearchOptions(crates) {
         var elem = document.getElementById("crate-search");
 
         if (!elem) {
-            enableSearchInput();
             return;
         }
         var savedCrate = getSettingValue("saved-filter-crate");
@@ -2880,7 +2873,6 @@ function defocusSearchBar() {
                 elem.value = savedCrate;
             }
         }
-        enableSearchInput();
     };
 
     function buildHelperPopup() {
@@ -2972,7 +2964,7 @@ function defocusSearchBar() {
         search_input.addEventListener("blur", function() {
             search_input.placeholder = search_input.origPlaceholder;
         });
-        enableSearchInput();
+        search_input.removeAttribute('disabled');
 
         var crateSearchDropDown = document.getElementById("crate-search");
         crateSearchDropDown.addEventListener("focus", loadSearch);


### PR DESCRIPTION
enableSearchInput was called from two places:

- setupSearchLoader
- addSearchOptions, which is itself called from setupSearchLoader only

This commit can safely get rid of the addSearchOptions calls entirely, and since the setupSearchLoader call is immediately preceded by other method calls on search_input, there's no need to check if it's set.