### PR TITLE
rustdoc: Use substrings instead of split to grab enum variant paths

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1548,9 +1548,9 @@ function defocusSearchBar() {
                 } else if (type === "structfield" && parentType === "variant") {
                     // Structfields belonging to variants are special: the
                     // final path element is the enum name.
-                    var splitPath = item.path.split("::");
-                    var enumName = splitPath.pop();
-                    path = splitPath.join("::");
+                    var enumNameIdx = item.path.lastIndexOf("::");
+                    var enumName = item.path.substr(enumNameIdx + 2);
+                    path = item.path.substr(0, enumNameIdx);
                     displayPath = path + "::" + enumName + "::" + myparent.name + "::";
                     anchor = "#variant." + myparent.name + ".field." + name;
                     pageType = "enum";


### PR DESCRIPTION
Both versions are about equally readable, but this version avoids scanning the entire path and building an intermediate array (`split()` in Rust is a lazy iterator, but not in JavaScript).