### PR TITLE
Allow rustdoc to handle asm! of foreign architectures

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -528,6 +528,7 @@ fn reg_to_llvm(reg: InlineAsmRegOrRegClass, layout: Option<&TyAndLayout<'tcx>>) 
             InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
                 bug!("LLVM backend does not support SPIR-V")
             }
+            InlineAsmRegClass::Err => unreachable!(),
         }
         .to_string(),
     }
@@ -594,6 +595,7 @@ fn modifier_to_llvm(
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
+        InlineAsmRegClass::Err => unreachable!(),
     }
 }
 
@@ -637,6 +639,7 @@ fn dummy_output_type(cx: &CodegenCx<'ll, 'tcx>, reg: InlineAsmRegClass) -> &'ll 
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
+        InlineAsmRegClass::Err => unreachable!(),
     }
 }
 

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -229,6 +229,8 @@ pub enum InlineAsmReg {
     Mips(MipsInlineAsmReg),
     SpirV(SpirVInlineAsmReg),
     Wasm(WasmInlineAsmReg),
+    // Placeholder for invalid register constraints for the current target
+    Err,
 }
 
 impl InlineAsmReg {
@@ -240,6 +242,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => r.name(),
             Self::Hexagon(r) => r.name(),
             Self::Mips(r) => r.name(),
+            Self::Err => "<reg>",
         }
     }
 
@@ -251,6 +254,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => InlineAsmRegClass::RiscV(r.reg_class()),
             Self::Hexagon(r) => InlineAsmRegClass::Hexagon(r.reg_class()),
             Self::Mips(r) => InlineAsmRegClass::Mips(r.reg_class()),
+            Self::Err => InlineAsmRegClass::Err,
         }
     }
 
@@ -309,6 +313,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => r.emit(out, arch, modifier),
             Self::Hexagon(r) => r.emit(out, arch, modifier),
             Self::Mips(r) => r.emit(out, arch, modifier),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -320,6 +325,7 @@ impl InlineAsmReg {
             Self::RiscV(_) => cb(self),
             Self::Hexagon(r) => r.overlapping_regs(|r| cb(Self::Hexagon(r))),
             Self::Mips(_) => cb(self),
+            Self::Err => unreachable!(),
         }
     }
 }
@@ -346,6 +352,8 @@ pub enum InlineAsmRegClass {
     Mips(MipsInlineAsmRegClass),
     SpirV(SpirVInlineAsmRegClass),
     Wasm(WasmInlineAsmRegClass),
+    // Placeholder for invalid register constraints for the current target
+    Err,
 }
 
 impl InlineAsmRegClass {
@@ -360,6 +368,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.name(),
             Self::SpirV(r) => r.name(),
             Self::Wasm(r) => r.name(),
+            Self::Err => rustc_span::symbol::sym::reg,
         }
     }
 
@@ -377,6 +386,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Mips),
             Self::SpirV(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::SpirV),
             Self::Wasm(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Wasm),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -401,6 +411,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_modifier(arch, ty),
             Self::SpirV(r) => r.suggest_modifier(arch, ty),
             Self::Wasm(r) => r.suggest_modifier(arch, ty),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -421,6 +432,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.default_modifier(arch),
             Self::SpirV(r) => r.default_modifier(arch),
             Self::Wasm(r) => r.default_modifier(arch),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -440,6 +452,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.supported_types(arch),
             Self::SpirV(r) => r.supported_types(arch),
             Self::Wasm(r) => r.supported_types(arch),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -476,6 +489,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.valid_modifiers(arch),
             Self::SpirV(r) => r.valid_modifiers(arch),
             Self::Wasm(r) => r.valid_modifiers(arch),
+            Self::Err => unreachable!(),
         }
     }
 }

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -313,7 +313,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => r.emit(out, arch, modifier),
             Self::Hexagon(r) => r.emit(out, arch, modifier),
             Self::Mips(r) => r.emit(out, arch, modifier),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
     }
 
@@ -325,7 +325,7 @@ impl InlineAsmReg {
             Self::RiscV(_) => cb(self),
             Self::Hexagon(r) => r.overlapping_regs(|r| cb(Self::Hexagon(r))),
             Self::Mips(_) => cb(self),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
     }
 }
@@ -386,7 +386,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Mips),
             Self::SpirV(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::SpirV),
             Self::Wasm(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Wasm),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -411,7 +411,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_modifier(arch, ty),
             Self::SpirV(r) => r.suggest_modifier(arch, ty),
             Self::Wasm(r) => r.suggest_modifier(arch, ty),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -432,7 +432,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.default_modifier(arch),
             Self::SpirV(r) => r.default_modifier(arch),
             Self::Wasm(r) => r.default_modifier(arch),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -452,7 +452,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.supported_types(arch),
             Self::SpirV(r) => r.supported_types(arch),
             Self::Wasm(r) => r.supported_types(arch),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -489,7 +489,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.valid_modifiers(arch),
             Self::SpirV(r) => r.valid_modifiers(arch),
             Self::Wasm(r) => r.valid_modifiers(arch),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 }

--- a/src/test/rustdoc-ui/asm-foreign.rs
+++ b/src/test/rustdoc-ui/asm-foreign.rs
@@ -1,0 +1,19 @@
+// check-pass
+// Make sure rustdoc accepts asm! for a foreign architecture.
+
+#![feature(asm)]
+
+pub unsafe fn aarch64(a: f64, b: f64) {
+    let c;
+    asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+        || {};
+        b
+    });
+    c
+}
+
+pub unsafe fn x86(a: f64, b: f64) {
+    let c;
+    asm!("addsd {}, {}, xmm0", out(xmm_reg) c, in(xmm_reg) a, in("xmm0") b);
+    c
+}

--- a/src/test/rustdoc/asm-foreign.rs
+++ b/src/test/rustdoc/asm-foreign.rs
@@ -1,9 +1,9 @@
-// check-pass
 // Make sure rustdoc accepts asm! for a foreign architecture.
 
 #![feature(asm)]
 
-pub unsafe fn aarch64(a: f64, b: f64) {
+// @has asm_foreign/fn.aarch64.html
+pub unsafe fn aarch64(a: f64, b: f64) -> f64 {
     let c;
     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
         || {};
@@ -12,7 +12,8 @@ pub unsafe fn aarch64(a: f64, b: f64) {
     c
 }
 
-pub unsafe fn x86(a: f64, b: f64) {
+// @has asm_foreign/fn.x86.html
+pub unsafe fn x86(a: f64, b: f64) -> f64 {
     let c;
     asm!("addsd {}, {}, xmm0", out(xmm_reg) c, in(xmm_reg) a, in("xmm0") b);
     c

--- a/src/test/rustdoc/asm-foreign2.rs
+++ b/src/test/rustdoc/asm-foreign2.rs
@@ -1,0 +1,11 @@
+// only-aarch64
+// Make sure rustdoc accepts options(att_syntax) asm! on non-x86 targets.
+
+#![feature(asm)]
+
+// @has asm_foreign2/fn.x86.html
+pub unsafe fn x86(x: i64) -> i64 {
+    let y;
+    asm!("movq {}, {}", in(reg) x, out(reg) y, options(att_syntax));
+    y
+}

--- a/src/test/ui/issues/issue-82869.rs
+++ b/src/test/ui/issues/issue-82869.rs
@@ -1,0 +1,23 @@
+// only-x86_64
+// Make sure rustc doesn't ICE on asm! for a foreign architecture.
+
+#![feature(asm)]
+#![crate_type = "rlib"]
+
+pub unsafe fn aarch64(a: f64, b: f64) -> f64 {
+    let c;
+    asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+        || {};
+        b
+    });
+    //~^^^^ invalid register class
+    //~^^^^^ invalid register class
+    //~^^^^^^ invalid register
+    c
+}
+
+pub unsafe fn x86(a: f64, b: f64) -> f64 {
+    let c;
+    asm!("addsd {}, {}, xmm0", out(xmm_reg) c, in(xmm_reg) a, in("xmm0") b);
+    c
+}

--- a/src/test/ui/issues/issue-82869.stderr
+++ b/src/test/ui/issues/issue-82869.stderr
@@ -1,0 +1,24 @@
+error: invalid register class `vreg`: unknown register class
+  --> $DIR/issue-82869.rs:9:32
+   |
+LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+   |                                ^^^^^^^^^^^
+
+error: invalid register class `vreg`: unknown register class
+  --> $DIR/issue-82869.rs:9:45
+   |
+LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+   |                                             ^^^^^^^^^^
+
+error: invalid register `d0`: unknown register
+  --> $DIR/issue-82869.rs:9:57
+   |
+LL |       asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+   |  _________________________________________________________^
+LL | |         || {};
+LL | |         b
+LL | |     });
+   | |_____^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This allows rustdoc to process code containing `asm!` for architectures other than the current one. Since this never reaches codegen, we just replace target-specific registers and register classes with a dummy one.

Fixes #82869