### PR TITLE
Implement a conversion from &'a Cow<[u8]> to IoSlice<'a>

### DIFF
--- a/library/std/src/io/buffered/tests.rs
+++ b/library/std/src/io/buffered/tests.rs
@@ -1,3 +1,4 @@
+use crate::borrow::Cow;
 use crate::io::prelude::*;
 use crate::io::{self, BufReader, BufWriter, ErrorKind, IoSlice, LineWriter, SeekFrom};
 use crate::panic;
@@ -967,4 +968,26 @@ fn single_formatted_write() {
     // have this limitation.
     writeln!(&mut writer, "{}, {}!", "hello", "world").unwrap();
     assert_eq!(writer.get_ref().events, [RecordedEvent::Write("hello, world!\n".to_string())]);
+}
+
+/// Test that IoSlice can be constructed from borrowed and owned Cows.
+#[test]
+fn ioslice_from_cow() {
+    let writer = ProgrammableSink::default();
+    let mut writer = LineWriter::new(writer);
+
+    fn write_vectored<'a, T: Into<IoSlice<'a>>, W: Write>(writer: &mut LineWriter<W>, content: T) -> usize {
+        writer.write_vectored(&[content.into()]).unwrap()
+    }
+
+    let content: &[u8] = b"Hello\n";
+    let content = Cow::Borrowed(content);
+    let content2 = Cow::Owned(b"World\n".to_vec());
+
+    let count = write_vectored(&mut writer, &content);
+    assert_eq!(count, 6);
+    assert_eq!(&writer.get_ref().buffer, b"Hello\n");
+    let count = write_vectored(&mut writer, &content2);
+    assert_eq!(count, 6);
+    assert_eq!(&writer.get_ref().buffer, b"Hello\nWorld\n");
 }

--- a/library/std/src/io/buffered/tests.rs
+++ b/library/std/src/io/buffered/tests.rs
@@ -976,7 +976,10 @@ fn ioslice_from_cow() {
     let writer = ProgrammableSink::default();
     let mut writer = LineWriter::new(writer);
 
-    fn write_vectored<'a, T: Into<IoSlice<'a>>, W: Write>(writer: &mut LineWriter<W>, content: T) -> usize {
+    fn write_vectored<'a, T: Into<IoSlice<'a>>, W: Write>(
+        writer: &mut LineWriter<W>,
+        content: T,
+    ) -> usize {
         writer.write_vectored(&[content.into()]).unwrap()
     }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -251,6 +251,7 @@
 #[cfg(test)]
 mod tests;
 
+use crate::borrow::{Borrow, Cow};
 use crate::cmp;
 use crate::fmt;
 use crate::memchr;
@@ -1208,6 +1209,13 @@ impl<'a> Deref for IoSlice<'a> {
     #[inline]
     fn deref(&self) -> &[u8] {
         self.0.as_slice()
+    }
+}
+
+#[stable(feature = "ioslice_from_cow_u8", since = "1.52.0")]
+impl<'a> From<&'a Cow<'_, [u8]>> for IoSlice<'a> {
+    fn from(buf: &'a Cow<'_, [u8]>) -> IoSlice<'a> {
+        IoSlice::new(buf.borrow())
     }
 }
 


### PR DESCRIPTION
Note that this has to take a reference to a `Cow` because `IoSlice` cannot take ownership of a `Cow::Owned`.

Fixes #72519