### PR TITLE
rustdoc: allow list syntax for #[doc(alias)] attributes

### DIFF
--- a/src/doc/rustdoc/src/advanced-features.md
+++ b/src/doc/rustdoc/src/advanced-features.md
@@ -81,3 +81,10 @@ Then, when looking for it through the `rustdoc` search, if you enter "x" or
 "big", search will show the `BigX` struct first.
 
 There are some limitations on the doc alias names though: you can't use `"` or whitespace.
+
+You can add multiple aliases at the same time by using a list:
+
+```rust,no_run
+#[doc(alias("x", "big"))]
+pub struct BigX;
+```

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -911,24 +911,23 @@ impl Attributes {
     }
 
     crate fn get_doc_aliases(&self) -> FxHashSet<String> {
-        self.other_attrs
-            .lists(sym::doc)
-            .filter(|a| a.has_name(sym::alias))
-            .map(|a| {
-                if let Some(values) = a.meta_item_list() {
-                    values
-                        .iter()
-                        .map(|l| match l.literal().unwrap().kind {
-                            ast::LitKind::Str(s, _) => s.as_str().to_string(),
-                            _ => unreachable!(),
-                        })
-                        .collect::<Vec<_>>()
-                } else {
-                    vec![a.value_str().map(|s| s.to_string()).unwrap()]
+        let mut aliases = FxHashSet::default();
+
+        for attr in self.other_attrs.lists(sym::doc).filter(|a| a.has_name(sym::alias)) {
+            if let Some(values) = attr.meta_item_list() {
+                for l in values {
+                    match l.literal().unwrap().kind {
+                        ast::LitKind::Str(s, _) => {
+                            aliases.insert(s.as_str().to_string());
+                        }
+                        _ => unreachable!(),
+                    }
                 }
-            })
-            .flatten()
-            .collect::<FxHashSet<_>>()
+            } else {
+                aliases.insert(attr.value_str().map(|s| s.to_string()).unwrap());
+            }
+        }
+        aliases
     }
 }
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -914,8 +914,20 @@ impl Attributes {
         self.other_attrs
             .lists(sym::doc)
             .filter(|a| a.has_name(sym::alias))
-            .filter_map(|a| a.value_str().map(|s| s.to_string()))
-            .filter(|v| !v.is_empty())
+            .map(|a| {
+                if let Some(values) = a.meta_item_list() {
+                    values
+                        .iter()
+                        .map(|l| match l.literal().unwrap().kind {
+                            ast::LitKind::Str(s, _) => s.as_str().to_string(),
+                            _ => unreachable!(),
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    vec![a.value_str().map(|s| s.to_string()).unwrap()]
+                }
+            })
+            .flatten()
             .collect::<FxHashSet<_>>()
     }
 }

--- a/src/test/rustdoc-ui/check-doc-alias-attr.rs
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.rs
@@ -1,11 +1,11 @@
 #![crate_type = "lib"]
 
 #[doc(alias = "foo")] // ok!
+#[doc(alias("bar", "baz"))] // ok!
 pub struct Bar;
 
 #[doc(alias)] //~ ERROR
 #[doc(alias = 0)] //~ ERROR
-#[doc(alias("bar"))] //~ ERROR
 #[doc(alias = "\"")] //~ ERROR
 #[doc(alias = "\n")] //~ ERROR
 #[doc(alias = "
@@ -13,4 +13,16 @@ pub struct Bar;
 #[doc(alias = "\t")] //~ ERROR
 #[doc(alias = " hello")] //~ ERROR
 #[doc(alias = "hello ")] //~ ERROR
+#[doc(alias = "")] //~ ERROR
 pub struct Foo;
+
+#[doc(alias(0))] //~ ERROR
+#[doc(alias("\""))] //~ ERROR
+#[doc(alias("\n"))] //~ ERROR
+#[doc(alias("
+"))] //~^ ERROR
+#[doc(alias("\t"))] //~ ERROR
+#[doc(alias(" hello"))] //~ ERROR
+#[doc(alias("hello "))] //~ ERROR
+#[doc(alias(""))] //~ ERROR
+pub struct Foo2;

--- a/src/test/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.stderr
@@ -1,20 +1,14 @@
-error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:6:7
+error: doc alias attribute expects a string `#[doc(alias = "a")]` or a list of strings `#[doc(alias("a", "b"))]`
+  --> $DIR/check-doc-alias-attr.rs:7:7
    |
 LL | #[doc(alias)]
    |       ^^^^^
 
-error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:7:7
+error: doc alias attribute expects a string `#[doc(alias = "a")]` or a list of strings `#[doc(alias("a", "b"))]`
+  --> $DIR/check-doc-alias-attr.rs:8:7
    |
 LL | #[doc(alias = 0)]
    |       ^^^^^^^^^
-
-error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:8:7
-   |
-LL | #[doc(alias("bar"))]
-   |       ^^^^^^^^^^^^
 
 error: '\"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:9:15
@@ -54,5 +48,61 @@ error: `#[doc(alias = "...")]` cannot start or end with ' '
 LL | #[doc(alias = "hello ")]
    |               ^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: `#[doc(alias = "...")]` attribute cannot have empty value
+  --> $DIR/check-doc-alias-attr.rs:16:15
+   |
+LL | #[doc(alias = "")]
+   |               ^^
+
+error: `#[doc(alias("a"))]` expects string literals
+  --> $DIR/check-doc-alias-attr.rs:19:13
+   |
+LL | #[doc(alias(0))]
+   |             ^
+
+error: '\"' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:20:13
+   |
+LL | #[doc(alias("\""))]
+   |             ^^^^
+
+error: '\n' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:21:13
+   |
+LL | #[doc(alias("\n"))]
+   |             ^^^^
+
+error: '\n' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:22:13
+   |
+LL |   #[doc(alias("
+   |  _____________^
+LL | | "))]
+   | |_^
+
+error: '\t' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:24:13
+   |
+LL | #[doc(alias("\t"))]
+   |             ^^^^
+
+error: `#[doc(alias("..."))]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:25:13
+   |
+LL | #[doc(alias(" hello"))]
+   |             ^^^^^^^^
+
+error: `#[doc(alias("..."))]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:26:13
+   |
+LL | #[doc(alias("hello "))]
+   |             ^^^^^^^^
+
+error: `#[doc(alias("..."))]` attribute cannot have empty value
+  --> $DIR/check-doc-alias-attr.rs:27:13
+   |
+LL | #[doc(alias(""))]
+   |             ^^
+
+error: aborting due to 17 previous errors
 

--- a/src/test/ui/rustdoc/check-doc-alias-attr.rs
+++ b/src/test/ui/rustdoc/check-doc-alias-attr.rs
@@ -1,11 +1,11 @@
 #![crate_type = "lib"]
 
 #[doc(alias = "foo")] // ok!
+#[doc(alias("bar", "baz"))] // ok!
 pub struct Bar;
 
 #[doc(alias)] //~ ERROR
 #[doc(alias = 0)] //~ ERROR
-#[doc(alias("bar"))] //~ ERROR
 #[doc(alias = "\"")] //~ ERROR
 #[doc(alias = "\n")] //~ ERROR
 #[doc(alias = "
@@ -13,4 +13,16 @@ pub struct Bar;
 #[doc(alias = "\t")] //~ ERROR
 #[doc(alias = " hello")] //~ ERROR
 #[doc(alias = "hello ")] //~ ERROR
+#[doc(alias = "")] //~ ERROR
 pub struct Foo;
+
+#[doc(alias(0))] //~ ERROR
+#[doc(alias("\""))] //~ ERROR
+#[doc(alias("\n"))] //~ ERROR
+#[doc(alias("
+"))] //~^ ERROR
+#[doc(alias("\t"))] //~ ERROR
+#[doc(alias(" hello"))] //~ ERROR
+#[doc(alias("hello "))] //~ ERROR
+#[doc(alias(""))] //~ ERROR
+pub struct Foo2;

--- a/src/test/ui/rustdoc/check-doc-alias-attr.stderr
+++ b/src/test/ui/rustdoc/check-doc-alias-attr.stderr
@@ -1,20 +1,14 @@
-error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:6:7
+error: doc alias attribute expects a string `#[doc(alias = "a")]` or a list of strings `#[doc(alias("a", "b"))]`
+  --> $DIR/check-doc-alias-attr.rs:7:7
    |
 LL | #[doc(alias)]
    |       ^^^^^
 
-error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:7:7
+error: doc alias attribute expects a string `#[doc(alias = "a")]` or a list of strings `#[doc(alias("a", "b"))]`
+  --> $DIR/check-doc-alias-attr.rs:8:7
    |
 LL | #[doc(alias = 0)]
    |       ^^^^^^^^^
-
-error: doc alias attribute expects a string: #[doc(alias = "a")]
-  --> $DIR/check-doc-alias-attr.rs:8:7
-   |
-LL | #[doc(alias("bar"))]
-   |       ^^^^^^^^^^^^
 
 error: '\"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:9:15
@@ -54,5 +48,61 @@ error: `#[doc(alias = "...")]` cannot start or end with ' '
 LL | #[doc(alias = "hello ")]
    |               ^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: `#[doc(alias = "...")]` attribute cannot have empty value
+  --> $DIR/check-doc-alias-attr.rs:16:15
+   |
+LL | #[doc(alias = "")]
+   |               ^^
+
+error: `#[doc(alias("a"))]` expects string literals
+  --> $DIR/check-doc-alias-attr.rs:19:13
+   |
+LL | #[doc(alias(0))]
+   |             ^
+
+error: '\"' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:20:13
+   |
+LL | #[doc(alias("\""))]
+   |             ^^^^
+
+error: '\n' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:21:13
+   |
+LL | #[doc(alias("\n"))]
+   |             ^^^^
+
+error: '\n' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:22:13
+   |
+LL |   #[doc(alias("
+   |  _____________^
+LL | | "))]
+   | |_^
+
+error: '\t' character isn't allowed in `#[doc(alias("..."))]`
+  --> $DIR/check-doc-alias-attr.rs:24:13
+   |
+LL | #[doc(alias("\t"))]
+   |             ^^^^
+
+error: `#[doc(alias("..."))]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:25:13
+   |
+LL | #[doc(alias(" hello"))]
+   |             ^^^^^^^^
+
+error: `#[doc(alias("..."))]` cannot start or end with ' '
+  --> $DIR/check-doc-alias-attr.rs:26:13
+   |
+LL | #[doc(alias("hello "))]
+   |             ^^^^^^^^
+
+error: `#[doc(alias("..."))]` attribute cannot have empty value
+  --> $DIR/check-doc-alias-attr.rs:27:13
+   |
+LL | #[doc(alias(""))]
+   |             ^^
+
+error: aborting due to 17 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/81205.

It now allows to have:

```rust
#[doc(alias = "x")]
// and:
#[doc(alias("y", "z"))]
```

cc @jplatte 
r? @jyn514 