### PR TITLE
Inline the `core::arch` documentation into `std`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -394,7 +394,6 @@ pub use alloc_crate::vec;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::any;
 #[stable(feature = "simd_arch", since = "1.27.0")]
-#[doc(no_inline)]
 pub use core::arch;
 #[stable(feature = "core_array", since = "1.36.0")]
 pub use core::array;


### PR DESCRIPTION
This PR removes the `#[doc(no_inline)]`-attribute from the `pub use` statement of the `core::arch`-module. This has the effect, that the module is not listed under the re-exported section in the documentation (it is the only item in a re-exports-section in the `std`), but as a normal module.

This also removes the only mention of the `core`-crate in the `std` crate, which is desirable, as only a subset of Rust users know `core` and its relationship with the `std`.

The git history did not reveal, why this was added in the first place. If there is a reason, I can close this PR :wink: 