### PR TITLE
Inline hint on trivial from/into_/as_ functions

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -659,6 +659,7 @@ impl String {
     /// assert_eq!(rebuilt, "hello");
     /// ```
     #[unstable(feature = "vec_into_raw_parts", reason = "new API", issue = "65816")]
+    #[inline]
     pub fn into_raw_parts(self) -> (*mut u8, usize, usize) {
         self.vec.into_raw_parts()
     }
@@ -1615,6 +1616,7 @@ impl FromUtf8Error {
     /// assert_eq!(&[0, 159], value.unwrap_err().as_bytes());
     /// ```
     #[stable(feature = "from_utf8_error_as_bytes", since = "1.26.0")]
+    #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[..]
     }
@@ -1638,6 +1640,7 @@ impl FromUtf8Error {
     /// assert_eq!(vec![0, 159], value.unwrap_err().into_bytes());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn into_bytes(self) -> Vec<u8> {
         self.bytes
     }
@@ -2318,6 +2321,7 @@ impl From<Box<str>> for String {
     ///
     /// assert_eq!("hello world", s3)
     /// ```
+    #[inline]
     fn from(s: Box<str>) -> String {
         s.into_string()
     }
@@ -2489,6 +2493,7 @@ impl<'a> Drain<'a> {
     /// assert_eq!(drain.as_str(), "bc");
     /// ```
     #[unstable(feature = "string_drain_as_str", issue = "76905")] // Note: uncomment AsRef impls below when stabilizing.
+    #[inline]
     pub fn as_str(&self) -> &str {
         self.iter.as_str()
     }

--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -297,6 +297,7 @@ impl FromVecWithNulError {
     ///
     /// assert_eq!(&bytes[..], value.unwrap_err().as_bytes());
     /// ```
+    #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         &self.bytes[..]
     }
@@ -665,6 +666,7 @@ impl CString {
     ///            CStr::from_bytes_with_nul(b"foo\0").expect("CStr::from_bytes_with_nul failed"));
     /// ```
     #[stable(feature = "into_boxed_c_str", since = "1.20.0")]
+    #[inline]
     pub fn into_boxed_c_str(self) -> Box<CStr> {
         unsafe { Box::from_raw(Box::into_raw(self.into_inner()) as *mut CStr) }
     }
@@ -1012,6 +1014,7 @@ impl NulError {
     /// assert_eq!(nul_error.into_vec(), b"foo\0bar");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn into_vec(self) -> Vec<u8> {
         self.1
     }
@@ -1086,12 +1089,14 @@ impl IntoStringError {
     /// Consumes this error, returning original [`CString`] which generated the
     /// error.
     #[stable(feature = "cstring_into", since = "1.7.0")]
+    #[inline]
     pub fn into_cstring(self) -> CString {
         self.inner
     }
 
     /// Access the underlying UTF-8 error that was the cause of this error.
     #[stable(feature = "cstring_into", since = "1.7.0")]
+    #[inline]
     pub fn utf8_error(&self) -> Utf8Error {
         self.error
     }

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -369,6 +369,7 @@ impl From<String> for OsString {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + AsRef<OsStr>> From<&T> for OsString {
+    #[inline]
     fn from(s: &T) -> OsString {
         s.as_ref().to_os_string()
     }
@@ -774,6 +775,7 @@ impl OsStr {
     /// assert_eq!("grüße, jürgen ❤", s.to_ascii_lowercase());
     /// ```
     #[unstable(feature = "osstring_ascii", issue = "70516")]
+    #[inline]
     pub fn to_ascii_lowercase(&self) -> OsString {
         OsString::from_inner(self.inner.to_ascii_lowercase())
     }
@@ -796,6 +798,7 @@ impl OsStr {
     /// assert_eq!("GRüßE, JüRGEN ❤", s.to_ascii_uppercase());
     /// ```
     #[unstable(feature = "osstring_ascii", issue = "70516")]
+    #[inline]
     pub fn to_ascii_uppercase(&self) -> OsString {
         OsString::from_inner(self.inner.to_ascii_uppercase())
     }

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -584,16 +584,19 @@ impl File {
 }
 
 impl AsInner<fs_imp::File> for File {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::File {
         &self.inner
     }
 }
 impl FromInner<fs_imp::File> for File {
+    #[inline]
     fn from_inner(f: fs_imp::File) -> File {
         File { inner: f }
     }
 }
 impl IntoInner<fs_imp::File> for File {
+    #[inline]
     fn into_inner(self) -> fs_imp::File {
         self.inner
     }
@@ -925,12 +928,14 @@ impl OpenOptions {
 }
 
 impl AsInner<fs_imp::OpenOptions> for OpenOptions {
+    #[inline]
     fn as_inner(&self) -> &fs_imp::OpenOptions {
         &self.0
     }
 }
 
 impl AsInnerMut<fs_imp::OpenOptions> for OpenOptions {
+    #[inline]
     fn as_inner_mut(&mut self) -> &mut fs_imp::OpenOptions {
         &mut self.0
     }

--- a/library/std/src/io/buffered/mod.rs
+++ b/library/std/src/io/buffered/mod.rs
@@ -88,6 +88,7 @@ impl<W> IntoInnerError<W> {
     /// };
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
     pub fn error(&self) -> &Error {
         &self.1
     }

--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -514,12 +514,14 @@ impl SocketAddrV6 {
 }
 
 impl FromInner<c::sockaddr_in> for SocketAddrV4 {
+    #[inline]
     fn from_inner(addr: c::sockaddr_in) -> SocketAddrV4 {
         SocketAddrV4 { inner: addr }
     }
 }
 
 impl FromInner<c::sockaddr_in6> for SocketAddrV6 {
+    #[inline]
     fn from_inner(addr: c::sockaddr_in6) -> SocketAddrV6 {
         SocketAddrV6 { inner: addr }
     }
@@ -528,6 +530,7 @@ impl FromInner<c::sockaddr_in6> for SocketAddrV6 {
 #[stable(feature = "ip_from_ip", since = "1.16.0")]
 impl From<SocketAddrV4> for SocketAddr {
     /// Converts a [`SocketAddrV4`] into a [`SocketAddr::V4`].
+    #[inline]
     fn from(sock4: SocketAddrV4) -> SocketAddr {
         SocketAddr::V4(sock4)
     }
@@ -536,6 +539,7 @@ impl From<SocketAddrV4> for SocketAddr {
 #[stable(feature = "ip_from_ip", since = "1.16.0")]
 impl From<SocketAddrV6> for SocketAddr {
     /// Converts a [`SocketAddrV6`] into a [`SocketAddr::V6`].
+    #[inline]
     fn from(sock6: SocketAddrV6) -> SocketAddr {
         SocketAddr::V6(sock6)
     }

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -991,6 +991,7 @@ impl Ord for Ipv4Addr {
 }
 
 impl IntoInner<c::in_addr> for Ipv4Addr {
+    #[inline]
     fn into_inner(self) -> c::in_addr {
         self.inner
     }
@@ -1798,11 +1799,13 @@ impl Ord for Ipv6Addr {
 }
 
 impl AsInner<c::in6_addr> for Ipv6Addr {
+    #[inline]
     fn as_inner(&self) -> &c::in6_addr {
         &self.inner
     }
 }
 impl FromInner<c::in6_addr> for Ipv6Addr {
+    #[inline]
     fn from_inner(addr: c::in6_addr) -> Ipv6Addr {
         Ipv6Addr { inner: addr }
     }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2533,6 +2533,7 @@ impl Path {
     /// Converts a [`Box<Path>`](Box) into a [`PathBuf`] without copying or
     /// allocating.
     #[stable(feature = "into_boxed_path", since = "1.20.0")]
+    #[inline]
     pub fn into_path_buf(self: Box<Path>) -> PathBuf {
         let rw = Box::into_raw(self) as *mut OsStr;
         let inner = unsafe { Box::from_raw(rw) };

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -1619,6 +1619,7 @@ impl From<RecvError> for RecvTimeoutError {
     /// This conversion always returns `RecvTimeoutError::Disconnected`.
     ///
     /// No data is allocated on the heap.
+    #[inline]
     fn from(err: RecvError) -> RecvTimeoutError {
         match err {
             RecvError => RecvTimeoutError::Disconnected,

--- a/library/std/src/sys/unix/ext/io.rs
+++ b/library/std/src/sys/unix/ext/io.rs
@@ -142,6 +142,7 @@ impl IntoRawFd for fs::File {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO
     }
@@ -149,6 +150,7 @@ impl AsRawFd for io::Stdin {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO
     }
@@ -156,6 +158,7 @@ impl AsRawFd for io::Stdout {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO
     }
@@ -163,6 +166,7 @@ impl AsRawFd for io::Stderr {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdinLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO
     }
@@ -170,6 +174,7 @@ impl<'a> AsRawFd for io::StdinLock<'a> {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdoutLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO
     }
@@ -177,6 +182,7 @@ impl<'a> AsRawFd for io::StdoutLock<'a> {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StderrLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO
     }

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -73,11 +73,13 @@ impl FileDesc {
         unsafe { FileDesc { fd } }
     }
 
+    #[inline]
     pub fn raw(&self) -> c_int {
         self.fd
     }
 
     /// Extracts the actual file descriptor without closing it.
+    #[inline]
     pub fn into_raw(self) -> c_int {
         let fd = self.fd;
         mem::forget(self);
@@ -285,6 +287,7 @@ impl<'a> Read for &'a FileDesc {
 }
 
 impl AsInner<c_int> for FileDesc {
+    #[inline]
     fn as_inner(&self) -> &c_int {
         &self.fd
     }

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -416,6 +416,7 @@ impl FileType {
 }
 
 impl FromInner<u32> for FilePermissions {
+    #[inline]
     fn from_inner(mode: u32) -> FilePermissions {
         FilePermissions { mode: mode as mode_t }
     }

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -237,6 +237,7 @@ pub mod net {
     }
 
     impl FromInner<Socket> for TcpStream {
+        #[inline]
         fn from_inner(socket: Socket) -> TcpStream {
             TcpStream { inner: socket }
         }

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -518,6 +518,7 @@ impl ExitStatus {
 
 /// Converts a raw `c_int` to a type-safe `ExitStatus` by wrapping it without copying.
 impl From<c_int> for ExitStatus {
+    #[inline]
     fn from(a: c_int) -> ExitStatus {
         ExitStatus(a)
     }

--- a/library/std/src/sys/wasi/ext/io.rs
+++ b/library/std/src/sys/wasi/ext/io.rs
@@ -144,36 +144,42 @@ impl IntoRawFd for fs::File {
 }
 
 impl AsRawFd for io::Stdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO as RawFd
     }
 }
 
 impl AsRawFd for io::Stdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO as RawFd
     }
 }
 
 impl AsRawFd for io::Stderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StdinLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StdoutLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StderrLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO as RawFd
     }

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -95,6 +95,7 @@ impl FileAttr {
         Ok(SystemTime::from_wasi_timestamp(self.meta.ctim))
     }
 
+    #[inline]
     pub fn as_wasi(&self) -> &wasi::Filestat {
         &self.meta
     }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -106,10 +106,12 @@ impl TcpStream {
         unsupported()
     }
 
+    #[inline]
     pub fn fd(&self) -> &WasiFd {
         &self.fd
     }
 
+    #[inline]
     pub fn into_fd(self) -> WasiFd {
         self.fd
     }
@@ -322,10 +324,12 @@ impl UdpSocket {
         unsupported()
     }
 
+    #[inline]
     pub fn fd(&self) -> &WasiFd {
         &self.fd
     }
 
+    #[inline]
     pub fn into_fd(self) -> WasiFd {
         self.fd
     }

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -418,12 +418,14 @@ impl Drop for Socket {
 }
 
 impl AsInner<c::SOCKET> for Socket {
+    #[inline]
     fn as_inner(&self) -> &c::SOCKET {
         &self.0
     }
 }
 
 impl FromInner<c::SOCKET> for Socket {
+    #[inline]
     fn from_inner(sock: c::SOCKET) -> Socket {
         Socket(sock)
     }

--- a/library/std/src/sys/windows/os_str.rs
+++ b/library/std/src/sys/windows/os_str.rs
@@ -14,18 +14,21 @@ pub struct Buf {
 }
 
 impl IntoInner<Wtf8Buf> for Buf {
+    #[inline]
     fn into_inner(self) -> Wtf8Buf {
         self.inner
     }
 }
 
 impl FromInner<Wtf8Buf> for Buf {
+    #[inline]
     fn from_inner(inner: Wtf8Buf) -> Self {
         Buf { inner }
     }
 }
 
 impl AsInner<Wtf8> for Buf {
+    #[inline]
     fn as_inner(&self) -> &Wtf8 {
         &self.inner
     }
@@ -72,10 +75,12 @@ impl Buf {
         self.inner.capacity()
     }
 
+    #[inline]
     pub fn from_string(s: String) -> Buf {
         Buf { inner: Wtf8Buf::from_string(s) }
     }
 
+    #[inline]
     pub fn as_slice(&self) -> &Slice {
         // SAFETY: Slice is just a wrapper for Wtf8,
         // and self.inner.as_slice() returns &Wtf8.
@@ -83,6 +88,7 @@ impl Buf {
         unsafe { mem::transmute(self.inner.as_slice()) }
     }
 
+    #[inline]
     pub fn as_mut_slice(&mut self) -> &mut Slice {
         // SAFETY: Slice is just a wrapper for Wtf8,
         // and self.inner.as_mut_slice() returns &mut Wtf8.
@@ -145,10 +151,12 @@ impl Slice {
         unsafe { mem::transmute(Wtf8::from_str(s)) }
     }
 
+    #[inline]
     pub fn to_str(&self) -> Option<&str> {
         self.inner.as_str()
     }
 
+    #[inline]
     pub fn to_string_lossy(&self) -> Cow<'_, str> {
         self.inner.to_string_lossy()
     }
@@ -159,6 +167,7 @@ impl Slice {
         Buf { inner: buf }
     }
 
+    #[inline]
     pub fn clone_into(&self, buf: &mut Buf) {
         self.inner.clone_into(&mut buf.inner)
     }

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -43,18 +43,21 @@ impl From<OsString> for EnvKey {
 }
 
 impl From<EnvKey> for OsString {
+    #[inline]
     fn from(k: EnvKey) -> Self {
         k.0
     }
 }
 
 impl Borrow<OsStr> for EnvKey {
+    #[inline]
     fn borrow(&self) -> &OsStr {
         &self.0
     }
 }
 
 impl AsRef<OsStr> for EnvKey {
+    #[inline]
     fn as_ref(&self) -> &OsStr {
         &self.0
     }
@@ -322,12 +325,14 @@ impl Stdio {
 }
 
 impl From<AnonPipe> for Stdio {
+    #[inline]
     fn from(pipe: AnonPipe) -> Stdio {
         Stdio::Handle(pipe.into_handle())
     }
 }
 
 impl From<File> for Stdio {
+    #[inline]
     fn from(file: File) -> Stdio {
         Stdio::Handle(file.into_handle())
     }

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -387,10 +387,12 @@ impl TcpListener {
         Ok(TcpListener { inner: sock })
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }
 
+    #[inline]
     pub fn into_socket(self) -> Socket {
         self.inner
     }
@@ -439,6 +441,7 @@ impl TcpListener {
 }
 
 impl FromInner<Socket> for TcpListener {
+    #[inline]
     fn from_inner(socket: Socket) -> TcpListener {
         TcpListener { inner: socket }
     }
@@ -477,10 +480,12 @@ impl UdpSocket {
         Ok(UdpSocket { inner: sock })
     }
 
+    #[inline]
     pub fn socket(&self) -> &Socket {
         &self.inner
     }
 
+    #[inline]
     pub fn into_socket(self) -> Socket {
         self.inner
     }

--- a/library/std/src/sys_common/os_str_bytes.rs
+++ b/library/std/src/sys_common/os_str_bytes.rs
@@ -253,9 +253,12 @@ pub trait OsStringExt: Sealed {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl OsStringExt for OsString {
+    #[inline]
     fn from_vec(vec: Vec<u8>) -> OsString {
         FromInner::from_inner(Buf { inner: vec })
     }
+
+    #[inline]
     fn into_vec(self) -> Vec<u8> {
         self.into_inner().inner
     }

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -626,6 +626,7 @@ impl Wtf8 {
         }
     }
 
+    #[inline]
     pub fn clone_into(&self, buf: &mut Wtf8Buf) {
         self.bytes.clone_into(&mut buf.bytes)
     }

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -615,6 +615,7 @@ impl SystemTimeError {
     /// }
     /// ```
     #[stable(feature = "time2", since = "1.8.0")]
+    #[inline]
     pub fn duration(&self) -> Duration {
         self.0
     }
@@ -636,6 +637,7 @@ impl fmt::Display for SystemTimeError {
 }
 
 impl FromInner<time::SystemTime> for SystemTime {
+    #[inline]
     fn from_inner(time: time::SystemTime) -> SystemTime {
         SystemTime(time)
     }


### PR DESCRIPTION
I've noticed there's a bunch of small functions in std that aren't marked as inlineable. 

The PR is not meant to be exhaustive — there's probably more that could be inlined, but I didn't want to make a huge PR.