### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,13 @@
 Thank you for your interest in contributing to Rust! There are many ways to contribute
 and we appreciate all of them.
 
-To get started, read the [Contributing to Rust] chapter of the [rustc-dev-guide].
+Documentation for contributing to Rust is located in the [Guide to Rustc Development](https://rustc-dev-guide.rust-lang.org/),
+commonly known as the [rustc-dev-guide]. Despite the name, this guide documents
+not just how to develop rustc (the Rust compiler), but also how to contribute to any part
+of the Rust project.
+
+To get started with contributing, please read the [Contributing to Rust] chapter of the guide.
+That chapter explains how to get your development environment set up and how to get help.
 
 ## About the [rustc-dev-guide]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,25 @@
 # Contributing to Rust
 
-Thank you for your interest in contributing to Rust!
+Thank you for your interest in contributing to Rust! There are many ways to contribute
+and we appreciate all of them.
 
 To get started, read the [Contributing to Rust] chapter of the [rustc-dev-guide].
+
+## About the [rustc-dev-guide]
+
+The [rustc-dev-guide] is meant to help document how rustc –the Rust compiler– works,
+as well as to help new contributors get involved in rustc development. It is recommend
+to read and understand the [rustc-dev-guide] before making a contribution. This guide
+talks about the different bots in the Rust ecosystem, the Rust development tools,
+bootstrapping, the compiler architecture, source code representation, and more.
+
+## [Getting help](https://rustc-dev-guide.rust-lang.org/getting-started.html#asking-questions)
+
+There are many ways you can get help when you're stuck. Rust has many platforms for this:
+[internals], [rust-zulip], and [rust-discord]. It is recommended to ask for help on
+the [rust-zulip], but any of these platforms are a great way to seek help and even
+find a mentor! You can learn more about asking questions and getting help in the
+[Asking Questions](https://rustc-dev-guide.rust-lang.org/getting-started.html#asking-questions) chapter of the [rustc-dev-guide].
 
 ## Bug reports
 
@@ -13,3 +30,6 @@ refer to [this section][contributing-bug-reports] and [open an issue][issue temp
 [rustc-dev-guide]: https://rustc-dev-guide.rust-lang.org/
 [contributing-bug-reports]: https://rustc-dev-guide.rust-lang.org/contributing.html#bug-reports
 [issue template]: https://github.com/rust-lang/rust/issues/new/choose
+[internals]: https://internals.rust-lang.org
+[rust-discord]: http://discord.gg/rust-lang
+[rust-zulip]: https://rust-lang.zulipchat.com


### PR DESCRIPTION
Fixes #77215

As mentioned in #77215, the current CONTRIBUTING.md links to the rustc-dev-guide.
Even though the rustc-dev-guide has lots of useful information for contributors,
one is already confused by reading the first line of the current CONTRIBUTING.md.

> To get started, read the [Getting Started] guide in the [rustc-dev-guide].

This line tells the contributor to go and read the rustc-dev-guide. What is
the rustc-dev-guide? What does rustc even mean? These are some of the
questions that went into my head when reading this line as a first-time
contributor. By explaining what the rustc-dev-guide is and some platforms
to get help, a new contributor understands what the first step is and the process
is much clearer. The `About the [rustc-dev-guide]` section explains what
the rustc-dev-guide is, what rustc is, and the purpose out of reading the
guide. The `Getting help` section points the user to some places where
they can get help, find a mentor, and introduce themselves.