### PR TITLE
In std::ops::Shr the implementation of SpinVector using vec rotate fns

### DIFF
--- a/library/core/src/ops/bit.rs
+++ b/library/core/src/ops/bit.rs
@@ -411,16 +411,14 @@ bitxor_impl! { bool usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
 ///
 ///     fn shl(self, rhs: usize) -> Self::Output {
 ///         // Rotate the vector by `rhs` places.
-///         let (a, b) = self.vec.split_at(rhs);
-///         let mut spun_vector = vec![];
-///         spun_vector.extend_from_slice(b);
-///         spun_vector.extend_from_slice(a);
+///         let mut spun_vector = self.vec.clone();
+///         spun_vector.rotate_left(rhs);
 ///         Self { vec: spun_vector }
 ///     }
 /// }
 ///
-/// assert_eq!(SpinVector { vec: vec![0, 1, 2, 3, 4] } << 2,
-///            SpinVector { vec: vec![2, 3, 4, 0, 1] });
+/// assert_eq!(SpinVector { vec: vec![0, 1, 2, 3, 4] } << 3,
+///            SpinVector { vec: vec![3, 4, 0, 1, 2] });
 /// ```
 #[lang = "shl"]
 #[doc(alias = "<<")]
@@ -529,16 +527,14 @@ shl_impl_all! { u8 u16 u32 u64 u128 usize i8 i16 i32 i64 isize i128 }
 ///
 ///     fn shr(self, rhs: usize) -> Self::Output {
 ///         // Rotate the vector by `rhs` places.
-///         let (a, b) = self.vec.split_at(self.vec.len() - rhs);
-///         let mut spun_vector = vec![];
-///         spun_vector.extend_from_slice(b);
-///         spun_vector.extend_from_slice(a);
+///         let mut spun_vector = self.vec.clone();
+///         spun_vector.rotate_right(rhs);
 ///         Self { vec: spun_vector }
 ///     }
 /// }
 ///
-/// assert_eq!(SpinVector { vec: vec![0, 1, 2, 3, 4] } >> 2,
-///            SpinVector { vec: vec![3, 4, 0, 1, 2] });
+/// assert_eq!(SpinVector { vec: vec![0, 1, 2, 3, 4] } >> 3,
+///            SpinVector { vec: vec![2, 3, 4, 0, 1] });
 /// ```
 #[lang = "shr"]
 #[doc(alias = ">>")]


### PR DESCRIPTION
close https://github.com/rust-lang/rust/issues/81820

It may be a little more obvious with 3.