### PR TITLE
Allow const prop for copies and moves on mir-opt-level=2

### DIFF
--- a/compiler/rustc_mir/src/transform/const_prop.rs
+++ b/compiler/rustc_mir/src/transform/const_prop.rs
@@ -1072,9 +1072,9 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
     fn visit_operand(&mut self, operand: &mut Operand<'tcx>, location: Location) {
         self.super_operand(operand, location);
 
-        // Only const prop copies and moves on `mir_opt_level=3` as doing so
+        // Only const prop copies and moves on `mir_opt_level=2` as doing so
         // currently slightly increases compile time in some cases.
-        if self.tcx.sess.mir_opt_level() >= 3 {
+        if self.tcx.sess.mir_opt_level() >= 2 {
             self.propagate_operand(operand)
         }
     }


### PR DESCRIPTION
Let's test the performance of making this change, note that mir-opt-level is 2 by default in optimized builds.