### PR TITLE
Allow dest prop on mir-opt-level=2

### DIFF
--- a/compiler/rustc_mir/src/transform/dest_prop.rs
+++ b/compiler/rustc_mir/src/transform/dest_prop.rs
@@ -132,9 +132,9 @@ impl<'tcx> MirPass<'tcx> for DestinationPropagation {
             return;
         }
 
-        // Only run at mir-opt-level=3 or higher for now (we don't fix up debuginfo and remove
+        // Only run at mir-opt-level=2 or higher for now (we don't fix up debuginfo and remove
         // storage statements at the moment).
-        if tcx.sess.mir_opt_level() < 3 {
+        if tcx.sess.mir_opt_level() < 2 {
             return;
         }
 


### PR DESCRIPTION
Let's test the performance of making this change, note that mir-opt-level is 2 by default in optimized builds.

r? @oli-obk 