### PR TITLE
Allow early otherwise branch on mir-opt-level=2

### DIFF
--- a/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
+++ b/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
@@ -26,7 +26,7 @@ pub struct EarlyOtherwiseBranch;
 
 impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        if tcx.sess.mir_opt_level() < 3 {
+        if tcx.sess.mir_opt_level() < 2 {
             return;
         }
         trace!("running EarlyOtherwiseBranch on {:?}", body.source);


### PR DESCRIPTION
Let's test the performance of making this change, note that mir-opt-level is 2 by default in optimized builds.

r? @oli-obk 