### PR TITLE
Allow match branches on mir-opt-level=2

### DIFF
--- a/compiler/rustc_mir/src/transform/match_branches.rs
+++ b/compiler/rustc_mir/src/transform/match_branches.rs
@@ -40,7 +40,7 @@ pub struct MatchBranchSimplification;
 
 impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        if tcx.sess.mir_opt_level() < 3 {
+        if tcx.sess.mir_opt_level() < 2 {
             return;
         }
 


### PR DESCRIPTION
Let's test the performance of making this change, note that mir-opt-level is 2 by default in optimized builds.

r? @oli-obk 