### PR TITLE
Turn old edition lint (anonymous-parameters) into warn-by-default on 2015

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1768,6 +1768,7 @@ mod super_keyword {}
 /// In the 2015 edition the parameters pattern was not needed for traits:
 ///
 /// ```rust,edition2015
+/// # #![allow(anonymous_parameters)]
 /// trait Tr {
 ///     fn f(i32);
 /// }

--- a/src/test/ui/anon-params/anon-params-edition-hygiene.rs
+++ b/src/test/ui/anon-params/anon-params-edition-hygiene.rs
@@ -2,6 +2,9 @@
 // edition:2018
 // aux-build:anon-params-edition-hygiene.rs
 
+// This warning is still surfaced
+#![allow(anonymous_parameters)]
+
 #[macro_use]
 extern crate anon_params_edition_hygiene;
 

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.rs
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.rs
@@ -12,7 +12,7 @@ trait NonObjectSafe3 {
 }
 
 trait NonObjectSafe4 {
-    fn foo(&self, &Self);
+    fn foo(&self, s: &Self);
 }
 
 fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {

--- a/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -57,12 +57,12 @@ LL | fn return_non_object_safe_rc() -> std::rc::Rc<dyn NonObjectSafe4> {
    |
    = help: consider moving `foo` to another trait
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/feature-gate-object_safe_for_dispatch.rs:15:19
+  --> $DIR/feature-gate-object_safe_for_dispatch.rs:15:22
    |
 LL | trait NonObjectSafe4 {
    |       -------------- this trait cannot be made into an object...
-LL |     fn foo(&self, &Self);
-   |                   ^^^^^ ...because method `foo` references the `Self` type in this parameter
+LL |     fn foo(&self, s: &Self);
+   |                      ^^^^^ ...because method `foo` references the `Self` type in this parameter
 
 error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:38:16

--- a/src/test/ui/issues/issue-78720.rs
+++ b/src/test/ui/issues/issue-78720.rs
@@ -4,7 +4,7 @@ fn server() -> impl {
 }
 
 trait FilterBase2 {
-    fn map2<F>(self, F) -> Map2<F> {}
+    fn map2<F>(self, f: F) -> Map2<F> {}
     //~^ ERROR mismatched types
     //~^^ ERROR the size for values of type `Self` cannot be known at compilation time
 }

--- a/src/test/ui/issues/issue-78720.stderr
+++ b/src/test/ui/issues/issue-78720.stderr
@@ -25,10 +25,10 @@ LL | struct Map2<Segment2, F> {
    |                     ^^^
 
 error[E0308]: mismatched types
-  --> $DIR/issue-78720.rs:7:36
+  --> $DIR/issue-78720.rs:7:39
    |
-LL |     fn map2<F>(self, F) -> Map2<F> {}
-   |                                    ^^ expected struct `Map2`, found `()`
+LL |     fn map2<F>(self, f: F) -> Map2<F> {}
+   |                                       ^^ expected struct `Map2`, found `()`
    |
    = note: expected struct `Map2<F>`
            found unit type `()`
@@ -36,17 +36,17 @@ LL |     fn map2<F>(self, F) -> Map2<F> {}
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/issue-78720.rs:7:16
    |
-LL |     fn map2<F>(self, F) -> Map2<F> {}
+LL |     fn map2<F>(self, f: F) -> Map2<F> {}
    |                ^^^^ doesn't have a size known at compile-time
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider further restricting `Self`
    |
-LL |     fn map2<F>(self, F) -> Map2<F> where Self: Sized {}
-   |                                    ^^^^^^^^^^^^^^^^^
+LL |     fn map2<F>(self, f: F) -> Map2<F> where Self: Sized {}
+   |                                       ^^^^^^^^^^^^^^^^^
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
-LL |     fn map2<F>(&self, F) -> Map2<F> {}
+LL |     fn map2<F>(&self, f: F) -> Map2<F> {}
    |                ^
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/parser/variadic-ffi-semantic-restrictions.rs
+++ b/src/test/ui/parser/variadic-ffi-semantic-restrictions.rs
@@ -1,4 +1,5 @@
 #![feature(c_variadic)]
+#![allow(anonymous_parameters)]
 
 fn main() {}
 

--- a/src/test/ui/parser/variadic-ffi-semantic-restrictions.stderr
+++ b/src/test/ui/parser/variadic-ffi-semantic-restrictions.stderr
@@ -1,203 +1,203 @@
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:5:19
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:6:19
    |
 LL | fn f1_1(x: isize, ...) {}
    |                   ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:8:9
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:9:9
    |
 LL | fn f1_2(...) {}
    |         ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:8:9
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:9:9
    |
 LL | fn f1_2(...) {}
    |         ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:12:30
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:13:30
    |
 LL | extern "C" fn f2_1(x: isize, ...) {}
    |                              ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:15:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:16:20
    |
 LL | extern "C" fn f2_2(...) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:15:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:16:20
    |
 LL | extern "C" fn f2_2(...) {}
    |                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:19:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:20:20
    |
 LL | extern "C" fn f2_3(..., x: isize) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:19:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:20:20
    |
 LL | extern "C" fn f2_3(..., x: isize) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:23:30
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:24:30
    |
 LL | extern "C" fn f3_1(x: isize, ...) {}
    |                              ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:26:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:27:20
    |
 LL | extern "C" fn f3_2(...) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:26:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:27:20
    |
 LL | extern "C" fn f3_2(...) {}
    |                    ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:30:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:31:20
    |
 LL | extern "C" fn f3_3(..., x: isize) {}
    |                    ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:30:20
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:31:20
    |
 LL | extern "C" fn f3_3(..., x: isize) {}
    |                    ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:35:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:36:13
    |
 LL |     fn e_f1(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:37:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:38:13
    |
 LL |     fn e_f2(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:44:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:45:23
    |
 LL |     fn i_f1(x: isize, ...) {}
    |                       ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:46:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:47:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:46:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:47:13
    |
 LL |     fn i_f2(...) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:49:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:49:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:13
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:49:28
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:50:28
    |
 LL |     fn i_f3(..., x: isize, ...) {}
    |                            ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:53:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:54:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:53:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:54:13
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:53:28
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:54:28
    |
 LL |     fn i_f4(..., x: isize, ...) {}
    |                            ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:60:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:61:23
    |
 LL |     fn t_f1(x: isize, ...) {}
    |                       ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:62:23
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:63:23
    |
 LL |     fn t_f2(x: isize, ...);
    |                       ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:65:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:64:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:65:13
    |
 LL |     fn t_f3(...) {}
    |             ^^^
 
 error: C-variadic function must be declared with at least one named argument
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:68:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:67:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:68:13
    |
 LL |     fn t_f4(...);
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:71:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:70:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:71:13
    |
 LL |     fn t_f5(..., x: isize) {}
    |             ^^^
 
 error: `...` must be the last argument of a C-variadic function
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:73:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:74:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^
 
 error: only foreign or `unsafe extern "C" functions may be C-variadic
-  --> $DIR/variadic-ffi-semantic-restrictions.rs:73:13
+  --> $DIR/variadic-ffi-semantic-restrictions.rs:74:13
    |
 LL |     fn t_f6(..., x: isize);
    |             ^^^

--- a/src/test/ui/proc-macro/trait-fn-args-2015.rs
+++ b/src/test/ui/proc-macro/trait-fn-args-2015.rs
@@ -3,6 +3,8 @@
 // check-pass
 // aux-build:test-macros.rs
 
+#![allow(anonymous_parameters)]
+
 #[macro_use]
 extern crate test_macros;
 

--- a/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.rs
+++ b/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.rs
@@ -1,6 +1,7 @@
 // aux-build:ident-mac.rs
 
 #![feature(c_variadic)]
+#![allow(anonymous_parameters)]
 
 extern crate ident_mac;
 use ident_mac::id;

--- a/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.stderr
@@ -1,173 +1,173 @@
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:10:23
+  --> $DIR/proc-macro-cannot-be-used.rs:11:23
    |
 LL | extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
    |                       ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:10:40
+  --> $DIR/proc-macro-cannot-be-used.rs:11:40
    |
 LL | extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
    |                                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:14:40
+  --> $DIR/proc-macro-cannot-be-used.rs:15:40
    |
 LL | unsafe extern "C" fn cvar(arg1: i32, #[id] mut args: ...) {}
    |                                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:17:30
+  --> $DIR/proc-macro-cannot-be-used.rs:18:30
    |
 LL | type Alias = extern "C" fn(#[id] u8, #[id] ...);
    |                              ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:17:40
+  --> $DIR/proc-macro-cannot-be-used.rs:18:40
    |
 LL | type Alias = extern "C" fn(#[id] u8, #[id] ...);
    |                                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:21:11
+  --> $DIR/proc-macro-cannot-be-used.rs:22:11
    |
 LL | fn free(#[id] arg1: u8) {
    |           ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:23:18
+  --> $DIR/proc-macro-cannot-be-used.rs:24:18
    |
 LL |     let lam = |#[id] W(x), #[id] y: usize| ();
    |                  ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:23:30
+  --> $DIR/proc-macro-cannot-be-used.rs:24:30
    |
 LL |     let lam = |#[id] W(x), #[id] y: usize| ();
    |                              ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:29:20
+  --> $DIR/proc-macro-cannot-be-used.rs:30:20
    |
 LL |     fn inherent1(#[id] self, #[id] arg1: u8) {}
    |                    ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:29:32
+  --> $DIR/proc-macro-cannot-be-used.rs:30:32
    |
 LL |     fn inherent1(#[id] self, #[id] arg1: u8) {}
    |                                ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:32:20
+  --> $DIR/proc-macro-cannot-be-used.rs:33:20
    |
 LL |     fn inherent2(#[id] &self, #[id] arg1: u8) {}
    |                    ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:32:33
+  --> $DIR/proc-macro-cannot-be-used.rs:33:33
    |
 LL |     fn inherent2(#[id] &self, #[id] arg1: u8) {}
    |                                 ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:35:24
+  --> $DIR/proc-macro-cannot-be-used.rs:36:24
    |
 LL |     fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
    |                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:35:44
+  --> $DIR/proc-macro-cannot-be-used.rs:36:44
    |
 LL |     fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
    |                                            ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:38:24
+  --> $DIR/proc-macro-cannot-be-used.rs:39:24
    |
 LL |     fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
    |                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:38:47
+  --> $DIR/proc-macro-cannot-be-used.rs:39:47
    |
 LL |     fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
    |                                               ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:41:40
+  --> $DIR/proc-macro-cannot-be-used.rs:42:40
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8) {}
    |                                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:41:56
+  --> $DIR/proc-macro-cannot-be-used.rs:42:56
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8) {}
    |                                                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:47:17
+  --> $DIR/proc-macro-cannot-be-used.rs:48:17
    |
 LL |     fn trait1(#[id] self, #[id] arg1: u8);
    |                 ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:47:29
+  --> $DIR/proc-macro-cannot-be-used.rs:48:29
    |
 LL |     fn trait1(#[id] self, #[id] arg1: u8);
    |                             ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:50:17
+  --> $DIR/proc-macro-cannot-be-used.rs:51:17
    |
 LL |     fn trait2(#[id] &self, #[id] arg1: u8);
    |                 ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:50:30
+  --> $DIR/proc-macro-cannot-be-used.rs:51:30
    |
 LL |     fn trait2(#[id] &self, #[id] arg1: u8);
    |                              ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:53:21
+  --> $DIR/proc-macro-cannot-be-used.rs:54:21
    |
 LL |     fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
    |                     ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:53:41
+  --> $DIR/proc-macro-cannot-be-used.rs:54:41
    |
 LL |     fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
    |                                         ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:56:21
+  --> $DIR/proc-macro-cannot-be-used.rs:57:21
    |
 LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
    |                     ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:56:44
+  --> $DIR/proc-macro-cannot-be-used.rs:57:44
    |
 LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
    |                                            ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:56:60
+  --> $DIR/proc-macro-cannot-be-used.rs:57:60
    |
 LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
    |                                                            ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:60:40
+  --> $DIR/proc-macro-cannot-be-used.rs:61:40
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8);
    |                                        ^^ not a non-macro attribute
 
 error: expected non-macro attribute, found attribute macro `id`
-  --> $DIR/proc-macro-cannot-be-used.rs:60:56
+  --> $DIR/proc-macro-cannot-be-used.rs:61:56
    |
 LL |     fn issue_64682_associated_fn<'a>(#[id] arg1: u8, #[id] arg2: u8);
    |                                                        ^^ not a non-macro attribute

--- a/src/test/ui/specialization/issue-39448.rs
+++ b/src/test/ui/specialization/issue-39448.rs
@@ -18,7 +18,7 @@ impl FromA<u8> for u16 {
 }
 
 trait FromA<T> {
-    fn from(T) -> Self;
+    fn from(t: T) -> Self;
 }
 
 impl<T: A, U: A + FromA<T>> FromA<T> for U {

--- a/src/test/ui/typeck/issue-65611.rs
+++ b/src/test/ui/typeck/issue-65611.rs
@@ -17,7 +17,7 @@ pub unsafe trait Array {
 
 pub trait Index : PartialEq + Copy {
     fn to_usize(self) -> usize;
-    fn from(usize) -> Self;
+    fn from(i: usize) -> Self;
 }
 
 impl Index for usize {


### PR DESCRIPTION
This makes `anonymous_parameters` <s>and `keyword_idents` </s>warn-by-default on the 2015 edition. I would also like to do this for `absolute_paths_not_starting_with_crate`, but I feel that case is slightly less clear-cut.

Note that this only affects code on the 2015 edition, such code is illegal in future editions anyway.

This was spurred by https://github.com/dtolnay/syn/issues/972: old edition syntax breaks tooling (like syn), and while the tooling should be free to find its balance on how much to support prior editions, it does seem like we should be nudging such code towards the newer edition, and we can do that by turning this Allow lint into a Warn.

In general, I feel like migration lints from an old edition should be made Warn after a year or so, and idiom lints for the new edition should be made Warn after a couple months.

cc @m-ou-se, this is for stuff from the 2015-2018 migration but you might be interested.