### PR TITLE
Update README.md to use the correct cmake version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ by running `./x.py --help` or reading the [rustc dev guide][rustcguidebuild].
    * `g++` 5.1 or later or `clang++` 3.5 or later
    * `python` 3 or 2.7
    * GNU `make` 3.81 or later
-   * `cmake` 3.4.3 or later
+   * `cmake` 3.13.4 or later
    * `ninja`
    * `curl`
    * `git`


### PR DESCRIPTION
LLVM requires at least cmake 3.13.4 and cmake is only required to build
LLVM.

https://www.llvm.org/docs/CMake.html

Also closes #42555