### PR TITLE
Bump tracing-tree dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5460,9 +5460,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-tree"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a60657cfbf397c603257a8230b3f427e6a2a4e5911a59331b9bb4dffff5b608"
+checksum = "1712b40907f8d9bc2bc66763ab61dec914b7123d7149e59feb0d4e2a95fc4967"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -12,7 +12,7 @@ libc = "0.2"
 atty = "0.2"
 tracing = { version = "0.1.25" }
 tracing-subscriber = { version = "0.2.16", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
-tracing-tree = "0.1.8"
+tracing-tree = "0.1.9"
 rustc_middle = { path = "../rustc_middle" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_target = { path = "../rustc_target" }

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.9"
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }
 tracing = "0.1"
-tracing-tree = "0.1.6"
+tracing-tree = "0.1.9"
 
 [dependencies.tracing-subscriber]
 version = "0.2.13"


### PR DESCRIPTION
This bump fixes two small rendering things that were annoying me:

* The first level didn't have an opening line
* When wraparound happens, there was no warning, the levels just disappeared. Now there is a line that shows that wraparound is happening

See https://github.com/davidbarsky/tracing-tree/pull/31/files for how the look changes