### PR TITLE
Fix nojs style issues

### DIFF
--- a/src/librustdoc/html/static/noscript.css
+++ b/src/librustdoc/html/static/noscript.css
@@ -23,3 +23,13 @@ rules.
 #main .impl-items .hidden {
 	display: block !important;
 }
+
+#main .impl-items h4.hidden {
+	/* Without this rule, the version and the "[src]" span aren't on the same line as the header. */
+	display: flex !important;
+}
+
+#main .attributes {
+	/* Since there is no toggle (the "[-]") when JS is disabled, no need for this margin either. */
+	margin-left: 0 !important;
+}

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1343,7 +1343,7 @@ h4 > .notable-traits {
 @media (min-width: 701px) {
 	/* In case there is no documentation before a code block, we need to add some margin at the top
 	to prevent an overlay between the "collapse toggle" and the information tooltip.
-	However, it's needed needed with smaller screen width because the doc/code block is always put
+	However, it's not needed with smaller screen width because the doc/code block is always put
 	"one line" below. */
 	.information:first-child > .tooltip {
 		margin-top: 16px;

--- a/src/test/rustdoc-gui/lib.rs
+++ b/src/test/rustdoc-gui/lib.rs
@@ -27,6 +27,11 @@ pub fn foo() {}
 /// Just a normal struct.
 pub struct Foo;
 
+impl Foo {
+    #[must_use]
+    pub fn must_use(&self) -> bool { true }
+}
+
 /// Just a normal enum.
 pub enum WhoLetTheDogOut {
     /// Woof!

--- a/src/test/rustdoc-gui/nojs-attr-pos.goml
+++ b/src/test/rustdoc-gui/nojs-attr-pos.goml
@@ -1,0 +1,5 @@
+// Check that the attributes are well positioned when javascript is disabled (since
+// there is no toggle to display)
+javascript: false
+goto: file://|DOC_PATH|/struct.Foo.html
+assert: (".attributes", {"margin-left": "0px"})


### PR DESCRIPTION
There are two issues fixed here:
 1. The position of "{version}" and "[src]" spans.
 2. The position of attributes (on top of functions)

Please note that these issues only happen if you have disabled javascript.

Before:

![Screenshot from 2021-03-09 20-45-54](https://user-images.githubusercontent.com/3050060/110534652-9e048e00-811f-11eb-979e-6d85545edd65.png)

After:

![Screenshot from 2021-03-09 21-01-32](https://user-images.githubusercontent.com/3050060/110534667-a1981500-811f-11eb-8a19-32f4d5381a2b.png)

In the last commit, I added a test to enforce the attributes position. I need to think how to enforce it for the spans but that can comes later on.

r? @Nemo157 
