### PR TITLE
Replace closures_captures and upvar_capture with closure_min_captures

### DIFF
--- a/compiler/rustc_middle/src/ty/closure.rs
+++ b/compiler/rustc_middle/src/ty/closure.rs
@@ -168,6 +168,56 @@ impl CapturedPlace<'tcx> {
             base => bug!("Expected upvar, found={:?}", base),
         }
     }
+
+    /// Returns the `LocalDefId` of the closure that captureed this Place
+    pub fn get_closure_local_def_id(&self) -> LocalDefId {
+        match self.place.base {
+            HirPlaceBase::Upvar(upvar_id) => upvar_id.closure_expr_id,
+            base => bug!("expected upvar, found={:?}", base),
+        }
+    }
+
+    /// Return span pointing to use that resulted in selecting the current capture kind
+    pub fn get_capture_kind_span(&self, tcx: TyCtxt<'tcx>) -> Span {
+        if let Some(capture_kind_expr_id) = self.info.capture_kind_expr_id {
+            tcx.hir().span(capture_kind_expr_id)
+        } else if let Some(path_expr_id) = self.info.path_expr_id {
+            tcx.hir().span(path_expr_id)
+        } else {
+            // Fallback on upvars mentioned if neither path or capture expr id is captured
+
+            // Safe to unwrap since we know this place is captured by the closure, therefore the closure must have upvars.
+            tcx.upvars_mentioned(self.get_closure_local_def_id()).unwrap()
+                [&self.get_root_variable()]
+                .span
+        }
+    }
+}
+
+/// Return true if the `proj_possible_ancestor` represents an ancestor path
+/// to `proj_capture` or `proj_possible_ancestor` is same as `proj_capture`,
+/// assuming they both start off of the same root variable.
+///
+/// **Note:** It's the caller's responsibility to ensure that both lists of projections
+///           start off of the same root variable.
+///
+/// Eg: 1. `foo.x` which is represented using `projections=[Field(x)]` is an ancestor of
+///        `foo.x.y` which is represented using `projections=[Field(x), Field(y)]`.
+///        Note both `foo.x` and `foo.x.y` start off of the same root variable `foo`.
+///     2. Since we only look at the projections here function will return `bar.x` as an a valid
+///        ancestor of `foo.x.y`. It's the caller's responsibility to ensure that both projections
+///        list are being applied to the same root variable.
+pub fn is_ancestor_or_same_capture(
+    proj_possible_ancestor: &[HirProjectionKind],
+    proj_capture: &[HirProjectionKind],
+) -> bool {
+    // We want to make sure `is_ancestor_or_same_capture("x.0.0", "x.0")` to return false.
+    // Therefore we can't just check if all projections are same in the zipped iterator below.
+    if proj_possible_ancestor.len() > proj_capture.len() {
+        return false;
+    }
+
+    proj_possible_ancestor.iter().zip(proj_capture).all(|(a, b)| a == b)
 }
 
 /// Part of `MinCaptureInformationMap`; describes the capture kind (&, &mut, move)

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -30,9 +30,7 @@ use rustc_attr as attr;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sharded::{IntoPointer, ShardedHashMap};
-use rustc_data_structures::stable_hasher::{
-    hash_stable_hashmap, HashStable, StableHasher, StableVec,
-};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableVec};
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{self, Lock, Lrc, WorkerLocal};
 use rustc_errors::ErrorReported;
@@ -386,9 +384,6 @@ pub struct TypeckResults<'tcx> {
     /// <https://github.com/rust-lang/rfcs/blob/master/text/2005-match-ergonomics.md#definitions>
     pat_adjustments: ItemLocalMap<Vec<Ty<'tcx>>>,
 
-    /// Borrows
-    pub upvar_capture_map: ty::UpvarCaptureMap<'tcx>,
-
     /// Records the reasons that we picked the kind of each closure;
     /// not all closures are present in the map.
     closure_kind_origins: ItemLocalMap<(Span, HirPlace<'tcx>)>,
@@ -423,12 +418,6 @@ pub struct TypeckResults<'tcx> {
     /// All the opaque types that are restricted to concrete types
     /// by this function.
     pub concrete_opaque_types: FxHashMap<DefId, ResolvedOpaqueTy<'tcx>>,
-
-    /// Given the closure ID this map provides the list of UpvarIDs used by it.
-    /// The upvarID contains the HIR node ID and it also contains the full path
-    /// leading to the member of the struct or tuple that is used instead of the
-    /// entire variable.
-    pub closure_captures: ty::UpvarListMap,
 
     /// Tracks the minimum captures required for a closure;
     /// see `MinCaptureInformationMap` for more details.
@@ -482,7 +471,6 @@ impl<'tcx> TypeckResults<'tcx> {
             adjustments: Default::default(),
             pat_binding_modes: Default::default(),
             pat_adjustments: Default::default(),
-            upvar_capture_map: Default::default(),
             closure_kind_origins: Default::default(),
             liberated_fn_sigs: Default::default(),
             fru_field_types: Default::default(),
@@ -490,7 +478,6 @@ impl<'tcx> TypeckResults<'tcx> {
             used_trait_imports: Lrc::new(Default::default()),
             tainted_by_errors: None,
             concrete_opaque_types: Default::default(),
-            closure_captures: Default::default(),
             closure_min_captures: Default::default(),
             closure_fake_reads: Default::default(),
             generator_interior_types: ty::Binder::dummy(Default::default()),
@@ -675,10 +662,6 @@ impl<'tcx> TypeckResults<'tcx> {
             .flatten()
     }
 
-    pub fn upvar_capture(&self, upvar_id: ty::UpvarId) -> ty::UpvarCapture<'tcx> {
-        self.upvar_capture_map[&upvar_id]
-    }
-
     pub fn closure_kind_origins(&self) -> LocalTableInContext<'_, (Span, HirPlace<'tcx>)> {
         LocalTableInContext { hir_owner: self.hir_owner, data: &self.closure_kind_origins }
     }
@@ -722,7 +705,7 @@ impl<'tcx> TypeckResults<'tcx> {
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let ty::TypeckResults {
-            hir_owner,
+            hir_owner: _,
             ref type_dependent_defs,
             ref field_indices,
             ref user_provided_types,
@@ -732,17 +715,13 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             ref adjustments,
             ref pat_binding_modes,
             ref pat_adjustments,
-            ref upvar_capture_map,
             ref closure_kind_origins,
             ref liberated_fn_sigs,
             ref fru_field_types,
-
             ref coercion_casts,
-
             ref used_trait_imports,
             tainted_by_errors,
             ref concrete_opaque_types,
-            ref closure_captures,
             ref closure_min_captures,
             ref closure_fake_reads,
             ref generator_interior_types,
@@ -759,17 +738,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             adjustments.hash_stable(hcx, hasher);
             pat_binding_modes.hash_stable(hcx, hasher);
             pat_adjustments.hash_stable(hcx, hasher);
-            hash_stable_hashmap(hcx, hasher, upvar_capture_map, |up_var_id, hcx| {
-                let ty::UpvarId { var_path, closure_expr_id } = *up_var_id;
-
-                assert_eq!(var_path.hir_id.owner, hir_owner);
-
-                (
-                    hcx.local_def_path_hash(var_path.hir_id.owner),
-                    var_path.hir_id.local_id,
-                    hcx.local_def_path_hash(closure_expr_id),
-                )
-            });
 
             closure_kind_origins.hash_stable(hcx, hasher);
             liberated_fn_sigs.hash_stable(hcx, hasher);
@@ -778,7 +746,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
             used_trait_imports.hash_stable(hcx, hasher);
             tainted_by_errors.hash_stable(hcx, hasher);
             concrete_opaque_types.hash_stable(hcx, hasher);
-            closure_captures.hash_stable(hcx, hasher);
             closure_min_captures.hash_stable(hcx, hasher);
             closure_fake_reads.hash_stable(hcx, hasher);
             generator_interior_types.hash_stable(hcx, hasher);

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -705,7 +705,7 @@ impl<'tcx> TypeckResults<'tcx> {
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let ty::TypeckResults {
-            hir_owner: _,
+            hir_owner,
             ref type_dependent_defs,
             ref field_indices,
             ref user_provided_types,
@@ -729,6 +729,8 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
         } = *self;
 
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
+            hcx.local_def_path_hash(hir_owner);
+
             type_dependent_defs.hash_stable(hcx, hasher);
             field_indices.hash_stable(hcx, hasher);
             user_provided_types.hash_stable(hcx, hasher);

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -881,7 +881,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let hir_typeck_results = self.typeck_results;
 
         // In analyze_closure() in upvar.rs we gathered a list of upvars used by a
-        // indexed closure and we stored in a map called closure_captures in TypeckResults
+        // indexed closure and we stored in a map called closure_min_captures in TypeckResults
         // with the closure's DefId. Here, we run through that vec of UpvarIds for
         // the given closure and use the necessary information to create upvar
         // debuginfo and to fill `self.upvar_mutbls`.

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -61,7 +61,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         wbcx.visit_body(body);
         wbcx.visit_min_capture_map();
         wbcx.visit_fake_reads_map();
-        wbcx.visit_upvar_capture_map();
         wbcx.visit_closures();
         wbcx.visit_liberated_fn_sigs();
         wbcx.visit_fru_field_types();
@@ -78,9 +77,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         wbcx.typeck_results.treat_byte_string_as_slice =
             mem::take(&mut self.typeck_results.borrow_mut().treat_byte_string_as_slice);
-
-        wbcx.typeck_results.closure_captures =
-            mem::take(&mut self.typeck_results.borrow_mut().closure_captures);
 
         if self.is_tainted_by_errors() {
             // FIXME(eddyb) keep track of `ErrorReported` from where the error was emitted.
@@ -387,22 +383,6 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             resolved_closure_fake_reads.insert(*closure_def_id, resolved_fake_reads);
         }
         self.typeck_results.closure_fake_reads = resolved_closure_fake_reads;
-    }
-
-    fn visit_upvar_capture_map(&mut self) {
-        for (upvar_id, upvar_capture) in self.fcx.typeck_results.borrow().upvar_capture_map.iter() {
-            let new_upvar_capture = match *upvar_capture {
-                ty::UpvarCapture::ByValue(span) => ty::UpvarCapture::ByValue(span),
-                ty::UpvarCapture::ByRef(ref upvar_borrow) => {
-                    ty::UpvarCapture::ByRef(ty::UpvarBorrow {
-                        kind: upvar_borrow.kind,
-                        region: self.tcx().lifetimes.re_erased,
-                    })
-                }
-            };
-            debug!("Upvar capture for {:?} resolved to {:?}", upvar_id, new_upvar_capture);
-            self.typeck_results.upvar_capture_map.insert(*upvar_id, new_upvar_capture);
-        }
     }
 
     fn visit_closures(&mut self) {

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness.rs
@@ -1,0 +1,91 @@
+// check-pass
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+#![allow(unreachable_code)]
+#![warn(unused)]
+
+#[derive(Debug)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+pub fn f() {
+    let mut a = 1;
+    let mut c = Point{ x:1, y:0 };
+
+    // Captured by value, but variable is dead on entry.
+    (move || {
+        // This will not trigger a warning for unused variable as
+        // c.x will be treated as a Non-tracked place
+        c.x = 1;
+        println!("{}", c.x);
+        a = 1; //~ WARN value captured by `a` is never read
+        println!("{}", a);
+    })();
+
+    // Read and written to, but never actually used.
+    (move || {
+        // This will not trigger a warning for unused variable as
+        // c.x will be treated as a Non-tracked place
+        c.x += 1;
+        a += 1; //~ WARN unused variable: `a`
+    })();
+
+    (move || {
+        println!("{}", c.x);
+        // Value is read by closure itself on later invocations.
+        // This will not trigger a warning for unused variable as
+        // c.x will be treated as a Non-tracked place
+        c.x += 1;
+        println!("{}", a);
+        a += 1;
+    })();
+    let b = Box::new(42);
+    (move || {
+        println!("{}", c.x);
+        // Never read because this is FnOnce closure.
+        // This will not trigger a warning for unused variable as
+        // c.x will be treated as a Non-tracked place
+        c.x += 1;
+        println!("{}", a);
+        a += 1; //~ WARN value assigned to `a` is never read
+        drop(b);
+    })();
+}
+
+#[derive(Debug)]
+struct MyStruct<'a>  {
+    x: Option<& 'a str>,
+    y: i32,
+}
+
+pub fn nested() {
+    let mut a : Option<& str>;
+    a = None;
+    let mut b : Option<& str>;
+    b = None;
+    let mut d = MyStruct{ x: None, y: 1};
+    let mut e = MyStruct{ x: None, y: 1};
+    (|| {
+        (|| {
+            // This will not trigger a warning for unused variable as
+            // d.x will be treated as a Non-tracked place
+            d.x = Some("d1");
+            d.x = Some("d2");
+            a = Some("d1"); //~ WARN value assigned to `a` is never read
+            a = Some("d2");
+        })();
+        (move || {
+            // This will not trigger a warning for unused variable as
+            //e.x will be treated as a Non-tracked place
+            e.x = Some("e1");
+            e.x = Some("e2");
+            b = Some("e1"); //~ WARN value assigned to `b` is never read
+                            //~| WARN unused variable: `b`
+            b = Some("e2"); //~ WARN value assigned to `b` is never read
+        })();
+    })();
+}
+
+fn main() {}

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness.stderr
@@ -1,0 +1,79 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/liveness.rs:2:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+warning: value captured by `a` is never read
+  --> $DIR/liveness.rs:23:9
+   |
+LL |         a = 1;
+   |         ^
+   |
+note: the lint level is defined here
+  --> $DIR/liveness.rs:5:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
+   = help: did you mean to capture by reference instead?
+
+warning: unused variable: `a`
+  --> $DIR/liveness.rs:32:9
+   |
+LL |         a += 1;
+   |         ^
+   |
+note: the lint level is defined here
+  --> $DIR/liveness.rs:5:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+   = help: did you mean to capture by reference instead?
+
+warning: value assigned to `a` is never read
+  --> $DIR/liveness.rs:52:9
+   |
+LL |         a += 1;
+   |         ^
+   |
+   = help: maybe it is overwritten before being read?
+
+warning: value assigned to `a` is never read
+  --> $DIR/liveness.rs:76:13
+   |
+LL |             a = Some("d1");
+   |             ^
+   |
+   = help: maybe it is overwritten before being read?
+
+warning: value assigned to `b` is never read
+  --> $DIR/liveness.rs:84:13
+   |
+LL |             b = Some("e1");
+   |             ^
+   |
+   = help: maybe it is overwritten before being read?
+
+warning: value assigned to `b` is never read
+  --> $DIR/liveness.rs:86:13
+   |
+LL |             b = Some("e2");
+   |             ^
+   |
+   = help: maybe it is overwritten before being read?
+
+warning: unused variable: `b`
+  --> $DIR/liveness.rs:84:13
+   |
+LL |             b = Some("e1");
+   |             ^
+   |
+   = help: did you mean to capture by reference instead?
+
+warning: 8 warnings emitted
+

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.rs
@@ -1,0 +1,42 @@
+// check-pass
+#![feature(capture_disjoint_fields)]
+//~^ WARNING: the feature `capture_disjoint_fields` is incomplete
+#![warn(unused)]
+
+#[derive(Debug)]
+struct MyStruct {
+    a: i32,
+    b: i32,
+}
+
+pub fn unintentional_copy_one() {
+    let mut a = 1;
+    let mut last = MyStruct{ a: 1, b: 1};
+    let mut f = move |s| {
+        // This will not trigger a warning for unused variable
+        // as last.a will be treated as a Non-tracked place
+        last.a = s;
+        a = s;
+        //~^ WARN value assigned to `a` is never read
+        //~| WARN unused variable: `a`
+    };
+    f(2);
+    f(3);
+    f(4);
+}
+
+pub fn unintentional_copy_two() {
+    let mut a = 1;
+    let mut sum = MyStruct{ a: 1, b: 0};
+    (1..10).for_each(move |x| {
+        // This will not trigger a warning for unused variable
+        // as sum.b will be treated as a Non-tracked place
+        sum.b += x;
+        a += x; //~ WARN unused variable: `a`
+    });
+}
+
+fn main() {
+    unintentional_copy_one();
+    unintentional_copy_two();
+}

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/liveness_unintentional_copy.stderr
@@ -1,0 +1,47 @@
+warning: the feature `capture_disjoint_fields` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/liveness_unintentional_copy.rs:2:12
+   |
+LL | #![feature(capture_disjoint_fields)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+   = note: see issue #53488 <https://github.com/rust-lang/rust/issues/53488> for more information
+
+warning: value assigned to `a` is never read
+  --> $DIR/liveness_unintentional_copy.rs:19:9
+   |
+LL |         a = s;
+   |         ^
+   |
+note: the lint level is defined here
+  --> $DIR/liveness_unintentional_copy.rs:4:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_assignments)]` implied by `#[warn(unused)]`
+   = help: maybe it is overwritten before being read?
+
+warning: unused variable: `a`
+  --> $DIR/liveness_unintentional_copy.rs:19:9
+   |
+LL |         a = s;
+   |         ^
+   |
+note: the lint level is defined here
+  --> $DIR/liveness_unintentional_copy.rs:4:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+   = help: did you mean to capture by reference instead?
+
+warning: unused variable: `a`
+  --> $DIR/liveness_unintentional_copy.rs:35:9
+   |
+LL |         a += x;
+   |         ^
+   |
+   = help: did you mean to capture by reference instead?
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
Removed all uses of closures_captures and upvar_capture and refactored code to work with closure_min_captures. This also involved removing functions that were no longer needed like the bridge.

Closes https://github.com/rust-lang/project-rfc-2229/issues/18
r? @nikomatsakis

