### PR TITLE
Remove `masked_crates` from `clean::Crate`

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -57,7 +57,6 @@ crate struct Crate {
     // These are later on moved into `CACHEKEY`, leaving the map empty.
     // Only here so that they can be filtered through the rustdoc passes.
     crate external_traits: Rc<RefCell<FxHashMap<DefId, TraitWithExtraInfo>>>,
-    crate masked_crates: FxHashSet<CrateNum>,
     crate collapsed: bool,
 }
 

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -7,7 +7,6 @@ use crate::clean::{
 };
 use crate::core::DocContext;
 
-use rustc_data_structures::fx::FxHashSet;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
@@ -38,7 +37,6 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     // Clean the crate, translating the entire librustc_ast AST to one that is
     // understood by rustdoc.
     let mut module = module.clean(cx);
-    let mut masked_crates = FxHashSet::default();
 
     match *module.kind {
         ItemKind::ModuleItem(ref module) => {
@@ -49,7 +47,7 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
                     && (it.attrs.has_doc_flag(sym::masked)
                         || cx.tcx.is_compiler_builtins(it.def_id.krate))
                 {
-                    masked_crates.insert(it.def_id.krate);
+                    cx.cache.masked_crates.insert(it.def_id.krate);
                 }
             }
         }
@@ -82,7 +80,6 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
         externs,
         primitives,
         external_traits: cx.external_traits.clone(),
-        masked_crates,
         collapsed: false,
     }
 }

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -89,12 +89,16 @@ crate struct Cache {
     /// This is stored in `Cache` so it doesn't need to be passed through all rustdoc functions.
     crate document_private: bool,
 
+    /// Crates marked with [`#[doc(masked)]`][doc_masked].
+    ///
+    /// [doc_masked]: https://doc.rust-lang.org/nightly/unstable-book/language-features/doc-masked.html
+    crate masked_crates: FxHashSet<CrateNum>,
+
     // Private fields only used when initially crawling a crate to build a cache
     stack: Vec<String>,
     parent_stack: Vec<DefId>,
     parent_is_trait_impl: bool,
     stripped_mod: bool,
-    masked_crates: FxHashSet<CrateNum>,
 
     crate search_index: Vec<IndexItem>,
     crate deref_trait_did: Option<DefId>,
@@ -146,7 +150,6 @@ impl Cache {
         // Crawl the crate to build various caches used for the output
         debug!(?self.crate_version);
         self.traits = krate.external_traits.take();
-        self.masked_crates = mem::take(&mut krate.masked_crates);
 
         // Cache where all our extern crates are located
         // FIXME: this part is specific to HTML so it'd be nice to remove it from the common code


### PR DESCRIPTION
Previously, `masked_crates` existed both on `Cache` and on
`clean::Crate`. During cache population, the `clean::Crate` version was
`take`n and moved to `Cache`.

This change removes the version on `clean::Crate` and instead directly
mutates `Cache.masked_crates` to initialize it. This has the advantage
of avoiding duplication and avoiding unnecessary allocation, as well as
making the flow of information through rustdoc less confusing.

The one downside I see is that `clean::utils::krate()` now uses the side
effect of mutating `DocContext.cache` instead of returning the data
directly, but it already mutated the `Cache` for other things (e.g.,
`deref_trait_did`) so it's not really new behavior. Also,
`clean::utils::krate()` is only called once (and is meant to only be
called once since it performs expensive and potentially destructive
operations) so the mutation shouldn't be an issue.

Follow-up to https://github.com/rust-lang/rust/pull/82018#discussion_r584197747.

cc @jyn514
