### PR TITLE
Treat header as first paragraph for shortened markdown descriptions

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1093,6 +1093,7 @@ fn markdown_summary_with_limit(md: &str, length_limit: usize) -> (String, bool) 
                 Tag::Emphasis => s.push_str("</em>"),
                 Tag::Strong => s.push_str("</strong>"),
                 Tag::Paragraph => break,
+                Tag::Heading(..) => break,
                 _ => {}
             },
             Event::HardBreak | Event::SoftBreak => {

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -235,6 +235,7 @@ fn test_short_markdown_summary() {
     t("code `let x = i32;` ...", "code <code>let x = i32;</code> …");
     t("type `Type<'static>` ...", "type <code>Type<'static></code> …");
     t("# top header", "top header");
+    t("# top header\n\nfollowed by a paragraph", "top header");
     t("## header", "header");
     t("first paragraph\n\nsecond paragraph", "first paragraph");
     t("```\nfn main() {}\n```", "");

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -286,11 +286,7 @@ impl Serialize for TypeWithKind {
     where
         S: Serializer,
     {
-        let mut seq = serializer.serialize_seq(None)?;
-        seq.serialize_element(&self.ty.name)?;
-        let x: ItemType = self.kind.into();
-        seq.serialize_element(&x)?;
-        seq.end()
+        (&self.ty.name, ItemType::from(self.kind)).serialize(serializer)
     }
 }
 


### PR DESCRIPTION
"The Rust Standard LibraryThe Rust Standard Library is the …" is an awful description.
