### PR TITLE
update MSYS2 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ build.
 
 [MSYS2][msys2] can be used to easily build Rust on Windows:
 
-[msys2]: https://msys2.github.io/
+[msys2]: https://www.msys2.org/
 
 1. Grab the latest [MSYS2 installer][msys2] and go through the installer.
 


### PR DESCRIPTION
Now https://msys2.github.io/ redirects to https://www.msys2.org/, so the README might just link to that immediately.