### PR TITLE
fix copy_nonoverlapping

### DIFF
--- a/src/test/ui/consts/copy-intrinsic.rs
+++ b/src/test/ui/consts/copy-intrinsic.rs
@@ -1,0 +1,31 @@
+// ignore-tidy-linelength
+#![feature(const_mut_refs, const_intrinsic_copy, const_ptr_offset)]
+use std::ptr;
+
+const COPY_ZERO: () = unsafe {
+    // Since we are not copying anything, this should be allowed.
+    let src = ();
+    let mut dst = ();
+    ptr::copy_nonoverlapping(&src as *const _ as *const i32, &mut dst as *mut _ as *mut i32, 0);
+};
+
+const COPY_OOB_1: () = unsafe {
+    let mut x = 0i32;
+    let dangle = (&mut x as *mut i32).wrapping_add(10);
+    // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
+    ptr::copy_nonoverlapping(0x100 as *const i32, dangle, 0); //~ ERROR any use of this value will cause an error
+    //~| memory access failed: pointer must be in-bounds
+    //~| previously accepted
+};
+const COPY_OOB_2: () = unsafe {
+    let x = 0i32;
+    let dangle = (&x as *const i32).wrapping_add(10);
+    // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
+    ptr::copy_nonoverlapping(dangle, 0x100 as *mut i32, 0); //~ ERROR any use of this value will cause an error
+    //~| memory access failed: pointer must be in-bounds
+    //~| previously accepted
+};
+
+
+fn main() {
+}

--- a/src/test/ui/consts/copy-intrinsic.stderr
+++ b/src/test/ui/consts/copy-intrinsic.stderr
@@ -1,0 +1,37 @@
+error: any use of this value will cause an error
+  --> $DIR/copy-intrinsic.rs:16:5
+   |
+LL | / const COPY_OOB_1: () = unsafe {
+LL | |     let mut x = 0i32;
+LL | |     let dangle = (&mut x as *mut i32).wrapping_add(10);
+LL | |     // Even if the first ptr is an int ptr and this is a ZST copy, we should detect dangling 2nd ptrs.
+LL | |     ptr::copy_nonoverlapping(0x100 as *const i32, dangle, 0);
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc4 which has size 4
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $DIR/copy-intrinsic.rs:24:5
+   |
+LL | / const COPY_OOB_2: () = unsafe {
+LL | |     let x = 0i32;
+LL | |     let dangle = (&x as *const i32).wrapping_add(10);
+LL | |     // Even if the second ptr is an int ptr and this is a ZST copy, we should detect dangling 1st ptrs.
+LL | |     ptr::copy_nonoverlapping(dangle, 0x100 as *mut i32, 0);
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: pointer must be in-bounds at offset 40, but is outside bounds of alloc6 which has size 4
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/rust-lang/rust/pull/77511

r? @oli-obk 
Fixes https://github.com/rust-lang/rust/issues/82961