### PR TITLE
Improve display of Unix wait statuses, notably giving names for signals

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -178,7 +178,7 @@ pub mod signal_lookup {
     }
 
     pub static descrs: Lookups = Lookups {
-        sigfoo_np: Weak::new("sigdescr_pn\0"),   // glibc >=2.32
+        sigfoo_np: Weak::new("sigdescr_np\0"),   // glibc >=2.32
         sys_sigfoos: Weak::new("sys_siglist\0"), // FreeBSD/NetBSD/OpenBSD
     };
 

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -206,7 +206,7 @@ pub mod signal_lookup {
     }
 }
 
-#[cfg(arget_env = "musl")]
+#[cfg(target_env = "musl")]
 pub mod signal_lookup {
     pub struct ViaStrsignal;
     pub static descrs: ViaStrSignal = ViaStrSignal;

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -179,7 +179,7 @@ pub mod signal_lookup {
 
     pub static descrs: Lookups = Lookups {
         sigfoo_np: Weak::new("sigdescr_pn\0"),   // glibc >=2.32
-        sys_sigfoos: Weak::new("sys_siglist\0"), // FeeBSD/NetBSD/OpenBSD
+        sys_sigfoos: Weak::new("sys_siglist\0"), // FreeBSD/NetBSD/OpenBSD
     };
 
     pub static abbrevs: Lookups = Lookups {

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -158,7 +158,7 @@ unsafe fn ptr_to_maybe_str(p: *const c_char) -> Option<&'static str> {
 
 // This is pretty universal - the nix crate makes the same assumption.  We need it to be no larger
 // than the platform's actual value - but, only on platforms where there is sys_siglist or
-// sys_signame.  This value is a pretty safe bet, and we have a test caee for it.
+// sys_signame.  This value is a pretty safe bet, and we have a test case for it.
 const NSIG: usize = 32;
 
 #[cfg(not(target_env = "musl"))]

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -183,7 +183,7 @@ pub mod signal_lookup {
     };
 
     pub static abbrevs: Lookups = Lookups {
-        sigfoo_np: Weak::new("sigabbrev_pn\0"),  // glibc >=2.32
+        sigfoo_np: Weak::new("sigabbrev_np\0"),  // glibc >=2.32
         sys_sigfoos: Weak::new("sys_signame\0"), // glibc < 2.23, BSDs, and other trad unix
     };
 

--- a/library/std/src/sys/unix/os/tests.rs
+++ b/library/std/src/sys/unix/os/tests.rs
@@ -21,3 +21,26 @@ fn test_parse_glibc_version() {
         assert_eq!(parsed, parse_glibc_version(version_str));
     }
 }
+
+#[test]
+fn try_all_signals() {
+    fn chk(l: &dyn SignalLookupMethod, sig: usize) {
+        let got = l.lookup(sig as i32);
+        println!("{:2} {:?}", sig, got);
+        if let Some(got) = got {
+            for &c in got.as_bytes() {
+                assert!(c == b' ' || c.is_ascii_graphic(), "sig={} got={:?}", c, &got);
+            }
+        }
+    }
+
+    for sig in 0..NSIG {
+        chk(&signal_lookup::descrs, sig);
+        chk(&signal_lookup::abbrevs, sig);
+    }
+
+    // 1..15 are anciently conventional signal numbers; check they can be looked up:
+    for sig in 1..15 {
+        assert!(signal_lookup::descrs.lookup(sig).is_some());
+    }
+}

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -526,20 +526,20 @@ impl From<c_int> for ExitStatus {
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(code) = self.code() {
-            write!(f, "exit status: {}", code)
+            write!(f, "exit status: {}", code)?;
         } else if let Some(signal) = self.signal() {
+            write!(f, "signal: {}", signal)?;
             if self.core_dumped() {
-                write!(f, "signal: {} (core dumped)", signal)
-            } else {
-                write!(f, "signal: {}", signal)
+                write!(f, " (core dumped)")?;
             }
         } else if let Some(signal) = self.stopped_signal() {
-            write!(f, "stopped (not terminated) by signal: {}", signal)
+            write!(f, "stopped (not terminated) by signal: {}", signal)?;
         } else if self.continued() {
-            write!(f, "continued (WIFCONTINUED)")
+            write!(f, "continued (WIFCONTINUED)")?;
         } else {
-            write!(f, "unrecognised wait status: {} {:#x}", self.0, self.0)
+            write!(f, "unrecognised wait status: {} {:#x}", self.0, self.0)?;
         }
+        Ok(())
     }
 }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -526,7 +526,7 @@ impl From<c_int> for ExitStatus {
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(code) = self.code() {
-            write!(f, "exit code: {}", code)
+            write!(f, "exit status: {}", code)
         } else if let Some(signal) = self.signal() {
             if self.core_dumped() {
                 write!(f, "signal: {} (core dumped)", signal)

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -4,6 +4,7 @@ use crate::io::{self, Error, ErrorKind};
 use crate::ptr;
 use crate::sys;
 use crate::sys::cvt;
+use crate::sys::os::signal_display;
 use crate::sys::process::process_common::*;
 
 #[cfg(target_os = "vxworks")]
@@ -528,12 +529,14 @@ impl fmt::Display for ExitStatus {
         if let Some(code) = self.code() {
             write!(f, "exit status: {}", code)?;
         } else if let Some(signal) = self.signal() {
-            write!(f, "signal: {}", signal)?;
+            write!(f, "signal: ")?;
+            signal_display(f, signal)?;
             if self.core_dumped() {
                 write!(f, " (core dumped)")?;
             }
         } else if let Some(signal) = self.stopped_signal() {
-            write!(f, "stopped (not terminated) by signal: {}", signal)?;
+            write!(f, "stopped (not terminated) by signal: ")?;
+            signal_display(f, signal)?;
         } else if self.continued() {
             write!(f, "continued (WIFCONTINUED)")?;
         } else {

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -9,8 +9,8 @@ fn exitstatus_display_tests() {
 
     t(0x0000f, "signal: 15");
     t(0x0008b, "signal: 11 (core dumped)");
-    t(0x00000, "exit code: 0");
-    t(0x0ff00, "exit code: 255");
+    t(0x00000, "exit status: 0");
+    t(0x0ff00, "exit status: 255");
 
     // On MacOS, 0x0137f is WIFCONTINUED, not WIFSTOPPED.  Probably *BSD is similar.
     //   https://github.com/rust-lang/rust/pull/82749#issuecomment-790525956

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -1,30 +1,34 @@
 #[test]
+#[rustfmt::skip] // avoids tidy destroying the legibility of the hex/string tables
 fn exitstatus_display_tests() {
     // In practice this is the same on every Unix.
     // If some weird platform turns out to be different, and this test fails, use #[cfg].
     use crate::os::unix::process::ExitStatusExt;
     use crate::process::ExitStatus;
 
-    let t = |v, s| assert_eq!(s, format!("{}", <ExitStatus as ExitStatusExt>::from_raw(v)));
+    let t = |v, exp: &[&str]| {
+        let got = format!("{}", <ExitStatus as ExitStatusExt>::from_raw(v));
+        assert!(exp.contains(&got.as_str()), "exp={:?} got={:?}", exp, &got);
+    };
 
-    t(0x0000f, "signal: 15");
-    t(0x0008b, "signal: 11 (core dumped)");
-    t(0x00000, "exit status: 0");
-    t(0x0ff00, "exit status: 255");
+    t(0x0000f, &["signal: 15"]);
+    t(0x0008b, &["signal: 11 (core dumped)"]);
+    t(0x00000, &["exit status: 0"]);
+    t(0x0ff00, &["exit status: 255"]);
 
     // On MacOS, 0x0137f is WIFCONTINUED, not WIFSTOPPED.  Probably *BSD is similar.
     //   https://github.com/rust-lang/rust/pull/82749#issuecomment-790525956
     // The purpose of this test is to test our string formatting, not our understanding of the wait
     // status magic numbers.  So restrict these to Linux.
     if cfg!(target_os = "linux") {
-        t(0x0137f, "stopped (not terminated) by signal: 19");
-        t(0x0ffff, "continued (WIFCONTINUED)");
+        t(0x0137f, &["stopped (not terminated) by signal: 19"]);
+        t(0x0ffff, &["continued (WIFCONTINUED)"]);
     }
 
     // Testing "unrecognised wait status" is hard because the wait.h macros typically
     // assume that the value came from wait and isn't mad.  With the glibc I have here
     // this works:
     if cfg!(all(target_os = "linux", target_env = "gnu")) {
-        t(0x000ff, "unrecognised wait status: 255 0xff");
+        t(0x000ff, &["unrecognised wait status: 255 0xff"]);
     }
 }

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -2,7 +2,7 @@
 #[rustfmt::skip] // avoids tidy destroying the legibility of the hex/string tables
 fn exitstatus_display_tests() {
     // In practice this is the same on every Unix.
-    // If some weird platform turns out to be different, and this test fails, use #[cfg].
+    // If some weird platform turns out to be different, and this test fails, use if cfg!
     use crate::os::unix::process::ExitStatusExt;
     use crate::process::ExitStatus;
 
@@ -10,6 +10,11 @@ fn exitstatus_display_tests() {
         let got = format!("{}", <ExitStatus as ExitStatusExt>::from_raw(v));
         assert!(exp.contains(&got.as_str()), "got={:?} exp={:?}", &got, exp);
     };
+
+    // SuS says that wait status 0 corresponds to WIFEXITED and WEXITSTATUS==0.
+    // The implementation of `ExitStatusError` relies on this fact.
+    // So this one must always pass - don't disable this one with cfg!
+    t(0x00000, &["exit status: 0"]);
 
     // We cope with a variety of conventional signal strings, both with and without the signal
     // abbrevation too.  It would be better to compare this with the result of strsignal but that
@@ -20,7 +25,6 @@ fn exitstatus_display_tests() {
                  "signal: Terminated (SIGTERM)"]);
     t(0x0008b, &["signal: Segmentation fault (core dumped)",
                  "signal: Segmentation fault (SIGSEGV) (core dumped)"]);
-    t(0x00000, &["exit status: 0"]);
     t(0x0ff00, &["exit status: 255"]);
 
     // On MacOS, 0x0137f is WIFCONTINUED, not WIFSTOPPED.  Probably *BSD is similar.


### PR DESCRIPTION
The motivations here are:
 * Provide signal names (eg `Segmentation fault (SIGSEGV)`) rather than numbers (eg `signal 11`)
 * Correct the string for `WIFEXITED` to describe the value as the `exit status`

These two changes are behavioural changes to the existing APIs so insta-stable.  But I hope they won't be controversial.

Providing signal names requires adding a facility (exposed as unstable in this MR) to do the number to string conversion.  The implementation of that (and indeed the exposed API) is not entirely straightforward because of the lack of `strsignal_r` and non-portability of `sys_siglist` and `sys_signame`.

The test cases for `ExitStatus as Display` need to be updated to contain the new strings.  Signal strings are very widely shared across Unices so I am *hoping* that this will work everywhere.  However, it is quite possible that this test case will need adjustment on some platform.  Additionally, I have not been able to test this myself on anything with a very recent glibc (2.32 or later), for which this code needs special handling.  So it might be worth running this through `@bors try` to spot any issues.