### PR TITLE
Add a Span to `OpTy` so subsequent uses can report more precise error spans on the use of the `OpTy`.

### DIFF
--- a/compiler/rustc_mir/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_mir/src/const_eval/eval_queries.rs
@@ -13,6 +13,7 @@ use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::traits::Reveal;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, subst::Subst, TyCtxt};
+use rustc_span::DUMMY_SP;
 use rustc_span::source_map::Span;
 use rustc_target::abi::{Abi, LayoutOf};
 use std::convert::TryInto;
@@ -230,7 +231,7 @@ pub fn eval_to_const_value_raw_provider<'tcx>(
         };
         return eval_nullary_intrinsic(tcx, key.param_env, def_id, substs).map_err(|error| {
             let span = tcx.def_span(def_id);
-            let error = ConstEvalErr { error: error.into_kind(), stacktrace: vec![], span };
+            let error = ConstEvalErr { error: error.into_kind(), stacktrace: vec![], span, extra_span: DUMMY_SP };
             error.report_as_error(tcx.at(span), "could not evaluate nullary intrinsic")
         });
     }
@@ -330,7 +331,7 @@ pub fn eval_to_allocation_raw_provider<'tcx>(
                 } else {
                     "evaluation of constant value failed"
                 };
-                Err(err.report_as_error(ecx.tcx.at(ecx.cur_span()), msg))
+                Err(err.report_as_error(ecx.tcx.at(ecx.cur_spans().0), msg))
             }
         }
         Ok(mplace) => {

--- a/compiler/rustc_mir/src/const_eval/mod.rs
+++ b/compiler/rustc_mir/src/const_eval/mod.rs
@@ -46,7 +46,7 @@ pub(crate) fn destructure_const<'tcx>(
 ) -> mir::DestructuredConst<'tcx> {
     trace!("destructure_const: {:?}", val);
     let ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
-    let op = ecx.const_to_op(val, None).unwrap();
+    let op = ecx.const_to_op(val, None, DUMMY_SP).unwrap();
 
     // We go to `usize` as we cannot allocate anything bigger anyway.
     let (field_count, variant, down) = match val.ty.kind() {
@@ -80,7 +80,7 @@ pub(crate) fn deref_const<'tcx>(
 ) -> &'tcx ty::Const<'tcx> {
     trace!("deref_const: {:?}", val);
     let ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
-    let op = ecx.const_to_op(val, None).unwrap();
+    let op = ecx.const_to_op(val, None, DUMMY_SP).unwrap();
     let mplace = ecx.deref_operand(&op).unwrap();
     if let Scalar::Ptr(ptr) = mplace.ptr {
         assert_eq!(

--- a/compiler/rustc_mir/src/interpret/cast.rs
+++ b/compiler/rustc_mir/src/interpret/cast.rs
@@ -51,7 +51,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
                         if self.tcx.has_attr(def_id, sym::rustc_args_required_const) {
                             span_bug!(
-                                self.cur_span(),
+                                self.cur_spans().0,
                                 "reifying a fn ptr that requires const arguments"
                             );
                         }
@@ -67,7 +67,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         let fn_ptr = self.memory.create_fn_alloc(FnVal::Instance(instance));
                         self.write_scalar(fn_ptr, dest)?;
                     }
-                    _ => span_bug!(self.cur_span(), "reify fn pointer on {:?}", src.layout.ty),
+                    _ => span_bug!(self.cur_spans().0, "reify fn pointer on {:?}", src.layout.ty),
                 }
             }
 
@@ -78,7 +78,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         // No change to value
                         self.write_immediate(*src, dest)?;
                     }
-                    _ => span_bug!(self.cur_span(), "fn to unsafe fn cast on {:?}", cast_ty),
+                    _ => span_bug!(self.cur_spans().0, "fn to unsafe fn cast on {:?}", cast_ty),
                 }
             }
 
@@ -98,7 +98,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         let fn_ptr = self.memory.create_fn_alloc(FnVal::Instance(instance));
                         self.write_scalar(fn_ptr, dest)?;
                     }
-                    _ => span_bug!(self.cur_span(), "closure fn pointer on {:?}", src.layout.ty),
+                    _ => span_bug!(self.cur_spans().0, "closure fn pointer on {:?}", src.layout.ty),
                 }
             }
         }
@@ -167,7 +167,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 return match **src {
                     Immediate::ScalarPair(data, _) => Ok(data.into()),
                     Immediate::Scalar(..) => span_bug!(
-                        self.cur_span(),
+                        self.cur_spans().0,
                         "{:?} input to a fat-to-thin cast ({:?} -> {:?})",
                         *src,
                         src.layout.ty,
@@ -221,7 +221,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             // Casts to bool are not permitted by rustc, no need to handle them here.
-            _ => span_bug!(self.cur_span(), "invalid int to {:?} cast", cast_ty),
+            _ => span_bug!(self.cur_spans().0, "invalid int to {:?} cast", cast_ty),
         }
     }
 
@@ -253,7 +253,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // float -> f64
             Float(FloatTy::F64) => Scalar::from_f64(f.convert(&mut false).value),
             // That's it.
-            _ => span_bug!(self.cur_span(), "invalid float to {:?} cast", dest_ty),
+            _ => span_bug!(self.cur_spans().0, "invalid float to {:?} cast", dest_ty),
         }
     }
 
@@ -293,7 +293,12 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             _ => {
-                span_bug!(self.cur_span(), "invalid unsizing {:?} -> {:?}", src.layout.ty, cast_ty)
+                span_bug!(
+                    self.cur_spans().0,
+                    "invalid unsizing {:?} -> {:?}",
+                    src.layout.ty,
+                    cast_ty
+                )
             }
         }
     }
@@ -315,7 +320,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 if def_a.is_box() || def_b.is_box() {
                     if !def_a.is_box() || !def_b.is_box() {
                         span_bug!(
-                            self.cur_span(),
+                            self.cur_spans().0,
                             "invalid unsizing between {:?} -> {:?}",
                             src.layout.ty,
                             cast_ty.ty
@@ -348,7 +353,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Ok(())
             }
             _ => span_bug!(
-                self.cur_span(),
+                self.cur_spans().0,
                 "unsize_into: invalid conversion: {:?} -> {:?}",
                 src.layout,
                 dest.layout

--- a/compiler/rustc_mir/src/interpret/intrinsics.rs
+++ b/compiler/rustc_mir/src/interpret/intrinsics.rs
@@ -13,7 +13,10 @@ use rustc_middle::mir::{
 use rustc_middle::ty;
 use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::{Ty, TyCtxt};
-use rustc_span::symbol::{sym, Symbol};
+use rustc_span::{
+    symbol::{sym, Symbol},
+    DUMMY_SP,
+};
 use rustc_target::abi::{Abi, LayoutOf as _, Primitive, Size};
 
 use super::{
@@ -172,7 +175,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let val =
                     self.tcx.const_eval_global_id(self.param_env, gid, Some(self.tcx.span))?;
                 let const_ = ty::Const { val: ty::ConstKind::Value(val), ty };
-                let val = self.const_to_op(&const_, None)?;
+                let val = self.const_to_op(&const_, None, DUMMY_SP)?;
                 self.copy_op(&val, dest)?;
             }
 

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -336,7 +336,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         if let Ok(imm) = self.try_read_immediate(op)? {
             Ok(imm)
         } else {
-            span_bug!(self.cur_span(), "primitive read failed for type: {:?}", op.layout.ty);
+            span_bug!(self.cur_spans().0, "primitive read failed for type: {:?}", op.layout.ty);
         }
     }
 
@@ -390,7 +390,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Immediate::from(val)
             }
             Immediate::Scalar(val) => span_bug!(
-                self.cur_span(),
+                self.cur_spans().0,
                 "field access on non aggregate {:#?}, {:#?}",
                 val,
                 op.layout
@@ -582,7 +582,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 return Ok(self.eval_to_allocation(GlobalId { instance, promoted })?.into());
             }
             ty::ConstKind::Infer(..) | ty::ConstKind::Placeholder(..) => {
-                span_bug!(self.cur_span(), "const_to_op: Unexpected ConstKind {:?}", val)
+                span_bug!(self.cur_spans().0, "const_to_op: Unexpected ConstKind {:?}", val)
             }
             ty::ConstKind::Value(val_val) => val_val,
         };
@@ -690,7 +690,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                             .discriminants(def_id, *self.tcx)
                             .find(|(_, var)| var.val == discr_bits)
                     }
-                    _ => span_bug!(self.cur_span(), "tagged layout for non-adt non-generator"),
+                    _ => span_bug!(self.cur_spans().0, "tagged layout for non-adt non-generator"),
                 }
                 .ok_or_else(|| err_ub!(InvalidTag(tag_val.erase_tag())))?;
                 // Return the cast value, and the index.

--- a/compiler/rustc_mir/src/interpret/operator.rs
+++ b/compiler/rustc_mir/src/interpret/operator.rs
@@ -60,7 +60,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Le => l <= r,
             Gt => l > r,
             Ge => l >= r,
-            _ => span_bug!(self.cur_span(), "Invalid operation on char: {:?}", bin_op),
+            _ => span_bug!(self.cur_spans().0, "Invalid operation on char: {:?}", bin_op),
         };
         (Scalar::from_bool(res), false, self.tcx.types.bool)
     }
@@ -83,7 +83,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             BitAnd => l & r,
             BitOr => l | r,
             BitXor => l ^ r,
-            _ => span_bug!(self.cur_span(), "Invalid operation on bool: {:?}", bin_op),
+            _ => span_bug!(self.cur_spans().0, "Invalid operation on bool: {:?}", bin_op),
         };
         (Scalar::from_bool(res), false, self.tcx.types.bool)
     }
@@ -109,7 +109,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Mul => ((l * r).value.into(), ty),
             Div => ((l / r).value.into(), ty),
             Rem => ((l % r).value.into(), ty),
-            _ => span_bug!(self.cur_span(), "invalid float op: `{:?}`", bin_op),
+            _ => span_bug!(self.cur_spans().0, "invalid float op: `{:?}`", bin_op),
         };
         (val, false, ty)
     }
@@ -154,7 +154,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // For the remaining ops, the types must be the same on both sides
         if left_layout.ty != right_layout.ty {
             span_bug!(
-                self.cur_span(),
+                self.cur_spans().0,
                 "invalid asymmetric binary op {:?}: {:?} ({:?}), {:?} ({:?})",
                 bin_op,
                 l,
@@ -252,7 +252,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             _ => span_bug!(
-                self.cur_span(),
+                self.cur_spans().0,
                 "invalid binary op {:?}: {:?}, {:?} (both {:?})",
                 bin_op,
                 l,
@@ -335,7 +335,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 M::binary_ptr_op(self, bin_op, left, right)
             }
             _ => span_bug!(
-                self.cur_span(),
+                self.cur_spans().0,
                 "Invalid MIR: bad LHS type for binop: {:?}",
                 left.layout.ty
             ),
@@ -372,7 +372,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let val = val.to_bool()?;
                 let res = match un_op {
                     Not => !val,
-                    _ => span_bug!(self.cur_span(), "Invalid bool op {:?}", un_op),
+                    _ => span_bug!(self.cur_spans().0, "Invalid bool op {:?}", un_op),
                 };
                 Ok((Scalar::from_bool(res), false, self.tcx.types.bool))
             }
@@ -380,7 +380,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let res = match (un_op, fty) {
                     (Neg, FloatTy::F32) => Scalar::from_f32(-val.to_f32()?),
                     (Neg, FloatTy::F64) => Scalar::from_f64(-val.to_f64()?),
-                    _ => span_bug!(self.cur_span(), "Invalid float op {:?}", un_op),
+                    _ => span_bug!(self.cur_spans().0, "Invalid float op {:?}", un_op),
                 };
                 Ok((res, false, layout.ty))
             }

--- a/compiler/rustc_mir/src/interpret/terminator.rs
+++ b/compiler/rustc_mir/src/interpret/terminator.rs
@@ -235,7 +235,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     ty::FnDef(..) => instance_ty.fn_sig(*self.tcx).abi(),
                     ty::Closure(..) => Abi::RustCall,
                     ty::Generator(..) => Abi::Rust,
-                    _ => span_bug!(self.cur_span(), "unexpected callee ty: {:?}", instance_ty),
+                    _ => span_bug!(self.cur_spans().0, "unexpected callee ty: {:?}", instance_ty),
                 }
             };
             let normalize_abi = |abi| match abi {

--- a/compiler/rustc_mir/src/transform/const_prop.rs
+++ b/compiler/rustc_mir/src/transform/const_prop.rs
@@ -482,7 +482,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return None;
         }
 
-        match self.ecx.const_to_op(c.literal, None) {
+        match self.ecx.const_to_op(c.literal, None, c.span) {
             Ok(op) => Some(op),
             Err(error) => {
                 let tcx = self.ecx.tcx.at(c.span);

--- a/src/test/ui/const-ptr/out_of_bounds_read.stderr
+++ b/src/test/ui/const-ptr/out_of_bounds_read.stderr
@@ -16,6 +16,11 @@ LL |     const _READ: u32 = unsafe { ptr::read(PAST_END_PTR) };
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+note: for thingy here
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |                             ^^^
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -35,6 +40,11 @@ LL |     const _CONST_READ: u32 = unsafe { PAST_END_PTR.read() };
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+note: for thingy here
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |                             ^^^
 
 error: any use of this value will cause an error
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -54,6 +64,11 @@ LL |     const _MUT_READ: u32 = unsafe { (PAST_END_PTR as *mut u32).read() };
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+note: for thingy here
+  --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
+   |
+LL |         copy_nonoverlapping(src, tmp.as_mut_ptr(), 1);
+   |                             ^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/copy-intrinsic.stderr
+++ b/src/test/ui/consts/copy-intrinsic.stderr
@@ -15,6 +15,11 @@ LL | | };
    = note: `#[deny(const_err)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+note: for thingy here
+  --> $DIR/copy-intrinsic.rs:16:51
+   |
+LL |     ptr::copy_nonoverlapping(0x100 as *const i32, dangle, 0);
+   |                                                   ^^^^^^
 
 error: any use of this value will cause an error
   --> $DIR/copy-intrinsic.rs:24:5
@@ -32,6 +37,11 @@ LL | | };
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+note: for thingy here
+  --> $DIR/copy-intrinsic.rs:24:30
+   |
+LL |     ptr::copy_nonoverlapping(dangle, 0x100 as *mut i32, 0);
+   |                              ^^^^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
With a small perf impact (only measurable on stress tests), we can report errors on intrinsics and other operations directly on the argument that was problematic instead of highlighting the entire intrinsic/function call.