### PR TITLE
fix error message for copy(_nonoverlapping) overflow

### DIFF
--- a/compiler/rustc_mir/src/interpret/step.rs
+++ b/compiler/rustc_mir/src/interpret/step.rs
@@ -160,7 +160,10 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let layout = self.layout_of(src.layout.ty.builtin_deref(true).unwrap().ty)?;
         let (size, align) = (layout.size, layout.align.abi);
         let size = size.checked_mul(count, self).ok_or_else(|| {
-            err_ub_format!("overflow computing total size of `copy_nonoverlapping`")
+            err_ub_format!(
+                "overflow computing total size of `{}`",
+                if nonoverlapping { "copy_nonoverlapping" } else { "copy" }
+            )
         })?;
 
         // Make sure we check both pointers for an access of the total size and aligment,

--- a/src/test/ui/consts/copy-intrinsic.rs
+++ b/src/test/ui/consts/copy-intrinsic.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 #![feature(const_mut_refs, const_intrinsic_copy, const_ptr_offset)]
-use std::ptr;
+use std::{ptr, mem};
 
 const COPY_ZERO: () = unsafe {
     // Since we are not copying anything, this should be allowed.
@@ -26,6 +26,20 @@ const COPY_OOB_2: () = unsafe {
     //~| previously accepted
 };
 
+const COPY_SIZE_OVERFLOW: () = unsafe {
+    let x = 0;
+    let mut y = 0;
+    ptr::copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    //~| overflow computing total size of `copy`
+    //~| previously accepted
+};
+const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
+    let x = 0;
+    let mut y = 0;
+    ptr::copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1)); //~ ERROR any use of this value will cause an error
+    //~| overflow computing total size of `copy_nonoverlapping`
+    //~| previously accepted
+};
 
 fn main() {
 }

--- a/src/test/ui/consts/copy-intrinsic.stderr
+++ b/src/test/ui/consts/copy-intrinsic.stderr
@@ -33,5 +33,37 @@ LL | | };
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error: aborting due to 2 previous errors
+error: any use of this value will cause an error
+  --> $DIR/copy-intrinsic.rs:32:5
+   |
+LL | / const COPY_SIZE_OVERFLOW: () = unsafe {
+LL | |     let x = 0;
+LL | |     let mut y = 0;
+LL | |     ptr::copy(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy`
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $DIR/copy-intrinsic.rs:39:5
+   |
+LL | / const COPY_NONOVERLAPPING_SIZE_OVERFLOW: () = unsafe {
+LL | |     let x = 0;
+LL | |     let mut y = 0;
+LL | |     ptr::copy_nonoverlapping(&x, &mut y, 1usize << (mem::size_of::<usize>() * 8 - 1));
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow computing total size of `copy_nonoverlapping`
+LL | |
+LL | |
+LL | | };
+   | |__-
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes an error message regression introduced in https://github.com/rust-lang/rust/pull/77511 (and adds tests).

r? @oli-obk 