### PR TITLE
Rename `Option::get_or_default` to `get_or_insert_default`

### DIFF
--- a/compiler/rustc_mir/src/lib.rs
+++ b/compiler/rustc_mir/src/lib.rs
@@ -25,7 +25,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(stmt_expr_attributes)]
 #![feature(trait_alias)]
 #![feature(option_expect_none)]
-#![feature(option_get_or_default)]
+#![feature(option_get_or_insert_default)]
 #![feature(or_patterns)]
 #![feature(once_cell)]
 #![feature(control_flow_enum)]

--- a/compiler/rustc_mir/src/transform/coverage/graph.rs
+++ b/compiler/rustc_mir/src/transform/coverage/graph.rs
@@ -392,7 +392,8 @@ impl BasicCoverageBlockData {
             }
         }
         let operand = counter_kind.as_operand_id();
-        if let Some(replaced) = self.edge_from_bcbs.get_or_default().insert(from_bcb, counter_kind)
+        if let Some(replaced) =
+            self.edge_from_bcbs.get_or_insert_default().insert(from_bcb, counter_kind)
         {
             Error::from_string(format!(
                 "attempt to set an edge counter more than once; from_bcb: \

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -854,34 +854,6 @@ impl<T> Option<T> {
     // Entry-like operations to insert if None and return a reference
     /////////////////////////////////////////////////////////////////////////
 
-    /// Inserts the default value into the option if it is [`None`], then
-    /// returns a mutable reference to the contained value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(option_get_or_default)]
-    ///
-    /// let mut x = None;
-    ///
-    /// {
-    ///     let y: &mut u32 = x.get_or_default();
-    ///     assert_eq!(y, &0);
-    ///
-    ///     *y = 7;
-    /// }
-    ///
-    /// assert_eq!(x, Some(7));
-    /// ```
-    #[inline]
-    #[unstable(feature = "option_get_or_default", issue = "82901")]
-    pub fn get_or_default(&mut self) -> &mut T
-    where
-        T: Default,
-    {
-        self.get_or_insert_with(Default::default)
-    }
-
     /// Inserts `value` into the option if it is [`None`], then
     /// returns a mutable reference to the contained value.
     ///
@@ -903,6 +875,34 @@ impl<T> Option<T> {
     #[stable(feature = "option_entry", since = "1.20.0")]
     pub fn get_or_insert(&mut self, value: T) -> &mut T {
         self.get_or_insert_with(|| value)
+    }
+
+    /// Inserts the default value into the option if it is [`None`], then
+    /// returns a mutable reference to the contained value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_get_or_insert_default)]
+    ///
+    /// let mut x = None;
+    ///
+    /// {
+    ///     let y: &mut u32 = x.get_or_insert_default();
+    ///     assert_eq!(y, &0);
+    ///
+    ///     *y = 7;
+    /// }
+    ///
+    /// assert_eq!(x, Some(7));
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_get_or_insert_default", issue = "82901")]
+    pub fn get_or_insert_default(&mut self) -> &mut T
+    where
+        T: Default,
+    {
+        self.get_or_insert_with(Default::default)
     }
 
     /// Inserts a value computed from `f` into the option if it is [`None`],


### PR DESCRIPTION
...as [suggested](https://github.com/rust-lang/rust/issues/82901#issuecomment-793548515) by @m-ou-se. In hindsight this seems rather obvious, at least to me.

r? @joshtriplett 