### PR TITLE
Fix "run" button position in error index

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -332,6 +332,7 @@ table th {
 
 /* Code snippets */
 
+.example-wrap { position: relative; }
 pre.rust { position: relative; }
 a.test-arrow {
 	background-color: rgba(78, 139, 202, 0.2);

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -347,10 +347,10 @@ nav.sub {
 .rustdoc:not(.source) .example-wrap {
 	display: inline-flex;
 	margin-bottom: 10px;
-	position: relative;
 }
 
 .example-wrap {
+	position: relative;
 	width: 100%;
 }
 


### PR DESCRIPTION
This isn't really a rustdoc issue but I still made the same fix in the `rustdoc.css` file (doesn't hurt).

Before:

![Screenshot from 2021-03-10 16-35-49](https://user-images.githubusercontent.com/3050060/110655807-aa402800-81bf-11eb-8a88-bc979efd1697.png)

After:

![Screenshot from 2021-03-10 16-40-08](https://user-images.githubusercontent.com/3050060/110655843-b4622680-81bf-11eb-8670-42975d92b4eb.png)

cc @jyn514 (considering this is quite a big bug and an easy fix)
r? @Nemo157 
