### PR TITLE
Custom error on literal names from other languages

### DIFF
--- a/src/test/ui/lint/recommend-literal.rs
+++ b/src/test/ui/lint/recommend-literal.rs
@@ -1,0 +1,35 @@
+type Real = double;
+//~^ ERROR cannot find type `double` in this scope
+//~| HELP perhaps you intended to use this type
+
+fn main() {
+    let x: Real = 3.5;
+    let y: long = 74802374902374923;
+    //~^ ERROR cannot find type `long` in this scope
+    //~| HELP perhaps you intended to use this type
+}
+
+fn z(a: boolean) {
+    //~^ ERROR cannot find type `boolean` in this scope
+    //~| HELP perhaps you intended to use this type
+}
+
+fn a() -> byte {
+//~^ ERROR cannot find type `byte` in this scope
+//~| HELP perhaps you intended to use this type
+    3
+}
+
+struct Data { //~ HELP you might be missing a type parameter
+    width: float,
+    //~^ ERROR cannot find type `float` in this scope
+    //~| HELP perhaps you intended to use this type
+    depth: Option<int>,
+    //~^ ERROR cannot find type `int` in this scope
+    //~| HELP perhaps you intended to use this type
+}
+
+trait Stuff {}
+impl Stuff for short {}
+//~^ ERROR cannot find type `short` in this scope
+//~| HELP perhaps you intended to use this type

--- a/src/test/ui/lint/recommend-literal.stderr
+++ b/src/test/ui/lint/recommend-literal.stderr
@@ -1,0 +1,72 @@
+error[E0412]: cannot find type `double` in this scope
+  --> $DIR/recommend-literal.rs:1:13
+   |
+LL | type Real = double;
+   |             ^^^^^^
+   |             |
+   |             not found in this scope
+   |             help: perhaps you intended to use this type: `f64`
+
+error[E0412]: cannot find type `long` in this scope
+  --> $DIR/recommend-literal.rs:7:12
+   |
+LL |     let y: long = 74802374902374923;
+   |            ^^^^
+   |            |
+   |            not found in this scope
+   |            help: perhaps you intended to use this type: `i64`
+
+error[E0412]: cannot find type `boolean` in this scope
+  --> $DIR/recommend-literal.rs:12:9
+   |
+LL | fn z(a: boolean) {
+   |         ^^^^^^^
+   |         |
+   |         not found in this scope
+   |         help: perhaps you intended to use this type: `bool`
+
+error[E0412]: cannot find type `byte` in this scope
+  --> $DIR/recommend-literal.rs:17:11
+   |
+LL | fn a() -> byte {
+   |           ^^^^
+   |           |
+   |           not found in this scope
+   |           help: perhaps you intended to use this type: `u8`
+
+error[E0412]: cannot find type `float` in this scope
+  --> $DIR/recommend-literal.rs:24:12
+   |
+LL |     width: float,
+   |            ^^^^^
+   |            |
+   |            not found in this scope
+   |            help: perhaps you intended to use this type: `f32`
+
+error[E0412]: cannot find type `int` in this scope
+  --> $DIR/recommend-literal.rs:27:19
+   |
+LL |     depth: Option<int>,
+   |                   ^^^ not found in this scope
+   |
+help: perhaps you intended to use this type
+   |
+LL |     depth: Option<i32>,
+   |                   ^^^
+help: you might be missing a type parameter
+   |
+LL | struct Data<int> {
+   |            ^^^^^
+
+error[E0412]: cannot find type `short` in this scope
+  --> $DIR/recommend-literal.rs:33:16
+   |
+LL | impl Stuff for short {}
+   |                ^^^^^
+   |                |
+   |                not found in this scope
+   |                help: perhaps you intended to use this type: `i16`
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
This detects all Java literal types and all single word C data types, and suggests the corresponding Rust literal type.