### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1801,7 +1801,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         crate_lint: CrateLint,
     ) -> PartialRes {
         tracing::debug!(
-            "smart_resolve_path_fragment(id={:?},qself={:?},path={:?}",
+            "smart_resolve_path_fragment(id={:?}, qself={:?}, path={:?})",
             id,
             qself,
             path
@@ -1841,11 +1841,10 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
 
             // Before we start looking for candidates, we have to get our hands
             // on the type user is trying to perform invocation on; basically:
-            // we're transforming `HashMap::new` into just `HashMap`
-            let path = if let Some((_, path)) = path.split_last() {
-                path
-            } else {
-                return Some(parent_err);
+            // we're transforming `HashMap::new` into just `HashMap`.
+            let path = match path.split_last() {
+                Some((_, path)) if !path.is_empty() => path,
+                _ => return Some(parent_err),
             };
 
             let (mut err, candidates) =

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1290,7 +1290,7 @@ pub fn parse_error_format(
     error_format
 }
 
-fn parse_crate_edition(matches: &getopts::Matches) -> Edition {
+pub fn parse_crate_edition(matches: &getopts::Matches) -> Edition {
     let edition = match matches.opt_str("edition") {
         Some(arg) => Edition::from_str(&arg).unwrap_or_else(|_| {
             early_error(

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -353,12 +353,13 @@ where
             }
 
             let mut completed_test = res.unwrap();
-            let running_test = running_tests.remove(&completed_test.desc).unwrap();
-            if let Some(join_handle) = running_test.join_handle {
-                if let Err(_) = join_handle.join() {
-                    if let TrOk = completed_test.result {
-                        completed_test.result =
-                            TrFailedMsg("panicked after reporting success".to_string());
+            if let Some(running_test) = running_tests.remove(&completed_test.desc) {
+                if let Some(join_handle) = running_test.join_handle {
+                    if let Err(_) = join_handle.join() {
+                        if let TrOk = completed_test.result {
+                            completed_test.result =
+                                TrFailedMsg("panicked after reporting success".to_string());
+                        }
                     }
                 }
             }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -16,7 +16,7 @@ use rustc_session::config::{CodegenOptions, DebuggingOptions, ErrorOutputType, E
 use rustc_session::getopts;
 use rustc_session::lint::Level;
 use rustc_session::search_paths::SearchPath;
-use rustc_span::edition::{Edition, DEFAULT_EDITION};
+use rustc_span::edition::Edition;
 use rustc_target::spec::TargetTriple;
 
 use crate::core::new_handler;
@@ -469,17 +469,7 @@ impl Options {
             }
         }
 
-        let edition = if let Some(e) = matches.opt_str("edition") {
-            match e.parse() {
-                Ok(e) => e,
-                Err(_) => {
-                    diag.struct_err("could not parse edition").emit();
-                    return Err(1);
-                }
-            }
-        } else {
-            DEFAULT_EDITION
-        };
+        let edition = config::parse_crate_edition(&matches);
 
         let mut id_map = html::markdown::IdMap::new();
         id_map.populate(&html::render::INITIAL_IDS);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1344,7 +1344,6 @@ impl AllTypes {
                          </a>\
                      </span>
                  </span>
-                 <span class=\"in-band\">List of all items</span>\
              </h1>",
         );
         // Note: print_entries does not escape the title, because we know the current set of titles

--- a/src/librustdoc/html/render/tests.rs
+++ b/src/librustdoc/html/render/tests.rs
@@ -38,3 +38,14 @@ fn test_name_sorting() {
     sorted.sort_by(|&l, r| compare_names(l, r));
     assert_eq!(names, sorted);
 }
+
+#[test]
+fn test_all_types_prints_header_once() {
+    // Regression test for #82477
+    let all_types = AllTypes::new();
+
+    let mut buffer = Buffer::new();
+    all_types.print(&mut buffer);
+
+    assert_eq!(1, buffer.into_inner().matches("List of all items").count());
+}

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1206,7 +1206,10 @@ impl LinkCollector<'_, '_> {
                     // for discussion on the matter.
                     verify(kind, id)?;
 
+                    // FIXME: it would be nice to check that the feature gate was enabled in the original crate, not just ignore it altogether.
+                    // However I'm not sure how to check that across crates.
                     if prim == PrimitiveType::RawPointer
+                        && item.def_id.is_local()
                         && !self.cx.tcx.features().intra_doc_pointers
                     {
                         let span = super::source_span_for_markdown_range(

--- a/src/test/rustdoc-ui/intra-doc/auxiliary/pointer-reexports-allowed.rs
+++ b/src/test/rustdoc-ui/intra-doc/auxiliary/pointer-reexports-allowed.rs
@@ -1,0 +1,4 @@
+#![feature(intra_doc_pointers)]
+#![crate_name = "inner"]
+/// Link to [some pointer](*const::to_raw_parts)
+pub fn foo() {}

--- a/src/test/rustdoc-ui/intra-doc/pointer-reexports-allowed.rs
+++ b/src/test/rustdoc-ui/intra-doc/pointer-reexports-allowed.rs
@@ -1,0 +1,4 @@
+// aux-build:pointer-reexports-allowed.rs
+// check-pass
+extern crate inner;
+pub use inner::foo;

--- a/src/test/ui/resolve/issue-82156.rs
+++ b/src/test/ui/resolve/issue-82156.rs
@@ -1,0 +1,3 @@
+fn main() {
+    super(); //~ ERROR failed to resolve: there are too many leading `super` keywords
+}

--- a/src/test/ui/resolve/issue-82156.stderr
+++ b/src/test/ui/resolve/issue-82156.stderr
@@ -1,0 +1,9 @@
+error[E0433]: failed to resolve: there are too many leading `super` keywords
+  --> $DIR/issue-82156.rs:2:5
+   |
+LL |     super();
+   |     ^^^^^ there are too many leading `super` keywords
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/typeck/typeck_type_placeholder_item.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.rs
@@ -208,3 +208,15 @@ impl Qux for Struct {
     const D: _ = 42;
     //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 }
+
+fn map<T>(_: fn() -> Option<&'static T>) -> Option<T> {
+    None
+}
+
+fn value() -> Option<&'static _> {
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+    Option::<&'static u8>::None
+}
+
+const _: Option<_> = map(value);
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -158,7 +158,7 @@ LL | fn test11(x: &usize) -> &_ {
    |                         -^
    |                         ||
    |                         |not allowed in type signatures
-   |                         help: replace with the correct return type: `&&usize`
+   |                         help: replace with the correct return type: `&'static &'static usize`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:52:52
@@ -411,6 +411,24 @@ LL | type Y = impl Trait<_>;
    |                     ^ not allowed in type signatures
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:216:31
+   |
+LL | fn value() -> Option<&'static _> {
+   |               ----------------^-
+   |               |               |
+   |               |               not allowed in type signatures
+   |               help: replace with the correct return type: `Option<&'static u8>`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item.rs:221:10
+   |
+LL | const _: Option<_> = map(value);
+   |          ^^^^^^^^^
+   |          |
+   |          not allowed in type signatures
+   |          help: replace `_` with the correct type: `Option<u8>`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:140:31
    |
 LL |     fn method_test1(&self, x: _);
@@ -614,7 +632,7 @@ LL |     const D: _ = 42;
    |              not allowed in type signatures
    |              help: replace `_` with the correct type: `i32`
 
-error: aborting due to 67 previous errors
+error: aborting due to 69 previous errors
 
 Some errors have detailed explanations: E0121, E0282, E0403.
 For more information about an error, try `rustc --explain E0121`.


### PR DESCRIPTION
This backports some beta-accepted PRs and one additional LLVM fix for s390x.

- rustdoc: treat edition 2021 as unstable #82207
- Fix popping singleton paths in when generating E0433 #82259
- libtest: Fix unwrap panic on duplicate TestDesc #82274
- [intra-doc links] Don't check feature gates of items re-exported across crates #82295
- rustdoc: Remove duplicate "List of all items" #82484
- Substitute erased lifetimes on bad placeholder type #82494
- Revert LLVM D81803 because it broke Windows 7 #82605
- [SystemZ] Assign the full space for promoted and split outgoing args. rust-lang/llvm-project#95

r? @Mark-Simulacrum 