### PR TITLE
Prevent JS error when there is no dependency or other crate documented (or --disable-per-crate-search has been used)

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2955,7 +2955,11 @@ function defocusSearchBar() {
         enableSearchInput();
 
         var crateSearchDropDown = document.getElementById("crate-search");
-        crateSearchDropDown.addEventListener("focus", loadSearch);
+        // `crateSearchDropDown` can be null in case there is only crate because in that case, the
+        // crate filter dropdown is removed.
+        if (crateSearchDropDown) {
+            crateSearchDropDown.addEventListener("focus", loadSearch);
+        }
         var params = getQueryStringParams();
         if (params.search !== undefined) {
             loadSearch();


### PR DESCRIPTION
When there is only one crate, the dropdown is removed, creating an error (that you can see pretty easily on docs.rs for example).

r? @jyn514 