### PR TITLE
stabilize debug_non_exhaustive

### DIFF
--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -185,7 +185,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     ///     "Bar { bar: 10, .. }",
     /// );
     /// ```
-    #[stable(feature = "debug_non_exhaustive", since = "1.52.0")]
+    #[stable(feature = "debug_non_exhaustive", since = "1.53.0")]
     pub fn finish_non_exhaustive(&mut self) -> fmt::Result {
         self.result = self.result.and_then(|_| {
             // Draw non-exhaustive dots (`..`), and open brace if necessary (no fields).

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -185,7 +185,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     ///     "Bar { bar: 10, .. }",
     /// );
     /// ```
-    #[stable(feature = "debug_non_exhaustive", since = "1.51.0")]
+    #[stable(feature = "debug_non_exhaustive", since = "1.52.0")]
     pub fn finish_non_exhaustive(&mut self) -> fmt::Result {
         self.result = self.result.and_then(|_| {
             // Draw non-exhaustive dots (`..`), and open brace if necessary (no fields).

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -165,7 +165,6 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(debug_non_exhaustive)]
     /// use std::fmt;
     ///
     /// struct Bar {
@@ -186,7 +185,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
     ///     "Bar { bar: 10, .. }",
     /// );
     /// ```
-    #[unstable(feature = "debug_non_exhaustive", issue = "67364")]
+    #[stable(feature = "debug_non_exhaustive", since = "1.51.0")]
     pub fn finish_non_exhaustive(&mut self) -> fmt::Result {
         self.result = self.result.and_then(|_| {
             // Draw non-exhaustive dots (`..`), and open brace if necessary (no fields).

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -20,7 +20,6 @@
 #![feature(core_intrinsics)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
-#![feature(debug_non_exhaustive)]
 #![feature(dec2flt)]
 #![feature(div_duration)]
 #![feature(duration_consts_2)]


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/67364

but it is still an open question whether the other `Debug*` struct's should have a similar method. I would guess that would best be put underneath a new feature gate, as this one seems uncontroversial enough to stabilize as is