### PR TITLE
Sidebar trait items order

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2122,13 +2122,13 @@ fn sidebar_trait(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, t: &clean
         items: &[clean::Item],
         before: &str,
         filter: impl Fn(&clean::Item) -> bool,
-        write: impl Fn(&mut Buffer, String),
+        write: impl Fn(&mut Buffer, &str),
         after: &str,
     ) {
         let mut items = items
             .iter()
             .filter_map(|m| match m.name {
-                Some(ref name) if filter(m) => Some(name.to_string()),
+                Some(ref name) if filter(m) => Some(name.as_str()),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -2137,7 +2137,7 @@ fn sidebar_trait(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, t: &clean
             items.sort_unstable();
             out.push_str(before);
             for item in items.into_iter() {
-                write(out, item);
+                write(out, &item);
             }
             out.push_str(after);
         }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2122,19 +2122,19 @@ fn sidebar_trait(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, t: &clean
         items: &[clean::Item],
         before: &str,
         filter: impl Fn(&clean::Item) -> bool,
-        write: impl Fn(&mut Buffer, &Symbol),
+        write: impl Fn(&mut Buffer, String),
         after: &str,
     ) {
         let mut items = items
             .iter()
             .filter_map(|m| match m.name {
-                Some(ref name) if filter(m) => Some(name),
+                Some(ref name) if filter(m) => Some(name.to_string()),
                 _ => None,
             })
             .collect::<Vec<_>>();
 
         if !items.is_empty() {
-            items.sort();
+            items.sort_unstable();
             out.push_str(before);
             for item in items.into_iter() {
                 write(out, item);

--- a/src/test/rustdoc-gui/lib.rs
+++ b/src/test/rustdoc-gui/lib.rs
@@ -47,14 +47,19 @@ pub fn some_more_function<T: fmt::Debug>(t: &T) -> String {
 
 /// Woohoo! A trait!
 pub trait AnotherOne {
+    /// Some func 3.
+    fn func3();
+
     /// Some func 1.
     fn func1();
+
+    fn another();
+    fn why_not();
 
     /// Some func 2.
     fn func2();
 
-    /// Some func 3.
-    fn func3();
+    fn hello();
 }
 
 /// Check for "i" signs in lists!

--- a/src/test/rustdoc-gui/trait-sidebar-item-order.goml
+++ b/src/test/rustdoc-gui/trait-sidebar-item-order.goml
@@ -1,0 +1,7 @@
+goto: file://|DOC_PATH|/trait.AnotherOne.html
+assert: (".sidebar-links a:nth-of-type(1)", "another")
+assert: (".sidebar-links a:nth-of-type(2)", "func1")
+assert: (".sidebar-links a:nth-of-type(3)", "func2")
+assert: (".sidebar-links a:nth-of-type(4)", "func3")
+assert: (".sidebar-links a:nth-of-type(5)", "hello")
+assert: (".sidebar-links a:nth-of-type(6)", "why_not")


### PR DESCRIPTION
We were actually sorting `Symbol` and not `String`, creating a completely invalid sort result. I added a test to prevent regressions.

r? @jyn514 