### PR TITLE
Validate rustc_layout_scalar_valid_range_{start,end} attributes

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -120,6 +120,7 @@ impl NestedMetaItem {
 }
 
 impl Attribute {
+    #[inline]
     pub fn has_name(&self, name: Symbol) -> bool {
         match self.kind {
             AttrKind::Normal(ref item, _) => item.path == name,

--- a/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
+++ b/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
@@ -1,0 +1,23 @@
+#![feature(rustc_attrs)]
+
+#[rustc_layout_scalar_valid_range_start(u32::MAX)] //~ ERROR
+pub struct A(u32);
+
+#[rustc_layout_scalar_valid_range_end(1, 2)] //~ ERROR
+pub struct B(u8);
+
+#[rustc_layout_scalar_valid_range_end(a = "a")] //~ ERROR
+pub struct C(i32);
+
+#[rustc_layout_scalar_valid_range_end(1)] //~ ERROR
+enum E {
+    X = 1,
+    Y = 14,
+}
+
+fn main() {
+    let _ = A(0);
+    let _ = B(0);
+    let _ = C(0);
+    let _ = E::X;
+}

--- a/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.stderr
+++ b/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.stderr
@@ -1,0 +1,31 @@
+error: expected exactly one integer literal argument
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:3:1
+   |
+LL | #[rustc_layout_scalar_valid_range_start(u32::MAX)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected exactly one integer literal argument
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:6:1
+   |
+LL | #[rustc_layout_scalar_valid_range_end(1, 2)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected exactly one integer literal argument
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:9:1
+   |
+LL | #[rustc_layout_scalar_valid_range_end(a = "a")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute should be applied to a struct
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:12:1
+   |
+LL |   #[rustc_layout_scalar_valid_range_end(1)]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / enum E {
+LL | |     X = 1,
+LL | |     Y = 14,
+LL | | }
+   | |_- not a struct
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #82251, fixes #82981.