### PR TITLE
Add `reverse` search alias for Iterator::rev()

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2737,6 +2737,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
+    #[doc(alias = "reverse")]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn rev(self) -> Rev<Self>
     where


### PR DESCRIPTION
When searching for "reverse" in rustdoc you can't find the rev method on Iterator so here is a search alias for that.