### PR TITLE
Update char::escape_debug_ext to handle different escapes in strings and chars

### DIFF
--- a/library/alloc/tests/fmt.rs
+++ b/library/alloc/tests/fmt.rs
@@ -68,10 +68,7 @@ fn test_format_macro_interface() {
     t!(format!("{:?}", 10_usize), "10");
     t!(format!("{:?}", "true"), "\"true\"");
     t!(format!("{:?}", "foo\nbar"), "\"foo\\nbar\"");
-    t!(
-        format!("{:?}", "foo\n\"bar\"\r\n\'baz\'\t\\qux\\"),
-        r#""foo\n\"bar\"\r\n\'baz\'\t\\qux\\""#
-    );
+    t!(format!("{:?}", "foo\n\"bar\"\r\n\'baz\'\t\\qux\\"), r#""foo\n\"bar\"\r\n'baz'\t\\qux\\""#);
     t!(format!("{:?}", "foo\0bar\x01baz\u{7f}q\u{75}x"), r#""foo\u{0}bar\u{1}baz\u{7f}qux""#);
     t!(format!("{:o}", 10_usize), "12");
     t!(format!("{:x}", 10_usize), "a");

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -45,6 +45,8 @@ pub use self::methods::encode_utf8_raw;
 use crate::fmt::{self, Write};
 use crate::iter::FusedIterator;
 
+pub(crate) use self::methods::EscapeDebugExtArgs;
+
 // UTF-8 ranges and tags for encoding characters
 const TAG_CONT: u8 = 0b1000_0000;
 const TAG_TWO_B: u8 = 0b1100_0000;

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -3,6 +3,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
+use crate::char::EscapeDebugExtArgs;
 use crate::marker::PhantomData;
 use crate::mem;
 use crate::num::flt2dec;
@@ -2054,7 +2055,11 @@ impl Debug for str {
         f.write_char('"')?;
         let mut from = 0;
         for (i, c) in self.char_indices() {
-            let esc = c.escape_debug();
+            let esc = c.escape_debug_ext(EscapeDebugExtArgs {
+                escape_grapheme_extended: true,
+                escape_single_quote: false,
+                escape_double_quote: true,
+            });
             // If char needs escaping, flush backlog so far and write, else skip
             if esc.len() != 1 {
                 f.write_str(&self[from..i])?;
@@ -2080,7 +2085,11 @@ impl Display for str {
 impl Debug for char {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.write_char('\'')?;
-        for c in self.escape_debug() {
+        for c in self.escape_debug_ext(EscapeDebugExtArgs {
+            escape_grapheme_extended: true,
+            escape_single_quote: true,
+            escape_double_quote: false,
+        }) {
             f.write_char(c)?
         }
         f.write_char('\'')

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -15,7 +15,7 @@ mod validations;
 use self::pattern::Pattern;
 use self::pattern::{DoubleEndedSearcher, ReverseSearcher, Searcher};
 
-use crate::char;
+use crate::char::{self, EscapeDebugExtArgs};
 use crate::mem;
 use crate::slice::{self, SliceIndex};
 
@@ -2342,7 +2342,7 @@ impl str {
         EscapeDebug {
             inner: chars
                 .next()
-                .map(|first| first.escape_debug_ext(true))
+                .map(|first| first.escape_debug_ext(EscapeDebugExtArgs::ESCAPE_ALL))
                 .into_iter()
                 .flatten()
                 .chain(chars.flat_map(CharEscapeDebugContinue)),
@@ -2460,7 +2460,11 @@ impl_fn_for_zst! {
 
     #[derive(Clone)]
     struct CharEscapeDebugContinue impl Fn = |c: char| -> char::EscapeDebug {
-        c.escape_debug_ext(false)
+        c.escape_debug_ext(EscapeDebugExtArgs {
+            escape_grapheme_extended: false,
+            escape_single_quote: true,
+            escape_double_quote: true
+        })
     };
 
     #[derive(Clone)]

--- a/src/test/rustdoc-ui/check-doc-alias-attr.stderr
+++ b/src/test/rustdoc-ui/check-doc-alias-attr.stderr
@@ -10,7 +10,7 @@ error: doc alias attribute expects a string `#[doc(alias = "a")]` or a list of s
 LL | #[doc(alias = 0)]
    |       ^^^^^^^^^
 
-error: '\"' character isn't allowed in `#[doc(alias = "...")]`
+error: '"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:9:15
    |
 LL | #[doc(alias = "\"")]
@@ -60,7 +60,7 @@ error: `#[doc(alias("a"))]` expects string literals
 LL | #[doc(alias(0))]
    |             ^
 
-error: '\"' character isn't allowed in `#[doc(alias("..."))]`
+error: '"' character isn't allowed in `#[doc(alias("..."))]`
   --> $DIR/check-doc-alias-attr.rs:20:13
    |
 LL | #[doc(alias("\""))]

--- a/src/test/ui/rustdoc/check-doc-alias-attr.stderr
+++ b/src/test/ui/rustdoc/check-doc-alias-attr.stderr
@@ -10,7 +10,7 @@ error: doc alias attribute expects a string `#[doc(alias = "a")]` or a list of s
 LL | #[doc(alias = 0)]
    |       ^^^^^^^^^
 
-error: '\"' character isn't allowed in `#[doc(alias = "...")]`
+error: '"' character isn't allowed in `#[doc(alias = "...")]`
   --> $DIR/check-doc-alias-attr.rs:9:15
    |
 LL | #[doc(alias = "\"")]
@@ -60,7 +60,7 @@ error: `#[doc(alias("a"))]` expects string literals
 LL | #[doc(alias(0))]
    |             ^
 
-error: '\"' character isn't allowed in `#[doc(alias("..."))]`
+error: '"' character isn't allowed in `#[doc(alias("..."))]`
   --> $DIR/check-doc-alias-attr.rs:20:13
    |
 LL | #[doc(alias("\""))]


### PR DESCRIPTION
Fixes #83046

The program

    fn main() {
        println!("{:?}", '"');
        println!("{:?}", "'");
    }

would previously print

    '\"'
    "\'"

With this patch it now prints:

    '"'
    "'"