### PR TITLE
WIP: ~15% Faster str to int parsing (when base 10)

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -849,7 +849,7 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
     };
 
     let mut result = T::from_u32(0);
-    if radix == 10 {
+    if mem::size_of::<T>() <= mem::size_of::<u32>() && radix == 10 {
         // The cpu can reorder these adds as each mul isn't dependent
         // on the previous answer.
         let factors = &MULTIPLIER[MULTIPLIER.len() - src.len()..];

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -850,9 +850,9 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 
     let mut result = T::from_u32(0);
     if mem::size_of::<T>() <= mem::size_of::<u32>() && radix == 10 {
-        // The cpu can reorder these adds as each mul isn't dependent
-        // on the previous answer.
-        let factors = &MULTIPLIER[MULTIPLIER.len() - src.len()..];
+        // The ALU can reorder these adds and do more in parallel
+        // as each mul isn't dependent on the previous answer.
+        let factors = &MULTIPLIER[MULTIPLIER.len() - digits.len()..];
         let mut idx = 0;
         if is_positive {
             // The number is positive


### PR DESCRIPTION
I saw a c++ talk on numbers and wondered if the same trick would work here.

Rather than multiplying the same number each time, if we're multiplying different numbers then the ALU can reorder them (as they have fewer data dependencies and add is commutative) and do more of them in parallel.

If radix is called with a constant (which it is 99% of the time) I'm pretty sure that llvm evaluates the `if radix == 10` at compile time - I noticed that when `radix == 16` llvm can figure out that it can shift rather than multiply! Pretty impressive in my book that it can spot that!

Speedup wise I'm seeing it go from 1.4ns to 1.2ns. Not earth shattering, but not to be sniffed at either.