### PR TITLE
Enable `-W semicolon_in_expressions_from_macros` in bootstrap

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -900,8 +900,8 @@ class RustBuild(object):
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
             env["RUSTFLAGS"] += " -C linker=" + target_linker
-        # cfg(bootstrap): Add `-Wsemicolon_in_expressions_from_macros` after the next beta bump
         env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes"
+        env["RUSTFLAGS"] += " -Wsemicolon_in_expressions_from_macros"
         if self.get_toml("deny-warnings", "rust") != "false":
             env["RUSTFLAGS"] += " -Dwarnings"
 

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1270,12 +1270,7 @@ impl<'a> Builder<'a> {
             // some code doesn't go through this `rustc` wrapper.
             lint_flags.push("-Wrust_2018_idioms");
             lint_flags.push("-Wunused_lifetimes");
-            // cfg(bootstrap): unconditionally enable this warning after the next beta bump
-            // This is currently disabled for the stage1 libstd, since build scripts
-            // will end up using the bootstrap compiler (which doesn't yet support this lint)
-            if compiler.stage != 0 && mode != Mode::Std {
-                lint_flags.push("-Wsemicolon_in_expressions_from_macros");
-            }
+            lint_flags.push("-Wsemicolon_in_expressions_from_macros");
 
             if self.config.deny_warnings {
                 lint_flags.push("-Dwarnings");


### PR DESCRIPTION
Now that stdarch has been updated, we can do this without breaking the
build.