### PR TITLE
More precise spans for HIR paths

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -149,8 +149,16 @@ impl PathSegment {
     pub fn from_ident(ident: Ident) -> Self {
         PathSegment { ident, id: DUMMY_NODE_ID, args: None }
     }
+
     pub fn path_root(span: Span) -> Self {
         PathSegment::from_ident(Ident::new(kw::PathRoot, span))
+    }
+
+    pub fn span(&self) -> Span {
+        match &self.args {
+            Some(args) => self.ident.span.to(args.span()),
+            None => self.ident.span,
+        }
     }
 }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1809,7 +1809,7 @@ impl<'hir> QPath<'hir> {
     pub fn span(&self) -> Span {
         match *self {
             QPath::Resolved(_, path) => path.span,
-            QPath::TypeRelative(_, ps) => ps.ident.span,
+            QPath::TypeRelative(qself, ps) => qself.span.to(ps.ident.span),
             QPath::LangItem(_, span) => span,
         }
     }

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -104,7 +104,7 @@ pub fn report_object_safety_error(
          <https://doc.rust-lang.org/reference/items/traits.html#object-safety>",
     );
 
-    if tcx.sess.trait_methods_not_found.borrow().contains(&span) {
+    if tcx.sess.trait_methods_not_found.borrow().iter().any(|full_span| full_span.contains(span)) {
         // Avoid emitting error caused by non-existing method (#58734)
         err.cancel();
     }

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1414,8 +1414,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         name: Symbol,
     ) {
         let mut err = struct_span_err!(self.tcx().sess, span, E0223, "ambiguous associated type");
-        if let (Some(_), Ok(snippet)) = (
-            self.tcx().sess.confused_type_with_std_module.borrow().get(&span),
+        if let (true, Ok(snippet)) = (
+            self.tcx()
+                .sess
+                .confused_type_with_std_module
+                .borrow()
+                .keys()
+                .any(|full_span| full_span.contains(span)),
             self.tcx().sess.source_map().span_to_snippet(span),
         ) {
             err.span_suggestion(

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -439,7 +439,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         qpath: &QPath<'_>,
         hir_id: hir::HirId,
     ) -> Option<(&'tcx ty::VariantDef, Ty<'tcx>)> {
-        let path_span = qpath.qself_span();
+        let path_span = qpath.span();
         let (def, ty) = self.finish_resolving_struct_path(qpath, path_span, hir_id);
         let variant = match def {
             Res::Err => {

--- a/src/test/ui/bad/bad-sized.rs
+++ b/src/test/ui/bad/bad-sized.rs
@@ -5,4 +5,5 @@ pub fn main() {
     //~^ ERROR only auto traits can be used as additional traits in a trait object
     //~| ERROR the size for values of type
     //~| ERROR the size for values of type
+    //~| ERROR the size for values of type
 }

--- a/src/test/ui/bad/bad-sized.stderr
+++ b/src/test/ui/bad/bad-sized.stderr
@@ -31,7 +31,20 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    = help: the trait `Sized` is not implemented for `dyn Trait`
    = note: required by `Vec::<T>::new`
 
-error: aborting due to 3 previous errors
+error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
+  --> $DIR/bad-sized.rs:4:37
+   |
+LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
+   |                                     ^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                - required by this bound in `Vec`
+   |
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0225, E0277.
 For more information about an error, try `rustc --explain E0225`.

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
@@ -10,7 +10,7 @@ warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:19:5
    |
 LL |     MustUseDeprecated::new();
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:13:17

--- a/src/test/ui/issues/issue-78622.stderr
+++ b/src/test/ui/issues/issue-78622.stderr
@@ -2,7 +2,7 @@ error[E0223]: ambiguous associated type
   --> $DIR/issue-78622.rs:5:5
    |
 LL |     S::A::<f> {}
-   |     ^^^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
+   |     ^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -56,7 +56,7 @@ LL | struct Inline<T>
    |               - required by this bound in `Inline`
 ...
 LL |     let dst = Inline::<dyn Debug>::new(0);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |               ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Debug`
 help: consider relaxing the implicit `Sized` restriction

--- a/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
+++ b/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
@@ -13,7 +13,7 @@ help: the lifetime requirements from the `impl` do not correspond to the require
   --> $DIR/issue-75361-mismatched-impl.rs:12:55
    |
 LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
-   |                                                       ^^^^^^^^^^^^^^ consider borrowing this type parameter in the trait
+   |                                                       ^^^^ consider borrowing this type parameter in the trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -222,7 +222,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:101:9
    |
 LL |         Pub::CONST;
-   |         ^^^^^^^^^^ private type
+   |         ^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -56,7 +56,7 @@ error: type `Priv` is private
   --> $DIR/private-inferred-type.rs:104:5
    |
 LL |     m::Pub::INHERENT_ASSOC_CONST;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
+   |     ^^^^^^ private type
 
 error: type `Priv` is private
   --> $DIR/private-inferred-type.rs:105:5

--- a/src/test/ui/regions/issue-28848.stderr
+++ b/src/test/ui/regions/issue-28848.stderr
@@ -2,7 +2,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/issue-28848.rs:10:5
    |
 LL |     Foo::<'a, 'b>::xmute(u)
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined on the function body at 9:16
   --> $DIR/issue-28848.rs:9:16

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -100,7 +100,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:160:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(1);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:160:12
@@ -124,7 +124,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:166:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(0);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:166:12
@@ -136,7 +136,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:171:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(1);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:171:12
@@ -160,7 +160,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:178:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(0);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:178:12

--- a/src/test/ui/structs/struct-path-associated-type.stderr
+++ b/src/test/ui/structs/struct-path-associated-type.stderr
@@ -14,7 +14,7 @@ error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
    |
 LL |     let z = T::A::<u8> {};
-   |             ^^^^^^^^^^ not a struct
+   |             ^^^^ not a struct
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:18:9
@@ -38,7 +38,7 @@ error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:33:13
    |
 LL |     let z = S::A::<u8> {};
-   |             ^^^^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
+   |             ^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:35:9

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
   --> $DIR/mut-borrow-needed-by-trait.rs:17:14
    |
 LL |     let fp = BufWriter::new(fp);
-   |              ^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   |              ^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
    | 
   ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |

--- a/src/test/ui/suggestions/suggest-std-when-using-type.stderr
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.stderr
@@ -2,12 +2,12 @@ error[E0223]: ambiguous associated type
   --> $DIR/suggest-std-when-using-type.rs:2:14
    |
 LL |     let pi = f32::consts::PI;
-   |              ^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^
    |
 help: you are looking for the module in `std`, not the primitive type
    |
 LL |     let pi = std::f32::consts::PI;
-   |              ^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^
 
 error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope
   --> $DIR/suggest-std-when-using-type.rs:5:14

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -113,7 +113,7 @@ error[E0038]: the trait `assoc_const::C` cannot be made into an object
   --> $DIR/item-privacy.rs:101:5
    |
 LL |     C::A;
-   |     ^^^^ `assoc_const::C` cannot be made into an object
+   |     ^ `assoc_const::C` cannot be made into an object
    |
    = help: consider moving `C` to another trait
    = help: consider moving `B` to another trait

--- a/src/test/ui/unspecified-self-in-trait-ref.stderr
+++ b/src/test/ui/unspecified-self-in-trait-ref.stderr
@@ -31,7 +31,7 @@ LL | | }
    | |_- type parameter `A` must be specified for this
 ...
 LL |       let e = Bar::<usize>::lol();
-   |               ^^^^^^^^^^^^^^^^^ missing reference to `A`
+   |               ^^^^^^^^^^^^ missing reference to `A`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/wf/wf-static-method.stderr
+++ b/src/test/ui/wf/wf-static-method.stderr
@@ -19,7 +19,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/wf-static-method.rs:26:18
    |
 LL |         let me = Self::make_me();
-   |                  ^^^^^^^^^^^^^
+   |                  ^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined on the impl at 23:10
   --> $DIR/wf-static-method.rs:23:10

--- a/src/tools/clippy/tests/ui/use_self.fixed
+++ b/src/tools/clippy/tests/ui/use_self.fixed
@@ -312,17 +312,18 @@ mod issue4140 {
         fn try_from(value: T) -> Result<Self, Error<Self::From, Self::To>>;
     }
 
-    impl<F, T> TryFrom<F> for T
-    where
-        T: From<F>,
-    {
-        type From = Self;
-        type To = Self;
+    // FIXME: Suggested fix results in infinite recursion.
+    // impl<F, T> TryFrom<F> for T
+    // where
+    //     T: From<F>,
+    // {
+    //     type From = Self::From;
+    //     type To = Self::To;
 
-        fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
-            Ok(From::from(value))
-        }
-    }
+    //     fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
+    //         Ok(From::from(value))
+    //     }
+    // }
 
     impl From<bool> for i64 {
         type From = bool;

--- a/src/tools/clippy/tests/ui/use_self.rs
+++ b/src/tools/clippy/tests/ui/use_self.rs
@@ -312,17 +312,18 @@ mod issue4140 {
         fn try_from(value: T) -> Result<Self, Error<Self::From, Self::To>>;
     }
 
-    impl<F, T> TryFrom<F> for T
-    where
-        T: From<F>,
-    {
-        type From = T::From;
-        type To = T::To;
+    // FIXME: Suggested fix results in infinite recursion.
+    // impl<F, T> TryFrom<F> for T
+    // where
+    //     T: From<F>,
+    // {
+    //     type From = Self::From;
+    //     type To = Self::To;
 
-        fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
-            Ok(From::from(value))
-        }
-    }
+    //     fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
+    //         Ok(From::from(value))
+    //     }
+    // }
 
     impl From<bool> for i64 {
         type From = bool;

--- a/src/tools/clippy/tests/ui/use_self.stderr
+++ b/src/tools/clippy/tests/ui/use_self.stderr
@@ -157,22 +157,10 @@ LL |             Foo { value }
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:319:21
-   |
-LL |         type From = T::From;
-   |                     ^^^^^^^ help: use the applicable keyword: `Self`
-
-error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:320:19
-   |
-LL |         type To = T::To;
-   |                   ^^^^^ help: use the applicable keyword: `Self`
-
-error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:453:13
+  --> $DIR/use_self.rs:454:13
    |
 LL |             A::new::<submod::B>(submod::B {})
    |             ^ help: use the applicable keyword: `Self`
 
-error: aborting due to 29 previous errors
+error: aborting due to 27 previous errors
 

--- a/src/tools/clippy/tests/ui/zero_sized_btreemap_values.stderr
+++ b/src/tools/clippy/tests/ui/zero_sized_btreemap_values.stderr
@@ -83,7 +83,7 @@ error: map with zero-sized value type
   --> $DIR/zero_sized_btreemap_values.rs:64:35
    |
 LL |     let _: BTreeMap<String, ()> = BTreeMap::new();
-   |                                   ^^^^^^^^^^^^^
+   |                                   ^^^^^^^^
    |
    = help: consider using a set instead
 

--- a/src/tools/clippy/tests/ui/zero_sized_hashmap_values.stderr
+++ b/src/tools/clippy/tests/ui/zero_sized_hashmap_values.stderr
@@ -83,7 +83,7 @@ error: map with zero-sized value type
   --> $DIR/zero_sized_hashmap_values.rs:64:34
    |
 LL |     let _: HashMap<String, ()> = HashMap::new();
-   |                                  ^^^^^^^^^^^^
+   |                                  ^^^^^^^
    |
    = help: consider using a set instead
 


### PR DESCRIPTION
`Ty::assoc_item` is lowered to `<Ty>::assoc_item` in HIR, but `Ty` got span from the whole path.
This PR fixes that, and adjusts some diagnostic code that relied on `Ty` having the whole path span.

This is a pre-requisite for https://github.com/rust-lang/rust/pull/82868 (we cannot report suggestions like `Tr::assoc` -> `<dyn Tr>::assoc` with the current imprecise spans).
r? @estebank 