### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -58,7 +58,7 @@ crate fn render<T: Print, S: Print>(
     {style_files}\
     <script id=\"default-settings\"{default_settings}></script>\
     <script src=\"{static_root_path}storage{suffix}.js\"></script>\
-    <script src=\"{static_root_path}crates{suffix}.js\"></script>\
+    <script src=\"{root_path}crates{suffix}.js\"></script>\
     <noscript><link rel=\"stylesheet\" href=\"{static_root_path}noscript{suffix}.css\"></noscript>\
     {css_extension}\
     {favicon}\

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2955,7 +2955,11 @@ function defocusSearchBar() {
         enableSearchInput();
 
         var crateSearchDropDown = document.getElementById("crate-search");
-        crateSearchDropDown.addEventListener("focus", loadSearch);
+        // `crateSearchDropDown` can be null in case there is only crate because in that case, the
+        // crate filter dropdown is removed.
+        if (crateSearchDropDown) {
+            crateSearchDropDown.addEventListener("focus", loadSearch);
+        }
         var params = getQueryStringParams();
         if (params.search !== undefined) {
             loadSearch();


### PR DESCRIPTION
Successful merges:

 - #83028 (Prevent JS error when there is no dependency or other crate documented (or --disable-per-crate-search has been used))
 - #83094 (crates.js should use root_path and not static_root_path)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83028,83094)
<!-- homu-ignore:end -->