### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -343,6 +343,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         "intra_doc_link_resolution_failure",
         "use `rustdoc::broken_intra_doc_links` instead",
     );
+    store.register_removed("rustdoc", "use `rustdoc::all` instead");
 
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -1343,7 +1343,9 @@ impl<'p, 'tcx> Fields<'p, 'tcx> {
         match &mut fields {
             Fields::Vec(pats) => {
                 for (i, pat) in new_pats {
-                    pats[i] = pat
+                    if let Some(p) = pats.get_mut(i) {
+                        *p = pat;
+                    }
                 }
             }
             Fields::Filtered { fields, .. } => {

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1176,7 +1176,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut no_field_errors = true;
 
         let mut inexistent_fields = vec![];
-        let mut invisible_fields = vec![];
         // Typecheck each field.
         for field in fields {
             let span = field.span;
@@ -1192,12 +1191,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     field_map
                         .get(&ident)
                         .map(|(i, f)| {
-                            if !f
-                                .vis
-                                .is_accessible_from(tcx.parent_module(pat.hir_id).to_def_id(), tcx)
-                            {
-                                invisible_fields.push(field.ident);
-                            }
                             self.write_field_index(field.hir_id, *i);
                             self.tcx.check_stability(f.did, Some(pat.hir_id), span);
                             self.field_ty(span, f, substs)
@@ -1288,13 +1281,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.error_tuple_variant_index_shorthand(variant, pat, fields)
                 {
                     err.emit();
-                } else if !invisible_fields.is_empty() {
-                    let mut err = self.error_invisible_fields(
-                        adt.variant_descr(),
-                        &invisible_fields,
-                        variant,
-                    );
-                    err.emit();
                 }
             }
         }
@@ -1371,41 +1357,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         .span_label(span, format!("multiple uses of `{}` in pattern", ident))
         .span_label(other_field, format!("first use of `{}`", ident))
         .emit();
-    }
-
-    fn error_invisible_fields(
-        &self,
-        kind_name: &str,
-        invisible_fields: &[Ident],
-        variant: &ty::VariantDef,
-    ) -> DiagnosticBuilder<'tcx> {
-        let spans = invisible_fields.iter().map(|ident| ident.span).collect::<Vec<_>>();
-        let (field_names, t) = if invisible_fields.len() == 1 {
-            (format!("a field named `{}`", invisible_fields[0]), "is")
-        } else {
-            (
-                format!(
-                    "fields named {}",
-                    invisible_fields
-                        .iter()
-                        .map(|ident| format!("`{}`", ident))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ),
-                "are",
-            )
-        };
-        let err = struct_span_err!(
-            self.tcx.sess,
-            spans,
-            E0603,
-            "cannot match on {} of {} `{}`, which {} not accessible in current scope",
-            field_names,
-            kind_name,
-            self.tcx.def_path_str(variant.def_id),
-            t
-        );
-        err
     }
 
     fn error_inexistent_fields(

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -154,7 +154,7 @@ fn assert_failed_inner(
         Some(args) => panic!(
             r#"assertion failed: `(left {} right)`
   left: `{:?}`,
- right: `{:?}: {}`"#,
+ right: `{:?}`: {}"#,
             op, left, right, args
         ),
         None => panic!(

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -650,13 +650,11 @@ fn open_parent(p: &Path) -> io::Result<(ManuallyDrop<WasiFd>, PathBuf)> {
                 );
                 return Err(io::Error::new(io::ErrorKind::Other, msg));
             }
-            let len = CStr::from_ptr(buf.as_ptr().cast()).to_bytes().len();
-            buf.set_len(len);
-            buf.shrink_to_fit();
+            let relative = CStr::from_ptr(relative_path).to_bytes().to_vec();
 
             return Ok((
                 ManuallyDrop::new(WasiFd::from_raw(fd as u32)),
-                PathBuf::from(OsString::from_vec(buf)),
+                PathBuf::from(OsString::from_vec(relative)),
             ));
         }
     }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -58,7 +58,7 @@ crate fn render<T: Print, S: Print>(
     {style_files}\
     <script id=\"default-settings\"{default_settings}></script>\
     <script src=\"{static_root_path}storage{suffix}.js\"></script>\
-    <script src=\"{static_root_path}crates{suffix}.js\"></script>\
+    <script src=\"{root_path}crates{suffix}.js\"></script>\
     <noscript><link rel=\"stylesheet\" href=\"{static_root_path}noscript{suffix}.css\"></noscript>\
     {css_extension}\
     {favicon}\

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2955,7 +2955,11 @@ function defocusSearchBar() {
         enableSearchInput();
 
         var crateSearchDropDown = document.getElementById("crate-search");
-        crateSearchDropDown.addEventListener("focus", loadSearch);
+        // `crateSearchDropDown` can be null in case there is only crate because in that case, the
+        // crate filter dropdown is removed.
+        if (crateSearchDropDown) {
+            crateSearchDropDown.addEventListener("focus", loadSearch);
+        }
         var params = getQueryStringParams();
         if (params.search !== undefined) {
             loadSearch();

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -175,8 +175,8 @@ crate fn register_lints(_sess: &Session, lint_store: &mut LintStore) {
     lint_store.register_lints(&**RUSTDOC_LINTS);
     lint_store.register_group(
         true,
-        "rustdoc",
-        None,
+        "rustdoc::all",
+        Some("rustdoc"),
         RUSTDOC_LINTS.iter().map(|&lint| LintId::of(lint)).collect(),
     );
     for lint in &*RUSTDOC_LINTS {

--- a/src/test/incremental/issue-82920-predicate-order-miscompile.rs
+++ b/src/test/incremental/issue-82920-predicate-order-miscompile.rs
@@ -1,0 +1,31 @@
+// revisions: rpass1 rpass2
+
+trait MyTrait: One + Two {}
+impl<T> One for T {
+    fn method_one(&self) -> usize {
+        1
+    }
+}
+impl<T> Two for T {
+    fn method_two(&self) -> usize {
+        2
+    }
+}
+impl<T: One + Two> MyTrait for T {}
+
+fn main() {
+    let a: &dyn MyTrait = &true;
+    assert_eq!(a.method_one(), 1);
+    assert_eq!(a.method_two(), 2);
+}
+
+// Re-order traits 'One' and 'Two' between compilation
+// sessions
+
+#[cfg(rpass1)]
+trait One { fn method_one(&self) -> usize; }
+
+trait Two { fn method_two(&self) -> usize; }
+
+#[cfg(rpass2)]
+trait One { fn method_one(&self) -> usize; }

--- a/src/test/rustdoc-ui/check-fail.rs
+++ b/src/test/rustdoc-ui/check-fail.rs
@@ -1,7 +1,7 @@
 // compile-flags: -Z unstable-options --check
 
 #![deny(missing_docs)]
-#![deny(rustdoc)]
+#![deny(rustdoc::all)]
 
 //! ```rust,testharness
 //~^ ERROR

--- a/src/test/rustdoc-ui/check-fail.stderr
+++ b/src/test/rustdoc-ui/check-fail.stderr
@@ -19,9 +19,9 @@ LL | pub fn foo() {}
 note: the lint level is defined here
   --> $DIR/check-fail.rs:4:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?
   --> $DIR/check-fail.rs:6:1
@@ -35,9 +35,9 @@ LL | | //! ```
 note: the lint level is defined here
   --> $DIR/check-fail.rs:4:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc::all)]`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?

--- a/src/test/rustdoc-ui/check.rs
+++ b/src/test/rustdoc-ui/check.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs)]
 //~^ WARN
 //~^^ WARN
-#![warn(rustdoc)]
+#![warn(rustdoc::all)]
 
 pub fn foo() {}
 //~^ WARN

--- a/src/test/rustdoc-ui/check.stderr
+++ b/src/test/rustdoc-ui/check.stderr
@@ -4,7 +4,7 @@ warning: missing documentation for the crate
 LL | / #![warn(missing_docs)]
 LL | |
 LL | |
-LL | | #![warn(rustdoc)]
+LL | | #![warn(rustdoc::all)]
 LL | |
 LL | | pub fn foo() {}
    | |_______________^
@@ -26,9 +26,9 @@ warning: no documentation found for this crate's top-level module
 note: the lint level is defined here
   --> $DIR/check.rs:7:9
    |
-LL | #![warn(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[warn(rustdoc::missing_crate_level_docs)]` implied by `#[warn(rustdoc)]`
+LL | #![warn(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[warn(rustdoc::missing_crate_level_docs)]` implied by `#[warn(rustdoc::all)]`
    = help: The following guide may be of use:
            https://doc.rust-lang.org/nightly/rustdoc/how-to-write-documentation.html
 
@@ -38,7 +38,7 @@ warning: missing code example in this documentation
 LL | / #![warn(missing_docs)]
 LL | |
 LL | |
-LL | | #![warn(rustdoc)]
+LL | | #![warn(rustdoc::all)]
 LL | |
 LL | | pub fn foo() {}
    | |_______________^
@@ -46,9 +46,9 @@ LL | | pub fn foo() {}
 note: the lint level is defined here
   --> $DIR/check.rs:7:9
    |
-LL | #![warn(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[warn(rustdoc::missing_doc_code_examples)]` implied by `#[warn(rustdoc)]`
+LL | #![warn(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[warn(rustdoc::missing_doc_code_examples)]` implied by `#[warn(rustdoc::all)]`
 
 warning: missing code example in this documentation
   --> $DIR/check.rs:9:1

--- a/src/test/rustdoc-ui/lint-group.rs
+++ b/src/test/rustdoc-ui/lint-group.rs
@@ -4,7 +4,7 @@
 //! println!("sup");
 //! ```
 
-#![deny(rustdoc)]
+#![deny(rustdoc::all)]
 
 /// what up, let's make an [error]
 ///

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -7,9 +7,9 @@ LL | /// wait, this doesn't have a doctest?
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
 
 error: documentation test in private item
   --> $DIR/lint-group.rs:19:1
@@ -24,9 +24,9 @@ LL | | /// ```
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::private_doc_tests)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::private_doc_tests)]` implied by `#[deny(rustdoc::all)]`
 
 error: missing code example in this documentation
   --> $DIR/lint-group.rs:26:1
@@ -43,9 +43,9 @@ LL | /// what up, let's make an [error]
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc::all)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unclosed HTML tag `unknown`
@@ -57,9 +57,9 @@ LL | /// <unknown>
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc::all)]`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/rustdoc-ui/unknown-renamed-lints.rs
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.rs
@@ -12,6 +12,9 @@
 #![deny(non_autolinks)]
 //~^ ERROR renamed to `rustdoc::non_autolinks`
 
+#![deny(rustdoc)]
+//~^ ERROR removed: use `rustdoc::all` instead
+
 // Explicitly don't try to handle this case, it was never valid
 #![deny(rustdoc::intra_doc_link_resolution_failure)]
 //~^ ERROR unknown lint

--- a/src/test/rustdoc-ui/unknown-renamed-lints.stderr
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.stderr
@@ -34,13 +34,19 @@ error: lint `non_autolinks` has been renamed to `rustdoc::non_autolinks`
 LL | #![deny(non_autolinks)]
    |         ^^^^^^^^^^^^^ help: use the new name: `rustdoc::non_autolinks`
 
+error: lint `rustdoc` has been removed: use `rustdoc::all` instead
+  --> $DIR/unknown-renamed-lints.rs:15:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+
 error: unknown lint: `rustdoc::intra_doc_link_resolution_failure`
-  --> $DIR/unknown-renamed-lints.rs:16:9
+  --> $DIR/unknown-renamed-lints.rs:19:9
    |
 LL | #![deny(rustdoc::intra_doc_link_resolution_failure)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Compilation failed, aborting rustdoc
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -18,7 +18,7 @@ pub use impl_trait_aux::func2;
 
 // @has impl_trait/fn.func3.html
 // @has - '//pre[@class="rust fn"]' "func3("
-// @has - '//pre[@class="rust fn"]' "_x: impl Clone + Iterator<Item = impl Iterator<Item = u8>>)"
+// @has - '//pre[@class="rust fn"]' "_x: impl Iterator<Item = impl Iterator<Item = u8>> + Clone)"
 // @!has - '//pre[@class="rust fn"]' 'where'
 pub use impl_trait_aux::func3;
 

--- a/src/test/rustdoc/unit-return.rs
+++ b/src/test/rustdoc/unit-return.rs
@@ -10,8 +10,8 @@ pub fn f0<F: FnMut(u8) + Clone>(f: F) {}
 // @has 'foo/fn.f1.html' '//*[@class="rust fn"]' 'F: FnMut(u16) + Clone'
 pub fn f1<F: FnMut(u16) -> () + Clone>(f: F) {}
 
-// @has 'foo/fn.f2.html' '//*[@class="rust fn"]' 'F: Clone + FnMut(u32)'
+// @has 'foo/fn.f2.html' '//*[@class="rust fn"]' 'F: FnMut(u32) + Clone'
 pub use unit_return::f2;
 
-// @has 'foo/fn.f3.html' '//*[@class="rust fn"]' 'F: Clone + FnMut(u64)'
+// @has 'foo/fn.f3.html' '//*[@class="rust fn"]' 'F: FnMut(u64) + Clone'
 pub use unit_return::f3;

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -1,15 +1,3 @@
-error[E0277]: `<<Self as Case1>::C as Iterator>::Item` is not an iterator
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:27:5
-   |
-LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `<<Self as Case1>::C as Iterator>::Item` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
-help: consider further restricting the associated type
-   |
-LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Iterator {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0277]: `<<Self as Case1>::C as Iterator>::Item` cannot be sent between threads safely
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:27:36
    |
@@ -26,6 +14,23 @@ help: consider further restricting the associated type
    |
 LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Send {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: `<<Self as Case1>::C as Iterator>::Item` is not an iterator
+  --> $DIR/bad-bounds-on-assoc-in-trait.rs:27:43
+   |
+LL |     type C: Clone + Iterator<Item: Send + Iterator<Item: for<'a> Lam<&'a u8, App: Debug>> + Sync>;
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `<<Self as Case1>::C as Iterator>::Item` is not an iterator
+   | 
+  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL | pub trait Iterator {
+   | ------------------ required by this bound in `Iterator`
+   |
+   = help: the trait `Iterator` is not implemented for `<<Self as Case1>::C as Iterator>::Item`
+help: consider further restricting the associated type
+   |
+LL | trait Case1 where <<Self as Case1>::C as Iterator>::Item: Iterator {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `<<Self as Case1>::C as Iterator>::Item` cannot be shared between threads safely
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:27:93

--- a/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
+++ b/src/test/ui/associated-types/associated-type-projection-from-multiple-supertraits.stderr
@@ -20,12 +20,12 @@ LL | fn dent<C:BoxCar>(c: C, color: C::Color) {
    |
 help: use fully qualified syntax to disambiguate
    |
-LL | fn dent<C:BoxCar>(c: C, color: <C as Box>::Color) {
-   |                                ^^^^^^^^^^^^^^^^^
-help: use fully qualified syntax to disambiguate
-   |
 LL | fn dent<C:BoxCar>(c: C, color: <C as Vehicle>::Color) {
    |                                ^^^^^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn dent<C:BoxCar>(c: C, color: <C as Box>::Color) {
+   |                                ^^^^^^^^^^^^^^^^^
 
 error[E0222]: ambiguous associated type `Color` in bounds of `BoxCar`
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:37
@@ -42,8 +42,8 @@ LL | fn dent_object<COLOR>(c: dyn BoxCar<Color=COLOR>) {
    = help: consider introducing a new type parameter `T` and adding `where` constraints:
                where
                    T: BoxCar,
-                   T: Box::Color = COLOR,
-                   T: Vehicle::Color = COLOR
+                   T: Vehicle::Color = COLOR,
+                   T: Box::Color = COLOR
 
 error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:23:30
@@ -73,12 +73,12 @@ LL | fn paint<C:BoxCar>(c: C, d: C::Color) {
    |
 help: use fully qualified syntax to disambiguate
    |
-LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
-   |                             ^^^^^^^^^^^^^^^^^
-help: use fully qualified syntax to disambiguate
-   |
 LL | fn paint<C:BoxCar>(c: C, d: <C as Vehicle>::Color) {
    |                             ^^^^^^^^^^^^^^^^^^^^^
+help: use fully qualified syntax to disambiguate
+   |
+LL | fn paint<C:BoxCar>(c: C, d: <C as Box>::Color) {
+   |                             ^^^^^^^^^^^^^^^^^
 
 error[E0191]: the value of the associated types `Color` (from trait `Box`), `Color` (from trait `Vehicle`) must be specified
   --> $DIR/associated-type-projection-from-multiple-supertraits.rs:32:32

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -13,20 +13,6 @@ help: consider further restricting `Self`
 LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:20:5
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^-------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |                   |
-   |     |                   required by this bound in `UncheckedCopy::Output`
-   |     the trait `Deref` is not implemented for `Self`
-   |
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + Deref {
-   |                            ^^^^^^^
-
 error[E0277]: cannot add-assign `&'static str` to `Self`
   --> $DIR/defaults-unsound-62211-1.rs:20:5
    |
@@ -40,6 +26,20 @@ help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Self: Deref` is not satisfied
+  --> $DIR/defaults-unsound-62211-1.rs:20:5
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |     ^^^^^^^^^^^^^^^^^^^^-------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |                   |
+   |     |                   required by this bound in `UncheckedCopy::Output`
+   |     the trait `Deref` is not implemented for `Self`
+   |
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + Deref {
+   |                            ^^^^^^^
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-1.rs:20:5

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -13,20 +13,6 @@ help: consider further restricting `Self`
 LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:20:5
-   |
-LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^-------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |     |                   |
-   |     |                   required by this bound in `UncheckedCopy::Output`
-   |     the trait `Deref` is not implemented for `Self`
-   |
-help: consider further restricting `Self`
-   |
-LL | trait UncheckedCopy: Sized + Deref {
-   |                            ^^^^^^^
-
 error[E0277]: cannot add-assign `&'static str` to `Self`
   --> $DIR/defaults-unsound-62211-2.rs:20:5
    |
@@ -40,6 +26,20 @@ help: consider further restricting `Self`
    |
 LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Self: Deref` is not satisfied
+  --> $DIR/defaults-unsound-62211-2.rs:20:5
+   |
+LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
+   |     ^^^^^^^^^^^^^^^^^^^^-------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |                   |
+   |     |                   required by this bound in `UncheckedCopy::Output`
+   |     the trait `Deref` is not implemented for `Self`
+   |
+help: consider further restricting `Self`
+   |
+LL | trait UncheckedCopy: Sized + Deref {
+   |                            ^^^^^^^
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
   --> $DIR/defaults-unsound-62211-2.rs:20:5

--- a/src/test/ui/issues/issue-40827.stderr
+++ b/src/test/ui/issues/issue-40827.stderr
@@ -1,17 +1,3 @@
-error[E0277]: `Rc<Foo>` cannot be sent between threads safely
-  --> $DIR/issue-40827.rs:14:5
-   |
-LL | fn f<T: Send>(_: T) {}
-   |         ---- required by this bound in `f`
-...
-LL |     f(Foo(Arc::new(Bar::B(None))));
-   |     ^ `Rc<Foo>` cannot be sent between threads safely
-   |
-   = help: within `Bar`, the trait `Send` is not implemented for `Rc<Foo>`
-   = note: required because it appears within the type `Bar`
-   = note: required because of the requirements on the impl of `Send` for `Arc<Bar>`
-   = note: required because it appears within the type `Foo`
-
 error[E0277]: `Rc<Foo>` cannot be shared between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
@@ -22,6 +8,20 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `Rc<Foo>` cannot be shared between threads safely
    |
    = help: within `Bar`, the trait `Sync` is not implemented for `Rc<Foo>`
+   = note: required because it appears within the type `Bar`
+   = note: required because of the requirements on the impl of `Send` for `Arc<Bar>`
+   = note: required because it appears within the type `Foo`
+
+error[E0277]: `Rc<Foo>` cannot be sent between threads safely
+  --> $DIR/issue-40827.rs:14:5
+   |
+LL | fn f<T: Send>(_: T) {}
+   |         ---- required by this bound in `f`
+...
+LL |     f(Foo(Arc::new(Bar::B(None))));
+   |     ^ `Rc<Foo>` cannot be sent between threads safely
+   |
+   = help: within `Bar`, the trait `Send` is not implemented for `Rc<Foo>`
    = note: required because it appears within the type `Bar`
    = note: required because of the requirements on the impl of `Send` for `Arc<Bar>`
    = note: required because it appears within the type `Foo`

--- a/src/test/ui/lint/rustdoc-group.rs
+++ b/src/test/ui/lint/rustdoc-group.rs
@@ -1,0 +1,5 @@
+// check-pass
+// compile-flags: --crate-type lib
+#![deny(rustdoc)]
+//~^ WARNING removed: use `rustdoc::all`
+#![deny(rustdoc::all)] // has no effect when run with rustc directly

--- a/src/test/ui/lint/rustdoc-group.stderr
+++ b/src/test/ui/lint/rustdoc-group.stderr
@@ -1,0 +1,10 @@
+warning: lint `rustdoc` has been removed: use `rustdoc::all` instead
+  --> $DIR/rustdoc-group.rs:3:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+   |
+   = note: `#[warn(renamed_and_removed_lints)]` on by default
+
+warning: 1 warning emitted
+

--- a/src/test/ui/macros/assert-eq-macro-msg.rs
+++ b/src/test/ui/macros/assert-eq-macro-msg.rs
@@ -1,0 +1,9 @@
+// run-fail
+// error-pattern:panicked at 'assertion failed: `(left == right)`
+// error-pattern: left: `2`
+// error-pattern:right: `3`: 1 + 1 definitely should be 3'
+// ignore-emscripten no processes
+
+fn main() {
+    assert_eq!(1 + 1, 3, "1 + 1 definitely should be 3");
+}

--- a/src/test/ui/macros/assert-matches-macro-msg.rs
+++ b/src/test/ui/macros/assert-matches-macro-msg.rs
@@ -1,0 +1,11 @@
+// run-fail
+// error-pattern:panicked at 'assertion failed: `(left matches right)`
+// error-pattern: left: `2`
+// error-pattern:right: `3`: 1 + 1 definitely should be 3'
+// ignore-emscripten no processes
+
+#![feature(assert_matches)]
+
+fn main() {
+    assert_matches!(1 + 1, 3, "1 + 1 definitely should be 3");
+}

--- a/src/test/ui/macros/assert-ne-macro-msg.rs
+++ b/src/test/ui/macros/assert-ne-macro-msg.rs
@@ -1,0 +1,9 @@
+// run-fail
+// error-pattern:panicked at 'assertion failed: `(left != right)`
+// error-pattern: left: `2`
+// error-pattern:right: `2`: 1 + 1 definitely should not be 2'
+// ignore-emscripten no processes
+
+fn main() {
+    assert_ne!(1 + 1, 2, "1 + 1 definitely should not be 2");
+}

--- a/src/test/ui/structs/struct-variant-privacy-xc.rs
+++ b/src/test/ui/structs/struct-variant-privacy-xc.rs
@@ -4,8 +4,7 @@ extern crate struct_variant_privacy;
 fn f(b: struct_variant_privacy::Bar) {
     //~^ ERROR enum `Bar` is private
     match b {
-        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR cannot match on
-                                                         //~^ ERROR enum `Bar` is private
+        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.rs
+++ b/src/test/ui/structs/struct-variant-privacy-xc.rs
@@ -1,9 +1,11 @@
 // aux-build:struct_variant_privacy.rs
 extern crate struct_variant_privacy;
 
-fn f(b: struct_variant_privacy::Bar) { //~ ERROR enum `Bar` is private
+fn f(b: struct_variant_privacy::Bar) {
+    //~^ ERROR enum `Bar` is private
     match b {
-        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
+        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR cannot match on
+                                                         //~^ ERROR enum `Bar` is private
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -22,12 +22,6 @@ note: the enum `Bar` is defined here
 LL | enum Bar {
    | ^^^^^^^^
 
-error[E0603]: cannot match on a field named `a` of variant `struct_variant_privacy::Bar::Baz`, which is not accessible in current scope
-  --> $DIR/struct-variant-privacy-xc.rs:7:44
-   |
-LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
-   |                                            ^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -11,7 +11,7 @@ LL | enum Bar {
    | ^^^^^^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy-xc.rs:6:33
+  --> $DIR/struct-variant-privacy-xc.rs:7:33
    |
 LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
    |                                 ^^^ private enum
@@ -22,6 +22,12 @@ note: the enum `Bar` is defined here
 LL | enum Bar {
    | ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0603]: cannot match on a field named `a` of variant `struct_variant_privacy::Bar::Baz`, which is not accessible in current scope
+  --> $DIR/struct-variant-privacy-xc.rs:7:44
+   |
+LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
+   |                                            ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy.rs
+++ b/src/test/ui/structs/struct-variant-privacy.rs
@@ -1,12 +1,14 @@
 mod foo {
     enum Bar {
-        Baz { a: isize }
+        Baz { a: isize },
     }
 }
 
-fn f(b: foo::Bar) { //~ ERROR enum `Bar` is private
+fn f(b: foo::Bar) {
+    //~^ ERROR enum `Bar` is private
     match b {
         foo::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
+                                      //~^ ERROR cannot match on
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy.rs
+++ b/src/test/ui/structs/struct-variant-privacy.rs
@@ -8,7 +8,6 @@ fn f(b: foo::Bar) {
     //~^ ERROR enum `Bar` is private
     match b {
         foo::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
-                                      //~^ ERROR cannot match on
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -22,12 +22,6 @@ note: the enum `Bar` is defined here
 LL |     enum Bar {
    |     ^^^^^^^^
 
-error[E0603]: cannot match on a field named `a` of variant `Bar::Baz`, which is not accessible in current scope
-  --> $DIR/struct-variant-privacy.rs:10:25
-   |
-LL |         foo::Bar::Baz { a: _a } => {}
-   |                         ^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -11,7 +11,7 @@ LL |     enum Bar {
    |     ^^^^^^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy.rs:9:14
+  --> $DIR/struct-variant-privacy.rs:10:14
    |
 LL |         foo::Bar::Baz { a: _a } => {}
    |              ^^^ private enum
@@ -22,6 +22,12 @@ note: the enum `Bar` is defined here
 LL |     enum Bar {
    |     ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0603]: cannot match on a field named `a` of variant `Bar::Baz`, which is not accessible in current scope
+  --> $DIR/struct-variant-privacy.rs:10:25
+   |
+LL |         foo::Bar::Baz { a: _a } => {}
+   |                         ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/suggestions/missing-trait-bounds-for-method-call.stderr
+++ b/src/test/ui/suggestions/missing-trait-bounds-for-method-call.stderr
@@ -8,9 +8,9 @@ LL |         self.foo();
    |              ^^^ method cannot be called on `&Foo<T>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
-           `T: Bar`
-           which is required by `Foo<T>: Bar`
            `T: Default`
+           which is required by `Foo<T>: Bar`
+           `T: Bar`
            which is required by `Foo<T>: Bar`
 help: consider restricting the type parameters to satisfy the trait bounds
    |

--- a/src/test/ui/traits/inductive-overflow/simultaneous.stderr
+++ b/src/test/ui/traits/inductive-overflow/simultaneous.stderr
@@ -1,4 +1,4 @@
-error[E0275]: overflow evaluating the requirement `{integer}: Tweedledum`
+error[E0275]: overflow evaluating the requirement `{integer}: Tweedledee`
   --> $DIR/simultaneous.rs:18:5
    |
 LL | fn is_ee<T: Combo>(t: T) {

--- a/src/test/ui/typeck/issue-82772.rs
+++ b/src/test/ui/typeck/issue-82772.rs
@@ -1,13 +1,13 @@
 // edition:2018
 
 fn main() {
-    use a::LocalModPrivateStruct;
-    let Box { 1: _, .. }: Box<()>; //~ ERROR cannot match on
-    let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
-    //~^ ERROR cannot match on
+    use a::ModPrivateStruct;
+    let Box { 0: _, .. }: Box<()>; //~ ERROR field `0` of
+    let Box { 1: _, .. }: Box<()>; //~ ERROR field `1` of
+    let ModPrivateStruct { 1: _, .. } = ModPrivateStruct::default(); //~ ERROR field `1` of
 }
 
 mod a {
     #[derive(Default)]
-    pub struct LocalModPrivateStruct(u8, u8);
+    pub struct ModPrivateStruct(u8, u8);
 }

--- a/src/test/ui/typeck/issue-82772.rs
+++ b/src/test/ui/typeck/issue-82772.rs
@@ -1,0 +1,13 @@
+// edition:2018
+
+fn main() {
+    use a::LocalModPrivateStruct;
+    let Box { 1: _, .. }: Box<()>; //~ ERROR cannot match on
+    let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
+    //~^ ERROR cannot match on
+}
+
+mod a {
+    #[derive(Default)]
+    pub struct LocalModPrivateStruct(u8, u8);
+}

--- a/src/test/ui/typeck/issue-82772.stderr
+++ b/src/test/ui/typeck/issue-82772.stderr
@@ -1,15 +1,21 @@
-error[E0603]: cannot match on a field named `1` of struct `Box`, which is not accessible in current scope
+error[E0451]: field `0` of struct `Box` is private
   --> $DIR/issue-82772.rs:5:15
    |
-LL |     let Box { 1: _, .. }: Box<()>;
-   |               ^
+LL |     let Box { 0: _, .. }: Box<()>;
+   |               ^^^^ private field
 
-error[E0603]: cannot match on a field named `1` of struct `LocalModPrivateStruct`, which is not accessible in current scope
-  --> $DIR/issue-82772.rs:6:33
+error[E0451]: field `1` of struct `Box` is private
+  --> $DIR/issue-82772.rs:6:15
    |
-LL |     let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
-   |                                 ^
+LL |     let Box { 1: _, .. }: Box<()>;
+   |               ^^^^ private field
 
-error: aborting due to 2 previous errors
+error[E0451]: field `1` of struct `ModPrivateStruct` is private
+  --> $DIR/issue-82772.rs:7:28
+   |
+LL |     let ModPrivateStruct { 1: _, .. } = ModPrivateStruct::default();
+   |                            ^^^^ private field
 
-For more information about this error, try `rustc --explain E0603`.
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/src/test/ui/typeck/issue-82772.stderr
+++ b/src/test/ui/typeck/issue-82772.stderr
@@ -1,0 +1,15 @@
+error[E0603]: cannot match on a field named `1` of struct `Box`, which is not accessible in current scope
+  --> $DIR/issue-82772.rs:5:15
+   |
+LL |     let Box { 1: _, .. }: Box<()>;
+   |               ^
+
+error[E0603]: cannot match on a field named `1` of struct `LocalModPrivateStruct`, which is not accessible in current scope
+  --> $DIR/issue-82772.rs:6:33
+   |
+LL |     let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
+   |                                 ^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0603`.


### PR DESCRIPTION
Successful merges:

 - #82789 (Get with field index from pattern slice instead of directly indexing)
 - #82798 (Rename `rustdoc` to `rustdoc::all`)
 - #82804 (std: Fix a bug on the wasm32-wasi target opening files)
 - #83028 (Prevent JS error when there is no dependency or other crate documented (or --disable-per-crate-search has been used))
 - #83070 (Update cargo)
 - #83074 (Avoid sorting predicates by `DefId`)
 - #83081 (Fix panic message of `assert_failed_inner`)
 - #83094 (crates.js should use root_path and not static_root_path)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=82789,82798,82804,83028,83070,83074,83081,83094)
<!-- homu-ignore:end -->