### PR TITLE
Find more invalid doc attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4268,6 +4268,7 @@ name = "rustc_passes"
 version = "0.0.0"
 dependencies = [
  "rustc_ast",
+ "rustc_ast_pretty",
  "rustc_attr",
  "rustc_data_structures",
  "rustc_errors",

--- a/compiler/rustc_passes/Cargo.toml
+++ b/compiler/rustc_passes/Cargo.toml
@@ -19,3 +19,4 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_span = { path = "../rustc_span" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_lexer = { path = "../rustc_lexer" }
+rustc_ast_pretty = { path = "../rustc_ast_pretty" }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -597,13 +597,10 @@ impl CheckAttrVisitor<'tcx> {
                                 hir_id,
                                 i_meta.span,
                                 |lint| {
-                                    let msg = if let Ok(snippet) =
-                                        self.tcx.sess.source_map().span_to_snippet(i_meta.path.span)
-                                    {
-                                        format!("unknown `doc` attribute `{}`", snippet,)
-                                    } else {
-                                        String::from("unknown `doc` attribute")
-                                    };
+                                    let msg = format!(
+                                        "unknown `doc` attribute `{}`",
+                                        rustc_ast_pretty::pprust::path_to_string(&i_meta.path),
+                                    );
                                     lint.build(&msg).emit();
                                 },
                             );

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -605,6 +605,16 @@ impl CheckAttrVisitor<'tcx> {
                             return false;
                         }
                     }
+                } else {
+                    self.tcx.struct_span_lint_hir(
+                        INVALID_DOC_ATTRIBUTES,
+                        hir_id,
+                        meta.span(),
+                        |lint| {
+                            lint.build(&format!("unknown `doc` attribute")).emit();
+                        },
+                    );
+                    return false;
                 }
             }
         }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -597,11 +597,14 @@ impl CheckAttrVisitor<'tcx> {
                                 hir_id,
                                 i_meta.span,
                                 |lint| {
-                                    lint.build(&format!(
-                                        "unknown `doc` attribute `{}`",
-                                        i_meta.name_or_empty()
-                                    ))
-                                    .emit();
+                                    let msg = if let Ok(snippet) =
+                                        self.tcx.sess.source_map().span_to_snippet(i_meta.path.span)
+                                    {
+                                        format!("unknown `doc` attribute `{}`", snippet,)
+                                    } else {
+                                        String::from("unknown `doc` attribute")
+                                    };
+                                    lint.build(&msg).emit();
                                 },
                             );
                             is_valid = false;
@@ -613,7 +616,7 @@ impl CheckAttrVisitor<'tcx> {
                         hir_id,
                         meta.span(),
                         |lint| {
-                            lint.build(&format!("unknown `doc` attribute")).emit();
+                            lint.build(&format!("invalid `doc` attribute")).emit();
                         },
                     );
                     is_valid = false;

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -520,7 +520,7 @@ impl CheckAttrVisitor<'tcx> {
                 .struct_span_err(
                     meta.span(),
                     &format!(
-                        "`#![doc({} = \"...\")]` isn't allowed as a crate level attribute",
+                        "`#![doc({} = \"...\")]` isn't allowed as a crate-level attribute",
                         attr_name,
                     ),
                 )
@@ -559,7 +559,7 @@ impl CheckAttrVisitor<'tcx> {
                                 |lint| {
                                     lint.build(
                                         "`#![doc(test(...)]` is only allowed \
-                                         as a crate level attribute",
+                                         as a crate-level attribute",
                                     )
                                     .emit();
                                 },

--- a/src/test/rustdoc-ui/doc-alias-crate-level.stderr
+++ b/src/test/rustdoc-ui/doc-alias-crate-level.stderr
@@ -4,7 +4,7 @@ error: '\'' character isn't allowed in `#[doc(alias = "...")]`
 LL | #[doc(alias = "shouldn't work!")]
    |               ^^^^^^^^^^^^^^^^^
 
-error: `#![doc(alias = "...")]` isn't allowed as a crate level attribute
+error: `#![doc(alias = "...")]` isn't allowed as a crate-level attribute
   --> $DIR/doc-alias-crate-level.rs:1:8
    |
 LL | #![doc(alias = "crate-level-not-working")]

--- a/src/test/rustdoc-ui/doc-attr.rs
+++ b/src/test/rustdoc-ui/doc-attr.rs
@@ -10,12 +10,12 @@
 pub fn foo() {}
 
 #[doc(123)]
-//~^ ERROR unknown `doc` attribute
+//~^ ERROR invalid `doc` attribute
 //~| WARN
 #[doc("hello", "bar")]
-//~^ ERROR unknown `doc` attribute
+//~^ ERROR invalid `doc` attribute
 //~| WARN
-//~| ERROR unknown `doc` attribute
+//~| ERROR invalid `doc` attribute
 //~| WARN
 #[doc(foo::bar, crate::bar::baz = "bye")]
 //~^ ERROR unknown `doc` attribute

--- a/src/test/rustdoc-ui/doc-attr.rs
+++ b/src/test/rustdoc-ui/doc-attr.rs
@@ -8,3 +8,18 @@
 //~^ ERROR unknown `doc` attribute
 //~^^ WARN
 pub fn foo() {}
+
+#[doc(123)]
+//~^ ERROR unknown `doc` attribute
+//~| WARN
+#[doc("hello", "bar")]
+//~^ ERROR unknown `doc` attribute
+//~| WARN
+//~| ERROR unknown `doc` attribute
+//~| WARN
+#[doc(foo::bar, crate::bar::baz = "bye")]
+//~^ ERROR unknown `doc` attribute
+//~| WARN
+//~| ERROR unknown `doc` attribute
+//~| WARN
+fn bar() {}

--- a/src/test/rustdoc-ui/doc-attr.stderr
+++ b/src/test/rustdoc-ui/doc-attr.stderr
@@ -13,6 +13,51 @@ LL | #![deny(warnings)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
+error: unknown `doc` attribute
+  --> $DIR/doc-attr.rs:12:7
+   |
+LL | #[doc(123)]
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: unknown `doc` attribute
+  --> $DIR/doc-attr.rs:15:7
+   |
+LL | #[doc("hello", "bar")]
+   |       ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: unknown `doc` attribute
+  --> $DIR/doc-attr.rs:15:16
+   |
+LL | #[doc("hello", "bar")]
+   |                ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: unknown `doc` attribute ``
+  --> $DIR/doc-attr.rs:20:7
+   |
+LL | #[doc(foo::bar, crate::bar::baz = "bye")]
+   |       ^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: unknown `doc` attribute ``
+  --> $DIR/doc-attr.rs:20:17
+   |
+LL | #[doc(foo::bar, crate::bar::baz = "bye")]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
 error: unknown `doc` attribute `as_ptr`
   --> $DIR/doc-attr.rs:3:8
    |
@@ -22,5 +67,5 @@ LL | #![doc(as_ptr)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: aborting due to 2 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/rustdoc-ui/doc-attr.stderr
+++ b/src/test/rustdoc-ui/doc-attr.stderr
@@ -13,7 +13,7 @@ LL | #![deny(warnings)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute
+error: invalid `doc` attribute
   --> $DIR/doc-attr.rs:12:7
    |
 LL | #[doc(123)]
@@ -22,7 +22,7 @@ LL | #[doc(123)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute
+error: invalid `doc` attribute
   --> $DIR/doc-attr.rs:15:7
    |
 LL | #[doc("hello", "bar")]
@@ -31,7 +31,7 @@ LL | #[doc("hello", "bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute
+error: invalid `doc` attribute
   --> $DIR/doc-attr.rs:15:16
    |
 LL | #[doc("hello", "bar")]
@@ -40,7 +40,7 @@ LL | #[doc("hello", "bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute ``
+error: unknown `doc` attribute `foo::bar`
   --> $DIR/doc-attr.rs:20:7
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
@@ -49,7 +49,7 @@ LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute ``
+error: unknown `doc` attribute `crate::bar::baz`
   --> $DIR/doc-attr.rs:20:17
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]

--- a/src/test/rustdoc-ui/doc-attr2.stderr
+++ b/src/test/rustdoc-ui/doc-attr2.stderr
@@ -1,4 +1,4 @@
-error: `#![doc(test(...)]` is only allowed as a crate level attribute
+error: `#![doc(test(...)]` is only allowed as a crate-level attribute
   --> $DIR/doc-attr2.rs:4:7
    |
 LL | #[doc(test(no_crate_inject))]
@@ -13,7 +13,7 @@ LL | #![deny(warnings)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: `#![doc(test(...)]` is only allowed as a crate level attribute
+error: `#![doc(test(...)]` is only allowed as a crate-level attribute
   --> $DIR/doc-attr2.rs:9:12
    |
 LL |     #![doc(test(no_crate_inject))]

--- a/src/test/ui/attributes/doc-attr.rs
+++ b/src/test/ui/attributes/doc-attr.rs
@@ -17,4 +17,9 @@ pub fn foo() {}
 //~| WARN
 //~| ERROR unknown `doc` attribute
 //~| WARN
+#[doc(foo::bar, crate::bar::baz = "bye")]
+//~^ ERROR unknown `doc` attribute
+//~| WARN
+//~| ERROR unknown `doc` attribute
+//~| WARN
 fn bar() {}

--- a/src/test/ui/attributes/doc-attr.rs
+++ b/src/test/ui/attributes/doc-attr.rs
@@ -10,12 +10,12 @@
 pub fn foo() {}
 
 #[doc(123)]
-//~^ ERROR unknown `doc` attribute
+//~^ ERROR invalid `doc` attribute
 //~| WARN
 #[doc("hello", "bar")]
-//~^ ERROR unknown `doc` attribute
+//~^ ERROR invalid `doc` attribute
 //~| WARN
-//~| ERROR unknown `doc` attribute
+//~| ERROR invalid `doc` attribute
 //~| WARN
 #[doc(foo::bar, crate::bar::baz = "bye")]
 //~^ ERROR unknown `doc` attribute

--- a/src/test/ui/attributes/doc-attr.rs
+++ b/src/test/ui/attributes/doc-attr.rs
@@ -15,4 +15,6 @@ pub fn foo() {}
 #[doc("hello", "bar")]
 //~^ ERROR unknown `doc` attribute
 //~| WARN
+//~| ERROR unknown `doc` attribute
+//~| WARN
 fn bar() {}

--- a/src/test/ui/attributes/doc-attr.rs
+++ b/src/test/ui/attributes/doc-attr.rs
@@ -8,3 +8,11 @@
 //~^ ERROR unknown `doc` attribute
 //~^^ WARN
 pub fn foo() {}
+
+#[doc(123)]
+//~^ ERROR unknown `doc` attribute
+//~| WARN
+#[doc("hello", "bar")]
+//~^ ERROR unknown `doc` attribute
+//~| WARN
+fn bar() {}

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -40,6 +40,24 @@ LL | #[doc("hello", "bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
+error: unknown `doc` attribute ``
+  --> $DIR/doc-attr.rs:20:7
+   |
+LL | #[doc(foo::bar, crate::bar::baz = "bye")]
+   |       ^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: unknown `doc` attribute ``
+  --> $DIR/doc-attr.rs:20:17
+   |
+LL | #[doc(foo::bar, crate::bar::baz = "bye")]
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
 error: unknown `doc` attribute `as_ptr`
   --> $DIR/doc-attr.rs:3:8
    |
@@ -49,5 +67,5 @@ LL | #![doc(as_ptr)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -13,7 +13,7 @@ LL | #![deny(warnings)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute
+error: invalid `doc` attribute
   --> $DIR/doc-attr.rs:12:7
    |
 LL | #[doc(123)]
@@ -22,7 +22,7 @@ LL | #[doc(123)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute
+error: invalid `doc` attribute
   --> $DIR/doc-attr.rs:15:7
    |
 LL | #[doc("hello", "bar")]
@@ -31,7 +31,7 @@ LL | #[doc("hello", "bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute
+error: invalid `doc` attribute
   --> $DIR/doc-attr.rs:15:16
    |
 LL | #[doc("hello", "bar")]
@@ -40,7 +40,7 @@ LL | #[doc("hello", "bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute ``
+error: unknown `doc` attribute `foo::bar`
   --> $DIR/doc-attr.rs:20:7
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]
@@ -49,7 +49,7 @@ LL | #[doc(foo::bar, crate::bar::baz = "bye")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: unknown `doc` attribute ``
+error: unknown `doc` attribute `crate::bar::baz`
   --> $DIR/doc-attr.rs:20:17
    |
 LL | #[doc(foo::bar, crate::bar::baz = "bye")]

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -13,6 +13,24 @@ LL | #![deny(warnings)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
+error: unknown `doc` attribute
+  --> $DIR/doc-attr.rs:12:7
+   |
+LL | #[doc(123)]
+   |       ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
+error: unknown `doc` attribute
+  --> $DIR/doc-attr.rs:15:7
+   |
+LL | #[doc("hello", "bar")]
+   |       ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
 error: unknown `doc` attribute `as_ptr`
   --> $DIR/doc-attr.rs:3:8
    |
@@ -22,5 +40,5 @@ LL | #![doc(as_ptr)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/attributes/doc-attr.stderr
+++ b/src/test/ui/attributes/doc-attr.stderr
@@ -31,6 +31,15 @@ LL | #[doc("hello", "bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
+error: unknown `doc` attribute
+  --> $DIR/doc-attr.rs:15:16
+   |
+LL | #[doc("hello", "bar")]
+   |                ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
+
 error: unknown `doc` attribute `as_ptr`
   --> $DIR/doc-attr.rs:3:8
    |
@@ -40,5 +49,5 @@ LL | #![doc(as_ptr)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/attributes/doc-attr2.stderr
+++ b/src/test/ui/attributes/doc-attr2.stderr
@@ -1,4 +1,4 @@
-error: `#![doc(test(...)]` is only allowed as a crate level attribute
+error: `#![doc(test(...)]` is only allowed as a crate-level attribute
   --> $DIR/doc-attr2.rs:4:7
    |
 LL | #[doc(test(no_crate_inject))]
@@ -13,7 +13,7 @@ LL | #![deny(warnings)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
 
-error: `#![doc(test(...)]` is only allowed as a crate level attribute
+error: `#![doc(test(...)]` is only allowed as a crate-level attribute
   --> $DIR/doc-attr2.rs:9:12
    |
 LL |     #![doc(test(no_crate_inject))]

--- a/src/test/ui/rustdoc/doc-alias-crate-level.stderr
+++ b/src/test/ui/rustdoc/doc-alias-crate-level.stderr
@@ -4,7 +4,7 @@ error: '\'' character isn't allowed in `#[doc(alias = "...")]`
 LL | #[doc(alias = "shouldn't work!")]
    |               ^^^^^^^^^^^^^^^^^
 
-error: `#![doc(alias = "...")]` isn't allowed as a crate level attribute
+error: `#![doc(alias = "...")]` isn't allowed as a crate-level attribute
   --> $DIR/doc-alias-crate-level.rs:5:8
    |
 LL | #![doc(alias = "not working!")]

--- a/src/test/ui/rustdoc/doc_keyword.stderr
+++ b/src/test/ui/rustdoc/doc_keyword.stderr
@@ -10,7 +10,7 @@ error: `#[doc(keyword = "...")]` can only be used on modules
 LL | #[doc(keyword = "hall")]
    |       ^^^^^^^^^^^^^^^^
 
-error: `#![doc(keyword = "...")]` isn't allowed as a crate level attribute
+error: `#![doc(keyword = "...")]` isn't allowed as a crate-level attribute
   --> $DIR/doc_keyword.rs:4:8
    |
 LL | #![doc(keyword = "hello")]


### PR DESCRIPTION
- Lint on `#[doc(123)]`, `#[doc("hello")]`, etc.
- Lint every attribute; e.g., will now report two warnings for `#[doc(foo, bar)]`
- Add hyphen to "crate level"
- Display paths like `#[doc(foo::bar)]` correctly instead of as an empty string