### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -712,16 +712,24 @@ pub fn non_durable_rename(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::fs::rename(src, dst)
 }
 
-// Note: Also used by librustdoc, see PR #43348. Consider moving this struct elsewhere.
-//
-// FIXME: Currently the `everybody_loops` transformation is not applied to:
-//  * `const fn`, due to issue #43636 that `loop` is not supported for const evaluation. We are
-//    waiting for miri to fix that.
-//  * `impl Trait`, due to issue #43869 that functions returning impl Trait cannot be diverging.
-//    Solving this may require `!` to implement every trait, which relies on the an even more
-//    ambitious form of the closed RFC #1637. See also [#34511].
-//
-// [#34511]: https://github.com/rust-lang/rust/issues/34511#issuecomment-322340401
+/// Replaces function bodies with `loop {}` (an infinite loop). This gets rid of
+/// all semantic errors in the body while still satisfying the return type,
+/// except in certain cases, see below for more.
+///
+/// This pass is known as `everybody_loops`. Very punny.
+///
+/// As of March 2021, `everybody_loops` is only used for the
+/// `-Z unpretty=everybody_loops` debugging option.
+///
+/// FIXME: Currently the `everybody_loops` transformation is not applied to:
+///  * `const fn`; support could be added, but hasn't. Originally `const fn`
+///    was skipped due to issue #43636 that `loop` was not supported for
+///    const evaluation.
+///  * `impl Trait`, due to issue #43869 that functions returning impl Trait cannot be diverging.
+///    Solving this may require `!` to implement every trait, which relies on the an even more
+///    ambitious form of the closed RFC #1637. See also [#34511].
+///
+/// [#34511]: https://github.com/rust-lang/rust/issues/34511#issuecomment-322340401
 pub struct ReplaceBodyWithLoop<'a, 'b> {
     within_static_or_const: bool,
     nested_blocks: Option<Vec<ast::Block>>,

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -343,6 +343,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         "intra_doc_link_resolution_failure",
         "use `rustdoc::broken_intra_doc_links` instead",
     );
+    store.register_removed("rustdoc", "use `rustdoc::all` instead");
 
     store.register_removed("unknown_features", "replaced by an error");
     store.register_removed("unsigned_negation", "replaced by negate_unsigned feature gate");

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -1343,7 +1343,9 @@ impl<'p, 'tcx> Fields<'p, 'tcx> {
         match &mut fields {
             Fields::Vec(pats) => {
                 for (i, pat) in new_pats {
-                    pats[i] = pat
+                    if let Some(p) = pats.get_mut(i) {
+                        *p = pat;
+                    }
                 }
             }
             Fields::Filtered { fields, .. } => {

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1176,7 +1176,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut no_field_errors = true;
 
         let mut inexistent_fields = vec![];
-        let mut invisible_fields = vec![];
         // Typecheck each field.
         for field in fields {
             let span = field.span;
@@ -1192,12 +1191,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     field_map
                         .get(&ident)
                         .map(|(i, f)| {
-                            if !f
-                                .vis
-                                .is_accessible_from(tcx.parent_module(pat.hir_id).to_def_id(), tcx)
-                            {
-                                invisible_fields.push(field.ident);
-                            }
                             self.write_field_index(field.hir_id, *i);
                             self.tcx.check_stability(f.did, Some(pat.hir_id), span);
                             self.field_ty(span, f, substs)
@@ -1288,13 +1281,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     self.error_tuple_variant_index_shorthand(variant, pat, fields)
                 {
                     err.emit();
-                } else if !invisible_fields.is_empty() {
-                    let mut err = self.error_invisible_fields(
-                        adt.variant_descr(),
-                        &invisible_fields,
-                        variant,
-                    );
-                    err.emit();
                 }
             }
         }
@@ -1371,41 +1357,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         .span_label(span, format!("multiple uses of `{}` in pattern", ident))
         .span_label(other_field, format!("first use of `{}`", ident))
         .emit();
-    }
-
-    fn error_invisible_fields(
-        &self,
-        kind_name: &str,
-        invisible_fields: &[Ident],
-        variant: &ty::VariantDef,
-    ) -> DiagnosticBuilder<'tcx> {
-        let spans = invisible_fields.iter().map(|ident| ident.span).collect::<Vec<_>>();
-        let (field_names, t) = if invisible_fields.len() == 1 {
-            (format!("a field named `{}`", invisible_fields[0]), "is")
-        } else {
-            (
-                format!(
-                    "fields named {}",
-                    invisible_fields
-                        .iter()
-                        .map(|ident| format!("`{}`", ident))
-                        .collect::<Vec<String>>()
-                        .join(", ")
-                ),
-                "are",
-            )
-        };
-        let err = struct_span_err!(
-            self.tcx.sess,
-            spans,
-            E0603,
-            "cannot match on {} of {} `{}`, which {} not accessible in current scope",
-            field_names,
-            kind_name,
-            self.tcx.def_path_str(variant.def_id),
-            t
-        );
-        err
     }
 
     fn error_inexistent_fields(

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2737,6 +2737,7 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), None);
     /// ```
     #[inline]
+    #[doc(alias = "reverse")]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn rev(self) -> Rev<Self>
     where

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -154,7 +154,7 @@ fn assert_failed_inner(
         Some(args) => panic!(
             r#"assertion failed: `(left {} right)`
   left: `{:?}`,
- right: `{:?}: {}`"#,
+ right: `{:?}`: {}"#,
             op, left, right, args
         ),
         None => panic!(

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -48,6 +48,17 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 ///
 /// let ten_millis = Duration::from_millis(10);
 /// ```
+///
+/// # Formatting `Duration` values
+///
+/// `Duration` intentionally does not have a `Display` impl, as there are a
+/// variety of ways to format spans of time for human readability. `Duration`
+/// provides a `Debug` impl that shows the full precision of the value.
+///
+/// The `Debug` output uses the non-ASCII "µs" suffix for microseconds. If your
+/// program output may appear in contexts that cannot rely on full Unicode
+/// compatibility, you may wish to format `Duration` objects yourself or use a
+/// crate to do so.
 #[stable(feature = "duration", since = "1.3.0")]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct Duration {

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -5,6 +5,7 @@ use crate::borrow::{Borrow, Cow};
 use crate::cmp;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
+use crate::iter::{Extend, FromIterator};
 use crate::ops;
 use crate::rc::Rc;
 use crate::str::FromStr;
@@ -1180,5 +1181,49 @@ impl FromStr for OsString {
     #[inline]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(OsString::from(s))
+    }
+}
+
+#[stable(feature = "osstring_extend", since = "1.52.0")]
+impl Extend<OsString> for OsString {
+    #[inline]
+    fn extend<T: IntoIterator<Item = OsString>>(&mut self, iter: T) {
+        for s in iter {
+            self.push(&s);
+        }
+    }
+}
+
+#[stable(feature = "osstring_extend", since = "1.52.0")]
+impl<'a> Extend<&'a OsStr> for OsString {
+    #[inline]
+    fn extend<T: IntoIterator<Item = &'a OsStr>>(&mut self, iter: T) {
+        for s in iter {
+            self.push(s);
+        }
+    }
+}
+
+#[stable(feature = "osstring_extend", since = "1.52.0")]
+impl FromIterator<OsString> for OsString {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = OsString>>(iter: I) -> Self {
+        let mut buf = Self::new();
+        for s in iter {
+            buf.push(&s);
+        }
+        buf
+    }
+}
+
+#[stable(feature = "osstring_extend", since = "1.52.0")]
+impl<'a> FromIterator<&'a OsStr> for OsString {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = &'a OsStr>>(iter: I) -> Self {
+        let mut buf = Self::new();
+        for s in iter {
+            buf.push(s);
+        }
+        buf
     }
 }

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1208,11 +1208,18 @@ impl<'a> Extend<&'a OsStr> for OsString {
 impl FromIterator<OsString> for OsString {
     #[inline]
     fn from_iter<I: IntoIterator<Item = OsString>>(iter: I) -> Self {
-        let mut buf = Self::new();
-        for s in iter {
-            buf.push(&s);
+        let mut iterator = iter.into_iter();
+
+        // Because we're iterating over `OsString`s, we can avoid at least
+        // one allocation by getting the first string from the iterator
+        // and appending to it all the subsequent strings.
+        match iterator.next() {
+            None => OsString::new(),
+            Some(mut buf) => {
+                buf.extend(iterator);
+                buf
+            }
         }
-        buf
     }
 }
 

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -650,13 +650,11 @@ fn open_parent(p: &Path) -> io::Result<(ManuallyDrop<WasiFd>, PathBuf)> {
                 );
                 return Err(io::Error::new(io::ErrorKind::Other, msg));
             }
-            let len = CStr::from_ptr(buf.as_ptr().cast()).to_bytes().len();
-            buf.set_len(len);
-            buf.shrink_to_fit();
+            let relative = CStr::from_ptr(relative_path).to_bytes().to_vec();
 
             return Ok((
                 ManuallyDrop::new(WasiFd::from_raw(fd as u32)),
-                PathBuf::from(OsString::from_vec(buf)),
+                PathBuf::from(OsString::from_vec(relative)),
             ));
         }
     }

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -175,8 +175,8 @@ crate fn register_lints(_sess: &Session, lint_store: &mut LintStore) {
     lint_store.register_lints(&**RUSTDOC_LINTS);
     lint_store.register_group(
         true,
-        "rustdoc",
-        None,
+        "rustdoc::all",
+        Some("rustdoc"),
         RUSTDOC_LINTS.iter().map(|&lint| LintId::of(lint)).collect(),
     );
     for lint in &*RUSTDOC_LINTS {

--- a/src/test/rustdoc-ui/check-fail.rs
+++ b/src/test/rustdoc-ui/check-fail.rs
@@ -1,7 +1,7 @@
 // compile-flags: -Z unstable-options --check
 
 #![deny(missing_docs)]
-#![deny(rustdoc)]
+#![deny(rustdoc::all)]
 
 //! ```rust,testharness
 //~^ ERROR

--- a/src/test/rustdoc-ui/check-fail.stderr
+++ b/src/test/rustdoc-ui/check-fail.stderr
@@ -19,9 +19,9 @@ LL | pub fn foo() {}
 note: the lint level is defined here
   --> $DIR/check-fail.rs:4:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?
   --> $DIR/check-fail.rs:6:1
@@ -35,9 +35,9 @@ LL | | //! ```
 note: the lint level is defined here
   --> $DIR/check-fail.rs:4:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(rustdoc::all)]`
    = help: the code block will either not be tested if not marked as a rust one or the code will be wrapped inside a main function
 
 error: unknown attribute `testharness`. Did you mean `test_harness`?

--- a/src/test/rustdoc-ui/check.rs
+++ b/src/test/rustdoc-ui/check.rs
@@ -4,7 +4,7 @@
 #![warn(missing_docs)]
 //~^ WARN
 //~^^ WARN
-#![warn(rustdoc)]
+#![warn(rustdoc::all)]
 
 pub fn foo() {}
 //~^ WARN

--- a/src/test/rustdoc-ui/check.stderr
+++ b/src/test/rustdoc-ui/check.stderr
@@ -4,7 +4,7 @@ warning: missing documentation for the crate
 LL | / #![warn(missing_docs)]
 LL | |
 LL | |
-LL | | #![warn(rustdoc)]
+LL | | #![warn(rustdoc::all)]
 LL | |
 LL | | pub fn foo() {}
    | |_______________^
@@ -26,9 +26,9 @@ warning: no documentation found for this crate's top-level module
 note: the lint level is defined here
   --> $DIR/check.rs:7:9
    |
-LL | #![warn(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[warn(rustdoc::missing_crate_level_docs)]` implied by `#[warn(rustdoc)]`
+LL | #![warn(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[warn(rustdoc::missing_crate_level_docs)]` implied by `#[warn(rustdoc::all)]`
    = help: The following guide may be of use:
            https://doc.rust-lang.org/nightly/rustdoc/how-to-write-documentation.html
 
@@ -38,7 +38,7 @@ warning: missing code example in this documentation
 LL | / #![warn(missing_docs)]
 LL | |
 LL | |
-LL | | #![warn(rustdoc)]
+LL | | #![warn(rustdoc::all)]
 LL | |
 LL | | pub fn foo() {}
    | |_______________^
@@ -46,9 +46,9 @@ LL | | pub fn foo() {}
 note: the lint level is defined here
   --> $DIR/check.rs:7:9
    |
-LL | #![warn(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[warn(rustdoc::missing_doc_code_examples)]` implied by `#[warn(rustdoc)]`
+LL | #![warn(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[warn(rustdoc::missing_doc_code_examples)]` implied by `#[warn(rustdoc::all)]`
 
 warning: missing code example in this documentation
   --> $DIR/check.rs:9:1

--- a/src/test/rustdoc-ui/lint-group.rs
+++ b/src/test/rustdoc-ui/lint-group.rs
@@ -4,7 +4,7 @@
 //! println!("sup");
 //! ```
 
-#![deny(rustdoc)]
+#![deny(rustdoc::all)]
 
 /// what up, let's make an [error]
 ///

--- a/src/test/rustdoc-ui/lint-group.stderr
+++ b/src/test/rustdoc-ui/lint-group.stderr
@@ -7,9 +7,9 @@ LL | /// wait, this doesn't have a doctest?
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::missing_doc_code_examples)]` implied by `#[deny(rustdoc::all)]`
 
 error: documentation test in private item
   --> $DIR/lint-group.rs:19:1
@@ -24,9 +24,9 @@ LL | | /// ```
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::private_doc_tests)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::private_doc_tests)]` implied by `#[deny(rustdoc::all)]`
 
 error: missing code example in this documentation
   --> $DIR/lint-group.rs:26:1
@@ -43,9 +43,9 @@ LL | /// what up, let's make an [error]
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc::all)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: unclosed HTML tag `unknown`
@@ -57,9 +57,9 @@ LL | /// <unknown>
 note: the lint level is defined here
   --> $DIR/lint-group.rs:7:9
    |
-LL | #![deny(rustdoc)]
-   |         ^^^^^^^
-   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc)]`
+LL | #![deny(rustdoc::all)]
+   |         ^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc::all)]`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/rustdoc-ui/unknown-renamed-lints.rs
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.rs
@@ -12,6 +12,9 @@
 #![deny(non_autolinks)]
 //~^ ERROR renamed to `rustdoc::non_autolinks`
 
+#![deny(rustdoc)]
+//~^ ERROR removed: use `rustdoc::all` instead
+
 // Explicitly don't try to handle this case, it was never valid
 #![deny(rustdoc::intra_doc_link_resolution_failure)]
 //~^ ERROR unknown lint

--- a/src/test/rustdoc-ui/unknown-renamed-lints.stderr
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.stderr
@@ -34,13 +34,19 @@ error: lint `non_autolinks` has been renamed to `rustdoc::non_autolinks`
 LL | #![deny(non_autolinks)]
    |         ^^^^^^^^^^^^^ help: use the new name: `rustdoc::non_autolinks`
 
+error: lint `rustdoc` has been removed: use `rustdoc::all` instead
+  --> $DIR/unknown-renamed-lints.rs:15:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+
 error: unknown lint: `rustdoc::intra_doc_link_resolution_failure`
-  --> $DIR/unknown-renamed-lints.rs:16:9
+  --> $DIR/unknown-renamed-lints.rs:19:9
    |
 LL | #![deny(rustdoc::intra_doc_link_resolution_failure)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Compilation failed, aborting rustdoc
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/lint/rustdoc-group.rs
+++ b/src/test/ui/lint/rustdoc-group.rs
@@ -1,0 +1,5 @@
+// check-pass
+// compile-flags: --crate-type lib
+#![deny(rustdoc)]
+//~^ WARNING removed: use `rustdoc::all`
+#![deny(rustdoc::all)] // has no effect when run with rustc directly

--- a/src/test/ui/lint/rustdoc-group.stderr
+++ b/src/test/ui/lint/rustdoc-group.stderr
@@ -1,0 +1,10 @@
+warning: lint `rustdoc` has been removed: use `rustdoc::all` instead
+  --> $DIR/rustdoc-group.rs:3:9
+   |
+LL | #![deny(rustdoc)]
+   |         ^^^^^^^
+   |
+   = note: `#[warn(renamed_and_removed_lints)]` on by default
+
+warning: 1 warning emitted
+

--- a/src/test/ui/macros/assert-eq-macro-msg.rs
+++ b/src/test/ui/macros/assert-eq-macro-msg.rs
@@ -1,0 +1,9 @@
+// run-fail
+// error-pattern:panicked at 'assertion failed: `(left == right)`
+// error-pattern: left: `2`
+// error-pattern:right: `3`: 1 + 1 definitely should be 3'
+// ignore-emscripten no processes
+
+fn main() {
+    assert_eq!(1 + 1, 3, "1 + 1 definitely should be 3");
+}

--- a/src/test/ui/macros/assert-matches-macro-msg.rs
+++ b/src/test/ui/macros/assert-matches-macro-msg.rs
@@ -1,0 +1,11 @@
+// run-fail
+// error-pattern:panicked at 'assertion failed: `(left matches right)`
+// error-pattern: left: `2`
+// error-pattern:right: `3`: 1 + 1 definitely should be 3'
+// ignore-emscripten no processes
+
+#![feature(assert_matches)]
+
+fn main() {
+    assert_matches!(1 + 1, 3, "1 + 1 definitely should be 3");
+}

--- a/src/test/ui/macros/assert-ne-macro-msg.rs
+++ b/src/test/ui/macros/assert-ne-macro-msg.rs
@@ -1,0 +1,9 @@
+// run-fail
+// error-pattern:panicked at 'assertion failed: `(left != right)`
+// error-pattern: left: `2`
+// error-pattern:right: `2`: 1 + 1 definitely should not be 2'
+// ignore-emscripten no processes
+
+fn main() {
+    assert_ne!(1 + 1, 2, "1 + 1 definitely should not be 2");
+}

--- a/src/test/ui/structs/struct-variant-privacy-xc.rs
+++ b/src/test/ui/structs/struct-variant-privacy-xc.rs
@@ -4,8 +4,7 @@ extern crate struct_variant_privacy;
 fn f(b: struct_variant_privacy::Bar) {
     //~^ ERROR enum `Bar` is private
     match b {
-        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR cannot match on
-                                                         //~^ ERROR enum `Bar` is private
+        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.rs
+++ b/src/test/ui/structs/struct-variant-privacy-xc.rs
@@ -1,9 +1,11 @@
 // aux-build:struct_variant_privacy.rs
 extern crate struct_variant_privacy;
 
-fn f(b: struct_variant_privacy::Bar) { //~ ERROR enum `Bar` is private
+fn f(b: struct_variant_privacy::Bar) {
+    //~^ ERROR enum `Bar` is private
     match b {
-        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
+        struct_variant_privacy::Bar::Baz { a: _a } => {} //~ ERROR cannot match on
+                                                         //~^ ERROR enum `Bar` is private
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -22,12 +22,6 @@ note: the enum `Bar` is defined here
 LL | enum Bar {
    | ^^^^^^^^
 
-error[E0603]: cannot match on a field named `a` of variant `struct_variant_privacy::Bar::Baz`, which is not accessible in current scope
-  --> $DIR/struct-variant-privacy-xc.rs:7:44
-   |
-LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
-   |                                            ^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy-xc.stderr
+++ b/src/test/ui/structs/struct-variant-privacy-xc.stderr
@@ -11,7 +11,7 @@ LL | enum Bar {
    | ^^^^^^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy-xc.rs:6:33
+  --> $DIR/struct-variant-privacy-xc.rs:7:33
    |
 LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
    |                                 ^^^ private enum
@@ -22,6 +22,12 @@ note: the enum `Bar` is defined here
 LL | enum Bar {
    | ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0603]: cannot match on a field named `a` of variant `struct_variant_privacy::Bar::Baz`, which is not accessible in current scope
+  --> $DIR/struct-variant-privacy-xc.rs:7:44
+   |
+LL |         struct_variant_privacy::Bar::Baz { a: _a } => {}
+   |                                            ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy.rs
+++ b/src/test/ui/structs/struct-variant-privacy.rs
@@ -1,12 +1,14 @@
 mod foo {
     enum Bar {
-        Baz { a: isize }
+        Baz { a: isize },
     }
 }
 
-fn f(b: foo::Bar) { //~ ERROR enum `Bar` is private
+fn f(b: foo::Bar) {
+    //~^ ERROR enum `Bar` is private
     match b {
         foo::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
+                                      //~^ ERROR cannot match on
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy.rs
+++ b/src/test/ui/structs/struct-variant-privacy.rs
@@ -8,7 +8,6 @@ fn f(b: foo::Bar) {
     //~^ ERROR enum `Bar` is private
     match b {
         foo::Bar::Baz { a: _a } => {} //~ ERROR enum `Bar` is private
-                                      //~^ ERROR cannot match on
     }
 }
 

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -22,12 +22,6 @@ note: the enum `Bar` is defined here
 LL |     enum Bar {
    |     ^^^^^^^^
 
-error[E0603]: cannot match on a field named `a` of variant `Bar::Baz`, which is not accessible in current scope
-  --> $DIR/struct-variant-privacy.rs:10:25
-   |
-LL |         foo::Bar::Baz { a: _a } => {}
-   |                         ^
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/structs/struct-variant-privacy.stderr
+++ b/src/test/ui/structs/struct-variant-privacy.stderr
@@ -11,7 +11,7 @@ LL |     enum Bar {
    |     ^^^^^^^^
 
 error[E0603]: enum `Bar` is private
-  --> $DIR/struct-variant-privacy.rs:9:14
+  --> $DIR/struct-variant-privacy.rs:10:14
    |
 LL |         foo::Bar::Baz { a: _a } => {}
    |              ^^^ private enum
@@ -22,6 +22,12 @@ note: the enum `Bar` is defined here
 LL |     enum Bar {
    |     ^^^^^^^^
 
-error: aborting due to 2 previous errors
+error[E0603]: cannot match on a field named `a` of variant `Bar::Baz`, which is not accessible in current scope
+  --> $DIR/struct-variant-privacy.rs:10:25
+   |
+LL |         foo::Bar::Baz { a: _a } => {}
+   |                         ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0603`.

--- a/src/test/ui/typeck/issue-82772.rs
+++ b/src/test/ui/typeck/issue-82772.rs
@@ -1,13 +1,13 @@
 // edition:2018
 
 fn main() {
-    use a::LocalModPrivateStruct;
-    let Box { 1: _, .. }: Box<()>; //~ ERROR cannot match on
-    let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
-    //~^ ERROR cannot match on
+    use a::ModPrivateStruct;
+    let Box { 0: _, .. }: Box<()>; //~ ERROR field `0` of
+    let Box { 1: _, .. }: Box<()>; //~ ERROR field `1` of
+    let ModPrivateStruct { 1: _, .. } = ModPrivateStruct::default(); //~ ERROR field `1` of
 }
 
 mod a {
     #[derive(Default)]
-    pub struct LocalModPrivateStruct(u8, u8);
+    pub struct ModPrivateStruct(u8, u8);
 }

--- a/src/test/ui/typeck/issue-82772.rs
+++ b/src/test/ui/typeck/issue-82772.rs
@@ -1,0 +1,13 @@
+// edition:2018
+
+fn main() {
+    use a::LocalModPrivateStruct;
+    let Box { 1: _, .. }: Box<()>; //~ ERROR cannot match on
+    let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
+    //~^ ERROR cannot match on
+}
+
+mod a {
+    #[derive(Default)]
+    pub struct LocalModPrivateStruct(u8, u8);
+}

--- a/src/test/ui/typeck/issue-82772.stderr
+++ b/src/test/ui/typeck/issue-82772.stderr
@@ -1,15 +1,21 @@
-error[E0603]: cannot match on a field named `1` of struct `Box`, which is not accessible in current scope
+error[E0451]: field `0` of struct `Box` is private
   --> $DIR/issue-82772.rs:5:15
    |
-LL |     let Box { 1: _, .. }: Box<()>;
-   |               ^
+LL |     let Box { 0: _, .. }: Box<()>;
+   |               ^^^^ private field
 
-error[E0603]: cannot match on a field named `1` of struct `LocalModPrivateStruct`, which is not accessible in current scope
-  --> $DIR/issue-82772.rs:6:33
+error[E0451]: field `1` of struct `Box` is private
+  --> $DIR/issue-82772.rs:6:15
    |
-LL |     let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
-   |                                 ^
+LL |     let Box { 1: _, .. }: Box<()>;
+   |               ^^^^ private field
 
-error: aborting due to 2 previous errors
+error[E0451]: field `1` of struct `ModPrivateStruct` is private
+  --> $DIR/issue-82772.rs:7:28
+   |
+LL |     let ModPrivateStruct { 1: _, .. } = ModPrivateStruct::default();
+   |                            ^^^^ private field
 
-For more information about this error, try `rustc --explain E0603`.
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0451`.

--- a/src/test/ui/typeck/issue-82772.stderr
+++ b/src/test/ui/typeck/issue-82772.stderr
@@ -1,0 +1,15 @@
+error[E0603]: cannot match on a field named `1` of struct `Box`, which is not accessible in current scope
+  --> $DIR/issue-82772.rs:5:15
+   |
+LL |     let Box { 1: _, .. }: Box<()>;
+   |               ^
+
+error[E0603]: cannot match on a field named `1` of struct `LocalModPrivateStruct`, which is not accessible in current scope
+  --> $DIR/issue-82772.rs:6:33
+   |
+LL |     let LocalModPrivateStruct { 1: _, .. } = LocalModPrivateStruct::default();
+   |                                 ^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0603`.


### PR DESCRIPTION
Successful merges:

 - #81465 (Add documentation about formatting `Duration` values)
 - #82121 (Implement Extend and FromIterator for OsString)
 - #82617 (Document `everybody_loops`)
 - #82789 (Get with field index from pattern slice instead of directly indexing)
 - #82798 (Rename `rustdoc` to `rustdoc::all`)
 - #82804 (std: Fix a bug on the wasm32-wasi target opening files)
 - #82943 (Demonstrate best practice for feeding stdin of a child processes)
 - #83066 (Add `reverse` search alias for Iterator::rev())
 - #83070 (Update cargo)
 - #83081 (Fix panic message of `assert_failed_inner`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=81465,82121,82617,82789,82798,82804,82943,83066,83070,83081)
<!-- homu-ignore:end -->