### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,7 +4774,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.1",
+ "semver-parser 0.10.2",
  "serde",
 ]
 
@@ -4786,9 +4786,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
 dependencies = [
  "pest",
 ]

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2297,7 +2297,7 @@ impl FnRetTy {
     }
 }
 
-#[derive(Clone, PartialEq, Encodable, Decodable, Debug)]
+#[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug)]
 pub enum Inline {
     Yes,
     No,

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -149,8 +149,16 @@ impl PathSegment {
     pub fn from_ident(ident: Ident) -> Self {
         PathSegment { ident, id: DUMMY_NODE_ID, args: None }
     }
+
     pub fn path_root(span: Span) -> Self {
         PathSegment::from_ident(Ident::new(kw::PathRoot, span))
+    }
+
+    pub fn span(&self) -> Span {
+        match &self.args {
+            Some(args) => self.ident.span.to(args.span()),
+            None => self.ident.span,
+        }
     }
 }
 

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -120,6 +120,7 @@ impl NestedMetaItem {
 }
 
 impl Attribute {
+    #[inline]
     pub fn has_name(&self, name: Symbol) -> bool {
         match self.kind {
             AttrKind::Normal(ref item, _) => item.path == name,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1809,7 +1809,7 @@ impl<'hir> QPath<'hir> {
     pub fn span(&self) -> Span {
         match *self {
             QPath::Resolved(_, path) => path.span,
-            QPath::TypeRelative(_, ps) => ps.ident.span,
+            QPath::TypeRelative(qself, ps) => qself.span.to(ps.ident.span),
             QPath::LangItem(_, span) => span,
         }
     }

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -104,7 +104,7 @@ pub fn report_object_safety_error(
          <https://doc.rust-lang.org/reference/items/traits.html#object-safety>",
     );
 
-    if tcx.sess.trait_methods_not_found.borrow().contains(&span) {
+    if tcx.sess.trait_methods_not_found.borrow().iter().any(|full_span| full_span.contains(span)) {
         // Avoid emitting error caused by non-existing method (#58734)
         err.cancel();
     }

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -427,7 +427,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.unit()
             }
             ExprKind::Index { .. } | ExprKind::Deref { .. } | ExprKind::Field { .. } => {
-                debug_assert!(Category::of(&expr.kind) == Some(Category::Place));
+                debug_assert_eq!(Category::of(&expr.kind), Some(Category::Place));
 
                 // Create a "fake" temporary variable so that we check that the
                 // value is Sized. Usually, this is caught in type checking, but
@@ -435,8 +435,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 if !destination.projection.is_empty() {
                     this.local_decls.push(LocalDecl::new(expr.ty, expr.span));
                 }
-
-                debug_assert!(Category::of(&expr.kind) == Some(Category::Place));
 
                 let place = unpack!(block = this.as_place(block, expr));
                 let rvalue = Rvalue::Use(this.consume_by_copy_or_move(place));

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -291,7 +291,7 @@ impl<'a> Parser<'a> {
         Ok(P(ast::Local { ty, pat, init, id: DUMMY_NODE_ID, span: lo.to(hi), attrs, tokens: None }))
     }
 
-    /// Parses the RHS of a local variable declaration (e.g., '= 14;').
+    /// Parses the RHS of a local variable declaration (e.g., `= 14;`).
     fn parse_initializer(&mut self, eq_optional: bool) -> PResult<'a, Option<P<Expr>>> {
         let eq_consumed = match self.token.kind {
             token::BinOpEq(..) => {
@@ -306,6 +306,7 @@ impl<'a> Parser<'a> {
                     "=".to_string(),
                     Applicability::MaybeIncorrect,
                 )
+                .help("if you meant to overwrite, remove the `let` binding")
                 .emit();
                 self.bump();
                 true

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1111,6 +1111,7 @@ symbols! {
         size_of,
         size_of_val,
         sized,
+        skip,
         slice,
         slice_alloc,
         slice_patterns,

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1413,8 +1413,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         name: Symbol,
     ) {
         let mut err = struct_span_err!(self.tcx().sess, span, E0223, "ambiguous associated type");
-        if let (Some(_), Ok(snippet)) = (
-            self.tcx().sess.confused_type_with_std_module.borrow().get(&span),
+        if let (true, Ok(snippet)) = (
+            self.tcx()
+                .sess
+                .confused_type_with_std_module
+                .borrow()
+                .keys()
+                .any(|full_span| full_span.contains(span)),
             self.tcx().sess.source_map().span_to_snippet(span),
         ) {
             err.span_suggestion(

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -439,7 +439,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         qpath: &QPath<'_>,
         hir_id: hir::HirId,
     ) -> Option<(&'tcx ty::VariantDef, Ty<'tcx>)> {
-        let path_span = qpath.qself_span();
+        let path_span = qpath.span();
         let (def, ty) = self.finish_resolving_struct_path(qpath, path_span, hir_id);
         let variant = match def {
             Res::Err => {

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -512,7 +512,7 @@ unsafe fn swap_nonoverlapping_bytes(x: *mut u8, y: *mut u8, len: usize) {
         let t = t.as_mut_ptr() as *mut u8;
 
         // SAFETY: As `i < len`, and as the caller must guarantee that `x` and `y` are valid
-        // for `len` bytes, `x + i` and `y + i` must be valid adresses, which fulfills the
+        // for `len` bytes, `x + i` and `y + i` must be valid addresses, which fulfills the
         // safety contract for `add`.
         //
         // Also, the caller must guarantee that `x` and `y` are valid for writes, properly aligned,

--- a/library/std/src/os/linux/mod.rs
+++ b/library/std/src/os/linux/mod.rs
@@ -3,4 +3,5 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod fs;
+pub mod process;
 pub mod raw;

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -1,6 +1,6 @@
 //! Linux-specific extensions to primitives in the `std::process` module.
 
-#![unstable(feature = "linux_pidfd", issue = "none")]
+#![unstable(feature = "linux_pidfd", issue = "82971")]
 
 use crate::io::Result;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -31,13 +31,14 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 ///
 /// // The file descriptor will be closed when `pidfd` is dropped.
 /// ```
-/// Refer to the man page of `pidfd_open(2)` for further details.
+/// Refer to the man page of [`pidfd_open(2)`] for further details.
 ///
 /// [`Command`]: process::Command
 /// [`create_pidfd`]: CommandExt::create_pidfd
 /// [`Child`]: process::Child
 /// [`pidfd`]: fn@ChildExt::pidfd
 /// [`take_pidfd`]: ChildExt::take_pidfd
+/// [`pidfd_open(2)`]: https://man7.org/linux/man-pages/man2/pidfd_open.2.html
 #[derive(Debug)]
 pub struct PidFd {
     inner: FileDesc,

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -1,0 +1,47 @@
+//! Linux-specific extensions to primitives in the `std::process` module.
+
+#![unstable(feature = "linux_pidfd", issue = "none")]
+
+use crate::process;
+use crate::sys_common::AsInnerMut;
+use crate::io::Result;
+
+/// Os-specific extensions to [`process::Child`]
+///
+/// [`process::Child`]: crate::process::Child
+pub trait ChildExt {
+    /// Obtains the pidfd created for this child process, if available.
+    ///
+    /// A pidfd will only ever be available if `create_pidfd(true)` was called
+    /// when the corresponding `Command` was created.
+    ///
+    /// Even if `create_pidfd(true)` is called, a pidfd may not be available
+    /// due to an older version of Linux being in use, or if
+    /// some other error occured.
+    ///
+    /// See `man pidfd_open` for more details about pidfds.
+    fn pidfd(&self) -> Result<i32>;
+}
+
+/// Os-specific extensions to [`process::Command`]
+///
+/// [`process::Command`]: crate::process::Command
+pub trait CommandExt {
+    /// Sets whether or this `Command` will attempt to create a pidfd
+    /// for the child. If this method is never called, a pidfd will
+    /// not be crated.
+    ///
+    /// The pidfd can be retrieved from the child via [`ChildExt::pidfd`]
+    ///
+    /// A pidfd will only be created if it is possible to do so
+    /// in a guaranteed race-free manner (e.g. if the `clone3` system call is
+    /// supported). Otherwise, [`ChildExit::pidfd`] will return an error.
+    fn create_pidfd(&mut self, val: bool) -> &mut process::Command;
+}
+
+impl CommandExt for process::Command {
+    fn create_pidfd(&mut self, val: bool) -> &mut process::Command {
+        self.as_inner_mut().create_pidfd(val);
+        self
+    }
+}

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -2,40 +2,142 @@
 
 #![unstable(feature = "linux_pidfd", issue = "none")]
 
-use crate::process;
-use crate::sys_common::AsInnerMut;
 use crate::io::Result;
+use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use crate::process;
+use crate::sys::fd::FileDesc;
+use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
-/// Os-specific extensions to [`process::Child`]
+/// This type represents a file descriptor that refers to a process.
 ///
-/// [`process::Child`]: crate::process::Child
-pub trait ChildExt {
-    /// Obtains the pidfd created for this child process, if available.
-    ///
-    /// A pidfd will only ever be available if `create_pidfd(true)` was called
-    /// when the corresponding `Command` was created.
-    ///
-    /// Even if `create_pidfd(true)` is called, a pidfd may not be available
-    /// due to an older version of Linux being in use, or if
-    /// some other error occured.
-    ///
-    /// See `man pidfd_open` for more details about pidfds.
-    fn pidfd(&self) -> Result<i32>;
+/// A `PidFd` can be obtained by setting the corresponding option on [`Command`]
+/// with [`create_pidfd`]. Subsequently, the created pidfd can be retrieved
+/// from the [`Child`] by calling [`pidfd`] or [`take_pidfd`].
+///
+/// Example:
+/// ```no_run
+/// #![feature(linux_pidfd)]
+/// use std::os::linux::process::{CommandExt, ChildExt};
+/// use std::process::Command;
+///
+/// let mut child = Command::new("echo")
+///     .create_pidfd(true)
+///     .spawn()
+///     .expect("Failed to spawn child");
+///
+/// let pidfd = child
+///     .take_pidfd()
+///     .expect("Failed to retrieve pidfd");
+///
+/// // The file descriptor will be closed when `pidfd` is dropped.
+/// ```
+/// Refer to the man page of `pidfd_open(2)` for further details.
+///
+/// [`Command`]: process::Command
+/// [`create_pidfd`]: CommandExt::create_pidfd
+/// [`Child`]: process::Child
+/// [`pidfd`]: fn@ChildExt::pidfd
+/// [`take_pidfd`]: ChildExt::take_pidfd
+#[derive(Debug)]
+pub struct PidFd {
+    inner: FileDesc,
 }
 
-/// Os-specific extensions to [`process::Command`]
+impl AsInner<FileDesc> for PidFd {
+    fn as_inner(&self) -> &FileDesc {
+        &self.inner
+    }
+}
+
+impl FromInner<FileDesc> for PidFd {
+    fn from_inner(inner: FileDesc) -> PidFd {
+        PidFd { inner }
+    }
+}
+
+impl IntoInner<FileDesc> for PidFd {
+    fn into_inner(self) -> FileDesc {
+        self.inner
+    }
+}
+
+impl AsRawFd for PidFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_inner().raw()
+    }
+}
+
+impl FromRawFd for PidFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self::from_inner(FileDesc::new(fd))
+    }
+}
+
+impl IntoRawFd for PidFd {
+    fn into_raw_fd(self) -> RawFd {
+        self.into_inner().into_raw()
+    }
+}
+
+mod private_child_ext {
+    pub trait Sealed {}
+    impl Sealed for crate::process::Child {}
+}
+
+/// Os-specific extensions for [`Child`]
 ///
-/// [`process::Command`]: crate::process::Command
-pub trait CommandExt {
-    /// Sets whether or this `Command` will attempt to create a pidfd
-    /// for the child. If this method is never called, a pidfd will
-    /// not be crated.
+/// [`Child`]: process::Child
+pub trait ChildExt: private_child_ext::Sealed {
+    /// Obtains a reference to the [`PidFd`] created for this [`Child`], if available.
     ///
-    /// The pidfd can be retrieved from the child via [`ChildExt::pidfd`]
+    /// A pidfd will only be available if its creation was requested with
+    /// [`create_pidfd`] when the corresponding [`Command`] was created.
+    ///
+    /// Even if requested, a pidfd may not be available due to an older
+    /// version of Linux being in use, or if some other error occurred.
+    ///
+    /// [`Command`]: process::Command
+    /// [`create_pidfd`]: CommandExt::create_pidfd
+    /// [`Child`]: process::Child
+    fn pidfd(&self) -> Result<&PidFd>;
+
+    /// Takes ownership of the [`PidFd`] created for this [`Child`], if available.
+    ///
+    /// A pidfd will only be available if its creation was requested with
+    /// [`create_pidfd`] when the corresponding [`Command`] was created.
+    ///
+    /// Even if requested, a pidfd may not be available due to an older
+    /// version of Linux being in use, or if some other error occurred.
+    ///
+    /// [`Command`]: process::Command
+    /// [`create_pidfd`]: CommandExt::create_pidfd
+    /// [`Child`]: process::Child
+    fn take_pidfd(&mut self) -> Result<PidFd>;
+}
+
+mod private_command_ext {
+    pub trait Sealed {}
+    impl Sealed for crate::process::Command {}
+}
+
+/// Os-specific extensions for [`Command`]
+///
+/// [`Command`]: process::Command
+pub trait CommandExt: private_command_ext::Sealed {
+    /// Sets whether a [`PidFd`](struct@PidFd) should be created for the [`Child`]
+    /// spawned by this [`Command`].
+    /// By default, no pidfd will be created.
+    ///
+    /// The pidfd can be retrieved from the child with [`pidfd`] or [`take_pidfd`].
     ///
     /// A pidfd will only be created if it is possible to do so
-    /// in a guaranteed race-free manner (e.g. if the `clone3` system call is
-    /// supported). Otherwise, [`ChildExit::pidfd`] will return an error.
+    /// in a guaranteed race-free manner (e.g. if the `clone3` system call
+    /// is supported). Otherwise, [`pidfd`] will return an error.
+    ///
+    /// [`Command`]: process::Command
+    /// [`Child`]: process::Child
+    /// [`pidfd`]: fn@ChildExt::pidfd
+    /// [`take_pidfd`]: ChildExt::take_pidfd
     fn create_pidfd(&mut self, val: bool) -> &mut process::Command;
 }
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -161,7 +161,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 /// [`wait`]: Child::wait
 #[stable(feature = "process", since = "1.0.0")]
 pub struct Child {
-    handle: imp::Process,
+    pub(crate) handle: imp::Process,
 
     /// The handle for writing to the child's standard input (stdin), if it has
     /// been captured. To avoid partially moving

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -79,6 +79,7 @@ pub struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
+    pub(crate) make_pidfd: bool,
 }
 
 // Create a new type for argv, so that we can make it `Send` and `Sync`
@@ -141,6 +142,7 @@ impl Command {
             stdin: None,
             stdout: None,
             stderr: None,
+            make_pidfd: false,
         }
     }
 
@@ -175,6 +177,10 @@ impl Command {
     }
     pub fn groups(&mut self, groups: &[gid_t]) {
         self.groups = Some(Box::from(groups));
+    }
+    
+    pub fn create_pidfd(&mut self, val: bool) {
+        self.make_pidfd = val;
     }
 
     pub fn saw_nul(&self) -> bool {

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -79,7 +79,7 @@ pub struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
-    pub(crate) make_pidfd: bool,
+    pub(crate) create_pidfd: bool,
 }
 
 // Create a new type for argv, so that we can make it `Send` and `Sync`
@@ -142,7 +142,7 @@ impl Command {
             stdin: None,
             stdout: None,
             stderr: None,
-            make_pidfd: false,
+            create_pidfd: false,
         }
     }
 
@@ -178,9 +178,9 @@ impl Command {
     pub fn groups(&mut self, groups: &[gid_t]) {
         self.groups = Some(Box::from(groups));
     }
-    
+
     pub fn create_pidfd(&mut self, val: bool) {
-        self.make_pidfd = val;
+        self.create_pidfd = val;
     }
 
     pub fn saw_nul(&self) -> bool {

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -3,16 +3,20 @@ use crate::fmt;
 use crate::io::{self, Error, ErrorKind};
 use crate::mem;
 use crate::ptr;
+use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys;
 use crate::sys::cvt;
 use crate::sys::process::process_common::*;
-use crate::sync::atomic::{AtomicBool, Ordering};
+use crate::sys_common::FromInner;
+
+#[cfg(target_os = "linux")]
+use crate::os::linux::process::PidFd;
 
 #[cfg(target_os = "vxworks")]
 use libc::RTP_ID as pid_t;
 
 #[cfg(not(target_os = "vxworks"))]
-use libc::{c_int, gid_t, pid_t, uid_t};
+use libc::{c_int, c_long, gid_t, pid_t, uid_t};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Command
@@ -78,12 +82,12 @@ impl Command {
                 }
                 n => {
                     drop(env_lock);
-                    n as pid_t
+                    n
                 }
             }
         };
 
-        let mut p = Process { pid, status: None, pidfd };
+        let mut p = Process::new(pid, pidfd);
         drop(output);
         let mut bytes = [0; 8];
 
@@ -118,82 +122,84 @@ impl Command {
 
     // Attempts to fork the process. If successful, returns
     // Ok((0, -1)) in the child, and Ok((child_pid, child_pidfd)) in the parent.
-    fn do_fork(&mut self) -> Result<(libc::c_long, libc::pid_t), io::Error> {
+    fn do_fork(&mut self) -> Result<(pid_t, pid_t), io::Error> {
         // If we fail to create a pidfd for any reason, this will
         // stay as -1, which indicates an error
-        let mut pidfd: libc::pid_t = -1;
+        let mut pidfd: pid_t = -1;
 
         // On Linux, attempt to use the `clone3` syscall, which
-        // supports more argument (in particular, the ability to create a pidfd).
+        // supports more arguments (in particular, the ability to create a pidfd).
         // If this fails, we will fall through this block to a call to `fork()`
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                static HAS_CLONE3: AtomicBool = AtomicBool::new(true);
+        #[cfg(target_os = "linux")]
+        {
+            static HAS_CLONE3: AtomicBool = AtomicBool::new(true);
 
-                const CLONE_PIDFD: u64 = 0x00001000;
+            const CLONE_PIDFD: u64 = 0x00001000;
 
-                #[repr(C)]
-                struct clone_args {
-                    flags: u64,
-                    pidfd: u64,
-                    child_tid: u64,
-                    parent_tid: u64,
-                    exit_signal: u64,
-                    stack: u64,
-                    stack_size: u64,
-                    tls: u64,
-                    set_tid: u64,
-                    set_tid_size: u64,
-                    cgroup: u64,
+            #[repr(C)]
+            struct clone_args {
+                flags: u64,
+                pidfd: u64,
+                child_tid: u64,
+                parent_tid: u64,
+                exit_signal: u64,
+                stack: u64,
+                stack_size: u64,
+                tls: u64,
+                set_tid: u64,
+                set_tid_size: u64,
+                cgroup: u64,
+            }
+
+            syscall! {
+                fn clone3(cl_args: *mut clone_args, len: libc::size_t) -> c_long
+            }
+
+            if HAS_CLONE3.load(Ordering::Relaxed) {
+                let mut flags = 0;
+                if self.create_pidfd {
+                    flags |= CLONE_PIDFD;
                 }
 
-                syscall! {
-                    fn clone3(cl_args: *mut clone_args, len: libc::size_t) -> libc::c_long
-                }
+                let mut args = clone_args {
+                    flags,
+                    pidfd: &mut pidfd as *mut pid_t as u64,
+                    child_tid: 0,
+                    parent_tid: 0,
+                    exit_signal: libc::SIGCHLD as u64,
+                    stack: 0,
+                    stack_size: 0,
+                    tls: 0,
+                    set_tid: 0,
+                    set_tid_size: 0,
+                    cgroup: 0,
+                };
 
-                if HAS_CLONE3.load(Ordering::Relaxed) {
-                    let mut flags = 0;
-                    if self.make_pidfd {
-                        flags |= CLONE_PIDFD;
-                    }
+                let args_ptr = &mut args as *mut clone_args;
+                let args_size = crate::mem::size_of::<clone_args>();
 
-                    let mut args = clone_args {
-                        flags,
-                        pidfd: &mut pidfd as *mut libc::pid_t as u64,
-                        child_tid: 0,
-                        parent_tid: 0,
-                        exit_signal: libc::SIGCHLD as u64,
-                        stack: 0,
-                        stack_size: 0,
-                        tls: 0,
-                        set_tid: 0,
-                        set_tid_size: 0,
-                        cgroup: 0
-                    };
-
-                    let args_ptr = &mut args as *mut clone_args;
-                    let args_size = crate::mem::size_of::<clone_args>();
-
-                    let res = cvt(unsafe { clone3(args_ptr, args_size) });
-                    match res {
-                        Ok(n) => return Ok((n, pidfd)),
-                        Err(e) => match e.raw_os_error() {
-                            // Multiple threads can race to execute this store,
-                            // but that's fine - that just means that multiple threads
-                            // will have tried and failed to execute the same syscall,
-                            // with no other side effects.
-                            Some(libc::ENOSYS) => HAS_CLONE3.store(false, Ordering::Relaxed),
-                            _ => return Err(e)
-                        }
-                    }
+                let res = cvt(unsafe { clone3(args_ptr, args_size) });
+                match res {
+                    Ok(n) => return Ok((n as pid_t, pidfd)),
+                    Err(e) => match e.raw_os_error() {
+                        // Multiple threads can race to execute this store,
+                        // but that's fine - that just means that multiple threads
+                        // will have tried and failed to execute the same syscall,
+                        // with no other side effects.
+                        Some(libc::ENOSYS) => HAS_CLONE3.store(false, Ordering::Relaxed),
+                        // Fallback to fork if `EPERM` is returned. (e.g. blocked by seccomp)
+                        Some(libc::EPERM) => {}
+                        _ => return Err(e),
+                    },
                 }
             }
         }
+
         // If we get here, we are either not on Linux,
         // or we are on Linux and the 'clone3' syscall does not exist
-        cvt(unsafe { libc::fork() }.into()).map(|res| (res, pidfd))
+        // or we do not have permission to call it
+        cvt(unsafe { libc::fork() }).map(|res| (res, pidfd))
     }
-
 
     pub fn exec(&mut self, default: Stdio) -> io::Error {
         let envp = self.capture_env();
@@ -346,6 +352,8 @@ impl Command {
     #[cfg(not(any(
         target_os = "macos",
         target_os = "freebsd",
+        all(target_os = "linux", target_env = "gnu"),
+        all(target_os = "linux", target_env = "musl"),
     )))]
     fn posix_spawn(
         &mut self,
@@ -360,6 +368,8 @@ impl Command {
     #[cfg(any(
         target_os = "macos",
         target_os = "freebsd",
+        all(target_os = "linux", target_env = "gnu"),
+        all(target_os = "linux", target_env = "musl"),
     ))]
     fn posix_spawn(
         &mut self,
@@ -374,6 +384,7 @@ impl Command {
             || (self.env_saw_path() && !self.program_is_path())
             || !self.get_closures().is_empty()
             || self.get_groups().is_some()
+            || self.create_pidfd
         {
             return Ok(None);
         }
@@ -418,7 +429,7 @@ impl Command {
             None => None,
         };
 
-        let mut p = Process { pid: 0, status: None };
+        let mut p = Process::new(0, -1);
 
         struct PosixSpawnFileActions<'a>(&'a mut MaybeUninit<libc::posix_spawn_file_actions_t>);
 
@@ -508,14 +519,25 @@ pub struct Process {
     pid: pid_t,
     status: Option<ExitStatus>,
     // On Linux, stores the pidfd created for this child.
-    // This is -1 if the user did not request pidfd creation,
+    // This is None if the user did not request pidfd creation,
     // or if the pidfd could not be created for some reason
     // (e.g. the `clone3` syscall was not available).
     #[cfg(target_os = "linux")]
-    pidfd: libc::c_int,
+    pidfd: Option<PidFd>,
 }
 
 impl Process {
+    #[cfg(target_os = "linux")]
+    fn new(pid: pid_t, pidfd: pid_t) -> Self {
+        let pidfd = (pidfd >= 0).then(|| PidFd::from_inner(sys::fd::FileDesc::new(pidfd)));
+        Process { pid, status: None, pidfd }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn new(pid: pid_t, _pidfd: pid_t) -> Self {
+        Process { pid, status: None }
+    }
+
     pub fn id(&self) -> u32 {
         self.pid as u32
     }
@@ -632,12 +654,18 @@ impl fmt::Display for ExitStatus {
 #[cfg(target_os = "linux")]
 #[unstable(feature = "linux_pidfd", issue = "none")]
 impl crate::os::linux::process::ChildExt for crate::process::Child {
-    fn pidfd(&self) -> crate::io::Result<i32> {
-        if self.handle.pidfd > 0 {
-            Ok(self.handle.pidfd)
-        } else {
-            Err(crate::io::Error::from(crate::io::ErrorKind::Other))
-        }
+    fn pidfd(&self) -> io::Result<&PidFd> {
+        self.handle
+            .pidfd
+            .as_ref()
+            .ok_or_else(|| Error::new(ErrorKind::Other, "No pidfd was created."))
+    }
+
+    fn take_pidfd(&mut self) -> io::Result<PidFd> {
+        self.handle
+            .pidfd
+            .take()
+            .ok_or_else(|| Error::new(ErrorKind::Other, "No pidfd was created."))
     }
 }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -652,7 +652,7 @@ impl fmt::Display for ExitStatus {
 }
 
 #[cfg(target_os = "linux")]
-#[unstable(feature = "linux_pidfd", issue = "none")]
+#[unstable(feature = "linux_pidfd", issue = "82971")]
 impl crate::os::linux::process::ChildExt for crate::process::Child {
     fn pidfd(&self) -> io::Result<&PidFd> {
         self.handle

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -6,6 +6,7 @@ use crate::ptr;
 use crate::sys;
 use crate::sys::cvt;
 use crate::sys::process::process_common::*;
+use crate::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_os = "vxworks")]
 use libc::RTP_ID as pid_t;
@@ -48,7 +49,8 @@ impl Command {
         // a lock any more because the parent won't do anything and the child is
         // in its own process. Thus the parent drops the lock guard while the child
         // forgets it to avoid unlocking it on a new thread, which would be invalid.
-        let (env_lock, result) = unsafe { (sys::os::env_lock(), cvt(libc::fork())?) };
+        let env_lock = unsafe { sys::os::env_lock() };
+        let (result, pidfd) = self.do_fork()?;
 
         let pid = unsafe {
             match result {
@@ -76,12 +78,12 @@ impl Command {
                 }
                 n => {
                     drop(env_lock);
-                    n
+                    n as pid_t
                 }
             }
         };
 
-        let mut p = Process { pid, status: None };
+        let mut p = Process { pid, status: None, pidfd };
         drop(output);
         let mut bytes = [0; 8];
 
@@ -113,6 +115,85 @@ impl Command {
             }
         }
     }
+
+    // Attempts to fork the process. If successful, returns
+    // Ok((0, -1)) in the child, and Ok((child_pid, child_pidfd)) in the parent.
+    fn do_fork(&mut self) -> Result<(libc::c_long, libc::pid_t), io::Error> {
+        // If we fail to create a pidfd for any reason, this will
+        // stay as -1, which indicates an error
+        let mut pidfd: libc::pid_t = -1;
+
+        // On Linux, attempt to use the `clone3` syscall, which
+        // supports more argument (in prarticular, the ability to create a pidfd).
+        // If this fails, we will fall through this block to a call to `fork()`
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                static HAS_CLONE3: AtomicBool = AtomicBool::new(true);
+
+                const CLONE_PIDFD: u64 = 0x00001000;
+
+                #[repr(C)]
+                struct clone_args {
+                    flags: u64,
+                    pidfd: u64,
+                    child_tid: u64,
+                    parent_tid: u64,
+                    exit_signal: u64,
+                    stack: u64,
+                    stack_size: u64,
+                    tls: u64,
+                    set_tid: u64,
+                    set_tid_size: u64,
+                    cgroup: u64,
+                }
+
+                syscall! {
+                    fn clone3(cl_args: *mut clone_args, len: libc::size_t) -> libc::c_long
+                }
+
+                if HAS_CLONE3.load(Ordering::Relaxed) {
+                    let mut flags = 0;
+                    if self.make_pidfd {
+                        flags |= CLONE_PIDFD;
+                    }
+
+                    let mut args = clone_args {
+                        flags,
+                        pidfd: &mut pidfd as *mut libc::pid_t as u64,
+                        child_tid: 0,
+                        parent_tid: 0,
+                        exit_signal: libc::SIGCHLD as u64,
+                        stack: 0,
+                        stack_size: 0,
+                        tls: 0,
+                        set_tid: 0,
+                        set_tid_size: 0,
+                        cgroup: 0
+                    };
+
+                    let args_ptr = &mut args as *mut clone_args;
+                    let args_size = crate::mem::size_of::<clone_args>();
+
+                    let res = cvt(unsafe { clone3(args_ptr, args_size) });
+                    match res {
+                        Ok(n) => return Ok((n, pidfd)),
+                        Err(e) => match e.raw_os_error() {
+                            // Multiple threads can race to execute this store,
+                            // but that's fine - that just means that multiple threads
+                            // will have tried and failed to execute the same syscall,
+                            // with no other side effects.
+                            Some(libc::ENOSYS) => HAS_CLONE3.store(false, Ordering::Relaxed),
+                            _ => return Err(e)
+                        }
+                    }
+                }
+            }
+        }
+        // If we get here, we are either not on Linux,
+        // or we are on Linux and the 'clone3' syscall does not exist
+        cvt(unsafe { libc::fork() }.into()).map(|res| (res, pidfd))
+    }
+
 
     pub fn exec(&mut self, default: Stdio) -> io::Error {
         let envp = self.capture_env();
@@ -265,8 +346,6 @@ impl Command {
     #[cfg(not(any(
         target_os = "macos",
         target_os = "freebsd",
-        all(target_os = "linux", target_env = "gnu"),
-        all(target_os = "linux", target_env = "musl"),
     )))]
     fn posix_spawn(
         &mut self,
@@ -281,8 +360,6 @@ impl Command {
     #[cfg(any(
         target_os = "macos",
         target_os = "freebsd",
-        all(target_os = "linux", target_env = "gnu"),
-        all(target_os = "linux", target_env = "musl"),
     ))]
     fn posix_spawn(
         &mut self,
@@ -430,6 +507,12 @@ impl Command {
 pub struct Process {
     pid: pid_t,
     status: Option<ExitStatus>,
+    // On Linux, stores the pidfd created for this child.
+    // This is -1 if the user did not request pidfd creation,
+    // or if the pidfd could not be created for some reason
+    // (e.g. the `clone3` syscall was not available).
+    #[cfg(target_os = "linux")]
+    pidfd: libc::c_int,
 }
 
 impl Process {
@@ -542,6 +625,18 @@ impl fmt::Display for ExitStatus {
             write!(f, "continued (WIFCONTINUED)")
         } else {
             write!(f, "unrecognised wait status: {} {:#x}", self.0, self.0)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[unstable(feature = "linux_pidfd", issue = "none")]
+impl crate::os::linux::process::ChildExt for crate::process::Child {
+    fn pidfd(&self) -> crate::io::Result<i32> {
+        if self.handle.pidfd > 0 {
+            Ok(self.handle.pidfd)
+        } else {
+            Err(crate::io::Error::from(crate::io::ErrorKind::Other))
         }
     }
 }

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -124,7 +124,7 @@ impl Command {
         let mut pidfd: libc::pid_t = -1;
 
         // On Linux, attempt to use the `clone3` syscall, which
-        // supports more argument (in prarticular, the ability to create a pidfd).
+        // supports more argument (in particular, the ability to create a pidfd).
         // If this fails, we will fall through this block to a call to `fork()`
         cfg_if::cfg_if! {
             if #[cfg(target_os = "linux")] {

--- a/library/std/src/sys_common/thread_local_dtor.rs
+++ b/library/std/src/sys_common/thread_local_dtor.rs
@@ -1,6 +1,6 @@
 //! Thread-local destructor
 //!
-//! Besides thread-local "keys" (pointer-sized non-adressable thread-local store
+//! Besides thread-local "keys" (pointer-sized non-addressable thread-local store
 //! with an associated destructor), many platforms also provide thread-local
 //! destructors that are not associated with any particular data. These are
 //! often more efficient.

--- a/src/test/ui/bad/bad-sized.rs
+++ b/src/test/ui/bad/bad-sized.rs
@@ -5,4 +5,5 @@ pub fn main() {
     //~^ ERROR only auto traits can be used as additional traits in a trait object
     //~| ERROR the size for values of type
     //~| ERROR the size for values of type
+    //~| ERROR the size for values of type
 }

--- a/src/test/ui/bad/bad-sized.stderr
+++ b/src/test/ui/bad/bad-sized.stderr
@@ -31,7 +31,20 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    = help: the trait `Sized` is not implemented for `dyn Trait`
    = note: required by `Vec::<T>::new`
 
-error: aborting due to 3 previous errors
+error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
+  --> $DIR/bad-sized.rs:4:37
+   |
+LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
+   |                                     ^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                - required by this bound in `Vec`
+   |
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0225, E0277.
 For more information about an error, try `rustc --explain E0225`.

--- a/src/test/ui/command/command-create-pidfd.rs
+++ b/src/test/ui/command/command-create-pidfd.rs
@@ -1,0 +1,27 @@
+// run-pass
+// linux-only - pidfds are a linux-specific concept
+
+#![feature(linux_pidfd)]
+use std::os::linux::process::{CommandExt, ChildExt};
+use std::process::Command;
+
+fn main() {
+    // We don't assert the precise value, since the standard libarary
+    // may be opened other file descriptors before our code ran.
+    let _ = Command::new("echo")
+        .create_pidfd(true)
+        .spawn()
+        .unwrap()
+        .pidfd().expect("failed to obtain pidfd");
+
+    let _ = Command::new("echo")
+        .create_pidfd(false)
+        .spawn()
+        .unwrap()
+        .pidfd().expect_err("pidfd should not have been created when create_pid(false) is set");
+
+    let _ = Command::new("echo")
+        .spawn()
+        .unwrap()
+        .pidfd().expect_err("pidfd should not have been created");
+}

--- a/src/test/ui/command/command-create-pidfd.rs
+++ b/src/test/ui/command/command-create-pidfd.rs
@@ -6,8 +6,8 @@ use std::os::linux::process::{CommandExt, ChildExt};
 use std::process::Command;
 
 fn main() {
-    // We don't assert the precise value, since the standard libarary
-    // may be opened other file descriptors before our code ran.
+    // We don't assert the precise value, since the standard library
+    // might have opened other file descriptors before our code runs.
     let _ = Command::new("echo")
         .create_pidfd(true)
         .spawn()

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
@@ -10,7 +10,7 @@ warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:19:5
    |
 LL |     MustUseDeprecated::new();
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:13:17

--- a/src/test/ui/conditional-compilation/inner-cfg-non-inline-mod.rs
+++ b/src/test/ui/conditional-compilation/inner-cfg-non-inline-mod.rs
@@ -1,0 +1,7 @@
+// check-pass
+
+mod module_with_cfg;
+
+mod module_with_cfg {} // Ok, the module above is configured away by an inner attribute.
+
+fn main() {}

--- a/src/test/ui/conditional-compilation/module_with_cfg.rs
+++ b/src/test/ui/conditional-compilation/module_with_cfg.rs
@@ -1,0 +1,3 @@
+// ignore-test
+
+#![cfg_attr(all(), cfg(FALSE))]

--- a/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
+++ b/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
@@ -1,0 +1,23 @@
+#![feature(rustc_attrs)]
+
+#[rustc_layout_scalar_valid_range_start(u32::MAX)] //~ ERROR
+pub struct A(u32);
+
+#[rustc_layout_scalar_valid_range_end(1, 2)] //~ ERROR
+pub struct B(u8);
+
+#[rustc_layout_scalar_valid_range_end(a = "a")] //~ ERROR
+pub struct C(i32);
+
+#[rustc_layout_scalar_valid_range_end(1)] //~ ERROR
+enum E {
+    X = 1,
+    Y = 14,
+}
+
+fn main() {
+    let _ = A(0);
+    let _ = B(0);
+    let _ = C(0);
+    let _ = E::X;
+}

--- a/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.stderr
+++ b/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.stderr
@@ -1,0 +1,31 @@
+error: expected exactly one integer literal argument
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:3:1
+   |
+LL | #[rustc_layout_scalar_valid_range_start(u32::MAX)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected exactly one integer literal argument
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:6:1
+   |
+LL | #[rustc_layout_scalar_valid_range_end(1, 2)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: expected exactly one integer literal argument
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:9:1
+   |
+LL | #[rustc_layout_scalar_valid_range_end(a = "a")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute should be applied to a struct
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:12:1
+   |
+LL |   #[rustc_layout_scalar_valid_range_end(1)]
+   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | / enum E {
+LL | |     X = 1,
+LL | |     Y = 14,
+LL | | }
+   | |_- not a struct
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/issues/issue-78622.stderr
+++ b/src/test/ui/issues/issue-78622.stderr
@@ -2,7 +2,7 @@ error[E0223]: ambiguous associated type
   --> $DIR/issue-78622.rs:5:5
    |
 LL |     S::A::<f> {}
-   |     ^^^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
+   |     ^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -56,7 +56,7 @@ LL | struct Inline<T>
    |               - required by this bound in `Inline`
 ...
 LL |     let dst = Inline::<dyn Debug>::new(0);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |               ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Debug`
 help: consider relaxing the implicit `Sized` restriction

--- a/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
+++ b/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
@@ -13,7 +13,7 @@ help: the lifetime requirements from the `impl` do not correspond to the require
   --> $DIR/issue-75361-mismatched-impl.rs:12:55
    |
 LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
-   |                                                       ^^^^^^^^^^^^^^ consider borrowing this type parameter in the trait
+   |                                                       ^^^^ consider borrowing this type parameter in the trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/let-binop.stderr
+++ b/src/test/ui/parser/let-binop.stderr
@@ -3,18 +3,24 @@ error: can't reassign to an uninitialized variable
    |
 LL |     let a: i8 *= 1;
    |               ^^ help: initialize the variable
+   |
+   = help: if you meant to overwrite, remove the `let` binding
 
 error: can't reassign to an uninitialized variable
   --> $DIR/let-binop.rs:6:11
    |
 LL |     let b += 1;
    |           ^^ help: initialize the variable
+   |
+   = help: if you meant to overwrite, remove the `let` binding
 
 error: can't reassign to an uninitialized variable
   --> $DIR/let-binop.rs:8:11
    |
 LL |     let c *= 1;
    |           ^^ help: initialize the variable
+   |
+   = help: if you meant to overwrite, remove the `let` binding
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -222,7 +222,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:101:9
    |
 LL |         Pub::CONST;
-   |         ^^^^^^^^^^ private type
+   |         ^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -56,7 +56,7 @@ error: type `Priv` is private
   --> $DIR/private-inferred-type.rs:104:5
    |
 LL |     m::Pub::INHERENT_ASSOC_CONST;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
+   |     ^^^^^^ private type
 
 error: type `Priv` is private
   --> $DIR/private-inferred-type.rs:105:5

--- a/src/test/ui/proc-macro/inner-attr-non-inline-mod.rs
+++ b/src/test/ui/proc-macro/inner-attr-non-inline-mod.rs
@@ -1,0 +1,18 @@
+// compile-flags: -Z span-debug
+// error-pattern:custom inner attributes are unstable
+// error-pattern:inner macro attributes are unstable
+// error-pattern:this was previously accepted
+// aux-build:test-macros.rs
+
+#![no_std] // Don't load unnecessary hygiene information from std
+extern crate std;
+
+#[macro_use]
+extern crate test_macros;
+
+#[deny(unused_attributes)]
+mod module_with_attrs;
+//~^ ERROR non-inline modules in proc macro input are unstable
+//~| ERROR custom inner attributes are unstable
+
+fn main() {}

--- a/src/test/ui/proc-macro/inner-attr-non-inline-mod.stderr
+++ b/src/test/ui/proc-macro/inner-attr-non-inline-mod.stderr
@@ -1,0 +1,40 @@
+error[E0658]: inner macro attributes are unstable
+  --> $DIR/module_with_attrs.rs:4:4
+   |
+LL | #![print_attr]
+   |    ^^^^^^^^^^
+   |
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+
+error[E0658]: non-inline modules in proc macro input are unstable
+  --> $DIR/inner-attr-non-inline-mod.rs:14:1
+   |
+LL | mod module_with_attrs;
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #54727 <https://github.com/rust-lang/rust/issues/54727> for more information
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+
+error[E0658]: custom inner attributes are unstable
+  --> $DIR/inner-attr-non-inline-mod.rs:14:1
+   |
+LL | mod module_with_attrs;
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+
+error: custom inner attributes are unstable
+  --> $DIR/module_with_attrs.rs:3:4
+   |
+LL | #![rustfmt::skip]
+   |    ^^^^^^^^^^^^^
+   |
+   = note: `#[deny(soft_unstable)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/proc-macro/inner-attr-non-inline-mod.stdout
+++ b/src/test/ui/proc-macro/inner-attr-non-inline-mod.stdout
@@ -1,0 +1,76 @@
+PRINT-ATTR INPUT (DISPLAY): #[deny(unused_attributes)] mod module_with_attrs { # ! [rustfmt :: skip] }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Punct {
+        ch: '#',
+        spacing: Alone,
+        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+    },
+    Group {
+        delimiter: Bracket,
+        stream: TokenStream [
+            Ident {
+                ident: "deny",
+                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "unused_attributes",
+                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                    },
+                ],
+                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+            },
+        ],
+        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+    },
+    Ident {
+        ident: "mod",
+        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+    },
+    Ident {
+        ident: "module_with_attrs",
+        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Punct {
+                ch: '#',
+                spacing: Joint,
+                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+            },
+            Group {
+                delimiter: Bracket,
+                stream: TokenStream [
+                    Ident {
+                        ident: "rustfmt",
+                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                    },
+                    Punct {
+                        ch: ':',
+                        spacing: Joint,
+                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                    },
+                    Punct {
+                        ch: ':',
+                        spacing: Alone,
+                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                    },
+                    Ident {
+                        ident: "skip",
+                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                    },
+                ],
+                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+            },
+        ],
+        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+    },
+]

--- a/src/test/ui/proc-macro/module_with_attrs.rs
+++ b/src/test/ui/proc-macro/module_with_attrs.rs
@@ -1,0 +1,4 @@
+// ignore-test
+
+#![rustfmt::skip]
+#![print_attr]

--- a/src/test/ui/regions/issue-28848.stderr
+++ b/src/test/ui/regions/issue-28848.stderr
@@ -2,7 +2,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/issue-28848.rs:10:5
    |
 LL |     Foo::<'a, 'b>::xmute(u)
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined on the function body at 9:16
   --> $DIR/issue-28848.rs:9:16

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -100,7 +100,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:160:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(1);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:160:12
@@ -124,7 +124,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:166:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(0);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:166:12
@@ -136,7 +136,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:171:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(1);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:171:12
@@ -160,7 +160,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:178:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(0);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:178:12

--- a/src/test/ui/structs/struct-path-associated-type.stderr
+++ b/src/test/ui/structs/struct-path-associated-type.stderr
@@ -14,7 +14,7 @@ error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
    |
 LL |     let z = T::A::<u8> {};
-   |             ^^^^^^^^^^ not a struct
+   |             ^^^^ not a struct
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:18:9
@@ -38,7 +38,7 @@ error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:33:13
    |
 LL |     let z = S::A::<u8> {};
-   |             ^^^^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
+   |             ^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:35:9

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
   --> $DIR/mut-borrow-needed-by-trait.rs:17:14
    |
 LL |     let fp = BufWriter::new(fp);
-   |              ^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   |              ^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
    | 
   ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |

--- a/src/test/ui/suggestions/suggest-std-when-using-type.stderr
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.stderr
@@ -2,12 +2,12 @@ error[E0223]: ambiguous associated type
   --> $DIR/suggest-std-when-using-type.rs:2:14
    |
 LL |     let pi = f32::consts::PI;
-   |              ^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^
    |
 help: you are looking for the module in `std`, not the primitive type
    |
 LL |     let pi = std::f32::consts::PI;
-   |              ^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^
 
 error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope
   --> $DIR/suggest-std-when-using-type.rs:5:14

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -113,7 +113,7 @@ error[E0038]: the trait `assoc_const::C` cannot be made into an object
   --> $DIR/item-privacy.rs:101:5
    |
 LL |     C::A;
-   |     ^^^^ `assoc_const::C` cannot be made into an object
+   |     ^ `assoc_const::C` cannot be made into an object
    |
    = help: consider moving `C` to another trait
    = help: consider moving `B` to another trait

--- a/src/test/ui/unspecified-self-in-trait-ref.stderr
+++ b/src/test/ui/unspecified-self-in-trait-ref.stderr
@@ -31,7 +31,7 @@ LL | | }
    | |_- type parameter `A` must be specified for this
 ...
 LL |       let e = Bar::<usize>::lol();
-   |               ^^^^^^^^^^^^^^^^^ missing reference to `A`
+   |               ^^^^^^^^^^^^ missing reference to `A`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/wf/wf-static-method.stderr
+++ b/src/test/ui/wf/wf-static-method.stderr
@@ -19,7 +19,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/wf-static-method.rs:26:18
    |
 LL |         let me = Self::make_me();
-   |                  ^^^^^^^^^^^^^
+   |                  ^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined on the impl at 23:10
   --> $DIR/wf-static-method.rs:23:10


### PR DESCRIPTION
Successful merges:

 - #81825 (Add Linux-specific pidfd process extensions (take 2))
 - #82399 (expand: Resolve and expand inner attributes on out-of-line modules)
 - #83054 (Validate rustc_layout_scalar_valid_range_{start,end} attributes)
 - #83062 (Improve the wording for the `can't reassign` error)
 - #83092 (More precise spans for HIR paths)
 - #83110 (Fix typos in `library/core/src/ptr/mod.rs` and `library/std/src/sys_common/thread_local_dtor.rs`)
 - #83113 (Minor refactoring in try_index_step)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=81825,82399,83054,83062,83092,83110,83113)
<!-- homu-ignore:end -->