### PR TITLE
Make `extern_mod_stmt_cnum` into a regular function

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1277,10 +1277,6 @@ rustc_queries! {
     query item_children(def_id: DefId) -> &'tcx [Export<hir::HirId>] {
         desc { |tcx| "collecting child items of `{}`", tcx.def_path_str(def_id) }
     }
-    query extern_mod_stmt_cnum(def_id: LocalDefId) -> Option<CrateNum> {
-        desc { |tcx| "computing crate imported by `{}`", tcx.def_path_str(def_id.to_def_id()) }
-    }
-
     query get_lib_features(_: CrateNum) -> LibFeatures {
         storage(ArenaCacheSelector<'tcx>)
         eval_always

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1550,6 +1550,12 @@ impl<'tcx> TyCtxt<'tcx> {
             def_kind => (def_kind.article(), def_kind.descr(def_id)),
         }
     }
+
+    /// Returns the `CrateNum` of the crate that the given `extern crate` statement
+    /// resolves to.
+    pub fn extern_mod_stmt_cnum(self, id: LocalDefId) -> Option<CrateNum> {
+        self.extern_crate_map.get(&id).cloned()
+    }
 }
 
 /// A trait implemented for all `X<'a>` types that can be safely and
@@ -2755,7 +2761,6 @@ pub fn provide(providers: &mut ty::query::Providers) {
         let id = tcx.hir().local_def_id_to_hir_id(id.expect_local());
         tcx.stability().local_deprecation_entry(id)
     };
-    providers.extern_mod_stmt_cnum = |tcx, id| tcx.extern_crate_map.get(&id).cloned();
     providers.all_crate_nums = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
         tcx.arena.alloc_slice(&tcx.cstore.crates_untracked())


### PR DESCRIPTION
cc #83126

It's very short, so there's no need for it to go through the query
system.