### PR TITLE
Introduce `TyInterner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4546,6 +4546,7 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_serialize",
+ "smallvec 1.4.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4546,7 +4546,7 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_serialize",
- "smallvec 1.4.2",
+ "smallvec 1.6.1",
 ]
 
 [[package]]

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -733,10 +733,10 @@ macro_rules! declare_arena {
                 self.dropless.alloc_slice(value)
             }
 
-            pub fn alloc_from_iter<'a, T: ArenaAllocatable<'tcx, U>, U>(
-                &'a self,
-                iter: impl ::std::iter::IntoIterator<Item = T>,
-            ) -> &'a mut [T] {
+            pub fn alloc_from_iter<T: ArenaAllocatable<'tcx, U>, U, V: IntoIterator<Item = T>>(
+                &self,
+                iter: V,
+            ) -> &mut [T] {
                 T::allocate_from_iter(self, iter)
             }
         }

--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -495,12 +495,10 @@ impl MetaItemKind {
     fn token_trees_and_spacings(&self, span: Span) -> Vec<TreeAndSpacing> {
         match *self {
             MetaItemKind::Word => vec![],
-            MetaItemKind::NameValue(ref lit) => {
-                vec![
-                    TokenTree::token(token::Eq, span).into(),
-                    TokenTree::Token(lit.to_token()).into(),
-                ]
-            }
+            MetaItemKind::NameValue(ref lit) => vec![
+                TokenTree::token(token::Eq, span).into(),
+                TokenTree::Token(lit.to_token()).into(),
+            ],
             MetaItemKind::List(ref list) => {
                 let mut tokens = Vec::new();
                 for (i, item) in list.iter().enumerate() {

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -27,8 +27,7 @@ use rustc_middle::middle::cstore::{ForeignModule, LinkagePreference, NativeLib};
 use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportLevel};
 use rustc_middle::mir::interpret::{AllocDecodingSession, AllocDecodingState};
 use rustc_middle::mir::{self, Body, Promoted};
-use rustc_middle::ty::codec::TyDecoder;
-use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_middle::ty::{self, codec::TyDecoder, Ty, TyCtxt, TyInterner};
 use rustc_serialize::{opaque, Decodable, Decoder};
 use rustc_session::Session;
 use rustc_span::hygiene::ExpnDataDecodeMode;
@@ -279,6 +278,11 @@ impl<'a, 'tcx> TyDecoder<'tcx> for DecodeContext<'a, 'tcx> {
     #[inline]
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx.expect("missing TyCtxt in DecodeContext")
+    }
+
+    #[inline]
+    fn interner(&self) -> TyInterner<'tcx> {
+        self.tcx().interner()
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -15,7 +15,7 @@ macro_rules! arena_types {
             // AdtDef are interned and compared by address
             [] adt_def: rustc_middle::ty::AdtDef,
             [] steal_mir: rustc_data_structures::steal::Steal<rustc_middle::mir::Body<$tcx>>,
-            [decode] mir: rustc_middle::mir::Body<$tcx>,
+            [] mir: rustc_middle::mir::Body<$tcx>,
             [] steal_promoted:
                 rustc_data_structures::steal::Steal<
                     rustc_index::vec::IndexVec<
@@ -23,16 +23,16 @@ macro_rules! arena_types {
                         rustc_middle::mir::Body<$tcx>
                     >
                 >,
-            [decode] promoted:
+            [] promoted:
                 rustc_index::vec::IndexVec<
                     rustc_middle::mir::Promoted,
                     rustc_middle::mir::Body<$tcx>
                 >,
-            [decode] typeck_results: rustc_middle::ty::TypeckResults<$tcx>,
-            [decode] borrowck_result:
+            [] typeck_results: rustc_middle::ty::TypeckResults<$tcx>,
+            [] borrowck_result:
                 rustc_middle::mir::BorrowCheckResult<$tcx>,
-            [decode] unsafety_check_result: rustc_middle::mir::UnsafetyCheckResult,
-            [decode] code_region: rustc_middle::mir::coverage::CodeRegion,
+            [] unsafety_check_result: rustc_middle::mir::UnsafetyCheckResult,
+            [] code_region: rustc_middle::mir::coverage::CodeRegion,
             [] const_allocs: rustc_middle::mir::interpret::Allocation,
             // Required for the incremental on-disk cache
             [few] mir_keys: rustc_hir::def_id::DefIdSet,
@@ -99,11 +99,11 @@ macro_rules! arena_types {
             // Note that this deliberately duplicates items in the `rustc_hir::arena`,
             // since we need to allocate this type on both the `rustc_hir` arena
             // (during lowering) and the `librustc_middle` arena (for decoding MIR)
-            [decode] asm_template: rustc_ast::InlineAsmTemplatePiece,
+            [] asm_template: rustc_ast::InlineAsmTemplatePiece,
 
             // This is used to decode the &'tcx [Span] for InlineAsm's line_spans.
-            [decode] span: rustc_span::Span,
-            [decode] used_trait_imports: rustc_data_structures::fx::FxHashSet<rustc_hir::def_id::LocalDefId>,
+            [] span: rustc_span::Span,
+            [] used_trait_imports: rustc_data_structures::fx::FxHashSet<rustc_hir::def_id::LocalDefId>,
         ], $tcx);
     )
 }

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -111,11 +111,12 @@ use rustc_macros::HashStable;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_serialize::{Decodable, Encodable};
 use rustc_target::abi::Endian;
+use rustc_type_ir::Interner;
 
 use crate::mir;
 use crate::ty::codec::{TyDecoder, TyEncoder};
 use crate::ty::subst::GenericArgKind;
-use crate::ty::{self, Instance, Ty, TyCtxt};
+use crate::ty::{self, Instance, Ty, TyCtxt, TyInterner};
 
 pub use self::error::{
     struct_error, CheckInAllocMsg, ErrorHandled, EvalToAllocationRawResult, EvalToConstValueResult,
@@ -301,7 +302,9 @@ impl<'s> AllocDecodingSession<'s> {
                         AllocDiscriminant::Alloc => {
                             // If this is an allocation, we need to reserve an
                             // `AllocId` so we can decode cyclic graphs.
-                            let alloc_id = decoder.tcx().reserve_alloc_id();
+                            let alloc_id = <TyInterner<'tcx> as Interner<D>>::reserve_alloc_id(
+                                decoder.interner(),
+                            );
                             *entry =
                                 State::InProgress(TinyList::new_single(self.session_id), alloc_id);
                             Some(alloc_id)
@@ -345,7 +348,11 @@ impl<'s> AllocDecodingSession<'s> {
                     // We already have a reserved `AllocId`.
                     let alloc_id = alloc_id.unwrap();
                     trace!("decoded alloc {:?}: {:#?}", alloc_id, alloc);
-                    decoder.tcx().set_alloc_id_same_memory(alloc_id, alloc);
+                    <TyInterner<'tcx> as Interner<D>>::set_alloc_id_same_memory(
+                        decoder.interner(),
+                        alloc_id,
+                        alloc,
+                    );
                     Ok(alloc_id)
                 }
                 AllocDiscriminant::Fn => {
@@ -353,7 +360,10 @@ impl<'s> AllocDecodingSession<'s> {
                     trace!("creating fn alloc ID");
                     let instance = ty::Instance::decode(decoder)?;
                     trace!("decoded fn alloc instance: {:?}", instance);
-                    let alloc_id = decoder.tcx().create_fn_alloc(instance);
+                    let alloc_id = <TyInterner<'tcx> as Interner<D>>::create_fn_alloc(
+                        decoder.interner(),
+                        instance,
+                    );
                     Ok(alloc_id)
                 }
                 AllocDiscriminant::Static => {
@@ -361,7 +371,10 @@ impl<'s> AllocDecodingSession<'s> {
                     trace!("creating extern static alloc ID");
                     let did = <DefId as Decodable<D>>::decode(decoder)?;
                     trace!("decoded static def-ID: {:?}", did);
-                    let alloc_id = decoder.tcx().create_static_alloc(did);
+                    let alloc_id = <TyInterner<'tcx> as Interner<D>>::create_static_alloc(
+                        decoder.interner(),
+                        did,
+                    );
                     Ok(alloc_id)
                 }
             }
@@ -545,7 +558,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
     /// Freezes an `AllocId` created with `reserve` by pointing it at an `Allocation`. May be called
     /// twice for the same `(AllocId, Allocation)` pair.
-    fn set_alloc_id_same_memory(self, id: AllocId, mem: &'tcx Allocation) {
+    pub fn set_alloc_id_same_memory(self, id: AllocId, mem: &'tcx Allocation) {
         self.alloc_map.lock().alloc_map.insert_same(id, GlobalAlloc::Memory(mem));
     }
 }

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -222,10 +222,7 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for Ty<'tcx> {
                 decoder.with_position(shorthand, Ty::decode)
             })
         } else {
-            Ok(<TyInterner<'tcx> as Interner<D>>::mk_ty(
-                decoder.interner(),
-                ty::TyKind::decode(decoder)?,
-            ))
+            Ok(decoder.interner().mk_ty(ty::TyKind::decode(decoder)?))
         }
     }
 }
@@ -248,8 +245,7 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Binder<ty::PredicateKind<'tc
 impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Predicate<'tcx> {
     fn decode(decoder: &mut D) -> Result<ty::Predicate<'tcx>, D::Error> {
         let predicate_kind = Decodable::decode(decoder)?;
-        let predicate =
-            <TyInterner<'tcx> as Interner<D>>::mk_predicate(decoder.interner(), predicate_kind);
+        let predicate = decoder.interner().mk_predicate(predicate_kind);
         Ok(predicate)
     }
 }
@@ -257,10 +253,7 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Predicate<'tcx> {
 impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for SubstsRef<'tcx> {
     fn decode(decoder: &mut D) -> Result<Self, D::Error> {
         let len = decoder.read_usize()?;
-        Ok(<TyInterner<'tcx> as Interner<D>>::mk_substs(
-            decoder.interner(),
-            (0..len).map(|_| Decodable::decode(decoder)),
-        )?)
+        Ok(decoder.interner().mk_substs((0..len).map(|_| Decodable::decode(decoder)))?)
     }
 }
 
@@ -276,10 +269,7 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for mir::Place<'tcx> {
 
 impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Region<'tcx> {
     fn decode(decoder: &mut D) -> Result<Self, D::Error> {
-        Ok(<TyInterner<'tcx> as Interner<D>>::mk_region(
-            decoder.interner(),
-            Decodable::decode(decoder)?,
-        ))
+        Ok(decoder.interner().mk_region(Decodable::decode(decoder)?))
     }
 }
 
@@ -288,10 +278,7 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for CanonicalVarInfos<'tcx> {
         let len = decoder.read_usize()?;
         let interned: Result<Vec<CanonicalVarInfo<'tcx>>, _> =
             (0..len).map(|_| Decodable::decode(decoder)).collect();
-        Ok(<TyInterner<'tcx> as Interner<D>>::intern_canonical_var_infos(
-            decoder.interner(),
-            interned?.as_slice(),
-        ))
+        Ok(decoder.interner().intern_canonical_var_infos(interned?.as_slice()))
     }
 }
 
@@ -336,25 +323,21 @@ impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D>
 {
     fn decode(decoder: &mut D) -> Result<&'tcx Self, D::Error> {
         let len = decoder.read_usize()?;
-        decoder.tcx().mk_poly_existential_predicates((0..len).map(|_| Decodable::decode(decoder)))
+        Ok(decoder
+            .interner()
+            .mk_poly_existential_predicates((0..len).map(|_| Decodable::decode(decoder)))?)
     }
 }
 
 impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for ty::Const<'tcx> {
     fn decode(decoder: &mut D) -> Result<&'tcx Self, D::Error> {
-        Ok(<TyInterner<'tcx> as Interner<D>>::mk_const(
-            decoder.interner(),
-            Decodable::decode(decoder)?,
-        ))
+        Ok(decoder.interner().mk_const(Decodable::decode(decoder)?))
     }
 }
 
 impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for Allocation {
     fn decode(decoder: &mut D) -> Result<&'tcx Self, D::Error> {
-        Ok(<TyInterner<'tcx> as Interner<D>>::intern_const_alloc(
-            decoder.interner(),
-            Decodable::decode(decoder)?,
-        ))
+        Ok(decoder.interner().intern_const_alloc(Decodable::decode(decoder)?))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -160,7 +160,6 @@ encodable_via_deref! {
 pub trait TyDecoder<'tcx>: Decoder {
     const CLEAR_CROSS_CRATE: bool;
 
-    //fn tcx(&self) -> TyCtxt<'tcx>;
     fn interner(&self) -> TyInterner<'tcx>;
 
     fn peek_byte(&self) -> u8;

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -276,7 +276,10 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for mir::Place<'tcx> {
 
 impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Region<'tcx> {
     fn decode(decoder: &mut D) -> Result<Self, D::Error> {
-        Ok(decoder.tcx().mk_region(Decodable::decode(decoder)?))
+        Ok(<TyInterner<'tcx> as Interner<D>>::mk_region(
+            decoder.interner(),
+            Decodable::decode(decoder)?,
+        ))
     }
 }
 
@@ -285,7 +288,10 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for CanonicalVarInfos<'tcx> {
         let len = decoder.read_usize()?;
         let interned: Result<Vec<CanonicalVarInfo<'tcx>>, _> =
             (0..len).map(|_| Decodable::decode(decoder)).collect();
-        Ok(decoder.tcx().intern_canonical_var_infos(interned?.as_slice()))
+        Ok(<TyInterner<'tcx> as Interner<D>>::intern_canonical_var_infos(
+            decoder.interner(),
+            interned?.as_slice(),
+        ))
     }
 }
 
@@ -336,13 +342,19 @@ impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D>
 
 impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for ty::Const<'tcx> {
     fn decode(decoder: &mut D) -> Result<&'tcx Self, D::Error> {
-        Ok(decoder.tcx().mk_const(Decodable::decode(decoder)?))
+        Ok(<TyInterner<'tcx> as Interner<D>>::mk_const(
+            decoder.interner(),
+            Decodable::decode(decoder)?,
+        ))
     }
 }
 
 impl<'tcx, D: TyDecoder<'tcx>> RefDecodable<'tcx, D> for Allocation {
     fn decode(decoder: &mut D) -> Result<&'tcx Self, D::Error> {
-        Ok(decoder.tcx().intern_const_alloc(Decodable::decode(decoder)?))
+        Ok(<TyInterner<'tcx> as Interner<D>>::intern_const_alloc(
+            decoder.interner(),
+            Decodable::decode(decoder)?,
+        ))
     }
 }
 

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -222,8 +222,10 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for Ty<'tcx> {
                 decoder.with_position(shorthand, Ty::decode)
             })
         } else {
-            let tcx = decoder.tcx();
-            Ok(tcx.mk_ty(ty::TyKind::decode(decoder)?))
+            Ok(<TyInterner<'tcx> as Interner<D>>::mk_ty(
+                decoder.interner(),
+                ty::TyKind::decode(decoder)?,
+            ))
         }
     }
 }
@@ -255,8 +257,10 @@ impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for ty::Predicate<'tcx> {
 impl<'tcx, D: TyDecoder<'tcx>> Decodable<D> for SubstsRef<'tcx> {
     fn decode(decoder: &mut D) -> Result<Self, D::Error> {
         let len = decoder.read_usize()?;
-        let tcx = decoder.tcx();
-        tcx.mk_substs((0..len).map(|_| Decodable::decode(decoder)))
+        Ok(<TyInterner<'tcx> as Interner<D>>::mk_substs(
+            decoder.interner(),
+            (0..len).map(|_| Decodable::decode(decoder)),
+        )?)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -385,7 +385,7 @@ impl<'tcx> Interner for TyInterner<'tcx> {
     }
 
     fn def_path_hash_to_def_id(self, hash: Self::DefPathHash) -> Option<Self::DefId> {
-        self.tcx.queries.on_disk_cache.as_ref().unwrap().def_path_hash_to_def_id(self.tcx, hash)
+        self.tcx.on_disk_cache.as_ref().unwrap().def_path_hash_to_def_id(self.tcx, hash)
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -18,11 +18,11 @@ use crate::ty::query::{self, OnDiskCache, TyCtxtAt};
 use crate::ty::subst::{GenericArg, GenericArgKind, InternalSubsts, Subst, SubstsRef, UserSubsts};
 use crate::ty::TyKind::*;
 use crate::ty::{
-    self, codec::TyDecoder, AdtDef, AdtKind, Binder, BindingMode, BoundVar, CanonicalPolyFnSig,
-    Const, ConstVid, DefIdTree, ExistentialPredicate, FloatTy, FloatVar, FloatVid,
-    GenericParamDefKind, InferConst, InferTy, Instance, IntTy, IntVar, IntVid, List, ParamConst,
-    ParamTy, PolyFnSig, Predicate, PredicateInner, PredicateKind, ProjectionTy, Region, RegionKind,
-    ReprOptions, TraitObjectVisitor, Ty, TyKind, TyS, TyVar, TyVid, TypeAndMut, UintTy, Visibility,
+    self, AdtDef, AdtKind, Binder, BindingMode, BoundVar, CanonicalPolyFnSig, Const, ConstVid,
+    DefIdTree, ExistentialPredicate, FloatTy, FloatVar, FloatVid, GenericParamDefKind, InferConst,
+    InferTy, Instance, IntTy, IntVar, IntVid, List, ParamConst, ParamTy, PolyFnSig, Predicate,
+    PredicateInner, PredicateKind, ProjectionTy, Region, RegionKind, ReprOptions,
+    TraitObjectVisitor, Ty, TyKind, TyS, TyVar, TyVid, TypeAndMut, UintTy, Visibility,
 };
 use rustc_ast as ast;
 use rustc_ast::expand::allocator::AllocatorKind;
@@ -47,10 +47,7 @@ use rustc_hir::{
 };
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_macros::HashStable;
-use rustc_serialize::{
-    opaque::{FileEncodeResult, FileEncoder},
-    Decoder,
-};
+use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
 use rustc_session::config::{BorrowckMode, CrateType, OutputFilenames};
 use rustc_session::lint::{Level, Lint};
 use rustc_session::Session;
@@ -77,9 +74,12 @@ pub struct TyInterner<'tcx> {
 }
 
 #[allow(rustc::usage_of_ty_tykind)]
-impl<'tcx, D: Decoder + TyDecoder<'tcx>> Interner<D> for TyInterner<'tcx> {
+impl<'tcx> Interner for TyInterner<'tcx> {
     type GenericArg = GenericArg<'tcx>;
     type ListGenericArg = &'tcx List<GenericArg<'tcx>>;
+
+    type ExistentialPredicate = ty::Binder<ExistentialPredicate<'tcx>>;
+    type ListExistentialPredicate = &'tcx List<Binder<ExistentialPredicate<'tcx>>>;
 
     type Predicate = Predicate<'tcx>;
     type BinderPredicateKind = Binder<PredicateKind<'tcx>>;
@@ -118,6 +118,15 @@ impl<'tcx, D: Decoder + TyDecoder<'tcx>> Interner<D> for TyInterner<'tcx> {
         iter: I,
     ) -> I::Output {
         self.tcx.mk_substs(iter)
+    }
+
+    fn mk_poly_existential_predicates<
+        I: InternAs<[Self::ExistentialPredicate], Self::ListExistentialPredicate>,
+    >(
+        self,
+        iter: I,
+    ) -> I::Output {
+        self.tcx.mk_poly_existential_predicates(iter)
     }
 
     fn intern_const_alloc(self, alloc: Self::Allocation) -> Self::InternedAllocation {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -52,7 +52,6 @@ use rustc_hir::{
 };
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_macros::HashStable;
-use rustc_middle::arena::ArenaAllocatable;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
 use rustc_session::config::{BorrowckMode, CrateType, OutputFilenames};
 use rustc_session::lint::{Level, Lint};
@@ -193,7 +192,7 @@ impl<'tcx> Interner for TyInterner<'tcx> {
         self,
         iter: impl IntoIterator<Item = Self::Span>,
     ) -> Self::AllocatedSpanSlice {
-        self.tcx.arena.alloc_from_iter(iter)
+        self.tcx.arena.alloc_from_iter::<Self::Span, Self::Span, _>(iter)
     }
 
     fn alloc_promoted(self, value: Self::Promoted) -> Self::AllocatedPromoted {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -59,7 +59,7 @@ pub use self::consts::{Const, ConstInt, ConstKind, InferConst, ScalarInt};
 pub use self::context::{
     tls, CanonicalUserType, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations,
     CtxtInterners, DelaySpanBugEmitted, FreeRegionInfo, GeneratorInteriorTypeCause, GlobalCtxt,
-    Lift, ResolvedOpaqueTy, TyCtxt, TypeckResults, UserType, UserTypeAnnotationIndex,
+    Lift, ResolvedOpaqueTy, TyCtxt, TyInterner, TypeckResults, UserType, UserTypeAnnotationIndex,
 };
 pub use self::instance::{Instance, InstanceDef};
 pub use self::list::List;

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -6,7 +6,7 @@ use crate::ty::context::TyCtxt;
 use crate::ty::{self, Ty, TyInterner};
 use rustc_data_structures::fingerprint::{Fingerprint, FingerprintDecoder, FingerprintEncoder};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexSet};
-use rustc_data_structures::sync::{HashMapExt, Lock, Lrc, OnceCell};
+use rustc_data_structures::sync::{Lock, Lrc, OnceCell};
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::unhash::UnhashMap;
 use rustc_errors::Diagnostic;
@@ -741,10 +741,10 @@ where
 impl<'a, 'tcx> TyDecoder<'tcx> for CacheDecoder<'a, 'tcx> {
     const CLEAR_CROSS_CRATE: bool = false;
 
-    #[inline]
-    fn tcx(&self) -> TyCtxt<'tcx> {
-        self.tcx
-    }
+    // #[inline]
+    // fn tcx(&self) -> TyCtxt<'tcx> {
+    //     self.tcx
+    // }
 
     #[inline]
     fn interner(&self) -> TyInterner<'tcx> {
@@ -769,18 +769,18 @@ impl<'a, 'tcx> TyDecoder<'tcx> for CacheDecoder<'a, 'tcx> {
     where
         F: FnOnce(&mut Self) -> Result<Ty<'tcx>, Self::Error>,
     {
-        let tcx = self.tcx();
+        let mut interner = self.interner();
 
         let cache_key =
             ty::CReaderCacheKey { cnum: CrateNum::ReservedForIncrCompCache, pos: shorthand };
 
-        if let Some(&ty) = tcx.ty_rcache.borrow().get(&cache_key) {
+        if let Some(ty) = interner.get_cached_ty(cache_key) {
             return Ok(ty);
         }
 
         let ty = or_insert_with(self)?;
         // This may overwrite the entry, but it should overwrite with the same value.
-        tcx.ty_rcache.borrow_mut().insert_same(cache_key, ty);
+        interner.insert_same_cached_ty(cache_key, ty);
         Ok(ty)
     }
 

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -741,11 +741,6 @@ where
 impl<'a, 'tcx> TyDecoder<'tcx> for CacheDecoder<'a, 'tcx> {
     const CLEAR_CROSS_CRATE: bool = false;
 
-    // #[inline]
-    // fn tcx(&self) -> TyCtxt<'tcx> {
-    //     self.tcx
-    // }
-
     #[inline]
     fn interner(&self) -> TyInterner<'tcx> {
         self.tcx.interner()

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -28,6 +28,7 @@ use rustc_span::hygiene::{
 use rustc_span::source_map::{SourceMap, StableSourceFileId};
 use rustc_span::CachingSourceMapView;
 use rustc_span::{BytePos, ExpnData, SourceFile, Span, DUMMY_SP};
+use rustc_type_ir::Interner;
 use std::collections::hash_map::Entry;
 use std::iter::FromIterator;
 use std::mem;
@@ -909,12 +910,12 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for DefId {
         // If we get to this point, then all of the query inputs were green,
         // which means that the definition with this hash is guaranteed to
         // still exist in the current compilation session.
-        Ok(d.tcx()
-            .on_disk_cache
-            .as_ref()
-            .unwrap()
-            .def_path_hash_to_def_id(d.tcx(), def_path_hash)
-            .unwrap())
+
+        let def_if = <TyInterner<'tcx> as Interner<CacheDecoder<'_, '_>>>::def_path_hash_to_def_id(
+            d.interner(),
+            def_path_hash,
+        );
+        Ok(def_if.unwrap())
     }
 }
 

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -3,7 +3,7 @@ use crate::mir::interpret::{AllocDecodingSession, AllocDecodingState};
 use crate::mir::{self, interpret};
 use crate::ty::codec::{RefDecodable, TyDecoder, TyEncoder};
 use crate::ty::context::TyCtxt;
-use crate::ty::{self, Ty};
+use crate::ty::{self, Ty, TyInterner};
 use rustc_data_structures::fingerprint::{Fingerprint, FingerprintDecoder, FingerprintEncoder};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexSet};
 use rustc_data_structures::sync::{HashMapExt, Lock, Lrc, OnceCell};
@@ -743,6 +743,11 @@ impl<'a, 'tcx> TyDecoder<'tcx> for CacheDecoder<'a, 'tcx> {
     #[inline]
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
+    }
+
+    #[inline]
+    fn interner(&self) -> TyInterner<'tcx> {
+        self.tcx.interner()
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/ty/query/on_disk_cache.rs
@@ -911,10 +911,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for DefId {
         // which means that the definition with this hash is guaranteed to
         // still exist in the current compilation session.
 
-        let def_if = <TyInterner<'tcx> as Interner<CacheDecoder<'_, '_>>>::def_path_hash_to_def_id(
-            d.interner(),
-            def_path_hash,
-        );
+        let def_if = d.interner().def_path_hash_to_def_id(def_path_hash);
         Ok(def_if.unwrap())
     }
 }

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -13,3 +13,4 @@ rustc_index = { path = "../rustc_index" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_macros = { path = "../rustc_macros" }
+smallvec = { version = "1.0", features = ["union", "may_dangle"] }

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -9,16 +9,18 @@ extern crate rustc_macros;
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::unify::{EqUnifyValue, UnifyKey};
-use rustc_serialize::{Decodable, Decoder};
 use smallvec::SmallVec;
 use std::fmt;
 use std::mem::discriminant;
 
-pub trait Interner<D: Decoder> {
+pub trait Interner {
     type GenericArg;
     type ListGenericArg;
 
-    type Predicate: Decodable<D>;
+    type ExistentialPredicate;
+    type ListExistentialPredicate;
+
+    type Predicate;
     type BinderPredicateKind;
 
     type Ty;
@@ -53,6 +55,12 @@ pub trait Interner<D: Decoder> {
         self,
         ts: &[Self::CanonicalVarInfo],
     ) -> Self::ListCanonicalVarInfo;
+    fn mk_poly_existential_predicates<
+        I: InternAs<[Self::ExistentialPredicate], Self::ListExistentialPredicate>,
+    >(
+        self,
+        iter: I,
+    ) -> I::Output;
     fn mk_region(self, kind: Self::RegionKind) -> Self::Region;
     fn mk_const(self, c: Self::Const) -> Self::InternedConst;
     fn def_path_hash_to_def_id(self, hash: Self::DefPathHash) -> Option<Self::DefId>;

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -23,11 +23,39 @@ pub trait Interner<D: Decoder> {
 
     type Ty;
     type TyKind;
+    type Allocation;
+    type AllocationId;
+
+    type InternedAllocation;
+    type Instance;
+    type DefId;
+
+    type CanonicalVarInfo;
+    type ListCanonicalVarInfo;
+
+    type RegionKind;
+    type Region;
+
+    type Const;
+    type InternedConst;
+    type DefPathHash;
 
     fn mk_predicate(self, binder: Self::BinderPredicateKind) -> Self::Predicate;
     fn mk_ty(self, st: Self::TyKind) -> Self::Ty;
     fn mk_substs<I: InternAs<[Self::GenericArg], Self::ListGenericArg>>(self, iter: I)
     -> I::Output;
+    fn intern_const_alloc(self, alloc: Self::Allocation) -> Self::InternedAllocation;
+    fn reserve_alloc_id(self) -> Self::AllocationId;
+    fn set_alloc_id_same_memory(self, id: Self::AllocationId, mem: Self::InternedAllocation);
+    fn create_fn_alloc(self, instance: Self::Instance) -> Self::AllocationId;
+    fn create_static_alloc(self, static_id: Self::DefId) -> Self::AllocationId;
+    fn intern_canonical_var_infos(
+        self,
+        ts: &[Self::CanonicalVarInfo],
+    ) -> Self::ListCanonicalVarInfo;
+    fn mk_region(self, kind: Self::RegionKind) -> Self::Region;
+    fn mk_const(self, c: Self::Const) -> Self::InternedConst;
+    fn def_path_hash_to_def_id(self, hash: Self::DefPathHash) -> Option<Self::DefId>;
 }
 
 pub trait InternAs<T: ?Sized, R> {

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -9,8 +9,20 @@ extern crate rustc_macros;
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::unify::{EqUnifyValue, UnifyKey};
+use rustc_serialize::{Decodable, Decoder};
 use std::fmt;
 use std::mem::discriminant;
+
+pub trait Interner<D: Decoder> {
+    type Predicate: Decodable<D>;
+    type BinderPredicateKind;
+
+    fn mk_predicate(self, binder: Self::BinderPredicateKind) -> Self::Predicate;
+}
+
+pub trait HasInterner<D: Decoder> {
+    type Interner: Interner<D>;
+}
 
 bitflags! {
     /// Flags that we track on types. These flags are propagated upwards


### PR DESCRIPTION
This is a draft PR which attempt to remove the `TyDecoder` dependency on `TyCtx` 