### PR TITLE
Remove `#[doc(hidden)]` from macros in std::prelude.

### DIFF
--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -39,24 +39,14 @@ pub use crate::result::Result::{self, Err, Ok};
 #[allow(deprecated)]
 #[doc(no_inline)]
 pub use core::prelude::v1::{
-    asm, assert, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
-    format_args_nl, global_asm, include, include_bytes, include_str, line, llvm_asm, log_syntax,
-    module_path, option_env, stringify, trace_macros, Clone, Copy, Debug, Default, Eq, Hash, Ord,
-    PartialEq, PartialOrd,
-};
-
-// FIXME: Attribute and internal derive macros are not documented because for them rustdoc generates
-// dead links which fail link checker testing.
-#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow(deprecated)]
-#[doc(hidden)]
-pub use core::prelude::v1::{
-    bench, global_allocator, test, test_case, RustcDecodable, RustcEncodable,
+    asm, assert, bench, cfg, column, compile_error, concat, concat_idents, env, file, format_args,
+    format_args_nl, global_allocator, global_asm, include, include_bytes, include_str, line,
+    llvm_asm, log_syntax, module_path, option_env, stringify, test, test_case, trace_macros, Clone,
+    Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, RustcDecodable, RustcEncodable,
 };
 
 #[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[doc(hidden)]
 pub use core::prelude::v1::derive;
 
 #[unstable(


### PR DESCRIPTION
Seems like this rustdoc bug was fixed.

Fixes #63268.
cc https://github.com/rust-lang/rfcs/pull/3090#issuecomment-799516718

r? @jyn514 