### PR TITLE
No background for code in portability snippets

### DIFF
--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -266,7 +266,7 @@ a {
 
 .stab.portability > code {
 	color: #e6e1cf;
-	background-color: transparent;
+	background: none;
 }
 
 #help > div {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -222,10 +222,7 @@ a.test-arrow {
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; color: #2f2f2f; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; color: #2f2f2f; }
-
-.stab.portability > code {
-	color: #ddd;
-}
+.stab.portability > code { background: none; }
 
 #help > div {
 	background: #4d4d4d;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -220,10 +220,7 @@ a.test-arrow {
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; }
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; }
-
-.stab.portability > code {
-	color: #000;
-}
+.stab.portability > code { background: none; }
 
 #help > div {
 	background: #e9e9e9;


### PR DESCRIPTION
This better matches the appearance of this kind of snippet in the full
item view and is less jarring to read due to repeated
foreground-background changes.

![Listing of items in a module with some portability snippets attached to some of the items (light theme). The portability snippet has a light blue background and all of the text in it, monospace or not, is the same colour – black](https://user-images.githubusercontent.com/679122/111196363-1900f500-85b5-11eb-8f97-e283c59002a4.png)
![Listing of items in a module with some portability snippets attached to some of the items (dark theme). The portability snippet has a light blue background and all of the text in it, monospace or not, is the same colour – black](https://user-images.githubusercontent.com/679122/111196366-19998b80-85b5-11eb-9914-4d14d9d13ed3.png)

There should be no observable changes to the ayu theme.