### PR TITLE
Specify *.woff2 files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 *.mir linguist-language=Rust
 src/etc/installer/gfx/* binary
 *.woff binary
+*.woff2 binary
 src/vendor/** -text
 Cargo.lock linguist-generated=false
 


### PR DESCRIPTION
This prevents older git versions to change the "line endings".
Fixes #83159.