### PR TITLE
Suggest using a temporary variable to fix borrowck errors

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/find_all_local_uses.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/find_all_local_uses.rs
@@ -1,0 +1,26 @@
+use std::collections::BTreeSet;
+
+use rustc_middle::mir::visit::{PlaceContext, Visitor};
+use rustc_middle::mir::{Body, Local, Location};
+
+/// Find all uses of (including assignments to) a [`Local`].
+///
+/// Uses `BTreeSet` so output is deterministic.
+pub(super) fn find<'tcx>(body: &Body<'tcx>, local: Local) -> BTreeSet<Location> {
+    let mut visitor = AllLocalUsesVisitor { for_local: local, uses: BTreeSet::default() };
+    visitor.visit_body(body);
+    visitor.uses
+}
+
+struct AllLocalUsesVisitor {
+    for_local: Local,
+    uses: BTreeSet<Location>,
+}
+
+impl<'tcx> Visitor<'tcx> for AllLocalUsesVisitor {
+    fn visit_local(&mut self, local: &Local, _context: PlaceContext, location: Location) {
+        if *local == self.for_local {
+            self.uses.insert(location);
+        }
+    }
+}

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -19,6 +19,7 @@ use rustc_target::abi::VariantIdx;
 use super::borrow_set::BorrowData;
 use super::MirBorrowckCtxt;
 
+mod find_all_local_uses;
 mod find_use;
 mod outlives_suggestion;
 mod region_name;

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -12,6 +12,7 @@ use crate::ty::print::{FmtPrinter, Printer};
 use crate::ty::subst::{Subst, SubstsRef};
 use crate::ty::{self, List, Ty, TyCtxt};
 use crate::ty::{AdtDef, InstanceDef, Region, ScalarInt, UserTypeAnnotationIndex};
+
 use rustc_hir::def::{CtorKind, Namespace};
 use rustc_hir::def_id::{DefId, CRATE_DEF_INDEX};
 use rustc_hir::{self, GeneratorKind};
@@ -30,6 +31,9 @@ use rustc_serialize::{Decodable, Encodable};
 use rustc_span::symbol::Symbol;
 use rustc_span::{Span, DUMMY_SP};
 use rustc_target::asm::InlineAsmRegOrRegClass;
+
+use either::Either;
+
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::fmt::{self, Debug, Display, Formatter, Write};
@@ -501,6 +505,16 @@ impl<'tcx> Body<'tcx> {
     #[inline]
     pub fn terminator_loc(&self, bb: BasicBlock) -> Location {
         Location { block: bb, statement_index: self[bb].statements.len() }
+    }
+
+    pub fn stmt_at(&self, location: Location) -> Either<&Statement<'tcx>, &Terminator<'tcx>> {
+        let Location { block, statement_index } = location;
+        let block_data = &self.basic_blocks[block];
+        block_data
+            .statements
+            .get(statement_index)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(block_data.terminator()))
     }
 
     #[inline]

--- a/src/test/ui/borrowck/suggest-local-var-double-mut.rs
+++ b/src/test/ui/borrowck/suggest-local-var-double-mut.rs
@@ -1,0 +1,27 @@
+// See issue #77834.
+
+#![crate_type = "lib"]
+
+mod method_syntax {
+    struct Foo;
+
+    impl Foo {
+        fn foo(&mut self, _: f32) -> i32 { todo!() }
+        fn bar(&mut self) -> f32 { todo!() }
+        fn baz(&mut self) {
+            self.foo(self.bar()); //~ ERROR
+        }
+    }
+}
+
+mod fully_qualified_syntax {
+    struct Foo;
+
+    impl Foo {
+        fn foo(&mut self, _: f32) -> i32 { todo!() }
+        fn bar(&mut self) -> f32 { todo!() }
+        fn baz(&mut self) {
+            Self::foo(self, Self::bar(self)); //~ ERROR
+        }
+    }
+}

--- a/src/test/ui/borrowck/suggest-local-var-double-mut.stderr
+++ b/src/test/ui/borrowck/suggest-local-var-double-mut.stderr
@@ -1,0 +1,44 @@
+error[E0499]: cannot borrow `*self` as mutable more than once at a time
+  --> $DIR/suggest-local-var-double-mut.rs:12:22
+   |
+LL |             self.foo(self.bar());
+   |             ---------^^^^^^^^^^-
+   |             |    |   |
+   |             |    |   second mutable borrow occurs here
+   |             |    first borrow later used by call
+   |             first mutable borrow occurs here
+   |
+help: try adding a local storing this argument...
+  --> $DIR/suggest-local-var-double-mut.rs:12:22
+   |
+LL |             self.foo(self.bar());
+   |                      ^^^^^^^^^^
+help: ...and then using that local as the argument to this call
+  --> $DIR/suggest-local-var-double-mut.rs:12:13
+   |
+LL |             self.foo(self.bar());
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error[E0499]: cannot borrow `*self` as mutable more than once at a time
+  --> $DIR/suggest-local-var-double-mut.rs:24:39
+   |
+LL |             Self::foo(self, Self::bar(self));
+   |             --------- ----            ^^^^ second mutable borrow occurs here
+   |             |         |
+   |             |         first mutable borrow occurs here
+   |             first borrow later used by call
+   |
+help: try adding a local storing this argument...
+  --> $DIR/suggest-local-var-double-mut.rs:24:29
+   |
+LL |             Self::foo(self, Self::bar(self));
+   |                             ^^^^^^^^^^^^^^^
+help: ...and then using that local as the argument to this call
+  --> $DIR/suggest-local-var-double-mut.rs:24:13
+   |
+LL |             Self::foo(self, Self::bar(self));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0499`.

--- a/src/test/ui/borrowck/suggest-local-var-imm-and-mut.nll.stderr
+++ b/src/test/ui/borrowck/suggest-local-var-imm-and-mut.nll.stderr
@@ -1,0 +1,33 @@
+error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as immutable
+  --> $DIR/suggest-local-var-imm-and-mut.rs:12:22
+   |
+LL |             self.foo(self.bar());
+   |             ---------^^^^^^^^^^-
+   |             |    |   |
+   |             |    |   mutable borrow occurs here
+   |             |    immutable borrow later used by call
+   |             immutable borrow occurs here
+   |
+help: try adding a local storing this argument...
+  --> $DIR/suggest-local-var-imm-and-mut.rs:12:22
+   |
+LL |             self.foo(self.bar());
+   |                      ^^^^^^^^^^
+help: ...and then using that local as the argument to this call
+  --> $DIR/suggest-local-var-imm-and-mut.rs:12:13
+   |
+LL |             self.foo(self.bar());
+   |             ^^^^^^^^^^^^^^^^^^^^
+
+error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as immutable
+  --> $DIR/suggest-local-var-imm-and-mut.rs:24:39
+   |
+LL |             Self::foo(self, Self::bar(self));
+   |             --------- ----            ^^^^ mutable borrow occurs here
+   |             |         |
+   |             |         immutable borrow occurs here
+   |             immutable borrow later used by call
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/suggest-local-var-imm-and-mut.rs
+++ b/src/test/ui/borrowck/suggest-local-var-imm-and-mut.rs
@@ -1,0 +1,27 @@
+// See issue #77834.
+
+#![crate_type = "lib"]
+
+mod method_syntax {
+    struct Foo;
+
+    impl Foo {
+        fn foo(&self, _: f32) -> i32 { todo!() }
+        fn bar(&mut self) -> f32 { todo!() }
+        fn baz(&mut self) {
+            self.foo(self.bar()); //~ ERROR
+        }
+    }
+}
+
+mod fully_qualified_syntax {
+    struct Foo;
+
+    impl Foo {
+        fn foo(&self, _: f32) -> i32 { todo!() }
+        fn bar(&mut self) -> f32 { todo!() }
+        fn baz(&mut self) {
+            Self::foo(self, Self::bar(self)); //~ ERROR
+        }
+    }
+}

--- a/src/test/ui/borrowck/suggest-local-var-imm-and-mut.stderr
+++ b/src/test/ui/borrowck/suggest-local-var-imm-and-mut.stderr
@@ -1,0 +1,22 @@
+error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as immutable
+  --> $DIR/suggest-local-var-imm-and-mut.rs:12:22
+   |
+LL |             self.foo(self.bar());
+   |             ---------^^^^^^^^^^-
+   |             |    |   |
+   |             |    |   mutable borrow occurs here
+   |             |    immutable borrow later used by call
+   |             immutable borrow occurs here
+
+error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as immutable
+  --> $DIR/suggest-local-var-imm-and-mut.rs:24:29
+   |
+LL |             Self::foo(self, Self::bar(self));
+   |             --------- ----  ^^^^^^^^^^^^^^^ mutable borrow occurs here
+   |             |         |
+   |             |         immutable borrow occurs here
+   |             immutable borrow later used by call
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/two-phase-cannot-nest-mut-self-calls.stderr
+++ b/src/test/ui/borrowck/two-phase-cannot-nest-mut-self-calls.stderr
@@ -13,6 +13,23 @@ LL | |
 LL | |         0
 LL | |     });
    | |______- immutable borrow occurs here
+   |
+help: try adding a local storing this argument...
+  --> $DIR/two-phase-cannot-nest-mut-self-calls.rs:16:9
+   |
+LL |         vec.push(2);
+   |         ^^^^^^^^^^^
+help: ...and then using that local as the argument to this call
+  --> $DIR/two-phase-cannot-nest-mut-self-calls.rs:14:5
+   |
+LL | /     vec.get({
+LL | |
+LL | |         vec.push(2);
+LL | |
+LL | |
+LL | |         0
+LL | |     });
+   | |______^
 
 error: aborting due to previous error
 

--- a/src/test/ui/codemap_tests/one_line.stderr
+++ b/src/test/ui/codemap_tests/one_line.stderr
@@ -7,6 +7,17 @@ LL |     v.push(v.pop().unwrap());
    |     | |    second mutable borrow occurs here
    |     | first borrow later used by call
    |     first mutable borrow occurs here
+   |
+help: try adding a local storing this argument...
+  --> $DIR/one_line.rs:3:12
+   |
+LL |     v.push(v.pop().unwrap());
+   |            ^^^^^^^
+help: ...and then using that local as the argument to this call
+  --> $DIR/one_line.rs:3:5
+   |
+LL |     v.push(v.pop().unwrap());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #77834.

In Rust, nesting method calls with both require `&mut` access to `self`
produces a borrow-check error:

    error[E0499]: cannot borrow `*self` as mutable more than once at a time
     --> src/lib.rs:7:14
      |
    7 |     self.foo(self.bar());
      |     ---------^^^^^^^^^^-
      |     |    |   |
      |     |    |   second mutable borrow occurs here
      |     |    first borrow later used by call
      |     first mutable borrow occurs here

That's because Rust has a left-to-right evaluation order, and the method
receiver is passed first. Thus, the argument to the method cannot then
mutate `self`.

There's an easy solution to this error: just extract a local variable
for the inner argument:

    let tmp = self.bar();
    self.foo(tmp);

However, the error doesn't give any suggestion of how to solve the
problem. As a result, new users may assume that it's impossible to
express their code correctly and get stuck.

This commit adds a (non-structured) suggestion to extract a local
variable for the inner argument to solve the error. The suggestion uses
heuristics that eliminate most false positives, though there are a few
false negatives (cases where the suggestion should be emitted but is
not). Those other cases can be implemented in a future change.
