### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 *.mir linguist-language=Rust
 src/etc/installer/gfx/* binary
 *.woff binary
+*.woff2 binary
 src/vendor/** -text
 Cargo.lock linguist-generated=false
 

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -149,8 +149,16 @@ impl PathSegment {
     pub fn from_ident(ident: Ident) -> Self {
         PathSegment { ident, id: DUMMY_NODE_ID, args: None }
     }
+
     pub fn path_root(span: Span) -> Self {
         PathSegment::from_ident(Ident::new(kw::PathRoot, span))
+    }
+
+    pub fn span(&self) -> Span {
+        match &self.args {
+            Some(args) => self.ident.span.to(args.span()),
+            None => self.ident.span,
+        }
     }
 }
 

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -784,33 +784,6 @@ impl Nonterminal {
             NtTT(tt) => tt.span(),
         }
     }
-
-    /// This nonterminal looks like some specific enums from
-    /// `proc-macro-hack` and `procedural-masquerade` crates.
-    /// We need to maintain some special pretty-printing behavior for them due to incorrect
-    /// asserts in old versions of those crates and their wide use in the ecosystem.
-    /// See issue #73345 for more details.
-    /// FIXME(#73933): Remove this eventually.
-    pub fn pretty_printing_compatibility_hack(&self) -> bool {
-        let item = match self {
-            NtItem(item) => item,
-            NtStmt(stmt) => match &stmt.kind {
-                ast::StmtKind::Item(item) => item,
-                _ => return false,
-            },
-            _ => return false,
-        };
-
-        let name = item.ident.name;
-        if name == sym::ProceduralMasqueradeDummyType || name == sym::ProcMacroHack {
-            if let ast::ItemKind::Enum(enum_def, _) = &item.kind {
-                if let [variant] = &*enum_def.variants {
-                    return variant.ident.name == sym::Input;
-                }
-            }
-        }
-        false
-    }
 }
 
 impl PartialEq for Nonterminal {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -438,31 +438,6 @@ impl<'a> TokenStreamLowering<'a> {
     }
 }
 
-struct ImplTraitTypeIdVisitor<'a> {
-    ids: &'a mut SmallVec<[NodeId; 1]>,
-}
-
-impl Visitor<'_> for ImplTraitTypeIdVisitor<'_> {
-    fn visit_ty(&mut self, ty: &Ty) {
-        match ty.kind {
-            TyKind::Typeof(_) | TyKind::BareFn(_) => return,
-
-            TyKind::ImplTrait(id, _) => self.ids.push(id),
-            _ => {}
-        }
-        visit::walk_ty(self, ty);
-    }
-
-    fn visit_path_segment(&mut self, path_span: Span, path_segment: &PathSegment) {
-        if let Some(ref p) = path_segment.args {
-            if let GenericArgs::Parenthesized(_) = **p {
-                return;
-            }
-        }
-        visit::walk_path_segment(self, path_span, path_segment)
-    }
-}
-
 impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_crate(mut self, c: &Crate) -> hir::Crate<'hir> {
         /// Full-crate AST visitor that inserts into a fresh

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -528,6 +528,7 @@ fn reg_to_llvm(reg: InlineAsmRegOrRegClass, layout: Option<&TyAndLayout<'tcx>>) 
             InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
                 bug!("LLVM backend does not support SPIR-V")
             }
+            InlineAsmRegClass::Err => unreachable!(),
         }
         .to_string(),
     }
@@ -594,6 +595,7 @@ fn modifier_to_llvm(
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
+        InlineAsmRegClass::Err => unreachable!(),
     }
 }
 
@@ -637,6 +639,7 @@ fn dummy_output_type(cx: &CodegenCx<'ll, 'tcx>, reg: InlineAsmRegClass) -> &'ll 
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
+        InlineAsmRegClass::Err => unreachable!(),
     }
 }
 

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -90,7 +90,8 @@ impl MultiItemModifier for ProcMacroDerive {
             }
             _ => unreachable!(),
         };
-        let input = if item.pretty_printing_compatibility_hack() {
+        let input = if crate::base::pretty_printing_compatibility_hack(&item, &ecx.sess.parse_sess)
+        {
             TokenTree::token(token::Interpolated(Lrc::new(item)), DUMMY_SP).into()
         } else {
             nt_to_tokenstream(&item, &ecx.sess.parse_sess, CanSynthesizeMissingTokens::Yes)

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -187,7 +187,7 @@ impl FromInternal<(TreeAndSpacing, &'_ ParseSess, &'_ mut Vec<Self>)>
                         delimiter: Delimiter::None,
                         stream,
                         span: DelimSpan::from_single(span),
-                        flatten: nt.pretty_printing_compatibility_hack(),
+                        flatten: crate::base::pretty_printing_compatibility_hack(&nt, sess),
                     })
                 }
             }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1809,7 +1809,7 @@ impl<'hir> QPath<'hir> {
     pub fn span(&self) -> Span {
         match *self {
             QPath::Resolved(_, path) => path.span,
-            QPath::TypeRelative(_, ps) => ps.ident.span,
+            QPath::TypeRelative(qself, ps) => qself.span.to(ps.ident.span),
             QPath::LangItem(_, span) => span,
         }
     }

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -104,7 +104,7 @@ pub fn report_object_safety_error(
          <https://doc.rust-lang.org/reference/items/traits.html#object-safety>",
     );
 
-    if tcx.sess.trait_methods_not_found.borrow().contains(&span) {
+    if tcx.sess.trait_methods_not_found.borrow().iter().any(|full_span| full_span.contains(span)) {
         // Avoid emitting error caused by non-existing method (#58734)
         err.cancel();
     }

--- a/compiler/rustc_middle/src/hir/map/collector.rs
+++ b/compiler/rustc_middle/src/hir/map/collector.rs
@@ -52,6 +52,7 @@ fn insert_vec_map<K: Idx, V: Clone>(map: &mut IndexVec<K, Option<V>>, k: K, v: V
     if i >= len {
         map.extend(repeat(None).take(i - len + 1));
     }
+    debug_assert!(map[k].is_none());
     map[k] = Some(v);
 }
 
@@ -216,9 +217,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
             // Overwrite the dummy hash with the real HIR owner hash.
             nodes.hash = hash;
 
-            // FIXME: feature(impl_trait_in_bindings) broken and trigger this assert
-            //assert!(data.signature.is_none());
-
+            debug_assert!(data.signature.is_none());
             data.signature =
                 Some(self.arena.alloc(Owner { parent: entry.parent, node: entry.node }));
         } else {

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -229,6 +229,8 @@ pub enum InlineAsmReg {
     Mips(MipsInlineAsmReg),
     SpirV(SpirVInlineAsmReg),
     Wasm(WasmInlineAsmReg),
+    // Placeholder for invalid register constraints for the current target
+    Err,
 }
 
 impl InlineAsmReg {
@@ -240,6 +242,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => r.name(),
             Self::Hexagon(r) => r.name(),
             Self::Mips(r) => r.name(),
+            Self::Err => "<reg>",
         }
     }
 
@@ -251,6 +254,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => InlineAsmRegClass::RiscV(r.reg_class()),
             Self::Hexagon(r) => InlineAsmRegClass::Hexagon(r.reg_class()),
             Self::Mips(r) => InlineAsmRegClass::Mips(r.reg_class()),
+            Self::Err => InlineAsmRegClass::Err,
         }
     }
 
@@ -309,6 +313,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => r.emit(out, arch, modifier),
             Self::Hexagon(r) => r.emit(out, arch, modifier),
             Self::Mips(r) => r.emit(out, arch, modifier),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -320,6 +325,7 @@ impl InlineAsmReg {
             Self::RiscV(_) => cb(self),
             Self::Hexagon(r) => r.overlapping_regs(|r| cb(Self::Hexagon(r))),
             Self::Mips(_) => cb(self),
+            Self::Err => unreachable!(),
         }
     }
 }
@@ -346,6 +352,8 @@ pub enum InlineAsmRegClass {
     Mips(MipsInlineAsmRegClass),
     SpirV(SpirVInlineAsmRegClass),
     Wasm(WasmInlineAsmRegClass),
+    // Placeholder for invalid register constraints for the current target
+    Err,
 }
 
 impl InlineAsmRegClass {
@@ -360,6 +368,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.name(),
             Self::SpirV(r) => r.name(),
             Self::Wasm(r) => r.name(),
+            Self::Err => rustc_span::symbol::sym::reg,
         }
     }
 
@@ -377,6 +386,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Mips),
             Self::SpirV(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::SpirV),
             Self::Wasm(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Wasm),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -401,6 +411,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_modifier(arch, ty),
             Self::SpirV(r) => r.suggest_modifier(arch, ty),
             Self::Wasm(r) => r.suggest_modifier(arch, ty),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -421,6 +432,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.default_modifier(arch),
             Self::SpirV(r) => r.default_modifier(arch),
             Self::Wasm(r) => r.default_modifier(arch),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -440,6 +452,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.supported_types(arch),
             Self::SpirV(r) => r.supported_types(arch),
             Self::Wasm(r) => r.supported_types(arch),
+            Self::Err => unreachable!(),
         }
     }
 
@@ -476,6 +489,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.valid_modifiers(arch),
             Self::SpirV(r) => r.valid_modifiers(arch),
             Self::Wasm(r) => r.valid_modifiers(arch),
+            Self::Err => unreachable!(),
         }
     }
 }

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -313,7 +313,7 @@ impl InlineAsmReg {
             Self::RiscV(r) => r.emit(out, arch, modifier),
             Self::Hexagon(r) => r.emit(out, arch, modifier),
             Self::Mips(r) => r.emit(out, arch, modifier),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
     }
 
@@ -325,7 +325,7 @@ impl InlineAsmReg {
             Self::RiscV(_) => cb(self),
             Self::Hexagon(r) => r.overlapping_regs(|r| cb(Self::Hexagon(r))),
             Self::Mips(_) => cb(self),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmReg::Err"),
         }
     }
 }
@@ -386,7 +386,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Mips),
             Self::SpirV(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::SpirV),
             Self::Wasm(r) => r.suggest_class(arch, ty).map(InlineAsmRegClass::Wasm),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -411,7 +411,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.suggest_modifier(arch, ty),
             Self::SpirV(r) => r.suggest_modifier(arch, ty),
             Self::Wasm(r) => r.suggest_modifier(arch, ty),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -432,7 +432,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.default_modifier(arch),
             Self::SpirV(r) => r.default_modifier(arch),
             Self::Wasm(r) => r.default_modifier(arch),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -452,7 +452,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.supported_types(arch),
             Self::SpirV(r) => r.supported_types(arch),
             Self::Wasm(r) => r.supported_types(arch),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 
@@ -489,7 +489,7 @@ impl InlineAsmRegClass {
             Self::Mips(r) => r.valid_modifiers(arch),
             Self::SpirV(r) => r.valid_modifiers(arch),
             Self::Wasm(r) => r.valid_modifiers(arch),
-            Self::Err => unreachable!(),
+            Self::Err => unreachable!("Use of InlineAsmRegClass::Err"),
         }
     }
 }

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1414,8 +1414,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         name: Symbol,
     ) {
         let mut err = struct_span_err!(self.tcx().sess, span, E0223, "ambiguous associated type");
-        if let (Some(_), Ok(snippet)) = (
-            self.tcx().sess.confused_type_with_std_module.borrow().get(&span),
+        if let (true, Ok(snippet)) = (
+            self.tcx()
+                .sess
+                .confused_type_with_std_module
+                .borrow()
+                .keys()
+                .any(|full_span| full_span.contains(span)),
             self.tcx().sess.source_map().span_to_snippet(span),
         ) {
             err.span_suggestion(

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -439,7 +439,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         qpath: &QPath<'_>,
         hir_id: hir::HirId,
     ) -> Option<(&'tcx ty::VariantDef, Ty<'tcx>)> {
-        let path_span = qpath.qself_span();
+        let path_span = qpath.span();
         let (def, ty) = self.finish_resolving_struct_path(qpath, path_span, hir_id);
         let variant = match def {
             Res::Err => {

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -126,7 +126,7 @@ use self::spec_extend::SpecExtend;
 
 mod spec_extend;
 
-/// A contiguous growable array type, written `Vec<T>` but pronounced 'vector'.
+/// A contiguous growable array type, written as `Vec<T>` and pronounced 'vector'.
 ///
 /// # Examples
 ///
@@ -215,7 +215,7 @@ mod spec_extend;
 ///
 /// # Slicing
 ///
-/// A `Vec` can be mutable. Slices, on the other hand, are read-only objects.
+/// A `Vec` can be mutable. On the other hand, slices are read-only objects.
 /// To get a [slice][prim@slice], use [`&`]. Example:
 ///
 /// ```
@@ -352,7 +352,7 @@ mod spec_extend;
 /// not break, however: using `unsafe` code to write to the excess capacity,
 /// and then increasing the length to match, is always valid.
 ///
-/// `Vec` does not currently guarantee the order in which elements are dropped.
+/// Currently, `Vec` does not guarantee the order in which elements are dropped.
 /// The order has changed in the past and may change again.
 ///
 /// [`get`]: ../../std/vec/struct.Vec.html#method.get

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1468,6 +1468,10 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(core_intrinsics, libstd_sys_internals)]
+    #[rustc_deprecated(
+        since = "1.52.0",
+        reason = "rustc-serialize is deprecated and no longer supported"
+    )]
     pub macro RustcDecodable($item:item) {
         /* compiler built-in */
     }
@@ -1476,6 +1480,10 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(core_intrinsics)]
+    #[rustc_deprecated(
+        since = "1.52.0",
+        reason = "rustc-serialize is deprecated and no longer supported"
+    )]
     pub macro RustcEncodable($item:item) {
         /* compiler built-in */
     }

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -61,7 +61,7 @@ pub use crate::{
 };
 
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow(deprecated)]
+#[allow(deprecated, deprecated_in_future)]
 #[doc(no_inline)]
 pub use crate::macros::builtin::{
     bench, global_allocator, test, test_case, RustcDecodable, RustcEncodable,

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -48,7 +48,7 @@ pub use core::prelude::v1::{
 // FIXME: Attribute and internal derive macros are not documented because for them rustdoc generates
 // dead links which fail link checker testing.
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow(deprecated)]
+#[allow(deprecated, deprecated_in_future)]
 #[doc(hidden)]
 pub use core::prelude::v1::{
     bench, global_allocator, test, test_case, RustcDecodable, RustcEncodable,

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -122,7 +122,21 @@ impl Step for Linkcheck {
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
-        run.path("src/tools/linkchecker").default_condition(builder.config.docs)
+        let run = run.path("src/tools/linkchecker");
+        let hosts = &builder.hosts;
+        let targets = &builder.targets;
+
+        // if we have different hosts and targets, some things may be built for
+        // the host (e.g. rustc) and others for the target (e.g. std). The
+        // documentation built for each will contain broken links to
+        // docs built for the other platform (e.g. rustc linking to cargo)
+        if (hosts != targets) && !hosts.is_empty() && !targets.is_empty() {
+            panic!(
+                "Linkcheck currently does not support builds with different hosts and targets.
+You can skip linkcheck with --exclude src/tools/linkchecker"
+            );
+        }
+        run.default_condition(builder.config.docs)
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/disabled/riscv64gc-linux/Dockerfile
@@ -98,6 +98,6 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --qemu-riscv64-rootfs=/tmp/rootfs
-ENV SCRIPT python3 ../x.py --stage 2 test --target riscv64gc-unknown-linux-gnu
+ENV SCRIPT python3 ../x.py --stage 2 test --host='' --target riscv64gc-unknown-linux-gnu
 
 ENV NO_CHANGE_USER=1

--- a/src/ci/docker/host-x86_64/x86_64-gnu-llvm-9/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-llvm-9/Dockerfile
@@ -46,6 +46,7 @@ ENV SCRIPT python2.7 ../x.py --stage 2 test --exclude src/tools/tidy && \
            # This is intended to make sure that both `--pass=check` continues to
            # work.
            #
-           python2.7 ../x.py --stage 2 test src/test/ui --pass=check --target=i686-unknown-linux-gnu && \
+           python2.7 ../x.py --stage 2 test src/test/ui --pass=check \
+                             --host='' --target=i686-unknown-linux-gnu && \
            # Run tidy at the very end, after all the other tests.
            python2.7 ../x.py --stage 2 test src/tools/tidy

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1905,8 +1905,8 @@ function defocusSearchBar() {
                 len = itemTypes.length;
                 var lastPath = "";
                 for (i = 0; i < len; ++i) {
-		            // This object should have exactly the same set of fields as the "crateRow"
-		            // object defined above.
+                    // This object should have exactly the same set of fields as the "crateRow"
+                    // object defined above.
                     var row = {
                         crate: crate,
                         ty: itemTypes[i],

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -856,7 +856,7 @@ function defocusSearchBar() {
                         // We need to find the type that matches the most to remove it in order
                         // to move forward.
                         var vlength = val.generics.length;
-                        for (var x = 0; x < vlength; ++x) {
+                        for (x = 0; x < vlength; ++x) {
                             var lev = MAX_LEV_DISTANCE + 1;
                             var firstGeneric = getObjectNameFromId(val.generics[x]);
                             var match = undefined;

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -847,7 +847,7 @@ function defocusSearchBar() {
                 if (val.generics.length > 0) {
                     if (obj.length > GENERICS_DATA &&
                           obj[GENERICS_DATA].length >= val.generics.length) {
-                        var elems = {};
+                        var elems = Object.create(null);
                         var elength = object[GENERICS_DATA].length;
                         for (var x = 0; x < elength; ++x) {
                             elems[getObjectNameFromId(obj[GENERICS_DATA][x])] += 1;
@@ -899,7 +899,7 @@ function defocusSearchBar() {
                         if (val.generics && val.generics.length !== 0) {
                             if (obj.length > GENERICS_DATA &&
                                   obj[GENERICS_DATA].length >= val.generics.length) {
-                                var elems = {};
+                                var elems = Object.create(null);
                                 len = obj[GENERICS_DATA].length;
                                 for (x = 0; x < len; ++x) {
                                     elems[getObjectNameFromId(obj[GENERICS_DATA][x])] += 1;

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1833,18 +1833,12 @@ function defocusSearchBar() {
             showResults(execSearch(query, index, filterCrates));
         }
 
-        function generateId(ty) {
-            if (ty.parent && ty.parent.name) {
-                return itemTypes[ty.ty] + ty.path + ty.parent.name + ty.name;
-            }
-            return itemTypes[ty.ty] + ty.path + ty.name;
-        }
-
         function buildIndex(rawSearchIndex) {
             searchIndex = [];
             var searchWords = [];
             var i;
             var currentIndex = 0;
+            var id = 0;
 
             for (var crate in rawSearchIndex) {
                 if (!hasOwnProperty(rawSearchIndex, crate)) { continue; }
@@ -1866,10 +1860,10 @@ function defocusSearchBar() {
                     desc: rawSearchIndex[crate].doc,
                     parent: undefined,
                     type: null,
-                    id: "",
+                    id: id,
                     nameWithoutUnderscores: nameWithoutUnderscores,
                 };
-                crateRow.id = generateId(crateRow);
+                id += 1;
                 searchIndex.push(crateRow);
                 currentIndex += 1;
 
@@ -1921,10 +1915,10 @@ function defocusSearchBar() {
                         desc: itemDescs[i],
                         parent: itemParentIdxs[i] > 0 ? paths[itemParentIdxs[i] - 1] : undefined,
                         type: itemFunctionSearchTypes[i],
-                        id: "",
+                        id: id,
                         nameWithoutUnderscores: nameWithoutUnderscores,
                     };
-                    row.id = generateId(row);
+                    id += 1;
                     searchIndex.push(row);
                     if (typeof row.name === "string") {
                         var word = row.name.toLowerCase();

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1304,11 +1304,11 @@ function defocusSearchBar() {
 
                     if (searchWords[j].indexOf(split[i]) > -1 ||
                         searchWords[j].indexOf(val) > -1 ||
-                        ty.nameWithoutUnderscores.indexOf(val) > -1)
+                        ty.normalizedName.indexOf(val) > -1)
                     {
                         // filter type: ... queries
                         if (typePassesFilter(typeFilter, ty.ty) && results[fullId] === undefined) {
-                            index = ty.nameWithoutUnderscores.indexOf(val);
+                            index = ty.normalizedName.indexOf(val);
                         }
                     }
                     if ((lev = levenshtein(searchWords[j], val)) <= MAX_LEV_DISTANCE) {
@@ -1846,7 +1846,7 @@ function defocusSearchBar() {
                 var crateSize = 0;
 
                 searchWords.push(crate);
-                var nameWithoutUnderscores = crate.indexOf("_") === -1
+                var normalizedName = crate.indexOf("_") === -1
                     ? crate
                     : crate.replace(/_/g, "");
                 // This object should have exactly the same set of fields as the "row"
@@ -1861,7 +1861,7 @@ function defocusSearchBar() {
                     parent: undefined,
                     type: null,
                     id: id,
-                    nameWithoutUnderscores: nameWithoutUnderscores,
+                    normalizedName: normalizedName,
                 };
                 id += 1;
                 searchIndex.push(crateRow);
@@ -1904,9 +1904,16 @@ function defocusSearchBar() {
                 for (i = 0; i < len; ++i) {
                     // This object should have exactly the same set of fields as the "crateRow"
                     // object defined above.
-                    var nameWithoutUnderscores = itemNames[i].indexOf("_") === -1
-                        ? itemNames[i]
-                        : itemNames[i].replace(/_/g, "");
+                    if (typeof itemNames[i] === "string") {
+                        var word = itemNames[i].toLowerCase();
+                        searchWords.push(word);
+                    } else {
+                        var word = "";
+                        searchWords.push("");
+                    }
+                    var normalizedName = word.indexOf("_") === -1
+                        ? word
+                        : word.replace(/_/g, "");
                     var row = {
                         crate: crate,
                         ty: itemTypes[i],
@@ -1916,16 +1923,10 @@ function defocusSearchBar() {
                         parent: itemParentIdxs[i] > 0 ? paths[itemParentIdxs[i] - 1] : undefined,
                         type: itemFunctionSearchTypes[i],
                         id: id,
-                        nameWithoutUnderscores: nameWithoutUnderscores,
+                        normalizedName: normalizedName,
                     };
                     id += 1;
                     searchIndex.push(row);
-                    if (typeof row.name === "string") {
-                        var word = row.name.toLowerCase();
-                        searchWords.push(word);
-                    } else {
-                        searchWords.push("");
-                    }
                     lastPath = row.path;
                     crateSize += 1;
                 }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1303,11 +1303,11 @@ function defocusSearchBar() {
 
                     if (searchWords[j].indexOf(split[i]) > -1 ||
                         searchWords[j].indexOf(val) > -1 ||
-                        searchWords[j].replace(/_/g, "").indexOf(val) > -1)
+                        ty.nameWithoutUnderscores.indexOf(val) > -1)
                     {
                         // filter type: ... queries
                         if (typePassesFilter(typeFilter, ty.ty) && results[fullId] === undefined) {
-                            index = searchWords[j].replace(/_/g, "").indexOf(val);
+                            index = ty.nameWithoutUnderscores.indexOf(val);
                         }
                     }
                     if ((lev = levenshtein(searchWords[j], val)) <= MAX_LEV_DISTANCE) {
@@ -1860,6 +1860,7 @@ function defocusSearchBar() {
                     parent: undefined,
                     type: null,
                     id: "",
+                    nameWithoutUnderscores: crate.replace(/_/g, ""),
                 };
                 crateRow.id = generateId(crateRow);
                 searchIndex.push(crateRow);
@@ -1909,6 +1910,7 @@ function defocusSearchBar() {
                         parent: itemParentIdxs[i] > 0 ? paths[itemParentIdxs[i] - 1] : undefined,
                         type: itemFunctionSearchTypes[i],
                         id: "",
+                        nameWithoutUnderscores: itemNames[i].replace(/_/g, ""),
                     };
                     row.id = generateId(row);
                     searchIndex.push(row);

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1852,6 +1852,9 @@ function defocusSearchBar() {
                 var crateSize = 0;
 
                 searchWords.push(crate);
+                // This object should have exactly the same set of fields as the "row"
+                // object defined below. Your JavaScript runtime will thank you.
+                // https://mathiasbynens.be/notes/shapes-ics
                 var crateRow = {
                     crate: crate,
                     ty: 1, // == ExternCrate
@@ -1902,6 +1905,8 @@ function defocusSearchBar() {
                 len = itemTypes.length;
                 var lastPath = "";
                 for (i = 0; i < len; ++i) {
+		            // This object should have exactly the same set of fields as the "crateRow"
+		            // object defined above.
                     var row = {
                         crate: crate,
                         ty: itemTypes[i],

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -859,7 +859,7 @@ function defocusSearchBar() {
                         for (x = 0; x < vlength; ++x) {
                             var lev = MAX_LEV_DISTANCE + 1;
                             var firstGeneric = getObjectNameFromId(val.generics[x]);
-                            var match = undefined;
+                            var match = null;
                             if (elems[firstGeneric]) {
                                 match = firstGeneric;
                                 lev = 0;
@@ -872,7 +872,7 @@ function defocusSearchBar() {
                                     }
                                 }
                             }
-                            if (match !== undefined) {
+                            if (match !== null) {
                                 elems[match] -= 1;
                                 if (elems[match] == 0) {
                                     delete elems[match];

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1836,7 +1836,7 @@ function defocusSearchBar() {
         function buildIndex(rawSearchIndex) {
             searchIndex = [];
             var searchWords = [];
-            var i;
+            var i, word;
             var currentIndex = 0;
             var id = 0;
 
@@ -1905,10 +1905,10 @@ function defocusSearchBar() {
                     // This object should have exactly the same set of fields as the "crateRow"
                     // object defined above.
                     if (typeof itemNames[i] === "string") {
-                        var word = itemNames[i].toLowerCase();
+                        word = itemNames[i].toLowerCase();
                         searchWords.push(word);
                     } else {
-                        var word = "";
+                        word = "";
                         searchWords.push("");
                     }
                     var normalizedName = word.indexOf("_") === -1

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -833,11 +833,11 @@ function defocusSearchBar() {
                 };
             }
 
-            function getObjectFromId(id) {
+            function getObjectNameFromId(id) {
                 if (typeof id === "number") {
-                    return searchIndex[id];
+                    return searchIndex[id].name;
                 }
-                return {'name': id};
+                return id;
             }
 
             function checkGenerics(obj, val) {
@@ -854,9 +854,9 @@ function defocusSearchBar() {
                         var vlength = val.generics.length;
                         for (var y = 0; y < vlength; ++y) {
                             var lev = { pos: -1, lev: MAX_LEV_DISTANCE + 1};
-                            var firstGeneric = getObjectFromId(val.generics[y]).name;
+                            var firstGeneric = getObjectNameFromId(val.generics[y]);
                             for (var x = 0, elength = elems.length; x < elength; ++x) {
-                                var tmp_lev = levenshtein(getObjectFromId(elems[x]).name,
+                                var tmp_lev = levenshtein(getObjectNameFromId(elems[x]),
                                                                           firstGeneric);
                                 if (tmp_lev < lev.lev) {
                                     lev.lev = tmp_lev;
@@ -892,10 +892,10 @@ function defocusSearchBar() {
                                 len = val.generics.length;
                                 for (y = 0; allFound === true && y < len; ++y) {
                                     allFound = false;
-                                    firstGeneric = getObjectFromId(val.generics[y]).name;
+                                    firstGeneric = getObjectNameFromId(val.generics[y]);
                                     e_len = elems.length;
                                     for (x = 0; allFound === false && x < e_len; ++x) {
-                                        allFound = getObjectFromId(elems[x]).name === firstGeneric;
+                                        allFound = getObjectNameFromId(elems[x]) === firstGeneric;
                                     }
                                     if (allFound === true) {
                                         elems.splice(x - 1, 1);

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1852,6 +1852,9 @@ function defocusSearchBar() {
                 var crateSize = 0;
 
                 searchWords.push(crate);
+                var nameWithoutUnderscores = crate.indexOf("_") === -1
+                    ? crate
+                    : crate.replace(/_/g, "");
                 // This object should have exactly the same set of fields as the "row"
                 // object defined below. Your JavaScript runtime will thank you.
                 // https://mathiasbynens.be/notes/shapes-ics
@@ -1864,7 +1867,7 @@ function defocusSearchBar() {
                     parent: undefined,
                     type: null,
                     id: "",
-                    nameWithoutUnderscores: crate.replace(/_/g, ""),
+                    nameWithoutUnderscores: nameWithoutUnderscores,
                 };
                 crateRow.id = generateId(crateRow);
                 searchIndex.push(crateRow);
@@ -1907,6 +1910,9 @@ function defocusSearchBar() {
                 for (i = 0; i < len; ++i) {
                     // This object should have exactly the same set of fields as the "crateRow"
                     // object defined above.
+                    var nameWithoutUnderscores = itemNames[i].indexOf("_") === -1
+                        ? itemNames[i]
+                        : itemNames[i].replace(/_/g, "");
                     var row = {
                         crate: crate,
                         ty: itemTypes[i],
@@ -1916,7 +1922,7 @@ function defocusSearchBar() {
                         parent: itemParentIdxs[i] > 0 ? paths[itemParentIdxs[i] - 1] : undefined,
                         type: itemFunctionSearchTypes[i],
                         id: "",
-                        nameWithoutUnderscores: itemNames[i].replace(/_/g, ""),
+                        nameWithoutUnderscores: nameWithoutUnderscores,
                     };
                     row.id = generateId(row);
                     searchIndex.push(row);

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -843,6 +843,7 @@ function defocusSearchBar() {
             function checkGenerics(obj, val) {
                 // The names match, but we need to be sure that all generics kinda
                 // match as well.
+                var tmp_lev, elem_name;
                 if (val.generics.length > 0) {
                     if (obj.length > GENERICS_DATA &&
                           obj[GENERICS_DATA].length >= val.generics.length) {
@@ -864,8 +865,8 @@ function defocusSearchBar() {
                                 match = firstGeneric;
                                 lev = 0;
                             } else {
-                                for (var elem_name in elems) {
-                                    var tmp_lev = levenshtein(elem_name, firstGeneric);
+                                for (elem_name in elems) {
+                                    tmp_lev = levenshtein(elem_name, firstGeneric);
                                     if (tmp_lev < lev) {
                                         lev = tmp_lev;
                                         match = elem_name;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -136,11 +136,12 @@ h1, h2, h3, h4,
 #source-sidebar, #sidebar-toggle,
 /* This selector is for the items listed in the "all items" page. */
 #main > ul.docblock > li > a {
-	font-family: "Fira Sans", Arial;
+	font-family: "Fira Sans", Arial, sans-serif;
 }
 
 .content ul.crate a.crate {
-	font: 16px/1.6 "Fira Sans";
+	font-size: 16px/1.6;
+	font-family: "Fira Sans", Arial, sans-serif;
 }
 
 ol, ul {
@@ -482,7 +483,7 @@ h4 > code, h3 > code, .invisible > code {
 }
 #main > .since {
 	top: inherit;
-	font-family: "Fira Sans", Arial;
+	font-family: "Fira Sans", Arial, sans-serif;
 }
 
 .content table:not(.table-display) {
@@ -1301,7 +1302,7 @@ h4 > .notable-traits {
 
 .help-button {
 	right: 30px;
-	font-family: "Fira Sans", Arial;
+	font-family: "Fira Sans", Arial, sans-serif;
 	text-align: center;
 	font-size: 17px;
 }

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -266,7 +266,7 @@ a {
 
 .stab.portability > code {
 	color: #e6e1cf;
-	background-color: transparent;
+	background: none;
 }
 
 #help > div {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -222,10 +222,7 @@ a.test-arrow {
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; color: #2f2f2f; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; color: #2f2f2f; }
-
-.stab.portability > code {
-	color: #ddd;
-}
+.stab.portability > code { background: none; }
 
 #help > div {
 	background: #4d4d4d;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -220,10 +220,7 @@ a.test-arrow {
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; }
 .stab.deprecated { background: #F3DFFF; border-color: #7F0087; }
 .stab.portability { background: #C4ECFF; border-color: #7BA5DB; }
-
-.stab.portability > code {
-	color: #000;
-}
+.stab.portability > code { background: none; }
 
 #help > div {
 	background: #e9e9e9;

--- a/src/test/run-make/incr-prev-body-beyond-eof/Makefile
+++ b/src/test/run-make/incr-prev-body-beyond-eof/Makefile
@@ -1,3 +1,5 @@
+# ignore-none no-std is not supported
+
 include ../../run-make-fulldeps/tools.mk
 
 # Tests that we don't ICE during incremental compilation after modifying a

--- a/src/test/run-make/incr-prev-body-beyond-eof/Makefile
+++ b/src/test/run-make/incr-prev-body-beyond-eof/Makefile
@@ -1,8 +1,5 @@
 include ../../run-make-fulldeps/tools.mk
 
-# FIXME https://github.com/rust-lang/rust/issues/78911
-# ignore-32bit wrong/no cross compiler and sometimes we pass wrong gcc args (-m64)
-
 # Tests that we don't ICE during incremental compilation after modifying a
 # function span such that its previous end line exceeds the number of lines
 # in the new file, but its start line/column and length remain the same.
@@ -14,6 +11,6 @@ all:
 	mkdir $(SRC)
 	mkdir $(INCR)
 	cp a.rs $(SRC)/main.rs
-	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs
+	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs --target $(TARGET)
 	cp b.rs $(SRC)/main.rs
-	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs
+	$(RUSTC) -C incremental=$(INCR) $(SRC)/main.rs --target $(TARGET)

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,5 +1,6 @@
 # ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
 #                              so it won't work with remote-test-server
+# ignore-none no-std is not supported
 
 include ../../run-make-fulldeps/tools.mk
 

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,13 +1,10 @@
 include ../../run-make-fulldeps/tools.mk
 
-# FIXME https://github.com/rust-lang/rust/issues/78911
-# ignore-32bit wrong/no cross compiler and sometimes we pass wrong gcc args (-m64)
-
 all: foo
 	$(call RUN,foo)
 
 foo: foo.rs $(call NATIVE_STATICLIB,foo)
-	$(RUSTC) $< -lfoo $(EXTRARSCXXFLAGS)
+	$(RUSTC) $< -lfoo $(EXTRARSCXXFLAGS) --target $(TARGET)
 
 $(TMPDIR)/libfoo.o: foo.cpp
 	$(call COMPILE_OBJ_CXX,$@,$<)

--- a/src/test/run-make/issue-36710/Makefile
+++ b/src/test/run-make/issue-36710/Makefile
@@ -1,3 +1,6 @@
+# ignore-riscv64 $(call RUN,foo) expects to run the target executable natively
+#                              so it won't work with remote-test-server
+
 include ../../run-make-fulldeps/tools.mk
 
 all: foo

--- a/src/test/rustdoc-ui/asm-foreign.rs
+++ b/src/test/rustdoc-ui/asm-foreign.rs
@@ -1,0 +1,19 @@
+// check-pass
+// Make sure rustdoc accepts asm! for a foreign architecture.
+
+#![feature(asm)]
+
+pub unsafe fn aarch64(a: f64, b: f64) {
+    let c;
+    asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+        || {};
+        b
+    });
+    c
+}
+
+pub unsafe fn x86(a: f64, b: f64) {
+    let c;
+    asm!("addsd {}, {}, xmm0", out(xmm_reg) c, in(xmm_reg) a, in("xmm0") b);
+    c
+}

--- a/src/test/rustdoc/asm-foreign.rs
+++ b/src/test/rustdoc/asm-foreign.rs
@@ -1,9 +1,9 @@
-// check-pass
 // Make sure rustdoc accepts asm! for a foreign architecture.
 
 #![feature(asm)]
 
-pub unsafe fn aarch64(a: f64, b: f64) {
+// @has asm_foreign/fn.aarch64.html
+pub unsafe fn aarch64(a: f64, b: f64) -> f64 {
     let c;
     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
         || {};
@@ -12,7 +12,8 @@ pub unsafe fn aarch64(a: f64, b: f64) {
     c
 }
 
-pub unsafe fn x86(a: f64, b: f64) {
+// @has asm_foreign/fn.x86.html
+pub unsafe fn x86(a: f64, b: f64) -> f64 {
     let c;
     asm!("addsd {}, {}, xmm0", out(xmm_reg) c, in(xmm_reg) a, in("xmm0") b);
     c

--- a/src/test/rustdoc/asm-foreign2.rs
+++ b/src/test/rustdoc/asm-foreign2.rs
@@ -1,0 +1,11 @@
+// only-aarch64
+// Make sure rustdoc accepts options(att_syntax) asm! on non-x86 targets.
+
+#![feature(asm)]
+
+// @has asm_foreign2/fn.x86.html
+pub unsafe fn x86(x: i64) -> i64 {
+    let y;
+    asm!("movq {}, {}", in(reg) x, out(reg) y, options(att_syntax));
+    y
+}

--- a/src/test/ui/bad/bad-sized.rs
+++ b/src/test/ui/bad/bad-sized.rs
@@ -5,4 +5,5 @@ pub fn main() {
     //~^ ERROR only auto traits can be used as additional traits in a trait object
     //~| ERROR the size for values of type
     //~| ERROR the size for values of type
+    //~| ERROR the size for values of type
 }

--- a/src/test/ui/bad/bad-sized.stderr
+++ b/src/test/ui/bad/bad-sized.stderr
@@ -31,7 +31,20 @@ LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
    = help: the trait `Sized` is not implemented for `dyn Trait`
    = note: required by `Vec::<T>::new`
 
-error: aborting due to 3 previous errors
+error[E0277]: the size for values of type `dyn Trait` cannot be known at compilation time
+  --> $DIR/bad-sized.rs:4:37
+   |
+LL |     let x: Vec<dyn Trait + Sized> = Vec::new();
+   |                                     ^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |                - required by this bound in `Vec`
+   |
+   = help: the trait `Sized` is not implemented for `dyn Trait`
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0225, E0277.
 For more information about an error, try `rustc --explain E0225`.

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.stderr
@@ -10,7 +10,7 @@ warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:19:5
    |
 LL |     MustUseDeprecated::new();
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^
 
 warning: use of deprecated struct `MustUseDeprecated`
   --> $DIR/cfg-attr-multi-true.rs:13:17

--- a/src/test/ui/issues/issue-78622.stderr
+++ b/src/test/ui/issues/issue-78622.stderr
@@ -2,7 +2,7 @@ error[E0223]: ambiguous associated type
   --> $DIR/issue-78622.rs:5:5
    |
 LL |     S::A::<f> {}
-   |     ^^^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
+   |     ^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-82869.rs
+++ b/src/test/ui/issues/issue-82869.rs
@@ -1,0 +1,23 @@
+// only-x86_64
+// Make sure rustc doesn't ICE on asm! for a foreign architecture.
+
+#![feature(asm)]
+#![crate_type = "rlib"]
+
+pub unsafe fn aarch64(a: f64, b: f64) -> f64 {
+    let c;
+    asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+        || {};
+        b
+    });
+    //~^^^^ invalid register class
+    //~^^^^^ invalid register class
+    //~^^^^^^ invalid register
+    c
+}
+
+pub unsafe fn x86(a: f64, b: f64) -> f64 {
+    let c;
+    asm!("addsd {}, {}, xmm0", out(xmm_reg) c, in(xmm_reg) a, in("xmm0") b);
+    c
+}

--- a/src/test/ui/issues/issue-82869.stderr
+++ b/src/test/ui/issues/issue-82869.stderr
@@ -1,0 +1,24 @@
+error: invalid register class `vreg`: unknown register class
+  --> $DIR/issue-82869.rs:9:32
+   |
+LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+   |                                ^^^^^^^^^^^
+
+error: invalid register class `vreg`: unknown register class
+  --> $DIR/issue-82869.rs:9:45
+   |
+LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+   |                                             ^^^^^^^^^^
+
+error: invalid register `d0`: unknown register
+  --> $DIR/issue-82869.rs:9:57
+   |
+LL |       asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
+   |  _________________________________________________________^
+LL | |         || {};
+LL | |         b
+LL | |     });
+   | |_____^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/mir/issue-80742.stderr
+++ b/src/test/ui/mir/issue-80742.stderr
@@ -56,7 +56,7 @@ LL | struct Inline<T>
    |               - required by this bound in `Inline`
 ...
 LL |     let dst = Inline::<dyn Debug>::new(0);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |               ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `dyn Debug`
 help: consider relaxing the implicit `Sized` restriction

--- a/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
+++ b/src/test/ui/mismatched_types/issue-75361-mismatched-impl.stderr
@@ -13,7 +13,7 @@ help: the lifetime requirements from the `impl` do not correspond to the require
   --> $DIR/issue-75361-mismatched-impl.rs:12:55
    |
 LL |   fn adjacent_edges(&self) -> Box<dyn MyTrait<Item = &Self::EdgeType>>;
-   |                                                       ^^^^^^^^^^^^^^ consider borrowing this type parameter in the trait
+   |                                                       ^^^^ consider borrowing this type parameter in the trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/associated-item-privacy-inherent.stderr
+++ b/src/test/ui/privacy/associated-item-privacy-inherent.stderr
@@ -222,7 +222,7 @@ error: type `priv_parent_substs::Priv` is private
   --> $DIR/associated-item-privacy-inherent.rs:101:9
    |
 LL |         Pub::CONST;
-   |         ^^^^^^^^^^ private type
+   |         ^^^ private type
 ...
 LL |     priv_parent_substs::mac!();
    |     --------------------------- in this macro invocation

--- a/src/test/ui/privacy/private-inferred-type.stderr
+++ b/src/test/ui/privacy/private-inferred-type.stderr
@@ -56,7 +56,7 @@ error: type `Priv` is private
   --> $DIR/private-inferred-type.rs:104:5
    |
 LL |     m::Pub::INHERENT_ASSOC_CONST;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ private type
+   |     ^^^^^^ private type
 
 error: type `Priv` is private
   --> $DIR/private-inferred-type.rs:105:5

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.rs
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.rs
@@ -1,0 +1,13 @@
+// check-pass
+// aux-build:test-macros.rs
+
+#[macro_use]
+extern crate test_macros;
+
+#[derive(Print)]
+enum ProceduralMasqueradeDummyType { //~ WARN using
+//~| WARN this was previously
+    Input
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
@@ -1,0 +1,25 @@
+warning: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:8:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(proc_macro_back_compat)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+warning: 1 warning emitted
+
+Future incompatibility report: Future breakage date: None, diagnostic:
+warning: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:8:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(proc_macro_back_compat)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
@@ -1,0 +1,22 @@
+PRINT-DERIVE INPUT (DISPLAY): enum ProceduralMasqueradeDummyType { Input, }
+PRINT-DERIVE RE-COLLECTED (DISPLAY): enum ProceduralMasqueradeDummyType { Input }
+PRINT-DERIVE INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "enum",
+        span: #0 bytes(100..104),
+    },
+    Ident {
+        ident: "ProceduralMasqueradeDummyType",
+        span: #0 bytes(105..134),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [
+            Ident {
+                ident: "Input",
+                span: #0 bytes(186..191),
+            },
+        ],
+        span: #0 bytes(135..193),
+    },
+]

--- a/src/test/ui/regions/issue-28848.stderr
+++ b/src/test/ui/regions/issue-28848.stderr
@@ -2,7 +2,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/issue-28848.rs:10:5
    |
 LL |     Foo::<'a, 'b>::xmute(u)
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined on the function body at 9:16
   --> $DIR/issue-28848.rs:9:16

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -100,7 +100,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:160:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(1);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:160:12
@@ -124,7 +124,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:166:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(0);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
   --> $DIR/generics-default-stability.rs:166:12
@@ -136,7 +136,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:171:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(1);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:171:12
@@ -160,7 +160,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:178:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(0);
-   |                            ^^^^^^^^^^^^
+   |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
   --> $DIR/generics-default-stability.rs:178:12

--- a/src/test/ui/structs/struct-path-associated-type.stderr
+++ b/src/test/ui/structs/struct-path-associated-type.stderr
@@ -14,7 +14,7 @@ error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
    |
 LL |     let z = T::A::<u8> {};
-   |             ^^^^^^^^^^ not a struct
+   |             ^^^^ not a struct
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:18:9
@@ -38,7 +38,7 @@ error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:33:13
    |
 LL |     let z = S::A::<u8> {};
-   |             ^^^^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
+   |             ^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:35:9

--- a/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
+++ b/src/test/ui/suggestions/mut-borrow-needed-by-trait.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `&dyn std::io::Write: std::io::Write` is not satis
   --> $DIR/mut-borrow-needed-by-trait.rs:17:14
    |
 LL |     let fp = BufWriter::new(fp);
-   |              ^^^^^^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
+   |              ^^^^^^^^^ the trait `std::io::Write` is not implemented for `&dyn std::io::Write`
    | 
   ::: $SRC_DIR/std/src/io/buffered/bufwriter.rs:LL:COL
    |

--- a/src/test/ui/suggestions/suggest-std-when-using-type.stderr
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.stderr
@@ -2,12 +2,12 @@ error[E0223]: ambiguous associated type
   --> $DIR/suggest-std-when-using-type.rs:2:14
    |
 LL |     let pi = f32::consts::PI;
-   |              ^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^
    |
 help: you are looking for the module in `std`, not the primitive type
    |
 LL |     let pi = std::f32::consts::PI;
-   |              ^^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^^^^^
 
 error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope
   --> $DIR/suggest-std-when-using-type.rs:5:14

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -113,7 +113,7 @@ error[E0038]: the trait `assoc_const::C` cannot be made into an object
   --> $DIR/item-privacy.rs:101:5
    |
 LL |     C::A;
-   |     ^^^^ `assoc_const::C` cannot be made into an object
+   |     ^ `assoc_const::C` cannot be made into an object
    |
    = help: consider moving `C` to another trait
    = help: consider moving `B` to another trait

--- a/src/test/ui/unspecified-self-in-trait-ref.stderr
+++ b/src/test/ui/unspecified-self-in-trait-ref.stderr
@@ -31,7 +31,7 @@ LL | | }
    | |_- type parameter `A` must be specified for this
 ...
 LL |       let e = Bar::<usize>::lol();
-   |               ^^^^^^^^^^^^^^^^^ missing reference to `A`
+   |               ^^^^^^^^^^^^ missing reference to `A`
    |
    = note: because of the default `Self` reference, type parameters must be specified on object types
 

--- a/src/test/ui/wf/wf-static-method.stderr
+++ b/src/test/ui/wf/wf-static-method.stderr
@@ -19,7 +19,7 @@ error[E0478]: lifetime bound not satisfied
   --> $DIR/wf-static-method.rs:26:18
    |
 LL |         let me = Self::make_me();
-   |                  ^^^^^^^^^^^^^
+   |                  ^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined on the impl at 23:10
   --> $DIR/wf-static-method.rs:23:10

--- a/src/tools/clippy/tests/ui/use_self.fixed
+++ b/src/tools/clippy/tests/ui/use_self.fixed
@@ -312,17 +312,18 @@ mod issue4140 {
         fn try_from(value: T) -> Result<Self, Error<Self::From, Self::To>>;
     }
 
-    impl<F, T> TryFrom<F> for T
-    where
-        T: From<F>,
-    {
-        type From = Self;
-        type To = Self;
+    // FIXME: Suggested fix results in infinite recursion.
+    // impl<F, T> TryFrom<F> for T
+    // where
+    //     T: From<F>,
+    // {
+    //     type From = Self::From;
+    //     type To = Self::To;
 
-        fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
-            Ok(From::from(value))
-        }
-    }
+    //     fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
+    //         Ok(From::from(value))
+    //     }
+    // }
 
     impl From<bool> for i64 {
         type From = bool;

--- a/src/tools/clippy/tests/ui/use_self.rs
+++ b/src/tools/clippy/tests/ui/use_self.rs
@@ -312,17 +312,18 @@ mod issue4140 {
         fn try_from(value: T) -> Result<Self, Error<Self::From, Self::To>>;
     }
 
-    impl<F, T> TryFrom<F> for T
-    where
-        T: From<F>,
-    {
-        type From = T::From;
-        type To = T::To;
+    // FIXME: Suggested fix results in infinite recursion.
+    // impl<F, T> TryFrom<F> for T
+    // where
+    //     T: From<F>,
+    // {
+    //     type From = Self::From;
+    //     type To = Self::To;
 
-        fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
-            Ok(From::from(value))
-        }
-    }
+    //     fn try_from(value: F) -> Result<Self, Error<Self::From, Self::To>> {
+    //         Ok(From::from(value))
+    //     }
+    // }
 
     impl From<bool> for i64 {
         type From = bool;

--- a/src/tools/clippy/tests/ui/use_self.stderr
+++ b/src/tools/clippy/tests/ui/use_self.stderr
@@ -157,22 +157,10 @@ LL |             Foo { value }
    |             ^^^ help: use the applicable keyword: `Self`
 
 error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:319:21
-   |
-LL |         type From = T::From;
-   |                     ^^^^^^^ help: use the applicable keyword: `Self`
-
-error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:320:19
-   |
-LL |         type To = T::To;
-   |                   ^^^^^ help: use the applicable keyword: `Self`
-
-error: unnecessary structure name repetition
-  --> $DIR/use_self.rs:453:13
+  --> $DIR/use_self.rs:454:13
    |
 LL |             A::new::<submod::B>(submod::B {})
    |             ^ help: use the applicable keyword: `Self`
 
-error: aborting due to 29 previous errors
+error: aborting due to 27 previous errors
 

--- a/src/tools/clippy/tests/ui/zero_sized_btreemap_values.stderr
+++ b/src/tools/clippy/tests/ui/zero_sized_btreemap_values.stderr
@@ -83,7 +83,7 @@ error: map with zero-sized value type
   --> $DIR/zero_sized_btreemap_values.rs:64:35
    |
 LL |     let _: BTreeMap<String, ()> = BTreeMap::new();
-   |                                   ^^^^^^^^^^^^^
+   |                                   ^^^^^^^^
    |
    = help: consider using a set instead
 

--- a/src/tools/clippy/tests/ui/zero_sized_hashmap_values.stderr
+++ b/src/tools/clippy/tests/ui/zero_sized_hashmap_values.stderr
@@ -83,7 +83,7 @@ error: map with zero-sized value type
   --> $DIR/zero_sized_hashmap_values.rs:64:34
    |
 LL |     let _: HashMap<String, ()> = HashMap::new();
-   |                                  ^^^^^^^^^^^^
+   |                                  ^^^^^^^
    |
    = help: consider using a set instead
 


### PR DESCRIPTION
Successful merges:

 - #80839 (Riscv64linux Test fixes)
 - #82838 (Allow rustdoc to handle asm! of foreign architectures)
 - #83072 (Update `Vec` docs)
 - #83077 (rustdoc: reduce GC work during search)
 - #83092 (More precise spans for HIR paths)
 - #83124 (Do not insert impl_trait_in_bindings opaque definitions twice.)
 - #83156 (Fall-back to sans-serif if Arial is not available)
 - #83157 (No background for code in portability snippets)
 - #83160 (Deprecate RustcEncodable and RustcDecodable.)
 - #83162 (Specify *.woff2 files as binary)
 - #83168 (Extend `proc_macro_back_compat` lint to `procedural-masquerade`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=80839,82838,83072,83077,83092,83124,83156,83157,83160,83162,83168)
<!-- homu-ignore:end -->