### PR TITLE
ci/docker: Add SDK/NDK level 21 to android docker for 32bit platforms

### DIFF
--- a/src/ci/docker/host-x86_64/dist-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-android/Dockerfile
@@ -9,6 +9,8 @@ RUN . /scripts/android-ndk.sh && \
     download_ndk android-ndk-r15c-linux-x86_64.zip && \
     make_standalone_toolchain arm 14 && \
     make_standalone_toolchain x86 14 && \
+    make_standalone_toolchain arm 21 && \
+    make_standalone_toolchain x86 21 && \
     make_standalone_toolchain arm64 21 && \
     make_standalone_toolchain x86_64 21 && \
     remove_ndk


### PR DESCRIPTION
Certain features of Linux (getauxval() and epoll_create1()) are only
available in android SDK/NDK levels 18 and 21 respectively.  The 32bit
platform is currently on level 14 for compatibility with Android 4.0.

This patch adds SDK/NDK level 21 to the docker for 32 bit platforms,
while leaving the default setup at level 14.

With this done, projects such as `rustup` which rely on these dockers
can build with modern ecosystem crates such as tokio 1.0, by using
the level 21 toolchain, but those which do not need to switch will
be unaffected, since the level 14 toolchain remains available.
