### PR TITLE
Use delay_span_bug instead of panic in layout_scalar_valid_range

### DIFF
--- a/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
+++ b/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.rs
@@ -15,6 +15,13 @@ enum E {
     Y = 14,
 }
 
+#[rustc_layout_scalar_valid_range_start(rustc_layout_scalar_valid_range_start)] //~ ERROR
+struct NonZero<T>(T);
+
+fn not_field() -> impl Send {
+    NonZero(false)
+}
+
 fn main() {
     let _ = A(0);
     let _ = B(0);

--- a/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.stderr
+++ b/src/test/ui/invalid/invalid_rustc_layout_scalar_valid_range.stderr
@@ -27,5 +27,11 @@ LL | |     Y = 14,
 LL | | }
    | |_- not a struct
 
-error: aborting due to 4 previous errors
+error: expected exactly one integer literal argument
+  --> $DIR/invalid_rustc_layout_scalar_valid_range.rs:18:1
+   |
+LL | #[rustc_layout_scalar_valid_range_start(rustc_layout_scalar_valid_range_start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
#83054 introduced validation of scalar range attributes, but panicking
code that uses the attribute remained reachable. Use `delay_span_bug`
instead to avoid the ICE.

Fixes #83180.