### PR TITLE
use checkout@v2 in CI for master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,7 +622,7 @@ jobs:
     if: "github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'rust-lang-ci/rust'"
     steps:
       - name: checkout the source code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
       - name: publish toolstate

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -655,7 +655,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'rust-lang-ci/rust'
     steps:
       - name: checkout the source code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 2
 


### PR DESCRIPTION
Updates CI workflow to use checkout@v2 from v1 (as other parts of CI) for master, plus slightly faster checkout as result
compare v2
https://github.com/rust-lang-ci/rust/commit/2ccf06302c08d7d4911aad40e66a9a3ee731c6f9/checks/2113902859/logs
and v1 logs
https://github.com/rust-lang-ci/rust/commit/2ccf06302c08d7d4911aad40e66a9a3ee731c6f9/checks/2115229351/logs