### PR TITLE
Don't warn about old rustdoc lint names (temporarily)

### DIFF
--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -100,6 +100,11 @@ enum TargetLint {
     /// Lint with this name existed previously, but has been removed/deprecated.
     /// The string argument is the reason for removal.
     Removed(String),
+
+    /// A lint name that should give no warnings and have no effect.
+    ///
+    /// This is used by rustc to avoid warning about old rustdoc lints before rustdoc registers them as tool lints.
+    Ignored,
 }
 
 pub enum FindLintError {
@@ -266,6 +271,33 @@ impl LintStore {
         }
     }
 
+    /// This lint should be available with either the old or the new name.
+    ///
+    /// Using the old name will not give a warning.
+    /// You must register a lint with the new name before calling this function.
+    #[track_caller]
+    pub fn register_alias(&mut self, old_name: &str, new_name: &str) {
+        let target = match self.by_name.get(new_name) {
+            Some(&Id(lint_id)) => lint_id,
+            _ => bug!("cannot add alias {} for lint {} that does not exist", old_name, new_name),
+        };
+        match self.by_name.insert(old_name.to_string(), Id(target)) {
+            None | Some(Ignored) => {}
+            Some(x) => bug!("duplicate specification of lint {} (was {:?})", old_name, x),
+        }
+    }
+
+    /// This lint should give no warning and have no effect.
+    ///
+    /// This is used by rustc to avoid warning about old rustdoc lints before rustdoc registers them as tool lints.
+    #[track_caller]
+    pub fn register_ignored(&mut self, name: &str) {
+        if self.by_name.insert(name.to_string(), Ignored).is_some() {
+            bug!("duplicate specification of lint {}", name);
+        }
+    }
+
+    /// This lint has been renamed; warn about using the new name and apply the lint.
     #[track_caller]
     pub fn register_renamed(&mut self, old_name: &str, new_name: &str) {
         let target = match self.by_name.get(new_name) {
@@ -284,6 +316,7 @@ impl LintStore {
             Some(&Id(lint_id)) => Ok(vec![lint_id]),
             Some(&Renamed(_, lint_id)) => Ok(vec![lint_id]),
             Some(&Removed(_)) => Err(FindLintError::Removed),
+            Some(&Ignored) => Ok(vec![]),
             None => loop {
                 return match self.lint_groups.get(lint_name) {
                     Some(LintGroup { lint_ids, depr, .. }) => {
@@ -427,6 +460,7 @@ impl LintStore {
                 }
             },
             Some(&Id(ref id)) => CheckLintNameResult::Ok(slice::from_ref(id)),
+            Some(&Ignored) => CheckLintNameResult::Ok(&[]),
         }
     }
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -340,7 +340,7 @@ fn register_builtins(store: &mut LintStore, no_interleave_lints: bool) {
         "non_autolinks",
     ];
     for rustdoc_lint in RUSTDOC_LINTS {
-        store.register_removed(rustdoc_lint, &format!("use `rustdoc::{}` instead", rustdoc_lint));
+        store.register_ignored(rustdoc_lint);
     }
     store.register_removed(
         "intra_doc_link_resolution_failure",

--- a/src/librustdoc/lint.rs
+++ b/src/librustdoc/lint.rs
@@ -181,7 +181,7 @@ crate fn register_lints(_sess: &Session, lint_store: &mut LintStore) {
     );
     for lint in &*RUSTDOC_LINTS {
         let name = lint.name_lower();
-        lint_store.register_renamed(&name.replace("rustdoc::", ""), &name);
+        lint_store.register_alias(&name.replace("rustdoc::", ""), &name);
     }
     lint_store
         .register_renamed("intra_doc_link_resolution_failure", "rustdoc::broken_intra_doc_links");

--- a/src/test/rustdoc-ui/renamed-lint-still-applies.rs
+++ b/src/test/rustdoc-ui/renamed-lint-still-applies.rs
@@ -1,5 +1,6 @@
 // compile-args: --crate-type lib
 #![deny(broken_intra_doc_links)]
-//~^ WARNING renamed
+// FIXME: the old names for rustdoc lints should warn by default once `rustdoc::` makes it to the
+// stable channel.
 //! [x]
 //~^ ERROR unresolved link

--- a/src/test/rustdoc-ui/renamed-lint-still-applies.stderr
+++ b/src/test/rustdoc-ui/renamed-lint-still-applies.stderr
@@ -1,13 +1,5 @@
-warning: lint `broken_intra_doc_links` has been renamed to `rustdoc::broken_intra_doc_links`
-  --> $DIR/renamed-lint-still-applies.rs:2:9
-   |
-LL | #![deny(broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::broken_intra_doc_links`
-   |
-   = note: `#[warn(renamed_and_removed_lints)]` on by default
-
 error: unresolved link to `x`
-  --> $DIR/renamed-lint-still-applies.rs:4:6
+  --> $DIR/renamed-lint-still-applies.rs:5:6
    |
 LL | //! [x]
    |      ^ no item named `x` in scope
@@ -17,7 +9,8 @@ note: the lint level is defined here
    |
 LL | #![deny(broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(broken_intra_doc_links)]`
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/unknown-renamed-lints.rs
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.rs
@@ -10,7 +10,8 @@
 //~^ ERROR renamed to `rustdoc::broken_intra_doc_links`
 
 #![deny(non_autolinks)]
-//~^ ERROR renamed to `rustdoc::non_autolinks`
+// FIXME: the old names for rustdoc lints should warn by default once `rustdoc::` makes it to the
+// stable channel.
 
 #![deny(rustdoc)]
 //~^ ERROR removed: use `rustdoc::all` instead

--- a/src/test/rustdoc-ui/unknown-renamed-lints.stderr
+++ b/src/test/rustdoc-ui/unknown-renamed-lints.stderr
@@ -28,25 +28,19 @@ note: the lint level is defined here
 LL | #![deny(renamed_and_removed_lints)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: lint `non_autolinks` has been renamed to `rustdoc::non_autolinks`
-  --> $DIR/unknown-renamed-lints.rs:12:9
-   |
-LL | #![deny(non_autolinks)]
-   |         ^^^^^^^^^^^^^ help: use the new name: `rustdoc::non_autolinks`
-
 error: lint `rustdoc` has been removed: use `rustdoc::all` instead
-  --> $DIR/unknown-renamed-lints.rs:15:9
+  --> $DIR/unknown-renamed-lints.rs:16:9
    |
 LL | #![deny(rustdoc)]
    |         ^^^^^^^
 
 error: unknown lint: `rustdoc::intra_doc_link_resolution_failure`
-  --> $DIR/unknown-renamed-lints.rs:19:9
+  --> $DIR/unknown-renamed-lints.rs:20:9
    |
 LL | #![deny(rustdoc::intra_doc_link_resolution_failure)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: Compilation failed, aborting rustdoc
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/rustdoc-renamed.rs
+++ b/src/test/ui/lint/rustdoc-renamed.rs
@@ -11,4 +11,5 @@
 #![deny(intra_doc_link_resolution_failure)]
 //~^ ERROR removed: use `rustdoc::broken_intra_doc_links`
 #![deny(non_autolinks)]
-//~^ ERROR removed: use `rustdoc::non_autolinks`
+// FIXME: the old names for rustdoc lints should warn by default once `rustdoc::` makes it to the
+// stable channel.

--- a/src/test/ui/lint/rustdoc-renamed.stderr
+++ b/src/test/ui/lint/rustdoc-renamed.stderr
@@ -10,11 +10,5 @@ note: the lint level is defined here
 LL | #![deny(renamed_and_removed_lints)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: lint `non_autolinks` has been removed: use `rustdoc::non_autolinks` instead
-  --> $DIR/rustdoc-renamed.rs:13:9
-   |
-LL | #![deny(non_autolinks)]
-   |         ^^^^^^^^^^^^^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/80527, rustdoc users have an unpleasant situation: they can either use the new tool lint names (`rustdoc::non_autolinks`) or they can use the old names (`non_autolinks`). If they use the tool lints, they get a hard error on stable compilers, because rustc rejects all tool names it doesn't recognize (https://github.com/rust-lang/rust/issues/66079#issuecomment-788589193). If they use the old name, they get a warning to rename the lint to the new name. The only way to compile without warnings is to add `#[allow(renamed_removed_lints)]`, which defeats the whole point of the change: we *want* people to switch to the new name.

To avoid people silencing the lint and never migrating to the tool lint, this avoids warning about the old name, while still allowing you to use the new name. Once the new `rustdoc` tool name makes it to the stable channel, we can change these lints to warn again.

This adds the new lint functions `register_alias` and `register_ignored` - I didn't see an existing way to do this.

r? @Manishearth cc @rust-lang/rustdoc