### PR TITLE
Allow method resolution to work on reference receiver types with Self : Sized bounds with reference trait implementations

### DIFF
--- a/src/test/ui/resolve/issue-82825-mut.rs
+++ b/src/test/ui/resolve/issue-82825-mut.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+trait Trait {
+    fn static_call(&mut self) where Self: Sized;
+    fn maybe_dynamic_call(&self) {
+        unimplemented!("unsupported maybe_dynamic_call");
+    }
+}
+
+impl<T: ?Sized + Trait> Trait for &mut T {
+    fn static_call(&mut self) where Self: Sized {
+        (**self).maybe_dynamic_call();
+    }
+}
+
+fn foo(mut x: &mut dyn Trait) {
+    x.static_call();
+}
+
+fn main() {}

--- a/src/test/ui/resolve/issue-82825.rs
+++ b/src/test/ui/resolve/issue-82825.rs
@@ -2,7 +2,6 @@
 
 trait Trait {
     fn static_call(&self) where Self: Sized;
-    
     fn maybe_dynamic_call(&self) {
         unimplemented!("unsupported maybe_dynamic_call");
     }

--- a/src/test/ui/resolve/issue-82825.rs
+++ b/src/test/ui/resolve/issue-82825.rs
@@ -1,0 +1,21 @@
+// check-pass
+
+trait Trait {
+    fn static_call(&self) where Self: Sized;
+    
+    fn maybe_dynamic_call(&self) {
+        unimplemented!("unsupported maybe_dynamic_call");
+    }
+}
+
+impl<T: ?Sized + Trait> Trait for &T {
+    fn static_call(&self) where Self: Sized {
+        (**self).maybe_dynamic_call();
+    }
+}
+
+fn foo(x: &dyn Trait) {
+    x.static_call();
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/82825

In situations in which we have a trait method that takes a reference receiver type, a Self : Sized bound and a trait implementation for a reference type, the adjustments that the compiler applies are insufficient to fulfill the Sized bound on Self. To allow the compiler to resolve the correct method we autoref during method probing, after a sized bound violation was found, try to confirm the new method candidate and check if all resulting obligations can be fulfilled.