### PR TITLE
Deprecate std::os::haiku::raw, which accidentally wasn't deprecated

### DIFF
--- a/library/std/src/os/haiku/raw.rs
+++ b/library/std/src/os/haiku/raw.rs
@@ -1,6 +1,13 @@
 //! Haiku-specific raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![rustc_deprecated(
+    since = "1.53.0",
+    reason = "these type aliases are no longer supported by \
+              the standard library, the `libc` crate on \
+              crates.io should be used instead for the correct \
+              definitions"
+)]
 #![allow(deprecated)]
 
 use crate::os::raw::c_long;


### PR DESCRIPTION
In early 2016, all `std::os::*::raw` modules [were deprecated](https://github.com/rust-lang/rust/commit/aa23c98450063992473d40d707273903f8a3937d) in accordance with [RFC 1415](https://github.com/rust-lang/rfcs/blob/master/text/1415-trim-std-os.md). However, at this same time support for Haiku was being added to libstd, landing shortly after the aforementioned commit, and due to some crossed wires a `std::os::haiku::raw` module was added and was not marked as deprecated.

I have been in correspondence with the author of the Haiku patch, @nielx, who has confirmed that this was simply an oversight and that the definitions from the libc crate should be preferred instead.