### PR TITLE
Display error details when a `mmap` call fails

### DIFF
--- a/library/std/src/sys/unix/stack_overflow.rs
+++ b/library/std/src/sys/unix/stack_overflow.rs
@@ -39,6 +39,7 @@ impl Drop for Handler {
 ))]
 mod imp {
     use super::Handler;
+    use crate::io;
     use crate::mem;
     use crate::ptr;
 
@@ -149,11 +150,11 @@ mod imp {
             0,
         );
         if stackp == MAP_FAILED {
-            panic!("failed to allocate an alternative stack");
+            panic!("failed to allocate an alternative stack: {}", io::Error::last_os_error());
         }
         let guard_result = libc::mprotect(stackp, page_size(), PROT_NONE);
         if guard_result != 0 {
-            panic!("failed to set up alternative stack guard page");
+            panic!("failed to set up alternative stack guard page: {}", io::Error::last_os_error());
         }
         stackp.add(page_size())
     }

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -231,6 +231,7 @@ pub mod guard {
     use libc::{mmap, mprotect};
     use libc::{MAP_ANON, MAP_FAILED, MAP_FIXED, MAP_PRIVATE, PROT_NONE, PROT_READ, PROT_WRITE};
 
+    use crate::io;
     use crate::ops::Range;
     use crate::sync::atomic::{AtomicUsize, Ordering};
     use crate::sys::os;
@@ -361,12 +362,12 @@ pub mod guard {
                 0,
             );
             if result != stackaddr || result == MAP_FAILED {
-                panic!("failed to allocate a guard page");
+                panic!("failed to allocate a guard page: {}", io::Error::last_os_error());
             }
 
             let result = mprotect(stackaddr, page_size, PROT_NONE);
             if result != 0 {
-                panic!("failed to protect the guard page");
+                panic!("failed to protect the guard page: {}", io::Error::last_os_error());
             }
 
             let guardaddr = stackaddr as usize;


### PR DESCRIPTION
Fixes #82388