### PR TITLE
rustdoc: use more precise relative URLs

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2284,13 +2284,6 @@ impl Clean<Item> for (&hir::MacroDef<'_>, Option<Symbol>) {
             let vis = item.vis.clean(cx);
             let def_id = item.def_id.to_def_id();
 
-            // Since this occurs in `clean()`, there are no cache entries for vis.print_with_space,
-            // so no links can be made.
-            //
-            // It's important that we maintain this invariant, because this is supposed to generate
-            // source code, not HTML.
-            assert!(cx.cache.paths.is_empty());
-
             if matchers.len() <= 1 {
                 format!(
                     "{}macro {}{} {{\n    ...\n}}",

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2284,6 +2284,13 @@ impl Clean<Item> for (&hir::MacroDef<'_>, Option<Symbol>) {
             let vis = item.vis.clean(cx);
             let def_id = item.def_id.to_def_id();
 
+            // Since this occurs in `clean()`, there are no cache entries for vis.print_with_space,
+            // so no links can be made.
+            //
+            // It's important that we maintain this invariant, because this is supposed to generate
+            // source code, not HTML.
+            assert!(cx.cache.paths.is_empty());
+
             if matchers.len() <= 1 {
                 format!(
                     "{}macro {}{} {{\n    ...\n}}",

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -125,8 +125,8 @@ fn comma_sep<T: fmt::Display>(items: impl Iterator<Item = T>) -> impl fmt::Displ
 }
 
 crate fn print_generic_bounds<'a, 'tcx: 'a>(
-    cx: &'a Context<'tcx>,
     bounds: &'a [clean::GenericBound],
+    cx: &'a Context<'tcx>,
 ) -> impl fmt::Display + 'a + Captures<'tcx> {
     display_fn(move |f| {
         let mut bounds_dup = FxHashSet::default();
@@ -155,9 +155,9 @@ impl clean::GenericParamDef {
 
                 if !bounds.is_empty() {
                     if f.alternate() {
-                        write!(f, ": {:#}", print_generic_bounds(cx, bounds))?;
+                        write!(f, ": {:#}", print_generic_bounds(bounds, cx))?;
                     } else {
-                        write!(f, ":&nbsp;{}", print_generic_bounds(cx, bounds))?;
+                        write!(f, ":&nbsp;{}", print_generic_bounds(bounds, cx))?;
                     }
                 }
 
@@ -239,13 +239,13 @@ crate fn print_where_clause<'a, 'tcx: 'a>(
                         clause.push_str(&format!(
                             "{:#}: {:#}",
                             ty.print(cx),
-                            print_generic_bounds(cx, bounds)
+                            print_generic_bounds(bounds, cx)
                         ));
                     } else {
                         clause.push_str(&format!(
                             "{}: {}",
                             ty.print(cx),
-                            print_generic_bounds(cx, bounds)
+                            print_generic_bounds(bounds, cx)
                         ));
                     }
                 }
@@ -819,9 +819,9 @@ fn fmt_type<'cx>(
         }
         clean::ImplTrait(ref bounds) => {
             if f.alternate() {
-                write!(f, "impl {:#}", print_generic_bounds(cx, bounds))
+                write!(f, "impl {:#}", print_generic_bounds(bounds, cx))
             } else {
-                write!(f, "impl {}", print_generic_bounds(cx, bounds))
+                write!(f, "impl {}", print_generic_bounds(bounds, cx))
             }
         }
         clean::QPath { ref name, ref self_type, ref trait_ } => {
@@ -1013,21 +1013,21 @@ impl clean::FnDecl {
     /// * `asyncness`: Whether the function is async or not.
     crate fn full_print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'tcx>,
         header_len: usize,
         indent: usize,
         asyncness: hir::IsAsync,
+        cx: &'a Context<'tcx>,
     ) -> impl fmt::Display + 'a + Captures<'tcx> {
-        display_fn(move |f| self.inner_full_print(cx, header_len, indent, asyncness, f))
+        display_fn(move |f| self.inner_full_print(header_len, indent, asyncness, f, cx))
     }
 
     fn inner_full_print(
         &self,
-        cx: &Context<'_>,
         header_len: usize,
         indent: usize,
         asyncness: hir::IsAsync,
         f: &mut fmt::Formatter<'_>,
+        cx: &Context<'_>,
     ) -> fmt::Result {
         let amp = if f.alternate() { "&" } else { "&amp;" };
         let mut args = String::new();
@@ -1134,8 +1134,8 @@ impl clean::FnDecl {
 impl clean::Visibility {
     crate fn print_with_space<'a, 'tcx: 'a>(
         self,
-        cx: &'a Context<'tcx>,
         item_did: DefId,
+        cx: &'a Context<'tcx>,
     ) -> impl fmt::Display + 'a + Captures<'tcx> {
         let to_print = match self {
             clean::Public => "pub ".to_owned(),
@@ -1320,9 +1320,9 @@ impl clean::TypeBinding {
                 clean::TypeBindingKind::Constraint { ref bounds } => {
                     if !bounds.is_empty() {
                         if f.alternate() {
-                            write!(f, ": {:#}", print_generic_bounds(cx, bounds))?;
+                            write!(f, ": {:#}", print_generic_bounds(bounds, cx))?;
                         } else {
-                            write!(f, ":&nbsp;{}", print_generic_bounds(cx, bounds))?;
+                            write!(f, ":&nbsp;{}", print_generic_bounds(bounds, cx))?;
                         }
                     }
                 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -124,10 +124,10 @@ fn comma_sep<T: fmt::Display>(items: impl Iterator<Item = T>) -> impl fmt::Displ
     })
 }
 
-crate fn print_generic_bounds<'a, 'cx: 'a>(
-    cx: &'a Context<'cx>,
+crate fn print_generic_bounds<'a, 'tcx: 'a>(
+    cx: &'a Context<'tcx>,
     bounds: &'a [clean::GenericBound],
-) -> impl fmt::Display + 'a + Captures<'cx> {
+) -> impl fmt::Display + 'a + Captures<'tcx> {
     display_fn(move |f| {
         let mut bounds_dup = FxHashSet::default();
 
@@ -144,10 +144,10 @@ crate fn print_generic_bounds<'a, 'cx: 'a>(
 }
 
 impl clean::GenericParamDef {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match self.kind {
             clean::GenericParamDefKind::Lifetime => write!(f, "{}", self.name),
             clean::GenericParamDefKind::Type { ref bounds, ref default, .. } => {
@@ -183,10 +183,10 @@ impl clean::GenericParamDef {
 }
 
 impl clean::Generics {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| {
             let real_params =
                 self.params.iter().filter(|p| !p.is_synthetic_type_param()).collect::<Vec<_>>();
@@ -205,12 +205,12 @@ impl clean::Generics {
 /// * The Generics from which to emit a where-clause.
 /// * The number of spaces to indent each line with.
 /// * Whether the where-clause needs to add a comma and newline after the last bound.
-crate fn print_where_clause<'a, 'cx: 'a>(
+crate fn print_where_clause<'a, 'tcx: 'a>(
     gens: &'a clean::Generics,
-    cx: &'a Context<'cx>,
+    cx: &'a Context<'tcx>,
     indent: usize,
     end_newline: bool,
-) -> impl fmt::Display + 'a + Captures<'cx> {
+) -> impl fmt::Display + 'a + Captures<'tcx> {
     display_fn(move |f| {
         if gens.where_predicates.is_empty() {
             return Ok(());
@@ -314,10 +314,10 @@ impl clean::Constant {
 }
 
 impl clean::PolyTrait {
-    fn print<'a, 'cx: 'a>(
+    fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| {
             if !self.generic_params.is_empty() {
                 if f.alternate() {
@@ -344,10 +344,10 @@ impl clean::PolyTrait {
 }
 
 impl clean::GenericBound {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match self {
             clean::GenericBound::Outlives(lt) => write!(f, "{}", lt.print()),
             clean::GenericBound::TraitBound(ty, modifier) => {
@@ -367,10 +367,10 @@ impl clean::GenericBound {
 }
 
 impl clean::GenericArgs {
-    fn print<'a, 'cx: 'a>(
+    fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| {
             match self {
                 clean::GenericArgs::AngleBracketed { args, bindings } => {
@@ -602,10 +602,10 @@ fn primitive_link(
 }
 
 /// Helper to render type parameters
-fn tybounds<'a, 'cx: 'a>(
+fn tybounds<'a, 'tcx: 'a>(
     param_names: &'a Option<Vec<clean::GenericBound>>,
-    cx: &'a Context<'cx>,
-) -> impl fmt::Display + 'a + Captures<'cx> {
+    cx: &'a Context<'tcx>,
+) -> impl fmt::Display + 'a + Captures<'tcx> {
     display_fn(move |f| match *param_names {
         Some(ref params) => {
             for param in params {
@@ -882,20 +882,20 @@ fn fmt_type<'cx>(
 }
 
 impl clean::Type {
-    crate fn print<'b, 'a: 'b, 'cx: 'a>(
+    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'b + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'b + Captures<'tcx> {
         display_fn(move |f| fmt_type(self, f, false, cx))
     }
 }
 
 impl clean::Impl {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
         use_absolute: bool,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| {
             if f.alternate() {
                 write!(f, "impl{:#} ", self.generics.print(cx))?;
@@ -924,10 +924,10 @@ impl clean::Impl {
 }
 
 impl clean::Arguments {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| {
             for (i, input) in self.values.iter().enumerate() {
                 if !input.name.is_empty() {
@@ -948,10 +948,10 @@ impl clean::Arguments {
 }
 
 impl clean::FnRetTy {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match self {
             clean::Return(clean::Tuple(tys)) if tys.is_empty() => Ok(()),
             clean::Return(ty) if f.alternate() => {
@@ -964,10 +964,10 @@ impl clean::FnRetTy {
 }
 
 impl clean::BareFunctionDecl {
-    fn print_hrtb_with_space<'a, 'cx: 'a>(
+    fn print_hrtb_with_space<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| {
             if !self.generic_params.is_empty() {
                 write!(f, "for<{}> ", comma_sep(self.generic_params.iter().map(|g| g.print(cx))))
@@ -979,10 +979,10 @@ impl clean::BareFunctionDecl {
 }
 
 impl clean::FnDecl {
-    crate fn print<'b, 'a: 'b, 'cx: 'a>(
+    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'b + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'b + Captures<'tcx> {
         display_fn(move |f| {
             let ellipsis = if self.c_variadic { ", ..." } else { "" };
             if f.alternate() {
@@ -1011,13 +1011,13 @@ impl clean::FnDecl {
     /// * `indent`: The number of spaces to indent each successive line with, if line-wrapping is
     ///   necessary.
     /// * `asyncness`: Whether the function is async or not.
-    crate fn full_print<'a, 'cx: 'a>(
+    crate fn full_print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
+        cx: &'a Context<'tcx>,
         header_len: usize,
         indent: usize,
         asyncness: hir::IsAsync,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| self.inner_full_print(cx, header_len, indent, asyncness, f))
     }
 
@@ -1132,11 +1132,11 @@ impl clean::FnDecl {
 }
 
 impl clean::Visibility {
-    crate fn print_with_space<'a, 'cx: 'a>(
+    crate fn print_with_space<'a, 'tcx: 'a>(
         self,
-        cx: &'a Context<'cx>,
+        cx: &'a Context<'tcx>,
         item_did: DefId,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         let to_print = match self {
             clean::Public => "pub ".to_owned(),
             clean::Inherited => String::new(),
@@ -1256,10 +1256,10 @@ impl PrintWithSpace for hir::Mutability {
 }
 
 impl clean::Import {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match self.kind {
             clean::ImportKind::Simple(name) => {
                 if name == self.source.path.last() {
@@ -1280,10 +1280,10 @@ impl clean::Import {
 }
 
 impl clean::ImportSource {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match self.did {
             Some(did) => resolved_path(f, did, &self.path, true, false, cx),
             _ => {
@@ -1303,10 +1303,10 @@ impl clean::ImportSource {
 }
 
 impl clean::TypeBinding {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| {
             f.write_str(&*self.name.as_str())?;
             match self.kind {
@@ -1347,10 +1347,10 @@ crate fn print_default_space<'a>(v: bool) -> &'a str {
 }
 
 impl clean::GenericArg {
-    crate fn print<'a, 'cx: 'a>(
+    crate fn print<'a, 'tcx: 'a>(
         &'a self,
-        cx: &'a Context<'cx>,
-    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        cx: &'a Context<'tcx>,
+    ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match self {
             clean::GenericArg::Lifetime(lt) => fmt::Display::fmt(&lt.print(), f),
             clean::GenericArg::Type(ty) => fmt::Display::fmt(&ty.print(cx), f),

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -20,6 +20,7 @@ use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
 use crate::html::escape::Escape;
 use crate::html::render::cache::ExternalLocation;
+use crate::html::render::Context;
 use crate::html::render::CURRENT_DEPTH;
 
 crate trait Print {
@@ -123,32 +124,30 @@ fn comma_sep<T: fmt::Display>(items: impl Iterator<Item = T>) -> impl fmt::Displ
     })
 }
 
-crate fn print_generic_bounds<'a, 'tcx: 'a>(
+crate fn print_generic_bounds<'a, 'cx: 'a>(
+    cx: &'a Context<'cx>,
     bounds: &'a [clean::GenericBound],
-    cache: &'a Cache,
-    tcx: TyCtxt<'tcx>,
-) -> impl fmt::Display + 'a + Captures<'tcx> {
+) -> impl fmt::Display + 'a + Captures<'cx> {
     display_fn(move |f| {
         let mut bounds_dup = FxHashSet::default();
 
         for (i, bound) in
-            bounds.iter().filter(|b| bounds_dup.insert(b.print(cache, tcx).to_string())).enumerate()
+            bounds.iter().filter(|b| bounds_dup.insert(b.print(cx).to_string())).enumerate()
         {
             if i > 0 {
                 f.write_str(" + ")?;
             }
-            fmt::Display::fmt(&bound.print(cache, tcx), f)?;
+            fmt::Display::fmt(&bound.print(cx), f)?;
         }
         Ok(())
     })
 }
 
 impl clean::GenericParamDef {
-    crate fn print<'a, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| match self.kind {
             clean::GenericParamDefKind::Lifetime => write!(f, "{}", self.name),
             clean::GenericParamDefKind::Type { ref bounds, ref default, .. } => {
@@ -156,17 +155,17 @@ impl clean::GenericParamDef {
 
                 if !bounds.is_empty() {
                     if f.alternate() {
-                        write!(f, ": {:#}", print_generic_bounds(bounds, cache, tcx))?;
+                        write!(f, ": {:#}", print_generic_bounds(cx, bounds))?;
                     } else {
-                        write!(f, ":&nbsp;{}", print_generic_bounds(bounds, cache, tcx))?;
+                        write!(f, ":&nbsp;{}", print_generic_bounds(cx, bounds))?;
                     }
                 }
 
                 if let Some(ref ty) = default {
                     if f.alternate() {
-                        write!(f, " = {:#}", ty.print(cache, tcx))?;
+                        write!(f, " = {:#}", ty.print(cx))?;
                     } else {
-                        write!(f, "&nbsp;=&nbsp;{}", ty.print(cache, tcx))?;
+                        write!(f, "&nbsp;=&nbsp;{}", ty.print(cx))?;
                     }
                 }
 
@@ -174,9 +173,9 @@ impl clean::GenericParamDef {
             }
             clean::GenericParamDefKind::Const { ref ty, .. } => {
                 if f.alternate() {
-                    write!(f, "const {}: {:#}", self.name, ty.print(cache, tcx))
+                    write!(f, "const {}: {:#}", self.name, ty.print(cx))
                 } else {
-                    write!(f, "const {}:&nbsp;{}", self.name, ty.print(cache, tcx))
+                    write!(f, "const {}:&nbsp;{}", self.name, ty.print(cx))
                 }
             }
         })
@@ -184,11 +183,10 @@ impl clean::GenericParamDef {
 }
 
 impl clean::Generics {
-    crate fn print<'a, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| {
             let real_params =
                 self.params.iter().filter(|p| !p.is_synthetic_type_param()).collect::<Vec<_>>();
@@ -196,9 +194,9 @@ impl clean::Generics {
                 return Ok(());
             }
             if f.alternate() {
-                write!(f, "<{:#}>", comma_sep(real_params.iter().map(|g| g.print(cache, tcx))))
+                write!(f, "<{:#}>", comma_sep(real_params.iter().map(|g| g.print(cx))))
             } else {
-                write!(f, "&lt;{}&gt;", comma_sep(real_params.iter().map(|g| g.print(cache, tcx))))
+                write!(f, "&lt;{}&gt;", comma_sep(real_params.iter().map(|g| g.print(cx))))
             }
         })
     }
@@ -207,13 +205,12 @@ impl clean::Generics {
 /// * The Generics from which to emit a where-clause.
 /// * The number of spaces to indent each line with.
 /// * Whether the where-clause needs to add a comma and newline after the last bound.
-crate fn print_where_clause<'a, 'tcx: 'a>(
+crate fn print_where_clause<'a, 'cx: 'a>(
     gens: &'a clean::Generics,
-    cache: &'a Cache,
-    tcx: TyCtxt<'tcx>,
+    cx: &'a Context<'cx>,
     indent: usize,
     end_newline: bool,
-) -> impl fmt::Display + 'a + Captures<'tcx> {
+) -> impl fmt::Display + 'a + Captures<'cx> {
     display_fn(move |f| {
         if gens.where_predicates.is_empty() {
             return Ok(());
@@ -241,14 +238,14 @@ crate fn print_where_clause<'a, 'tcx: 'a>(
                     if f.alternate() {
                         clause.push_str(&format!(
                             "{:#}: {:#}",
-                            ty.print(cache, tcx),
-                            print_generic_bounds(bounds, cache, tcx)
+                            ty.print(cx),
+                            print_generic_bounds(cx, bounds)
                         ));
                     } else {
                         clause.push_str(&format!(
                             "{}: {}",
-                            ty.print(cache, tcx),
-                            print_generic_bounds(bounds, cache, tcx)
+                            ty.print(cx),
+                            print_generic_bounds(cx, bounds)
                         ));
                     }
                 }
@@ -258,24 +255,16 @@ crate fn print_where_clause<'a, 'tcx: 'a>(
                         lifetime.print(),
                         bounds
                             .iter()
-                            .map(|b| b.print(cache, tcx).to_string())
+                            .map(|b| b.print(cx).to_string())
                             .collect::<Vec<_>>()
                             .join(" + ")
                     ));
                 }
                 clean::WherePredicate::EqPredicate { lhs, rhs } => {
                     if f.alternate() {
-                        clause.push_str(&format!(
-                            "{:#} == {:#}",
-                            lhs.print(cache, tcx),
-                            rhs.print(cache, tcx),
-                        ));
+                        clause.push_str(&format!("{:#} == {:#}", lhs.print(cx), rhs.print(cx),));
                     } else {
-                        clause.push_str(&format!(
-                            "{} == {}",
-                            lhs.print(cache, tcx),
-                            rhs.print(cache, tcx),
-                        ));
+                        clause.push_str(&format!("{} == {}", lhs.print(cx), rhs.print(cx),));
                     }
                 }
             }
@@ -325,42 +314,40 @@ impl clean::Constant {
 }
 
 impl clean::PolyTrait {
-    fn print<'a, 'tcx: 'a>(
+    fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| {
             if !self.generic_params.is_empty() {
                 if f.alternate() {
                     write!(
                         f,
                         "for<{:#}> ",
-                        comma_sep(self.generic_params.iter().map(|g| g.print(cache, tcx)))
+                        comma_sep(self.generic_params.iter().map(|g| g.print(cx)))
                     )?;
                 } else {
                     write!(
                         f,
                         "for&lt;{}&gt; ",
-                        comma_sep(self.generic_params.iter().map(|g| g.print(cache, tcx)))
+                        comma_sep(self.generic_params.iter().map(|g| g.print(cx)))
                     )?;
                 }
             }
             if f.alternate() {
-                write!(f, "{:#}", self.trait_.print(cache, tcx))
+                write!(f, "{:#}", self.trait_.print(cx))
             } else {
-                write!(f, "{}", self.trait_.print(cache, tcx))
+                write!(f, "{}", self.trait_.print(cx))
             }
         })
     }
 }
 
 impl clean::GenericBound {
-    crate fn print<'a, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| match self {
             clean::GenericBound::Outlives(lt) => write!(f, "{}", lt.print()),
             clean::GenericBound::TraitBound(ty, modifier) => {
@@ -370,9 +357,9 @@ impl clean::GenericBound {
                     hir::TraitBoundModifier::MaybeConst => "?const",
                 };
                 if f.alternate() {
-                    write!(f, "{}{:#}", modifier_str, ty.print(cache, tcx))
+                    write!(f, "{}{:#}", modifier_str, ty.print(cx))
                 } else {
-                    write!(f, "{}{}", modifier_str, ty.print(cache, tcx))
+                    write!(f, "{}{}", modifier_str, ty.print(cx))
                 }
             }
         })
@@ -380,11 +367,10 @@ impl clean::GenericBound {
 }
 
 impl clean::GenericArgs {
-    fn print<'a, 'tcx: 'a>(
+    fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| {
             match self {
                 clean::GenericArgs::AngleBracketed { args, bindings } => {
@@ -401,9 +387,9 @@ impl clean::GenericArgs {
                             }
                             comma = true;
                             if f.alternate() {
-                                write!(f, "{:#}", arg.print(cache, tcx))?;
+                                write!(f, "{:#}", arg.print(cx))?;
                             } else {
-                                write!(f, "{}", arg.print(cache, tcx))?;
+                                write!(f, "{}", arg.print(cx))?;
                             }
                         }
                         for binding in bindings {
@@ -412,9 +398,9 @@ impl clean::GenericArgs {
                             }
                             comma = true;
                             if f.alternate() {
-                                write!(f, "{:#}", binding.print(cache, tcx))?;
+                                write!(f, "{:#}", binding.print(cx))?;
                             } else {
-                                write!(f, "{}", binding.print(cache, tcx))?;
+                                write!(f, "{}", binding.print(cx))?;
                             }
                         }
                         if f.alternate() {
@@ -433,17 +419,17 @@ impl clean::GenericArgs {
                         }
                         comma = true;
                         if f.alternate() {
-                            write!(f, "{:#}", ty.print(cache, tcx))?;
+                            write!(f, "{:#}", ty.print(cx))?;
                         } else {
-                            write!(f, "{}", ty.print(cache, tcx))?;
+                            write!(f, "{}", ty.print(cx))?;
                         }
                     }
                     f.write_str(")")?;
                     if let Some(ref ty) = *output {
                         if f.alternate() {
-                            write!(f, " -> {:#}", ty.print(cache, tcx))?;
+                            write!(f, " -> {:#}", ty.print(cx))?;
                         } else {
-                            write!(f, " -&gt; {}", ty.print(cache, tcx))?;
+                            write!(f, " -&gt; {}", ty.print(cx))?;
                         }
                     }
                 }
@@ -453,56 +439,89 @@ impl clean::GenericArgs {
     }
 }
 
-crate fn href(did: DefId, cache: &Cache) -> Option<(String, ItemType, Vec<String>)> {
+crate fn href(did: DefId, cx: &Context<'_>) -> Option<(String, ItemType, Vec<String>)> {
+    let cache = &cx.cache();
+    let relative_to = &cx.current;
+    fn to_module_fqp(shortty: ItemType, fqp: &[String]) -> &[String] {
+        if shortty == ItemType::Module { &fqp[..] } else { &fqp[..fqp.len() - 1] }
+    }
+
     if !did.is_local() && !cache.access_levels.is_public(did) && !cache.document_private {
         return None;
     }
 
-    let depth = CURRENT_DEPTH.with(|l| l.get());
-    let (fqp, shortty, mut url) = match cache.paths.get(&did) {
-        Some(&(ref fqp, shortty)) => (fqp, shortty, "../".repeat(depth)),
+    let (fqp, shortty, mut url_parts) = match cache.paths.get(&did) {
+        Some(&(ref fqp, shortty)) => (fqp, shortty, {
+            let module_fqp = to_module_fqp(shortty, fqp);
+            href_relative_parts(module_fqp, relative_to)
+        }),
         None => {
             let &(ref fqp, shortty) = cache.external_paths.get(&did)?;
+            let module_fqp = to_module_fqp(shortty, fqp);
             (
                 fqp,
                 shortty,
                 match cache.extern_locations[&did.krate] {
-                    (.., ExternalLocation::Remote(ref s)) => s.to_string(),
-                    (.., ExternalLocation::Local) => "../".repeat(depth),
+                    (.., ExternalLocation::Remote(ref s)) => {
+                        let s = s.trim_end_matches('/');
+                        let mut s = vec![&s[..]];
+                        s.extend(module_fqp[..].iter().map(String::as_str));
+                        s
+                    }
+                    (.., ExternalLocation::Local) => href_relative_parts(module_fqp, relative_to),
                     (.., ExternalLocation::Unknown) => return None,
                 },
             )
         }
     };
-    for component in &fqp[..fqp.len() - 1] {
-        url.push_str(component);
-        url.push('/');
-    }
+    let last = &fqp.last().unwrap()[..];
+    let filename;
     match shortty {
         ItemType::Module => {
-            url.push_str(fqp.last().unwrap());
-            url.push_str("/index.html");
+            url_parts.push("index.html");
         }
         _ => {
-            url.push_str(shortty.as_str());
-            url.push('.');
-            url.push_str(fqp.last().unwrap());
-            url.push_str(".html");
+            filename = format!("{}.{}.html", shortty.as_str(), last);
+            url_parts.push(&filename);
         }
     }
-    Some((url, shortty, fqp.to_vec()))
+    Some((url_parts.join("/"), shortty, fqp.to_vec()))
+}
+
+/// Both paths should only be modules.
+/// This is because modules get their own directories; that is, `std::vec` and `std::vec::Vec` will
+/// both need `../iter/trait.Iterator.html` to get at the iterator trait.
+crate fn href_relative_parts<'a>(fqp: &'a [String], relative_to_fqp: &'a [String]) -> Vec<&'a str> {
+    for (i, (f, r)) in fqp.iter().zip(relative_to_fqp.iter()).enumerate() {
+        // e.g. linking to std::iter from std::vec (`dissimilar_part_count` will be 1)
+        if f != r {
+            let dissimilar_part_count = relative_to_fqp.len() - i;
+            let fqp_module = fqp[i..fqp.len()].iter().map(String::as_str);
+            return std::iter::repeat("..").take(dissimilar_part_count).chain(fqp_module).collect();
+        }
+    }
+    // e.g. linking to std::sync::atomic from std::sync
+    if relative_to_fqp.len() < fqp.len() {
+        fqp[relative_to_fqp.len()..fqp.len()].iter().map(String::as_str).collect()
+    // e.g. linking to std::sync from std::sync::atomic
+    } else if fqp.len() < relative_to_fqp.len() {
+        let dissimilar_part_count = relative_to_fqp.len() - fqp.len();
+        std::iter::repeat("..").take(dissimilar_part_count).collect()
+    // linking to the same module
+    } else {
+        Vec::new()
+    }
 }
 
 /// Used when rendering a `ResolvedPath` structure. This invokes the `path`
 /// rendering function with the necessary arguments for linking to a local path.
-fn resolved_path<'a, 'tcx: 'a>(
+fn resolved_path<'a, 'cx: 'a>(
     w: &mut fmt::Formatter<'_>,
     did: DefId,
     path: &clean::Path,
     print_all: bool,
     use_absolute: bool,
-    cache: &Cache,
-    tcx: TyCtxt<'tcx>,
+    cx: &'cx Context<'_>,
 ) -> fmt::Result {
     let last = path.segments.last().unwrap();
 
@@ -512,22 +531,22 @@ fn resolved_path<'a, 'tcx: 'a>(
         }
     }
     if w.alternate() {
-        write!(w, "{}{:#}", &last.name, last.args.print(cache, tcx))?;
+        write!(w, "{}{:#}", &last.name, last.args.print(cx))?;
     } else {
         let path = if use_absolute {
-            if let Some((_, _, fqp)) = href(did, cache) {
+            if let Some((_, _, fqp)) = href(did, cx) {
                 format!(
                     "{}::{}",
                     fqp[..fqp.len() - 1].join("::"),
-                    anchor(did, fqp.last().unwrap(), cache)
+                    anchor(did, fqp.last().unwrap(), cx)
                 )
             } else {
                 last.name.to_string()
             }
         } else {
-            anchor(did, &*last.name.as_str(), cache).to_string()
+            anchor(did, &*last.name.as_str(), cx).to_string()
         };
-        write!(w, "{}{}", path, last.args.print(cache, tcx))?;
+        write!(w, "{}{}", path, last.args.print(cx))?;
     }
     Ok(())
 }
@@ -583,16 +602,15 @@ fn primitive_link(
 }
 
 /// Helper to render type parameters
-fn tybounds<'a, 'tcx: 'a>(
+fn tybounds<'a, 'cx: 'a>(
     param_names: &'a Option<Vec<clean::GenericBound>>,
-    cache: &'a Cache,
-    tcx: TyCtxt<'tcx>,
-) -> impl fmt::Display + 'a + Captures<'tcx> {
+    cx: &'a Context<'cx>,
+) -> impl fmt::Display + 'a + Captures<'cx> {
     display_fn(move |f| match *param_names {
         Some(ref params) => {
             for param in params {
                 write!(f, " + ")?;
-                fmt::Display::fmt(&param.print(cache, tcx), f)?;
+                fmt::Display::fmt(&param.print(cx), f)?;
             }
             Ok(())
         }
@@ -600,9 +618,14 @@ fn tybounds<'a, 'tcx: 'a>(
     })
 }
 
-crate fn anchor<'a>(did: DefId, text: &'a str, cache: &'a Cache) -> impl fmt::Display + 'a {
+crate fn anchor<'a, 'cx: 'a>(
+    did: DefId,
+    text: &'a str,
+    cx: &'cx Context<'_>,
+) -> impl fmt::Display + 'a {
+    let parts = href(did, cx);
     display_fn(move |f| {
-        if let Some((url, short_ty, fqp)) = href(did, cache) {
+        if let Some((url, short_ty, fqp)) = parts {
             write!(
                 f,
                 r#"<a class="{}" href="{}" title="{} {}">{}</a>"#,
@@ -618,12 +641,11 @@ crate fn anchor<'a>(did: DefId, text: &'a str, cache: &'a Cache) -> impl fmt::Di
     })
 }
 
-fn fmt_type(
+fn fmt_type<'cx>(
     t: &clean::Type,
     f: &mut fmt::Formatter<'_>,
     use_absolute: bool,
-    cache: &Cache,
-    tcx: TyCtxt<'_>,
+    cx: &'cx Context<'_>,
 ) -> fmt::Result {
     debug!("fmt_type(t = {:?})", t);
 
@@ -634,69 +656,69 @@ fn fmt_type(
                 f.write_str("dyn ")?;
             }
             // Paths like `T::Output` and `Self::Output` should be rendered with all segments.
-            resolved_path(f, did, path, is_generic, use_absolute, cache, tcx)?;
-            fmt::Display::fmt(&tybounds(param_names, cache, tcx), f)
+            resolved_path(f, did, path, is_generic, use_absolute, cx)?;
+            fmt::Display::fmt(&tybounds(param_names, cx), f)
         }
         clean::Infer => write!(f, "_"),
-        clean::Primitive(prim) => primitive_link(f, prim, prim.as_str(), cache),
+        clean::Primitive(prim) => primitive_link(f, prim, prim.as_str(), &cx.cache()),
         clean::BareFunction(ref decl) => {
             if f.alternate() {
                 write!(
                     f,
                     "{:#}{}{:#}fn{:#}",
-                    decl.print_hrtb_with_space(cache, tcx),
+                    decl.print_hrtb_with_space(cx),
                     decl.unsafety.print_with_space(),
                     print_abi_with_space(decl.abi),
-                    decl.decl.print(cache, tcx),
+                    decl.decl.print(cx),
                 )
             } else {
                 write!(
                     f,
                     "{}{}{}",
-                    decl.print_hrtb_with_space(cache, tcx),
+                    decl.print_hrtb_with_space(cx),
                     decl.unsafety.print_with_space(),
                     print_abi_with_space(decl.abi)
                 )?;
-                primitive_link(f, PrimitiveType::Fn, "fn", cache)?;
-                write!(f, "{}", decl.decl.print(cache, tcx))
+                primitive_link(f, PrimitiveType::Fn, "fn", &cx.cache())?;
+                write!(f, "{}", decl.decl.print(cx))
             }
         }
         clean::Tuple(ref typs) => {
             match &typs[..] {
-                &[] => primitive_link(f, PrimitiveType::Unit, "()", cache),
+                &[] => primitive_link(f, PrimitiveType::Unit, "()", &cx.cache()),
                 &[ref one] => {
-                    primitive_link(f, PrimitiveType::Tuple, "(", cache)?;
+                    primitive_link(f, PrimitiveType::Tuple, "(", &cx.cache())?;
                     // Carry `f.alternate()` into this display w/o branching manually.
-                    fmt::Display::fmt(&one.print(cache, tcx), f)?;
-                    primitive_link(f, PrimitiveType::Tuple, ",)", cache)
+                    fmt::Display::fmt(&one.print(cx), f)?;
+                    primitive_link(f, PrimitiveType::Tuple, ",)", &cx.cache())
                 }
                 many => {
-                    primitive_link(f, PrimitiveType::Tuple, "(", cache)?;
+                    primitive_link(f, PrimitiveType::Tuple, "(", &cx.cache())?;
                     for (i, item) in many.iter().enumerate() {
                         if i != 0 {
                             write!(f, ", ")?;
                         }
-                        fmt::Display::fmt(&item.print(cache, tcx), f)?;
+                        fmt::Display::fmt(&item.print(cx), f)?;
                     }
-                    primitive_link(f, PrimitiveType::Tuple, ")", cache)
+                    primitive_link(f, PrimitiveType::Tuple, ")", &cx.cache())
                 }
             }
         }
         clean::Slice(ref t) => {
-            primitive_link(f, PrimitiveType::Slice, "[", cache)?;
-            fmt::Display::fmt(&t.print(cache, tcx), f)?;
-            primitive_link(f, PrimitiveType::Slice, "]", cache)
+            primitive_link(f, PrimitiveType::Slice, "[", &cx.cache())?;
+            fmt::Display::fmt(&t.print(cx), f)?;
+            primitive_link(f, PrimitiveType::Slice, "]", &cx.cache())
         }
         clean::Array(ref t, ref n) => {
-            primitive_link(f, PrimitiveType::Array, "[", cache)?;
-            fmt::Display::fmt(&t.print(cache, tcx), f)?;
+            primitive_link(f, PrimitiveType::Array, "[", &cx.cache())?;
+            fmt::Display::fmt(&t.print(cx), f)?;
             if f.alternate() {
-                primitive_link(f, PrimitiveType::Array, &format!("; {}]", n), cache)
+                primitive_link(f, PrimitiveType::Array, &format!("; {}]", n), &cx.cache())
             } else {
-                primitive_link(f, PrimitiveType::Array, &format!("; {}]", Escape(n)), cache)
+                primitive_link(f, PrimitiveType::Array, &format!("; {}]", Escape(n)), &cx.cache())
             }
         }
-        clean::Never => primitive_link(f, PrimitiveType::Never, "!", cache),
+        clean::Never => primitive_link(f, PrimitiveType::Never, "!", &cx.cache()),
         clean::RawPointer(m, ref t) => {
             let m = match m {
                 hir::Mutability::Mut => "mut",
@@ -708,15 +730,15 @@ fn fmt_type(
                         primitive_link(
                             f,
                             clean::PrimitiveType::RawPointer,
-                            &format!("*{} {:#}", m, t.print(cache, tcx)),
-                            cache,
+                            &format!("*{} {:#}", m, t.print(cx)),
+                            &cx.cache(),
                         )
                     } else {
                         primitive_link(
                             f,
                             clean::PrimitiveType::RawPointer,
-                            &format!("*{} {}", m, t.print(cache, tcx)),
-                            cache,
+                            &format!("*{} {}", m, t.print(cx)),
+                            &cx.cache(),
                         )
                     }
                 }
@@ -725,9 +747,9 @@ fn fmt_type(
                         f,
                         clean::PrimitiveType::RawPointer,
                         &format!("*{} ", m),
-                        cache,
+                        &cx.cache(),
                     )?;
-                    fmt::Display::fmt(&t.print(cache, tcx), f)
+                    fmt::Display::fmt(&t.print(cx), f)
                 }
             }
         }
@@ -747,15 +769,15 @@ fn fmt_type(
                                 primitive_link(
                                     f,
                                     PrimitiveType::Slice,
-                                    &format!("{}{}{}[{:#}]", amp, lt, m, bt.print(cache, tcx)),
-                                    cache,
+                                    &format!("{}{}{}[{:#}]", amp, lt, m, bt.print(cx)),
+                                    &cx.cache(),
                                 )
                             } else {
                                 primitive_link(
                                     f,
                                     PrimitiveType::Slice,
-                                    &format!("{}{}{}[{}]", amp, lt, m, bt.print(cache, tcx)),
-                                    cache,
+                                    &format!("{}{}{}[{}]", amp, lt, m, bt.print(cx)),
+                                    &cx.cache(),
                                 )
                             }
                         }
@@ -764,20 +786,20 @@ fn fmt_type(
                                 f,
                                 PrimitiveType::Slice,
                                 &format!("{}{}{}[", amp, lt, m),
-                                cache,
+                                &cx.cache(),
                             )?;
                             if f.alternate() {
-                                write!(f, "{:#}", bt.print(cache, tcx))?;
+                                write!(f, "{:#}", bt.print(cx))?;
                             } else {
-                                write!(f, "{}", bt.print(cache, tcx))?;
+                                write!(f, "{}", bt.print(cx))?;
                             }
-                            primitive_link(f, PrimitiveType::Slice, "]", cache)
+                            primitive_link(f, PrimitiveType::Slice, "]", &cx.cache())
                         }
                     }
                 }
                 clean::ResolvedPath { param_names: Some(ref v), .. } if !v.is_empty() => {
                     write!(f, "{}{}{}(", amp, lt, m)?;
-                    fmt_type(&ty, f, use_absolute, cache, tcx)?;
+                    fmt_type(&ty, f, use_absolute, cx)?;
                     write!(f, ")")
                 }
                 clean::Generic(..) => {
@@ -785,21 +807,21 @@ fn fmt_type(
                         f,
                         PrimitiveType::Reference,
                         &format!("{}{}{}", amp, lt, m),
-                        cache,
+                        &cx.cache(),
                     )?;
-                    fmt_type(&ty, f, use_absolute, cache, tcx)
+                    fmt_type(&ty, f, use_absolute, cx)
                 }
                 _ => {
                     write!(f, "{}{}{}", amp, lt, m)?;
-                    fmt_type(&ty, f, use_absolute, cache, tcx)
+                    fmt_type(&ty, f, use_absolute, cx)
                 }
             }
         }
         clean::ImplTrait(ref bounds) => {
             if f.alternate() {
-                write!(f, "impl {:#}", print_generic_bounds(bounds, cache, tcx))
+                write!(f, "impl {:#}", print_generic_bounds(cx, bounds))
             } else {
-                write!(f, "impl {}", print_generic_bounds(bounds, cache, tcx))
+                write!(f, "impl {}", print_generic_bounds(cx, bounds))
             }
         }
         clean::QPath { ref name, ref self_type, ref trait_ } => {
@@ -811,25 +833,15 @@ fn fmt_type(
             };
             if f.alternate() {
                 if should_show_cast {
-                    write!(
-                        f,
-                        "<{:#} as {:#}>::",
-                        self_type.print(cache, tcx),
-                        trait_.print(cache, tcx)
-                    )?
+                    write!(f, "<{:#} as {:#}>::", self_type.print(cx), trait_.print(cx))?
                 } else {
-                    write!(f, "{:#}::", self_type.print(cache, tcx))?
+                    write!(f, "{:#}::", self_type.print(cx))?
                 }
             } else {
                 if should_show_cast {
-                    write!(
-                        f,
-                        "&lt;{} as {}&gt;::",
-                        self_type.print(cache, tcx),
-                        trait_.print(cache, tcx)
-                    )?
+                    write!(f, "&lt;{} as {}&gt;::", self_type.print(cx), trait_.print(cx))?
                 } else {
-                    write!(f, "{}::", self_type.print(cache, tcx))?
+                    write!(f, "{}::", self_type.print(cx))?
                 }
             };
             match *trait_ {
@@ -844,7 +856,7 @@ fn fmt_type(
                 //        everything comes in as a fully resolved QPath (hard to
                 //        look at).
                 box clean::ResolvedPath { did, ref param_names, .. } => {
-                    match href(did, cache) {
+                    match href(did, cx) {
                         Some((ref url, _, ref path)) if !f.alternate() => {
                             write!(
                                 f,
@@ -870,64 +882,61 @@ fn fmt_type(
 }
 
 impl clean::Type {
-    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
+    crate fn print<'b, 'a: 'b, 'cx: 'a>(
         &'a self,
-        cache: &'b Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'b + Captures<'tcx> {
-        display_fn(move |f| fmt_type(self, f, false, cache, tcx))
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'b + Captures<'cx> {
+        display_fn(move |f| fmt_type(self, f, false, cx))
     }
 }
 
 impl clean::Impl {
-    crate fn print<'a, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
         use_absolute: bool,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| {
             if f.alternate() {
-                write!(f, "impl{:#} ", self.generics.print(cache, tcx))?;
+                write!(f, "impl{:#} ", self.generics.print(cx))?;
             } else {
-                write!(f, "impl{} ", self.generics.print(cache, tcx))?;
+                write!(f, "impl{} ", self.generics.print(cx))?;
             }
 
             if let Some(ref ty) = self.trait_ {
                 if self.negative_polarity {
                     write!(f, "!")?;
                 }
-                fmt::Display::fmt(&ty.print(cache, tcx), f)?;
+                fmt::Display::fmt(&ty.print(cx), f)?;
                 write!(f, " for ")?;
             }
 
             if let Some(ref ty) = self.blanket_impl {
-                fmt_type(ty, f, use_absolute, cache, tcx)?;
+                fmt_type(ty, f, use_absolute, cx)?;
             } else {
-                fmt_type(&self.for_, f, use_absolute, cache, tcx)?;
+                fmt_type(&self.for_, f, use_absolute, cx)?;
             }
 
-            fmt::Display::fmt(&print_where_clause(&self.generics, cache, tcx, 0, true), f)?;
+            fmt::Display::fmt(&print_where_clause(&self.generics, cx, 0, true), f)?;
             Ok(())
         })
     }
 }
 
 impl clean::Arguments {
-    crate fn print<'a, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| {
             for (i, input) in self.values.iter().enumerate() {
                 if !input.name.is_empty() {
                     write!(f, "{}: ", input.name)?;
                 }
                 if f.alternate() {
-                    write!(f, "{:#}", input.type_.print(cache, tcx))?;
+                    write!(f, "{:#}", input.type_.print(cx))?;
                 } else {
-                    write!(f, "{}", input.type_.print(cache, tcx))?;
+                    write!(f, "{}", input.type_.print(cx))?;
                 }
                 if i + 1 < self.values.len() {
                     write!(f, ", ")?;
@@ -939,33 +948,29 @@ impl clean::Arguments {
 }
 
 impl clean::FnRetTy {
-    crate fn print<'a, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| match self {
             clean::Return(clean::Tuple(tys)) if tys.is_empty() => Ok(()),
-            clean::Return(ty) if f.alternate() => write!(f, " -> {:#}", ty.print(cache, tcx)),
-            clean::Return(ty) => write!(f, " -&gt; {}", ty.print(cache, tcx)),
+            clean::Return(ty) if f.alternate() => {
+                write!(f, " -> {:#}", ty.print(cx))
+            }
+            clean::Return(ty) => write!(f, " -&gt; {}", ty.print(cx)),
             clean::DefaultReturn => Ok(()),
         })
     }
 }
 
 impl clean::BareFunctionDecl {
-    fn print_hrtb_with_space<'a, 'tcx: 'a>(
+    fn print_hrtb_with_space<'a, 'cx: 'a>(
         &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| {
             if !self.generic_params.is_empty() {
-                write!(
-                    f,
-                    "for<{}> ",
-                    comma_sep(self.generic_params.iter().map(|g| g.print(cache, tcx)))
-                )
+                write!(f, "for<{}> ", comma_sep(self.generic_params.iter().map(|g| g.print(cx))))
             } else {
                 Ok(())
             }
@@ -974,28 +979,27 @@ impl clean::BareFunctionDecl {
 }
 
 impl clean::FnDecl {
-    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
+    crate fn print<'b, 'a: 'b, 'cx: 'a>(
         &'a self,
-        cache: &'b Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'b + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'b + Captures<'cx> {
         display_fn(move |f| {
             let ellipsis = if self.c_variadic { ", ..." } else { "" };
             if f.alternate() {
                 write!(
                     f,
                     "({args:#}{ellipsis}){arrow:#}",
-                    args = self.inputs.print(cache, tcx),
+                    args = self.inputs.print(cx),
                     ellipsis = ellipsis,
-                    arrow = self.output.print(cache, tcx)
+                    arrow = self.output.print(cx)
                 )
             } else {
                 write!(
                     f,
                     "({args}{ellipsis}){arrow}",
-                    args = self.inputs.print(cache, tcx),
+                    args = self.inputs.print(cx),
                     ellipsis = ellipsis,
-                    arrow = self.output.print(cache, tcx)
+                    arrow = self.output.print(cx)
                 )
             }
         })
@@ -1007,21 +1011,19 @@ impl clean::FnDecl {
     /// * `indent`: The number of spaces to indent each successive line with, if line-wrapping is
     ///   necessary.
     /// * `asyncness`: Whether the function is async or not.
-    crate fn full_print<'b, 'a: 'b, 'tcx: 'a>(
+    crate fn full_print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'b Cache,
-        tcx: TyCtxt<'tcx>,
+        cx: &'a Context<'cx>,
         header_len: usize,
         indent: usize,
         asyncness: hir::IsAsync,
-    ) -> impl fmt::Display + 'b + Captures<'tcx> {
-        display_fn(move |f| self.inner_full_print(cache, tcx, header_len, indent, asyncness, f))
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
+        display_fn(move |f| self.inner_full_print(cx, header_len, indent, asyncness, f))
     }
 
     fn inner_full_print(
         &self,
-        cache: &Cache,
-        tcx: TyCtxt<'_>,
+        cx: &Context<'_>,
         header_len: usize,
         indent: usize,
         asyncness: hir::IsAsync,
@@ -1060,11 +1062,11 @@ impl clean::FnDecl {
                     }
                     clean::SelfExplicit(ref typ) => {
                         if f.alternate() {
-                            args.push_str(&format!("self: {:#}", typ.print(cache, tcx)));
+                            args.push_str(&format!("self: {:#}", typ.print(cx)));
                         } else {
-                            args.push_str(&format!("self: {}", typ.print(cache, tcx)));
+                            args.push_str(&format!("self: {}", typ.print(cx)));
                         }
-                        args_plain.push_str(&format!("self: {:#}", typ.print(cache, tcx)));
+                        args_plain.push_str(&format!("self: {:#}", typ.print(cx)));
                     }
                 }
             } else {
@@ -1078,11 +1080,11 @@ impl clean::FnDecl {
                 }
 
                 if f.alternate() {
-                    args.push_str(&format!("{:#}", input.type_.print(cache, tcx)));
+                    args.push_str(&format!("{:#}", input.type_.print(cx)));
                 } else {
-                    args.push_str(&input.type_.print(cache, tcx).to_string());
+                    args.push_str(&input.type_.print(cx).to_string());
                 }
-                args_plain.push_str(&format!("{:#}", input.type_.print(cache, tcx)));
+                args_plain.push_str(&format!("{:#}", input.type_.print(cx)));
             }
             if i + 1 < self.inputs.values.len() {
                 args.push(',');
@@ -1100,19 +1102,11 @@ impl clean::FnDecl {
         let arrow_plain;
         let arrow = if let hir::IsAsync::Async = asyncness {
             let output = self.sugared_async_return_type();
-            arrow_plain = format!("{:#}", output.print(cache, tcx));
-            if f.alternate() {
-                arrow_plain.clone()
-            } else {
-                format!("{}", output.print(cache, tcx))
-            }
+            arrow_plain = format!("{:#}", output.print(cx));
+            if f.alternate() { arrow_plain.clone() } else { format!("{}", output.print(cx)) }
         } else {
-            arrow_plain = format!("{:#}", self.output.print(cache, tcx));
-            if f.alternate() {
-                arrow_plain.clone()
-            } else {
-                format!("{}", self.output.print(cache, tcx))
-            }
+            arrow_plain = format!("{:#}", self.output.print(cx));
+            if f.alternate() { arrow_plain.clone() } else { format!("{}", self.output.print(cx)) }
         };
 
         let declaration_len = header_len + args_plain.len() + arrow_plain.len();
@@ -1138,12 +1132,11 @@ impl clean::FnDecl {
 }
 
 impl clean::Visibility {
-    crate fn print_with_space<'a, 'tcx: 'a>(
+    crate fn print_with_space<'a, 'cx: 'a>(
         self,
-        tcx: TyCtxt<'tcx>,
+        cx: &'a Context<'cx>,
         item_did: DefId,
-        cache: &'a Cache,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         let to_print = match self {
             clean::Public => "pub ".to_owned(),
             clean::Inherited => String::new(),
@@ -1151,7 +1144,7 @@ impl clean::Visibility {
                 // FIXME(camelid): This may not work correctly if `item_did` is a module.
                 //                 However, rustdoc currently never displays a module's
                 //                 visibility, so it shouldn't matter.
-                let parent_module = find_nearest_parent_module(tcx, item_did);
+                let parent_module = find_nearest_parent_module(cx.tcx(), item_did);
 
                 if vis_did.index == CRATE_DEF_INDEX {
                     "pub(crate) ".to_owned()
@@ -1160,17 +1153,17 @@ impl clean::Visibility {
                     // is the same as no visibility modifier
                     String::new()
                 } else if parent_module
-                    .map(|parent| find_nearest_parent_module(tcx, parent))
+                    .map(|parent| find_nearest_parent_module(cx.tcx(), parent))
                     .flatten()
                     == Some(vis_did)
                 {
                     "pub(super) ".to_owned()
                 } else {
-                    let path = tcx.def_path(vis_did);
+                    let path = cx.tcx().def_path(vis_did);
                     debug!("path={:?}", path);
                     // modified from `resolved_path()` to work with `DefPathData`
                     let last_name = path.data.last().unwrap().data.get_opt_name().unwrap();
-                    let anchor = anchor(vis_did, &last_name.as_str(), cache).to_string();
+                    let anchor = anchor(vis_did, &last_name.as_str(), cx).to_string();
 
                     let mut s = "pub(in ".to_owned();
                     for seg in &path.data[..path.data.len() - 1] {
@@ -1263,24 +1256,23 @@ impl PrintWithSpace for hir::Mutability {
 }
 
 impl clean::Import {
-    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'b Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'b + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| match self.kind {
             clean::ImportKind::Simple(name) => {
                 if name == self.source.path.last() {
-                    write!(f, "use {};", self.source.print(cache, tcx))
+                    write!(f, "use {};", self.source.print(cx))
                 } else {
-                    write!(f, "use {} as {};", self.source.print(cache, tcx), name)
+                    write!(f, "use {} as {};", self.source.print(cx), name)
                 }
             }
             clean::ImportKind::Glob => {
                 if self.source.path.segments.is_empty() {
                     write!(f, "use *;")
                 } else {
-                    write!(f, "use {}::*;", self.source.print(cache, tcx))
+                    write!(f, "use {}::*;", self.source.print(cx))
                 }
             }
         })
@@ -1288,20 +1280,19 @@ impl clean::Import {
 }
 
 impl clean::ImportSource {
-    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'b Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'b + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| match self.did {
-            Some(did) => resolved_path(f, did, &self.path, true, false, cache, tcx),
+            Some(did) => resolved_path(f, did, &self.path, true, false, cx),
             _ => {
                 for seg in &self.path.segments[..self.path.segments.len() - 1] {
                     write!(f, "{}::", seg.name)?;
                 }
                 let name = self.path.last_name();
                 if let hir::def::Res::PrimTy(p) = self.path.res {
-                    primitive_link(f, PrimitiveType::from(p), &*name, cache)?;
+                    primitive_link(f, PrimitiveType::from(p), &*name, &cx.cache())?;
                 } else {
                     write!(f, "{}", name)?;
                 }
@@ -1312,27 +1303,26 @@ impl clean::ImportSource {
 }
 
 impl clean::TypeBinding {
-    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'b Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'b + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| {
             f.write_str(&*self.name.as_str())?;
             match self.kind {
                 clean::TypeBindingKind::Equality { ref ty } => {
                     if f.alternate() {
-                        write!(f, " = {:#}", ty.print(cache, tcx))?;
+                        write!(f, " = {:#}", ty.print(cx))?;
                     } else {
-                        write!(f, " = {}", ty.print(cache, tcx))?;
+                        write!(f, " = {}", ty.print(cx))?;
                     }
                 }
                 clean::TypeBindingKind::Constraint { ref bounds } => {
                     if !bounds.is_empty() {
                         if f.alternate() {
-                            write!(f, ": {:#}", print_generic_bounds(bounds, cache, tcx))?;
+                            write!(f, ": {:#}", print_generic_bounds(cx, bounds))?;
                         } else {
-                            write!(f, ":&nbsp;{}", print_generic_bounds(bounds, cache, tcx))?;
+                            write!(f, ":&nbsp;{}", print_generic_bounds(cx, bounds))?;
                         }
                     }
                 }
@@ -1357,15 +1347,14 @@ crate fn print_default_space<'a>(v: bool) -> &'a str {
 }
 
 impl clean::GenericArg {
-    crate fn print<'b, 'a: 'b, 'tcx: 'a>(
+    crate fn print<'a, 'cx: 'a>(
         &'a self,
-        cache: &'b Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'b + Captures<'tcx> {
+        cx: &'a Context<'cx>,
+    ) -> impl fmt::Display + 'a + Captures<'cx> {
         display_fn(move |f| match self {
             clean::GenericArg::Lifetime(lt) => fmt::Display::fmt(&lt.print(), f),
-            clean::GenericArg::Type(ty) => fmt::Display::fmt(&ty.print(cache, tcx), f),
-            clean::GenericArg::Const(ct) => fmt::Display::fmt(&ct.print(tcx), f),
+            clean::GenericArg::Type(ty) => fmt::Display::fmt(&ty.print(cx), f),
+            clean::GenericArg::Const(ct) => fmt::Display::fmt(&ct.print(cx.tcx()), f),
         })
     }
 }

--- a/src/librustdoc/html/mod.rs
+++ b/src/librustdoc/html/mod.rs
@@ -8,3 +8,6 @@ crate mod render;
 crate mod sources;
 crate mod static_files;
 crate mod toc;
+
+#[cfg(test)]
+mod tests;

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -40,7 +40,7 @@ use crate::html::{layout, sources};
 crate struct Context<'tcx> {
     /// Current hierarchy of components leading down to what's currently being
     /// rendered
-    pub(super) current: Vec<String>,
+    pub(crate) current: Vec<String>,
     /// The current destination folder of where HTML artifacts should be placed.
     /// This changes as the context descends into the module hierarchy.
     pub(super) dst: PathBuf,
@@ -144,8 +144,12 @@ impl SharedContext<'_> {
 }
 
 impl<'tcx> Context<'tcx> {
-    pub(super) fn tcx(&self) -> TyCtxt<'tcx> {
+    pub(crate) fn tcx(&self) -> TyCtxt<'tcx> {
         self.shared.tcx
+    }
+
+    pub(crate) fn cache(&self) -> &Cache {
+        &self.cache
     }
 
     fn sess(&self) -> &'tcx Session {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -51,7 +51,6 @@ use rustc_hir::def::CtorKind;
 use rustc_hir::def_id::DefId;
 use rustc_hir::Mutability;
 use rustc_middle::middle::stability;
-use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::{kw, sym, Symbol};
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
@@ -61,7 +60,7 @@ use crate::docfs::PathError;
 use crate::error::Error;
 use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
-use crate::formats::{AssocItemRender, FormatRenderer, Impl, RenderMode};
+use crate::formats::{AssocItemRender, Impl, RenderMode};
 use crate::html::escape::Escape;
 use crate::html::format::{
     href, print_abi_with_space, print_default_space, print_generic_bounds, print_where_clause,
@@ -560,11 +559,10 @@ fn document_short(
         return;
     }
     if let Some(s) = item.doc_value() {
-        let mut summary_html = MarkdownSummaryLine(&s, &item.links(&cx.cache)).into_string();
+        let mut summary_html = MarkdownSummaryLine(&s, &item.links(cx)).into_string();
 
         if s.contains('\n') {
-            let link =
-                format!(r#" <a href="{}">Read more</a>"#, naive_assoc_href(item, link, cx.cache()));
+            let link = format!(r#" <a href="{}">Read more</a>"#, naive_assoc_href(item, link, cx));
 
             if let Some(idx) = summary_html.rfind("</p>") {
                 summary_html.insert_str(idx, &link);
@@ -599,7 +597,7 @@ fn document_full(
 ) {
     if let Some(s) = cx.shared.maybe_collapsed_doc_value(item) {
         debug!("Doc block: =====\n{}\n=====", s);
-        render_markdown(w, cx, &*s, item.links(&cx.cache), prefix, is_hidden);
+        render_markdown(w, cx, &*s, item.links(cx), prefix, is_hidden);
     } else if !prefix.is_empty() {
         if is_hidden {
             w.write_str("<div class=\"docblock hidden\">");
@@ -785,7 +783,7 @@ fn render_impls(
     w.write_str(&impls.join(""));
 }
 
-fn naive_assoc_href(it: &clean::Item, link: AssocItemLink<'_>, cache: &Cache) -> String {
+fn naive_assoc_href(it: &clean::Item, link: AssocItemLink<'_>, cx: &Context<'_>) -> String {
     use crate::formats::item_type::ItemType::*;
 
     let name = it.name.as_ref().unwrap();
@@ -799,7 +797,7 @@ fn naive_assoc_href(it: &clean::Item, link: AssocItemLink<'_>, cache: &Cache) ->
         AssocItemLink::Anchor(Some(ref id)) => format!("#{}", id),
         AssocItemLink::Anchor(None) => anchor,
         AssocItemLink::GotoSource(did, _) => {
-            href(did, cache).map(|p| format!("{}{}", p.0, anchor)).unwrap_or(anchor)
+            href(did, cx).map(|p| format!("{}{}", p.0, anchor)).unwrap_or(anchor)
         }
     }
 }
@@ -813,16 +811,14 @@ fn assoc_const(
     extra: &str,
     cx: &Context<'_>,
 ) {
-    let cache = cx.cache();
-    let tcx = cx.tcx();
     write!(
         w,
         "{}{}const <a href=\"{}\" class=\"constant\"><b>{}</b></a>: {}",
         extra,
-        it.visibility.print_with_space(tcx, it.def_id, cache),
-        naive_assoc_href(it, link, cache),
+        it.visibility.print_with_space(cx, it.def_id),
+        naive_assoc_href(it, link, cx),
         it.name.as_ref().unwrap(),
-        ty.print(cache, tcx)
+        ty.print(cx)
     );
 }
 
@@ -833,21 +829,20 @@ fn assoc_type(
     default: Option<&clean::Type>,
     link: AssocItemLink<'_>,
     extra: &str,
-    cache: &Cache,
-    tcx: TyCtxt<'_>,
+    cx: &Context<'_>,
 ) {
     write!(
         w,
         "{}type <a href=\"{}\" class=\"type\">{}</a>",
         extra,
-        naive_assoc_href(it, link, cache),
+        naive_assoc_href(it, link, cx),
         it.name.as_ref().unwrap()
     );
     if !bounds.is_empty() {
-        write!(w, ": {}", print_generic_bounds(bounds, cache, tcx))
+        write!(w, ": {}", print_generic_bounds(cx, bounds))
     }
     if let Some(default) = default {
-        write!(w, " = {}", default.print(cache, tcx))
+        write!(w, " = {}", default.print(cx))
     }
 }
 
@@ -897,8 +892,6 @@ fn render_assoc_item(
         parent: ItemType,
         cx: &Context<'_>,
     ) {
-        let cache = cx.cache();
-        let tcx = cx.tcx();
         let name = meth.name.as_ref().unwrap();
         let href = match link {
             AssocItemLink::Anchor(Some(ref id)) => format!("#{}", id),
@@ -912,19 +905,19 @@ fn render_assoc_item(
                     ItemType::TyMethod
                 };
 
-                href(did, cache)
+                href(did, cx)
                     .map(|p| format!("{}#{}.{}", p.0, ty, name))
                     .unwrap_or_else(|| format!("#{}.{}", ty, name))
             }
         };
-        let vis = meth.visibility.print_with_space(tcx, meth.def_id, cache).to_string();
+        let vis = meth.visibility.print_with_space(cx, meth.def_id).to_string();
         let constness = header.constness.print_with_space();
         let asyncness = header.asyncness.print_with_space();
         let unsafety = header.unsafety.print_with_space();
         let defaultness = print_default_space(meth.is_default());
         let abi = print_abi_with_space(header.abi).to_string();
         // NOTE: `{:#}` does not print HTML formatting, `{}` does. So `g.print` can't be reused between the length calculation and `write!`.
-        let generics_len = format!("{:#}", g.print(cache, tcx)).len();
+        let generics_len = format!("{:#}", g.print(cx)).len();
         let mut header_len = "fn ".len()
             + vis.len()
             + constness.len()
@@ -958,10 +951,10 @@ fn render_assoc_item(
             abi,
             href = href,
             name = name,
-            generics = g.print(cache, tcx),
-            decl = d.full_print(cache, tcx, header_len, indent, header.asyncness),
-            notable_traits = notable_traits_decl(&d, cache, tcx),
-            where_clause = print_where_clause(g, cache, tcx, indent, end_newline),
+            generics = g.print(cx),
+            decl = d.full_print(cx, header_len, indent, header.asyncness),
+            notable_traits = notable_traits_decl(&d, cx),
+            where_clause = print_where_clause(g, cx, indent, end_newline),
         )
     }
     match *item.kind {
@@ -988,8 +981,7 @@ fn render_assoc_item(
             default.as_ref(),
             link,
             if parent == ItemType::Trait { "    " } else { "" },
-            cx.cache(),
-            cx.tcx(),
+            cx,
         ),
         _ => panic!("render_assoc_item called on non-associated-item"),
     }
@@ -1076,11 +1068,9 @@ fn render_assoc_items(
                 RenderMode::Normal
             }
             AssocItemRender::DerefFor { trait_, type_, deref_mut_ } => {
-                let id = cx.derive_id(small_url_encode(format!(
-                    "deref-methods-{:#}",
-                    type_.print(cache, tcx)
-                )));
-                debug!("Adding {} to deref id map", type_.print(cache, tcx));
+                let id =
+                    cx.derive_id(small_url_encode(format!("deref-methods-{:#}", type_.print(cx))));
+                debug!("Adding {} to deref id map", type_.print(cx));
                 cx.deref_id_map.borrow_mut().insert(type_.def_id_full(cache).unwrap(), id.clone());
                 write!(
                     w,
@@ -1089,8 +1079,8 @@ fn render_assoc_items(
                          <a href=\"#{id}\" class=\"anchor\"></a>\
                      </h2>",
                     id = id,
-                    trait_ = trait_.print(cache, tcx),
-                    type_ = type_.print(cache, tcx),
+                    trait_ = trait_.print(cx),
+                    type_ = type_.print(cx),
                 );
                 RenderMode::ForDeref { mut_: deref_mut_ }
             }
@@ -1242,36 +1232,34 @@ fn should_render_item(item: &clean::Item, deref_mut_: bool, cache: &Cache) -> bo
     }
 }
 
-fn notable_traits_decl(decl: &clean::FnDecl, cache: &Cache, tcx: TyCtxt<'_>) -> String {
+fn notable_traits_decl(decl: &clean::FnDecl, cx: &Context<'_>) -> String {
     let mut out = Buffer::html();
     let mut trait_ = String::new();
 
-    if let Some(did) = decl.output.def_id_full(cache) {
-        if let Some(impls) = cache.impls.get(&did) {
+    if let Some(did) = decl.output.def_id_full(cx.cache()) {
+        if let Some(impls) = cx.cache().impls.get(&did) {
             for i in impls {
                 let impl_ = i.inner_impl();
-                if impl_
-                    .trait_
-                    .def_id()
-                    .map_or(false, |d| cache.traits.get(&d).map(|t| t.is_notable).unwrap_or(false))
-                {
+                if impl_.trait_.def_id().map_or(false, |d| {
+                    cx.cache().traits.get(&d).map(|t| t.is_notable).unwrap_or(false)
+                }) {
                     if out.is_empty() {
                         write!(
                             &mut out,
                             "<h3 class=\"notable\">Notable traits for {}</h3>\
                              <code class=\"content\">",
-                            impl_.for_.print(cache, tcx)
+                            impl_.for_.print(cx)
                         );
-                        trait_.push_str(&impl_.for_.print(cache, tcx).to_string());
+                        trait_.push_str(&impl_.for_.print(cx).to_string());
                     }
 
                     //use the "where" class here to make it small
                     write!(
                         &mut out,
                         "<span class=\"where fmt-newline\">{}</span>",
-                        impl_.print(cache, false, tcx)
+                        impl_.print(false, cx)
                     );
-                    let t_did = impl_.trait_.def_id_full(cache).unwrap();
+                    let t_did = impl_.trait_.def_id_full(cx.cache()).unwrap();
                     for it in &impl_.items {
                         if let clean::TypedefItem(ref tydef, _) = *it.kind {
                             out.push_str("<span class=\"where fmt-newline\">    ");
@@ -1282,8 +1270,7 @@ fn notable_traits_decl(decl: &clean::FnDecl, cache: &Cache, tcx: TyCtxt<'_>) -> 
                                 Some(&tydef.type_),
                                 AssocItemLink::GotoSource(t_did, &FxHashSet::default()),
                                 "",
-                                cache,
-                                tcx,
+                                cx,
                             );
                             out.push_str(";</span>");
                         }
@@ -1322,18 +1309,18 @@ fn render_impl(
     // in documentation pages for trait with automatic implementations like "Send" and "Sync".
     aliases: &[String],
 ) {
-    let traits = &cx.cache.traits;
     let tcx = cx.tcx();
     let cache = cx.cache();
+    let traits = &cache.traits;
     let trait_ = i.trait_did_full(cache).map(|did| &traits[&did]);
 
     if render_mode == RenderMode::Normal {
         let id = cx.derive_id(match i.inner_impl().trait_ {
             Some(ref t) => {
                 if is_on_foreign_type {
-                    get_id_for_impl_on_foreign_type(&i.inner_impl().for_, t, cache, tcx)
+                    get_id_for_impl_on_foreign_type(&i.inner_impl().for_, t, cx)
                 } else {
-                    format!("impl-{}", small_url_encode(format!("{:#}", t.print(cache, tcx))))
+                    format!("impl-{}", small_url_encode(format!("{:#}", t.print(cx))))
                 }
             }
             None => "impl".to_string(),
@@ -1345,7 +1332,7 @@ fn render_impl(
         };
         if let Some(use_absolute) = use_absolute {
             write!(w, "<h3 id=\"{}\" class=\"impl\"{}><code class=\"in-band\">", id, aliases);
-            write!(w, "{}", i.inner_impl().print(cache, use_absolute, tcx));
+            write!(w, "{}", i.inner_impl().print(use_absolute, cx));
             if show_def_docs {
                 for it in &i.inner_impl().items {
                     if let clean::TypedefItem(ref tydef, _) = *it.kind {
@@ -1357,8 +1344,7 @@ fn render_impl(
                             Some(&tydef.type_),
                             AssocItemLink::Anchor(None),
                             "",
-                            cache,
-                            tcx,
+                            cx,
                         );
                         w.write_str(";</span>");
                     }
@@ -1371,7 +1357,7 @@ fn render_impl(
                 "<h3 id=\"{}\" class=\"impl\"{}><code class=\"in-band\">{}</code>",
                 id,
                 aliases,
-                i.inner_impl().print(cache, false, tcx)
+                i.inner_impl().print(false, cx)
             );
         }
         write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
@@ -1398,7 +1384,7 @@ fn render_impl(
                 "<div class=\"docblock\">{}</div>",
                 Markdown(
                     &*dox,
-                    &i.impl_item.links(&cx.cache),
+                    &i.impl_item.links(cx),
                     &mut ids,
                     cx.shared.codes,
                     cx.shared.edition,
@@ -1495,8 +1481,7 @@ fn render_impl(
                     Some(&tydef.type_),
                     link.anchor(if trait_.is_some() { &source_id } else { &id }),
                     "",
-                    cx.cache(),
-                    tcx,
+                    cx,
                 );
                 w.write_str("</code>");
                 write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
@@ -1546,8 +1531,7 @@ fn render_impl(
                     default.as_ref(),
                     link.anchor(if trait_.is_some() { &source_id } else { &id }),
                     "",
-                    cx.cache(),
-                    tcx,
+                    cx,
                 );
                 w.write_str("</code>");
                 write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
@@ -1853,7 +1837,6 @@ fn small_url_encode(s: String) -> String {
 fn sidebar_assoc_items(cx: &Context<'_>, out: &mut Buffer, it: &clean::Item) {
     if let Some(v) = cx.cache.impls.get(&it.def_id) {
         let mut used_links = FxHashSet::default();
-        let tcx = cx.tcx();
         let cache = cx.cache();
 
         {
@@ -1888,9 +1871,9 @@ fn sidebar_assoc_items(cx: &Context<'_>, out: &mut Buffer, it: &clean::Item) {
                     .iter()
                     .filter_map(|it| {
                         if let Some(ref i) = it.inner_impl().trait_ {
-                            let i_display = format!("{:#}", i.print(cache, tcx));
+                            let i_display = format!("{:#}", i.print(cx));
                             let out = Escape(&i_display);
-                            let encoded = small_url_encode(format!("{:#}", i.print(cache, tcx)));
+                            let encoded = small_url_encode(format!("{:#}", i.print(cx)));
                             let generated = format!(
                                 "<a href=\"#impl-{}\">{}{}</a>",
                                 encoded,
@@ -1962,7 +1945,6 @@ fn sidebar_assoc_items(cx: &Context<'_>, out: &mut Buffer, it: &clean::Item) {
 
 fn sidebar_deref_methods(cx: &Context<'_>, out: &mut Buffer, impl_: &Impl, v: &Vec<Impl>) {
     let c = cx.cache();
-    let tcx = cx.tcx();
 
     debug!("found Deref: {:?}", impl_);
     if let Some((target, real_target)) =
@@ -2011,11 +1993,8 @@ fn sidebar_deref_methods(cx: &Context<'_>, out: &mut Buffer, impl_: &Impl, v: &V
                     out,
                     "<a class=\"sidebar-title\" href=\"#{}\">Methods from {}&lt;Target={}&gt;</a>",
                     id,
-                    Escape(&format!(
-                        "{:#}",
-                        impl_.inner_impl().trait_.as_ref().unwrap().print(c, tcx)
-                    )),
-                    Escape(&format!("{:#}", real_target.print(c, tcx))),
+                    Escape(&format!("{:#}", impl_.inner_impl().trait_.as_ref().unwrap().print(cx))),
+                    Escape(&format!("{:#}", real_target.print(cx))),
                 );
                 // We want links' order to be reproducible so we don't use unstable sort.
                 ret.sort();
@@ -2071,27 +2050,20 @@ fn sidebar_struct(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, s: &clea
 fn get_id_for_impl_on_foreign_type(
     for_: &clean::Type,
     trait_: &clean::Type,
-    cache: &Cache,
-    tcx: TyCtxt<'_>,
+    cx: &Context<'_>,
 ) -> String {
-    small_url_encode(format!(
-        "impl-{:#}-for-{:#}",
-        trait_.print(cache, tcx),
-        for_.print(cache, tcx)
-    ))
+    small_url_encode(format!("impl-{:#}-for-{:#}", trait_.print(cx), for_.print(cx),))
 }
 
-fn extract_for_impl_name(
-    item: &clean::Item,
-    cache: &Cache,
-    tcx: TyCtxt<'_>,
-) -> Option<(String, String)> {
+fn extract_for_impl_name(item: &clean::Item, cx: &Context<'_>) -> Option<(String, String)> {
     match *item.kind {
         clean::ItemKind::ImplItem(ref i) => {
             if let Some(ref trait_) = i.trait_ {
+                // Alternative format produces no URLs,
+                // so this parameter does nothing.
                 Some((
-                    format!("{:#}", i.for_.print(cache, tcx)),
-                    get_id_for_impl_on_foreign_type(&i.for_, trait_, cache, tcx),
+                    format!("{:#}", i.for_.print(cx)),
+                    get_id_for_impl_on_foreign_type(&i.for_, trait_, cx),
                 ))
             } else {
                 None
@@ -2172,7 +2144,6 @@ fn sidebar_trait(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, t: &clean
 
     if let Some(implementors) = cx.cache.implementors.get(&it.def_id) {
         let cache = cx.cache();
-        let tcx = cx.tcx();
         let mut res = implementors
             .iter()
             .filter(|i| {
@@ -2181,7 +2152,7 @@ fn sidebar_trait(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, t: &clean
                     .def_id_full(cache)
                     .map_or(false, |d| !cx.cache.paths.contains_key(&d))
             })
-            .filter_map(|i| extract_for_impl_name(&i.impl_item, cache, tcx))
+            .filter_map(|i| extract_for_impl_name(&i.impl_item, cx))
             .collect::<Vec<_>>();
 
         if !res.is_empty() {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -815,7 +815,7 @@ fn assoc_const(
         w,
         "{}{}const <a href=\"{}\" class=\"constant\"><b>{}</b></a>: {}",
         extra,
-        it.visibility.print_with_space(cx, it.def_id),
+        it.visibility.print_with_space(it.def_id, cx),
         naive_assoc_href(it, link, cx),
         it.name.as_ref().unwrap(),
         ty.print(cx)
@@ -839,7 +839,7 @@ fn assoc_type(
         it.name.as_ref().unwrap()
     );
     if !bounds.is_empty() {
-        write!(w, ": {}", print_generic_bounds(cx, bounds))
+        write!(w, ": {}", print_generic_bounds(bounds, cx))
     }
     if let Some(default) = default {
         write!(w, " = {}", default.print(cx))
@@ -910,7 +910,7 @@ fn render_assoc_item(
                     .unwrap_or_else(|| format!("#{}.{}", ty, name))
             }
         };
-        let vis = meth.visibility.print_with_space(cx, meth.def_id).to_string();
+        let vis = meth.visibility.print_with_space(meth.def_id, cx).to_string();
         let constness = header.constness.print_with_space();
         let asyncness = header.asyncness.print_with_space();
         let unsafety = header.unsafety.print_with_space();
@@ -952,7 +952,7 @@ fn render_assoc_item(
             href = href,
             name = name,
             generics = g.print(cx),
-            decl = d.full_print(cx, header_len, indent, header.asyncness),
+            decl = d.full_print(header_len, indent, header.asyncness, cx),
             notable_traits = notable_traits_decl(&d, cx),
             where_clause = print_where_clause(g, cx, indent, end_newline),
         )

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -15,9 +15,8 @@ use super::{
     render_impl, render_stability_since_raw, write_srclink, AssocItemLink, Context,
 };
 use crate::clean::{self, GetDefId};
-use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
-use crate::formats::{AssocItemRender, FormatRenderer, Impl, RenderMode};
+use crate::formats::{AssocItemRender, Impl, RenderMode};
 use crate::html::escape::Escape;
 use crate::html::format::{print_abi_with_space, print_where_clause, Buffer, PrintWithSpace};
 use crate::html::highlight;
@@ -268,15 +267,15 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
                     Some(ref src) => write!(
                         w,
                         "<tr><td><code>{}extern crate {} as {};",
-                        myitem.visibility.print_with_space(cx.tcx(), myitem.def_id, cx.cache()),
-                        anchor(myitem.def_id, &*src.as_str(), cx.cache()),
+                        myitem.visibility.print_with_space(cx, myitem.def_id),
+                        anchor(myitem.def_id, &*src.as_str(), cx),
                         myitem.name.as_ref().unwrap(),
                     ),
                     None => write!(
                         w,
                         "<tr><td><code>{}extern crate {};",
-                        myitem.visibility.print_with_space(cx.tcx(), myitem.def_id, cx.cache()),
-                        anchor(myitem.def_id, &*myitem.name.as_ref().unwrap().as_str(), cx.cache()),
+                        myitem.visibility.print_with_space(cx, myitem.def_id),
+                        anchor(myitem.def_id, &*myitem.name.as_ref().unwrap().as_str(), cx),
                     ),
                 }
                 w.write_str("</code></td></tr>");
@@ -286,8 +285,8 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
                 write!(
                     w,
                     "<tr><td><code>{}{}</code></td></tr>",
-                    myitem.visibility.print_with_space(cx.tcx(), myitem.def_id, cx.cache()),
-                    import.print(cx.cache(), cx.tcx()),
+                    myitem.visibility.print_with_space(cx, myitem.def_id),
+                    import.print(cx),
                 );
             }
 
@@ -318,7 +317,7 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
                      </tr>",
                     name = *myitem.name.as_ref().unwrap(),
                     stab_tags = extra_info_tags(myitem, item, cx.tcx()),
-                    docs = MarkdownSummaryLine(&doc_value, &myitem.links(&cx.cache)).into_string(),
+                    docs = MarkdownSummaryLine(&doc_value, &myitem.links(cx)).into_string(),
                     class = myitem.type_(),
                     add = add,
                     stab = stab.unwrap_or_else(String::new),
@@ -387,13 +386,13 @@ fn extra_info_tags(item: &clean::Item, parent: &clean::Item, tcx: TyCtxt<'_>) ->
 fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::Function) {
     let header_len = format!(
         "{}{}{}{}{:#}fn {}{:#}",
-        it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+        it.visibility.print_with_space(cx, it.def_id),
         f.header.constness.print_with_space(),
         f.header.asyncness.print_with_space(),
         f.header.unsafety.print_with_space(),
         print_abi_with_space(f.header.abi),
         it.name.as_ref().unwrap(),
-        f.generics.print(cx.cache(), cx.tcx())
+        f.generics.print(cx),
     )
     .len();
     w.write_str("<pre class=\"rust fn\">");
@@ -402,22 +401,22 @@ fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::
         w,
         "{vis}{constness}{asyncness}{unsafety}{abi}fn \
          {name}{generics}{decl}{notable_traits}{where_clause}</pre>",
-        vis = it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+        vis = it.visibility.print_with_space(cx, it.def_id),
         constness = f.header.constness.print_with_space(),
         asyncness = f.header.asyncness.print_with_space(),
         unsafety = f.header.unsafety.print_with_space(),
         abi = print_abi_with_space(f.header.abi),
         name = it.name.as_ref().unwrap(),
-        generics = f.generics.print(cx.cache(), cx.tcx()),
-        where_clause = print_where_clause(&f.generics, cx.cache(), cx.tcx(), 0, true),
-        decl = f.decl.full_print(cx.cache(), cx.tcx(), header_len, 0, f.header.asyncness),
-        notable_traits = notable_traits_decl(&f.decl, cx.cache(), cx.tcx()),
+        generics = f.generics.print(cx),
+        where_clause = print_where_clause(&f.generics, cx, 0, true),
+        decl = f.decl.full_print(cx, header_len, 0, f.header.asyncness),
+        notable_traits = notable_traits_decl(&f.decl, cx),
     );
     document(w, cx, it, None)
 }
 
 fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Trait) {
-    let bounds = bounds(&t.bounds, false, cx.cache(), cx.tcx());
+    let bounds = bounds(&t.bounds, false, cx);
     let types = t.items.iter().filter(|m| m.is_associated_type()).collect::<Vec<_>>();
     let consts = t.items.iter().filter(|m| m.is_associated_const()).collect::<Vec<_>>();
     let required = t.items.iter().filter(|m| m.is_ty_method()).collect::<Vec<_>>();
@@ -430,16 +429,16 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         write!(
             w,
             "{}{}{}trait {}{}{}",
-            it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+            it.visibility.print_with_space(cx, it.def_id),
             t.unsafety.print_with_space(),
             if t.is_auto { "auto " } else { "" },
             it.name.as_ref().unwrap(),
-            t.generics.print(cx.cache(), cx.tcx()),
+            t.generics.print(cx),
             bounds
         );
 
         if !t.generics.where_predicates.is_empty() {
-            write!(w, "{}", print_where_clause(&t.generics, cx.cache(), cx.tcx(), 0, true));
+            write!(w, "{}", print_where_clause(&t.generics, cx, 0, true));
         } else {
             w.write_str(" ");
         }
@@ -634,8 +633,8 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         let (mut synthetic, mut concrete): (Vec<&&Impl>, Vec<&&Impl>) =
             local.iter().partition(|i| i.inner_impl().synthetic);
 
-        synthetic.sort_by(|a, b| compare_impl(a, b, cx.cache(), cx.tcx()));
-        concrete.sort_by(|a, b| compare_impl(a, b, cx.cache(), cx.tcx()));
+        synthetic.sort_by(|a, b| compare_impl(a, b, cx));
+        concrete.sort_by(|a, b| compare_impl(a, b, cx));
 
         if !foreign.is_empty() {
             write_small_section_header(w, "foreign-impls", "Implementations on Foreign Types", "");
@@ -740,9 +739,9 @@ fn item_trait_alias(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clea
         w,
         "trait {}{}{} = {};</pre>",
         it.name.as_ref().unwrap(),
-        t.generics.print(cx.cache(), cx.tcx()),
-        print_where_clause(&t.generics, cx.cache(), cx.tcx(), 0, true),
-        bounds(&t.bounds, true, cx.cache(), cx.tcx())
+        t.generics.print(cx),
+        print_where_clause(&t.generics, cx, 0, true),
+        bounds(&t.bounds, true, cx)
     );
 
     document(w, cx, it, None);
@@ -761,9 +760,9 @@ fn item_opaque_ty(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean:
         w,
         "type {}{}{where_clause} = impl {bounds};</pre>",
         it.name.as_ref().unwrap(),
-        t.generics.print(cx.cache(), cx.tcx()),
-        where_clause = print_where_clause(&t.generics, cx.cache(), cx.tcx(), 0, true),
-        bounds = bounds(&t.bounds, false, cx.cache(), cx.tcx()),
+        t.generics.print(cx),
+        where_clause = print_where_clause(&t.generics, cx, 0, true),
+        bounds = bounds(&t.bounds, false, cx),
     );
 
     document(w, cx, it, None);
@@ -782,9 +781,9 @@ fn item_typedef(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::T
         w,
         "type {}{}{where_clause} = {type_};</pre>",
         it.name.as_ref().unwrap(),
-        t.generics.print(cx.cache(), cx.tcx()),
-        where_clause = print_where_clause(&t.generics, cx.cache(), cx.tcx(), 0, true),
-        type_ = t.type_.print(cx.cache(), cx.tcx()),
+        t.generics.print(cx),
+        where_clause = print_where_clause(&t.generics, cx, 0, true),
+        type_ = t.type_.print(cx),
     );
 
     document(w, cx, it, None);
@@ -831,7 +830,7 @@ fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Uni
                 id = id,
                 name = name,
                 shortty = ItemType::StructField,
-                ty = ty.print(cx.cache(), cx.tcx()),
+                ty = ty.print(cx),
             );
             if let Some(stability_class) = field.stability_class(cx.tcx()) {
                 write!(w, "<span class=\"stab {stab}\"></span>", stab = stability_class);
@@ -849,10 +848,10 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
         write!(
             w,
             "{}enum {}{}{}",
-            it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+            it.visibility.print_with_space(cx, it.def_id),
             it.name.as_ref().unwrap(),
-            e.generics.print(cx.cache(), cx.tcx()),
-            print_where_clause(&e.generics, cx.cache(), cx.tcx(), 0, true),
+            e.generics.print(cx),
+            print_where_clause(&e.generics, cx, 0, true),
         );
         if e.variants.is_empty() && !e.variants_stripped {
             w.write_str(" {}");
@@ -874,7 +873,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                                 if i > 0 {
                                     w.write_str(",&nbsp;")
                                 }
-                                write!(w, "{}", ty.print(cx.cache(), cx.tcx()));
+                                write!(w, "{}", ty.print(cx));
                             }
                             w.write_str(")");
                         }
@@ -924,7 +923,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                     if i > 0 {
                         w.write_str(",&nbsp;");
                     }
-                    write!(w, "{}", ty.print(cx.cache(), cx.tcx()));
+                    write!(w, "{}", ty.print(cx));
                 }
                 w.write_str(")");
             }
@@ -961,7 +960,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                              </span>",
                             id = id,
                             f = field.name.as_ref().unwrap(),
-                            t = ty.print(cx.cache(), cx.tcx())
+                            t = ty.print(cx)
                         );
                         document(w, cx, field, Some(variant));
                     }
@@ -1030,9 +1029,9 @@ fn item_constant(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, c: &clean::
     write!(
         w,
         "{vis}const {name}: {typ}",
-        vis = it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+        vis = it.visibility.print_with_space(cx, it.def_id),
         name = it.name.as_ref().unwrap(),
-        typ = c.type_.print(cx.cache(), cx.tcx()),
+        typ = c.type_.print(cx),
     );
 
     let value = c.value(cx.tcx());
@@ -1102,7 +1101,7 @@ fn item_struct(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::St
                     item_type = ItemType::StructField,
                     id = id,
                     name = field.name.as_ref().unwrap(),
-                    ty = ty.print(cx.cache(), cx.tcx())
+                    ty = ty.print(cx)
                 );
                 document(w, cx, field, Some(it));
             }
@@ -1117,10 +1116,10 @@ fn item_static(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::St
     write!(
         w,
         "{vis}static {mutability}{name}: {typ}</pre>",
-        vis = it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+        vis = it.visibility.print_with_space(cx, it.def_id),
         mutability = s.mutability.print_with_space(),
         name = it.name.as_ref().unwrap(),
-        typ = s.type_.print(cx.cache(), cx.tcx())
+        typ = s.type_.print(cx)
     );
     document(w, cx, it, None)
 }
@@ -1131,7 +1130,7 @@ fn item_foreign_type(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item) {
     write!(
         w,
         "    {}type {};\n}}</pre>",
-        it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+        it.visibility.print_with_space(cx, it.def_id),
         it.name.as_ref().unwrap(),
     );
 
@@ -1195,12 +1194,7 @@ pub(super) fn item_path(ty: ItemType, name: &str) -> String {
     }
 }
 
-fn bounds(
-    t_bounds: &[clean::GenericBound],
-    trait_alias: bool,
-    cache: &Cache,
-    tcx: TyCtxt<'_>,
-) -> String {
+fn bounds(t_bounds: &[clean::GenericBound], trait_alias: bool, cx: &Context<'_>) -> String {
     let mut bounds = String::new();
     if !t_bounds.is_empty() {
         if !trait_alias {
@@ -1210,7 +1204,7 @@ fn bounds(
             if i > 0 {
                 bounds.push_str(" + ");
             }
-            bounds.push_str(&p.print(cache, tcx).to_string());
+            bounds.push_str(&p.print(cx).to_string());
         }
     }
     bounds
@@ -1240,17 +1234,12 @@ fn render_stability_since(
     )
 }
 
-fn compare_impl<'a, 'b>(
-    lhs: &'a &&Impl,
-    rhs: &'b &&Impl,
-    cache: &Cache,
-    tcx: TyCtxt<'_>,
-) -> Ordering {
-    let lhs = format!("{}", lhs.inner_impl().print(cache, false, tcx));
-    let rhs = format!("{}", rhs.inner_impl().print(cache, false, tcx));
+fn compare_impl<'a, 'b>(lhs: &'a &&Impl, rhs: &'b &&Impl, cx: &Context<'_>) -> Ordering {
+    let lhss = format!("{}", lhs.inner_impl().print(false, cx));
+    let rhss = format!("{}", rhs.inner_impl().print(false, cx));
 
     // lhs and rhs are formatted as HTML, which may be unnecessary
-    compare_names(&lhs, &rhs)
+    compare_names(&lhss, &rhss)
 }
 
 fn render_implementor(
@@ -1300,13 +1289,13 @@ fn render_union(
     write!(
         w,
         "{}{}{}",
-        it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+        it.visibility.print_with_space(cx, it.def_id),
         if structhead { "union " } else { "" },
         it.name.as_ref().unwrap()
     );
     if let Some(g) = g {
-        write!(w, "{}", g.print(cx.cache(), cx.tcx()));
-        write!(w, "{}", print_where_clause(&g, cx.cache(), cx.tcx(), 0, true));
+        write!(w, "{}", g.print(cx));
+        write!(w, "{}", print_where_clause(&g, cx, 0, true));
     }
 
     write!(w, " {{\n{}", tab);
@@ -1322,9 +1311,9 @@ fn render_union(
             write!(
                 w,
                 "    {}{}: {},\n{}",
-                field.visibility.print_with_space(cx.tcx(), field.def_id, cx.cache()),
+                field.visibility.print_with_space(cx, field.def_id),
                 field.name.as_ref().unwrap(),
-                ty.print(cx.cache(), cx.tcx()),
+                ty.print(cx),
                 tab
             );
         }
@@ -1352,17 +1341,17 @@ fn render_struct(
     write!(
         w,
         "{}{}{}",
-        it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
+        it.visibility.print_with_space(cx, it.def_id),
         if structhead { "struct " } else { "" },
         it.name.as_ref().unwrap()
     );
     if let Some(g) = g {
-        write!(w, "{}", g.print(cx.cache(), cx.tcx()))
+        write!(w, "{}", g.print(cx))
     }
     match ty {
         CtorKind::Fictive => {
             if let Some(g) = g {
-                write!(w, "{}", print_where_clause(g, cx.cache(), cx.tcx(), 0, true),)
+                write!(w, "{}", print_where_clause(g, cx, 0, true),)
             }
             w.write_str(" {");
             let count_fields =
@@ -1378,9 +1367,9 @@ fn render_struct(
                         w,
                         "\n{}    {}{}: {},",
                         tab,
-                        field.visibility.print_with_space(cx.tcx(), field.def_id, cx.cache()),
+                        field.visibility.print_with_space(cx, field.def_id),
                         field.name.as_ref().unwrap(),
-                        ty.print(cx.cache(), cx.tcx()),
+                        ty.print(cx),
                     );
                 }
             }
@@ -1412,8 +1401,8 @@ fn render_struct(
                         write!(
                             w,
                             "{}{}",
-                            field.visibility.print_with_space(cx.tcx(), field.def_id, cx.cache()),
-                            ty.print(cx.cache(), cx.tcx()),
+                            field.visibility.print_with_space(cx, field.def_id),
+                            ty.print(cx),
                         )
                     }
                     _ => unreachable!(),
@@ -1421,14 +1410,14 @@ fn render_struct(
             }
             w.write_str(")");
             if let Some(g) = g {
-                write!(w, "{}", print_where_clause(g, cx.cache(), cx.tcx(), 0, false),)
+                write!(w, "{}", print_where_clause(g, cx, 0, false),)
             }
             w.write_str(";");
         }
         CtorKind::Const => {
             // Needed for PhantomData.
             if let Some(g) = g {
-                write!(w, "{}", print_where_clause(g, cx.cache(), cx.tcx(), 0, false),)
+                write!(w, "{}", print_where_clause(g, cx, 0, false),)
             }
             w.write_str(";");
         }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -267,14 +267,14 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
                     Some(ref src) => write!(
                         w,
                         "<tr><td><code>{}extern crate {} as {};",
-                        myitem.visibility.print_with_space(cx, myitem.def_id),
+                        myitem.visibility.print_with_space(myitem.def_id, cx),
                         anchor(myitem.def_id, &*src.as_str(), cx),
                         myitem.name.as_ref().unwrap(),
                     ),
                     None => write!(
                         w,
                         "<tr><td><code>{}extern crate {};",
-                        myitem.visibility.print_with_space(cx, myitem.def_id),
+                        myitem.visibility.print_with_space(myitem.def_id, cx),
                         anchor(myitem.def_id, &*myitem.name.as_ref().unwrap().as_str(), cx),
                     ),
                 }
@@ -285,7 +285,7 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
                 write!(
                     w,
                     "<tr><td><code>{}{}</code></td></tr>",
-                    myitem.visibility.print_with_space(cx, myitem.def_id),
+                    myitem.visibility.print_with_space(myitem.def_id, cx),
                     import.print(cx),
                 );
             }
@@ -386,7 +386,7 @@ fn extra_info_tags(item: &clean::Item, parent: &clean::Item, tcx: TyCtxt<'_>) ->
 fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::Function) {
     let header_len = format!(
         "{}{}{}{}{:#}fn {}{:#}",
-        it.visibility.print_with_space(cx, it.def_id),
+        it.visibility.print_with_space(it.def_id, cx),
         f.header.constness.print_with_space(),
         f.header.asyncness.print_with_space(),
         f.header.unsafety.print_with_space(),
@@ -401,7 +401,7 @@ fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::
         w,
         "{vis}{constness}{asyncness}{unsafety}{abi}fn \
          {name}{generics}{decl}{notable_traits}{where_clause}</pre>",
-        vis = it.visibility.print_with_space(cx, it.def_id),
+        vis = it.visibility.print_with_space(it.def_id, cx),
         constness = f.header.constness.print_with_space(),
         asyncness = f.header.asyncness.print_with_space(),
         unsafety = f.header.unsafety.print_with_space(),
@@ -409,7 +409,7 @@ fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::
         name = it.name.as_ref().unwrap(),
         generics = f.generics.print(cx),
         where_clause = print_where_clause(&f.generics, cx, 0, true),
-        decl = f.decl.full_print(cx, header_len, 0, f.header.asyncness),
+        decl = f.decl.full_print(header_len, 0, f.header.asyncness, cx),
         notable_traits = notable_traits_decl(&f.decl, cx),
     );
     document(w, cx, it, None)
@@ -429,7 +429,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         write!(
             w,
             "{}{}{}trait {}{}{}",
-            it.visibility.print_with_space(cx, it.def_id),
+            it.visibility.print_with_space(it.def_id, cx),
             t.unsafety.print_with_space(),
             if t.is_auto { "auto " } else { "" },
             it.name.as_ref().unwrap(),
@@ -848,7 +848,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
         write!(
             w,
             "{}enum {}{}{}",
-            it.visibility.print_with_space(cx, it.def_id),
+            it.visibility.print_with_space(it.def_id, cx),
             it.name.as_ref().unwrap(),
             e.generics.print(cx),
             print_where_clause(&e.generics, cx, 0, true),
@@ -1029,7 +1029,7 @@ fn item_constant(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, c: &clean::
     write!(
         w,
         "{vis}const {name}: {typ}",
-        vis = it.visibility.print_with_space(cx, it.def_id),
+        vis = it.visibility.print_with_space(it.def_id, cx),
         name = it.name.as_ref().unwrap(),
         typ = c.type_.print(cx),
     );
@@ -1116,7 +1116,7 @@ fn item_static(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::St
     write!(
         w,
         "{vis}static {mutability}{name}: {typ}</pre>",
-        vis = it.visibility.print_with_space(cx, it.def_id),
+        vis = it.visibility.print_with_space(it.def_id, cx),
         mutability = s.mutability.print_with_space(),
         name = it.name.as_ref().unwrap(),
         typ = s.type_.print(cx)
@@ -1130,7 +1130,7 @@ fn item_foreign_type(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item) {
     write!(
         w,
         "    {}type {};\n}}</pre>",
-        it.visibility.print_with_space(cx, it.def_id),
+        it.visibility.print_with_space(it.def_id, cx),
         it.name.as_ref().unwrap(),
     );
 
@@ -1289,7 +1289,7 @@ fn render_union(
     write!(
         w,
         "{}{}{}",
-        it.visibility.print_with_space(cx, it.def_id),
+        it.visibility.print_with_space(it.def_id, cx),
         if structhead { "union " } else { "" },
         it.name.as_ref().unwrap()
     );
@@ -1311,7 +1311,7 @@ fn render_union(
             write!(
                 w,
                 "    {}{}: {},\n{}",
-                field.visibility.print_with_space(cx, field.def_id),
+                field.visibility.print_with_space(field.def_id, cx),
                 field.name.as_ref().unwrap(),
                 ty.print(cx),
                 tab
@@ -1341,7 +1341,7 @@ fn render_struct(
     write!(
         w,
         "{}{}{}",
-        it.visibility.print_with_space(cx, it.def_id),
+        it.visibility.print_with_space(it.def_id, cx),
         if structhead { "struct " } else { "" },
         it.name.as_ref().unwrap()
     );
@@ -1367,7 +1367,7 @@ fn render_struct(
                         w,
                         "\n{}    {}{}: {},",
                         tab,
-                        field.visibility.print_with_space(cx, field.def_id),
+                        field.visibility.print_with_space(field.def_id, cx),
                         field.name.as_ref().unwrap(),
                         ty.print(cx),
                     );
@@ -1401,7 +1401,7 @@ fn render_struct(
                         write!(
                             w,
                             "{}{}",
-                            field.visibility.print_with_space(cx, field.def_id),
+                            field.visibility.print_with_space(field.def_id, cx),
                             ty.print(cx),
                         )
                     }

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -16,7 +16,6 @@ use crate::clean::Crate;
 use crate::config::{EmitType, RenderOptions};
 use crate::docfs::PathError;
 use crate::error::Error;
-use crate::formats::FormatRenderer;
 use crate::html::{layout, static_files};
 
 crate static FILES_UNVERSIONED: Lazy<FxHashMap<&str, &[u8]>> = Lazy::new(|| {
@@ -500,7 +499,7 @@ pub(super) fn write_shared(
                     None
                 } else {
                     Some(Implementor {
-                        text: imp.inner_impl().print(cx.cache(), false, cx.tcx()).to_string(),
+                        text: imp.inner_impl().print(false, cx).to_string(),
                         synthetic: imp.inner_impl().synthetic,
                         types: collect_paths_for_type(imp.inner_impl().for_.clone(), cx.cache()),
                     })

--- a/src/librustdoc/html/tests.rs
+++ b/src/librustdoc/html/tests.rs
@@ -1,0 +1,44 @@
+use crate::html::format::href_relative_parts;
+
+fn assert_relative_path(expected: &[&str], relative_to_fqp: &[&str], fqp: &[&str]) {
+    let relative_to_fqp: Vec<String> = relative_to_fqp.iter().copied().map(String::from).collect();
+    let fqp: Vec<String> = fqp.iter().copied().map(String::from).collect();
+    assert_eq!(expected, href_relative_parts(&fqp, &relative_to_fqp));
+}
+
+#[test]
+fn href_relative_parts_basic() {
+    let relative_to_fqp = &["std", "vec"];
+    let fqp = &["std", "iter"];
+    assert_relative_path(&["..", "iter"], relative_to_fqp, fqp);
+}
+#[test]
+fn href_relative_parts_parent_module() {
+    let relative_to_fqp = &["std", "vec"];
+    let fqp = &["std"];
+    assert_relative_path(&[".."], relative_to_fqp, fqp);
+}
+#[test]
+fn href_relative_parts_different_crate() {
+    let relative_to_fqp = &["std", "vec"];
+    let fqp = &["core", "iter"];
+    assert_relative_path(&["..", "..", "core", "iter"], relative_to_fqp, fqp);
+}
+#[test]
+fn href_relative_parts_same_module() {
+    let relative_to_fqp = &["std", "vec"];
+    let fqp = &["std", "vec"];
+    assert_relative_path(&[], relative_to_fqp, fqp);
+}
+#[test]
+fn href_relative_parts_child_module() {
+    let relative_to_fqp = &["std"];
+    let fqp = &["std", "vec"];
+    assert_relative_path(&["vec"], relative_to_fqp, fqp);
+}
+#[test]
+fn href_relative_parts_root() {
+    let relative_to_fqp = &[];
+    let fqp = &["std"];
+    assert_relative_path(&["std"], relative_to_fqp, fqp);
+}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -289,7 +289,13 @@ fn opts() -> Vec<RustcOptGroup> {
         stable("cfg", |o| o.optmulti("", "cfg", "pass a --cfg to rustc", "")),
         stable("extern", |o| o.optmulti("", "extern", "pass an --extern to rustc", "NAME[=PATH]")),
         unstable("extern-html-root-url", |o| {
-            o.optmulti("", "extern-html-root-url", "base URL to use for dependencies", "NAME=URL")
+            o.optmulti(
+                "",
+                "extern-html-root-url",
+                "base URL to use for dependencies; for example, \
+                 \"std=/doc\" links std::vec::Vec to /doc/std/vec/struct.Vec.html",
+                "NAME=URL",
+            )
         }),
         stable("plugin-path", |o| o.optmulti("", "plugin-path", "removed", "DIR")),
         stable("C", |o| {

--- a/src/test/rustdoc/assoc-types.rs
+++ b/src/test/rustdoc/assoc-types.rs
@@ -6,14 +6,14 @@ pub trait Index<I: ?Sized> {
     type Output: ?Sized;
     // @has - '//*[@id="tymethod.index"]//code' \
     //      "fn index<'a>(&'a self, index: I) -> &'a Self::Output"
-    // @has - '//*[@id="tymethod.index"]//code//a[@href="../assoc_types/trait.Index.html#associatedtype.Output"]' \
+    // @has - '//*[@id="tymethod.index"]//code//a[@href="trait.Index.html#associatedtype.Output"]' \
     //      "Output"
     fn index<'a>(&'a self, index: I) -> &'a Self::Output;
 }
 
 // @has assoc_types/fn.use_output.html
 // @has - '//*[@class="rust fn"]' '-> &T::Output'
-// @has - '//*[@class="rust fn"]//a[@href="../assoc_types/trait.Index.html#associatedtype.Output"]' 'Output'
+// @has - '//*[@class="rust fn"]//a[@href="trait.Index.html#associatedtype.Output"]' 'Output'
 pub fn use_output<T: Index<usize>>(obj: &T, index: usize) -> &T::Output {
     obj.index(index)
 }
@@ -24,12 +24,12 @@ pub trait Feed {
 
 // @has assoc_types/fn.use_input.html
 // @has - '//*[@class="rust fn"]' 'T::Input'
-// @has - '//*[@class="rust fn"]//a[@href="../assoc_types/trait.Feed.html#associatedtype.Input"]' 'Input'
+// @has - '//*[@class="rust fn"]//a[@href="trait.Feed.html#associatedtype.Input"]' 'Input'
 pub fn use_input<T: Feed>(_feed: &T, _element: T::Input) { }
 
 // @has assoc_types/fn.cmp_input.html
 // @has - '//*[@class="rust fn"]' 'where T::Input: PartialEq<U::Input>'
-// @has - '//*[@class="rust fn"]//a[@href="../assoc_types/trait.Feed.html#associatedtype.Input"]' 'Input'
+// @has - '//*[@class="rust fn"]//a[@href="trait.Feed.html#associatedtype.Input"]' 'Input'
 pub fn cmp_input<T: Feed, U: Feed>(a: &T::Input, b: &U::Input) -> bool
     where T::Input: PartialEq<U::Input>
 {

--- a/src/test/rustdoc/auxiliary/primitive-doc.rs
+++ b/src/test/rustdoc/auxiliary/primitive-doc.rs
@@ -1,0 +1,6 @@
+// compile-flags: --crate-type lib --edition 2018
+
+#[doc(primitive = "usize")]
+/// This is the built-in type `usize`.
+mod usize {
+}

--- a/src/test/rustdoc/check-styled-link.rs
+++ b/src/test/rustdoc/check-styled-link.rs
@@ -2,7 +2,7 @@
 
 pub struct Foo;
 
-// @has foo/struct.Bar.html '//a[@href="../foo/struct.Foo.html"]' 'Foo'
+// @has foo/struct.Bar.html '//a[@href="struct.Foo.html"]' 'Foo'
 
 /// Code-styled reference to [`Foo`].
 pub struct Bar;

--- a/src/test/rustdoc/cross-crate-primitive-doc.rs
+++ b/src/test/rustdoc/cross-crate-primitive-doc.rs
@@ -1,0 +1,9 @@
+// aux-build:primitive-doc.rs
+// compile-flags: --extern-html-root-url=primitive_doc=../ -Z unstable-options
+
+#![no_std]
+
+extern crate primitive_doc;
+
+// @has 'cross_crate_primitive_doc/fn.foo.html' '//a[@href="../primitive_doc/primitive.usize.html"]' 'usize'
+pub fn foo() -> usize { 0 }

--- a/src/test/rustdoc/default-trait-method-link.rs
+++ b/src/test/rustdoc/default-trait-method-link.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
-// @has foo/trait.Foo.html '//a[@href="../foo/trait.Foo.html#tymethod.req"]' 'req'
-// @has foo/trait.Foo.html '//a[@href="../foo/trait.Foo.html#method.prov"]' 'prov'
+// @has foo/trait.Foo.html '//a[@href="trait.Foo.html#tymethod.req"]' 'req'
+// @has foo/trait.Foo.html '//a[@href="trait.Foo.html#method.prov"]' 'prov'
 
 /// Always make sure to implement [`req`], but you don't have to implement [`prov`].
 ///

--- a/src/test/rustdoc/intra-doc-crate/self.rs
+++ b/src/test/rustdoc/intra-doc-crate/self.rs
@@ -3,7 +3,7 @@
 
 extern crate cross_crate_self;
 
-// @has self/struct.S.html '//a[@href="../self/struct.S.html#method.f"]' "Self::f"
-// @has self/struct.S.html '//a[@href="../self/struct.S.html"]' "Self"
+// @has self/struct.S.html '//a[@href="struct.S.html#method.f"]' "Self::f"
+// @has self/struct.S.html '//a[@href="struct.S.html"]' "Self"
 // @has self/struct.S.html '//a[@href="../cross_crate_self/index.html"]' "crate"
 pub use cross_crate_self::S;

--- a/src/test/rustdoc/intra-doc/anchors.rs
+++ b/src/test/rustdoc/intra-doc/anchors.rs
@@ -4,7 +4,7 @@
 pub struct Something;
 
 // @has anchors/struct.SomeOtherType.html
-// @has - '//a/@href' '../anchors/struct.Something.html#Anchor!'
+// @has - '//a/@href' 'struct.Something.html#Anchor!'
 
 /// I want...
 ///

--- a/src/test/rustdoc/intra-doc/associated-defaults.rs
+++ b/src/test/rustdoc/intra-doc/associated-defaults.rs
@@ -9,14 +9,14 @@ pub trait TraitWithDefault {
 }
 
 /// Link to [UsesDefaults::T] and [UsesDefaults::f]
-// @has 'associated_defaults/struct.UsesDefaults.html' '//a[@href="../associated_defaults/struct.UsesDefaults.html#associatedtype.T"]' 'UsesDefaults::T'
-// @has 'associated_defaults/struct.UsesDefaults.html' '//a[@href="../associated_defaults/struct.UsesDefaults.html#method.f"]' 'UsesDefaults::f'
+// @has 'associated_defaults/struct.UsesDefaults.html' '//a[@href="struct.UsesDefaults.html#associatedtype.T"]' 'UsesDefaults::T'
+// @has 'associated_defaults/struct.UsesDefaults.html' '//a[@href="struct.UsesDefaults.html#method.f"]' 'UsesDefaults::f'
 pub struct UsesDefaults;
 impl TraitWithDefault for UsesDefaults {}
 
 /// Link to [OverridesDefaults::T] and [OverridesDefaults::f]
-// @has 'associated_defaults/struct.OverridesDefaults.html' '//a[@href="../associated_defaults/struct.OverridesDefaults.html#associatedtype.T"]' 'OverridesDefaults::T'
-// @has 'associated_defaults/struct.OverridesDefaults.html' '//a[@href="../associated_defaults/struct.OverridesDefaults.html#method.f"]' 'OverridesDefaults::f'
+// @has 'associated_defaults/struct.OverridesDefaults.html' '//a[@href="struct.OverridesDefaults.html#associatedtype.T"]' 'OverridesDefaults::T'
+// @has 'associated_defaults/struct.OverridesDefaults.html' '//a[@href="struct.OverridesDefaults.html#method.f"]' 'OverridesDefaults::f'
 pub struct OverridesDefaults;
 impl TraitWithDefault for OverridesDefaults {
     type T = bool;

--- a/src/test/rustdoc/intra-doc/associated-items.rs
+++ b/src/test/rustdoc/intra-doc/associated-items.rs
@@ -9,10 +9,10 @@
 pub fn foo() {}
 
 /// Link to [MyStruct], [link from struct][MyStruct::method], [MyStruct::clone], [MyStruct::Input]
-// @has 'associated_items/struct.MyStruct.html' '//a[@href="../associated_items/struct.MyStruct.html"]' 'MyStruct'
-// @has 'associated_items/struct.MyStruct.html' '//a[@href="../associated_items/struct.MyStruct.html#method.method"]' 'link from struct'
-// @has 'associated_items/struct.MyStruct.html' '//a[@href="../associated_items/struct.MyStruct.html#method.clone"]' 'MyStruct::clone'
-// @has 'associated_items/struct.MyStruct.html' '//a[@href="../associated_items/struct.MyStruct.html#associatedtype.Input"]' 'MyStruct::Input'
+// @has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html"]' 'MyStruct'
+// @has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.method"]' 'link from struct'
+// @has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.clone"]' 'MyStruct::clone'
+// @has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#associatedtype.Input"]' 'MyStruct::Input'
 pub struct MyStruct { foo: () }
 
 impl Clone for MyStruct {
@@ -30,7 +30,7 @@ impl T for MyStruct {
     type Input = usize;
 
     /// [link from method][MyStruct::method] on method
-    // @has 'associated_items/struct.MyStruct.html' '//a[@href="../associated_items/struct.MyStruct.html#method.method"]' 'link from method'
+    // @has 'associated_items/struct.MyStruct.html' '//a[@href="struct.MyStruct.html#method.method"]' 'link from method'
     fn method(i: usize) {
     }
 }

--- a/src/test/rustdoc/intra-doc/basic.rs
+++ b/src/test/rustdoc/intra-doc/basic.rs
@@ -1,21 +1,21 @@
 // @has basic/index.html
-// @has - '//a/@href' '../basic/struct.ThisType.html'
-// @has - '//a/@href' '../basic/struct.ThisType.html#method.this_method'
-// @has - '//a/@href' '../basic/enum.ThisEnum.html'
-// @has - '//a/@href' '../basic/enum.ThisEnum.html#variant.ThisVariant'
-// @has - '//a/@href' '../basic/trait.ThisTrait.html'
-// @has - '//a/@href' '../basic/trait.ThisTrait.html#tymethod.this_associated_method'
-// @has - '//a/@href' '../basic/trait.ThisTrait.html#associatedtype.ThisAssociatedType'
-// @has - '//a/@href' '../basic/trait.ThisTrait.html#associatedconstant.THIS_ASSOCIATED_CONST'
-// @has - '//a/@href' '../basic/trait.ThisTrait.html'
-// @has - '//a/@href' '../basic/type.ThisAlias.html'
-// @has - '//a/@href' '../basic/union.ThisUnion.html'
-// @has - '//a/@href' '../basic/fn.this_function.html'
-// @has - '//a/@href' '../basic/constant.THIS_CONST.html'
-// @has - '//a/@href' '../basic/static.THIS_STATIC.html'
-// @has - '//a/@href' '../basic/macro.this_macro.html'
-// @has - '//a/@href' '../basic/trait.SoAmbiguous.html'
-// @has - '//a/@href' '../basic/fn.SoAmbiguous.html'
+// @has - '//a/@href' 'struct.ThisType.html'
+// @has - '//a/@href' 'struct.ThisType.html#method.this_method'
+// @has - '//a/@href' 'enum.ThisEnum.html'
+// @has - '//a/@href' 'enum.ThisEnum.html#variant.ThisVariant'
+// @has - '//a/@href' 'trait.ThisTrait.html'
+// @has - '//a/@href' 'trait.ThisTrait.html#tymethod.this_associated_method'
+// @has - '//a/@href' 'trait.ThisTrait.html#associatedtype.ThisAssociatedType'
+// @has - '//a/@href' 'trait.ThisTrait.html#associatedconstant.THIS_ASSOCIATED_CONST'
+// @has - '//a/@href' 'trait.ThisTrait.html'
+// @has - '//a/@href' 'type.ThisAlias.html'
+// @has - '//a/@href' 'union.ThisUnion.html'
+// @has - '//a/@href' 'fn.this_function.html'
+// @has - '//a/@href' 'constant.THIS_CONST.html'
+// @has - '//a/@href' 'static.THIS_STATIC.html'
+// @has - '//a/@href' 'macro.this_macro.html'
+// @has - '//a/@href' 'trait.SoAmbiguous.html'
+// @has - '//a/@href' 'fn.SoAmbiguous.html'
 //! In this crate we would like to link to:
 //!
 //! * [`ThisType`](ThisType)
@@ -46,7 +46,7 @@ macro_rules! this_macro {
     () => {};
 }
 
-// @has basic/struct.ThisType.html '//a/@href' '../basic/macro.this_macro.html'
+// @has basic/struct.ThisType.html '//a/@href' 'macro.this_macro.html'
 /// another link to [`this_macro!()`]
 pub struct ThisType;
 
@@ -72,10 +72,10 @@ pub trait SoAmbiguous {}
 pub fn SoAmbiguous() {}
 
 
-// @has basic/struct.SomeOtherType.html '//a/@href' '../basic/struct.ThisType.html'
-// @has - '//a/@href' '../basic/struct.ThisType.html#method.this_method'
-// @has - '//a/@href' '../basic/enum.ThisEnum.html'
-// @has - '//a/@href' '../basic/enum.ThisEnum.html#variant.ThisVariant'
+// @has basic/struct.SomeOtherType.html '//a/@href' 'struct.ThisType.html'
+// @has - '//a/@href' 'struct.ThisType.html#method.this_method'
+// @has - '//a/@href' 'enum.ThisEnum.html'
+// @has - '//a/@href' 'enum.ThisEnum.html#variant.ThisVariant'
 /// Shortcut links for:
 /// * [`ThisType`]
 /// * [`ThisType::this_method`]

--- a/src/test/rustdoc/intra-doc/cross-crate/additional_doc.rs
+++ b/src/test/rustdoc/intra-doc/cross-crate/additional_doc.rs
@@ -4,7 +4,7 @@
 
 extern crate my_rand;
 
-// @has 'additional_doc/trait.Rng.html' '//a[@href="../additional_doc/trait.Rng.html"]' 'Rng'
+// @has 'additional_doc/trait.Rng.html' '//a[@href="trait.Rng.html"]' 'Rng'
 // @has 'additional_doc/trait.Rng.html' '//a[@href="../my_rand/trait.RngCore.html"]' 'RngCore'
 /// This is an [`Rng`].
 pub use my_rand::Rng;

--- a/src/test/rustdoc/intra-doc/cross-crate/hidden.rs
+++ b/src/test/rustdoc/intra-doc/cross-crate/hidden.rs
@@ -6,5 +6,5 @@
 
 extern crate hidden_dep;
 
-// @has 'hidden/struct.Ready.html' '//a/@href' '../hidden/fn.ready.html'
+// @has 'hidden/struct.Ready.html' '//a/@href' 'fn.ready.html'
 pub use hidden_dep::future::{ready, Ready};

--- a/src/test/rustdoc/intra-doc/cross-crate/submodule-outer.rs
+++ b/src/test/rustdoc/intra-doc/cross-crate/submodule-outer.rs
@@ -11,6 +11,6 @@ pub mod bar {
 
 // NOTE: we re-exported both `Foo` and `Bar` here,
 // NOTE: so they are inlined and therefore we link to the current module.
-// @has 'submodule_outer/trait.Foo.html' '//a[@href="../submodule_outer/bar/trait.Bar.html"]' 'Bar'
-// @has 'submodule_outer/trait.Foo.html' '//a[@href="../submodule_outer/trait.Baz.html"]' 'Baz'
+// @has 'submodule_outer/trait.Foo.html' '//a[@href="bar/trait.Bar.html"]' 'Bar'
+// @has 'submodule_outer/trait.Foo.html' '//a[@href="trait.Baz.html"]' 'Baz'
 pub use ::bar_::{Foo, Baz};

--- a/src/test/rustdoc/intra-doc/disambiguators-removed.rs
+++ b/src/test/rustdoc/intra-doc/disambiguators-removed.rs
@@ -2,26 +2,26 @@
 // first try backticks
 /// Trait: [`trait@Name`], fn: [`fn@Name`], [`Name`][`macro@Name`]
 // @has disambiguators_removed/struct.AtDisambiguator.html
-// @has - '//a[@href="../disambiguators_removed/trait.Name.html"][code]' "Name"
-// @has - '//a[@href="../disambiguators_removed/fn.Name.html"][code]' "Name"
-// @has - '//a[@href="../disambiguators_removed/macro.Name.html"][code]' "Name"
+// @has - '//a[@href="trait.Name.html"][code]' "Name"
+// @has - '//a[@href="fn.Name.html"][code]' "Name"
+// @has - '//a[@href="macro.Name.html"][code]' "Name"
 pub struct AtDisambiguator;
 
 /// fn: [`Name()`], macro: [`Name!`]
 // @has disambiguators_removed/struct.SymbolDisambiguator.html
-// @has - '//a[@href="../disambiguators_removed/fn.Name.html"][code]' "Name()"
-// @has - '//a[@href="../disambiguators_removed/macro.Name.html"][code]' "Name!"
+// @has - '//a[@href="fn.Name.html"][code]' "Name()"
+// @has - '//a[@href="macro.Name.html"][code]' "Name!"
 pub struct SymbolDisambiguator;
 
 // Now make sure that backticks aren't added if they weren't already there
 /// [fn@Name]
 // @has disambiguators_removed/trait.Name.html
-// @has - '//a[@href="../disambiguators_removed/fn.Name.html"]' "Name"
-// @!has - '//a[@href="../disambiguators_removed/fn.Name.html"][code]' "Name"
+// @has - '//a[@href="fn.Name.html"]' "Name"
+// @!has - '//a[@href="fn.Name.html"][code]' "Name"
 
 // FIXME: this will turn !() into ! alone
 /// [Name!()]
-// @has - '//a[@href="../disambiguators_removed/macro.Name.html"]' "Name!"
+// @has - '//a[@href="macro.Name.html"]' "Name!"
 pub trait Name {}
 
 #[allow(non_snake_case)]
@@ -29,22 +29,22 @@ pub trait Name {}
 // Try collapsed reference links
 /// [macro@Name][]
 // @has disambiguators_removed/fn.Name.html
-// @has - '//a[@href="../disambiguators_removed/macro.Name.html"]' "Name"
+// @has - '//a[@href="macro.Name.html"]' "Name"
 
 // Try links that have the same text as a generated URL
-/// Weird URL aligned [../disambiguators_removed/macro.Name.html][trait@Name]
-// @has - '//a[@href="../disambiguators_removed/trait.Name.html"]' "../disambiguators_removed/macro.Name.html"
+/// Weird URL aligned [macro.Name.html][trait@Name]
+// @has - '//a[@href="trait.Name.html"]' "macro.Name.html"
 pub fn Name() {}
 
 #[macro_export]
 // Rustdoc doesn't currently handle links that have weird interspersing of inline code blocks.
 /// [fn@Na`m`e]
 // @has disambiguators_removed/macro.Name.html
-// @has - '//a[@href="../disambiguators_removed/fn.Name.html"]' "fn@Name"
+// @has - '//a[@href="fn.Name.html"]' "fn@Name"
 
 // It also doesn't handle any case where the code block isn't the whole link text:
 /// [trait@`Name`]
-// @has - '//a[@href="../disambiguators_removed/trait.Name.html"]' "trait@Name"
+// @has - '//a[@href="trait.Name.html"]' "trait@Name"
 macro_rules! Name {
     () => ()
 }

--- a/src/test/rustdoc/intra-doc/enum-struct-field.rs
+++ b/src/test/rustdoc/intra-doc/enum-struct-field.rs
@@ -11,4 +11,4 @@ pub enum Foo {
 /// I want [Foo::X::y].
 pub fn foo() {}
 
-// @has foo/fn.foo.html '//a/@href' '../foo/enum.Foo.html#variant.X.field.y'
+// @has foo/fn.foo.html '//a/@href' 'enum.Foo.html#variant.X.field.y'

--- a/src/test/rustdoc/intra-doc/extern-type.rs
+++ b/src/test/rustdoc/intra-doc/extern-type.rs
@@ -12,6 +12,6 @@ impl ExternType {
 
 // @has 'extern_type/foreigntype.ExternType.html'
 // @has 'extern_type/fn.links_to_extern_type.html' \
-// 'href="../extern_type/foreigntype.ExternType.html#method.f"'
+// 'href="foreigntype.ExternType.html#method.f"'
 /// See also [ExternType::f]
 pub fn links_to_extern_type() {}

--- a/src/test/rustdoc/intra-doc/issue-82209.rs
+++ b/src/test/rustdoc/intra-doc/issue-82209.rs
@@ -8,4 +8,4 @@ pub enum Foo {
     },
 }
 
-// @has foo/enum.Foo.html '//a/@href' '../foo/enum.Foo.html#variant.Bar.field.abc'
+// @has foo/enum.Foo.html '//a/@href' 'enum.Foo.html#variant.Bar.field.abc'

--- a/src/test/rustdoc/intra-doc/mod-ambiguity.rs
+++ b/src/test/rustdoc/intra-doc/mod-ambiguity.rs
@@ -6,11 +6,11 @@ pub fn foo() {
 }
 
 pub mod foo {}
-// @has mod_ambiguity/struct.A.html '//a/@href' '../mod_ambiguity/foo/index.html'
+// @has mod_ambiguity/struct.A.html '//a/@href' 'foo/index.html'
 /// Module is [`module@foo`]
 pub struct A;
 
 
-// @has mod_ambiguity/struct.B.html '//a/@href' '../mod_ambiguity/fn.foo.html'
+// @has mod_ambiguity/struct.B.html '//a/@href' 'fn.foo.html'
 /// Function is [`fn@foo`]
 pub struct B;

--- a/src/test/rustdoc/intra-doc/prim-precedence.rs
+++ b/src/test/rustdoc/intra-doc/prim-precedence.rs
@@ -11,6 +11,6 @@ pub mod char {
 pub struct MyString;
 
 /// See also [crate::char] and [mod@char]
-// @has prim_precedence/struct.MyString2.html '//*[@href="../prim_precedence/char/index.html"]' 'crate::char'
-// @has - '//*[@href="../prim_precedence/char/index.html"]' 'mod@char'
+// @has prim_precedence/struct.MyString2.html '//*[@href="char/index.html"]' 'crate::char'
+// @has - '//*[@href="char/index.html"]' 'mod@char'
 pub struct MyString2;

--- a/src/test/rustdoc/intra-doc/private.rs
+++ b/src/test/rustdoc/intra-doc/private.rs
@@ -4,9 +4,9 @@
 // make sure to update `rustdoc-ui/intra-doc/private.rs` if you update this file
 
 /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
-// @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html"]' 'DontDocMe'
-// @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html#method.f"]' 'DontDocMe::f'
-// @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html#structfield.x"]' 'DontDocMe::x'
+// @has private/struct.DocMe.html '//*a[@href="struct.DontDocMe.html"]' 'DontDocMe'
+// @has private/struct.DocMe.html '//*a[@href="struct.DontDocMe.html#method.f"]' 'DontDocMe::f'
+// @has private/struct.DocMe.html '//*a[@href="struct.DontDocMe.html#structfield.x"]' 'DontDocMe::x'
 pub struct DocMe;
 struct DontDocMe {
     x: usize,

--- a/src/test/rustdoc/intra-doc/proc-macro.rs
+++ b/src/test/rustdoc/intra-doc/proc-macro.rs
@@ -9,17 +9,17 @@ pub use proc_macro_macro::{DeriveA, attr_a};
 use proc_macro_macro::{DeriveB, attr_b};
 
 // @has proc_macro/struct.Foo.html
-// @has - '//a/@href' '../proc_macro/derive.DeriveA.html'
-// @has - '//a/@href' '../proc_macro/attr.attr_a.html'
-// @has - '//a/@href' '../proc_macro/trait.DeriveTrait.html'
+// @has - '//a/@href' 'derive.DeriveA.html'
+// @has - '//a/@href' 'attr.attr_a.html'
+// @has - '//a/@href' 'trait.DeriveTrait.html'
 // @has - '//a/@href' '../proc_macro_macro/derive.DeriveB.html'
 // @has - '//a/@href' '../proc_macro_macro/attr.attr_b.html'
 /// Link to [DeriveA], [attr_a], [DeriveB], [attr_b], [DeriveTrait]
 pub struct Foo;
 
 // @has proc_macro/struct.Bar.html
-// @has - '//a/@href' '../proc_macro/derive.DeriveA.html'
-// @has - '//a/@href' '../proc_macro/attr.attr_a.html'
+// @has - '//a/@href' 'derive.DeriveA.html'
+// @has - '//a/@href' 'attr.attr_a.html'
 /// Link to [deriveA](derive@DeriveA) [attr](macro@attr_a)
 pub struct Bar;
 

--- a/src/test/rustdoc/intra-doc/pub-use.rs
+++ b/src/test/rustdoc/intra-doc/pub-use.rs
@@ -13,7 +13,7 @@ extern crate inner;
 
 // @has outer/index.html
 // @ has - '//a[@href="https://doc.rust-lang.org/nightly/std/env/fn.var.html"]' "std::env"
-// @ has - '//a[@href="../outer/fn.f.html"]' "g"
+// @ has - '//a[@href="fn.f.html"]' "g"
 pub use f as g;
 
 // FIXME: same as above

--- a/src/test/rustdoc/intra-doc/raw-ident-self.rs
+++ b/src/test/rustdoc/intra-doc/raw-ident-self.rs
@@ -5,7 +5,7 @@ pub mod r#impl {
     impl S {
         /// See [Self::b].
         // @has raw_ident_self/impl/struct.S.html
-        // @has - '//a[@href="../../raw_ident_self/impl/struct.S.html#method.b"]' 'Self::b'
+        // @has - '//a[@href="struct.S.html#method.b"]' 'Self::b'
         pub fn a() {}
 
         pub fn b() {}

--- a/src/test/rustdoc/intra-doc/reexport-additional-docs.rs
+++ b/src/test/rustdoc/intra-doc/reexport-additional-docs.rs
@@ -3,13 +3,13 @@
 #![crate_name = "foo"]
 extern crate inner;
 
-// @has foo/struct.Inner.html '//a[@href="../foo/fn.with_code.html"]' 'crate::with_code'
+// @has foo/struct.Inner.html '//a[@href="fn.with_code.html"]' 'crate::with_code'
 /// [crate::with_code]
-// @has - '//a[@href="../foo/fn.with_code.html"]' 'different text'
+// @has - '//a[@href="fn.with_code.html"]' 'different text'
 /// [different text][with_code]
-// @has - '//a[@href="../foo/fn.me_too.html"]' 'me_too'
+// @has - '//a[@href="fn.me_too.html"]' 'me_too'
 #[doc = "[me_too]"]
-// @has - '//a[@href="../foo/fn.me_three.html"]' 'reference link'
+// @has - '//a[@href="fn.me_three.html"]' 'reference link'
 /// This [reference link]
 #[doc = "has an attr in the way"]
 ///

--- a/src/test/rustdoc/intra-doc/self.rs
+++ b/src/test/rustdoc/intra-doc/self.rs
@@ -1,8 +1,8 @@
 #![crate_name = "foo"]
 
 
-// @has foo/index.html '//a/@href' '../foo/struct.Foo.html#method.new'
-// @has foo/struct.Foo.html '//a/@href' '../foo/struct.Foo.html#method.new'
+// @has foo/index.html '//a/@href' 'struct.Foo.html#method.new'
+// @has foo/struct.Foo.html '//a/@href' 'struct.Foo.html#method.new'
 
 /// Use [`new`] to create a new instance.
 ///
@@ -15,8 +15,8 @@ impl Foo {
     }
 }
 
-// @has foo/index.html '//a/@href' '../foo/struct.Bar.html#method.new2'
-// @has foo/struct.Bar.html '//a/@href' '../foo/struct.Bar.html#method.new2'
+// @has foo/index.html '//a/@href' 'struct.Bar.html#method.new2'
+// @has foo/struct.Bar.html '//a/@href' 'struct.Bar.html#method.new2'
 
 /// Use [`new2`] to create a new instance.
 ///
@@ -30,7 +30,7 @@ impl Bar {
 }
 
 pub struct MyStruct {
-    // @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#structfield.struct_field'
+    // @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#structfield.struct_field'
 
     /// [`struct_field`]
     ///
@@ -39,7 +39,7 @@ pub struct MyStruct {
 }
 
 pub enum MyEnum {
-    // @has foo/enum.MyEnum.html '//a/@href' '../foo/enum.MyEnum.html#variant.EnumVariant'
+    // @has foo/enum.MyEnum.html '//a/@href' 'enum.MyEnum.html#variant.EnumVariant'
 
     /// [`EnumVariant`]
     ///
@@ -48,7 +48,7 @@ pub enum MyEnum {
 }
 
 pub union MyUnion {
-    // @has foo/union.MyUnion.html '//a/@href' '../foo/union.MyUnion.html#structfield.union_field'
+    // @has foo/union.MyUnion.html '//a/@href' 'union.MyUnion.html#structfield.union_field'
 
     /// [`union_field`]
     ///
@@ -57,21 +57,21 @@ pub union MyUnion {
 }
 
 pub trait MyTrait {
-    // @has foo/trait.MyTrait.html '//a/@href' '../foo/trait.MyTrait.html#associatedtype.AssoType'
+    // @has foo/trait.MyTrait.html '//a/@href' 'trait.MyTrait.html#associatedtype.AssoType'
 
     /// [`AssoType`]
     ///
     /// [`AssoType`]: Self::AssoType
     type AssoType;
 
-    // @has foo/trait.MyTrait.html '//a/@href' '../foo/trait.MyTrait.html#associatedconstant.ASSO_CONST'
+    // @has foo/trait.MyTrait.html '//a/@href' 'trait.MyTrait.html#associatedconstant.ASSO_CONST'
 
     /// [`ASSO_CONST`]
     ///
     /// [`ASSO_CONST`]: Self::ASSO_CONST
     const ASSO_CONST: i32 = 1;
 
-    // @has foo/trait.MyTrait.html '//a/@href' '../foo/trait.MyTrait.html#method.asso_fn'
+    // @has foo/trait.MyTrait.html '//a/@href' 'trait.MyTrait.html#method.asso_fn'
 
     /// [`asso_fn`]
     ///
@@ -80,7 +80,7 @@ pub trait MyTrait {
 }
 
 impl MyStruct {
-    // @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#method.for_impl'
+    // @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#method.for_impl'
 
     /// [`for_impl`]
     ///
@@ -91,21 +91,21 @@ impl MyStruct {
 }
 
 impl MyTrait for MyStruct {
-    // @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#associatedtype.AssoType'
+    // @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#associatedtype.AssoType'
 
     /// [`AssoType`]
     ///
     /// [`AssoType`]: Self::AssoType
     type AssoType = u32;
 
-    // @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#associatedconstant.ASSO_CONST'
+    // @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#associatedconstant.ASSO_CONST'
 
     /// [`ASSO_CONST`]
     ///
     /// [`ASSO_CONST`]: Self::ASSO_CONST
     const ASSO_CONST: i32 = 10;
 
-    // @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#method.asso_fn'
+    // @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#method.asso_fn'
 
     /// [`asso_fn`]
     ///

--- a/src/test/rustdoc/intra-doc/trait-impl.rs
+++ b/src/test/rustdoc/intra-doc/trait-impl.rs
@@ -5,21 +5,21 @@ pub struct MyStruct;
 
 impl MyTrait for MyStruct {
 
-// @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#associatedtype.AssoType'
+// @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#associatedtype.AssoType'
 
     /// [`AssoType`]
     ///
     /// [`AssoType`]: MyStruct::AssoType
     type AssoType = u32;
 
-// @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#associatedconstant.ASSO_CONST'
+// @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#associatedconstant.ASSO_CONST'
 
     /// [`ASSO_CONST`]
     ///
     /// [`ASSO_CONST`]: MyStruct::ASSO_CONST
     const ASSO_CONST: i32 = 10;
 
-// @has foo/struct.MyStruct.html '//a/@href' '../foo/struct.MyStruct.html#method.trait_fn'
+// @has foo/struct.MyStruct.html '//a/@href' 'struct.MyStruct.html#method.trait_fn'
 
     /// [`trait_fn`]
     ///

--- a/src/test/rustdoc/intra-doc/trait-item.rs
+++ b/src/test/rustdoc/intra-doc/trait-item.rs
@@ -2,7 +2,7 @@
 
 /// Link to [S::assoc_fn()]
 /// Link to [Default::default()]
-// @has trait_item/struct.S.html '//*[@href="../trait_item/struct.S.html#method.assoc_fn"]' 'S::assoc_fn()'
+// @has trait_item/struct.S.html '//*[@href="struct.S.html#method.assoc_fn"]' 'S::assoc_fn()'
 // @has - '//*[@href="https://doc.rust-lang.org/nightly/core/default/trait.Default.html#tymethod.default"]' 'Default::default()'
 pub struct S;
 

--- a/src/test/rustdoc/intra-link-self-cache.rs
+++ b/src/test/rustdoc/intra-link-self-cache.rs
@@ -1,12 +1,12 @@
 #![crate_name = "foo"]
-// @has foo/enum.E1.html '//a/@href' '../foo/enum.E1.html#variant.A'
+// @has foo/enum.E1.html '//a/@href' 'enum.E1.html#variant.A'
 
 /// [Self::A::b]
 pub enum E1 {
     A { b: usize }
 }
 
-// @has foo/enum.E2.html '//a/@href' '../foo/enum.E2.html#variant.A'
+// @has foo/enum.E2.html '//a/@href' 'enum.E2.html#variant.A'
 
 /// [Self::A::b]
 pub enum E2 {

--- a/src/test/rustdoc/issue-28478.rs
+++ b/src/test/rustdoc/issue-28478.rs
@@ -23,9 +23,9 @@ impl Foo {
 }
 
 impl Bar for Foo {
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#associatedtype.Bar"]' 'Bar'
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#associatedconstant.Baz"]' 'Baz'
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#tymethod.bar"]' 'bar'
+    // @has - '//*[@href="trait.Bar.html#associatedtype.Bar"]' 'Bar'
+    // @has - '//*[@href="trait.Bar.html#associatedconstant.Baz"]' 'Baz'
+    // @has - '//*[@href="trait.Bar.html#tymethod.bar"]' 'bar'
     fn bar() {}
-    // @has - '//*[@href="../issue_28478/trait.Bar.html#method.baz"]' 'baz'
+    // @has - '//*[@href="trait.Bar.html#method.baz"]' 'baz'
 }

--- a/src/test/rustdoc/issue-55364.rs
+++ b/src/test/rustdoc/issue-55364.rs
@@ -2,19 +2,19 @@
 
 // @has issue_55364/subone/index.html
 // These foo/bar links in the module's documentation should refer inside `subone`
-// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subone/fn.foo.html"]' 'foo'
-// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subone/fn.bar.html"]' 'bar'
+// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.foo.html"]' 'foo'
+// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.bar.html"]' 'bar'
 pub mod subone {
     //! See either [foo] or [bar].
 
     // This should refer to subone's `bar`
     // @has issue_55364/subone/fn.foo.html
-    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subone/fn.bar.html"]' 'bar'
+    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.bar.html"]' 'bar'
     /// See [bar]
     pub fn foo() {}
     // This should refer to subone's `foo`
     // @has issue_55364/subone/fn.bar.html
-    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subone/fn.foo.html"]' 'foo'
+    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.foo.html"]' 'foo'
     /// See [foo]
     pub fn bar() {}
 }
@@ -23,11 +23,11 @@ pub mod subone {
 
 // @has issue_55364/subtwo/index.html
 // These foo/bar links in the module's documentation should not reference inside `subtwo`
-// @!has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subtwo/fn.foo.html"]' 'foo'
-// @!has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subtwo/fn.bar.html"]' 'bar'
+// @!has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.foo.html"]' 'foo'
+// @!has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.bar.html"]' 'bar'
 // Instead it should be referencing the top level functions
-// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/fn.foo.html"]' 'foo'
-// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/fn.bar.html"]' 'bar'
+// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../fn.foo.html"]' 'foo'
+// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../fn.bar.html"]' 'bar'
 // Though there should be such links later
 // @has - '//section[@id="main"]/table//tr[@class="module-item"]/td/a[@class="fn"][@href="fn.foo.html"]' 'foo'
 // @has - '//section[@id="main"]/table//tr[@class="module-item"]/td/a[@class="fn"][@href="fn.bar.html"]' 'bar'
@@ -37,13 +37,13 @@ pub mod subtwo {
     // Despite the module's docs referring to the top level foo/bar,
     // this should refer to subtwo's `bar`
     // @has issue_55364/subtwo/fn.foo.html
-    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subtwo/fn.bar.html"]' 'bar'
+    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.bar.html"]' 'bar'
     /// See [bar]
     pub fn foo() {}
     // Despite the module's docs referring to the top level foo/bar,
     // this should refer to subtwo's `foo`
     // @has issue_55364/subtwo/fn.bar.html
-    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/subtwo/fn.foo.html"]' 'foo'
+    // @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="fn.foo.html"]' 'foo'
     /// See [foo]
     pub fn bar() {}
 }
@@ -59,8 +59,8 @@ pub fn bar() {}
 
 // @has issue_55364/subthree/index.html
 // This module should also refer to the top level foo/bar
-// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/fn.foo.html"]' 'foo'
-// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../../issue_55364/fn.bar.html"]' 'bar'
+// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../fn.foo.html"]' 'foo'
+// @has - '//section[@id="main"]/div[@class="docblock"]//a[@href="../fn.bar.html"]' 'bar'
 pub mod subthree {
     //! See either [foo][super::foo] or [bar][super::bar]
 }
@@ -68,8 +68,8 @@ pub mod subthree {
 // Next we go *deeper* - In order to ensure it's not just "this or parent"
 // we test `crate::` and a `super::super::...` chain
 // @has issue_55364/subfour/subfive/subsix/subseven/subeight/index.html
-// @has - '//section[@id="main"]/table//tr[@class="module-item"]/td[@class="docblock-short"]//a[@href="../../../../../../issue_55364/subone/fn.foo.html"]' 'other foo'
-// @has - '//section[@id="main"]/table//tr[@class="module-item"]/td[@class="docblock-short"]//a[@href="../../../../../../issue_55364/subtwo/fn.bar.html"]' 'other bar'
+// @has - '//section[@id="main"]/table//tr[@class="module-item"]/td[@class="docblock-short"]//a[@href="../../../../../subone/fn.foo.html"]' 'other foo'
+// @has - '//section[@id="main"]/table//tr[@class="module-item"]/td[@class="docblock-short"]//a[@href="../../../../../subtwo/fn.bar.html"]' 'other bar'
 pub mod subfour {
     pub mod subfive {
         pub mod subsix {

--- a/src/test/rustdoc/issue-72340.rs
+++ b/src/test/rustdoc/issue-72340.rs
@@ -10,7 +10,7 @@ impl Body {
 }
 
 impl Default for Body {
-    // @has foo/struct.Body.html '//a/@href' '../foo/struct.Body.html#method.empty'
+    // @has foo/struct.Body.html '//a/@href' 'struct.Body.html#method.empty'
 
     /// Returns [`Body::empty()`](Body::empty).
     fn default() -> Body {

--- a/src/test/rustdoc/link-assoc-const.rs
+++ b/src/test/rustdoc/link-assoc-const.rs
@@ -1,7 +1,7 @@
 #![crate_name = "foo"]
 
-// @has foo/index.html '//a[@href="../foo/foo/constant.FIRSTCONST.html"]' 'foo::FIRSTCONST'
-// @has foo/index.html '//a[@href="../foo/struct.Bar.html#associatedconstant.CONST"]' 'Bar::CONST'
+// @has foo/index.html '//a[@href="foo/constant.FIRSTCONST.html"]' 'foo::FIRSTCONST'
+// @has foo/index.html '//a[@href="struct.Bar.html#associatedconstant.CONST"]' 'Bar::CONST'
 
 //! We have here [`foo::FIRSTCONST`] and [`Bar::CONST`].
 

--- a/src/test/rustdoc/proc-macro.rs
+++ b/src/test/rustdoc/proc-macro.rs
@@ -61,12 +61,12 @@ pub fn some_derive(_item: TokenStream) -> TokenStream {
 // @has some_macros/foo/index.html
 mod foo {
     // @has - '//code' 'pub use some_proc_macro;'
-    // @has - '//a/@href' '../../some_macros/macro.some_proc_macro.html'
+    // @has - '//a/@href' '../macro.some_proc_macro.html'
     pub use some_proc_macro;
     // @has - '//code' 'pub use some_proc_attr;'
-    // @has - '//a/@href' '../../some_macros/attr.some_proc_attr.html'
+    // @has - '//a/@href' '../attr.some_proc_attr.html'
     pub use some_proc_attr;
     // @has - '//code' 'pub use some_derive;'
-    // @has - '//a/@href' '../../some_macros/derive.SomeDerive.html'
+    // @has - '//a/@href' '../derive.SomeDerive.html'
     pub use some_derive;
 }

--- a/src/test/rustdoc/raw-ident-eliminate-r-hashtag.rs
+++ b/src/test/rustdoc/raw-ident-eliminate-r-hashtag.rs
@@ -8,13 +8,13 @@ pub mod internal {
     ///
     /// [name]: mod
     /// [other name]: crate::internal::mod
-    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//*a[@href="../../raw_ident_eliminate_r_hashtag/internal/struct.mod.html"]' 'name'
-    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//*a[@href="../../raw_ident_eliminate_r_hashtag/internal/struct.mod.html"]' 'other name'
+    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//*a[@href="struct.mod.html"]' 'name'
+    // @has 'raw_ident_eliminate_r_hashtag/internal/struct.B.html' '//*a[@href="struct.mod.html"]' 'other name'
     pub struct B;
 }
 
 /// See [name].
 ///
 /// [name]: internal::mod
-// @has 'raw_ident_eliminate_r_hashtag/struct.A.html' '//*a[@href="../raw_ident_eliminate_r_hashtag/internal/struct.mod.html"]' 'name'
+// @has 'raw_ident_eliminate_r_hashtag/struct.A.html' '//*a[@href="internal/struct.mod.html"]' 'name'
 pub struct A;

--- a/src/test/rustdoc/struct-field.rs
+++ b/src/test/rustdoc/struct-field.rs
@@ -1,9 +1,9 @@
 #![crate_name = "foo"]
 
 
-// @has foo/index.html '//*[@class="docblock"]/p/a[@href="../foo/struct.Foo.html#structfield.bar"]' 'Foo::bar'
-// @has foo/index.html '//*[@class="docblock"]/p/a[@href="../foo/union.Bar.html#structfield.foo"]' 'Bar::foo'
-// @has foo/index.html '//*[@class="docblock"]/p/a[@href="../foo/enum.Uniooon.html#variant.X"]' 'Uniooon::X'
+// @has foo/index.html '//*[@class="docblock"]/p/a[@href="struct.Foo.html#structfield.bar"]' 'Foo::bar'
+// @has foo/index.html '//*[@class="docblock"]/p/a[@href="union.Bar.html#structfield.foo"]' 'Bar::foo'
+// @has foo/index.html '//*[@class="docblock"]/p/a[@href="enum.Uniooon.html#variant.X"]' 'Uniooon::X'
 
 //! Test with [Foo::bar], [Bar::foo], [Uniooon::X]
 

--- a/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
+++ b/src/test/rustdoc/trait-impl-items-links-and-anchors.rs
@@ -40,25 +40,25 @@ impl MyTrait for Vec<u8> {
 impl MyTrait for MyStruct {
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="associatedtype.Assoc-3"]//a[@class="type"]/@href' #associatedtype.Assoc
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="associatedtype.Assoc-3"]//a[@class="anchor"]/@href' #associatedtype.Assoc-3
-    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="associatedtype.Assoc"]//a[@class="type"]/@href' ../trait_impl_items_links_and_anchors/trait.MyTrait.html#associatedtype.Assoc
+    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="associatedtype.Assoc"]//a[@class="type"]/@href' trait.MyTrait.html#associatedtype.Assoc
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="associatedtype.Assoc"]//a[@class="anchor"]/@href' #associatedtype.Assoc
     type Assoc = bool;
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="associatedconstant.VALUE-3"]//a[@class="constant"]/@href' #associatedconstant.VALUE
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="associatedconstant.VALUE-3"]//a[@class="anchor"]/@href' #associatedconstant.VALUE-3
-    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="associatedconstant.VALUE"]//a[@class="constant"]/@href' ../trait_impl_items_links_and_anchors/trait.MyTrait.html#associatedconstant.VALUE
+    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="associatedconstant.VALUE"]//a[@class="constant"]/@href' trait.MyTrait.html#associatedconstant.VALUE
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="associatedconstant.VALUE"]//a[@class="anchor"]/@href' #associatedconstant.VALUE
     const VALUE: u32 = 20;
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="method.trait_function-2"]//a[@class="fnname"]/@href' #tymethod.trait_function
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="method.trait_function-2"]//a[@class="anchor"]/@href' #method.trait_function-2
-    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.trait_function"]//a[@class="fnname"]/@href' ../trait_impl_items_links_and_anchors/trait.MyTrait.html#tymethod.trait_function
+    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.trait_function"]//a[@class="fnname"]/@href' trait.MyTrait.html#tymethod.trait_function
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.trait_function"]//a[@class="anchor"]/@href' #method.trait_function
     fn trait_function(&self) {}
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="method.defaulted_override-3"]//a[@class="fnname"]/@href' #method.defaulted_override
     // @has trait_impl_items_links_and_anchors/trait.MyTrait.html '//h4[@id="method.defaulted_override-3"]//a[@class="anchor"]/@href' #method.defaulted_override-3
-    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.defaulted_override"]//a[@class="fnname"]/@href' ../trait_impl_items_links_and_anchors/trait.MyTrait.html#method.defaulted_override
+    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.defaulted_override"]//a[@class="fnname"]/@href' trait.MyTrait.html#method.defaulted_override
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.defaulted_override"]//a[@class="anchor"]/@href' #method.defaulted_override
     fn defaulted_override(&self) {}
-    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.defaulted"]//a[@class="fnname"]/@href' ../trait_impl_items_links_and_anchors/trait.MyTrait.html#method.defaulted
+    // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.defaulted"]//a[@class="fnname"]/@href' trait.MyTrait.html#method.defaulted
     // @has trait_impl_items_links_and_anchors/struct.MyStruct.html '//h4[@id="method.defaulted"]//a[@class="anchor"]/@href' #method.defaulted
 }
 

--- a/src/test/rustdoc/trait-self-link.rs
+++ b/src/test/rustdoc/trait-self-link.rs
@@ -1,4 +1,4 @@
-// @has trait_self_link/trait.Foo.html //a/@href ../trait_self_link/trait.Foo.html
+// @has trait_self_link/trait.Foo.html //a/@href trait.Foo.html
 pub trait Foo {}
 
 pub struct Bar;


### PR DESCRIPTION
This is a fairly large diff, and will probably conflict with https://github.com/rust-lang/rust/pull/82815 since it reduces (but does not eliminate) the use of the old depth variable.

Instead of using a depth counter and adding "../" to get to the top, this commit makes rustdoc actually compare the path of what it's linking from to the path that it's linking to. This makes the resulting HTML shorter.

Here's a comparison of one of the largest (non-source) files in the Rust standard library docs (about 4% improvement before gzipping).

    $ wc -c struct.Wrapping.old.html struct.Wrapping.new.html
    2387389 struct.Wrapping.old.html
    2298538 struct.Wrapping.new.html

Most if it can be efficiently gzipped away.

    $ wc -c struct.Wrapping.old.html.gz struct.Wrapping.new.html.gz
    70679 struct.Wrapping.old.html.gz
    70050 struct.Wrapping.new.html.gz

But it also makes a difference in the final DOM size, reducing it from 91MiB to 82MiB.