### PR TITLE
Suggestion for call on immutable binding of mutable type

### DIFF
--- a/src/test/ui/borrowck/mut-borrow-of-mut-ref.rs
+++ b/src/test/ui/borrowck/mut-borrow-of-mut-ref.rs
@@ -2,12 +2,36 @@
 #![crate_type = "rlib"]
 
 pub fn f(b: &mut i32) {
-    g(&mut b);
+    //~^ NOTE the binding is already a mutable borrow
+    //~| NOTE the binding is already a mutable borrow
+    h(&mut b);
     //~^ ERROR cannot borrow
+    //~| NOTE cannot borrow as mutable
     //~| HELP try removing `&mut` here
     g(&mut &mut b);
     //~^ ERROR cannot borrow
+    //~| NOTE cannot borrow as mutable
     //~| HELP try removing `&mut` here
 }
 
-pub fn g(_: &mut i32) {}
+pub fn g(b: &mut i32) { //~ NOTE the binding is already a mutable borrow
+    h(&mut &mut b);
+    //~^ ERROR cannot borrow
+    //~| NOTE cannot borrow as mutable
+    //~| HELP try removing `&mut` here
+}
+
+pub fn h(_: &mut i32) {}
+
+trait Foo {
+    fn bar(&mut self);
+}
+
+impl Foo for &mut String {
+    fn bar(&mut self) {}
+}
+
+pub fn baz(f: &mut String) { //~ HELP consider making the binding mutable
+    f.bar(); //~ ERROR cannot borrow `f` as mutable, as it is not declared as mutable
+    //~^ NOTE cannot borrow as mutable
+}

--- a/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -11,8 +11,9 @@ LL | pub fn f(b: &mut i32) {
    |             ^^^^^^^^
 help: try removing `&mut` here
    |
-LL |     h(b);
-   |      --
+LL -     h(&mut b);
+LL +     h(b);
+   | 
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:11:12
@@ -27,8 +28,9 @@ LL | pub fn f(b: &mut i32) {
    |             ^^^^^^^^
 help: try removing `&mut` here
    |
-LL |     g(&mut b);
-   |           --
+LL -     g(&mut &mut b);
+LL +     g(&mut b);
+   | 
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:18:12
@@ -43,8 +45,9 @@ LL | pub fn g(b: &mut i32) {
    |             ^^^^^^^^
 help: try removing `&mut` here
    |
-LL |     h(&mut b);
-   |           --
+LL -     h(&mut &mut b);
+LL +     h(&mut b);
+   | 
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:35:5
@@ -55,7 +58,7 @@ LL |     f.bar();
 help: consider making the binding mutable
    |
 LL | pub fn baz(mut f: &mut String) {
-   |            ^^^
+   |            +++
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -1,21 +1,65 @@
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:5:7
+  --> $DIR/mut-borrow-of-mut-ref.rs:7:7
    |
-LL |     g(&mut b);
+LL |     h(&mut b);
+   |       ^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/mut-borrow-of-mut-ref.rs:4:13
+   |
+LL | pub fn f(b: &mut i32) {
+   |             ^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/mut-borrow-of-mut-ref.rs:7:7
+   |
+LL |     h(&mut b);
    |       ^^^^^^
-   |       |
-   |       cannot borrow as mutable
-   |       help: try removing `&mut` here
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:8:12
+  --> $DIR/mut-borrow-of-mut-ref.rs:11:12
+   |
+LL |     g(&mut &mut b);
+   |            ^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/mut-borrow-of-mut-ref.rs:4:13
+   |
+LL | pub fn f(b: &mut i32) {
+   |             ^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/mut-borrow-of-mut-ref.rs:11:12
    |
 LL |     g(&mut &mut b);
    |            ^^^^^^
-   |            |
-   |            cannot borrow as mutable
-   |            help: try removing `&mut` here
 
-error: aborting due to 2 previous errors
+error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
+  --> $DIR/mut-borrow-of-mut-ref.rs:18:12
+   |
+LL |     h(&mut &mut b);
+   |            ^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/mut-borrow-of-mut-ref.rs:17:13
+   |
+LL | pub fn g(b: &mut i32) {
+   |             ^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/mut-borrow-of-mut-ref.rs:18:12
+   |
+LL |     h(&mut &mut b);
+   |            ^^^^^^
+
+error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+  --> $DIR/mut-borrow-of-mut-ref.rs:35:5
+   |
+LL |     f.bar();
+   |     ^ cannot borrow as mutable
+   |
+help: consider making the binding mutable
+   |
+LL | pub fn baz(mut f: &mut String) {
+   |            ^^^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -10,10 +10,9 @@ note: the binding is already a mutable borrow
 LL | pub fn f(b: &mut i32) {
    |             ^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/mut-borrow-of-mut-ref.rs:7:7
    |
-LL |     h(&mut b);
-   |       ^^^^^^
+LL |     h(b);
+   |      --
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:11:12
@@ -27,10 +26,9 @@ note: the binding is already a mutable borrow
 LL | pub fn f(b: &mut i32) {
    |             ^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/mut-borrow-of-mut-ref.rs:11:12
    |
-LL |     g(&mut &mut b);
-   |            ^^^^^^
+LL |     g(&mut b);
+   |           --
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:18:12
@@ -44,10 +42,9 @@ note: the binding is already a mutable borrow
 LL | pub fn g(b: &mut i32) {
    |             ^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/mut-borrow-of-mut-ref.rs:18:12
    |
-LL |     h(&mut &mut b);
-   |            ^^^^^^
+LL |     h(&mut b);
+   |           --
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:35:5

--- a/src/test/ui/did_you_mean/issue-31424.stderr
+++ b/src/test/ui/did_you_mean/issue-31424.stderr
@@ -2,10 +2,18 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-31424.rs:7:9
    |
 LL |         (&mut self).bar();
+   |         ^^^^^^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/issue-31424.rs:6:12
+   |
+LL |     fn foo(&mut self) {
+   |            ^^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/issue-31424.rs:7:9
+   |
+LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
-   |         |
-   |         cannot borrow as mutable
-   |         help: try removing `&mut` here
 
 warning: function cannot return without recursing
   --> $DIR/issue-31424.rs:13:5
@@ -23,10 +31,18 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-31424.rs:16:9
    |
 LL |         (&mut self).bar();
+   |         ^^^^^^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/issue-31424.rs:13:18
+   |
+LL |     fn bar(self: &mut Self) {
+   |                  ^^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/issue-31424.rs:16:9
+   |
+LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
-   |         |
-   |         cannot borrow as mutable
-   |         help: try removing `&mut` here
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/did_you_mean/issue-34126.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.stderr
@@ -2,10 +2,18 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-34126.rs:6:18
    |
 LL |         self.run(&mut self);
+   |                  ^^^^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/issue-34126.rs:5:14
+   |
+LL |     fn start(&mut self) {
+   |              ^^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/issue-34126.rs:6:18
+   |
+LL |         self.run(&mut self);
    |                  ^^^^^^^^^
-   |                  |
-   |                  cannot borrow as mutable
-   |                  help: try removing `&mut` here
 
 error[E0502]: cannot borrow `self` as mutable because it is also borrowed as immutable
   --> $DIR/issue-34126.rs:6:18

--- a/src/test/ui/did_you_mean/issue-34126.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.stderr
@@ -11,8 +11,9 @@ LL |     fn start(&mut self) {
    |              ^^^^^^^^^
 help: try removing `&mut` here
    |
-LL |         self.run(self);
-   |                 --
+LL -         self.run(&mut self);
+LL +         self.run(self);
+   | 
 
 error[E0502]: cannot borrow `self` as mutable because it is also borrowed as immutable
   --> $DIR/issue-34126.rs:6:18

--- a/src/test/ui/did_you_mean/issue-34126.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.stderr
@@ -10,10 +10,9 @@ note: the binding is already a mutable borrow
 LL |     fn start(&mut self) {
    |              ^^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/issue-34126.rs:6:18
    |
-LL |         self.run(&mut self);
-   |                  ^^^^^^^^^
+LL |         self.run(self);
+   |                 --
 
 error[E0502]: cannot borrow `self` as mutable because it is also borrowed as immutable
   --> $DIR/issue-34126.rs:6:18

--- a/src/test/ui/nll/issue-51191.stderr
+++ b/src/test/ui/nll/issue-51191.stderr
@@ -14,10 +14,18 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:7:9
    |
 LL |         (&mut self).bar();
+   |         ^^^^^^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/issue-51191.rs:4:18
+   |
+LL |     fn bar(self: &mut Self) {
+   |                  ^^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/issue-51191.rs:7:9
+   |
+LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
-   |         |
-   |         cannot borrow as mutable
-   |         help: try removing `&mut` here
 
 error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:13:9
@@ -43,10 +51,18 @@ error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:28:9
    |
 LL |         (&mut self).bar();
+   |         ^^^^^^^^^^^ cannot borrow as mutable
+   |
+note: the binding is already a mutable borrow
+  --> $DIR/issue-51191.rs:27:16
+   |
+LL |     fn mtblref(&mut self) {
+   |                ^^^^^^^^^
+help: try removing `&mut` here
+  --> $DIR/issue-51191.rs:28:9
+   |
+LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
-   |         |
-   |         cannot borrow as mutable
-   |         help: try removing `&mut` here
 
 error: aborting due to 5 previous errors; 1 warning emitted
 


### PR DESCRIPTION
When calling a method requiring a mutable self borrow on an inmutable
to a mutable borrow of the type, suggest making the binding mutable.

Fix #83241.