### PR TITLE
Revert the second deprecation of collections::Bound

### DIFF
--- a/library/std/src/collections/mod.rs
+++ b/library/std/src/collections/mod.rs
@@ -401,9 +401,10 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_deprecated(reason = "moved to `std::ops::Bound`", since = "1.52.0")]
+// FIXME(#82080) The deprecation here is only theoretical, and does not actually produce a warning.
+#[rustc_deprecated(reason = "moved to `std::ops::Bound`", since = "1.26.0")]
 #[doc(hidden)]
-pub type Bound<T> = crate::ops::Bound<T>;
+pub use crate::ops::Bound;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::collections::{binary_heap, btree_map, btree_set};


### PR DESCRIPTION
Per the review at https://github.com/rust-lang/rust/pull/82122#discussion_r596448078 and the decision at https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/unavoidable.20breakage.20when.20deprecating.20an.20enum.3F , revert this small portion of #82122 for the time being. This doesn't affect the other components of that patch, i.e. `intrinsics::drop_in_place` is still deprecated-for-real, and uses of `collections::Bound` remain removed from the repo.