### PR TITLE
Add simd_neg platform intrinsic

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
@@ -276,5 +276,6 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
         // simd_bitmask
         // simd_select
         // simd_rem
+        // simd_neg
     }
 }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1628,7 +1628,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
             out_elem
         );
     }
-    macro_rules! arith {
+    macro_rules! arith_bin {
         ($($name: ident: $($($p: ident),* => $call: ident),*;)*) => {
             $(if name == sym::$name {
                 match in_elem.kind() {
@@ -1644,7 +1644,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
             })*
         }
     }
-    arith! {
+    arith_bin! {
         simd_add: Uint, Int => add, Float => fadd;
         simd_sub: Uint, Int => sub, Float => fsub;
         simd_mul: Uint, Int => mul, Float => fmul;
@@ -1658,6 +1658,25 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
         simd_fmax: Float => maxnum;
         simd_fmin: Float => minnum;
 
+    }
+    macro_rules! arith_un {
+        ($($name: ident: $($($p: ident),* => $call: ident),*;)*) => {
+            $(if name == sym::$name {
+                match in_elem.kind() {
+                    $($(ty::$p(_))|* => {
+                        return Ok(bx.$call(args[0].immediate()))
+                    })*
+                    _ => {},
+                }
+                require!(false,
+                         "unsupported operation on `{}` with element `{}`",
+                         in_ty,
+                         in_elem)
+            })*
+        }
+    }
+    arith_un! {
+        simd_neg: Int => neg, Float => fneg;
     }
 
     if name == sym::simd_saturating_add || name == sym::simd_saturating_sub {

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1628,7 +1628,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
             out_elem
         );
     }
-    macro_rules! arith_bin {
+    macro_rules! arith_binary {
         ($($name: ident: $($($p: ident),* => $call: ident),*;)*) => {
             $(if name == sym::$name {
                 match in_elem.kind() {
@@ -1644,7 +1644,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
             })*
         }
     }
-    arith_bin! {
+    arith_binary! {
         simd_add: Uint, Int => add, Float => fadd;
         simd_sub: Uint, Int => sub, Float => fsub;
         simd_mul: Uint, Int => mul, Float => fmul;
@@ -1659,7 +1659,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
         simd_fmin: Float => minnum;
 
     }
-    macro_rules! arith_un {
+    macro_rules! arith_unary {
         ($($name: ident: $($($p: ident),* => $call: ident),*;)*) => {
             $(if name == sym::$name {
                 match in_elem.kind() {
@@ -1675,7 +1675,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
             })*
         }
     }
-    arith_un! {
+    arith_unary! {
         simd_neg: Int => neg, Float => fneg;
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1081,6 +1081,7 @@ symbols! {
         simd_lt,
         simd_mul,
         simd_ne,
+        simd_neg,
         simd_or,
         simd_reduce_add_ordered,
         simd_reduce_add_unordered,

--- a/compiler/rustc_typeck/src/check/intrinsic.rs
+++ b/compiler/rustc_typeck/src/check/intrinsic.rs
@@ -398,6 +398,7 @@ pub fn check_platform_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>)
         | sym::simd_fpow
         | sym::simd_saturating_add
         | sym::simd_saturating_sub => (1, vec![param(0), param(0)], param(0)),
+        sym::simd_neg => (1, vec![param(0)], param(0)),
         sym::simd_fsqrt
         | sym::simd_fsin
         | sym::simd_fcos

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-generic-arithmetic.rs
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-generic-arithmetic.rs
@@ -25,6 +25,8 @@ extern "platform-intrinsic" {
     fn simd_and<T>(x: T, y: T) -> T;
     fn simd_or<T>(x: T, y: T) -> T;
     fn simd_xor<T>(x: T, y: T) -> T;
+
+    fn simd_neg<T>(x: T) -> T;
 }
 
 fn main() {
@@ -60,6 +62,9 @@ fn main() {
         simd_xor(x, x);
         simd_xor(y, y);
 
+        simd_neg(x);
+        simd_neg(z);
+
 
         simd_add(0, 0);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
@@ -78,6 +83,9 @@ fn main() {
         simd_or(0, 0);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
         simd_xor(0, 0);
+        //~^ ERROR expected SIMD input type, found non-SIMD `i32`
+
+        simd_neg(0);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
 
 

--- a/src/test/ui/simd-intrinsic/simd-intrinsic-generic-arithmetic.stderr
+++ b/src/test/ui/simd-intrinsic/simd-intrinsic-generic-arithmetic.stderr
@@ -1,87 +1,93 @@
 error[E0511]: invalid monomorphization of `simd_add` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:64:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:69:9
    |
 LL |         simd_add(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_sub` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:66:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:71:9
    |
 LL |         simd_sub(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_mul` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:68:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:73:9
    |
 LL |         simd_mul(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_div` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:70:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:75:9
    |
 LL |         simd_div(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shl` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:72:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:77:9
    |
 LL |         simd_shl(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shr` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:74:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:79:9
    |
 LL |         simd_shr(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_and` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:76:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:81:9
    |
 LL |         simd_and(0, 0);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_or` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:78:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:83:9
    |
 LL |         simd_or(0, 0);
    |         ^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_xor` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:80:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:85:9
    |
 LL |         simd_xor(0, 0);
    |         ^^^^^^^^^^^^^^
 
+error[E0511]: invalid monomorphization of `simd_neg` intrinsic: expected SIMD input type, found non-SIMD `i32`
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:88:9
+   |
+LL |         simd_neg(0);
+   |         ^^^^^^^^^^^
+
 error[E0511]: invalid monomorphization of `simd_shl` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:84:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:92:9
    |
 LL |         simd_shl(z, z);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shr` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:86:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:94:9
    |
 LL |         simd_shr(z, z);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_and` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:88:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:96:9
    |
 LL |         simd_and(z, z);
    |         ^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_or` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:90:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:98:9
    |
 LL |         simd_or(z, z);
    |         ^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_xor` intrinsic: unsupported operation on `f32x4` with element `f32`
-  --> $DIR/simd-intrinsic-generic-arithmetic.rs:92:9
+  --> $DIR/simd-intrinsic-generic-arithmetic.rs:100:9
    |
 LL |         simd_xor(z, z);
    |         ^^^^^^^^^^^^^^
 
-error: aborting due to 14 previous errors
+error: aborting due to 15 previous errors
 
 For more information about this error, try `rustc --explain E0511`.

--- a/src/test/ui/simd/simd-intrinsic-generic-arithmetic.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-arithmetic.rs
@@ -45,6 +45,8 @@ extern "platform-intrinsic" {
     fn simd_and<T>(x: T, y: T) -> T;
     fn simd_or<T>(x: T, y: T) -> T;
     fn simd_xor<T>(x: T, y: T) -> T;
+
+    fn simd_neg<T>(x: T) -> T;
 }
 
 fn main() {
@@ -124,6 +126,11 @@ fn main() {
         all_eq!(simd_xor(x2, x1), i32x4(3, 1, 7, 1));
         all_eq_!(simd_xor(y1, y2), U32::<4>([3, 1, 7, 1]));
         all_eq_!(simd_xor(y2, y1), U32::<4>([3, 1, 7, 1]));
+
+        all_eq!(simd_neg(x1), i32x4(-1, -2, -3, -4));
+        all_eq!(simd_neg(x2), i32x4(-2, -3, -4, -5));
+        all_eq!(simd_neg(z1), f32x4(-1.0, -2.0, -3.0, -4.0));
+        all_eq!(simd_neg(z2), f32x4(-2.0, -3.0, -4.0, -5.0));
 
     }
 }


### PR DESCRIPTION
Stdarch needs to add simd_neg to support the implementation of vneg neon instructions. Look [here](https://github.com/rust-lang/stdarch/pull/1087)