### PR TITLE
Bump stdarch submodule

### DIFF
--- a/src/test/ui/consts/const_arg_local.rs
+++ b/src/test/ui/consts/const_arg_local.rs
@@ -1,13 +1,11 @@
-// only-x86_64
+#![feature(rustc_attrs)]
 
-#[cfg(target_arch = "x86")]
-use std::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+#[rustc_args_required_const(0)]
+fn foo(_imm8: i32) {}
 
-unsafe fn pclmul(a: __m128i, b: __m128i) -> __m128i {
+fn bar() {
     let imm8 = 3;
-    _mm_clmulepi64_si128(a, b, imm8) //~ ERROR argument 3 is required to be a constant
+    foo(imm8) //~ ERROR argument 1 is required to be a constant
 }
 
 fn main() {}

--- a/src/test/ui/consts/const_arg_local.stderr
+++ b/src/test/ui/consts/const_arg_local.stderr
@@ -1,8 +1,8 @@
-error: argument 3 is required to be a constant
-  --> $DIR/const_arg_local.rs:10:5
+error: argument 1 is required to be a constant
+  --> $DIR/const_arg_local.rs:8:5
    |
-LL |     _mm_clmulepi64_si128(a, b, imm8)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     foo(imm8)
+   |     ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const_arg_promotable.rs
+++ b/src/test/ui/consts/const_arg_promotable.rs
@@ -1,12 +1,10 @@
-// only-x86_64
+#![feature(rustc_attrs)]
 
-#[cfg(target_arch = "x86")]
-use std::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+#[rustc_args_required_const(0)]
+fn foo(_imm8: i32) {}
 
-unsafe fn pclmul(a: __m128i, b: __m128i) -> __m128i {
-    _mm_clmulepi64_si128(a, b, *&mut 42) //~ ERROR argument 3 is required to be a constant
+fn bar() {
+    foo(*&mut 42) //~ ERROR argument 1 is required to be a constant
 }
 
 fn main() {}

--- a/src/test/ui/consts/const_arg_promotable.stderr
+++ b/src/test/ui/consts/const_arg_promotable.stderr
@@ -1,8 +1,8 @@
-error: argument 3 is required to be a constant
-  --> $DIR/const_arg_promotable.rs:9:5
+error: argument 1 is required to be a constant
+  --> $DIR/const_arg_promotable.rs:7:5
    |
-LL |     _mm_clmulepi64_si128(a, b, *&mut 42)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     foo(*&mut 42)
+   |     ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const_arg_wrapper.rs
+++ b/src/test/ui/consts/const_arg_wrapper.rs
@@ -1,12 +1,10 @@
-// only-x86_64
+#![feature(rustc_attrs)]
 
-#[cfg(target_arch = "x86")]
-use std::arch::x86::*;
-#[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+#[rustc_args_required_const(0)]
+fn foo(_imm8: i32) {}
 
-unsafe fn pclmul(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
-    _mm_clmulepi64_si128(a, b, imm8) //~ ERROR argument 3 is required to be a constant
+fn bar(imm8: i32) {
+    foo(imm8) //~ ERROR argument 1 is required to be a constant
 }
 
 fn main() {}

--- a/src/test/ui/consts/const_arg_wrapper.stderr
+++ b/src/test/ui/consts/const_arg_wrapper.stderr
@@ -1,8 +1,8 @@
-error: argument 3 is required to be a constant
-  --> $DIR/const_arg_wrapper.rs:9:5
+error: argument 1 is required to be a constant
+  --> $DIR/const_arg_wrapper.rs:7:5
    |
-LL |     _mm_clmulepi64_si128(a, b, imm8)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     foo(imm8)
+   |     ^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Major changes:
- More AVX-512 intrinsics.
- More ARM & AArch64 NEON intrinsics.
- Updated unstable WASM intrinsics to latest draft standards.
- Intrinsics that previously used `#[rustc_args_required_const]` now use const generics. See #83167 for more details.
- `std_detect` is now a separate crate instead of a submodule of `std`.