### PR TITLE
Do not ICE on ty::Error as an error must already have been reported

### DIFF
--- a/src/test/ui/const-generics/type_mismatch.rs
+++ b/src/test/ui/const-generics/type_mismatch.rs
@@ -1,0 +1,9 @@
+fn foo<const N: usize>() -> [u8; N] {
+    bar::<N>() //~ ERROR mismatched types
+}
+
+fn bar<const N: u8>() -> [u8; N] {}
+//~^ ERROR mismatched types
+//~| ERROR mismatched types
+
+fn main() {}

--- a/src/test/ui/const-generics/type_mismatch.stderr
+++ b/src/test/ui/const-generics/type_mismatch.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:2:11
+   |
+LL |     bar::<N>()
+   |           ^ expected `u8`, found `usize`
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:5:31
+   |
+LL | fn bar<const N: u8>() -> [u8; N] {}
+   |                               ^ expected `usize`, found `u8`
+
+error[E0308]: mismatched types
+  --> $DIR/type_mismatch.rs:5:26
+   |
+LL | fn bar<const N: u8>() -> [u8; N] {}
+   |    ---                   ^^^^^^^ expected array `[u8; N]`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/type_not_in_scope.rs
+++ b/src/test/ui/const-generics/type_not_in_scope.rs
@@ -1,0 +1,11 @@
+impl X {
+    //~^ ERROR cannot find type
+    fn getn<const N: usize>() -> [u8; N] {
+        getn::<N>()
+    }
+}
+fn getn<const N: cfg_attr>() -> [u8; N] {}
+//~^ ERROR expected type, found built-in attribute `cfg_attr`
+//~| ERROR mismatched types
+
+fn main() {}

--- a/src/test/ui/const-generics/type_not_in_scope.stderr
+++ b/src/test/ui/const-generics/type_not_in_scope.stderr
@@ -1,0 +1,24 @@
+error[E0412]: cannot find type `X` in this scope
+  --> $DIR/type_not_in_scope.rs:1:6
+   |
+LL | impl X {
+   |      ^ not found in this scope
+
+error[E0573]: expected type, found built-in attribute `cfg_attr`
+  --> $DIR/type_not_in_scope.rs:7:18
+   |
+LL | fn getn<const N: cfg_attr>() -> [u8; N] {}
+   |                  ^^^^^^^^ not a type
+
+error[E0308]: mismatched types
+  --> $DIR/type_not_in_scope.rs:7:33
+   |
+LL | fn getn<const N: cfg_attr>() -> [u8; N] {}
+   |    ----                         ^^^^^^^ expected array `[u8; N]`, found `()`
+   |    |
+   |    implicitly returns `()` as its body has no tail or `return` expression
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0412, E0573.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
fixes #83253