### PR TITLE
Only enable assert_dep_graph when query-dep-graph is enabled.

### DIFF
--- a/compiler/rustc_incremental/src/assert_dep_graph.rs
+++ b/compiler/rustc_incremental/src/assert_dep_graph.rs
@@ -57,6 +57,10 @@ pub fn assert_dep_graph(tcx: TyCtxt<'_>) {
             dump_graph(tcx);
         }
 
+        if !tcx.sess.opts.debugging_opts.query_dep_graph {
+            return;
+        }
+
         // if the `rustc_attrs` feature is not enabled, then the
         // attributes we are interested in cannot be present anyway, so
         // skip the walk.

--- a/compiler/rustc_incremental/src/persist/dirty_clean.rs
+++ b/compiler/rustc_incremental/src/persist/dirty_clean.rs
@@ -148,6 +148,10 @@ impl Assertion {
 }
 
 pub fn check_dirty_clean_annotations(tcx: TyCtxt<'_>) {
+    if !tcx.sess.opts.debugging_opts.query_dep_graph {
+        return;
+    }
+
     // can't add `#[rustc_dirty]` etc without opting in to this feature
     if !tcx.features().rustc_attrs {
         return;

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -99,6 +99,12 @@ impl CheckAttrVisitor<'tcx> {
                 self.check_naked(hir_id, attr, span, target)
             } else if self.tcx.sess.check_name(attr, sym::rustc_legacy_const_generics) {
                 self.check_rustc_legacy_const_generics(&attr, span, target, item)
+            } else if self.tcx.sess.check_name(attr, sym::rustc_clean)
+                || self.tcx.sess.check_name(attr, sym::rustc_dirty)
+                || self.tcx.sess.check_name(attr, sym::rustc_if_this_changed)
+                || self.tcx.sess.check_name(attr, sym::rustc_then_this_would_need)
+            {
+                self.check_rustc_dirty_clean(&attr)
             } else {
                 // lint-only checks
                 if self.tcx.sess.check_name(attr, sym::cold) {
@@ -1009,6 +1015,19 @@ impl CheckAttrVisitor<'tcx> {
             false
         } else {
             true
+        }
+    }
+
+    /// Checks if `#[rustc_legacy_const_generics]` is applied to a function and has a valid argument.
+    fn check_rustc_dirty_clean(&self, attr: &Attribute) -> bool {
+        if self.tcx.sess.opts.debugging_opts.query_dep_graph {
+            true
+        } else {
+            self.tcx
+                .sess
+                .struct_span_err(attr.span, "attribute requires -Z query-dep-graph to be enabled")
+                .emit();
+            false
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1018,7 +1018,8 @@ impl CheckAttrVisitor<'tcx> {
         }
     }
 
-    /// Checks if `#[rustc_legacy_const_generics]` is applied to a function and has a valid argument.
+    /// Checks that the dep-graph debugging attributes are only present when the query-dep-graph
+    /// option is passed to the compiler.
     fn check_rustc_dirty_clean(&self, attr: &Attribute) -> bool {
         if self.tcx.sess.opts.debugging_opts.query_dep_graph {
             true

--- a/src/test/incremental/ich_nested_items.rs
+++ b/src/test/incremental/ich_nested_items.rs
@@ -3,6 +3,7 @@
 
 // revisions: cfail1 cfail2
 // build-pass (FIXME(62277): could be check-pass?)
+// compile-flags: -Z query-dep-graph
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/ich_resolve_results.rs
+++ b/src/test/incremental/ich_resolve_results.rs
@@ -2,6 +2,7 @@
 // `use` to something different.
 
 // revisions: rpass1 rpass2 rpass3
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 

--- a/src/test/incremental/spans_significant_w_panic.rs
+++ b/src/test/incremental/spans_significant_w_panic.rs
@@ -3,7 +3,7 @@
 
 // revisions:rpass1 rpass2
 
-// compile-flags: -C overflow-checks=on
+// compile-flags: -C overflow-checks=on -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/dep-graph/dep-graph-check-attr.rs
+++ b/src/test/ui/dep-graph/dep-graph-check-attr.rs
@@ -1,0 +1,20 @@
+// Test that using rustc_clean/dirty/if_this_changed/then_this_would_need
+// are forbidden when `-Z query-dep-graph` is not enabled.
+
+#![feature(rustc_attrs)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+#[rustc_dirty(hir_owner)] //~ ERROR attribute requires -Z query-dep-graph
+fn main() {}
+
+#[rustc_if_this_changed(hir_owner)] //~ ERROR attribute requires -Z query-dep-graph
+struct Foo<T> {
+    f: T,
+}
+
+#[rustc_clean(hir_owner)] //~ ERROR attribute requires -Z query-dep-graph
+type TypeAlias<T> = Foo<T>;
+
+#[rustc_then_this_would_need(variances_of)] //~ ERROR attribute requires -Z query-dep-graph
+trait Use<T> {}

--- a/src/test/ui/dep-graph/dep-graph-check-attr.stderr
+++ b/src/test/ui/dep-graph/dep-graph-check-attr.stderr
@@ -1,0 +1,26 @@
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:8:1
+   |
+LL | #[rustc_dirty(hir_owner)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:11:1
+   |
+LL | #[rustc_if_this_changed(hir_owner)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:16:1
+   |
+LL | #[rustc_clean(hir_owner)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:19:1
+   |
+LL | #[rustc_then_this_would_need(variances_of)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This is a debugging option. The only effect should be on rustc tests.

r? @michaelwoerister 