### PR TITLE
Debug-print result when an unstable fingerprint is detected

### DIFF
--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -590,7 +590,7 @@ fn incremental_verify_ich<CTX, K, V: Debug>(
 
     let old_hash = tcx.dep_graph().fingerprint_of(dep_node_index);
 
-    assert!(new_hash == old_hash, "found unstable fingerprints for {:?}", dep_node,);
+    assert!(new_hash == old_hash, "found unstable fingerprints for {:?}: {:?}", dep_node, result);
 }
 
 fn force_query_with_job<C, CTX>(


### PR DESCRIPTION
Helps with issues like #83311

I had previously tried to do this in https://github.com/rust-lang/rust/pull/80692, but it had a significant performance impact (even though the code was never actually run). Hopefully, this will be better now that https://github.com/rust-lang/rust/pull/79100 has been merged.