### PR TITLE
Fixes to inline assmebly tests

### DIFF
--- a/src/test/ui/asm/srcloc.rs
+++ b/src/test/ui/asm/srcloc.rs
@@ -1,7 +1,7 @@
 // no-system-llvm
 // only-x86_64
 // build-fail
-
+// compile-flags: -Ccodegen-units=1
 #![feature(asm)]
 
 // Checks that inline asm errors are mapped to the correct line in the source code.

--- a/src/test/ui/asm/sym.rs
+++ b/src/test/ui/asm/sym.rs
@@ -76,5 +76,5 @@ fn main() {
     std::thread::spawn(|| {
         assert_eq!(static_addr!(S1), &S1 as *const u32);
         assert_eq!(static_tls_addr!(S2), &S2 as *const u32);
-    });
+    }).join().unwrap();
 }


### PR DESCRIPTION
* Join test thread to make assertion effective in sym.rs test case
* Use a single codegen unit to reduce non-determinism in srcloc.rs test #82886