### PR TITLE
rustdoc: Hide item contents, not items

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -486,17 +486,6 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
             ],
         )
             .into(),
-        (
-            "Auto-hide item declarations",
-            vec![
-                ("auto-hide-struct", "Auto-hide structs declaration", true),
-                ("auto-hide-enum", "Auto-hide enums declaration", false),
-                ("auto-hide-union", "Auto-hide unions declaration", true),
-                ("auto-hide-trait", "Auto-hide traits declaration", true),
-                ("auto-hide-macro", "Auto-hide macros declaration", false),
-            ],
-        )
-            .into(),
         ("auto-hide-attributes", "Auto-hide item attributes.", true).into(),
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
         ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", true)

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1030,7 +1030,7 @@ fn render_attributes_in_pre(w: &mut Buffer, it: &clean::Item, prefix: &str) {
 // a div to produce a newline after it.
 fn render_attributes_in_code(w: &mut Buffer, it: &clean::Item) {
     for a in attributes(it) {
-        write!(w, "<div>{}</div>", a);
+        write!(w, "<div class=\"code-attribute\">{}</div>", a);
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -486,6 +486,7 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
             ],
         )
             .into(),
+        ("auto-hide-large-items", "Auto-hide item contents for large items.", true).into(),
         ("auto-hide-attributes", "Auto-hide item attributes.", true).into(),
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
         ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", true)

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -43,7 +43,6 @@ use std::path::PathBuf;
 use std::str;
 use std::string::ToString;
 
-use itertools::Itertools;
 use rustc_ast_pretty::pprust;
 use rustc_attr::{Deprecation, StabilityLevel};
 use rustc_data_structures::fx::FxHashSet;
@@ -487,7 +486,6 @@ fn settings(root_path: &str, suffix: &str, themes: &[StylePath]) -> Result<Strin
         )
             .into(),
         ("auto-hide-large-items", "Auto-hide item contents for large items.", true).into(),
-        ("auto-hide-attributes", "Auto-hide item attributes.", true).into(),
         ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
         ("auto-hide-trait-implementations", "Auto-hide trait implementation documentation", true)
             .into(),
@@ -936,19 +934,21 @@ fn render_assoc_item(
             + name.as_str().len()
             + generics_len;
 
-        let (indent, end_newline) = if parent == ItemType::Trait {
+        let (indent, indent_str, end_newline) = if parent == ItemType::Trait {
             header_len += 4;
-            (4, false)
+            let indent_str = "    ";
+            render_attributes_in_pre(w, meth, indent_str);
+            (4, indent_str, false)
         } else {
-            (0, true)
+            render_attributes_in_code(w, meth);
+            (0, "", true)
         };
-        render_attributes(w, meth, false);
         w.reserve(header_len + "<a href=\"\" class=\"fnname\">{".len() + "</a>".len());
         write!(
             w,
             "{}{}{}{}{}{}{}fn <a href=\"{href}\" class=\"fnname\">{name}</a>\
              {generics}{decl}{notable_traits}{where_clause}",
-            if parent == ItemType::Trait { "    " } else { "" },
+            indent_str,
             vis,
             constness,
             asyncness,
@@ -1004,35 +1004,33 @@ const ALLOWED_ATTRIBUTES: &[Symbol] = &[
     sym::non_exhaustive,
 ];
 
-// The `top` parameter is used when generating the item declaration to ensure it doesn't have a
-// left padding. For example:
-//
-// #[foo] <----- "top" attribute
-// struct Foo {
-//     #[bar] <---- not "top" attribute
-//     bar: usize,
-// }
-fn render_attributes(w: &mut Buffer, it: &clean::Item, top: bool) {
-    let attrs = it
-        .attrs
+fn attributes(it: &clean::Item) -> Vec<String> {
+    it.attrs
         .other_attrs
         .iter()
         .filter_map(|attr| {
             if ALLOWED_ATTRIBUTES.contains(&attr.name_or_empty()) {
-                Some(pprust::attribute_to_string(&attr))
+                Some(pprust::attribute_to_string(&attr).replace("\n", "").replace("  ", " "))
             } else {
                 None
             }
         })
-        .join("\n");
+        .collect()
+}
 
-    if !attrs.is_empty() {
-        write!(
-            w,
-            "<span class=\"docblock attributes{}\">{}</span>",
-            if top { " top-attr" } else { "" },
-            &attrs
-        );
+// When an attribute is rendered inside a `<pre>` tag, it is formatted using
+// a whitespace prefix and newline.
+fn render_attributes_in_pre(w: &mut Buffer, it: &clean::Item, prefix: &str) {
+    for a in attributes(it) {
+        write!(w, "{}{}\n", prefix, a);
+    }
+}
+
+// When an attribute is rendered inside a <code> tag, it is formatted using
+// a div to produce a newline after it.
+fn render_attributes_in_code(w: &mut Buffer, it: &clean::Item) {
+    for a in attributes(it) {
+        write!(w, "<div>{}</div>", a);
     }
 }
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -131,6 +131,23 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer)
     }
 }
 
+/// For large structs, enums, unions, etc, determine whether to hide their fields
+fn should_hide_fields(n_fields: usize) -> bool {
+    // todo: figure out what this should be
+    n_fields > 5
+}
+
+fn toggle_open(w: &mut Buffer, text: &str)
+{
+    write!(w, "<div class=\"docblock type-contents-toggle\" data-toggle-text=\"{}\">", text);
+}
+
+fn toggle_close(w: &mut Buffer)
+{
+    w.write_str("</div>");
+}
+
+
 fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[clean::Item]) {
     document(w, cx, item, None);
 
@@ -816,6 +833,10 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
             w.write_str(" {}");
         } else {
             w.write_str(" {\n");
+            let toggle = should_hide_fields(e.variants.len());
+            if toggle {
+                toggle_open(w, "variants");
+            }
             for v in &e.variants {
                 w.write_str("    ");
                 let name = v.name.as_ref().unwrap();
@@ -843,6 +864,9 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
 
             if e.variants_stripped {
                 w.write_str("    // some variants omitted\n");
+            }
+            if toggle {
+                toggle_close(w);
             }
             w.write_str("}");
         }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1171,7 +1171,7 @@ fn wrap_into_docblock<F>(w: &mut Buffer, f: F)
 where
     F: FnOnce(&mut Buffer),
 {
-    w.write_str("<div class=\"docblock type-decl hidden-by-usual-hider\">");
+    w.write_str("<div class=\"docblock type-decl\">");
     f(w);
     w.write_str("</div>")
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1363,7 +1363,7 @@ fn render_struct(
             w.write_str(" {");
             let count_fields = fields
                 .iter()
-                .filter(|f| if let clean::StructFieldItem(..) = *f.kind { true } else { false })
+                .filter(|f| matches!(clean::StructFieldItem(..) = *f.kind))
                 .count();
             let has_visible_fields = count_fields > 0;
             let toggle = should_hide_fields(count_fields);

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -139,7 +139,10 @@ fn should_hide_fields(n_fields: usize) -> bool {
 fn toggle_open(w: &mut Buffer, text: &str) {
     write!(
         w,
-        "<details class=\"rustdoc-toggle type-contents-toggle\"><summary class=\"hideme\"><span>Show {}</span></summary>",
+        "<details class=\"rustdoc-toggle type-contents-toggle\">\
+            <summary class=\"hideme\">\
+                <span>Show {}</span>\
+            </summary>",
         text
     );
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -464,7 +464,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
             // We also do this if the types + consts is large because otherwise we could
             // render a bunch of types and _then_ a bunch of consts just because both were
             // _just_ under the limit
-            if !toggle & should_hide_fields(types.len() + consts.len()) {
+            if !toggle && should_hide_fields(types.len() + consts.len()) {
                 toggle = true;
                 toggle_open(w, "associated constants and methods");
             }
@@ -475,7 +475,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
                 render_assoc_item(w, t, AssocItemLink::Anchor(None), ItemType::Trait, cx);
                 w.write_str(";\n");
             }
-            if !toggle & should_hide_fields(required.len() + provided.len()) {
+            if !toggle && should_hide_fields(required.len() + provided.len()) {
                 toggle = true;
                 toggle_open(w, "methods");
             }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -133,8 +133,7 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer)
 
 /// For large structs, enums, unions, etc, determine whether to hide their fields
 fn should_hide_fields(n_fields: usize) -> bool {
-    // todo: figure out what this should be
-    n_fields > 5
+    n_fields > 12
 }
 
 fn toggle_open(w: &mut Buffer, text: &str) {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -140,7 +140,7 @@ fn should_hide_fields(n_fields: usize) -> bool {
 fn toggle_open(w: &mut Buffer, text: &str) {
     write!(
         w,
-        "<details class=\"type-contents-toggle\"><summary class=\"hideme\"><span>Show {}</span></summary>",
+        "<details class=\"rustdoc-toggle type-contents-toggle\"><summary class=\"hideme\"><span>Show {}</span></summary>",
         text
     );
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1306,7 +1306,7 @@ fn render_union(
     write!(w, " {{\n{}", tab);
     let count_fields = fields
         .iter()
-        .filter(|f| if let clean::StructFieldItem(..) = *f.kind { true } else { false })
+        .filter(|f| matches!(clean::StructFieldItem(..), *f.kind))
         .count();
     let toggle = should_hide_fields(count_fields);
     if toggle {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2703,6 +2703,10 @@ function hideThemeButtonState() {
                         }
                     });
                 }
+            } else if (hasClass(e, "type-contents-toggle")) {
+                let text = e.getAttribute("data-toggle-text");
+                let tog = createToggle(toggle, `Show ${text}`, null, "", true);
+                e.parentNode.insertBefore(tog,  e);
             }
             if (e.parentNode.id === "main") {
                 var otherMessage = "";

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2705,8 +2705,12 @@ function hideThemeButtonState() {
                 }
             } else if (hasClass(e, "type-contents-toggle")) {
                 let text = e.getAttribute("data-toggle-text");
-                let tog = createToggle(toggle, `Show ${text}`, null, "", true);
+                let hideItemContents = getSettingValue("auto-hide-large-items") !== "false";
+                let tog = createToggle(toggle, `Show ${text}`, null, "", !hideItemContents);
                 e.parentNode.insertBefore(tog,  e);
+                if (hideItemContents) {
+                    collapseDocs(e.previousSibling.childNodes[0], "toggle");
+                }
             }
             if (e.parentNode.id === "main") {
                 var otherMessage = "";

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1,3 +1,4 @@
+// ignore-tidy-filelength
 // Local js definitions:
 /* global addClass, getSettingValue, hasClass */
 /* global onEach, onEachLazy, hasOwnProperty, removeClass, updateLocalStorage */
@@ -2574,7 +2575,7 @@ function hideThemeButtonState() {
         var toggle = createSimpleToggle(false);
         var hideMethodDocs = getSettingValue("auto-hide-method-docs") === "true";
         var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
-        let hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
+        var hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
         var func = function(e) {
             var next = e.nextElementSibling;

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2683,18 +2683,7 @@ function hideThemeButtonState() {
                 });
             }
         }
-        var showItemDeclarations = getSettingValue("auto-hide-" + className);
-        if (showItemDeclarations === null) {
-            if (className === "enum" || className === "macro") {
-                showItemDeclarations = "false";
-            } else if (className === "struct" || className === "union" || className === "trait") {
-                showItemDeclarations = "true";
-            } else {
-                // In case we found an unknown type, we just use the "parent" value.
-                showItemDeclarations = getSettingValue("auto-hide-declarations");
-            }
-        }
-        showItemDeclarations = showItemDeclarations === "false";
+
         function buildToggleWrapper(e) {
             if (hasClass(e, "autohide")) {
                 var wrap = e.previousElementSibling;
@@ -2721,11 +2710,8 @@ function hideThemeButtonState() {
                 var extraClass;
 
                 if (hasClass(e, "type-decl")) {
-                    fontSize = "20px";
-                    otherMessage = "&nbsp;Show&nbsp;declaration";
-                    if (showItemDeclarations === false) {
-                        extraClass = "collapsed";
-                    }
+                    // We do something special for these
+                    return;
                 } else if (hasClass(e, "sub-variant")) {
                     otherMessage = "&nbsp;Show&nbsp;fields";
                 } else if (hasClass(e, "non-exhaustive")) {
@@ -2750,11 +2736,8 @@ function hideThemeButtonState() {
                         otherMessage,
                         fontSize,
                         extraClass,
-                        hasClass(e, "type-decl") === false || showItemDeclarations === true),
+                        false),
                     e);
-                if (hasClass(e, "type-decl") === true && showItemDeclarations === true) {
-                    collapseDocs(e.previousSibling.childNodes[0], "toggle");
-                }
                 if (hasClass(e, "non-exhaustive") === true) {
                     collapseDocs(e.previousSibling.childNodes[0], "toggle");
                 }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1,4 +1,3 @@
-// ignore-tidy-filelength
 // Local js definitions:
 /* global addClass, getSettingValue, hasClass */
 /* global onEach, onEachLazy, hasOwnProperty, removeClass, updateLocalStorage */
@@ -2316,6 +2315,9 @@ function hideThemeButtonState() {
         if (hasClass(innerToggle, "will-expand")) {
             updateLocalStorage("rustdoc-collapse", "false");
             removeClass(innerToggle, "will-expand");
+            onEachLazy(document.getElementsByTagName("details"), function(e) {
+                e.open = true;
+            });
             onEveryMatchingChild(innerToggle, "inner", function(e) {
                 e.innerHTML = labelForToggleButton(false);
             });
@@ -2328,6 +2330,9 @@ function hideThemeButtonState() {
         } else {
             updateLocalStorage("rustdoc-collapse", "true");
             addClass(innerToggle, "will-expand");
+            onEachLazy(document.getElementsByTagName("details"), function(e) {
+                e.open = false;
+            });
             onEveryMatchingChild(innerToggle, "inner", function(e) {
                 var parent = e.parentNode;
                 var superParent = null;
@@ -2569,6 +2574,7 @@ function hideThemeButtonState() {
         var toggle = createSimpleToggle(false);
         var hideMethodDocs = getSettingValue("auto-hide-method-docs") === "true";
         var hideImplementors = getSettingValue("auto-collapse-implementors") !== "false";
+        let hideLargeItemContents = getSettingValue("auto-hide-large-items") !== "false";
 
         var func = function(e) {
             var next = e.nextElementSibling;
@@ -2615,6 +2621,14 @@ function hideThemeButtonState() {
         onEachLazy(document.getElementsByClassName("associatedconstant"), func);
         onEachLazy(document.getElementsByClassName("impl"), funcImpl);
         var impl_call = function() {};
+        // Large items are hidden by default in the HTML. If the setting overrides that, show 'em.
+        if (!hideLargeItemContents) {
+            onEachLazy(document.getElementsByTagName("details"), function (e) {
+                if (hasClass(e, "type-contents-toggle")) {
+                    e.open = true;
+                }
+            });
+        }
         if (hideMethodDocs === true) {
             impl_call = function(e, newToggle) {
                 if (e.id.match(/^impl(?:-\d+)?$/) === null) {
@@ -2703,14 +2717,6 @@ function hideThemeButtonState() {
                         }
                     });
                 }
-            } else if (hasClass(e, "type-contents-toggle")) {
-                let text = e.getAttribute("data-toggle-text");
-                let hideItemContents = getSettingValue("auto-hide-large-items") !== "false";
-                let tog = createToggle(toggle, `Show ${text}`, null, "", !hideItemContents);
-                e.parentNode.insertBefore(tog,  e);
-                if (hideItemContents) {
-                    collapseDocs(e.previousSibling.childNodes[0], "toggle");
-                }
             }
             if (e.parentNode.id === "main") {
                 var otherMessage = "";
@@ -2744,7 +2750,7 @@ function hideThemeButtonState() {
                         otherMessage,
                         fontSize,
                         extraClass,
-                        false),
+                        true),
                     e);
                 if (hasClass(e, "non-exhaustive") === true) {
                     collapseDocs(e.previousSibling.childNodes[0], "toggle");
@@ -2761,38 +2767,6 @@ function hideThemeButtonState() {
         if (pageId !== null) {
             expandSection(pageId);
         }
-    }());
-
-    function createToggleWrapper(tog) {
-        var span = document.createElement("span");
-        span.className = "toggle-label";
-        span.style.display = "none";
-        span.innerHTML = "&nbsp;Expand&nbsp;attributes";
-        tog.appendChild(span);
-
-        var wrapper = document.createElement("div");
-        wrapper.className = "toggle-wrapper toggle-attributes";
-        wrapper.appendChild(tog);
-        return wrapper;
-    }
-
-    (function() {
-        // To avoid checking on "rustdoc-item-attributes" value on every loop...
-        var itemAttributesFunc = function() {};
-        if (getSettingValue("auto-hide-attributes") !== "false") {
-            itemAttributesFunc = function(x) {
-                collapseDocs(x.previousSibling.childNodes[0], "toggle");
-            };
-        }
-        var attributesToggle = createToggleWrapper(createSimpleToggle(false));
-        onEachLazy(main.getElementsByClassName("attributes"), function(i_e) {
-            var attr_tog = attributesToggle.cloneNode(true);
-            if (hasClass(i_e, "top-attr") === true) {
-                addClass(attr_tog, "top-attr");
-            }
-            i_e.parentNode.insertBefore(attr_tog, i_e);
-            itemAttributesFunc(i_e);
-        });
     }());
 
     (function() {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1059,7 +1059,7 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 }
 
 /* for enum and struct fields */
-.enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock {
+.enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock, .union > .toggle-wrapper + .docblock {
 	margin-left: 0px;
 }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1058,8 +1058,8 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	margin-top: 3px;
 }
 
-/* for enum and struct fields */
-.enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock, .union > .toggle-wrapper + .docblock {
+/* for hiding fields/variants/associated items */
+.enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock, .union > .toggle-wrapper + .docblock, .trait > .toggle-wrapper + .docblock {
 	margin-left: 0px;
 }
 
@@ -1785,7 +1785,7 @@ div.name.expand::before {
 .type-decl > pre > .docblock.attributes.top-attr {
 	margin-left: 1.8em !important;
 }
-.type-decl > pre > .toggle-attributes {
+.type-decl > pre .toggle-attributes {
 	margin-left: 2.2em;
 }
 .type-decl > pre > .docblock.attributes {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -970,6 +970,10 @@ a.test-arrow:hover{
 	position: absolute;
 	left: -23px;
 	top: 0;
+
+	/* The click event for this is defined on the document,
+	   so bubbling does not work. See https://github.com/rust-lang/rust/issues/83332 */
+	z-index: 10;
 }
 
 h3 > .collapse-toggle, h4 > .collapse-toggle {
@@ -1054,10 +1058,9 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	margin-top: 3px;
 }
 
+/* for enum and struct fields */
 .enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock {
-	margin-left: 30px;
-	margin-bottom: 20px;
-	margin-top: 5px;
+	margin-left: 0px;
 }
 
 .docblock > .section-header:first-child {
@@ -1067,10 +1070,6 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 
 .docblock > .section-header:first-child:hover > a:before {
 	left: -10px;
-}
-
-.enum > .collapsed, .struct > .collapsed {
-	margin-bottom: 25px;
 }
 
 #main > .variant, #main > .structfield {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1756,20 +1756,20 @@ div.name.expand::before {
 /* The hideme class is used on summary tags that contain a span with
 	placeholder text shown only when the toggle is closed. For instance,
 	"Expand description" or "Show methods". */
-details > summary.hideme {
+details.rustdoc-toggle > summary.hideme {
 	cursor: pointer;
 }
 
-details > summary::-webkit-details-marker {
+details.rustdoc-toggle > summary::-webkit-details-marker {
 	display: none;
 }
 
-details > summary.hideme > span {
+details.rustdoc-toggle > summary.hideme > span {
 	margin-left: 9px;
 	color: #999;
 }
 
-details > summary::before {
+details.rustdoc-toggle > summary::before {
 	content: "[+]";
 	font-weight: 300;
 	font-size: 0.8em;
@@ -1777,11 +1777,11 @@ details > summary::before {
 	letter-spacing: 1px;
 }
 
-details > summary.hideme::before {
+details.rustdoc-toggle > summary.hideme::before {
 	position: relative;
 }
 
-details > summary:not(.hideme)::before {
+details.rustdoc-toggle > summary:not(.hideme)::before {
 	float: left;
 }
 
@@ -1790,19 +1790,19 @@ details > summary:not(.hideme)::before {
 	affect the layout of the items to its right. To do that, we use
 	absolute positioning. Note that we also set position: relative
 	on the parent <details> to make this work properly. */
-details[open] > summary.hideme {
+details.rustdoc-toggle[open] > summary.hideme {
 	position: absolute;
 }
 
-details[open] {
+details.rustdoc-toggle[open] {
 	position: relative;
 }
 
-details[open] > summary.hideme > span {
+details.rustdoc-toggle[open] > summary.hideme > span {
 	display: none;
 }
 
-details[open] > summary::before {
+details.rustdoc-toggle[open] > summary::before {
 	content: "[−]";
 	display: inline;
 }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1766,14 +1766,12 @@ details.rustdoc-toggle > summary::-webkit-details-marker {
 
 details.rustdoc-toggle > summary.hideme > span {
 	margin-left: 9px;
-	color: #999;
 }
 
 details.rustdoc-toggle > summary::before {
 	content: "[+]";
 	font-weight: 300;
 	font-size: 0.8em;
-	color: #999;
 	letter-spacing: 1px;
 }
 

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -970,10 +970,6 @@ a.test-arrow:hover{
 	position: absolute;
 	left: -23px;
 	top: 0;
-
-	/* The click event for this is defined on the document,
-	   so bubbling does not work. See https://github.com/rust-lang/rust/issues/83332 */
-	z-index: 10;
 }
 
 h3 > .collapse-toggle, h4 > .collapse-toggle {
@@ -1058,11 +1054,6 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	margin-top: 3px;
 }
 
-/* for hiding fields/variants/associated items */
-.enum > .toggle-wrapper + .docblock, .struct > .toggle-wrapper + .docblock, .union > .toggle-wrapper + .docblock, .trait > .toggle-wrapper + .docblock {
-	margin-left: 0px;
-}
-
 .docblock > .section-header:first-child {
 	margin-left: 15px;
 	margin-top: 0;
@@ -1076,22 +1067,6 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	display: block;
 }
 
-.attributes {
-	display: block;
-	margin-top: 0px !important;
-	margin-right: 0px;
-	margin-bottom: 0px !important;
-	margin-left: 30px;
-}
-.toggle-attributes.collapsed {
-	margin-bottom: 0;
-}
-.impl-items > .toggle-attributes {
-	margin-left: 20px;
-}
-.impl-items .attributes {
-	font-weight: 500;
-}
 
 :target > code {
 	opacity: 1;
@@ -1778,16 +1753,56 @@ div.name.expand::before {
 	top: 2px;
 }
 
-/* This part is to fix the "Expand attributes" part in the type declaration. */
-.type-decl > pre > .toggle-wrapper.toggle-attributes.top-attr {
-	margin-left: 0 !important;
+/* The hideme class is used on summary tags that contain a span with
+	placeholder text shown only when the toggle is closed. For instance,
+	"Expand description" or "Show methods". */
+details > summary.hideme {
+	cursor: pointer;
 }
-.type-decl > pre > .docblock.attributes.top-attr {
-	margin-left: 1.8em !important;
+
+details > summary::-webkit-details-marker {
+	display: none;
 }
-.type-decl > pre .toggle-attributes {
-	margin-left: 2.2em;
+
+details > summary.hideme > span {
+	margin-left: 9px;
+	color: #999;
 }
-.type-decl > pre > .docblock.attributes {
-	margin-left: 4em;
+
+details > summary::before {
+	content: "[+]";
+	font-weight: 300;
+	font-size: 0.8em;
+	color: #999;
+	letter-spacing: 1px;
+}
+
+details > summary.hideme::before {
+	position: relative;
+}
+
+details > summary:not(.hideme)::before {
+	float: left;
+}
+
+/* When a "hideme" summary is open and the "Expand description" or "Show
+	methods" text is hidden, we want the [-] toggle that remains to not
+	affect the layout of the items to its right. To do that, we use
+	absolute positioning. Note that we also set position: relative
+	on the parent <details> to make this work properly. */
+details[open] > summary.hideme {
+	position: absolute;
+}
+
+details[open] {
+	position: relative;
+}
+
+details[open] > summary.hideme > span {
+	display: none;
+}
+
+details[open] > summary::before {
+	content: "[−]";
+	display: inline;
 }

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -1,6 +1,5 @@
 // From rust:
 /* global resourcesSuffix */
-
 var darkThemes = ["dark", "ayu"];
 window.currentTheme = document.getElementById("themeStyle");
 window.mainTheme = document.getElementById("mainThemeStyle");

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -224,7 +224,9 @@ a {
 	color: #39AFD7;
 }
 
-.collapse-toggle {
+.collapse-toggle,
+details.rustdoc-toggle > summary.hideme > span,
+details.rustdoc-toggle > summary::before {
 	color: #999;
 }
 

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -218,7 +218,7 @@ a {
 	color: #c5c5c5;
 }
 
-.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
+.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow):not(.collapse-toggle),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
 #help a {
 	color: #39AFD7;

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -218,7 +218,7 @@ a {
 	color: #c5c5c5;
 }
 
-.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow):not(.collapse-toggle),
+.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
 #help a {
 	color: #39AFD7;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -186,7 +186,9 @@ a.test-arrow {
 	color: #dedede;
 }
 
-.collapse-toggle {
+.collapse-toggle,
+details.rustdoc-toggle > summary.hideme > span,
+details.rustdoc-toggle > summary::before {
 	color: #999;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -176,7 +176,7 @@ a {
 	color: #ddd;
 }
 
-.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow):not(.collapse-toggle),
+.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
 #help a {
 	color: #D2991D;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -176,7 +176,7 @@ a {
 	color: #ddd;
 }
 
-.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
+.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow):not(.collapse-toggle),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
 #help a {
 	color: #D2991D;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -184,7 +184,9 @@ a.test-arrow {
 	color: #f5f5f5;
 }
 
-.collapse-toggle {
+.collapse-toggle,
+details.rustdoc-toggle > summary.hideme > span,
+details.rustdoc-toggle > summary::before {
 	color: #999;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -174,7 +174,7 @@ a {
 	color: #000;
 }
 
-.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
+.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow):not(.collapse-toggle),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
 #help a {
 	color: #3873AD;

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -174,7 +174,7 @@ a {
 	color: #000;
 }
 
-.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow):not(.collapse-toggle),
+.docblock:not(.type-decl) a:not(.srclink):not(.test-arrow),
 .docblock-short a:not(.srclink):not(.test-arrow), .item-info a,
 #help a {
 	color: #3873AD;

--- a/src/test/rustdoc/attributes.rs
+++ b/src/test/rustdoc/attributes.rs
@@ -1,21 +1,21 @@
 #![crate_name = "foo"]
 
-// @has foo/fn.f.html '//*[@class="docblock attributes"]' '#[no_mangle]'
+// @has foo/fn.f.html '//*[@class="rust fn"]' '#[no_mangle]'
 #[no_mangle]
 pub extern "C" fn f() {}
 
-// @has foo/fn.g.html '//*[@class="docblock attributes"]' '#[export_name = "bar"]'
+// @has foo/fn.g.html '//*[@class="rust fn"]' '#[export_name = "bar"]'
 #[export_name = "bar"]
 pub extern "C" fn g() {}
 
-// @matches foo/enum.Foo.html '//*[@class="docblock attributes top-attr"]' \
-//      '(?m)\A#\[repr\(i64\)\]\n#\[must_use\]\Z'
+// @matches foo/enum.Foo.html '//*[@class="rust enum"]' \
+//      '#\[repr\(i64\)\]\n#\[must_use\]'
 #[repr(i64)]
 #[must_use]
 pub enum Foo {
     Bar,
 }
 
-// @has foo/struct.Repr.html '//*[@class="docblock attributes top-attr"]' '#[repr(C, align(8))]'
+// @has foo/struct.Repr.html '//*[@class="docblock type-decl"]' '#[repr(C, align(8))]'
 #[repr(C, align(8))]
 pub struct Repr;

--- a/src/test/rustdoc/item-hide-threshold.rs
+++ b/src/test/rustdoc/item-hide-threshold.rs
@@ -1,0 +1,155 @@
+#![allow(unused)]
+
+// @has 'item_hide_threshold/struct.PubStruct.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 0
+pub struct PubStruct {
+    pub a: usize,
+    pub b: usize,
+}
+
+// @has 'item_hide_threshold/struct.BigPubStruct.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
+// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show fields'
+pub struct BigPubStruct {
+    pub a: usize,
+    pub b: usize,
+    pub c: usize,
+    pub d: usize,
+    pub e: usize,
+    pub f: usize,
+    pub g: usize,
+    pub h: usize,
+    pub i: usize,
+    pub j: usize,
+    pub k: usize,
+    pub l: usize,
+    pub m: usize,
+}
+
+// @has 'item_hide_threshold/union.BigUnion.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
+// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show fields'
+pub union BigUnion {
+    pub a: usize,
+    pub b: usize,
+    pub c: usize,
+    pub d: usize,
+    pub e: usize,
+    pub f: usize,
+    pub g: usize,
+    pub h: usize,
+    pub i: usize,
+    pub j: usize,
+    pub k: usize,
+    pub l: usize,
+    pub m: usize,
+}
+
+// @has 'item_hide_threshold/union.Union.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 0
+pub union Union {
+    pub a: usize,
+    pub b: usize,
+    pub c: usize,
+}
+
+// @has 'item_hide_threshold/struct.PrivStruct.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 0
+// @has - '//div[@class="docblock type-decl"]' 'fields omitted'
+pub struct PrivStruct {
+    a: usize,
+    b: usize,
+}
+
+// @has 'item_hide_threshold/enum.Enum.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 0
+pub enum Enum {
+    A, B, C,
+    D {
+        a: u8,
+        b: u8
+    }
+}
+
+// @has 'item_hide_threshold/enum.LargeEnum.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
+// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show variants'
+pub enum LargeEnum {
+    A, B, C, D, E, F(u8), G, H, I, J, K, L, M
+}
+
+// @has 'item_hide_threshold/trait.Trait.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 0
+pub trait Trait {
+    type A;
+    #[must_use]
+    fn foo();
+    fn bar();
+}
+
+// @has 'item_hide_threshold/trait.GinormousTrait.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
+// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show associated items'
+pub trait GinormousTrait {
+    type A;
+    type B;
+    type C;
+    type D;
+    type E;
+    type F;
+    type G;
+    type H;
+    type I;
+    type J;
+    type K;
+    type L;
+    type M;
+    const N: usize = 1;
+    #[must_use]
+    fn foo();
+    fn bar();
+}
+
+// @has 'item_hide_threshold/trait.HugeTrait.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
+// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show associated constants and methods'
+pub trait HugeTrait {
+    type A;
+    const M: usize = 1;
+    const N: usize = 1;
+    const O: usize = 1;
+    const P: usize = 1;
+    const Q: usize = 1;
+    const R: usize = 1;
+    const S: usize = 1;
+    const T: usize = 1;
+    const U: usize = 1;
+    const V: usize = 1;
+    const W: usize = 1;
+    const X: usize = 1;
+    #[must_use]
+    fn foo();
+    fn bar();
+}
+
+// @has 'item_hide_threshold/trait.BigTrait.html'
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
+// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show methods'
+pub trait BigTrait {
+    type A;
+    #[must_use]
+    fn foo();
+    fn bar();
+    fn baz();
+    fn quux();
+    fn frob();
+    fn greeble();
+    fn blap();
+    fn whoop();
+    fn pow();
+    fn bang();
+    fn oomph();
+    fn argh();
+    fn wap();
+    fn ouch();
+}

--- a/src/test/rustdoc/trait-attributes.rs
+++ b/src/test/rustdoc/trait-attributes.rs
@@ -2,7 +2,7 @@
 
 
 pub trait Foo {
-    // @has foo/trait.Foo.html '//h3[@id="tymethod.foo"]//span[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/trait.Foo.html '//h3[@id="tymethod.foo"]//div[@class="code-attribute"]' '#[must_use]'
     #[must_use]
     fn foo();
 }
@@ -11,11 +11,11 @@ pub trait Foo {
 pub struct Bar;
 
 impl Bar {
-    // @has foo/struct.Bar.html '//h4[@id="method.bar"]//span[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/struct.Bar.html '//h4[@id="method.bar"]//div[@class="code-attribute"]' '#[must_use]'
     #[must_use]
     pub fn bar() {}
 
-    // @has foo/struct.Bar.html '//h4[@id="method.bar2"]//span[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/struct.Bar.html '//h4[@id="method.bar2"]//div[@class="code-attribute"]' '#[must_use]'
     #[must_use]
     pub fn bar2() {}
 }


### PR DESCRIPTION
This tweaks rustdoc to hide item contents instead of items, and only when there are too many of them.


This means that users will _always_ see the type parameters, and will _often_ see fields/etc as long as they are small. Traits have some heuristics for hiding only the methods or only the methods and the consts, since the associated types are super important.

I'm happy to play around with the heuristics here; we could potentially make it so that structs/enums/etc are always hidden but traits will try really hard to show type aliases.



This needs a test, but you can see it rendered at https://manishearth.net/sand/doc_render/bar/

<details>

<summary> Code example </summary>

```rust
pub struct PubStruct {
    pub a: usize,
    pub b: usize,
}

pub struct BigPubStruct {
    pub a: usize,
    pub b: usize,
    pub c: usize,
    pub d: usize,
    pub e: usize,
    pub f: usize,
}

pub union BigUnion {
    pub a: usize,
    pub b: usize,
    pub c: usize,
    pub d: usize,
    pub e: usize,
    pub f: usize,
}

pub union Union {
    pub a: usize,
    pub b: usize,
    pub c: usize,
}

pub struct PrivStruct {
    a: usize,
    b: usize,
}

pub enum Enum {
    A, B, C,
    D {
        a: u8,
        b: u8
    }
}

pub enum LargeEnum {
    A, B, C, D, E, F, G, H, I, J
}


pub trait Trait {
    type A;
    #[must_use]
    fn foo();
    fn bar();
}

pub trait GinormousTrait {
    type A;
    type B;
    type C;
    type D;
    type E;
    type F;
    const N: usize = 1;
    #[must_use]
    fn foo();
    fn bar();
}

pub trait HugeTrait {
    type A;
    const M: usize = 1;
    const N: usize = 1;
    const O: usize = 1;
    const P: usize = 1;
    const Q: usize = 1;
    #[must_use]
    fn foo();
    fn bar();
}

pub trait BigTrait {
    type A;
    #[must_use]
    fn foo();
    fn bar();
    fn baz();
    fn quux();
    fn frob();
    fn greeble();
}

#[macro_export]
macro_rules! foo {
    (a) => {a};
}
```

</details>


Fixes https://github.com/rust-lang/rust/issues/82114