### PR TITLE
Allow writing of incomplete UTF-8 sequences to the Windows console via stdout/stderr

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -71,6 +71,9 @@ pub use iter::SplitInclusive;
 #[unstable(feature = "str_internals", issue = "none")]
 pub use validations::next_code_point;
 
+#[unstable(feature = "str_internals", issue = "none")]
+pub use validations::utf8_char_width;
+
 use iter::MatchIndicesInternal;
 use iter::SplitInternal;
 use iter::{MatchesInternal, SplitNInternal};

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -69,10 +69,7 @@ pub use iter::SplitAsciiWhitespace;
 pub use iter::SplitInclusive;
 
 #[unstable(feature = "str_internals", issue = "none")]
-pub use validations::next_code_point;
-
-#[unstable(feature = "str_internals", issue = "none")]
-pub use validations::utf8_char_width;
+pub use validations::{next_code_point, utf8_char_width};
 
 use iter::MatchIndicesInternal;
 use iter::SplitInternal;

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -144,9 +144,9 @@ fn write(
                 incomplete_utf8.len = 1;
                 return Ok(1);
             } else {
-                return Err(io::Error::new_const(
+                return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    &"Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
+                    "Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
                 ));
             }
         }

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -339,7 +339,7 @@ impl Stdout {
 
 impl io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        write(c::STD_ERROR_HANDLE, buf, &mut self.incomplete_utf8)
+        write(c::STD_OUTPUT_HANDLE, buf, &mut self.incomplete_utf8)
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -101,8 +101,8 @@ fn write(
             match s {
                 Ok(s) => {
                     assert_eq!(char_width, s.len());
-                    let written = write_valid_utf8(handle, s)?;
-                    assert_eq!(written, s.len()); // guaranteed by write_valid_utf8() for single codepoint writes
+                    let written = write_valid_utf8_to_console(handle, s)?;
+                    assert_eq!(written, s.len()); // guaranteed by write_valid_utf8_to_console() for single codepoint writes
                     return Ok(1);
                 }
                 Err(_) => {
@@ -143,10 +143,10 @@ fn write(
         Err(e) => str::from_utf8(&data[..e.valid_up_to()]).unwrap(),
     };
 
-    write_valid_utf8(handle, utf8)
+    write_valid_utf8_to_console(handle, utf8)
 }
 
-fn write_valid_utf8(handle: c::HANDLE, utf8: &str) -> io::Result<usize> {
+fn write_valid_utf8_to_console(handle: c::HANDLE, utf8: &str) -> io::Result<usize> {
     let mut utf16 = [0u16; MAX_BUFFER_SIZE / 2];
     let mut len_utf16 = 0;
     for (chr, dest) in utf8.encode_utf16().zip(utf16.iter_mut()) {

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -84,9 +84,9 @@ fn write(
             if data[0] >> 6 != 0b10 {
                 incomplete_utf8.len = 0;
                 // not a continuation byte - reject
-                return Err(io::Error::new(
+                return Err(io::Error::new_const(
                     io::ErrorKind::InvalidData,
-                    "Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
+                    &"Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
                 ));
             }
             incomplete_utf8.bytes[incomplete_utf8.len as usize] = data[0];
@@ -106,9 +106,9 @@ fn write(
                     return Ok(1);
                 }
                 Err(_) => {
-                    return Err(io::Error::new(
+                    return Err(io::Error::new_const(
                         io::ErrorKind::InvalidData,
-                        "Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
+                        &"Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
                     ));
                 }
             }
@@ -134,9 +134,9 @@ fn write(
                 incomplete_utf8.len = 1;
                 return Ok(1);
             } else {
-                return Err(io::Error::new(
+                return Err(io::Error::new_const(
                     io::ErrorKind::InvalidData,
-                    "Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
+                    &"Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
                 ));
             }
         }

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -128,7 +128,7 @@ fn write(
     let utf8 = match str::from_utf8(&data[..len]) {
         Ok(s) => s,
         Err(ref e) if e.valid_up_to() == 0 => {
-            first_byte_char_width = utf8_char_width(data[0]);
+            let first_byte_char_width = utf8_char_width(data[0]);
             if first_byte_char_width > 1 && data.len() < first_byte_char_width {
                 incomplete_utf8.bytes[0] = data[0];
                 incomplete_utf8.len = 1;

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -8,6 +8,7 @@ use crate::str;
 use crate::sys::c;
 use crate::sys::cvt;
 use crate::sys::handle::Handle;
+use core::str::utf8_char_width;
 
 // Don't cache handles but get them fresh for every read/write. This allows us to track changes to
 // the value over time (such as if a process calls `SetStdHandle` while it's running). See #40490.
@@ -58,18 +59,6 @@ fn is_console(handle: c::HANDLE) -> bool {
     // MSYS. Which is exactly what we need, as only Windows Console needs a conversion to UTF-16.
     let mut mode = 0;
     unsafe { c::GetConsoleMode(handle, &mut mode) != 0 }
-}
-
-// Simple reimplementation of std::str::utf8_char_width() which is feature-gated
-fn utf8_char_width(b: u8) -> usize {
-    match b {
-        0x00..=0x7F => 1,
-        0x80..=0xC1 => 0,
-        0xC2..=0xDF => 2,
-        0xE0..=0xEF => 3,
-        0xF0..=0xF4 => 4,
-        0xF5..=0xFF => 0,
-    }
 }
 
 fn write(

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -128,7 +128,8 @@ fn write(
     let utf8 = match str::from_utf8(&data[..len]) {
         Ok(s) => s,
         Err(ref e) if e.valid_up_to() == 0 => {
-            if data.len() < utf8_char_width(data[0]) {
+            first_byte_char_width = utf8_char_width(data[0]);
+            if first_byte_char_width > 1 && data.len() < first_byte_char_width {
                 incomplete_utf8.bytes[0] = data[0];
                 incomplete_utf8.len = 1;
                 return Ok(1);

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -102,7 +102,7 @@ fn write(
                 Ok(s) => {
                     assert_eq!(char_width, s.len());
                     let written = write_valid_utf8(handle, s)?;
-                    assert_eq!(written, s.len()); // guaranteed by write0() for single codepoint writes
+                    assert_eq!(written, s.len()); // guaranteed by write_valid_utf8() for single codepoint writes
                     return Ok(1);
                 }
                 Err(_) => {

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -84,8 +84,8 @@ fn write(
             "Unexpected number of bytes for incomplete UTF-8 codepoint."
         );
         if data[0] >> 6 != 0b10 {
-            incomplete_utf8.len = 0;
             // not a continuation byte - reject
+            incomplete_utf8.len = 0;
             return Err(io::Error::new_const(
                 io::ErrorKind::InvalidData,
                 &"Windows stdio in console mode does not support writing non-UTF-8 byte sequences",


### PR DESCRIPTION
# Problem
Writes of just an incomplete UTF-8 byte sequence (e.g. `b"\xC3"` or `b"\xF0\x9F"`)  to stdout/stderr with a Windows console attached error with `io::ErrorKind::InvalidData, "Windows stdio in console mode does not support writing non-UTF-8 byte sequences"` even though further writes could complete the codepoint. This is currently a rare occurence since the [linewritershim](https://github.com/rust-lang/rust/blob/2c56ea38b045624dc8b42ec948fc169eaff1206a/library/std/src/io/buffered/linewritershim.rs) implementation flushes complete lines immediately and buffers up to 1024 bytes for incomplete lines. It can still happen as described in #83258. 

The problem will become more pronounced once the developer can switch stdout/stderr from line-buffered to block-buffered or immediate when the changes in the "Switchable buffering for Stdout" pull request (#78515) get merged.

# Patch description
If there is at least one valid UTF-8 codepoint all valid UTF-8 is passed through to the extracted `write_valid_utf8_to_console()` fn. The new code only comes into play if `write()` is being passed a short byte slice comprising an incomplete UTF-8 codepoint. In this case up to three bytes are buffered in the `IncompleteUtf8` struct associated with `Stdout` / `Stderr`. The bytes are accepted one at a time. As soon as an error can be detected `io::ErrorKind::InvalidData, "Windows stdio in console mode does not support writing non-UTF-8 byte sequences"` is returned. Once a complete UTF-8 codepoint is received it is passed to the `write_valid_utf8_to_console()` and the buffer length is set to zero.

Calling `flush()` will neither error nor write anything if an incomplete codepoint is present in the buffer.

# Tests
Currently there are no Windows-specific tests for console writing code at all. Writing (regression) tests for this problem is a bit challenging since unit tests and UI tests don't run in a console and suddenly popping up another console window might be surprising to developers running the testsuite and it might not work at all in CI builds. To just test the new functionality in unit tests the code would need to be refactored. Some guidance on how to proceed would be appreciated.

# Public API changes
* `std::str::verifications::utf8_char_width()` would be exposed as `std::str::utf8_char_width()` behind the "str_internals" feature gate.

# Related issues
* Fixes #83258.
* PR #78515 will exacerbate the problem.

# Open questions
* Add tests?
* Squash into one commit with better commit message?
