### PR TITLE
Simplify and fix byte skipping in format! string parser

### DIFF
--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -735,25 +735,24 @@ fn find_skips_from_snippet(
     };
 
     fn find_skips(snippet: &str, is_raw: bool) -> Vec<usize> {
-        let mut eat_ws = false;
         let mut s = snippet.char_indices().peekable();
         let mut skips = vec![];
         while let Some((pos, c)) = s.next() {
             match (c, s.peek()) {
                 // skip whitespace and empty lines ending in '\\'
                 ('\\', Some((next_pos, '\n'))) if !is_raw => {
-                    eat_ws = true;
                     skips.push(pos);
                     skips.push(*next_pos);
                     let _ = s.next();
-                }
-                ('\\', Some((next_pos, '\n' | 'n' | 't'))) if eat_ws => {
-                    skips.push(pos);
-                    skips.push(*next_pos);
-                    let _ = s.next();
-                }
-                (' ' | '\n' | '\t', _) if eat_ws => {
-                    skips.push(pos);
+
+                    while let Some((pos, c)) = s.peek() {
+                        if matches!(c, ' ' | '\n' | '\t') {
+                            skips.push(*pos);
+                            let _ = s.next();
+                        } else {
+                            break;
+                        }
+                    }
                 }
                 ('\\', Some((next_pos, 'n' | 't' | 'r' | '0' | '\\' | '\'' | '\"'))) => {
                     skips.push(*next_pos);
@@ -803,10 +802,6 @@ fn find_skips_from_snippet(
                             }
                         }
                     }
-                }
-                _ if eat_ws => {
-                    // `take_while(|c| c.is_whitespace())`
-                    eat_ws = false;
                 }
                 _ => {}
             }

--- a/src/test/ui/macros/issue-83340.rs
+++ b/src/test/ui/macros/issue-83340.rs
@@ -1,0 +1,8 @@
+// check-fail
+
+fn main() {
+    println!(
+        "\
+\n {} │", //~ ERROR: 1 positional argument in format string, but no arguments were given
+    );
+}

--- a/src/test/ui/macros/issue-83340.stderr
+++ b/src/test/ui/macros/issue-83340.stderr
@@ -1,0 +1,8 @@
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/issue-83340.rs:6:4
+   |
+LL | \n {} │",
+   |    ^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes '\\' handling in format strings.

Fixes #83340