### PR TITLE
Canonicalize path when displaying a `FileName::Real`

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -215,7 +215,11 @@ impl std::fmt::Display for FileName {
 impl From<PathBuf> for FileName {
     fn from(p: PathBuf) -> Self {
         assert!(!p.to_string_lossy().ends_with('>'));
-        FileName::Real(RealFileName::Named(p))
+        if cfg!(not(windows)) {
+            FileName::Real(RealFileName::Named(p.canonicalize().unwrap_or(p)))
+        } else {
+            FileName::Real(RealFileName::Named(p))
+        }
     }
 }
 

--- a/src/test/run-make-fulldeps/libtest-json/Makefile
+++ b/src/test/run-make-fulldeps/libtest-json/Makefile
@@ -5,6 +5,9 @@
 OUTPUT_FILE_DEFAULT := $(TMPDIR)/libtest-json-output-default.json
 OUTPUT_FILE_STDOUT_SUCCESS := $(TMPDIR)/libtest-json-output-stdout-success.json
 
+CANONIZED_FILE_DEFAULT := $(TMPDIR)/libtest-json-output-default-canonized.json
+CANONIZED_FILE_STDOUT_SUCCESS := $(TMPDIR)/libtest-json-output-stdout-success-canonized.json
+
 all:
 	$(RUSTC) --test f.rs
 	RUST_BACKTRACE=0 $(call RUN,f) -Z unstable-options --test-threads=1 --format=json > $(OUTPUT_FILE_DEFAULT) || true
@@ -13,6 +16,9 @@ all:
 	cat $(OUTPUT_FILE_DEFAULT) | "$(PYTHON)" validate_json.py
 	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | "$(PYTHON)" validate_json.py
 
+	cat output-default.json | "$(PYTHON)" canonicalize_path.py > $(CANONIZED_FILE_DEFAULT) || true
+	cat output-stdout-success.json | "$(PYTHON)" canonicalize_path.py > $(CANONIZED_FILE_STDOUT_SUCCESS) || true
+
 	# Normalize the actual output and compare to expected output file
-	cat $(OUTPUT_FILE_DEFAULT) | sed 's/"exec_time": [0-9.]*/"exec_time": $$TIME/' | diff output-default.json -
-	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | sed 's/"exec_time": [0-9.]*/"exec_time": $$TIME/' | diff output-stdout-success.json -
+	cat $(OUTPUT_FILE_DEFAULT) | sed 's/"exec_time": [0-9.]*/"exec_time": $/"IGNORED"/' | diff $(CANONIZED_FILE_DEFAULT) -
+	cat $(OUTPUT_FILE_STDOUT_SUCCESS) | sed 's/"exec_time": [0-9.]*/"exec_time": $/"IGNORED"/' | diff $(CANONIZED_FILE_STDOUT_SUCCESS) -

--- a/src/test/run-make-fulldeps/libtest-json/canonicalize_path.py
+++ b/src/test/run-make-fulldeps/libtest-json/canonicalize_path.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import sys
+import json
+import os.path
+
+for line in sys.stdin:
+    json_data = json.loads(line)
+    if "stdout" in json_data and "f.rs" in json_data["stdout"]:
+        normalized_path = os.path.join(os.getcwd(), "f.rs")
+        json_data["stdout"] = json_data["stdout"].replace("f.rs", normalized_path)
+    result = json.dumps(json_data).replace("{", "{ ")
+    result = result.replace("}", " }")
+    print(result)

--- a/src/test/run-make-fulldeps/libtest-json/output-default.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-default.json
@@ -7,4 +7,4 @@
 { "type": "test", "name": "c", "event": "ok" }
 { "type": "test", "event": "started", "name": "d" }
 { "type": "test", "name": "d", "event": "ignored" }
-{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": $TIME }
+{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": "IGNORED" }

--- a/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
@@ -7,4 +7,4 @@
 { "type": "test", "name": "c", "event": "ok", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:15:5\n" }
 { "type": "test", "event": "started", "name": "d" }
 { "type": "test", "name": "d", "event": "ignored" }
-{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": $TIME }
+{ "type": "suite", "event": "failed", "passed": 2, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": "IGNORED" }


### PR DESCRIPTION
Addresses #51349 (?)
Follow-up #68654

Currently, I see two rustdoc tests failing. Not sure If I should add test cases or modify something else.

r? @estebank

> Errors
> ---- [rustdoc] rustdoc/test_option_check/test.rs stdout ----
> 
> error: No test has been found... {"src/test/rustdoc/test_option_check/test.rs": [8, 15], "src/test/rustdoc/test_option_check/bar.rs": [6]}
> 
> ---- [rustdoc] rustdoc/test_option_check/bar.rs stdout ----
> 
> error: No test has been found... {"src/test/rustdoc/test_option_check/bar.rs": [6]}
> status: exit code: 0
> 
> failures:
>     [rustdoc] rustdoc/test_option_check/bar.rs
>     [rustdoc] rustdoc/test_option_check/test.rs
