### PR TITLE
Add unwrap_err_or to result

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -800,6 +800,26 @@ impl<T, E> Result<T, E> {
         }
     }
 
+    /// Returns the contained [`Err`] value or a provided default.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(option_result_unwrap_err_or)]
+    /// let x: Result<u32, &str> = Ok(9);
+    /// assert_eq!(x.unwrap_err_or("emergency failure"), "emergency failure");
+    /// ```
+    #[inline]
+    #[unstable(feature = "option_result_unwrap_err_or", reason = "newly added", issue = "none")]
+    pub fn unwrap_err_or(self, default: E) -> E {
+        match self {
+            Ok(_) => default,
+            Err(e) => e,
+        }
+    }
+
     /// Returns the contained [`Ok`] value or computes it from a closure.
     ///
     ///

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -82,6 +82,7 @@
 #![cfg_attr(bootstrap, feature(unsafe_block_in_unsafe_fn))]
 #![cfg_attr(not(bootstrap), feature(unsize))]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![feature(option_result_unwrap_err_or)]
 
 extern crate test;
 

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -97,6 +97,7 @@ fn test_unwrap_or() {
 
 #[test]
 fn test_unwrap_err_or() {
+    #![feature(option_result_unwrap_err_or)]
     let err: Result<isize, &'static str> = Err("Err");
     let err_ok: Result<isize, &'static str> = Ok(100);
 

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -96,6 +96,15 @@ fn test_unwrap_or() {
 }
 
 #[test]
+fn test_unwrap_err_or() {
+    let err: Result<isize, &'static str> = Err("Err");
+    let err_ok: Result<isize, &'static str> = Ok(100);
+
+    assert_eq!(err.unwrap_err_or("Other Err"), "Err");
+    assert_eq!(err_ok.unwrap_err_or("Other Err"), "Other Err");
+}
+
+#[test]
 fn test_ok_or_err() {
     let ok: Result<isize, isize> = Ok(100);
     let err: Result<isize, isize> = Err(200);

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -97,7 +97,6 @@ fn test_unwrap_or() {
 
 #[test]
 fn test_unwrap_err_or() {
-    #![feature(option_result_unwrap_err_or)]
     let err: Result<isize, &'static str> = Err("Err");
     let err_ok: Result<isize, &'static str> = Ok(100);
 


### PR DESCRIPTION
Added a simple api hole patch up to Result

### Usages
```rust
let x: Result<u32, &str> = Ok(9);
assert_eq!(x.unwrap_err_or("failure"), "failure");
```

After reading the rfc process, I didn't this was needed as its a small update. But I could be wrong 😄 