### PR TITLE
Remove Option::{unwrap_none, expect_none}.

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -150,7 +150,7 @@
 use crate::iter::{FromIterator, FusedIterator, TrustedLen};
 use crate::pin::Pin;
 use crate::{
-    fmt, hint, mem,
+    hint, mem,
     ops::{self, Deref, DerefMut},
 };
 
@@ -1121,90 +1121,6 @@ impl<T: Clone> Option<&mut T> {
     }
 }
 
-impl<T: fmt::Debug> Option<T> {
-    /// Consumes `self` while expecting [`None`] and returning nothing.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is a [`Some`], with a panic message including the
-    /// passed message, and the content of the [`Some`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(option_expect_none)]
-    ///
-    /// use std::collections::HashMap;
-    /// let mut squares = HashMap::new();
-    /// for i in -10..=10 {
-    ///     // This will not panic, since all keys are unique.
-    ///     squares.insert(i, i * i).expect_none("duplicate key");
-    /// }
-    /// ```
-    ///
-    /// ```should_panic
-    /// #![feature(option_expect_none)]
-    ///
-    /// use std::collections::HashMap;
-    /// let mut sqrts = HashMap::new();
-    /// for i in -10..=10 {
-    ///     // This will panic, since both negative and positive `i` will
-    ///     // insert the same `i * i` key, returning the old `Some(i)`.
-    ///     sqrts.insert(i * i, i).expect_none("duplicate key");
-    /// }
-    /// ```
-    #[inline]
-    #[track_caller]
-    #[unstable(feature = "option_expect_none", reason = "newly added", issue = "62633")]
-    pub fn expect_none(self, msg: &str) {
-        if let Some(val) = self {
-            expect_none_failed(msg, &val);
-        }
-    }
-
-    /// Consumes `self` while expecting [`None`] and returning nothing.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the value is a [`Some`], with a custom panic message provided
-    /// by the [`Some`]'s value.
-    ///
-    /// [`Some(v)`]: Some
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(option_unwrap_none)]
-    ///
-    /// use std::collections::HashMap;
-    /// let mut squares = HashMap::new();
-    /// for i in -10..=10 {
-    ///     // This will not panic, since all keys are unique.
-    ///     squares.insert(i, i * i).unwrap_none();
-    /// }
-    /// ```
-    ///
-    /// ```should_panic
-    /// #![feature(option_unwrap_none)]
-    ///
-    /// use std::collections::HashMap;
-    /// let mut sqrts = HashMap::new();
-    /// for i in -10..=10 {
-    ///     // This will panic, since both negative and positive `i` will
-    ///     // insert the same `i * i` key, returning the old `Some(i)`.
-    ///     sqrts.insert(i * i, i).unwrap_none();
-    /// }
-    /// ```
-    #[inline]
-    #[track_caller]
-    #[unstable(feature = "option_unwrap_none", reason = "newly added", issue = "62633")]
-    pub fn unwrap_none(self) {
-        if let Some(val) = self {
-            expect_none_failed("called `Option::unwrap_none()` on a `Some` value", &val);
-        }
-    }
-}
-
 impl<T: Default> Option<T> {
     /// Returns the contained [`Some`] value or a default
     ///
@@ -1319,14 +1235,6 @@ impl<T, E> Option<Result<T, E>> {
 #[track_caller]
 fn expect_failed(msg: &str) -> ! {
     panic!("{}", msg)
-}
-
-// This is a separate function to reduce the code size of .expect_none() itself.
-#[inline(never)]
-#[cold]
-#[track_caller]
-fn expect_none_failed(msg: &str, value: &dyn fmt::Debug) -> ! {
-    panic!("{}: {:?}", msg, value)
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/library/core/tests/iter/adapters/chain.rs
+++ b/library/core/tests/iter/adapters/chain.rs
@@ -174,14 +174,14 @@ fn test_iterator_chain_size_hint() {
 fn test_iterator_chain_unfused() {
     // Chain shouldn't be fused in its second iterator, depending on direction
     let mut iter = NonFused::new(empty()).chain(Toggle { is_empty: true });
-    iter.next().unwrap_none();
-    iter.next().unwrap();
-    iter.next().unwrap_none();
+    assert!(iter.next().is_none());
+    assert!(iter.next().is_some());
+    assert!(iter.next().is_none());
 
     let mut iter = Toggle { is_empty: true }.chain(NonFused::new(empty()));
-    iter.next_back().unwrap_none();
-    iter.next_back().unwrap();
-    iter.next_back().unwrap_none();
+    assert!(iter.next_back().is_none());
+    assert!(iter.next_back().is_some());
+    assert!(iter.next_back().is_none());
 }
 
 #[test]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -68,7 +68,6 @@
 #![feature(unwrap_infallible)]
 #![feature(option_result_unwrap_unchecked)]
 #![feature(result_into_ok_or_err)]
-#![feature(option_unwrap_none)]
 #![feature(peekable_peek_mut)]
 #![cfg_attr(not(bootstrap), feature(ptr_metadata))]
 #![feature(once_cell)]

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -25,7 +25,6 @@
 #![feature(nll)]
 #![feature(available_concurrency)]
 #![feature(internal_output_capture)]
-#![feature(option_unwrap_none)]
 #![feature(panic_unwind)]
 #![feature(staged_api)]
 #![feature(termination_trait_lib)]
@@ -298,8 +297,9 @@ where
             let test = remaining.pop().unwrap();
             let event = TestEvent::TeWait(test.desc.clone());
             notify_about_test_event(event)?;
-            run_test(opts, !opts.run_tests, test, run_strategy, tx.clone(), Concurrent::No)
-                .unwrap_none();
+            let join_handle =
+                run_test(opts, !opts.run_tests, test, run_strategy, tx.clone(), Concurrent::No);
+            assert!(join_handle.is_none());
             let completed_test = rx.recv().unwrap();
 
             let event = TestEvent::TeResult(completed_test);

--- a/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
+++ b/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
@@ -3,7 +3,6 @@
 // revisions: default mir-opt
 //[mir-opt] compile-flags: -Zmir-opt-level=4
 
-#![feature(option_expect_none, option_unwrap_none)]
 #![allow(unconditional_panic)]
 
 //! Test that panic locations for `#[track_caller]` functions in std have the correct
@@ -31,10 +30,6 @@ fn main() {
     let nope: Option<()> = None;
     assert_panicked(|| nope.unwrap());
     assert_panicked(|| nope.expect(""));
-
-    let yep: Option<()> = Some(());
-    assert_panicked(|| yep.unwrap_none());
-    assert_panicked(|| yep.expect_none(""));
 
     let oops: Result<(), ()> = Err(());
     assert_panicked(|| oops.unwrap());


### PR DESCRIPTION
This removes `Option::unwrap_none` and `Option::expect_none` since we're not going to stabilize them, see https://github.com/rust-lang/rust/issues/62633.

Closes #62633