### PR TITLE
Download a more recent LLVM version if `src/version` is modified

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -463,6 +463,8 @@ class RustBuild(object):
                 "--",
                 "{}/src/llvm-project".format(top_level),
                 "{}/src/bootstrap/download-ci-llvm-stamp".format(top_level),
+                # the LLVM shared object file is named `LLVM-12-rust-{version}-nightly`
+                "{}/src/version".format(top_level)
             ]).decode(sys.getdefaultencoding()).strip()
             llvm_assertions = self.get_toml('assertions', 'llvm') == 'true'
             llvm_root = self.llvm_root()


### PR DESCRIPTION
When bumping the bootstrap version, the name of the generated LLVM
shared object file is changed, even though it's the same contents as
before. If bootstrap tries to use an older version, it will get linking
errors:

```
Building rustdoc for stage1 (x86_64-unknown-linux-gnu)
   Compiling rustdoc-tool v0.0.0 (/home/joshua/rustc/src/tools/rustdoc)
error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" ... lots of args ...
  = note: /usr/bin/ld: cannot find -lLLVM-12-rust-1.53.0-nightly
          clang: error: linker command failed with exit code 1 (use -v to see invocation)

error: could not compile `rustdoc-tool`
```

Helps with https://github.com/rust-lang/rust/issues/81930.