### PR TITLE
[WIP] Start transforming documentation toggles into pure css ones

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -51,19 +51,20 @@ impl Print for &'_ str {
 crate struct Buffer {
     for_html: bool,
     buffer: String,
+    crate label_id_count: usize,
 }
 
 impl Buffer {
     crate fn empty_from(v: &Buffer) -> Buffer {
-        Buffer { for_html: v.for_html, buffer: String::new() }
+        Buffer { for_html: v.for_html, buffer: String::new(), label_id_count: 0 }
     }
 
     crate fn html() -> Buffer {
-        Buffer { for_html: true, buffer: String::new() }
+        Buffer { for_html: true, buffer: String::new(), label_id_count: 0 }
     }
 
     crate fn new() -> Buffer {
-        Buffer { for_html: false, buffer: String::new() }
+        Buffer { for_html: false, buffer: String::new(), label_id_count: 0 }
     }
 
     crate fn is_empty(&self) -> bool {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2249,8 +2249,13 @@ function defocusSearchBar() {
             });
             innerToggle.title = "collapse all docs";
             if (fromAutoCollapse !== true) {
+                // Old toggle handling.
                 onEachLazy(document.getElementsByClassName("collapse-toggle"), function(e) {
                     collapseDocs(e, "show");
+                });
+                // New toggle handling.
+                onEachLazy(document.getElementsByClassName("toggle"), function(e) {
+                    e.checked = true;
                 });
             }
         } else {
@@ -2270,6 +2275,7 @@ function defocusSearchBar() {
             });
             innerToggle.title = "expand all docs";
             if (fromAutoCollapse !== true) {
+                // Old toggle handling.
                 onEachLazy(document.getElementsByClassName("collapse-toggle"), function(e) {
                     var parent = e.parentNode;
                     var superParent = null;
@@ -2280,6 +2286,19 @@ function defocusSearchBar() {
                     if (!parent || !superParent || superParent.id !== "main" ||
                         hasClass(parent, "impl") === false) {
                         collapseDocs(e, "hide");
+                    }
+                });
+                // New toggle handling.
+                onEachLazy(document.getElementsByClassName("toggle"), function(e) {
+                    var parent = e.parentNode;
+                    var superParent = null;
+
+                    if (parent) {
+                        superParent = parent.parentNode;
+                    }
+                    if (!parent || !superParent || superParent.id !== "main" ||
+                        hasClass(parent, "impl") === false) {
+                        e.checked = false;
                     }
                 });
             }
@@ -2460,7 +2479,7 @@ function defocusSearchBar() {
             span.style.display = "none";
         }
         if (!otherMessage) {
-            span.innerHTML = "&nbsp;Expand&nbsp;description";
+           return null;
         } else {
             span.innerHTML = otherMessage;
         }
@@ -2506,11 +2525,9 @@ function defocusSearchBar() {
             if (!next) {
                 return;
             }
-            if (hasClass(next, "docblock")) {
-                var newToggle = toggle.cloneNode(true);
-                insertAfter(newToggle, e.childNodes[e.childNodes.length - 1]);
+            if (hasClass(next, "toggle")) {
                 if (hideMethodDocs === true && hasClass(e, "method") === true) {
-                    collapseDocs(newToggle, "hide");
+                    next.checked = true;
                 }
             }
         };
@@ -2672,14 +2689,15 @@ function defocusSearchBar() {
                     extraClass = "marg-left";
                 }
 
-                e.parentNode.insertBefore(
-                    createToggle(
+                var t = createToggle(
                         toggle,
                         otherMessage,
                         fontSize,
                         extraClass,
-                        hasClass(e, "type-decl") === false || showItemDeclarations === true),
-                    e);
+                        hasClass(e, "type-decl") === false || showItemDeclarations === true);
+                if (t) {
+                    e.parentNode.insertBefore(t, e);
+                }
                 if (hasClass(e, "type-decl") === true && showItemDeclarations === true) {
                     collapseDocs(e.previousSibling.childNodes[0], "toggle");
                 }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -80,6 +80,10 @@ html {
 	}
 }
 
+div {
+	position: relative;
+}
+
 /* General structure and fonts */
 
 body {
@@ -1767,4 +1771,43 @@ div.name.expand::before {
 }
 .type-decl > pre > .docblock.attributes {
 	margin-left: 4em;
+}
+
+input.toggle {
+	display: none;
+}
+input.toggle + label {
+	position: absolute;
+	top: 0;
+	font-family: "Fira Sans", Arial, sans-serif;
+	font-weight: 300;
+	cursor: pointer;
+}
+input.toggle + label:before {
+	content: "[+]";
+}
+input.toggle:checked + label:before {
+	content: "[-]";
+}
+input.toggle:not(:checked) + label + .docblock {
+	display: none;
+}
+h4 + input.toggle + label {
+	font-size: 0.8em;
+	top: 5px;
+}
+.type-decl + input.toggle + label {
+	top: initial;
+}
+.type-decl + input.toggle:not(:checked) + label {
+	margin-bottom: .6em;
+	height: 25px;
+	position: initial;
+}
+.type-decl + input.toggle:not(:checked) + label:before {
+	content: "[+]";
+}
+.type-decl + input.toggle:not(:checked) + label:after {
+	content: "Expand description";
+	margin-left: 6px;
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -186,7 +186,7 @@ a.test-arrow {
 	color: #dedede;
 }
 
-.collapse-toggle {
+.collapse-toggle, input.toggle + label {
 	color: #999;
 }
 


### PR DESCRIPTION
This is a first draft of #83332. I precise: this is a work in progress. However, with this we can already see what it'll look like after. I precise: even if incomplete, this is working.

For now, this PR switched the doc blocks toggles for the following parts:
 * item doc block (the one at the top)
 * methods doc blocks

Some explanations on how it works: I used a trick based on checkbox. I hide the checkbox and only print its label, so when you click on the label, you check/uncheck the checkbox. Now, that also brings some downsides too:
 * Positioning the label would be tricky without a parent so I had to add a `div` to wrap the function and its documentation. However, I see that as a positive point because we're finally "merging" the items and their documentation.
 * It makes the DOM heavier because we have to add a `div`, a `label` and an `input` for each item with documentation.

The advantages now:
 * It'll be **much** simpler to handle showing/hiding documentation since it'll be handled 100% with CSS. No more JS for this (except for toggling all toggles at once, this one will remain).
 * A lot less of weird JS that we had.
 * No more DOM manipulation when we arrive on a page to add the toggles (meaning better performance!).
 * It'll finally be possible to hide/show documentation even without JS.

There are some small display differences too because currently we use `width` on the -/+ sign to make the whole a big larger.

Before:

![Screenshot from 2021-03-21 22-37-59](https://user-images.githubusercontent.com/3050060/111921723-6dfda900-8a96-11eb-9811-714ccb5a8a7b.png)

After:

![Screenshot from 2021-03-21 22-38-03](https://user-images.githubusercontent.com/3050060/111921724-6e963f80-8a96-11eb-81c7-f6b19c4db6f4.png)

If this seems to be the right way to go, I'll clean up this PR (and finish to remove the remaining JS toggles) so we can finally have toggles 100% non-JS. \o/

r? @Manishearth 