### PR TITLE
Implement new proc macro diagnostics API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
- "clap 3.1.1",
+ "clap 3.1.6",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.1"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
@@ -609,7 +609,7 @@ dependencies = [
  "os_str_bytes",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.14.2",
+ "textwrap 0.15.0",
 ]
 
 [[package]]
@@ -5025,9 +5025,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -274,7 +274,6 @@ impl ToInternal<rustc_errors::Level> for Level {
     fn to_internal(self) -> rustc_errors::Level {
         match self {
             Level::Error => rustc_errors::Level::Error { lint: false },
-            Level::Warning => rustc_errors::Level::Warning,
             Level::Note => rustc_errors::Level::Note,
             Level::Help => rustc_errors::Level::Help,
             _ => unreachable!("unknown proc_macro::Level variant: {:?}", self),
@@ -396,7 +395,7 @@ impl server::Types for Rustc<'_, '_> {
     type Ident = Ident;
     type Literal = Literal;
     type SourceFile = Lrc<SourceFile>;
-    type MultiSpan = Vec<Span>;
+    type MultiSpan = MultiSpan;
     type Diagnostic = Diagnostic;
     type Span = Span;
 }
@@ -749,17 +748,20 @@ impl server::SourceFile for Rustc<'_, '_> {
 
 impl server::MultiSpan for Rustc<'_, '_> {
     fn new(&mut self) -> Self::MultiSpan {
-        vec![]
+        MultiSpan::new()
     }
-    fn push(&mut self, spans: &mut Self::MultiSpan, span: Self::Span) {
-        spans.push(span)
+    fn push_primary_span(&mut self, multispan: &mut Self::MultiSpan, span: Self::Span) {
+        multispan.push_primary_span(span)
+    }
+    fn push_span_label(&mut self, spans: &mut Self::MultiSpan, span: Self::Span, label: String) {
+        spans.push_span_label(span, label)
     }
 }
 
 impl server::Diagnostic for Rustc<'_, '_> {
     fn new(&mut self, level: Level, msg: &str, spans: Self::MultiSpan) -> Self::Diagnostic {
         let mut diag = Diagnostic::new(level.to_internal(), msg);
-        diag.set_span(MultiSpan::from_spans(spans));
+        diag.set_span(spans);
         diag
     }
     fn sub(
@@ -769,7 +771,7 @@ impl server::Diagnostic for Rustc<'_, '_> {
         msg: &str,
         spans: Self::MultiSpan,
     ) {
-        diag.sub(level.to_internal(), msg, MultiSpan::from_spans(spans), None);
+        diag.sub(level.to_internal(), msg, spans, None);
     }
     fn emit(&mut self, diag: Self::Diagnostic) {
         self.sess().span_diagnostic.emit_diagnostic(&diag);

--- a/compiler/rustc_macros/src/session_diagnostic.rs
+++ b/compiler/rustc_macros/src/session_diagnostic.rs
@@ -1,5 +1,4 @@
 #![deny(unused_must_use)]
-use proc_macro::Diagnostic;
 use quote::{format_ident, quote};
 use syn::spanned::Spanned;
 
@@ -105,8 +104,17 @@ impl SessionDiagnosticDeriveError {
     }
 }
 
-fn span_err(span: impl proc_macro::MultiSpan, msg: &str) -> proc_macro::Diagnostic {
-    Diagnostic::spanned(span, proc_macro::Level::Error, msg)
+macro_rules! with_help {
+    ($diag:expr, $msg:expr) => {{
+        #[cfg(bootstrap)]
+        {
+            $diag.help($msg)
+        }
+        #[cfg(not(bootstrap))]
+        {
+            $diag.with_help($msg)
+        }
+    }};
 }
 
 /// For methods that return a Result<_, SessionDiagnosticDeriveError>: emit a diagnostic on
@@ -122,11 +130,11 @@ macro_rules! throw_span_err {
 /// When possible, prefer using throw_span_err! over using this function directly. This only exists
 /// as a function to constrain `f` to an impl FnOnce.
 fn _throw_span_err(
-    span: impl proc_macro::MultiSpan,
+    span: proc_macro::Span,
     msg: &str,
     f: impl FnOnce(proc_macro::Diagnostic) -> proc_macro::Diagnostic,
 ) -> SessionDiagnosticDeriveError {
-    let diag = span_err(span, msg);
+    let diag = span.error(msg);
     f(diag).emit();
     SessionDiagnosticDeriveError::ErrorHandled
 }
@@ -194,8 +202,10 @@ impl<'a> SessionDiagnosticDerive<'a> {
                 // Finally, putting it altogether.
                 match builder.kind {
                     None => {
-                        span_err(ast.span().unwrap(), "`code` not specified")
-                        .help("use the [code = \"...\"] attribute to set this diagnostic's error code ")
+                        with_help!(
+                            ast.span().unwrap().error("`code` not specified"),
+                            "use the [code = \"...\"] attribute to set this diagnostic's error code"
+                        )
                         .emit();
                         SessionDiagnosticDeriveError::ErrorHandled.to_compile_error()
                     }
@@ -215,11 +225,10 @@ impl<'a> SessionDiagnosticDerive<'a> {
                     },
                 }
             } else {
-                span_err(
-                    ast.span().unwrap(),
-                    "`#[derive(SessionDiagnostic)]` can only be used on structs",
-                )
-                .emit();
+                ast.span()
+                    .unwrap()
+                    .error("`#[derive(SessionDiagnostic)]` can only be used on structs")
+                    .emit();
                 SessionDiagnosticDeriveError::ErrorHandled.to_compile_error()
             }
         };
@@ -481,17 +490,19 @@ impl<'a> SessionDiagnosticDeriveBuilder<'a> {
                                 throw_span_err!(
                                     info.span.unwrap(),
                                     "wrong types for suggestion",
-                                    |diag| {
-                                        diag.help("#[suggestion(...)] on a tuple field must be applied to fields of type (Span, Applicability)")
-                                    }
+                                    |diag| with_help!(
+                                        diag,
+                                        "#[suggestion(...)] on a tuple field must be applied to fields of type (Span, Applicability)"
+                                    )
                                 );
                             }
                             _ => throw_span_err!(
                                 info.span.unwrap(),
                                 "wrong field type for suggestion",
-                                |diag| {
-                                    diag.help("#[suggestion(...)] should be applied to fields of type Span or (Span, Applicability)")
-                                }
+                                |diag| with_help!(
+                                    diag,
+                                    "#[suggestion(...)] should be applied to fields of type Span or (Span, Applicability)"
+                                )
                             ),
                         })()?;
                         // Now read the key-value pairs.
@@ -537,9 +548,10 @@ impl<'a> SessionDiagnosticDeriveBuilder<'a> {
                             throw_span_err!(
                                 list.span().unwrap(),
                                 "missing suggestion message",
-                                |diag| {
-                                    diag.help("provide a suggestion message using #[suggestion(message = \"...\")]")
-                                }
+                                |diag| with_help!(
+                                    diag,
+                                    "provide a suggestion message using #[suggestion(message = \"...\")]"
+                                )
                             );
                         };
                         let code = code.unwrap_or_else(|| quote! { String::new() });
@@ -626,12 +638,9 @@ impl<'a> SessionDiagnosticDeriveBuilder<'a> {
                 }
             } else {
                 // This field doesn't exist. Emit a diagnostic.
-                Diagnostic::spanned(
-                    span.unwrap(),
-                    proc_macro::Level::Error,
-                    format!("`{}` doesn't refer to a field on this type", field),
-                )
-                .emit();
+                span.unwrap()
+                    .error(&format!("`{}` doesn't refer to a field on this type", field))
+                    .emit();
                 quote! {
                     "{#field}"
                 }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1050,6 +1050,10 @@ impl MultiSpan {
         MultiSpan { primary_spans: vec, span_labels: vec![] }
     }
 
+    pub fn push_primary_span(&mut self, span: Span) {
+        self.primary_spans.push(span);
+    }
+
     pub fn push_span_label(&mut self, span: Span, label: String) {
         self.span_labels.push((span, label));
     }

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -140,7 +140,8 @@ macro_rules! with_api {
             MultiSpan {
                 fn drop($self: $S::MultiSpan);
                 fn new() -> $S::MultiSpan;
-                fn push($self: &mut $S::MultiSpan, span: $S::Span);
+                fn push_primary_span($self: &mut $S::MultiSpan, span: $S::Span);
+                fn push_span_label($self: &mut $S::MultiSpan, span: $S::Span, label: String);
             },
             Diagnostic {
                 fn drop($self: $S::Diagnostic);
@@ -378,7 +379,6 @@ rpc_encode_decode!(
 rpc_encode_decode!(
     enum Level {
         Error,
-        Warning,
         Note,
         Help,
     }

--- a/library/proc_macro/src/diagnostic.rs
+++ b/library/proc_macro/src/diagnostic.rs
@@ -2,7 +2,8 @@ use crate::Span;
 use std::iter;
 
 /// An enum representing a diagnostic level.
-#[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
+#[doc(hidden)]
+#[unstable(feature = "proc_macro_internals", issue = "27812")]
 #[derive(Copy, Clone, Debug)]
 #[non_exhaustive]
 pub enum Level {

--- a/library/proc_macro/src/diagnostic.rs
+++ b/library/proc_macro/src/diagnostic.rs
@@ -57,13 +57,7 @@ pub trait Spanned {
 
 #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
 impl<S: Spanned, I: IntoIterator<Item = S>> Spanned for I {
-    // FIXME This _really_ should not be exposed publicly. It may be worthwhile
-    // to wait until `type_alias_impl_trait` is stabilized before exposing this
-    // type parameter.
-    //
-    // This is probably the case for other impls of this trait, but those are
-    // relatively trivial compared to this.
-    type Iter = iter::FlatMap<I::IntoIter, S::Iter, fn(S) -> S::Iter>;
+    type Iter = impl Iterator<Item = Span>;
 
     fn spans(self) -> Self::Iter {
         self.into_iter().flat_map(Spanned::spans)

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -31,6 +31,7 @@
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]
 #![feature(panic_update_hook)]
+#![feature(type_alias_impl_trait)]
 #![recursion_limit = "256"]
 
 #[unstable(feature = "proc_macro_internals", issue = "27812")]

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -39,8 +39,10 @@ pub mod bridge;
 
 mod diagnostic;
 
+#[unstable(feature = "proc_macro_internals", issue = "27812")]
+pub use diagnostic::Level;
 #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
-pub use diagnostic::{Diagnostic, Level, Spanned};
+pub use diagnostic::{Diagnostic, Spanned};
 
 use std::cmp::Ordering;
 use std::ops::RangeBounds;

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -40,7 +40,7 @@ pub mod bridge;
 mod diagnostic;
 
 #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
-pub use diagnostic::{Diagnostic, Level, MultiSpan};
+pub use diagnostic::{Diagnostic, Level, Spanned};
 
 use std::cmp::Ordering;
 use std::ops::RangeBounds;
@@ -323,12 +323,12 @@ impl !Send for Span {}
 impl !Sync for Span {}
 
 macro_rules! diagnostic_method {
-    ($name:ident, $level:expr) => {
+    ($name:ident) => {
         /// Creates a new `Diagnostic` with the given `message` at the span
         /// `self`.
         #[unstable(feature = "proc_macro_diagnostic", issue = "54140")]
-        pub fn $name<T: Into<String>>(self, message: T) -> Diagnostic {
-            Diagnostic::spanned(self, $level, message)
+        pub fn $name(self, message: &str) -> Diagnostic {
+            Diagnostic::$name(message).mark(self)
         }
     };
 }
@@ -457,10 +457,8 @@ impl Span {
         Span(bridge::client::Span::recover_proc_macro_span(id))
     }
 
-    diagnostic_method!(error, Level::Error);
-    diagnostic_method!(warning, Level::Warning);
-    diagnostic_method!(note, Level::Note);
-    diagnostic_method!(help, Level::Help);
+    diagnostic_method!(error);
+    diagnostic_method!(note);
 }
 
 /// Prints a span in a form convenient for debugging.

--- a/src/test/ui-fulldeps/session-derive-errors.stderr
+++ b/src/test/ui-fulldeps/session-derive-errors.stderr
@@ -39,7 +39,7 @@ error: `code` not specified
 LL | struct ErrorCodeNotProvided {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: use the [code = "..."] attribute to set this diagnostic's error code 
+   = help: use the [code = "..."] attribute to set this diagnostic's error code
 
 error: the `#[message = "..."]` attribute can only be applied to fields of type Span
   --> $DIR/session-derive-errors.rs:101:5

--- a/src/test/ui/annotate-snippet/auxiliary/multispan.rs
+++ b/src/test/ui/annotate-snippet/auxiliary/multispan.rs
@@ -21,7 +21,8 @@ fn parse(input: TokenStream) -> Result<(), Diagnostic> {
     if !hi_spans.is_empty() {
         return Err(Span::def_site()
                        .error("hello to you, too!")
-                       .span_note(hi_spans, "found these 'hi's"));
+                       .with_note("found these hi's")
+                       .mark(hi_spans));
     }
 
     Ok(())

--- a/src/test/ui/proc-macro/auxiliary/assert-span-pos.rs
+++ b/src/test/ui/proc-macro/auxiliary/assert-span-pos.rs
@@ -6,13 +6,12 @@
 
 extern crate proc_macro;
 
-use proc_macro::{TokenStream, TokenTree, Span};
+use proc_macro::{Span, TokenStream, TokenTree};
 
 fn lit_span(tt: TokenTree) -> (Span, String) {
     match tt {
-        TokenTree::Literal(..) |
-        TokenTree::Group(..) => (tt.span(), tt.to_string().trim().into()),
-        _ => panic!("expected a literal in token tree, got: {:?}", tt)
+        TokenTree::Literal(..) | TokenTree::Group(..) => (tt.span(), tt.to_string().trim().into()),
+        _ => panic!("expected a literal in token tree, got: {:?}", tt),
     }
 }
 
@@ -28,9 +27,11 @@ pub fn assert_span_pos(input: TokenStream) -> TokenStream {
 
     let sp1s = sp1.start();
     if (line, col) != (sp1s.line, sp1s.column) {
-        let msg = format!("line/column mismatch: ({}, {}) != ({}, {})", line, col,
-            sp1s.line, sp1s.column);
-        sp1.error(msg).emit();
+        let msg = format!(
+            "line/column mismatch: ({}, {}) != ({}, {})",
+            line, col, sp1s.line, sp1s.column
+        );
+        sp1.error(&msg).emit();
     }
 
     "".parse().unwrap()

--- a/src/test/ui/proc-macro/auxiliary/custom-quote.rs
+++ b/src/test/ui/proc-macro/auxiliary/custom-quote.rs
@@ -8,7 +8,7 @@
 extern crate proc_macro;
 use std::iter::FromIterator;
 use std::str::FromStr;
-use proc_macro::*;
+use proc_macro::{Delimiter, Group, TokenStream, TokenTree};
 
 #[proc_macro]
 pub fn custom_quote(input: TokenStream) -> TokenStream {

--- a/src/test/ui/proc-macro/auxiliary/multispan.rs
+++ b/src/test/ui/proc-macro/auxiliary/multispan.rs
@@ -21,7 +21,8 @@ fn parse(input: TokenStream) -> Result<(), Diagnostic> {
     if !hi_spans.is_empty() {
         return Err(Span::def_site()
                        .error("hello to you, too!")
-                       .span_note(hi_spans, "found these 'hi's"));
+                       .with_note("found these 'hi's")
+                       .mark_all(hi_spans));
     }
 
     Ok(())

--- a/src/test/ui/proc-macro/auxiliary/parent-source-spans.rs
+++ b/src/test/ui/proc-macro/auxiliary/parent-source-spans.rs
@@ -23,21 +23,21 @@ pub fn parent_source_spans(input: TokenStream) -> TokenStream {
     let _ = tokens.next();
     let (sp2, str2) = lit_span(tokens.next().expect("second string"));
 
-    sp1.error(format!("first final: {}", str1)).emit();
-    sp2.error(format!("second final: {}", str2)).emit();
+    sp1.error(&format!("first final: {}", str1)).emit();
+    sp2.error(&format!("second final: {}", str2)).emit();
 
     if let (Some(p1), Some(p2)) = (sp1.parent(), sp2.parent()) {
-        p1.error(format!("first parent: {}", str1)).emit();
-        p2.error(format!("second parent: {}", str2)).emit();
+        p1.error(&format!("first parent: {}", str1)).emit();
+        p2.error(&format!("second parent: {}", str2)).emit();
 
         if let (Some(gp1), Some(gp2)) = (p1.parent(), p2.parent()) {
-            gp1.error(format!("first grandparent: {}", str1)).emit();
-            gp2.error(format!("second grandparent: {}", str2)).emit();
+            gp1.error(&format!("first grandparent: {}", str1)).emit();
+            gp2.error(&format!("second grandparent: {}", str2)).emit();
         }
     }
 
-    sp1.source().error(format!("first source: {}", str1)).emit();
-    sp2.source().error(format!("second source: {}", str2)).emit();
+    sp1.source().error(&format!("first source: {}", str1)).emit();
+    sp2.source().error(&format!("second source: {}", str2)).emit();
 
     "ok".parse().unwrap()
 }

--- a/src/test/ui/proc-macro/auxiliary/resolved-located-at.rs
+++ b/src/test/ui/proc-macro/auxiliary/resolved-located-at.rs
@@ -14,9 +14,9 @@ pub fn resolve_located_at(input: TokenStream) -> TokenStream {
     match &*input.into_iter().collect::<Vec<_>>() {
         [a, b, ..] => {
             // The error is reported at input `a`.
-            let mut diag = Diagnostic::new(Level::Error, "expected error");
-            diag.set_spans(Span::def_site().located_at(a.span()));
-            diag.emit();
+            let diag = Diagnostic::error("expected error")
+                .mark(Span::def_site().located_at(a.span()))
+                .emit();
 
             // Resolves to `struct S;` at def site, but the error is reported at input `b`.
             let s = TokenTree::Ident(Ident::new("S", b.span().resolved_at(Span::def_site())));

--- a/src/test/ui/proc-macro/auxiliary/span-api-tests.rs
+++ b/src/test/ui/proc-macro/auxiliary/span-api-tests.rs
@@ -6,7 +6,7 @@
 
 extern crate proc_macro;
 
-use proc_macro::*;
+use proc_macro::{Literal, TokenStream, TokenTree};
 
 // Re-emits the input tokens by parsing them from strings
 #[proc_macro]

--- a/src/test/ui/proc-macro/auxiliary/subspan.rs
+++ b/src/test/ui/proc-macro/auxiliary/subspan.rs
@@ -19,7 +19,7 @@ fn parse(input: TokenStream) -> Result<(), Diagnostic> {
         }
 
         if !spans.is_empty() {
-            Err(Span::call_site().error("found 'hi's").span_note(spans, "here"))
+            Err(Span::call_site().error("found 'hi's").with_note("here").mark_all(spans))
         } else {
             Ok(())
         }

--- a/src/test/ui/proc-macro/auxiliary/three-equals.rs
+++ b/src/test/ui/proc-macro/auxiliary/three-equals.rs
@@ -14,9 +14,10 @@ fn parse(input: TokenStream) -> Result<(), Diagnostic> {
     for tree in input {
         let span = tree.span();
         if count >= 3 {
-            return Err(span.error(format!("expected EOF, found `{}`.", tree))
-                           .span_note(last_span, "last good input was here")
-                           .help("input must be: `===`"))
+            return Err(span.error(&format!("expected EOF, found `{}`.", tree))
+                           .with_note("last good input was here")
+                           .mark(last_span)
+                           .with_help("input must be: `===`"))
         }
 
         if let TokenTree::Punct(ref tt) = tree {
@@ -26,13 +27,13 @@ fn parse(input: TokenStream) -> Result<(), Diagnostic> {
                 continue
             }
         }
-        return Err(span.error(format!("expected `=`, found `{}`.", tree)));
+        return Err(span.error(&format!("expected `=`, found `{}`.", tree)));
     }
 
     if count < 3 {
         return Err(Span::def_site()
-                       .error(format!("found {} equal signs, need exactly 3", count))
-                       .help("input must be: `===`"))
+                       .error(&format!("found {} equal signs, need exactly 3", count))
+                       .with_help("input must be: `===`"))
     }
 
     Ok(())


### PR DESCRIPTION
See [#54140 (comment)](https://github.com/rust-lang/rust/issues/54140#issuecomment-802701867) for details.

In this PR, I remove the existing `MultiSpan` trait, replacing it with the proposed `Spanned` trait. The `Diagnostic` API has been rebuilt from the base struct.

The `Level` enum still needs to be removed, as it's not used anywhere in the public API.