### PR TITLE
2229 migration: Don't try resolve regions before writeback

### DIFF
--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -675,7 +675,7 @@ impl Locatable for hir::HirId {
 
 /// The Resolver. This is the type folding engine that detects
 /// unresolved types and so forth.
-crate struct Resolver<'cx, 'tcx> {
+struct Resolver<'cx, 'tcx> {
     tcx: TyCtxt<'tcx>,
     infcx: &'cx InferCtxt<'cx, 'tcx>,
     span: &'cx dyn Locatable,
@@ -686,7 +686,7 @@ crate struct Resolver<'cx, 'tcx> {
 }
 
 impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
-    crate fn new(
+    fn new(
         fcx: &'cx FnCtxt<'cx, 'tcx>,
         span: &'cx dyn Locatable,
         body: &'tcx hir::Body<'tcx>,

--- a/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.rs
@@ -1,0 +1,10 @@
+// run-pass
+
+#![warn(disjoint_capture_drop_reorder)]
+
+fn main() {
+    if let a = "" {
+    //~^ WARNING: irrefutable `if let` pattern
+        drop(|_: ()| drop(a));
+    }
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.stderr
@@ -1,0 +1,15 @@
+warning: irrefutable `if let` pattern
+  --> $DIR/issue-78720.rs:6:5
+   |
+LL | /     if let a = "" {
+LL | |
+LL | |         drop(|_: ()| drop(a));
+LL | |     }
+   | |_____^
+   |
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
+   = note: this pattern will always match, so the `if let` is useless
+   = help: consider replacing the `if let` with a `let`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
In the analysis use `resolve_vars_if_possible` instead of `fully_resolve`,
because we might not have performed regionck yet.

Fixes: #83176

r? @nikomatsakis 
