### PR TITLE
Add `x.py setup tools` which enables `download-rustc` by default

### DIFF
--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -1,4 +1,5 @@
-# These defaults are meant for contributors to the compiler who do not modify codegen or LLVM
+# These defaults are meant for contributors to tools which build on the
+# compiler, but do not modify it directly.
 [rust]
 # This enables `RUSTC_LOG=debug`, avoiding confusing situations
 # where adding `debug!()` appears to do nothing.
@@ -6,6 +7,9 @@
 debug-logging = true
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Download rustc from CI instead of building it from source.
+# This cuts compile times by almost 60x, but means you can't modify the compiler.
+download-rustc = "if-unchanged"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.


### PR DESCRIPTION
Helps with https://github.com/rust-lang/rust/issues/81930. I know I said in that issue that I should fix that rebasing rebuilds bootstrap, but the compile time improvement is so good I think it's ok to leave that fix for later (I still plan to work on it). I think all the outright bugs have been fixed :)

This builds on https://github.com/rust-lang/rust/pull/83368 so I can set the option to `if-unchanged`.

r? @Mark-Simulacrum