### PR TITLE
Faster parsing for lower numbers for radix up to 16

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -895,7 +895,11 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
             // sum of powers of 2 (x*10 can be written as x*8 + x*2).
             // When the compiler can't use these optimisations,
             // the latency of the multiplication can be hidden by issuing it
-            // before the result is needed.
+            // before the result is needed to improve performance on
+            // modern out-of-order CPU as multiplication here is slower
+            // than the other instructions, we can get the end result faster
+            // doing multiplication first and let the CPU spends other cycles
+            // doing other computation and get multiplication result later.
             let mul = result.checked_mul(radix);
             let x = (c as char).to_digit(radix).ok_or(PIE { kind: InvalidDigit })?;
             result = mul.ok_or_else(overflow_err)?;

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -867,8 +867,13 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 
     let mut result = T::from_u32(0);
 
-    if radix <= 16 && digits.len() <= mem::size_of::<T>() * 2 - is_signed_ty as usize {
-        // SAFETY: Consider the highest radix of 16:
+    if intrinsics::likely(
+        radix <= 16 && digits.len() <= mem::size_of::<T>() * 2 - is_signed_ty as usize,
+    ) {
+        // SAFETY: We can take this fast path when `radix.pow(digits.len()) - 1 <= T::MAX`
+        // but the condition above is a faster (conservative) approximation of this.
+        //
+        // Consider the highest radix of 16:
         // `u8::MAX` is `ff` (2 characters), `u16::MAX` is `ffff` (4 characters)
         // We can be sure that any src len of 2 would fit in a u8 so we don't need
         // to check for overflow.
@@ -887,9 +892,14 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
         let overflow_err = || PIE { kind: if is_positive { PosOverflow } else { NegOverflow } };
 
         for &c in digits {
+            // When `radix` is passed in as a literal, rather than doing a slow `imul`
+            // then the compiler can use a shift if `radix` is a power of 2.
+            // (*10 can also be turned into *8 + *2).
+            // When the compiler can't use these optimisations,
+            // there is a latency of several cycles so doing the
+            // multiply before we need to use the result helps.
             let mul = result.checked_mul(radix);
             let x = (c as char).to_digit(radix).ok_or(PIE { kind: InvalidDigit })?;
-            // multiply done early for performance reasons.
             result = mul.ok_or_else(overflow_err)?;
             result = additive_op(&result, x).ok_or_else(overflow_err)?;
         }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -867,9 +867,7 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 
     let mut result = T::from_u32(0);
 
-    if intrinsics::likely(
-        radix <= 16 && digits.len() <= mem::size_of::<T>() * 2 - is_signed_ty as usize,
-    ) {
+    if radix <= 16 && digits.len() <= mem::size_of::<T>() * 2 - is_signed_ty as usize {
         // SAFETY: We can take this fast path when `radix.pow(digits.len()) - 1 <= T::MAX`
         // but the condition above is a faster (conservative) approximation of this.
         //

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -769,12 +769,14 @@ pub enum FpCategory {
 
 #[doc(hidden)]
 trait FromStrRadixHelper: PartialOrd + Copy {
-    fn min_value() -> Self;
-    fn max_value() -> Self;
+    const MIN: Self;
     fn from_u32(u: u32) -> Self;
     fn checked_mul(&self, other: u32) -> Option<Self>;
     fn checked_sub(&self, other: u32) -> Option<Self>;
     fn checked_add(&self, other: u32) -> Option<Self>;
+    unsafe fn unchecked_mul(&self, other: u32) -> Self;
+    unsafe fn unchecked_sub(&self, other: u32) -> Self;
+    unsafe fn unchecked_add(&self, other: u32) -> Self;
 }
 
 macro_rules! from_str_radix_int_impl {
@@ -792,10 +794,7 @@ from_str_radix_int_impl! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }
 
 macro_rules! doit {
     ($($t:ty)*) => ($(impl FromStrRadixHelper for $t {
-        #[inline]
-        fn min_value() -> Self { Self::MIN }
-        #[inline]
-        fn max_value() -> Self { Self::MAX }
+        const MIN: Self = Self::MIN;
         #[inline]
         fn from_u32(u: u32) -> Self { u as Self }
         #[inline]
@@ -809,6 +808,27 @@ macro_rules! doit {
         #[inline]
         fn checked_add(&self, other: u32) -> Option<Self> {
             Self::checked_add(*self, other as Self)
+        }
+        #[inline]
+        unsafe fn unchecked_mul(&self, other: u32) -> Self {
+            // SAFETY:  Conditions of `Self::unchecked_mul` must be upheld by the caller.
+            unsafe {
+                Self::unchecked_mul(*self, other as Self)
+            }
+        }
+        #[inline]
+        unsafe fn unchecked_sub(&self, other: u32) -> Self {
+            // SAFETY:  Conditions of `Self::unchecked_sub` must be upheld by the caller.
+            unsafe {
+                Self::unchecked_sub(*self, other as Self)
+            }
+        }
+        #[inline]
+        unsafe fn unchecked_add(&self, other: u32) -> Self {
+            // SAFETY: Conditions of `Self::unchecked_add` must be upheld by the caller.
+            unsafe {
+                Self::unchecked_add(*self, other as Self)
+            }
         }
     })*)
 }
@@ -828,7 +848,7 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
         return Err(PIE { kind: Empty });
     }
 
-    let is_signed_ty = T::from_u32(0) > T::min_value();
+    let is_signed_ty = T::from_u32(0) > T::MIN;
 
     // all valid digits are ascii, so we will just iterate over the utf8 bytes
     // and cast them to chars. .to_digit() will safely return None for anything
@@ -846,37 +866,32 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
     };
 
     let mut result = T::from_u32(0);
-    if is_positive {
-        // The number is positive
-        for &c in digits {
-            let x = match (c as char).to_digit(radix) {
-                Some(x) => x,
-                None => return Err(PIE { kind: InvalidDigit }),
-            };
-            result = match result.checked_mul(radix) {
-                Some(result) => result,
-                None => return Err(PIE { kind: PosOverflow }),
-            };
-            result = match result.checked_add(x) {
-                Some(result) => result,
-                None => return Err(PIE { kind: PosOverflow }),
-            };
+
+    if radix <= 16 && digits.len() <= mem::size_of::<T>() * 2 - is_signed_ty as usize {
+        // SAFETY: Consider the highest radix of 16:
+        // `u8::MAX` is `ff` (2 characters), `u16::MAX` is `ffff` (4 characters)
+        // We can be sure that any src len of 2 would fit in a u8 so we don't need
+        // to check for overflow.
+        unsafe {
+            let unchecked_additive_op =
+                if is_positive { T::unchecked_add } else { T::unchecked_sub };
+
+            for &c in digits {
+                result = result.unchecked_mul(radix);
+                let x = (c as char).to_digit(radix).ok_or(PIE { kind: InvalidDigit })?;
+                result = unchecked_additive_op(&result, x);
+            }
         }
     } else {
-        // The number is negative
+        let additive_op = if is_positive { T::checked_add } else { T::checked_sub };
+        let overflow_err = || PIE { kind: if is_positive { PosOverflow } else { NegOverflow } };
+
         for &c in digits {
-            let x = match (c as char).to_digit(radix) {
-                Some(x) => x,
-                None => return Err(PIE { kind: InvalidDigit }),
-            };
-            result = match result.checked_mul(radix) {
-                Some(result) => result,
-                None => return Err(PIE { kind: NegOverflow }),
-            };
-            result = match result.checked_sub(x) {
-                Some(result) => result,
-                None => return Err(PIE { kind: NegOverflow }),
-            };
+            let mul = result.checked_mul(radix);
+            let x = (c as char).to_digit(radix).ok_or(PIE { kind: InvalidDigit })?;
+            // multiply done early for performance reasons.
+            result = mul.ok_or_else(overflow_err)?;
+            result = additive_op(&result, x).ok_or_else(overflow_err)?;
         }
     }
     Ok(result)

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -893,8 +893,8 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 
         for &c in digits {
             // When `radix` is passed in as a literal, rather than doing a slow `imul`
-            // then the compiler can use a shift if `radix` is a power of 2.
-            // (*10 can also be turned into *8 + *2).
+            // the compiler can use shifts if `radix` can be expressed as a
+            // sum of powers of 2 (x*10 can be written as x*8 + x*2).
             // When the compiler can't use these optimisations,
             // there is a latency of several cycles so doing the
             // multiply before we need to use the result helps.

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -896,8 +896,8 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
             // the compiler can use shifts if `radix` can be expressed as a
             // sum of powers of 2 (x*10 can be written as x*8 + x*2).
             // When the compiler can't use these optimisations,
-            // there is a latency of several cycles so doing the
-            // multiply before we need to use the result helps.
+            // the latency of the multiplication can be hidden by issuing it
+            // before the result is needed.
             let mul = result.checked_mul(radix);
             let x = (c as char).to_digit(radix).ok_or(PIE { kind: InvalidDigit })?;
             result = mul.ok_or_else(overflow_err)?;

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -873,7 +873,7 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
         // This bound is when `radix.pow(digits.len()) - 1 <= T::MAX` but the condition
         // above is a faster (conservative) approximation of this.
         //
-        // Consider radix 16 as it has the most chance of overflow per digit:
+        // Consider radix 16 as it has the highest information density per digit and will thus overflow the earliest:
         // `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
         // `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
         unsafe {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -868,13 +868,14 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
     let mut result = T::from_u32(0);
 
     if radix <= 16 && digits.len() <= mem::size_of::<T>() * 2 - is_signed_ty as usize {
-        // SAFETY: We can take this fast path when `radix.pow(digits.len()) - 1 <= T::MAX`
-        // but the condition above is a faster (conservative) approximation of this.
+        // SAFETY: If the len of the str is short compared to the range of the type
+        // we are parsing into, then we can be certain that an overflow will not occur.
+        // This bound is when `radix.pow(digits.len()) - 1 <= T::MAX` but the condition
+        // above is a faster (conservative) approximation of this.
         //
-        // Consider the highest radix of 16:
-        // `u8::MAX` is `ff` (2 characters), `u16::MAX` is `ffff` (4 characters)
-        // We can be sure that any src len of 2 would fit in a u8 so we don't need
-        // to check for overflow.
+        // Consider radix 16 as it has the most chance of overflow per digit:
+        // `u8::MAX` is `ff` - any str of len 2 is guaranteed to not overflow.
+        // `i8::MAX` is `7f` - only a str of len 1 is guaranteed to not overflow.
         unsafe {
             let unchecked_additive_op =
                 if is_positive { T::unchecked_add } else { T::unchecked_sub };


### PR DESCRIPTION
While musing on #83088 I noticed that we could use str len to establish if the input was guarenteed not to overflow the containing type.

From what I can see this is conservative enough (i64 having the least wiggle room) that we can safely skip the overflow checks because we have ruled out overflow and that seems to improve performance by 1/4 to 1/3 for numbers in the range. Given that most numbers are statistically on the small side rather than near the type limits, I'm tempted by this. As it stands it doesn't really help i8 much as it's so small a range of numbers, but it does work well with u8 ( `FF` ) which is far more common.

I don't like adding unsafety, but this might be worth it.