### PR TITLE
Unused var anlysis: don't consider uninhabited return value as early return

### DIFF
--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -976,16 +976,6 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             }
 
             hir::ExprKind::Call(ref f, ref args) => {
-                let m = self.ir.tcx.parent_module(expr.hir_id).to_def_id();
-                let succ = if self.ir.tcx.is_ty_uninhabited_from(
-                    m,
-                    self.typeck_results.expr_ty(expr),
-                    self.param_env,
-                ) {
-                    self.exit_ln
-                } else {
-                    succ
-                };
                 let succ = self.propagate_through_exprs(args, succ);
                 self.propagate_through_expr(&f, succ)
             }

--- a/src/test/ui/never_type/issue-83276.rs
+++ b/src/test/ui/never_type/issue-83276.rs
@@ -1,0 +1,13 @@
+// check-pass
+
+#![deny(unused_variables)]
+#![feature(never_type)]
+
+fn never() -> core::convert::Infallible {
+    panic!()
+}
+
+fn main() {
+    let n = never();
+    match n {}
+}

--- a/src/test/ui/never_type/never-assign-dead-code.rs
+++ b/src/test/ui/never_type/never-assign-dead-code.rs
@@ -6,7 +6,7 @@
 #![warn(unused)]
 
 fn main() {
-    let x: ! = panic!("aah"); //~ WARN unused
+    let x: ! = panic!("aah");
     drop(x); //~ WARN unreachable
     //~^ WARN unreachable
 }

--- a/src/test/ui/never_type/never-assign-dead-code.stderr
+++ b/src/test/ui/never_type/never-assign-dead-code.stderr
@@ -21,18 +21,5 @@ LL |     drop(x);
    |     |
    |     unreachable call
 
-warning: unused variable: `x`
-  --> $DIR/never-assign-dead-code.rs:9:9
-   |
-LL |     let x: ! = panic!("aah");
-   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
-   |
-note: the lint level is defined here
-  --> $DIR/never-assign-dead-code.rs:6:9
-   |
-LL | #![warn(unused)]
-   |         ^^^^^^
-   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
-
-warning: 3 warnings emitted
+warning: 2 warnings emitted
 


### PR DESCRIPTION
Previously calling a function that returns in uninhabited type (`!` or
`Infallible`) would be considered as an early return. This causes
"unused variable" warnings when the binding for the return value is
actually used:

    fn never() -> core::convert::Infallible {
        panic!()
    }

    fn main() {
        let n = never();
        match n {} // generates "unused variable" warning
    }

It doesn't make sense to generate an "unused variable" warning for
used variables, so we now don't consider uninhabited returns as early
return and avoid generating a warning in these cases.

- Existing test 'never-assign-dead-code' updated
- Regression test for #83276 added

Fixes #83276