### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/query/mod.rs
+++ b/compiler/rustc_middle/src/ty/query/mod.rs
@@ -217,8 +217,11 @@ macro_rules! define_callbacks {
             fn default() -> Self {
                 Providers {
                     $($name: |_, key| bug!(
-                        "`tcx.{}({:?})` unsupported by its crate",
-                         stringify!($name), key
+                        "`tcx.{}({:?})` unsupported by its crate; \
+                         perhaps the `{}` query was never assigned a provider function",
+                        stringify!($name),
+                        key,
+                        stringify!($name),
                     ),)*
                 }
             }

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -2,6 +2,9 @@
 authors = ["The Rust Project Developers"]
 name = "alloc"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/rust.git"
+description = "The Rust core allocation and collections library"
 autotests = false
 autobenches = false
 edition = "2018"

--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -2,6 +2,9 @@
 authors = ["The Rust Project Developers"]
 name = "core"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/rust.git"
+description = "The Rust Core Library"
 autotests = false
 autobenches = false
 edition = "2018"

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1228,7 +1228,11 @@ pub trait Iterator {
 
     /// Creates an iterator that skips the first `n` elements.
     ///
-    /// After they have been consumed, the rest of the elements are yielded.
+    /// `skip(n)` skips elements until `n` elements are skipped or the end of the
+    /// iterator is reached (whichever happens first). After that, all the remaining
+    /// elements are yielded. In particular, if the original iterator is too short,
+    /// then the returned iterator is empty.
+    ///
     /// Rather than overriding this method directly, instead override the `nth` method.
     ///
     /// # Examples
@@ -1252,7 +1256,14 @@ pub trait Iterator {
         Skip::new(self, n)
     }
 
-    /// Creates an iterator that yields its first `n` elements.
+    /// Creates an iterator that yields the first `n` elements, or fewer
+    /// if the underlying iterator ends sooner.
+    ///
+    /// `take(n)` yields elements until `n` elements are yielded or the end of
+    /// the iterator is reached (whichever happens first).
+    /// The returned iterator is a prefix of length `n` if the original iterator
+    /// contains at least `n` elements, otherwise it contains all of the
+    /// (fewer than `n`) elements of the original iterator.
     ///
     /// # Examples
     ///

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -456,9 +456,13 @@ pub trait Div<Rhs = Self> {
 }
 
 macro_rules! div_impl_integer {
-    ($($t:ty)*) => ($(
+    ($(($($t:ty)*) => $panic:expr),*) => ($($(
         /// This operation rounds towards zero, truncating any
         /// fractional part of the exact result.
+        ///
+        /// # Panics
+        ///
+        #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Div for $t {
             type Output = $t;
@@ -468,10 +472,13 @@ macro_rules! div_impl_integer {
         }
 
         forward_ref_binop! { impl Div, div for $t, $t }
-    )*)
+    )*)*)
 }
 
-div_impl_integer! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+div_impl_integer! {
+    (usize u8 u16 u32 u64 u128) => "This operation will panic if `other == 0`.",
+    (isize i8 i16 i32 i64 i128) => "This operation will panic if `other == 0` or the division results in overflow."
+}
 
 macro_rules! div_impl_float {
     ($($t:ty)*) => ($(

--- a/library/core/src/ops/arith.rs
+++ b/library/core/src/ops/arith.rs
@@ -556,9 +556,13 @@ pub trait Rem<Rhs = Self> {
 }
 
 macro_rules! rem_impl_integer {
-    ($($t:ty)*) => ($(
+    ($(($($t:ty)*) => $panic:expr),*) => ($($(
         /// This operation satisfies `n % d == n - (n / d) * d`. The
         /// result has the same sign as the left operand.
+        ///
+        /// # Panics
+        ///
+        #[doc = $panic]
         #[stable(feature = "rust1", since = "1.0.0")]
         impl Rem for $t {
             type Output = $t;
@@ -568,10 +572,13 @@ macro_rules! rem_impl_integer {
         }
 
         forward_ref_binop! { impl Rem, rem for $t, $t }
-    )*)
+    )*)*)
 }
 
-rem_impl_integer! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 }
+rem_impl_integer! {
+    (usize u8 u16 u32 u64 u128) => "This operation will panic if `other == 0`.",
+    (isize i8 i16 i32 i64 i128) => "This operation will panic if `other == 0` or if `self / other` results in overflow."
+}
 
 macro_rules! rem_impl_float {
     ($($t:ty)*) => ($(

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -66,7 +66,7 @@ pub use iter::{EscapeDebug, EscapeDefault, EscapeUnicode};
 pub use iter::SplitAsciiWhitespace;
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
-use iter::SplitInclusive;
+pub use iter::SplitInclusive;
 
 #[unstable(feature = "str_internals", issue = "none")]
 pub use validations::next_code_point;

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -2,6 +2,9 @@
 authors = ["The Rust Project Developers"]
 name = "panic_abort"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/rust.git"
+description = "Implementation of Rust panics via process aborts"
 edition = "2018"
 
 [lib]

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -2,6 +2,9 @@
 authors = ["The Rust Project Developers"]
 name = "panic_unwind"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/rust.git"
+description = "Implementation of Rust panics via stack unwinding"
 edition = "2018"
 
 [lib]

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -2,6 +2,8 @@
 authors = ["The Rust Project Developers"]
 name = "unwind"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/rust.git"
 edition = "2018"
 include = [
   '/libunwind/*',

--- a/src/test/ui/asm/inline-syntax.arm.stderr
+++ b/src/test/ui/asm/inline-syntax.arm.stderr
@@ -1,11 +1,11 @@
 error: att syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:22:15
+  --> $DIR/inline-syntax.rs:23:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: att syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:25:15
+  --> $DIR/inline-syntax.rs:26:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive

--- a/src/test/ui/asm/inline-syntax.rs
+++ b/src/test/ui/asm/inline-syntax.rs
@@ -1,3 +1,4 @@
+// needs-llvm-components: arm
 // revisions: x86_64 arm
 //[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
 //[arm] compile-flags: --target armv7-unknown-linux-gnueabihf

--- a/src/test/ui/asm/inline-syntax.x86_64.stderr
+++ b/src/test/ui/asm/inline-syntax.x86_64.stderr
@@ -1,17 +1,17 @@
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:18:15
+  --> $DIR/inline-syntax.rs:19:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:20:15
+  --> $DIR/inline-syntax.rs:21:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: using the .att_syntax directive may cause issues, use the att_syntax option instead
-  --> $DIR/inline-syntax.rs:22:15
+  --> $DIR/inline-syntax.rs:23:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL |         asm!("", "nop", options(att_syntax));
    |              --       ^^^^^^^^^^^^^^^^^^^^^
 
 error: using the .att_syntax directive may cause issues, use the att_syntax option instead
-  --> $DIR/inline-syntax.rs:25:15
+  --> $DIR/inline-syntax.rs:26:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,13 +33,13 @@ LL |         asm!("", "nop", options(att_syntax));
    |              --       ^^^^^^^^^^^^^^^^^^^^^
 
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:28:15
+  --> $DIR/inline-syntax.rs:29:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^ help: remove this assembler directive
 
 error: intel syntax is the default syntax on this target, and trying to use this directive may cause issues
-  --> $DIR/inline-syntax.rs:33:14
+  --> $DIR/inline-syntax.rs:34:14
    |
 LL |               .intel_syntax noprefix
    |  ______________^


### PR DESCRIPTION
Successful merges:

 - #82374 (Add license metadata for std dependencies)
 - #82683 (Document panicking cases for integer division and remainder)
 - #83272 (Clarify non-exact length in the Iterator::take documentation)
 - #83338 (Fix test for #82270)
 - #83351 (post-drop-elab check-const: explain why we still check qualifs)
 - #83367 (Improve error message for unassigned query provider)
 - #83372 (SplitInclusive is public API)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=82374,82683,83272,83338,83351,83367,83372)
<!-- homu-ignore:end -->