### PR TITLE
[stable] 1.51.0 release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,7 @@ Compiler
 - [Added tier 3\* support for the `armv5te-unknown-linux-uclibceabi` target.][78142]
 - [Added tier 3 support for the `aarch64-apple-ios-macabi` target.][77484]
 - [The `x86_64-unknown-freebsd` is now built with the full toolset.][79484]
+- [Dropped support for all cloudabi targets.][78439]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
 information on Rust's tiered platform support.
@@ -42,6 +43,23 @@ The following previously stable methods are now `const`.
 
 - [`IpAddr::is_ipv4`]
 - [`IpAddr::is_ipv6`]
+- [`IpAddr::is_unspecified`]
+- [`IpAddr::is_loopback`]
+- [`IpAddr::is_multicast`]
+- [`Ipv4Addr::octets`]
+- [`Ipv4Addr::is_loopback`]
+- [`Ipv4Addr::is_private`]
+- [`Ipv4Addr::is_link_local`]
+- [`Ipv4Addr::is_multicast`]
+- [`Ipv4Addr::is_broadcast`]
+- [`Ipv4Addr::is_documentation`]
+- [`Ipv4Addr::to_ipv6_compatible`]
+- [`Ipv4Addr::to_ipv6_mapped`]
+- [`Ipv6Addr::segments`]
+- [`Ipv6Addr::is_unspecified`]
+- [`Ipv6Addr::is_loopback`]
+- [`Ipv6Addr::is_multicast`]
+- [`Ipv6Addr::to_ipv4`]
 - [`Layout::size`]
 - [`Layout::align`]
 - [`Layout::from_size_align`]
@@ -50,7 +68,7 @@ The following previously stable methods are now `const`.
 - `saturating_pow` for all integer types.
 - `wrapping_pow` for all integer types.
 - `next_power_of_two` for all unsigned integer types.
-- `checked_power_of_two` for all unsigned integer types.
+- `checked_next_power_of_two` for all unsigned integer types.
 
 Cargo
 -----------------------
@@ -77,7 +95,6 @@ Compatibility Notes
 - [`#![test]` as an inner attribute is now considered unstable like other inner macro
   attributes, and reports an error by default through the `soft_unstable` lint.][79003]
 - [Overriding a `forbid` lint at the same level that it was set is now a hard error.][78864]
-- [Dropped support for all cloudabi targets.][78439]
 - [You can no longer intercept `panic!` calls by supplying your own macro.][78343] It's
   recommended to use the `#[panic_handler]` attribute to provide your own implementation.
 - [Semi-colons after item statements (e.g. `struct Foo {};`) now produce a warning.][78296]
@@ -104,6 +121,23 @@ Compatibility Notes
 [cargo/8725]: https://github.com/rust-lang/cargo/pull/8725
 [`IpAddr::is_ipv4`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_ipv4
 [`IpAddr::is_ipv6`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_ipv6
+[`IpAddr::is_unspecified`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_unspecified
+[`IpAddr::is_loopback`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_loopback
+[`IpAddr::is_multicast`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_multicast
+[`Ipv4Addr::octets`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.octets
+[`Ipv4Addr::is_loopback`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_loopback
+[`Ipv4Addr::is_private`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_private
+[`Ipv4Addr::is_link_local`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_link_local
+[`Ipv4Addr::is_multicast`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_multicast
+[`Ipv4Addr::is_broadcast`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_broadcast
+[`Ipv4Addr::is_documentation`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_documentation
+[`Ipv4Addr::to_ipv6_compatible`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.to_ipv6_compatible
+[`Ipv4Addr::to_ipv6_mapped`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.to_ipv6_mapped
+[`Ipv6Addr::segments`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.segments
+[`Ipv6Addr::is_unspecified`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.is_unspecified
+[`Ipv6Addr::is_loopback`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.is_loopback
+[`Ipv6Addr::is_multicast`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.is_multicast
+[`Ipv6Addr::to_ipv4`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.to_ipv4
 [`Layout::align`]: https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.align
 [`Layout::from_size_align`]: https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.from_size_align
 [`Layout::size`]: https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.size

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,174 @@
+Version 1.51.0 (2021-03-25)
+============================
+
+Language
+--------
+- [You can now parameterize items such as functions, traits, and `struct`s by constant
+  values in addition to by types and lifetimes.][79135] Also known as "const generics"
+  E.g. you can now write the following. Note: Only values of primitive integers, 
+  `bool`, or `char` types are currently permitted.
+  ```rust
+  struct GenericArray<T, const LENGTH: usize> {
+      inner: [T; LENGTH]
+  }
+
+  impl<T, const LENGTH: usize> GenericArray<T, LENGTH> {
+      const fn last(&self) -> Option<&T> {
+          if LENGTH == 0 {
+              None
+          } else {
+              Some(&self.inner[LENGTH - 1])
+          }
+      }
+  }
+  ```
+
+
+Compiler
+--------
+
+- [Added the `-Csplit-debuginfo` codegen option for macOS platforms.][79570]
+  This option controls whether debug information is split across multiple files
+  or packed into a single file. **Note** This option is unstable on other platforms.
+- [Added tier 3\* support for `aarch64_be-unknown-linux-gnu`,
+  `aarch64-unknown-linux-gnu_ilp32`, and `aarch64_be-unknown-linux-gnu_ilp32` targets.][81455]
+- [Added tier 3 support for `i386-unknown-linux-gnu` and `i486-unknown-linux-gnu` targets.][80662]
+- [The `target-cpu=native` option will now detect individual features of CPUs.][80749]
+- [Rust now uses `inline-asm` for stack probes when used with LLVM 11.0.1+][77885]
+
+\* Refer to Rust's [platform support page][forge-platform-support] for more
+information on Rust's tiered platform support.
+
+Libraries
+---------
+
+- [`Box::downcast` is now also implemented for any `dyn Any + Send + Sync` object.][80945]
+- [`str` now implements `AsMut<str>`.][80279]
+- [`u64` and `u128` now implement `From<char>`.][79502]
+- [`Error` is now implemented for `&T` where `T` implements `Error`.][75180]
+- [`Poll::{map_ok, map_err}` are now implemented for `Poll<Option<Result<T, E>>>`.][80968]
+- [`unsigned_abs` is now implemented for all signed integer types.][80959]
+- [`io::Empty` now implements `io::Seek`.][78044]
+- [`rc::Weak<T>` and `sync::Weak<T>`'s methods such as `as_ptr` are now implemented for
+  `T: ?Sized` types.][80764]
+
+Stabilized APIs
+---------------
+
+- [`Arc::decrement_strong_count`]
+- [`Arc::increment_strong_count`]
+- [`Once::call_once_force`]
+- [`Peekable::next_if_eq`]
+- [`Peekable::next_if`]
+- [`Seek::stream_position`]
+- [`array::IntoIter`]
+- [`panic::panic_any`]
+- [`ptr::addr_of!`]
+- [`ptr::addr_of_mut!`]
+- [`slice::fill_with`]
+- [`slice::split_inclusive_mut`]
+- [`slice::split_inclusive`]
+- [`slice::strip_prefix`]
+- [`slice::strip_suffix`]
+- [`str::split_inclusive`]
+- [`sync::OnceState`]
+- [`task::Wake`]
+
+Cargo
+-----
+- [Added the `split-debuginfo` profile option to control the -Csplit-debuginfo
+  codegen option.][cargo/9112]
+- [Added the `resolver` field to `Cargo.toml` to enable the new feature resolver
+  and CLI option behavior.][cargo/8997] Version 2 of the feature resolver will try
+  to avoid unifying features of dependencies where that unification could be unwanted.
+  Such as using the same dependency with a `std` feature in a build scripts and
+  proc-macros, while using the `no-std` feature in the final binary. See the
+  [Cargo book documentation][feature-resolver@2.0] for more information on the feature.
+
+Rustdoc
+-------
+
+- [Rustdoc will now include documentation for methods available from `Deref` traits.][80653]
+- [You can now provide a `--default-theme` flag which sets the default theme to use for
+  documentation.][79642]
+
+Various improvements to intra-doc links:
+
+- [You can link to non-path primitives such as `slice`.][80181]
+- [You can link to associated items.][74489]
+- [You can now include generic parameters when linking to items, like `Vec<T>`.][76934]
+
+Misc
+----
+- [You can now pass `--include-ignored` to tests (e.g. with
+  `cargo test -- --include-ignored`) to include testing tests marked `#[ignore]`.][80053]
+
+Compatibility Notes
+-------------------
+
+- [WASI platforms no longer use the `wasm-bindgen` ABI, and instead use the wasm32 ABI.][79998]
+- [`rustc` no longer promotes division, modulo and indexing operations to `const` that
+  could fail.][80579]
+- [The minimum version of glibc for the following platforms has been bumped to version 2.31
+  for the distributed artifacts.][81521]
+    - `armv5te-unknown-linux-gnueabi`
+    - `sparc64-unknown-linux-gnu`
+    - `thumbv7neon-unknown-linux-gnueabihf`
+    - `armv7-unknown-linux-gnueabi`
+    - `x86_64-unknown-linux-gnux32`
+
+Internal Only
+-------------
+
+- [Consistently avoid constructing optimized MIR when not doing codegen][80718]
+
+[79135]: https://github.com/rust-lang/rust/pull/79135
+[74489]: https://github.com/rust-lang/rust/pull/74489
+[76934]: https://github.com/rust-lang/rust/pull/76934
+[79570]: https://github.com/rust-lang/rust/pull/79570
+[80181]: https://github.com/rust-lang/rust/pull/80181
+[79642]: https://github.com/rust-lang/rust/pull/79642
+[80945]: https://github.com/rust-lang/rust/pull/80945
+[80279]: https://github.com/rust-lang/rust/pull/80279
+[80053]: https://github.com/rust-lang/rust/pull/80053
+[79502]: https://github.com/rust-lang/rust/pull/79502
+[75180]: https://github.com/rust-lang/rust/pull/75180
+[79135]: https://github.com/rust-lang/rust/pull/79135
+[81521]: https://github.com/rust-lang/rust/pull/81521
+[80968]: https://github.com/rust-lang/rust/pull/80968
+[80959]: https://github.com/rust-lang/rust/pull/80959
+[80718]: https://github.com/rust-lang/rust/pull/80718
+[80653]: https://github.com/rust-lang/rust/pull/80653
+[80579]: https://github.com/rust-lang/rust/pull/80579
+[79998]: https://github.com/rust-lang/rust/pull/79998
+[78044]: https://github.com/rust-lang/rust/pull/78044
+[81455]: https://github.com/rust-lang/rust/pull/81455
+[80764]: https://github.com/rust-lang/rust/pull/80764
+[80749]: https://github.com/rust-lang/rust/pull/80749
+[80662]: https://github.com/rust-lang/rust/pull/80662
+[77885]: https://github.com/rust-lang/rust/pull/77885
+[cargo/8997]: https://github.com/rust-lang/cargo/pull/8997
+[cargo/9112]: https://github.com/rust-lang/cargo/pull/9112
+[feature-resolver@2.0]: https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2
+[`Once::call_once_force`]: https://doc.rust-lang.org/stable/std/sync/struct.Once.html#method.call_once_force
+[`sync::OnceState`]: https://doc.rust-lang.org/stable/std/sync/struct.OnceState.html
+[`panic::panic_any`]: https://doc.rust-lang.org/stable/std/panic/fn.panic_any.html
+[`slice::strip_prefix`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.strip_prefix
+[`slice::strip_suffix`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.strip_prefix
+[`Arc::increment_strong_count`]: https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html#method.increment_strong_count
+[`Arc::decrement_strong_count`]: https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html#method.decrement_strong_count
+[`slice::fill_with`]: https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.fill_with
+[`ptr::addr_of!`]: https://doc.rust-lang.org/nightly/std/ptr/macro.addr_of.html
+[`ptr::addr_of_mut!`]: https://doc.rust-lang.org/nightly/std/ptr/macro.addr_of_mut.html
+[`array::IntoIter`]: https://doc.rust-lang.org/nightly/std/array/struct.IntoIter.html
+[`slice::split_inclusive`]: https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.split_inclusive
+[`slice::split_inclusive_mut`]: https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.split_inclusive_mut
+[`str::split_inclusive`]: https://doc.rust-lang.org/nightly/std/primitive.str.html#method.split_inclusive
+[`task::Wake`]: https://doc.rust-lang.org/nightly/std/task/trait.Wake.html
+[`Seek::stream_position`]: https://doc.rust-lang.org/nightly/std/io/trait.Seek.html#method.stream_position
+[`Peekable::next_if`]: https://doc.rust-lang.org/nightly/std/iter/struct.Peekable.html#method.next_if
+[`Peekable::next_if_eq`]: https://doc.rust-lang.org/nightly/std/iter/struct.Peekable.html#method.next_if_eq
+
 Version 1.50.0 (2021-02-11)
 ============================
 
@@ -12,7 +183,6 @@ Compiler
 - [Added tier 3\* support for the `armv5te-unknown-linux-uclibceabi` target.][78142]
 - [Added tier 3 support for the `aarch64-apple-ios-macabi` target.][77484]
 - [The `x86_64-unknown-freebsd` is now built with the full toolset.][79484]
-- [Dropped support for all cloudabi targets.][78439]
 
 \* Refer to Rust's [platform support page][forge-platform-support] for more
 information on Rust's tiered platform support.
@@ -43,23 +213,6 @@ The following previously stable methods are now `const`.
 
 - [`IpAddr::is_ipv4`]
 - [`IpAddr::is_ipv6`]
-- [`IpAddr::is_unspecified`]
-- [`IpAddr::is_loopback`]
-- [`IpAddr::is_multicast`]
-- [`Ipv4Addr::octets`]
-- [`Ipv4Addr::is_loopback`]
-- [`Ipv4Addr::is_private`]
-- [`Ipv4Addr::is_link_local`]
-- [`Ipv4Addr::is_multicast`]
-- [`Ipv4Addr::is_broadcast`]
-- [`Ipv4Addr::is_documentation`]
-- [`Ipv4Addr::to_ipv6_compatible`]
-- [`Ipv4Addr::to_ipv6_mapped`]
-- [`Ipv6Addr::segments`]
-- [`Ipv6Addr::is_unspecified`]
-- [`Ipv6Addr::is_loopback`]
-- [`Ipv6Addr::is_multicast`]
-- [`Ipv6Addr::to_ipv4`]
 - [`Layout::size`]
 - [`Layout::align`]
 - [`Layout::from_size_align`]
@@ -68,7 +221,7 @@ The following previously stable methods are now `const`.
 - `saturating_pow` for all integer types.
 - `wrapping_pow` for all integer types.
 - `next_power_of_two` for all unsigned integer types.
-- `checked_next_power_of_two` for all unsigned integer types.
+- `checked_power_of_two` for all unsigned integer types.
 
 Cargo
 -----------------------
@@ -95,6 +248,7 @@ Compatibility Notes
 - [`#![test]` as an inner attribute is now considered unstable like other inner macro
   attributes, and reports an error by default through the `soft_unstable` lint.][79003]
 - [Overriding a `forbid` lint at the same level that it was set is now a hard error.][78864]
+- [Dropped support for all cloudabi targets.][78439]
 - [You can no longer intercept `panic!` calls by supplying your own macro.][78343] It's
   recommended to use the `#[panic_handler]` attribute to provide your own implementation.
 - [Semi-colons after item statements (e.g. `struct Foo {};`) now produce a warning.][78296]
@@ -121,23 +275,6 @@ Compatibility Notes
 [cargo/8725]: https://github.com/rust-lang/cargo/pull/8725
 [`IpAddr::is_ipv4`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_ipv4
 [`IpAddr::is_ipv6`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_ipv6
-[`IpAddr::is_unspecified`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_unspecified
-[`IpAddr::is_loopback`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_loopback
-[`IpAddr::is_multicast`]: https://doc.rust-lang.org/stable/std/net/enum.IpAddr.html#method.is_multicast
-[`Ipv4Addr::octets`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.octets
-[`Ipv4Addr::is_loopback`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_loopback
-[`Ipv4Addr::is_private`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_private
-[`Ipv4Addr::is_link_local`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_link_local
-[`Ipv4Addr::is_multicast`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_multicast
-[`Ipv4Addr::is_broadcast`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_broadcast
-[`Ipv4Addr::is_documentation`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.is_documentation
-[`Ipv4Addr::to_ipv6_compatible`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.to_ipv6_compatible
-[`Ipv4Addr::to_ipv6_mapped`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html#method.to_ipv6_mapped
-[`Ipv6Addr::segments`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.segments
-[`Ipv6Addr::is_unspecified`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.is_unspecified
-[`Ipv6Addr::is_loopback`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.is_loopback
-[`Ipv6Addr::is_multicast`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.is_multicast
-[`Ipv6Addr::to_ipv4`]: https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html#method.to_ipv4
 [`Layout::align`]: https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.align
 [`Layout::from_size_align`]: https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.from_size_align
 [`Layout::size`]: https://doc.rust-lang.org/stable/std/alloc/struct.Layout.html#method.size

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -66,7 +66,7 @@ pub use iter::{EscapeDebug, EscapeDefault, EscapeUnicode};
 pub use iter::SplitAsciiWhitespace;
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
-use iter::SplitInclusive;
+pub use iter::SplitInclusive;
 
 #[unstable(feature = "str_internals", issue = "none")]
 pub use validations::next_code_point;

--- a/library/std/src/sys/unix/kernel_copy/tests.rs
+++ b/library/std/src/sys/unix/kernel_copy/tests.rs
@@ -65,6 +65,24 @@ fn copy_specialization() -> Result<()> {
     result.and(rm1).and(rm2)
 }
 
+#[test]
+fn copies_append_mode_sink() -> Result<()> {
+    let tmp_path = tmpdir();
+    let source_path = tmp_path.join("copies_append_mode.source");
+    let sink_path = tmp_path.join("copies_append_mode.sink");
+    let mut source =
+        OpenOptions::new().create(true).truncate(true).write(true).read(true).open(&source_path)?;
+    write!(source, "not empty")?;
+    source.seek(SeekFrom::Start(0))?;
+    let mut sink = OpenOptions::new().create(true).append(true).open(&sink_path)?;
+
+    let copied = crate::io::copy(&mut source, &mut sink)?;
+
+    assert_eq!(copied, 9);
+
+    Ok(())
+}
+
 #[bench]
 fn bench_file_to_file_copy(b: &mut test::Bencher) {
     const BYTES: usize = 128 * 1024;

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -654,13 +654,11 @@ fn open_parent(p: &Path) -> io::Result<(ManuallyDrop<WasiFd>, PathBuf)> {
                 );
                 return Err(io::Error::new(io::ErrorKind::Other, msg));
             }
-            let len = CStr::from_ptr(buf.as_ptr().cast()).to_bytes().len();
-            buf.set_len(len);
-            buf.shrink_to_fit();
+            let relative = CStr::from_ptr(relative_path).to_bytes().to_vec();
 
             return Ok((
                 ManuallyDrop::new(WasiFd::from_raw(fd as u32)),
-                PathBuf::from(OsString::from_vec(buf)),
+                PathBuf::from(OsString::from_vec(relative)),
             ));
         }
     }

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -68,7 +68,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 
 # Always set the release channel for bootstrap; this is normally not important (i.e., only dist
 # builds would seem to matter) but in practice bootstrap wants to know whether we're targeting


### PR DESCRIPTION
Also includes backports of the release notes, as well as:

*  SplitInclusive is public API #83372 
*  std: Fix a bug on the wasm32-wasi target opening files #82804 
*  Fix io::copy specialization using copy_file_range when writer was opened with O_APPEND #82417 

r? @Mark-Simulacrum 