### PR TITLE
rename :pat2018 -> :pat2015

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -688,13 +688,13 @@ pub enum NonterminalKind {
     Item,
     Block,
     Stmt,
-    Pat2018 {
-        /// Keep track of whether the user used `:pat2018` or `:pat` and we inferred it from the
+    Pat2015 {
+        /// Keep track of whether the user used `:pat2015` or `:pat` and we inferred it from the
         /// edition of the span. This is used for diagnostics.
         inferred: bool,
     },
     Pat2021 {
-        /// Keep track of whether the user used `:pat2018` or `:pat` and we inferred it from the
+        /// Keep track of whether the user used `:pat2015` or `:pat` and we inferred it from the
         /// edition of the span. This is used for diagnostics.
         inferred: bool,
     },
@@ -722,11 +722,11 @@ impl NonterminalKind {
             sym::stmt => NonterminalKind::Stmt,
             sym::pat => match edition() {
                 Edition::Edition2015 | Edition::Edition2018 => {
-                    NonterminalKind::Pat2018 { inferred: true }
+                    NonterminalKind::Pat2015 { inferred: true }
                 }
                 Edition::Edition2021 => NonterminalKind::Pat2021 { inferred: true },
             },
-            sym::pat2018 => NonterminalKind::Pat2018 { inferred: false },
+            sym::pat2015 => NonterminalKind::Pat2015 { inferred: false },
             sym::pat2021 => NonterminalKind::Pat2021 { inferred: false },
             sym::expr => NonterminalKind::Expr,
             sym::ty => NonterminalKind::Ty,
@@ -745,9 +745,9 @@ impl NonterminalKind {
             NonterminalKind::Item => sym::item,
             NonterminalKind::Block => sym::block,
             NonterminalKind::Stmt => sym::stmt,
-            NonterminalKind::Pat2018 { inferred: false } => sym::pat2018,
+            NonterminalKind::Pat2015 { inferred: false } => sym::pat2015,
             NonterminalKind::Pat2021 { inferred: false } => sym::pat2021,
-            NonterminalKind::Pat2018 { inferred: true }
+            NonterminalKind::Pat2015 { inferred: true }
             | NonterminalKind::Pat2021 { inferred: true } => sym::pat,
             NonterminalKind::Expr => sym::expr,
             NonterminalKind::Ty => sym::ty,

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -1080,7 +1080,7 @@ fn is_in_follow(tok: &mbe::TokenTree, kind: NonterminalKind) -> IsInFollow {
                     _ => IsInFollow::No(TOKENS),
                 }
             }
-            NonterminalKind::Pat2018 { .. } | NonterminalKind::Pat2021 { .. } => {
+            NonterminalKind::Pat2015 { .. } | NonterminalKind::Pat2021 { .. } => {
                 const TOKENS: &[&str] = &["`=>`", "`,`", "`=`", "`|`", "`if`", "`in`"];
                 match tok {
                     TokenTree::Token(token) => match token.kind {

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -63,13 +63,13 @@ pub(super) fn parse(
                                     let span = token.span.with_lo(start_sp.lo());
 
                                     match frag.name {
-                                        sym::pat2018 | sym::pat2021 => {
+                                        sym::pat2015 | sym::pat2021 => {
                                             if !features.edition_macro_pats {
                                                 feature_err(
                                                     sess,
                                                     sym::edition_macro_pats,
                                                     frag.span,
-                                                    "`pat2018` and `pat2021` are unstable.",
+                                                    "`pat2015` and `pat2021` are unstable.",
                                                 )
                                                 .emit();
                                             }

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -614,7 +614,7 @@ declare_features! (
     /// Allows arbitrary expressions in key-value attributes at parse time.
     (active, extended_key_value_attributes, "1.50.0", Some(78835), None),
 
-    /// `:pat2018` and `:pat2021` macro matchers.
+    /// `:pat2015` and `:pat2021` macro matchers.
     (active, edition_macro_pats, "1.51.0", Some(54883), None),
 
     /// Allows const generics to have default values (e.g. `struct Foo<const N: usize = 3>(...);`).

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -61,7 +61,7 @@ impl<'a> Parser<'a> {
                 },
                 _ => false,
             },
-            NonterminalKind::Pat2018 { .. } | NonterminalKind::Pat2021 { .. } => match token.kind {
+            NonterminalKind::Pat2015 { .. } | NonterminalKind::Pat2021 { .. } => match token.kind {
                 token::Ident(..) |                  // box, ref, mut, and other identifiers (can stricten)
                 token::OpenDelim(token::Paren) |    // tuple pattern
                 token::OpenDelim(token::Bracket) |  // slice pattern
@@ -118,9 +118,9 @@ impl<'a> Parser<'a> {
                     return Err(self.struct_span_err(self.token.span, "expected a statement"));
                 }
             },
-            NonterminalKind::Pat2018 { .. } | NonterminalKind::Pat2021 { .. } => {
+            NonterminalKind::Pat2015 { .. } | NonterminalKind::Pat2021 { .. } => {
                 token::NtPat(self.collect_tokens_no_attrs(|this| match kind {
-                    NonterminalKind::Pat2018 { .. } => this.parse_pat_no_top_alt(None),
+                    NonterminalKind::Pat2015 { .. } => this.parse_pat_no_top_alt(None),
                     NonterminalKind::Pat2021 { .. } => {
                         this.parse_pat_allow_top_alt(None, GateOr::Yes, RecoverComma::No)
                     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -845,7 +845,7 @@ symbols! {
         partial_ord,
         passes,
         pat,
-        pat2018,
+        pat2015,
         pat2021,
         path,
         pattern_parentheses,

--- a/src/test/ui/feature-gates/feature-gate-edition_macro_pats.rs
+++ b/src/test/ui/feature-gates/feature-gate-edition_macro_pats.rs
@@ -1,8 +1,8 @@
 // Feature gate test for `edition_macro_pats` feature.
 
 macro_rules! foo {
-    ($x:pat2018) => {}; //~ERROR `pat2018` and `pat2021` are unstable
-    ($x:pat2021) => {}; //~ERROR `pat2018` and `pat2021` are unstable
+    ($x:pat2015) => {}; //~ERROR `pat2015` and `pat2021` are unstable
+    ($x:pat2021) => {}; //~ERROR `pat2015` and `pat2021` are unstable
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-edition_macro_pats.stderr
+++ b/src/test/ui/feature-gates/feature-gate-edition_macro_pats.stderr
@@ -1,13 +1,13 @@
-error[E0658]: `pat2018` and `pat2021` are unstable.
+error[E0658]: `pat2015` and `pat2021` are unstable.
   --> $DIR/feature-gate-edition_macro_pats.rs:4:9
    |
-LL |     ($x:pat2018) => {};
+LL |     ($x:pat2015) => {};
    |         ^^^^^^^
    |
    = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
    = help: add `#![feature(edition_macro_pats)]` to the crate attributes to enable
 
-error[E0658]: `pat2018` and `pat2021` are unstable.
+error[E0658]: `pat2015` and `pat2021` are unstable.
   --> $DIR/feature-gate-edition_macro_pats.rs:5:9
    |
 LL |     ($x:pat2021) => {};

--- a/src/test/ui/macros/edition-macro-pats.rs
+++ b/src/test/ui/macros/edition-macro-pats.rs
@@ -4,7 +4,7 @@
 #![feature(edition_macro_pats)]
 
 macro_rules! foo {
-    (a $x:pat2018) => {};
+    (a $x:pat2015) => {};
     (b $x:pat2021) => {};
 }
 


### PR DESCRIPTION
as requested by T-lang on zulip: https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/or.20patterns/near/231133873

No functional changes here... just renaming.

r? @nikomatsakis 