### PR TITLE
Change `-W help` to display edition level.

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -895,7 +895,12 @@ Available lint options:
     let print_lints = |lints: Vec<&Lint>| {
         for lint in lints {
             let name = lint.name_lower().replace("_", "-");
-            println!("    {}  {:7.7}  {}", padded(&name), lint.default_level.as_str(), lint.desc);
+            println!(
+                "    {}  {:7.7}  {}",
+                padded(&name),
+                lint.default_level(sess.edition()).as_str(),
+                lint.desc
+            );
         }
         println!("\n");
     };


### PR DESCRIPTION
`-W help` was not honoring the `--edition` flag when displaying the default lint level. It was using the edition for sorting, but not for the final display.

This isn't important right now as there aren't any edition-specific lint levels. Also, the `declare_lint` macro is broken and doesn't even allow setting them right now. However, I figure it wouldn't hurt to fix this before I forget about it, in case edition-specific lints are ever used in the future.
