### PR TITLE
Codeblock tooltip position

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1346,7 +1346,7 @@ h4 > .notable-traits {
 	to prevent an overlay between the "collapse toggle" and the information tooltip.
 	However, it's not needed with smaller screen width because the doc/code block is always put
 	"one line" below. */
-	.information:first-child > .tooltip {
+	.docblock > .information:first-child > .tooltip {
 		margin-top: 16px;
 	}
 }

--- a/src/test/rustdoc-gui/check_info_sign_position.goml
+++ b/src/test/rustdoc-gui/check_info_sign_position.goml
@@ -1,0 +1,9 @@
+goto: file://|DOC_PATH|/index.html
+goto: ./fn.check_list_code_block.html
+// If the codeblock is the first element of the docblock, the information tooltip must have
+// have some top margin to avoid going over the toggle (the "[+]").
+assert: (".docblock > .information > .compile_fail", { "margin-top": "16px" })
+// Checks that the other codeblocks don't have this top margin.
+assert: ("ol > li > .information > .compile_fail", { "margin-top": "0px" })
+assert: ("ol > li > .information > .ignore", { "margin-top": "0px" })
+assert: (".docblock > .information > .ignore", { "margin-top": "0px" })

--- a/src/test/rustdoc-gui/lib.rs
+++ b/src/test/rustdoc-gui/lib.rs
@@ -57,16 +57,26 @@ pub trait AnotherOne {
     fn func3();
 }
 
+/// ```compile_fail
+/// whatever
+/// ```
+///
 /// Check for "i" signs in lists!
 ///
 /// 1. elem 1
-/// 2.test 1
-///   ```compile_fail
-///   fn foo() {}
-///   ```
+/// 2. test 1
+///    ```compile_fail
+///    fn foo() {}
+///    ```
 /// 3. elem 3
 /// 4. ```ignore (it's a test)
 ///    fn foo() {}
 ///    ```
 /// 5. elem 5
+///
+/// Final one:
+///
+/// ```ignore (still a test)
+/// let x = 12;
+/// ```
 pub fn check_list_code_block() {}


### PR DESCRIPTION
The codeblocks tooltips were misplaced. Normally, there is no top margin applied to a tooltip unless the codeblock is the first element of the doc block. The CSS rule was too vague though, applying it to all tooltips where the codeblock was the first child of its parent. Which can be easily seen with lists:

Before:

![Screenshot from 2021-03-22 22-05-16](https://user-images.githubusercontent.com/3050060/112059812-a667ba80-8b5c-11eb-88dd-1c598ceb3766.png)

After:

![Screenshot from 2021-03-22 22-06-31](https://user-images.githubusercontent.com/3050060/112059815-a7005100-8b5c-11eb-9e40-8fc57513e498.png)

r? @Nemo157 