### PR TITLE
rustdoc: Record crate name instead of using `None`

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -182,8 +182,6 @@ impl Cache {
             self.primitive_locations.insert(prim, def_id);
         }
 
-        self.stack.push(krate.name.to_string());
-
         krate = CacheBuilder { tcx, cache: self, empty_cache: Cache::default() }.fold_crate(krate);
 
         for (trait_did, dids, impl_) in self.orphan_trait_impls.drain(..) {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -76,7 +76,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             &Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Public },
             hir::CRATE_HIR_ID,
             &krate.item.module,
-            None,
+            Some(self.cx.tcx.crate_name),
         );
         top_level_module.is_crate = true;
         // Attach the crate's exported macros to the top-level module.

--- a/src/test/rustdoc-ui/intra-doc/private-from-crate-level.rs
+++ b/src/test/rustdoc-ui/intra-doc/private-from-crate-level.rs
@@ -1,0 +1,6 @@
+// check-pass
+
+//! [my_module]
+//~^ WARN public documentation for `private_from_crate_level` links to private item `my_module`
+
+mod my_module {}

--- a/src/test/rustdoc-ui/intra-doc/private-from-crate-level.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private-from-crate-level.stderr
@@ -1,0 +1,11 @@
+warning: public documentation for `private_from_crate_level` links to private item `my_module`
+  --> $DIR/private-from-crate-level.rs:3:6
+   |
+LL | //! [my_module]
+   |      ^^^^^^^^^ this item is private
+   |
+   = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
+   = note: this link will resolve properly if you pass `--document-private-items`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes #83365.

r? @jyn514
