### PR TITLE
Recover from `if (let ...)` in parsing, instead of lowering

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1145,6 +1145,17 @@ impl Expr {
         expr
     }
 
+    pub fn peel_parens_owned(self) -> Expr {
+        let mut expr = self;
+        loop {
+            let Expr { id, kind, span, attrs, tokens } = expr;
+            match kind {
+                ExprKind::Paren(inner) => expr = inner.into_inner(),
+                kind => return Expr { id, kind, span, attrs, tokens },
+            }
+        }
+    }
+
     /// Attempts to reparse as `Ty` (for diagnostic purposes).
     pub fn to_ty(&self) -> Option<P<Ty>> {
         let kind = match &self.kind {

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -97,23 +97,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     ExprKind::Let(ref pat, ref scrutinee) => {
                         self.lower_expr_if_let(e.span, pat, scrutinee, then, else_opt.as_deref())
                     }
-                    ExprKind::Paren(ref paren) => match paren.peel_parens().kind {
-                        ExprKind::Let(ref pat, ref scrutinee) => {
-                            // A user has written `if (let Some(x) = foo) {`, we want to avoid
-                            // confusing them with mentions of nightly features.
-                            // If this logic is changed, you will also likely need to touch
-                            // `unused::UnusedParens::check_expr`.
-                            self.if_let_expr_with_parens(cond, &paren.peel_parens());
-                            self.lower_expr_if_let(
-                                e.span,
-                                pat,
-                                scrutinee,
-                                then,
-                                else_opt.as_deref(),
-                            )
-                        }
-                        _ => self.lower_expr_if(cond, then, else_opt.as_deref()),
-                    },
                     _ => self.lower_expr_if(cond, then, else_opt.as_deref()),
                 },
                 ExprKind::While(ref cond, ref body, opt_label) => self
@@ -368,25 +351,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
         // Now lower everything as normal.
         let f = self.lower_expr(&f);
         hir::ExprKind::Call(f, self.lower_exprs(&real_args))
-    }
-
-    fn if_let_expr_with_parens(&mut self, cond: &Expr, paren: &Expr) {
-        let start = cond.span.until(paren.span);
-        let end = paren.span.shrink_to_hi().until(cond.span.shrink_to_hi());
-        self.sess
-            .struct_span_err(
-                vec![start, end],
-                "invalid parentheses around `let` expression in `if let`",
-            )
-            .multipart_suggestion(
-                "`if let` needs to be written without parentheses",
-                vec![(start, String::new()), (end, String::new())],
-                rustc_errors::Applicability::MachineApplicable,
-            )
-            .emit();
-        // Ideally, we'd remove the feature gating of a `let` expression since we are already
-        // complaining about it here, but `feature_gate::check_crate` has already run by now:
-        // self.sess.parse_sess.gated_spans.ungate_last(sym::let_chains, paren.span);
     }
 
     /// Emit an error and lower `ast::ExprKind::Let(pat, scrutinee)` into:

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate.rs
@@ -12,12 +12,10 @@ fn _if() {
     if let 0 = 1 {} // Stable!
 
     if (let 0 = 1) {}
-    //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR invalid parentheses around `let` expression in `if let`
+    //~^ ERROR invalid parentheses around `let` expression in `if let`
 
     if (((let 0 = 1))) {}
-    //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR invalid parentheses around `let` expression in `if let`
+    //~^ ERROR invalid parentheses around `let` expression in `if let`
 
     if true && let 0 = 1 {}
     //~^ ERROR `let` expressions in this position are experimental [E0658]
@@ -125,8 +123,7 @@ fn _macros() {
     //~| ERROR `let` expressions are not supported here
     //~| ERROR `let` expressions are not supported here
     use_expr!((let 0 = 1));
-    //~^ ERROR `let` expressions in this position are experimental [E0658]
-    //~| ERROR invalid parentheses around `let` expression in `if let`
+    //~^ ERROR invalid parentheses around `let` expression in `if let`
     //~| ERROR `let` expressions are not supported here
     #[cfg(FALSE)] (let 0 = 1);
     //~^ ERROR `let` expressions in this position are experimental [E0658]

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
@@ -1,332 +1,3 @@
-error: no rules expected the token `let`
-  --> $DIR/feature-gate.rs:133:15
-   |
-LL |     macro_rules! use_expr {
-   |     --------------------- when calling this macro
-...
-LL |     use_expr!(let 0 = 1);
-   |               ^^^ no rules expected this token in macro call
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:14:9
-   |
-LL |     if (let 0 = 1) {}
-   |         ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:18:11
-   |
-LL |     if (((let 0 = 1))) {}
-   |           ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:22:16
-   |
-LL |     if true && let 0 = 1 {}
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:26:8
-   |
-LL |     if let 0 = 1 && true {}
-   |        ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:30:9
-   |
-LL |     if (let 0 = 1) && true {}
-   |         ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:34:17
-   |
-LL |     if true && (let 0 = 1) {}
-   |                 ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:38:9
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |         ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:38:24
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |                        ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:8
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |        ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:21
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                     ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:35
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:48
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:44:61
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                             ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:56:8
-   |
-LL |     if let Range { start: _, end: _ } = (true..true) && false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:64:12
-   |
-LL |     while (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:68:14
-   |
-LL |     while (((let 0 = 1))) {}
-   |              ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:72:19
-   |
-LL |     while true && let 0 = 1 {}
-   |                   ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:76:11
-   |
-LL |     while let 0 = 1 && true {}
-   |           ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:80:12
-   |
-LL |     while (let 0 = 1) && true {}
-   |            ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:84:20
-   |
-LL |     while true && (let 0 = 1) {}
-   |                    ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:88:12
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:88:27
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |                           ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:11
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |           ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:24
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                        ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:38
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:51
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                   ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:94:64
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:106:11
-   |
-LL |     while let Range { start: _, end: _ } = (true..true) && false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:131:20
-   |
-LL |     #[cfg(FALSE)] (let 0 = 1);
-   |                    ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:114:17
-   |
-LL |     noop_expr!((let 0 = 1));
-   |                 ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:123:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
-error[E0658]: `let` expressions in this position are experimental
-  --> $DIR/feature-gate.rs:127:16
-   |
-LL |     use_expr!((let 0 = 1));
-   |                ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
-
 error: invalid parentheses around `let` expression in `if let`
   --> $DIR/feature-gate.rs:14:8
    |
@@ -339,7 +10,7 @@ LL |     if let 0 = 1 {}
    |       --       --
 
 error: invalid parentheses around `let` expression in `if let`
-  --> $DIR/feature-gate.rs:18:8
+  --> $DIR/feature-gate.rs:17:8
    |
 LL |     if (((let 0 = 1))) {}
    |        ^^^         ^^^
@@ -349,232 +20,8 @@ help: `if let` needs to be written without parentheses
 LL |     if let 0 = 1 {}
    |       --       --
 
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:22:16
-   |
-LL |     if true && let 0 = 1 {}
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:26:8
-   |
-LL |     if let 0 = 1 && true {}
-   |        ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:30:9
-   |
-LL |     if (let 0 = 1) && true {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:34:17
-   |
-LL |     if true && (let 0 = 1) {}
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:38:9
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |         ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:38:24
-   |
-LL |     if (let 0 = 1) && (let 0 = 1) {}
-   |                        ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:8
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |        ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:21
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                     ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:35
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                   ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:48
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:44:61
-   |
-LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                             ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:56:8
-   |
-LL |     if let Range { start: _, end: _ } = (true..true) && false {}
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:64:12
-   |
-LL |     while (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:68:14
-   |
-LL |     while (((let 0 = 1))) {}
-   |              ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:72:19
-   |
-LL |     while true && let 0 = 1 {}
-   |                   ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:76:11
-   |
-LL |     while let 0 = 1 && true {}
-   |           ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:80:12
-   |
-LL |     while (let 0 = 1) && true {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:84:20
-   |
-LL |     while true && (let 0 = 1) {}
-   |                    ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:88:12
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |            ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:88:27
-   |
-LL |     while (let 0 = 1) && (let 0 = 1) {}
-   |                           ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:11
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |           ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:24
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                        ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:38
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                      ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:51
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                   ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:94:64
-   |
-LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
-   |                                                                ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:106:11
-   |
-LL |     while let Range { start: _, end: _ } = (true..true) && false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:123:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
-error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:123:16
-   |
-LL |     use_expr!((let 0 = 1 && 0 == 0));
-   |                ^^^^^^^^^
-   |
-   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
-
 error: invalid parentheses around `let` expression in `if let`
-  --> $DIR/feature-gate.rs:127:15
+  --> $DIR/feature-gate.rs:125:15
    |
 LL |     use_expr!((let 0 = 1));
    |               ^         ^
@@ -584,14 +31,537 @@ help: `if let` needs to be written without parentheses
 LL |     use_expr!(let 0 = 1);
    |              --       --
 
+error: no rules expected the token `let`
+  --> $DIR/feature-gate.rs:130:15
+   |
+LL |     macro_rules! use_expr {
+   |     --------------------- when calling this macro
+...
+LL |     use_expr!(let 0 = 1);
+   |               ^^^ no rules expected this token in macro call
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:20:16
+   |
+LL |     if true && let 0 = 1 {}
+   |                ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:24:8
+   |
+LL |     if let 0 = 1 && true {}
+   |        ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:28:9
+   |
+LL |     if (let 0 = 1) && true {}
+   |         ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:32:17
+   |
+LL |     if true && (let 0 = 1) {}
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:36:9
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |         ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:36:24
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |                        ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:42:8
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |        ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:42:21
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                     ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:42:35
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                   ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:42:48
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:42:61
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                             ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:54:8
+   |
+LL |     if let Range { start: _, end: _ } = (true..true) && false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:62:12
+   |
+LL |     while (let 0 = 1) {}
+   |            ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:66:14
+   |
+LL |     while (((let 0 = 1))) {}
+   |              ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:70:19
+   |
+LL |     while true && let 0 = 1 {}
+   |                   ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:74:11
+   |
+LL |     while let 0 = 1 && true {}
+   |           ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:78:12
+   |
+LL |     while (let 0 = 1) && true {}
+   |            ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:82:20
+   |
+LL |     while true && (let 0 = 1) {}
+   |                    ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:86:12
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |            ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:86:27
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |                           ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:92:11
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |           ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:92:24
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                        ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:92:38
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                      ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:92:51
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                   ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:92:64
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                                ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:104:11
+   |
+LL |     while let Range { start: _, end: _ } = (true..true) && false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:128:20
+   |
+LL |     #[cfg(FALSE)] (let 0 = 1);
+   |                    ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:112:17
+   |
+LL |     noop_expr!((let 0 = 1));
+   |                 ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
+error[E0658]: `let` expressions in this position are experimental
+  --> $DIR/feature-gate.rs:121:16
+   |
+LL |     use_expr!((let 0 = 1 && 0 == 0));
+   |                ^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`
+
 error: `let` expressions are not supported here
-  --> $DIR/feature-gate.rs:127:16
+  --> $DIR/feature-gate.rs:20:16
+   |
+LL |     if true && let 0 = 1 {}
+   |                ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:24:8
+   |
+LL |     if let 0 = 1 && true {}
+   |        ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:28:9
+   |
+LL |     if (let 0 = 1) && true {}
+   |         ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:32:17
+   |
+LL |     if true && (let 0 = 1) {}
+   |                 ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:36:9
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |         ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:36:24
+   |
+LL |     if (let 0 = 1) && (let 0 = 1) {}
+   |                        ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:42:8
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |        ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:42:21
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                     ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:42:35
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                   ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:42:48
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:42:61
+   |
+LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                             ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:54:8
+   |
+LL |     if let Range { start: _, end: _ } = (true..true) && false {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:62:12
+   |
+LL |     while (let 0 = 1) {}
+   |            ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:66:14
+   |
+LL |     while (((let 0 = 1))) {}
+   |              ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:70:19
+   |
+LL |     while true && let 0 = 1 {}
+   |                   ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:74:11
+   |
+LL |     while let 0 = 1 && true {}
+   |           ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:78:12
+   |
+LL |     while (let 0 = 1) && true {}
+   |            ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:82:20
+   |
+LL |     while true && (let 0 = 1) {}
+   |                    ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:86:12
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |            ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:86:27
+   |
+LL |     while (let 0 = 1) && (let 0 = 1) {}
+   |                           ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:92:11
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |           ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:92:24
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                        ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:92:38
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                      ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:92:51
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                   ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:92:64
+   |
+LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
+   |                                                                ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:104:11
+   |
+LL |     while let Range { start: _, end: _ } = (true..true) && false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:121:16
+   |
+LL |     use_expr!((let 0 = 1 && 0 == 0));
+   |                ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:121:16
+   |
+LL |     use_expr!((let 0 = 1 && 0 == 0));
+   |                ^^^^^^^^^
+   |
+   = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
+
+error: `let` expressions are not supported here
+  --> $DIR/feature-gate.rs:125:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^^^^^^^
    |
    = note: only supported directly without parentheses in conditions of `if`- and `while`-expressions, as well as in `let` chains within parentheses
 
-error: aborting due to 65 previous errors
+error: aborting due to 62 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/rfc-2497-if-let-chains/issue-83274.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/issue-83274.rs
@@ -1,0 +1,7 @@
+// check-fail
+
+pub fn main() {
+    let x = Some(3);
+    if (let Some(y) = x) { //~ ERROR invalid parentheses around `let` expression in `if let`
+    }
+}

--- a/src/test/ui/rfc-2497-if-let-chains/issue-83274.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/issue-83274.stderr
@@ -1,0 +1,13 @@
+error: invalid parentheses around `let` expression in `if let`
+  --> $DIR/issue-83274.rs:5:8
+   |
+LL |     if (let Some(y) = x) {
+   |        ^               ^
+   |
+help: `if let` needs to be written without parentheses
+   |
+LL |     if let Some(y) = x {
+   |       --             --
+
+error: aborting due to previous error
+


### PR DESCRIPTION
When we recover from `if (let ...)` in lowering we can't "ungate" the
syntax after generating the error

    invalid parentheses around `let` expression in `if let`

as the feature_gate::check_crate pass has already run. This is mentioned
in these comments in the old code

> Ideally, we'd remove the feature gating of a `let` expression since we
> are already complaining about it here, but `feature_gate::check_crate`
> has already run by now

We now recover from `if (let ...)` in parsing, generate the error as
before, and "ungate" the syntax. For example, in this code:

    fn main() {
        let x = Some(3);
        if (let Some(y) = x) {}
    }

We would previously generate:

    error[E0658]: `let` expressions in this position are experimental
     --> test.rs:3:9
      |
    3 |     if (let Some(y) = x) {}
      |         ^^^^^^^^^^^^^^^
      |
      = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
      = help: add `#![feature(let_chains)]` to the crate attributes to enable
      = help: you can write `matches!(<expr>, <pattern>)` instead of `let <pattern> = <expr>`

    error: invalid parentheses around `let` expression in `if let`
     --> test.rs:3:8
      |
    3 |     if (let Some(y) = x) {}
      |        ^               ^
      |
    help: `if let` needs to be written without parentheses
      |
    3 |     if let Some(y) = x {}
      |       --             --

    error: aborting due to 2 previous errors

The first error doesn't make sense. With the "ungating" we now generate
just the second one:

    error: invalid parentheses around `let` expression in `if let`
     --> test.rs:3:8
      |
    3 |     if (let Some(y) = x) {}
      |        ^               ^
      |
    help: `if let` needs to be written without parentheses
      |
    3 |     if let Some(y) = x {}
      |       --             --

    error: aborting due to previous error

Fixes #83274