### PR TITLE
Expose str::SplitInclusive in alloc and therefore in std

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -46,7 +46,7 @@ pub use core::str::pattern;
 pub use core::str::EncodeUtf16;
 #[stable(feature = "split_ascii_whitespace", since = "1.34.0")]
 pub use core::str::SplitAsciiWhitespace;
-#[stable(feature = "split_inclusive", since = "1.51.0")]
+#[stable(feature = "split_inclusive", since = "1.53.0")]
 pub use core::str::SplitInclusive;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::SplitWhitespace;

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -46,6 +46,8 @@ pub use core::str::pattern;
 pub use core::str::EncodeUtf16;
 #[stable(feature = "split_ascii_whitespace", since = "1.34.0")]
 pub use core::str::SplitAsciiWhitespace;
+#[stable(feature = "split_inclusive", since = "1.51.0")]
+pub use core::str::SplitInclusive;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::str::SplitWhitespace;
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
This seems to have been omitted from the beginning when this feature was first introduced in 86bf96291d82.  Most users won't need to name this type which is probably why this wasn't noticed in the meantime.

See #83372 for a different but related bug.

### Notes for reviewers

I think I have got this right but TBH I am not very familiar with the relationship between core and std and so on.  <strike>I also haven't don't any kind of test (not even a build) yet.  I will do a local docs build to see that the type now appears in the std docs.</strike>  I did a local docs build and it has made this type appear as `std::str::SplitInclusive` as expected

The linkification of the return value from `str::split_inclusive` teleports me to the online url for `core::str::SplitInclusive`.  I think this may be a rustdoc anomaly (similar to #79630 maybe) but I am not sure.  Perhaps it means I haven't done the `std` -> `core` referrence correctly.

I made this insta-stable since it seems like simply a bug.  Please LMK if that is not right.  *(edited to add:)* In particular, IDK how this ought to relate to the (?)current release process.