### PR TITLE
Remove unnecessary `Option` wrapping around `Crate.module`

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -231,7 +231,7 @@ impl Clean<Item> for doctree::Module<'_> {
 
         let what_rustc_thinks = Item::from_hir_id_and_parts(
             self.id,
-            self.name,
+            Some(self.name),
             ModuleItem(Module { is_crate: self.is_crate, items }),
             cx,
         );

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -51,7 +51,7 @@ thread_local!(crate static MAX_DEF_IDX: RefCell<FxHashMap<CrateNum, DefIndex>> =
 crate struct Crate {
     crate name: Symbol,
     crate src: FileName,
-    crate module: Option<Item>,
+    crate module: Item,
     crate externs: Vec<(CrateNum, ExternalCrate)>,
     crate primitives: Vec<(DefId, PrimitiveType)>,
     // These are later on moved into `CACHEKEY`, leaving the map empty.

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -76,7 +76,7 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     Crate {
         name,
         src,
-        module: Some(module),
+        module,
         externs,
         primitives,
         external_traits: cx.external_traits.clone(),

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -474,21 +474,19 @@ crate fn run_global_ctxt(
 
     let mut krate = tcx.sess.time("clean_crate", || clean::krate(&mut ctxt));
 
-    if let Some(ref m) = krate.module {
-        if m.doc_value().map(|d| d.is_empty()).unwrap_or(true) {
-            let help = "The following guide may be of use:\n\
+    if krate.module.doc_value().map(|d| d.is_empty()).unwrap_or(true) {
+        let help = "The following guide may be of use:\n\
                 https://doc.rust-lang.org/nightly/rustdoc/how-to-write-documentation.html";
-            tcx.struct_lint_node(
-                crate::lint::MISSING_CRATE_LEVEL_DOCS,
-                DocContext::as_local_hir_id(tcx, m.def_id).unwrap(),
-                |lint| {
-                    let mut diag =
-                        lint.build("no documentation found for this crate's top-level module");
-                    diag.help(help);
-                    diag.emit();
-                },
-            );
-        }
+        tcx.struct_lint_node(
+            crate::lint::MISSING_CRATE_LEVEL_DOCS,
+            DocContext::as_local_hir_id(tcx, krate.module.def_id).unwrap(),
+            |lint| {
+                let mut diag =
+                    lint.build("no documentation found for this crate's top-level module");
+                diag.help(help);
+                diag.emit();
+            },
+        );
     }
 
     fn report_deprecated_attr(name: &str, diag: &rustc_errors::Handler, sp: Span) {
@@ -531,7 +529,7 @@ crate fn run_global_ctxt(
 
     // Process all of the crate attributes, extracting plugin metadata along
     // with the passes which we are supposed to run.
-    for attr in krate.module.as_ref().unwrap().attrs.lists(sym::doc) {
+    for attr in krate.module.attrs.lists(sym::doc) {
         let diag = ctxt.sess().diagnostic();
 
         let name = attr.name_or_empty();

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -5,7 +5,7 @@ use rustc_span::{self, Span, Symbol};
 use rustc_hir as hir;
 
 crate struct Module<'hir> {
-    crate name: Option<Symbol>,
+    crate name: Symbol,
     crate where_outer: Span,
     crate where_inner: Span,
     crate mods: Vec<Module<'hir>>,
@@ -18,7 +18,7 @@ crate struct Module<'hir> {
 }
 
 impl Module<'hir> {
-    crate fn new(name: Option<Symbol>) -> Module<'hir> {
+    crate fn new(name: Symbol) -> Module<'hir> {
         Module {
             name,
             id: hir::CRATE_HIR_ID,

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -87,7 +87,7 @@ crate trait DocFolder: Sized {
     }
 
     fn fold_crate(&mut self, mut c: Crate) -> Crate {
-        c.module = c.module.take().and_then(|module| self.fold_item(module));
+        c.module = self.fold_item(c.module).unwrap();
 
         {
             let external_traits = { std::mem::take(&mut *c.external_traits.borrow_mut()) };

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -182,8 +182,6 @@ impl Cache {
             self.primitive_locations.insert(prim, def_id);
         }
 
-        self.stack.push(krate.name.to_string());
-
         krate = CacheBuilder { tcx, cache: self, empty_cache: Cache::default() }.fold_crate(krate);
 
         for (trait_did, dids, impl_) in self.orphan_trait_impls.drain(..) {

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -127,11 +127,8 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
         crate_items.push(&*item);
     }
 
-    let crate_doc = krate
-        .module
-        .as_ref()
-        .map(|module| module.doc_value().map_or_else(String::new, |s| short_markdown_summary(&s)))
-        .unwrap_or_default();
+    let crate_doc =
+        krate.module.doc_value().map_or_else(String::new, |s| short_markdown_summary(&s));
 
     struct CrateData<'a> {
         doc: String,

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
-use rustc_span::edition::Edition;
+use rustc_span::{edition::Edition, Symbol};
 
 use rustdoc_json_types as types;
 
@@ -202,7 +202,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
 
     fn after_krate(
         &mut self,
-        _krate: &clean::Crate,
+        _crate_name: Symbol,
         _diag: &rustc_errors::Handler,
     ) -> Result<(), Error> {
         debug!("Done with crate");

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -131,12 +131,8 @@ crate fn collect_trait_impls(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
         }
     }
 
-    let items = if let Some(ref mut it) = krate.module {
-        if let ModuleItem(Module { ref mut items, .. }) = *it.kind {
-            items
-        } else {
-            panic!("collect-trait-impls can't run");
-        }
+    let items = if let ModuleItem(Module { ref mut items, .. }) = *krate.module.kind {
+        items
     } else {
         panic!("collect-trait-impls can't run");
     };

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -76,7 +76,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             &Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Public },
             hir::CRATE_HIR_ID,
             &krate.item.module,
-            None,
+            Some(self.cx.tcx.crate_name),
         );
         top_level_module.is_crate = true;
         // Attach the crate's exported macros to the top-level module.

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -76,7 +76,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             &Spanned { span: rustc_span::DUMMY_SP, node: hir::VisibilityKind::Public },
             hir::CRATE_HIR_ID,
             &krate.item.module,
-            Some(self.cx.tcx.crate_name),
+            self.cx.tcx.crate_name,
         );
         top_level_module.is_crate = true;
         // Attach the crate's exported macros to the top-level module.
@@ -114,7 +114,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     _ => continue 'exported_macros,
                 };
                 // Descend into the child module that matches this path segment (if any).
-                match cur_mod.mods.iter_mut().find(|child| child.name == Some(path_segment_ty_ns)) {
+                match cur_mod.mods.iter_mut().find(|child| child.name == path_segment_ty_ns) {
                     Some(child_mod) => cur_mod = &mut *child_mod,
                     None => continue 'exported_macros,
                 }
@@ -133,7 +133,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         vis: &'tcx hir::Visibility<'_>,
         id: hir::HirId,
         m: &'tcx hir::Mod<'tcx>,
-        name: Option<Symbol>,
+        name: Symbol,
     ) -> Module<'tcx> {
         let mut om = Module::new(name);
         om.where_outer = span;
@@ -312,13 +312,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 om.items.push((item, renamed))
             }
             hir::ItemKind::Mod(ref m) => {
-                om.mods.push(self.visit_mod_contents(
-                    item.span,
-                    &item.vis,
-                    item.hir_id(),
-                    m,
-                    Some(name),
-                ));
+                om.mods.push(self.visit_mod_contents(item.span, &item.vis, item.hir_id(), m, name));
             }
             hir::ItemKind::Fn(..)
             | hir::ItemKind::ExternCrate(..)

--- a/src/test/rustdoc-ui/intra-doc/private-from-crate-level.rs
+++ b/src/test/rustdoc-ui/intra-doc/private-from-crate-level.rs
@@ -1,0 +1,6 @@
+// check-pass
+
+//! [my_module]
+//~^ WARN public documentation for `private_from_crate_level` links to private item `my_module`
+
+mod my_module {}

--- a/src/test/rustdoc-ui/intra-doc/private-from-crate-level.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private-from-crate-level.stderr
@@ -1,0 +1,11 @@
+warning: public documentation for `private_from_crate_level` links to private item `my_module`
+  --> $DIR/private-from-crate-level.rs:3:6
+   |
+LL | //! [my_module]
+   |      ^^^^^^^^^ this item is private
+   |
+   = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
+   = note: this link will resolve properly if you pass `--document-private-items`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
I'm wondering if it was originally there so that we could `take` the
module which enables `after_krate` to take an `&Crate`. However, the two
impls of `after_krate` only use `Crate.name`, so we can pass just the
name instead.
