### PR TITLE
Add Result::into_err where the Ok variant is the never type

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1167,6 +1167,42 @@ impl<T, E: Into<!>> Result<T, E> {
     }
 }
 
+#[unstable(feature = "unwrap_infallible", reason = "newly added", issue = "61695")]
+impl<T: Into<!>, E> Result<T, E> {
+    /// Returns the contained [`Err`] value, but never panics.
+    ///
+    /// Unlike [`unwrap_err`], this method is known to never panic on the
+    /// result types it is implemented for. Therefore, it can be used
+    /// instead of `unwrap_err` as a maintainability safeguard that will fail
+    /// to compile if the ok type of the `Result` is later changed
+    /// to a type that can actually occur.
+    ///
+    /// [`unwrap_err`]: Result::unwrap_err
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # #![feature(never_type)]
+    /// # #![feature(unwrap_infallible)]
+    ///
+    /// fn only_bad_news() -> Result<!, String> {
+    ///     Err("Oops, it failed".into())
+    /// }
+    ///
+    /// let error: String = only_bad_news().into_err();
+    /// println!("{}", error);
+    /// ```
+    #[inline]
+    pub fn into_err(self) -> E {
+        match self {
+            Ok(x) => x.into(),
+            Err(e) => e,
+        }
+    }
+}
+
 impl<T: Deref, E> Result<T, E> {
     /// Converts from `Result<T, E>` (or `&Result<T, E>`) to `Result<&<T as Deref>::Target, &E>`.
     ///

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -226,6 +226,28 @@ pub fn test_into_ok() {
 }
 
 #[test]
+pub fn test_into_err() {
+    fn until_error_op() -> Result<!, isize> {
+        Err(666)
+    }
+
+    assert_eq!(until_error_op().into_err(), 666);
+
+    enum MyNeverToken {}
+    impl From<MyNeverToken> for ! {
+        fn from(never: MyNeverToken) -> ! {
+            match never {}
+        }
+    }
+
+    fn until_error_op2() -> Result<MyNeverToken, isize> {
+        Err(667)
+    }
+
+    assert_eq!(until_error_op2().into_err(), 667);
+}
+
+#[test]
 fn test_try() {
     fn try_result_some() -> Option<u8> {
         let val = Ok(1)?;


### PR DESCRIPTION
Equivalent of #66045 but for the inverse situation where `T: Into<!>` rather than `E: Into<!>`.

I'm using the same feature gate name. I can't see why one of these methods would be OK to stabilize but not the other.

Tracking issue: #61695