### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,11 +287,10 @@ dependencies = [
  "cargo-platform",
  "cargo-test-macro",
  "cargo-test-support",
+ "cargo-util",
  "clap",
- "core-foundation",
  "crates-io",
  "crossbeam-utils 0.8.0",
- "crypto-hash",
  "curl",
  "curl-sys",
  "env_logger 0.8.1",
@@ -313,7 +312,6 @@ dependencies = [
  "libgit2-sys",
  "log",
  "memchr",
- "miow 0.3.6",
  "num_cpus",
  "opener",
  "openssl",
@@ -322,12 +320,10 @@ dependencies = [
  "rand 0.8.3",
  "rustc-workspace-hack",
  "rustfix",
- "same-file",
  "semver 0.10.0",
  "serde",
  "serde_ignored",
  "serde_json",
- "shell-escape",
  "strip-ansi-escapes",
  "tar",
  "tempfile",
@@ -396,8 +392,9 @@ version = "0.1.0"
 name = "cargo-test-support"
 version = "0.1.0"
 dependencies = [
- "cargo",
+ "anyhow",
  "cargo-test-macro",
+ "cargo-util",
  "filetime",
  "flate2",
  "git2",
@@ -408,6 +405,26 @@ dependencies = [
  "tar",
  "toml",
  "url 2.1.1",
+]
+
+[[package]]
+name = "cargo-util"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "core-foundation",
+ "crypto-hash",
+ "filetime",
+ "hex 0.4.2",
+ "jobserver",
+ "libc",
+ "log",
+ "miow 0.3.6",
+ "same-file",
+ "shell-escape",
+ "tempfile",
+ "walkdir",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2765,9 +2782,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -4793,18 +4810,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5100,9 +5117,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.38"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
+checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -895,7 +895,12 @@ Available lint options:
     let print_lints = |lints: Vec<&Lint>| {
         for lint in lints {
             let name = lint.name_lower().replace("_", "-");
-            println!("    {}  {:7.7}  {}", padded(&name), lint.default_level.as_str(), lint.desc);
+            println!(
+                "    {}  {:7.7}  {}",
+                padded(&name),
+                lint.default_level(sess.edition()).as_str(),
+                lint.desc
+            );
         }
         println!("\n");
     };

--- a/compiler/rustc_incremental/src/assert_dep_graph.rs
+++ b/compiler/rustc_incremental/src/assert_dep_graph.rs
@@ -57,6 +57,10 @@ pub fn assert_dep_graph(tcx: TyCtxt<'_>) {
             dump_graph(tcx);
         }
 
+        if !tcx.sess.opts.debugging_opts.query_dep_graph {
+            return;
+        }
+
         // if the `rustc_attrs` feature is not enabled, then the
         // attributes we are interested in cannot be present anyway, so
         // skip the walk.

--- a/compiler/rustc_incremental/src/persist/dirty_clean.rs
+++ b/compiler/rustc_incremental/src/persist/dirty_clean.rs
@@ -148,6 +148,10 @@ impl Assertion {
 }
 
 pub fn check_dirty_clean_annotations(tcx: TyCtxt<'_>) {
+    if !tcx.sess.opts.debugging_opts.query_dep_graph {
+        return;
+    }
+
     // can't add `#[rustc_dirty]` etc without opting in to this feature
     if !tcx.features().rustc_attrs {
         return;

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -99,6 +99,12 @@ impl CheckAttrVisitor<'tcx> {
                 self.check_naked(hir_id, attr, span, target)
             } else if self.tcx.sess.check_name(attr, sym::rustc_legacy_const_generics) {
                 self.check_rustc_legacy_const_generics(&attr, span, target, item)
+            } else if self.tcx.sess.check_name(attr, sym::rustc_clean)
+                || self.tcx.sess.check_name(attr, sym::rustc_dirty)
+                || self.tcx.sess.check_name(attr, sym::rustc_if_this_changed)
+                || self.tcx.sess.check_name(attr, sym::rustc_then_this_would_need)
+            {
+                self.check_rustc_dirty_clean(&attr)
             } else {
                 // lint-only checks
                 if self.tcx.sess.check_name(attr, sym::cold) {
@@ -1009,6 +1015,19 @@ impl CheckAttrVisitor<'tcx> {
             false
         } else {
             true
+        }
+    }
+
+    /// Checks if `#[rustc_legacy_const_generics]` is applied to a function and has a valid argument.
+    fn check_rustc_dirty_clean(&self, attr: &Attribute) -> bool {
+        if self.tcx.sess.opts.debugging_opts.query_dep_graph {
+            true
+        } else {
+            self.tcx
+                .sess
+                .struct_span_err(attr.span, "attribute requires -Z query-dep-graph to be enabled")
+                .emit();
+            false
         }
     }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1018,7 +1018,8 @@ impl CheckAttrVisitor<'tcx> {
         }
     }
 
-    /// Checks if `#[rustc_legacy_const_generics]` is applied to a function and has a valid argument.
+    /// Checks that the dep-graph debugging attributes are only present when the query-dep-graph
+    /// option is passed to the compiler.
     fn check_rustc_dirty_clean(&self, attr: &Attribute) -> bool {
         if self.tcx.sess.opts.debugging_opts.query_dep_graph {
             true

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2293,7 +2293,7 @@ impl PpMode {
 
     pub fn needs_analysis(&self) -> bool {
         use PpMode::*;
-        matches!(*self, Mir | MirCFG)
+        matches!(*self, Mir | MirCFG | ThirTree)
     }
 }
 

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -675,7 +675,7 @@ impl Locatable for hir::HirId {
 
 /// The Resolver. This is the type folding engine that detects
 /// unresolved types and so forth.
-crate struct Resolver<'cx, 'tcx> {
+struct Resolver<'cx, 'tcx> {
     tcx: TyCtxt<'tcx>,
     infcx: &'cx InferCtxt<'cx, 'tcx>,
     span: &'cx dyn Locatable,
@@ -686,7 +686,7 @@ crate struct Resolver<'cx, 'tcx> {
 }
 
 impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
-    crate fn new(
+    fn new(
         fcx: &'cx FnCtxt<'cx, 'tcx>,
         span: &'cx dyn Locatable,
         body: &'tcx hir::Body<'tcx>,

--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -1036,7 +1036,7 @@ impl fmt::Display for NulError {
 impl From<NulError> for io::Error {
     /// Converts a [`NulError`] into a [`io::Error`].
     fn from(_: NulError) -> io::Error {
-        io::Error::new(io::ErrorKind::InvalidInput, "data provided contains a nul byte")
+        io::Error::new_const(io::ErrorKind::InvalidInput, &"data provided contains a nul byte")
     }
 }
 

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2188,7 +2188,10 @@ impl DirBuilder {
         match path.parent() {
             Some(p) => self.create_dir_all(p)?,
             None => {
-                return Err(io::Error::new(io::ErrorKind::Other, "failed to create whole tree"));
+                return Err(io::Error::new_const(
+                    io::ErrorKind::Other,
+                    &"failed to create whole tree",
+                ));
             }
         }
         match self.inner.mkdir(path) {

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -164,9 +164,9 @@ impl<W: Write> BufWriter<W> {
 
             match r {
                 Ok(0) => {
-                    return Err(Error::new(
+                    return Err(Error::new_const(
                         ErrorKind::WriteZero,
-                        "failed to write the buffered data",
+                        &"failed to write the buffered data",
                     ));
                 }
                 Ok(n) => guard.consume(n),

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -229,9 +229,9 @@ where
                 self.pos = n;
                 Ok(self.pos)
             }
-            None => Err(Error::new(
+            None => Err(Error::new_const(
                 ErrorKind::InvalidInput,
-                "invalid seek to a negative or overflowing position",
+                &"invalid seek to a negative or overflowing position",
             )),
         }
     }
@@ -328,9 +328,9 @@ fn slice_write_vectored(
 // Resizing write implementation
 fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usize> {
     let pos: usize = (*pos_mut).try_into().map_err(|_| {
-        Error::new(
+        Error::new_const(
             ErrorKind::InvalidInput,
-            "cursor position exceeds maximum possible vector length",
+            &"cursor position exceeds maximum possible vector length",
         )
     })?;
     // Make sure the internal buffer is as least as big as where we

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -69,6 +69,8 @@ impl fmt::Debug for Error {
 enum Repr {
     Os(i32),
     Simple(ErrorKind),
+    // &str is a fat pointer, but &&str is a thin pointer.
+    SimpleMessage(ErrorKind, &'static &'static str),
     Custom(Box<Custom>),
 }
 
@@ -259,6 +261,18 @@ impl Error {
         Error { repr: Repr::Custom(Box::new(Custom { kind, error })) }
     }
 
+    /// Creates a new I/O error from a known kind of error as well as a
+    /// constant message.
+    ///
+    /// This function not allocate.
+    ///
+    /// This function should maybe change to
+    /// `new_const<const MSG: &'static str>(kind: ErrorKind)`
+    /// in the future, when const generics allows that.
+    pub(crate) const fn new_const(kind: ErrorKind, message: &'static &'static str) -> Error {
+        Self { repr: Repr::SimpleMessage(kind, message) }
+    }
+
     /// Returns an error representing the last OS error which occurred.
     ///
     /// This function reads the value of `errno` for the target platform (e.g.
@@ -342,6 +356,7 @@ impl Error {
             Repr::Os(i) => Some(i),
             Repr::Custom(..) => None,
             Repr::Simple(..) => None,
+            Repr::SimpleMessage(..) => None,
         }
     }
 
@@ -377,6 +392,7 @@ impl Error {
         match self.repr {
             Repr::Os(..) => None,
             Repr::Simple(..) => None,
+            Repr::SimpleMessage(..) => None,
             Repr::Custom(ref c) => Some(&*c.error),
         }
     }
@@ -448,6 +464,7 @@ impl Error {
         match self.repr {
             Repr::Os(..) => None,
             Repr::Simple(..) => None,
+            Repr::SimpleMessage(..) => None,
             Repr::Custom(ref mut c) => Some(&mut *c.error),
         }
     }
@@ -484,6 +501,7 @@ impl Error {
         match self.repr {
             Repr::Os(..) => None,
             Repr::Simple(..) => None,
+            Repr::SimpleMessage(..) => None,
             Repr::Custom(c) => Some(c.error),
         }
     }
@@ -512,6 +530,7 @@ impl Error {
             Repr::Os(code) => sys::decode_error_kind(code),
             Repr::Custom(ref c) => c.kind,
             Repr::Simple(kind) => kind,
+            Repr::SimpleMessage(kind, _) => kind,
         }
     }
 }
@@ -527,6 +546,9 @@ impl fmt::Debug for Repr {
                 .finish(),
             Repr::Custom(ref c) => fmt::Debug::fmt(&c, fmt),
             Repr::Simple(kind) => fmt.debug_tuple("Kind").field(&kind).finish(),
+            Repr::SimpleMessage(kind, &message) => {
+                fmt.debug_struct("Error").field("kind", &kind).field("message", &message).finish()
+            }
         }
     }
 }
@@ -541,6 +563,7 @@ impl fmt::Display for Error {
             }
             Repr::Custom(ref c) => c.error.fmt(fmt),
             Repr::Simple(kind) => write!(fmt, "{}", kind.as_str()),
+            Repr::SimpleMessage(_, &msg) => msg.fmt(fmt),
         }
     }
 }
@@ -551,6 +574,7 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match self.repr {
             Repr::Os(..) | Repr::Simple(..) => self.kind().as_str(),
+            Repr::SimpleMessage(_, &msg) => msg,
             Repr::Custom(ref c) => c.error.description(),
         }
     }
@@ -560,6 +584,7 @@ impl error::Error for Error {
         match self.repr {
             Repr::Os(..) => None,
             Repr::Simple(..) => None,
+            Repr::SimpleMessage(..) => None,
             Repr::Custom(ref c) => c.error.cause(),
         }
     }
@@ -568,6 +593,7 @@ impl error::Error for Error {
         match self.repr {
             Repr::Os(..) => None,
             Repr::Simple(..) => None,
+            Repr::SimpleMessage(..) => None,
             Repr::Custom(ref c) => c.error.source(),
         }
     }

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -264,11 +264,11 @@ impl Error {
     /// Creates a new I/O error from a known kind of error as well as a
     /// constant message.
     ///
-    /// This function not allocate.
+    /// This function does not allocate.
     ///
     /// This function should maybe change to
     /// `new_const<const MSG: &'static str>(kind: ErrorKind)`
-    /// in the future, when const generics allows that.
+    /// in the future, when const generics allow that.
     pub(crate) const fn new_const(kind: ErrorKind, message: &'static &'static str) -> Error {
         Self { repr: Repr::SimpleMessage(kind, message) }
     }

--- a/library/std/src/io/error/tests.rs
+++ b/library/std/src/io/error/tests.rs
@@ -1,8 +1,14 @@
 use super::{Custom, Error, ErrorKind, Repr};
 use crate::error;
 use crate::fmt;
+use crate::mem::size_of;
 use crate::sys::decode_error_kind;
 use crate::sys::os::error_string;
+
+#[test]
+fn test_size() {
+    assert!(size_of::<Error>() <= size_of::<[usize; 2]>());
+}
 
 #[test]
 fn test_debug_error() {

--- a/library/std/src/io/error/tests.rs
+++ b/library/std/src/io/error/tests.rs
@@ -57,3 +57,13 @@ fn test_downcasting() {
     let extracted = err.into_inner().unwrap();
     extracted.downcast::<TestError>().unwrap();
 }
+
+#[test]
+fn test_const() {
+    const E: Error = Error::new_const(ErrorKind::NotFound, &"hello");
+
+    assert_eq!(E.kind(), ErrorKind::NotFound);
+    assert_eq!(E.to_string(), "hello");
+    assert!(format!("{:?}", E).contains("\"hello\""));
+    assert!(format!("{:?}", E).contains("NotFound"));
+}

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -263,7 +263,7 @@ impl Read for &[u8] {
     #[inline]
     fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
         if buf.len() > self.len() {
-            return Err(Error::new(ErrorKind::UnexpectedEof, "failed to fill whole buffer"));
+            return Err(Error::new_const(ErrorKind::UnexpectedEof, &"failed to fill whole buffer"));
         }
         let (a, b) = self.split_at(buf.len());
 
@@ -345,7 +345,7 @@ impl Write for &mut [u8] {
         if self.write(data)? == data.len() {
             Ok(())
         } else {
-            Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer"))
+            Err(Error::new_const(ErrorKind::WriteZero, &"failed to write whole buffer"))
         }
     }
 

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -333,7 +333,7 @@ where
         let ret = f(g.buf);
         if str::from_utf8(&g.buf[g.len..]).is_err() {
             ret.and_then(|_| {
-                Err(Error::new(ErrorKind::InvalidData, "stream did not contain valid UTF-8"))
+                Err(Error::new_const(ErrorKind::InvalidData, &"stream did not contain valid UTF-8"))
             })
         } else {
             g.len = g.buf.len();
@@ -429,7 +429,7 @@ pub(crate) fn default_read_exact<R: Read + ?Sized>(this: &mut R, mut buf: &mut [
         }
     }
     if !buf.is_empty() {
-        Err(Error::new(ErrorKind::UnexpectedEof, "failed to fill whole buffer"))
+        Err(Error::new_const(ErrorKind::UnexpectedEof, &"failed to fill whole buffer"))
     } else {
         Ok(())
     }
@@ -1432,7 +1432,10 @@ pub trait Write {
         while !buf.is_empty() {
             match self.write(buf) {
                 Ok(0) => {
-                    return Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer"));
+                    return Err(Error::new_const(
+                        ErrorKind::WriteZero,
+                        &"failed to write whole buffer",
+                    ));
                 }
                 Ok(n) => buf = &buf[n..],
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
@@ -1497,7 +1500,10 @@ pub trait Write {
         while !bufs.is_empty() {
             match self.write_vectored(bufs) {
                 Ok(0) => {
-                    return Err(Error::new(ErrorKind::WriteZero, "failed to write whole buffer"));
+                    return Err(Error::new_const(
+                        ErrorKind::WriteZero,
+                        &"failed to write whole buffer",
+                    ));
                 }
                 Ok(n) => bufs = IoSlice::advance(bufs, n),
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
@@ -1571,7 +1577,7 @@ pub trait Write {
                 if output.error.is_err() {
                     output.error
                 } else {
-                    Err(Error::new(ErrorKind::Other, "formatter error"))
+                    Err(Error::new_const(ErrorKind::Other, &"formatter error"))
                 }
             }
         }

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -152,12 +152,12 @@ fn take_eof() {
 
     impl Read for R {
         fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
-            Err(io::Error::new(io::ErrorKind::Other, ""))
+            Err(io::Error::new_const(io::ErrorKind::Other, &""))
         }
     }
     impl BufRead for R {
         fn fill_buf(&mut self) -> io::Result<&[u8]> {
-            Err(io::Error::new(io::ErrorKind::Other, ""))
+            Err(io::Error::new_const(io::ErrorKind::Other, &""))
         }
         fn consume(&mut self, _amt: usize) {}
     }

--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -88,6 +88,6 @@ where
         }
     }
     Err(last_err.unwrap_or_else(|| {
-        Error::new(ErrorKind::InvalidInput, "could not resolve to any addresses")
+        Error::new_const(ErrorKind::InvalidInput, &"could not resolve to any addresses")
     }))
 }

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -173,7 +173,7 @@ impl UdpSocket {
     pub fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], addr: A) -> io::Result<usize> {
         match addr.to_socket_addrs()?.next() {
             Some(addr) => self.0.send_to(buf, &addr),
-            None => Err(Error::new(ErrorKind::InvalidInput, "no addresses to send data to")),
+            None => Err(Error::new_const(ErrorKind::InvalidInput, &"no addresses to send data to")),
         }
     }
 

--- a/library/std/src/sys/hermit/fd.rs
+++ b/library/std/src/sys/hermit/fd.rs
@@ -46,7 +46,7 @@ impl FileDesc {
         self.duplicate_path(&[])
     }
     pub fn duplicate_path(&self, _path: &[u8]) -> io::Result<FileDesc> {
-        Err(io::Error::new(ErrorKind::Other, "duplicate isn't supported"))
+        Err(io::Error::new_const(ErrorKind::Other, &"duplicate isn't supported"))
     }
 
     pub fn nonblocking(&self) -> io::Result<bool> {
@@ -54,11 +54,11 @@ impl FileDesc {
     }
 
     pub fn set_cloexec(&self) -> io::Result<()> {
-        Err(io::Error::new(ErrorKind::Other, "cloexec isn't supported"))
+        Err(io::Error::new_const(ErrorKind::Other, &"cloexec isn't supported"))
     }
 
     pub fn set_nonblocking(&self, _nonblocking: bool) -> io::Result<()> {
-        Err(io::Error::new(ErrorKind::Other, "nonblocking isn't supported"))
+        Err(io::Error::new_const(ErrorKind::Other, &"nonblocking isn't supported"))
     }
 }
 

--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -226,7 +226,7 @@ impl OpenOptions {
             (false, _, true) => Ok(O_WRONLY | O_APPEND),
             (true, _, true) => Ok(O_RDWR | O_APPEND),
             (false, false, false) => {
-                Err(io::Error::new(ErrorKind::InvalidInput, "invalid access mode"))
+                Err(io::Error::new_const(ErrorKind::InvalidInput, &"invalid access mode"))
             }
         }
     }
@@ -236,12 +236,18 @@ impl OpenOptions {
             (true, false) => {}
             (false, false) => {
                 if self.truncate || self.create || self.create_new {
-                    return Err(io::Error::new(ErrorKind::InvalidInput, "invalid creation mode"));
+                    return Err(io::Error::new_const(
+                        ErrorKind::InvalidInput,
+                        &"invalid creation mode",
+                    ));
                 }
             }
             (_, true) => {
                 if self.truncate && !self.create_new {
-                    return Err(io::Error::new(ErrorKind::InvalidInput, "invalid creation mode"));
+                    return Err(io::Error::new_const(
+                        ErrorKind::InvalidInput,
+                        &"invalid creation mode",
+                    ));
                 }
             }
         }

--- a/library/std/src/sys/hermit/mod.rs
+++ b/library/std/src/sys/hermit/mod.rs
@@ -54,7 +54,10 @@ pub fn unsupported<T>() -> crate::io::Result<T> {
 }
 
 pub fn unsupported_err() -> crate::io::Error {
-    crate::io::Error::new(crate::io::ErrorKind::Other, "operation not supported on HermitCore yet")
+    crate::io::Error::new_const(
+        crate::io::ErrorKind::Other,
+        &"operation not supported on HermitCore yet",
+    )
 }
 
 // This enum is used as the storage for a bunch of types which can't actually

--- a/library/std/src/sys/hermit/stdio.rs
+++ b/library/std/src/sys/hermit/stdio.rs
@@ -40,7 +40,7 @@ impl io::Write for Stdout {
         unsafe { len = abi::write(1, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
-            Err(io::Error::new(io::ErrorKind::Other, "Stdout is not able to print"))
+            Err(io::Error::new_const(io::ErrorKind::Other, &"Stdout is not able to print"))
         } else {
             Ok(len as usize)
         }
@@ -52,7 +52,7 @@ impl io::Write for Stdout {
         unsafe { len = abi::write(1, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
-            Err(io::Error::new(io::ErrorKind::Other, "Stdout is not able to print"))
+            Err(io::Error::new_const(io::ErrorKind::Other, &"Stdout is not able to print"))
         } else {
             Ok(len as usize)
         }
@@ -81,7 +81,7 @@ impl io::Write for Stderr {
         unsafe { len = abi::write(2, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
-            Err(io::Error::new(io::ErrorKind::Other, "Stderr is not able to print"))
+            Err(io::Error::new_const(io::ErrorKind::Other, &"Stderr is not able to print"))
         } else {
             Ok(len as usize)
         }
@@ -93,7 +93,7 @@ impl io::Write for Stderr {
         unsafe { len = abi::write(2, data.as_ptr() as *const u8, data.len()) }
 
         if len < 0 {
-            Err(io::Error::new(io::ErrorKind::Other, "Stderr is not able to print"))
+            Err(io::Error::new_const(io::ErrorKind::Other, &"Stderr is not able to print"))
         } else {
             Ok(len as usize)
         }

--- a/library/std/src/sys/hermit/thread.rs
+++ b/library/std/src/sys/hermit/thread.rs
@@ -37,7 +37,7 @@ impl Thread {
             // The thread failed to start and as a result p was not consumed. Therefore, it is
             // safe to reconstruct the box so that it gets deallocated.
             drop(Box::from_raw(p));
-            Err(io::Error::new(io::ErrorKind::Other, "Unable to create thread!"))
+            Err(io::Error::new_const(io::ErrorKind::Other, &"Unable to create thread!"))
         } else {
             Ok(Thread { tid: tid })
         };

--- a/library/std/src/sys/sgx/mod.rs
+++ b/library/std/src/sys/sgx/mod.rs
@@ -50,7 +50,7 @@ pub fn unsupported<T>() -> crate::io::Result<T> {
 }
 
 pub fn unsupported_err() -> crate::io::Error {
-    crate::io::Error::new(ErrorKind::Other, "operation not supported on SGX yet")
+    crate::io::Error::new_const(ErrorKind::Other, &"operation not supported on SGX yet")
 }
 
 /// This function is used to implement various functions that doesn't exist,
@@ -61,9 +61,9 @@ pub fn unsupported_err() -> crate::io::Error {
 pub fn sgx_ineffective<T>(v: T) -> crate::io::Result<T> {
     static SGX_INEFFECTIVE_ERROR: AtomicBool = AtomicBool::new(false);
     if SGX_INEFFECTIVE_ERROR.load(Ordering::Relaxed) {
-        Err(crate::io::Error::new(
+        Err(crate::io::Error::new_const(
             ErrorKind::Other,
-            "operation can't be trusted to have any effect on SGX",
+            &"operation can't be trusted to have any effect on SGX",
         ))
     } else {
         Ok(v)

--- a/library/std/src/sys/sgx/net.rs
+++ b/library/std/src/sys/sgx/net.rs
@@ -97,9 +97,9 @@ impl TcpStream {
 
     pub fn connect_timeout(addr: &SocketAddr, dur: Duration) -> io::Result<TcpStream> {
         if dur == Duration::default() {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidInput,
-                "cannot set a 0 duration timeout",
+                &"cannot set a 0 duration timeout",
             ));
         }
         Self::connect(Ok(addr)) // FIXME: ignoring timeout
@@ -108,9 +108,9 @@ impl TcpStream {
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         match dur {
             Some(dur) if dur == Duration::default() => {
-                return Err(io::Error::new(
+                return Err(io::Error::new_const(
                     io::ErrorKind::InvalidInput,
-                    "cannot set a 0 duration timeout",
+                    &"cannot set a 0 duration timeout",
                 ));
             }
             _ => sgx_ineffective(()),
@@ -120,9 +120,9 @@ impl TcpStream {
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         match dur {
             Some(dur) if dur == Duration::default() => {
-                return Err(io::Error::new(
+                return Err(io::Error::new_const(
                     io::ErrorKind::InvalidInput,
-                    "cannot set a 0 duration timeout",
+                    &"cannot set a 0 duration timeout",
                 ));
             }
             _ => sgx_ineffective(()),

--- a/library/std/src/sys/unix/android.rs
+++ b/library/std/src/sys/unix/android.rs
@@ -96,7 +96,7 @@ pub fn ftruncate64(fd: c_int, size: u64) -> io::Result<()> {
             Some(f) => cvt_r(|| f(fd, size as i64)).map(drop),
             None => {
                 if size > i32::MAX as u64 {
-                    Err(io::Error::new(io::ErrorKind::InvalidInput, "cannot truncate >2GB"))
+                    Err(io::Error::new_const(io::ErrorKind::InvalidInput, &"cannot truncate >2GB"))
                 } else {
                     cvt_r(|| ftruncate(fd, size as i32)).map(drop)
                 }
@@ -123,7 +123,7 @@ pub unsafe fn cvt_pread64(
         if let Ok(o) = offset.try_into() {
             cvt(pread(fd, buf, count, o))
         } else {
-            Err(io::Error::new(io::ErrorKind::InvalidInput, "cannot pread >2GB"))
+            Err(io::Error::new_const(io::ErrorKind::InvalidInput, &"cannot pread >2GB"))
         }
     })
 }
@@ -141,7 +141,7 @@ pub unsafe fn cvt_pwrite64(
         if let Ok(o) = offset.try_into() {
             cvt(pwrite(fd, buf, count, o))
         } else {
-            Err(io::Error::new(io::ErrorKind::InvalidInput, "cannot pwrite >2GB"))
+            Err(io::Error::new_const(io::ErrorKind::InvalidInput, &"cannot pwrite >2GB"))
         }
     })
 }

--- a/library/std/src/sys/unix/ext/fs.rs
+++ b/library/std/src/sys/unix/ext/fs.rs
@@ -109,7 +109,7 @@ pub trait FileExt {
             }
         }
         if !buf.is_empty() {
-            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"))
+            Err(io::Error::new_const(io::ErrorKind::UnexpectedEof, &"failed to fill whole buffer"))
         } else {
             Ok(())
         }
@@ -191,9 +191,9 @@ pub trait FileExt {
         while !buf.is_empty() {
             match self.write_at(buf, offset) {
                 Ok(0) => {
-                    return Err(io::Error::new(
+                    return Err(io::Error::new_const(
                         io::ErrorKind::WriteZero,
-                        "failed to write whole buffer",
+                        &"failed to write whole buffer",
                     ));
                 }
                 Ok(n) => {

--- a/library/std/src/sys/unix/ext/net/addr.rs
+++ b/library/std/src/sys/unix/ext/net/addr.rs
@@ -29,16 +29,16 @@ pub(super) unsafe fn sockaddr_un(path: &Path) -> io::Result<(libc::sockaddr_un, 
     let bytes = path.as_os_str().as_bytes();
 
     if bytes.contains(&0) {
-        return Err(io::Error::new(
+        return Err(io::Error::new_const(
             io::ErrorKind::InvalidInput,
-            "paths may not contain interior null bytes",
+            &"paths may not contain interior null bytes",
         ));
     }
 
     if bytes.len() >= addr.sun_path.len() {
-        return Err(io::Error::new(
+        return Err(io::Error::new_const(
             io::ErrorKind::InvalidInput,
-            "path must be shorter than SUN_LEN",
+            &"path must be shorter than SUN_LEN",
         ));
     }
     for (dst, src) in addr.sun_path.iter_mut().zip(bytes.iter()) {
@@ -118,9 +118,9 @@ impl SocketAddr {
             // linux returns zero bytes of address
             len = sun_path_offset(&addr) as libc::socklen_t; // i.e., zero-length address
         } else if addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidInput,
-                "file descriptor did not correspond to a Unix socket",
+                &"file descriptor did not correspond to a Unix socket",
             ));
         }
 

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -357,17 +357,17 @@ impl FileAttr {
                         tv_nsec: ext.stx_btime.tv_nsec as _,
                     }))
                 } else {
-                    Err(io::Error::new(
+                    Err(io::Error::new_const(
                         io::ErrorKind::Other,
-                        "creation time is not available for the filesystem",
+                        &"creation time is not available for the filesystem",
                     ))
                 };
             }
         }
 
-        Err(io::Error::new(
+        Err(io::Error::new_const(
             io::ErrorKind::Other,
-            "creation time is not available on this platform \
+            &"creation time is not available on this platform \
                             currently",
         ))
     }
@@ -1156,9 +1156,9 @@ fn open_from(from: &Path) -> io::Result<(crate::fs::File, crate::fs::Metadata)> 
     let reader = File::open(from)?;
     let metadata = reader.metadata()?;
     if !metadata.is_file() {
-        return Err(Error::new(
+        return Err(Error::new_const(
             ErrorKind::InvalidInput,
-            "the source path is not an existing regular file",
+            &"the source path is not an existing regular file",
         ));
     }
     Ok((reader, metadata))

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -1,6 +1,6 @@
 macro_rules! unimpl {
     () => {
-        return Err(io::Error::new(io::ErrorKind::Other, "No networking available on L4Re."));
+        return Err(io::Error::new_const(io::ErrorKind::Other, &"No networking available on L4Re."));
     };
 }
 

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -139,9 +139,9 @@ impl Socket {
         let mut pollfd = libc::pollfd { fd: self.0.raw(), events: libc::POLLOUT, revents: 0 };
 
         if timeout.as_secs() == 0 && timeout.subsec_nanos() == 0 {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidInput,
-                "cannot set a 0 duration timeout",
+                &"cannot set a 0 duration timeout",
             ));
         }
 
@@ -150,7 +150,7 @@ impl Socket {
         loop {
             let elapsed = start.elapsed();
             if elapsed >= timeout {
-                return Err(io::Error::new(io::ErrorKind::TimedOut, "connection timed out"));
+                return Err(io::Error::new_const(io::ErrorKind::TimedOut, &"connection timed out"));
             }
 
             let timeout = timeout - elapsed;
@@ -177,7 +177,10 @@ impl Socket {
                     // for POLLHUP rather than read readiness
                     if pollfd.revents & libc::POLLHUP != 0 {
                         let e = self.take_error()?.unwrap_or_else(|| {
-                            io::Error::new(io::ErrorKind::Other, "no error set after POLLHUP")
+                            io::Error::new_const(
+                                io::ErrorKind::Other,
+                                &"no error set after POLLHUP",
+                            )
                         });
                         return Err(e);
                     }
@@ -318,9 +321,9 @@ impl Socket {
         let timeout = match dur {
             Some(dur) => {
                 if dur.as_secs() == 0 && dur.subsec_nanos() == 0 {
-                    return Err(io::Error::new(
+                    return Err(io::Error::new_const(
                         io::ErrorKind::InvalidInput,
-                        "cannot set a 0 duration timeout",
+                        &"cannot set a 0 duration timeout",
                     ));
                 }
 

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -286,9 +286,9 @@ pub fn current_exe() -> io::Result<PathBuf> {
                 0,
             ))?;
             if path_len <= 1 {
-                return Err(io::Error::new(
+                return Err(io::Error::new_const(
                     io::ErrorKind::Other,
-                    "KERN_PROC_PATHNAME sysctl returned zero-length string",
+                    &"KERN_PROC_PATHNAME sysctl returned zero-length string",
                 ));
             }
             let mut path: Vec<u8> = Vec::with_capacity(path_len);
@@ -309,9 +309,9 @@ pub fn current_exe() -> io::Result<PathBuf> {
         if curproc_exe.is_file() {
             return crate::fs::read_link(curproc_exe);
         }
-        Err(io::Error::new(
+        Err(io::Error::new_const(
             io::ErrorKind::Other,
-            "/proc/curproc/exe doesn't point to regular file.",
+            &"/proc/curproc/exe doesn't point to regular file.",
         ))
     }
     sysctl().or_else(|_| procfs())
@@ -328,7 +328,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
         cvt(libc::sysctl(mib, 4, argv.as_mut_ptr() as *mut _, &mut argv_len, ptr::null_mut(), 0))?;
         argv.set_len(argv_len as usize);
         if argv[0].is_null() {
-            return Err(io::Error::new(io::ErrorKind::Other, "no current exe available"));
+            return Err(io::Error::new_const(io::ErrorKind::Other, &"no current exe available"));
         }
         let argv0 = CStr::from_ptr(argv[0]).to_bytes();
         if argv0[0] == b'.' || argv0.iter().any(|b| *b == b'/') {
@@ -342,9 +342,9 @@ pub fn current_exe() -> io::Result<PathBuf> {
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "emscripten"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     match crate::fs::read_link("/proc/self/exe") {
-        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Err(io::Error::new(
+        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Err(io::Error::new_const(
             io::ErrorKind::Other,
-            "no /proc/self/exe available. Is /proc mounted?",
+            &"no /proc/self/exe available. Is /proc mounted?",
         )),
         other => other,
     }
@@ -430,7 +430,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
             _get_next_image_info(0, &mut cookie, &mut info, mem::size_of::<image_info>() as i32);
         if result != 0 {
             use crate::io::ErrorKind;
-            Err(io::Error::new(ErrorKind::Other, "Error getting executable path"))
+            Err(io::Error::new_const(ErrorKind::Other, &"Error getting executable path"))
         } else {
             let name = CStr::from_ptr(info.name.as_ptr()).to_bytes();
             Ok(PathBuf::from(OsStr::from_bytes(name)))
@@ -446,7 +446,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 #[cfg(any(target_os = "fuchsia", target_os = "l4re"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     use crate::io::ErrorKind;
-    Err(io::Error::new(ErrorKind::Other, "Not yet implemented!"))
+    Err(io::Error::new_const(ErrorKind::Other, &"Not yet implemented!"))
 }
 
 #[cfg(target_os = "vxworks")]

--- a/library/std/src/sys/unix/process/process_fuchsia.rs
+++ b/library/std/src/sys/unix/process/process_fuchsia.rs
@@ -22,9 +22,9 @@ impl Command {
         let envp = self.capture_env();
 
         if self.saw_nul() {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidInput,
-                "nul byte found in provided data",
+                &"nul byte found in provided data",
             ));
         }
 
@@ -37,7 +37,10 @@ impl Command {
 
     pub fn exec(&mut self, default: Stdio) -> io::Error {
         if self.saw_nul() {
-            return io::Error::new(io::ErrorKind::InvalidInput, "nul byte found in provided data");
+            return io::Error::new_const(
+                io::ErrorKind::InvalidInput,
+                &"nul byte found in provided data",
+            );
         }
 
         match self.setup_io(default, true) {
@@ -182,9 +185,9 @@ impl Process {
             ))?;
         }
         if actual != 1 {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidData,
-                "Failed to get exit status of process",
+                &"Failed to get exit status of process",
             ));
         }
         Ok(ExitStatus(proc_info.return_code))
@@ -220,9 +223,9 @@ impl Process {
             ))?;
         }
         if actual != 1 {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidData,
-                "Failed to get exit status of process",
+                &"Failed to get exit status of process",
             ));
         }
         Ok(Some(ExitStatus(proc_info.return_code)))

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -28,7 +28,10 @@ impl Command {
         let envp = self.capture_env();
 
         if self.saw_nul() {
-            return Err(io::Error::new(ErrorKind::InvalidInput, "nul byte found in provided data"));
+            return Err(io::Error::new_const(
+                ErrorKind::InvalidInput,
+                &"nul byte found in provided data",
+            ));
         }
 
         let (ours, theirs) = self.setup_io(default, needs_stdin)?;
@@ -118,7 +121,10 @@ impl Command {
         let envp = self.capture_env();
 
         if self.saw_nul() {
-            return io::Error::new(ErrorKind::InvalidInput, "nul byte found in provided data");
+            return io::Error::new_const(
+                ErrorKind::InvalidInput,
+                &"nul byte found in provided data",
+            );
         }
 
         match self.setup_io(default, true) {
@@ -442,9 +448,9 @@ impl Process {
         // and used for another process, and we probably shouldn't be killing
         // random processes, so just return an error.
         if self.status.is_some() {
-            Err(Error::new(
+            Err(Error::new_const(
                 ErrorKind::InvalidInput,
-                "invalid argument: can't kill an exited process",
+                &"invalid argument: can't kill an exited process",
             ))
         } else {
             cvt(unsafe { libc::kill(self.pid, libc::SIGKILL) }).map(drop)

--- a/library/std/src/sys/unsupported/common.rs
+++ b/library/std/src/sys/unsupported/common.rs
@@ -18,7 +18,7 @@ pub fn unsupported<T>() -> std_io::Result<T> {
 }
 
 pub fn unsupported_err() -> std_io::Error {
-    std_io::Error::new(std_io::ErrorKind::Other, "operation not supported on this platform")
+    std_io::Error::new_const(std_io::ErrorKind::Other, &"operation not supported on this platform")
 }
 
 pub fn decode_error_kind(_code: i32) -> crate::io::ErrorKind {

--- a/library/std/src/sys/unsupported/os.rs
+++ b/library/std/src/sys/unsupported/os.rs
@@ -80,11 +80,11 @@ pub fn getenv(_: &OsStr) -> io::Result<Option<OsString>> {
 }
 
 pub fn setenv(_: &OsStr, _: &OsStr) -> io::Result<()> {
-    Err(io::Error::new(io::ErrorKind::Other, "cannot set env vars on this platform"))
+    Err(io::Error::new_const(io::ErrorKind::Other, &"cannot set env vars on this platform"))
 }
 
 pub fn unsetenv(_: &OsStr) -> io::Result<()> {
-    Err(io::Error::new(io::ErrorKind::Other, "cannot unset env vars on this platform"))
+    Err(io::Error::new_const(io::ErrorKind::Other, &"cannot unset env vars on this platform"))
 }
 
 pub fn temp_dir() -> PathBuf {

--- a/library/std/src/sys/vxworks/process/process_vxworks.rs
+++ b/library/std/src/sys/vxworks/process/process_vxworks.rs
@@ -22,7 +22,10 @@ impl Command {
         let envp = self.capture_env();
 
         if self.saw_nul() {
-            return Err(io::Error::new(ErrorKind::InvalidInput, "nul byte found in provided data"));
+            return Err(io::Error::new_const(
+                ErrorKind::InvalidInput,
+                &"nul byte found in provided data",
+            ));
         }
         let (ours, theirs) = self.setup_io(default, needs_stdin)?;
         let mut p = Process { pid: 0, status: None };
@@ -134,9 +137,9 @@ impl Process {
         // and used for another process, and we probably shouldn't be killing
         // random processes, so just return an error.
         if self.status.is_some() {
-            Err(Error::new(
+            Err(Error::new_const(
                 ErrorKind::InvalidInput,
-                "invalid argument: can't kill an exited process",
+                &"invalid argument: can't kill an exited process",
             ))
         } else {
             cvt(unsafe { libc::kill(self.pid, libc::SIGKILL) }).map(drop)

--- a/library/std/src/sys/wasi/ext/fs.rs
+++ b/library/std/src/sys/wasi/ext/fs.rs
@@ -85,7 +85,7 @@ pub trait FileExt {
             }
         }
         if !buf.is_empty() {
-            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "failed to fill whole buffer"))
+            Err(io::Error::new_const(io::ErrorKind::UnexpectedEof, &"failed to fill whole buffer"))
         } else {
             Ok(())
         }
@@ -151,9 +151,9 @@ pub trait FileExt {
         while !buf.is_empty() {
             match self.write_at(buf, offset) {
                 Ok(0) => {
-                    return Err(io::Error::new(
+                    return Err(io::Error::new_const(
                         io::ErrorKind::WriteZero,
-                        "failed to write whole buffer",
+                        &"failed to write whole buffer",
                     ));
                 }
                 Ok(n) => {
@@ -532,5 +532,5 @@ pub fn symlink_path<P: AsRef<Path>, U: AsRef<Path>>(old_path: P, new_path: U) ->
 }
 
 fn osstr2str(f: &OsStr) -> io::Result<&str> {
-    f.to_str().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "input must be utf-8"))
+    f.to_str().ok_or_else(|| io::Error::new_const(io::ErrorKind::Other, &"input must be utf-8"))
 }

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -670,7 +670,7 @@ fn open_parent(p: &Path) -> io::Result<(ManuallyDrop<WasiFd>, PathBuf)> {
 }
 
 pub fn osstr2str(f: &OsStr) -> io::Result<&str> {
-    f.to_str().ok_or_else(|| io::Error::new(io::ErrorKind::Other, "input must be utf-8"))
+    f.to_str().ok_or_else(|| io::Error::new_const(io::ErrorKind::Other, &"input must be utf-8"))
 }
 
 pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -513,9 +513,9 @@ impl File {
                     )
                 }
                 _ => {
-                    return Err(io::Error::new(
+                    return Err(io::Error::new_const(
                         io::ErrorKind::Other,
-                        "Unsupported reparse point type",
+                        &"Unsupported reparse point type",
                     ));
                 }
             };
@@ -802,7 +802,7 @@ pub fn link(original: &Path, link: &Path) -> io::Result<()> {
 
 #[cfg(target_vendor = "uwp")]
 pub fn link(_original: &Path, _link: &Path) -> io::Result<()> {
-    return Err(io::Error::new(io::ErrorKind::Other, "hard link are not supported on UWP"));
+    return Err(io::Error::new_const(io::ErrorKind::Other, &"hard link are not supported on UWP"));
 }
 
 pub fn stat(path: &Path) -> io::Result<FileAttr> {

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -130,9 +130,9 @@ pub fn to_u16s<S: AsRef<OsStr>>(s: S) -> crate::io::Result<Vec<u16>> {
     fn inner(s: &OsStr) -> crate::io::Result<Vec<u16>> {
         let mut maybe_result: Vec<u16> = s.encode_wide().collect();
         if unrolled_find_u16s(0, &maybe_result).is_some() {
-            return Err(crate::io::Error::new(
+            return Err(crate::io::Error::new_const(
                 ErrorKind::InvalidInput,
-                "strings passed to WinAPI cannot contain NULs",
+                &"strings passed to WinAPI cannot contain NULs",
             ));
         }
         maybe_result.push(0);

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -136,9 +136,9 @@ impl Socket {
         }
 
         if timeout.as_secs() == 0 && timeout.subsec_nanos() == 0 {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidInput,
-                "cannot set a 0 duration timeout",
+                &"cannot set a 0 duration timeout",
             ));
         }
 
@@ -164,7 +164,7 @@ impl Socket {
             unsafe { cvt(c::select(1, ptr::null_mut(), &mut writefds, &mut errorfds, &timeout))? };
 
         match n {
-            0 => Err(io::Error::new(io::ErrorKind::TimedOut, "connection timed out")),
+            0 => Err(io::Error::new_const(io::ErrorKind::TimedOut, &"connection timed out")),
             _ => {
                 if writefds.fd_count != 1 {
                     if let Some(e) = self.take_error()? {
@@ -339,9 +339,9 @@ impl Socket {
             Some(dur) => {
                 let timeout = sys::dur2timeout(dur);
                 if timeout == 0 {
-                    return Err(io::Error::new(
+                    return Err(io::Error::new_const(
                         io::ErrorKind::InvalidInput,
-                        "cannot set a 0 duration timeout",
+                        &"cannot set a 0 duration timeout",
                     ));
                 }
                 timeout
@@ -370,7 +370,7 @@ impl Socket {
 
     #[cfg(target_vendor = "uwp")]
     fn set_no_inherit(&self) -> io::Result<()> {
-        Err(io::Error::new(io::ErrorKind::Other, "Unavailable on UWP"))
+        Err(io::Error::new_const(io::ErrorKind::Other, &"Unavailable on UWP"))
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -62,7 +62,7 @@ impl AsRef<OsStr> for EnvKey {
 
 fn ensure_no_nuls<T: AsRef<OsStr>>(str: T) -> io::Result<T> {
     if str.as_ref().encode_wide().any(|b| b == 0) {
-        Err(io::Error::new(ErrorKind::InvalidInput, "nul byte found in provided data"))
+        Err(io::Error::new_const(ErrorKind::InvalidInput, &"nul byte found in provided data"))
     } else {
         Ok(str)
     }

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -68,9 +68,9 @@ fn write(handle_id: c::DWORD, data: &[u8]) -> io::Result<usize> {
     let utf8 = match str::from_utf8(&data[..len]) {
         Ok(s) => s,
         Err(ref e) if e.valid_up_to() == 0 => {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidData,
-                "Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
+                &"Windows stdio in console mode does not support writing non-UTF-8 byte sequences",
             ));
         }
         Err(e) => str::from_utf8(&data[..e.valid_up_to()]).unwrap(),
@@ -149,9 +149,9 @@ impl io::Read for Stdin {
         if buf.len() == 0 {
             return Ok(0);
         } else if buf.len() < 4 {
-            return Err(io::Error::new(
+            return Err(io::Error::new_const(
                 io::ErrorKind::InvalidInput,
-                "Windows stdin in console mode does not support a buffer too small to \
+                &"Windows stdin in console mode does not support a buffer too small to \
                  guarantee holding one arbitrary UTF-8 character (4 bytes)",
             ));
         }
@@ -243,9 +243,9 @@ fn utf16_to_utf8(utf16: &[u16], utf8: &mut [u8]) -> io::Result<usize> {
             }
             Err(_) => {
                 // We can't really do any better than forget all data and return an error.
-                return Err(io::Error::new(
+                return Err(io::Error::new_const(
                     io::ErrorKind::InvalidData,
-                    "Windows stdin in console mode does not support non-UTF-16 input; \
+                    &"Windows stdin in console mode does not support non-UTF-16 input; \
                      encountered unpaired surrogate",
                 ));
             }

--- a/library/std/src/sys_common/fs.rs
+++ b/library/std/src/sys_common/fs.rs
@@ -9,9 +9,9 @@ pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
     let metadata = reader.metadata()?;
 
     if !metadata.is_file() {
-        return Err(Error::new(
+        return Err(Error::new_const(
             ErrorKind::InvalidInput,
-            "the source path is not an existing regular file",
+            &"the source path is not an existing regular file",
         ));
     }
 

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -108,7 +108,7 @@ pub fn sockaddr_to_addr(storage: &c::sockaddr_storage, len: usize) -> io::Result
                 *(storage as *const _ as *const c::sockaddr_in6)
             })))
         }
-        _ => Err(Error::new(ErrorKind::InvalidInput, "invalid argument")),
+        _ => Err(Error::new_const(ErrorKind::InvalidInput, &"invalid argument")),
     }
 }
 
@@ -171,7 +171,7 @@ impl TryFrom<&str> for LookupHost {
             ($e:expr, $msg:expr) => {
                 match $e {
                     Some(r) => r,
-                    None => return Err(io::Error::new(io::ErrorKind::InvalidInput, $msg)),
+                    None => return Err(io::Error::new_const(io::ErrorKind::InvalidInput, &$msg)),
                 }
             };
         }

--- a/library/std/src/thread/available_concurrency.rs
+++ b/library/std/src/thread/available_concurrency.rs
@@ -64,7 +64,7 @@ cfg_if::cfg_if! {
                 sysinfo.dwNumberOfProcessors as usize
             };
             match res {
-                0 => Err(io::Error::new(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform")),
+                0 => Err(io::Error::new_const(io::ErrorKind::NotFound, &"The number of hardware threads is not known for the target platform")),
                 cpus => Ok(unsafe { NonZeroUsize::new_unchecked(cpus) }),
             }
         }
@@ -81,7 +81,7 @@ cfg_if::cfg_if! {
         fn available_concurrency_internal() -> io::Result<NonZeroUsize> {
             match unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) } {
                 -1 => Err(io::Error::last_os_error()),
-                0 => Err(io::Error::new(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform")),
+                0 => Err(io::Error::new_const(io::ErrorKind::NotFound, &"The number of hardware threads is not known for the target platform")),
                 cpus => Ok(unsafe { NonZeroUsize::new_unchecked(cpus as usize) }),
             }
         }
@@ -114,7 +114,7 @@ cfg_if::cfg_if! {
                 if res == -1 {
                     return Err(io::Error::last_os_error());
                 } else if cpus == 0 {
-                    return Err(io::Error::new(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform"));
+                    return Err(io::Error::new_const(io::ErrorKind::NotFound, &"The number of hardware threads is not known for the target platform"));
                 }
             }
             Ok(unsafe { NonZeroUsize::new_unchecked(cpus as usize) })
@@ -142,7 +142,7 @@ cfg_if::cfg_if! {
             if res == -1 {
                 return Err(io::Error::last_os_error());
             } else if cpus == 0 {
-                return Err(io::Error::new(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform"));
+                return Err(io::Error::new_const(io::ErrorKind::NotFound, &"The number of hardware threads is not known for the target platform"));
             }
 
             Ok(unsafe { NonZeroUsize::new_unchecked(cpus as usize) })
@@ -150,7 +150,7 @@ cfg_if::cfg_if! {
     } else {
         // FIXME: implement on vxWorks, Redox, HermitCore, Haiku, l4re
         fn available_concurrency_internal() -> io::Result<NonZeroUsize> {
-            Err(io::Error::new(io::ErrorKind::NotFound, "The number of hardware threads is not known for the target platform"))
+            Err(io::Error::new_const(io::ErrorKind::NotFound, &"The number of hardware threads is not known for the target platform"))
         }
     }
 }

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -110,7 +110,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         };
 
         Some(Item {
-            source: Span::dummy(),
+            span: Span::dummy(),
             name: None,
             attrs: Default::default(),
             visibility: Inherited,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -102,7 +102,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                     .collect();
 
                 impls.push(Item {
-                    source: self.cx.tcx.def_span(impl_def_id).clean(self.cx),
+                    span: self.cx.tcx.def_span(impl_def_id).clean(self.cx),
                     name: None,
                     attrs: Default::default(),
                     visibility: Inherited,

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -459,7 +459,7 @@ fn build_module(
                 items.push(clean::Item {
                     name: None,
                     attrs: box clean::Attributes::default(),
-                    source: clean::Span::dummy(),
+                    span: clean::Span::dummy(),
                     def_id: DefId::local(CRATE_DEF_INDEX),
                     visibility: clean::Public,
                     kind: box clean::ImportItem(clean::Import::new_simple(

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -235,7 +235,7 @@ impl Clean<Item> for doctree::Module<'_> {
             ModuleItem(Module { is_crate: self.is_crate, items }),
             cx,
         );
-        Item { source: span.clean(cx), ..what_rustc_thinks }
+        Item { span: span.clean(cx), ..what_rustc_thinks }
     }
 }
 
@@ -2132,7 +2132,7 @@ fn clean_extern_crate(
     vec![Item {
         name: Some(name),
         attrs: box attrs.clean(cx),
-        source: krate.span.clean(cx),
+        span: krate.span.clean(cx),
         def_id: crate_def_id,
         visibility: krate.vis.clean(cx),
         kind: box ExternCrateItem { src: orig_name },

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -81,19 +81,15 @@ crate struct ExternalCrate {
 /// directly to the AST's concept of an item; it's a strict superset.
 #[derive(Clone)]
 crate struct Item {
-    /// The [`Span`] of this item in the source code.
     crate span: Span,
     /// The name of this item.
     /// Optional because not every item has a name, e.g. impls.
     crate name: Option<Symbol>,
-    /// Attributes on this item, e.g. `#[derive(...)]` or `#[inline]`.
     crate attrs: Box<Attributes>,
-    /// The visibility of this item (private, `pub`, `pub(crate)`, etc.).
     crate visibility: Visibility,
     /// Information about this item that is specific to what kind of item it is.
     /// E.g., struct vs enum vs function.
     crate kind: Box<ItemKind>,
-    /// The [`DefId`] of this item.
     crate def_id: DefId,
 }
 
@@ -565,6 +561,8 @@ impl<'a> FromIterator<&'a DocFragment> for String {
     }
 }
 
+/// The attributes on an [`Item`], including attributes like `#[derive(...)]` and `#[inline]`,
+/// as well as doc comments.
 #[derive(Clone, Debug, Default)]
 crate struct Attributes {
     crate doc_strings: Vec<DocFragment>,
@@ -1804,8 +1802,11 @@ impl From<hir::PrimTy> for PrimitiveType {
 
 #[derive(Copy, Clone, Debug)]
 crate enum Visibility {
+    /// `pub`
     Public,
+    /// visibility inherited from parent (e.g. for enum variant fields)
     Inherited,
+    /// `pub(crate)`, `pub(super)`, or `pub(in path::to::somewhere)`
     Restricted(DefId),
 }
 
@@ -1854,7 +1855,8 @@ crate enum Variant {
     Struct(VariantStruct),
 }
 
-/// Small wrapper around `rustc_span::Span` that adds helper methods and enforces calling `source_callsite`.
+/// Small wrapper around [`rustc_span::Span]` that adds helper methods
+/// and enforces calling [`rustc_span::Span::source_callsite()`].
 #[derive(Clone, Debug)]
 crate struct Span(rustc_span::Span);
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1866,12 +1866,12 @@ impl Span {
         Self(sp.source_callsite())
     }
 
-    crate fn dummy() -> Self {
-        Self(rustc_span::DUMMY_SP)
+    crate fn inner(&self) -> rustc_span::Span {
+        self.0
     }
 
-    crate fn span(&self) -> rustc_span::Span {
-        self.0
+    crate fn dummy() -> Self {
+        Self(rustc_span::DUMMY_SP)
     }
 
     crate fn is_dummy(&self) -> bool {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1804,7 +1804,9 @@ impl From<hir::PrimTy> for PrimitiveType {
 crate enum Visibility {
     /// `pub`
     Public,
-    /// visibility inherited from parent (e.g. for enum variant fields)
+    /// Visibility inherited from parent.
+    ///
+    /// For example, this is the visibility of private items and of enum variants.
     Inherited,
     /// `pub(crate)`, `pub(super)`, or `pub(in path::to::somewhere)`
     Restricted(DefId),

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -228,15 +228,15 @@ impl<'tcx> Context<'tcx> {
     /// may happen, for example, with externally inlined items where the source
     /// of their crate documentation isn't known.
     pub(super) fn src_href(&self, item: &clean::Item) -> Option<String> {
-        if item.source.is_dummy() {
+        if item.span.is_dummy() {
             return None;
         }
         let mut root = self.root_path();
         let mut path = String::new();
-        let cnum = item.source.cnum(self.sess());
+        let cnum = item.span.cnum(self.sess());
 
         // We can safely ignore synthetic `SourceFile`s.
-        let file = match item.source.filename(self.sess()) {
+        let file = match item.span.filename(self.sess()) {
             FileName::Real(ref path) => path.local_path().to_path_buf(),
             _ => return None,
         };
@@ -270,8 +270,8 @@ impl<'tcx> Context<'tcx> {
             (&*symbol, &path)
         };
 
-        let loline = item.source.lo(self.sess()).line;
-        let hiline = item.source.hi(self.sess()).line;
+        let loline = item.span.lo(self.sess()).line;
+        let hiline = item.span.hi(self.sess()).line;
         let lines =
             if loline == hiline { loline.to_string() } else { format!("{}-{}", loline, hiline) };
         Some(format!(

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -937,7 +937,7 @@ fn item_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Mac
             Some("macro"),
             None,
             None,
-            it.source.span().edition(),
+            it.span.span().edition(),
         );
     });
     document(w, cx, it, None)

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -937,7 +937,7 @@ fn item_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Mac
             Some("macro"),
             None,
             None,
-            it.span.span().edition(),
+            it.span.inner().edition(),
         );
     });
     document(w, cx, it, None)

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -41,11 +41,11 @@ impl DocFolder for SourceCollector<'_, '_> {
         // then we need to render it out to the filesystem.
         if self.scx.include_sources
             // skip all synthetic "files"
-            && item.source.filename(self.sess()).is_real()
+            && item.span.filename(self.sess()).is_real()
             // skip non-local files
-            && item.source.cnum(self.sess()) == LOCAL_CRATE
+            && item.span.cnum(self.sess()) == LOCAL_CRATE
         {
-            let filename = item.source.filename(self.sess());
+            let filename = item.span.filename(self.sess());
             // If it turns out that we couldn't read this file, then we probably
             // can't read any of the files (generating html output from json or
             // something like that), so just don't include sources for the

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -858,6 +858,15 @@ body.blur > :not(#help) {
 	font-size: 1.5em;
 }
 
+/* Black one-pixel outline around emoji shapes */
+.emoji {
+	text-shadow:
+		1px 0 0 black,
+		-1px 0 0 black,
+		0  1px 0 black,
+		0 -1px 0 black;
+}
+
 .module-item .stab {
 	border-radius: 3px;
 	display: inline-block;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1346,7 +1346,7 @@ h4 > .notable-traits {
 	to prevent an overlay between the "collapse toggle" and the information tooltip.
 	However, it's not needed with smaller screen width because the doc/code block is always put
 	"one line" below. */
-	.information:first-child > .tooltip {
+	.docblock > .information:first-child > .tooltip {
 		margin-top: 16px;
 	}
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -220,8 +220,8 @@ a.test-arrow {
 }
 
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
-.stab.deprecated { background: #F3DFFF; border-color: #7F0087; color: #2f2f2f; }
-.stab.portability { background: #C4ECFF; border-color: #7BA5DB; color: #2f2f2f; }
+.stab.deprecated { background: #ffc4c4; border-color: #db7b7b; color: #2f2f2f; }
+.stab.portability { background: #F3DFFF; border-color: #b07bdb; color: #2f2f2f; }
 .stab.portability > code { background: none; }
 
 #help > div {

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -218,8 +218,8 @@ a.test-arrow {
 }
 
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; }
-.stab.deprecated { background: #F3DFFF; border-color: #7F0087; }
-.stab.portability { background: #C4ECFF; border-color: #7BA5DB; }
+.stab.deprecated { background: #ffc4c4; border-color: #db7b7b; }
+.stab.portability { background: #F3DFFF; border-color: #b07bdb; }
 .stab.portability > code { background: none; }
 
 #help > div {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -33,7 +33,7 @@ impl JsonRenderer<'_> {
             id: from_def_id(def_id),
             crate_id: def_id.krate.as_u32(),
             name: name.map(|sym| sym.to_string()),
-            source: self.convert_span(span),
+            span: self.convert_span(span),
             visibility: self.convert_visibility(visibility),
             docs: attrs.collapsed_doc_value(),
             links: attrs

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -24,7 +24,7 @@ use std::collections::HashSet;
 impl JsonRenderer<'_> {
     pub(super) fn convert_item(&self, item: clean::Item) -> Option<Item> {
         let deprecation = item.deprecation(self.tcx);
-        let clean::Item { source, name, attrs, kind, visibility, def_id } = item;
+        let clean::Item { span, name, attrs, kind, visibility, def_id } = item;
         let inner = match *kind {
             clean::StrippedItem(_) => return None,
             x => from_clean_item_kind(x, self.tcx, &name),
@@ -33,7 +33,7 @@ impl JsonRenderer<'_> {
             id: from_def_id(def_id),
             crate_id: def_id.krate.as_u32(),
             name: name.map(|sym| sym.to_string()),
-            source: self.convert_span(source),
+            source: self.convert_span(span),
             visibility: self.convert_visibility(visibility),
             docs: attrs.collapsed_doc_value(),
             links: attrs

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -503,13 +503,13 @@ impl From<clean::Import> for Import {
         use clean::ImportKind::*;
         match import.kind {
             Simple(s) => Import {
-                span: import.source.path.whole_name(),
+                source: import.source.path.whole_name(),
                 name: s.to_string(),
                 id: import.source.did.map(from_def_id),
                 glob: false,
             },
             Glob => Import {
-                span: import.source.path.whole_name(),
+                source: import.source.path.whole_name(),
                 name: import.source.path.last_name().to_string(),
                 id: import.source.did.map(from_def_id),
                 glob: true,

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -109,7 +109,7 @@ impl JsonRenderer<'tcx> {
                                 .map(Clone::clone),
                             visibility: types::Visibility::Public,
                             inner: types::ItemEnum::Trait(trait_item.clone().into()),
-                            source: None,
+                            span: None,
                             docs: Default::default(),
                             links: Default::default(),
                             attrs: Default::default(),

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -246,7 +246,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                     )
                 })
                 .collect(),
-            format_version: 4,
+            format_version: 5,
         };
         let mut p = self.out_path.clone();
         p.push(output.index.get(&output.root).unwrap().name.clone().unwrap());

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -212,7 +212,7 @@ impl<'a, 'b> fold::DocFolder for CoverageCalculator<'a, 'b> {
                 return Some(i);
             }
             clean::ImplItem(ref impl_) => {
-                let filename = i.source.filename(self.ctx.sess());
+                let filename = i.span.filename(self.ctx.sess());
                 if let Some(ref tr) = impl_.trait_ {
                     debug!(
                         "impl {:#} for {:#} in {}",
@@ -243,7 +243,7 @@ impl<'a, 'b> fold::DocFolder for CoverageCalculator<'a, 'b> {
                     None,
                 );
 
-                let filename = i.source.filename(self.ctx.sess());
+                let filename = i.span.filename(self.ctx.sess());
                 let has_doc_example = tests.found_tests != 0;
                 let hir_id = self.ctx.tcx.hir().local_def_id_to_hir_id(i.def_id.expect_local());
                 let (level, source) = self.ctx.tcx.lint_level_at_node(MISSING_DOCS, hir_id);

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
                 // We couldn't calculate the span of the markdown block that had the error, so our
                 // diagnostics are going to be a bit lacking.
                 let mut diag = self.cx.sess().struct_span_warn(
-                    super::span_of_attrs(&item.attrs).unwrap_or(item.span.span()),
+                    super::span_of_attrs(&item.attrs).unwrap_or(item.span.inner()),
                     "doc comment contains an invalid Rust code block",
                 );
 
@@ -110,7 +110,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
 impl<'a, 'tcx> DocFolder for SyntaxChecker<'a, 'tcx> {
     fn fold_item(&mut self, item: clean::Item) -> Option<clean::Item> {
         if let Some(dox) = &item.attrs.collapsed_doc_value() {
-            let sp = span_of_attrs(&item.attrs).unwrap_or(item.span.span());
+            let sp = span_of_attrs(&item.attrs).unwrap_or(item.span.inner());
             let extra = crate::html::markdown::ExtraInfo::new_did(self.cx.tcx, item.def_id, sp);
             for code_block in markdown::rust_code_blocks(&dox, &extra) {
                 self.check_rust_syntax(&item, &dox, code_block);

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
                 // We couldn't calculate the span of the markdown block that had the error, so our
                 // diagnostics are going to be a bit lacking.
                 let mut diag = self.cx.sess().struct_span_warn(
-                    super::span_of_attrs(&item.attrs).unwrap_or(item.source.span()),
+                    super::span_of_attrs(&item.attrs).unwrap_or(item.span.span()),
                     "doc comment contains an invalid Rust code block",
                 );
 
@@ -110,7 +110,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
 impl<'a, 'tcx> DocFolder for SyntaxChecker<'a, 'tcx> {
     fn fold_item(&mut self, item: clean::Item) -> Option<clean::Item> {
         if let Some(dox) = &item.attrs.collapsed_doc_value() {
-            let sp = span_of_attrs(&item.attrs).unwrap_or(item.source.span());
+            let sp = span_of_attrs(&item.attrs).unwrap_or(item.span.span());
             let extra = crate::html::markdown::ExtraInfo::new_did(self.cx.tcx, item.def_id, sp);
             for code_block in markdown::rust_code_blocks(&dox, &extra) {
                 self.check_rust_syntax(&item, &dox, code_block);

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1226,7 +1226,7 @@ impl LinkCollector<'_, '_> {
                             &ori_link.range,
                             &item.attrs,
                         )
-                        .unwrap_or_else(|| span_of_attrs(&item.attrs).unwrap_or(item.span.span()));
+                        .unwrap_or_else(|| span_of_attrs(&item.attrs).unwrap_or(item.span.inner()));
 
                         rustc_session::parse::feature_err(
                             &self.cx.tcx.sess.parse_sess,
@@ -1691,7 +1691,7 @@ fn report_diagnostic(
     };
 
     let attrs = &item.attrs;
-    let sp = span_of_attrs(attrs).unwrap_or(item.span.span());
+    let sp = span_of_attrs(attrs).unwrap_or(item.span.inner());
 
     tcx.struct_span_lint_hir(lint, hir_id, sp, |lint| {
         let mut diag = lint.build(msg);

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1226,9 +1226,7 @@ impl LinkCollector<'_, '_> {
                             &ori_link.range,
                             &item.attrs,
                         )
-                        .unwrap_or_else(|| {
-                            span_of_attrs(&item.attrs).unwrap_or(item.source.span())
-                        });
+                        .unwrap_or_else(|| span_of_attrs(&item.attrs).unwrap_or(item.span.span()));
 
                         rustc_session::parse::feature_err(
                             &self.cx.tcx.sess.parse_sess,
@@ -1693,7 +1691,7 @@ fn report_diagnostic(
     };
 
     let attrs = &item.attrs;
-    let sp = span_of_attrs(attrs).unwrap_or(item.source.span());
+    let sp = span_of_attrs(attrs).unwrap_or(item.span.span());
 
     tcx.struct_span_lint_hir(lint, hir_id, sp, |lint| {
         let mut diag = lint.build(msg);

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -97,7 +97,7 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
     if tests.found_tests == 0 && cx.tcx.sess.is_nightly_build() {
         if should_have_doc_example(cx, &item) {
             debug!("reporting error for {:?} (hir_id={:?})", item, hir_id);
-            let sp = span_of_attrs(&item.attrs).unwrap_or(item.span.span());
+            let sp = span_of_attrs(&item.attrs).unwrap_or(item.span.inner());
             cx.tcx.struct_span_lint_hir(
                 crate::lint::MISSING_DOC_CODE_EXAMPLES,
                 hir_id,
@@ -109,7 +109,7 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
         cx.tcx.struct_span_lint_hir(
             crate::lint::PRIVATE_DOC_TESTS,
             hir_id,
-            span_of_attrs(&item.attrs).unwrap_or(item.span.span()),
+            span_of_attrs(&item.attrs).unwrap_or(item.span.inner()),
             |lint| lint.build("documentation test in private item").emit(),
         );
     }

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -97,7 +97,7 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
     if tests.found_tests == 0 && cx.tcx.sess.is_nightly_build() {
         if should_have_doc_example(cx, &item) {
             debug!("reporting error for {:?} (hir_id={:?})", item, hir_id);
-            let sp = span_of_attrs(&item.attrs).unwrap_or(item.source.span());
+            let sp = span_of_attrs(&item.attrs).unwrap_or(item.span.span());
             cx.tcx.struct_span_lint_hir(
                 crate::lint::MISSING_DOC_CODE_EXAMPLES,
                 hir_id,
@@ -109,7 +109,7 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
         cx.tcx.struct_span_lint_hir(
             crate::lint::PRIVATE_DOC_TESTS,
             hir_id,
-            span_of_attrs(&item.attrs).unwrap_or(item.source.span()),
+            span_of_attrs(&item.attrs).unwrap_or(item.span.span()),
             |lint| lint.build("documentation test in private item").emit(),
         );
     }

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -181,7 +181,7 @@ impl<'a, 'tcx> DocFolder for InvalidHtmlTagsLinter<'a, 'tcx> {
                 let sp = match super::source_span_for_markdown_range(tcx, &dox, range, &item.attrs)
                 {
                     Some(sp) => sp,
-                    None => span_of_attrs(&item.attrs).unwrap_or(item.span.span()),
+                    None => span_of_attrs(&item.attrs).unwrap_or(item.span.inner()),
                 };
                 tcx.struct_span_lint_hir(crate::lint::INVALID_HTML_TAGS, hir_id, sp, |lint| {
                     lint.build(msg).emit()

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -181,7 +181,7 @@ impl<'a, 'tcx> DocFolder for InvalidHtmlTagsLinter<'a, 'tcx> {
                 let sp = match super::source_span_for_markdown_range(tcx, &dox, range, &item.attrs)
                 {
                     Some(sp) => sp,
-                    None => span_of_attrs(&item.attrs).unwrap_or(item.source.span()),
+                    None => span_of_attrs(&item.attrs).unwrap_or(item.span.span()),
                 };
                 tcx.struct_span_lint_hir(crate::lint::INVALID_HTML_TAGS, hir_id, sp, |lint| {
                     lint.build(msg).emit()

--- a/src/librustdoc/passes/non_autolinks.rs
+++ b/src/librustdoc/passes/non_autolinks.rs
@@ -72,7 +72,7 @@ impl<'a, 'tcx> DocFolder for NonAutolinksLinter<'a, 'tcx> {
             let report_diag = |cx: &DocContext<'_>, msg: &str, url: &str, range: Range<usize>| {
                 let sp = super::source_span_for_markdown_range(cx.tcx, &dox, &range, &item.attrs)
                     .or_else(|| span_of_attrs(&item.attrs))
-                    .unwrap_or(item.span.span());
+                    .unwrap_or(item.span.inner());
                 cx.tcx.struct_span_lint_hir(crate::lint::NON_AUTOLINKS, hir_id, sp, |lint| {
                     lint.build(msg)
                         .span_suggestion(

--- a/src/librustdoc/passes/non_autolinks.rs
+++ b/src/librustdoc/passes/non_autolinks.rs
@@ -72,7 +72,7 @@ impl<'a, 'tcx> DocFolder for NonAutolinksLinter<'a, 'tcx> {
             let report_diag = |cx: &DocContext<'_>, msg: &str, url: &str, range: Range<usize>| {
                 let sp = super::source_span_for_markdown_range(cx.tcx, &dox, &range, &item.attrs)
                     .or_else(|| span_of_attrs(&item.attrs))
-                    .unwrap_or(item.source.span());
+                    .unwrap_or(item.span.span());
                 cx.tcx.struct_span_lint_hir(crate::lint::NON_AUTOLINKS, hir_id, sp, |lint| {
                     lint.build(msg)
                         .span_suggestion(

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -461,7 +461,7 @@ pub struct Impl {
 #[serde(rename_all = "snake_case")]
 pub struct Import {
     /// The full path being imported.
-    pub span: String,
+    pub source: String,
     /// May be different from the last segment of `source` when renaming imports:
     /// `use source as name;`
     pub name: String,

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -64,7 +64,7 @@ pub struct Item {
     pub name: Option<String>,
     /// The source location of this item (absent if it came from a macro expansion or inline
     /// assembly).
-    pub source: Option<Span>,
+    pub span: Option<Span>,
     /// By default all documented items are public, but you can tell rustdoc to output private items
     /// so this field is needed to differentiate.
     pub visibility: Visibility,

--- a/src/test/incremental/ich_nested_items.rs
+++ b/src/test/incremental/ich_nested_items.rs
@@ -3,6 +3,7 @@
 
 // revisions: cfail1 cfail2
 // build-pass (FIXME(62277): could be check-pass?)
+// compile-flags: -Z query-dep-graph
 
 #![crate_type = "rlib"]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/ich_resolve_results.rs
+++ b/src/test/incremental/ich_resolve_results.rs
@@ -2,6 +2,7 @@
 // `use` to something different.
 
 // revisions: rpass1 rpass2 rpass3
+// compile-flags: -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 

--- a/src/test/incremental/spans_significant_w_panic.rs
+++ b/src/test/incremental/spans_significant_w_panic.rs
@@ -3,7 +3,7 @@
 
 // revisions:rpass1 rpass2
 
-// compile-flags: -C overflow-checks=on
+// compile-flags: -C overflow-checks=on -Z query-dep-graph
 
 #![feature(rustc_attrs)]
 

--- a/src/test/rustdoc-gui/check_info_sign_position.goml
+++ b/src/test/rustdoc-gui/check_info_sign_position.goml
@@ -1,0 +1,9 @@
+goto: file://|DOC_PATH|/index.html
+goto: ./fn.check_list_code_block.html
+// If the codeblock is the first element of the docblock, the information tooltip must have
+// have some top margin to avoid going over the toggle (the "[+]").
+assert: (".docblock > .information > .compile_fail", { "margin-top": "16px" })
+// Checks that the other codeblocks don't have this top margin.
+assert: ("ol > li > .information > .compile_fail", { "margin-top": "0px" })
+assert: ("ol > li > .information > .ignore", { "margin-top": "0px" })
+assert: (".docblock > .information > .ignore", { "margin-top": "0px" })

--- a/src/test/rustdoc-gui/lib.rs
+++ b/src/test/rustdoc-gui/lib.rs
@@ -57,16 +57,26 @@ pub trait AnotherOne {
     fn func3();
 }
 
+/// ```compile_fail
+/// whatever
+/// ```
+///
 /// Check for "i" signs in lists!
 ///
 /// 1. elem 1
-/// 2.test 1
-///   ```compile_fail
-///   fn foo() {}
-///   ```
+/// 2. test 1
+///    ```compile_fail
+///    fn foo() {}
+///    ```
 /// 3. elem 3
 /// 4. ```ignore (it's a test)
 ///    fn foo() {}
 ///    ```
 /// 5. elem 5
+///
+/// Final one:
+///
+/// ```ignore (still a test)
+/// let x = 12;
+/// ```
 pub fn check_list_code_block() {}

--- a/src/test/rustdoc-json/nested.rs
+++ b/src/test/rustdoc-json/nested.rs
@@ -24,7 +24,7 @@ pub mod l1 {
         // @has - "$.index[*][?(@.name=='l3')].inner.items[*]" $l4_id
         pub struct L4;
     }
-    // @is nested.json "$.index[*][?(@.inner.span=='l3::L4')].kind" \"import\"
-    // @is - "$.index[*][?(@.inner.span=='l3::L4')].inner.glob" false
+    // @is nested.json "$.index[*][?(@.inner.source=='l3::L4')].kind" \"import\"
+    // @is - "$.index[*][?(@.inner.source=='l3::L4')].inner.glob" false
     pub use l3::L4;
 }

--- a/src/test/rustdoc-json/reexport/rename_public.rs
+++ b/src/test/rustdoc-json/reexport/rename_public.rs
@@ -13,5 +13,5 @@ pub mod inner {
 // @set import_id = - "$.index[*][?(@.inner.name=='NewName')].id"
 // @!has - "$.index[*][?(@.inner.name=='Public')]"
 // @has - "$.index[*][?(@.name=='rename_public')].inner.items[*]" $import_id
-// @is - "$.index[*][?(@.inner.name=='NewName')].inner.span" \"inner::Public\"
+// @is - "$.index[*][?(@.inner.name=='NewName')].inner.source" \"inner::Public\"
 pub use inner::Public as NewName;

--- a/src/test/rustdoc-json/reexport/simple_public.rs
+++ b/src/test/rustdoc-json/reexport/simple_public.rs
@@ -14,5 +14,5 @@ pub mod inner {
 
 // @set import_id = - "$.index[*][?(@.inner.name=='Public')].id"
 // @has - "$.index[*][?(@.name=='simple_public')].inner.items[*]" $import_id
-// @is - "$.index[*][?(@.inner.name=='Public')].inner.span" \"inner::Public\"
+// @is - "$.index[*][?(@.inner.name=='Public')].inner.source" \"inner::Public\"
 pub use inner::Public;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.rs
@@ -1,0 +1,10 @@
+// run-pass
+
+#![warn(disjoint_capture_drop_reorder)]
+
+fn main() {
+    if let a = "" {
+    //~^ WARNING: irrefutable `if let` pattern
+        drop(|_: ()| drop(a));
+    }
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/issue-78720.stderr
@@ -1,0 +1,15 @@
+warning: irrefutable `if let` pattern
+  --> $DIR/issue-78720.rs:6:5
+   |
+LL | /     if let a = "" {
+LL | |
+LL | |         drop(|_: ()| drop(a));
+LL | |     }
+   | |_____^
+   |
+   = note: `#[warn(irrefutable_let_patterns)]` on by default
+   = note: this pattern will always match, so the `if let` is useless
+   = help: consider replacing the `if let` with a `let`
+
+warning: 1 warning emitted
+

--- a/src/test/ui/dep-graph/dep-graph-check-attr.rs
+++ b/src/test/ui/dep-graph/dep-graph-check-attr.rs
@@ -1,0 +1,20 @@
+// Test that using rustc_clean/dirty/if_this_changed/then_this_would_need
+// are forbidden when `-Z query-dep-graph` is not enabled.
+
+#![feature(rustc_attrs)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+#[rustc_dirty(hir_owner)] //~ ERROR attribute requires -Z query-dep-graph
+fn main() {}
+
+#[rustc_if_this_changed(hir_owner)] //~ ERROR attribute requires -Z query-dep-graph
+struct Foo<T> {
+    f: T,
+}
+
+#[rustc_clean(hir_owner)] //~ ERROR attribute requires -Z query-dep-graph
+type TypeAlias<T> = Foo<T>;
+
+#[rustc_then_this_would_need(variances_of)] //~ ERROR attribute requires -Z query-dep-graph
+trait Use<T> {}

--- a/src/test/ui/dep-graph/dep-graph-check-attr.stderr
+++ b/src/test/ui/dep-graph/dep-graph-check-attr.stderr
@@ -1,0 +1,26 @@
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:8:1
+   |
+LL | #[rustc_dirty(hir_owner)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:11:1
+   |
+LL | #[rustc_if_this_changed(hir_owner)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:16:1
+   |
+LL | #[rustc_clean(hir_owner)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: attribute requires -Z query-dep-graph to be enabled
+  --> $DIR/dep-graph-check-attr.rs:19:1
+   |
+LL | #[rustc_then_this_would_need(variances_of)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/issues/issue-83048.rs
+++ b/src/test/ui/issues/issue-83048.rs
@@ -1,0 +1,5 @@
+// compile-flags: -Z unpretty=thir-tree
+
+pub fn main() {
+    break; //~ ERROR: `break` outside of a loop [E0268]
+}

--- a/src/test/ui/issues/issue-83048.stderr
+++ b/src/test/ui/issues/issue-83048.stderr
@@ -1,0 +1,9 @@
+error[E0268]: `break` outside of a loop
+  --> $DIR/issue-83048.rs:4:5
+   |
+LL |     break;
+   |     ^^^^^ cannot `break` outside of a loop
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0268`.


### PR DESCRIPTION
Successful merges:

 - #82994 (Rename `source` to `span` and `span` to `source`)
 - #83050 (Run analyses before thir-tree dumps)
 - #83313 (Only enable assert_dep_graph when query-dep-graph is enabled.)
 - #83353 (Add internal io::Error::new_const to avoid allocations.)
 - #83364 (2229 migration: Don't try resolve regions before writeback)
 - #83392 (Change `-W help` to display edition level.)
 - #83393 (Codeblock tooltip position)
 - #83405 (Slight visual improvements to warning boxes in the docs)
 - #83418 (Update cargo)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=82994,83050,83313,83353,83364,83392,83393,83405,83418)
<!-- homu-ignore:end -->