### PR TITLE
Add tests related to erroneous consts in dead code with --emit=mir

### DIFF
--- a/src/test/ui/consts/const-eval/panic-assoc-never-type-unused.rs
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type-unused.rs
@@ -1,0 +1,24 @@
+// compile-flags: --emit=mir,link
+
+// Variant of panic-assoc-never-type.rs.
+// Ensure that mir opts don't hide errors due to the usage of erroneous constants
+// in unused code.
+
+#![warn(const_err)]
+#![feature(const_panic)]
+#![feature(never_type)]
+
+struct PrintName;
+
+impl PrintName {
+    const VOID: ! = panic!();
+    //~^ WARN any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
+}
+
+fn foo() {
+    let _ = PrintName::VOID;
+    //~^ ERROR erroneous constant used
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/panic-assoc-never-type-unused.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-never-type-unused.stderr
@@ -1,0 +1,26 @@
+warning: any use of this value will cause an error
+  --> $DIR/panic-assoc-never-type-unused.rs:14:21
+   |
+LL |     const VOID: ! = panic!();
+   |     ----------------^^^^^^^^-
+   |                     |
+   |                     the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-never-type-unused.rs:14:21
+   |
+note: the lint level is defined here
+  --> $DIR/panic-assoc-never-type-unused.rs:7:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: erroneous constant used
+  --> $DIR/panic-assoc-never-type-unused.rs:20:13
+   |
+LL |     let _ = PrintName::VOID;
+   |             ^^^^^^^^^^^^^^^ referenced constant has errors
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-assoc-unit-type-unused.rs
+++ b/src/test/ui/consts/const-eval/panic-assoc-unit-type-unused.rs
@@ -1,0 +1,23 @@
+// compile-flags: --emit=mir,link
+
+// Variant of panic-assoc-never-type.rs.
+// Ensure that mir opts don't hide errors due to the usage of erroneous constants
+// in unused code, even for inhabited ZST constants.
+
+#![warn(const_err)]
+#![feature(const_panic)]
+
+struct PrintName;
+
+impl PrintName {
+    const UNIT: () = panic!();
+    //~^ WARN any use of this value will cause an error
+    //~| WARN this was previously accepted by the compiler but is being phased out
+}
+
+fn foo() {
+    let _ = PrintName::UNIT;
+    //~^ ERROR erroneous constant used
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/panic-assoc-unit-type-unused.stderr
+++ b/src/test/ui/consts/const-eval/panic-assoc-unit-type-unused.stderr
@@ -1,0 +1,26 @@
+warning: any use of this value will cause an error
+  --> $DIR/panic-assoc-unit-type-unused.rs:13:22
+   |
+LL |     const UNIT: () = panic!();
+   |     -----------------^^^^^^^^-
+   |                      |
+   |                      the evaluated program panicked at 'explicit panic', $DIR/panic-assoc-unit-type-unused.rs:13:22
+   |
+note: the lint level is defined here
+  --> $DIR/panic-assoc-unit-type-unused.rs:7:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: erroneous constant used
+  --> $DIR/panic-assoc-unit-type-unused.rs:19:13
+   |
+LL |     let _ = PrintName::UNIT;
+   |             ^^^^^^^^^^^^^^^ referenced constant has errors
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-never-type-unused.rs
+++ b/src/test/ui/consts/const-eval/panic-never-type-unused.rs
@@ -1,0 +1,20 @@
+// compile-flags: --emit=mir,link
+
+// Variant of panic-never-type.rs.
+// Ensure that mir opts don't hide errors due to the usage of erroneous constants
+// in unused code.
+
+#![warn(const_err)]
+#![feature(const_panic)]
+#![feature(never_type)]
+
+const VOID: ! = panic!();
+//~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
+
+fn foo() {
+    let _ = VOID;
+    //~^ ERROR erroneous constant used
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/panic-never-type-unused.stderr
+++ b/src/test/ui/consts/const-eval/panic-never-type-unused.stderr
@@ -1,0 +1,26 @@
+warning: any use of this value will cause an error
+  --> $DIR/panic-never-type-unused.rs:11:17
+   |
+LL | const VOID: ! = panic!();
+   | ----------------^^^^^^^^-
+   |                 |
+   |                 the evaluated program panicked at 'explicit panic', $DIR/panic-never-type-unused.rs:11:17
+   |
+note: the lint level is defined here
+  --> $DIR/panic-never-type-unused.rs:7:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: erroneous constant used
+  --> $DIR/panic-never-type-unused.rs:16:13
+   |
+LL |     let _ = VOID;
+   |             ^^^^ referenced constant has errors
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/panic-unit-type-unused.rs
+++ b/src/test/ui/consts/const-eval/panic-unit-type-unused.rs
@@ -1,0 +1,19 @@
+// compile-flags: --emit=mir,link
+
+// Variant of panic-never-type.rs.
+// Ensure that mir opts don't hide errors due to the usage of erroneous constants,
+// in unused code, even for inhabited ZST constants.
+
+#![warn(const_err)]
+#![feature(const_panic)]
+
+const UNIT: () = panic!();
+//~^ WARN any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
+
+fn foo() {
+    let _ = UNIT;
+    //~^ ERROR erroneous constant used
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/panic-unit-type-unused.stderr
+++ b/src/test/ui/consts/const-eval/panic-unit-type-unused.stderr
@@ -1,0 +1,26 @@
+warning: any use of this value will cause an error
+  --> $DIR/panic-unit-type-unused.rs:10:18
+   |
+LL | const UNIT: () = panic!();
+   | -----------------^^^^^^^^-
+   |                  |
+   |                  the evaluated program panicked at 'explicit panic', $DIR/panic-unit-type-unused.rs:10:18
+   |
+note: the lint level is defined here
+  --> $DIR/panic-unit-type-unused.rs:7:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: erroneous constant used
+  --> $DIR/panic-unit-type-unused.rs:15:13
+   |
+LL |     let _ = UNIT;
+   |             ^^^^ referenced constant has errors
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
The RemoveZsts pass (#83417) breaks all of these tests by removing a usage of the erroneous const.

r? @oli-obk 