### PR TITLE
Tell GitHub to highlight `config.toml.example` as TOML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 src/etc/installer/gfx/* binary
 src/vendor/** -text
 Cargo.lock linguist-generated=false
+config.toml.example linguist-language=TOML
 
 # Older git versions try to fix line endings on images and fonts, this prevents it.
 *.png binary


### PR DESCRIPTION
This should be a nice small quality of life improvement when looking at
`config.toml.example` on GitHub or looking at diffs of it in PRs.