### PR TITLE
LLVMWrapper: attractive nuisance macros

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -33,13 +33,6 @@
   (LLVM_VERSION_MAJOR > (major) ||                                             \
    LLVM_VERSION_MAJOR == (major) && LLVM_VERSION_MINOR >= (minor))
 
-#define LLVM_VERSION_EQ(major, minor)                                          \
-  (LLVM_VERSION_MAJOR == (major) && LLVM_VERSION_MINOR == (minor))
-
-#define LLVM_VERSION_LE(major, minor)                                          \
-  (LLVM_VERSION_MAJOR < (major) ||                                             \
-   LLVM_VERSION_MAJOR == (major) && LLVM_VERSION_MINOR <= (minor))
-
 #define LLVM_VERSION_LT(major, minor) (!LLVM_VERSION_GE((major), (minor)))
 
 #include "llvm/IR/LegacyPassManager.h"


### PR DESCRIPTION
This came up in the review of #83425: it's hard to imagine a use of
LLVM_VERSION_LE() or LLVM_VERSION_EQ() that's not asking for trouble
when a point release gets created, so let's just discard them to prevent
the issue.