### PR TITLE
Fix bootstrap tests on beta

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -585,8 +585,11 @@ mod dist {
             rustfix_coverage: false,
             pass: None,
         };
+        // Make sure rustfmt binary not being found isn't an error.
+        config.channel = "beta".to_string();
         let build = Build::new(config);
         let mut builder = Builder::new(&build);
+
         builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Test), &[]);
         let a = TargetSelection::from_user("A");
 


### PR DESCRIPTION
Forward-porting a fix from the beta branch, which led to test failure on beta.

r? @pietroalbini 