### PR TITLE
Fix error codes check run and ensure it will not go unnoticed again

### DIFF
--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
 
         // Checks that only make sense for the compiler.
         check!(errors, &compiler_path);
-        check!(error_codes_check, &src_path);
+        check!(error_codes_check, &[&src_path, &compiler_path]);
 
         // Checks that only make sense for the std libs.
         check!(pal, &library_path);


### PR DESCRIPTION
Fixes #83268.

The error codes explanations were not checked anymore. I fixed this issue and also added variables to ensure that this won't happen again (at least not silently).