### PR TITLE
Fix patch note about #80653 not mentioning nested nor recursive

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -87,7 +87,7 @@ Cargo
 Rustdoc
 -------
 
-- [Rustdoc will now include documentation for methods available from `Deref` traits.][80653]
+- [Rustdoc will now include documentation for methods available from _nested_ `Deref` traits.][80653]
 - [You can now provide a `--default-theme` flag which sets the default theme to use for
   documentation.][79642]
 


### PR DESCRIPTION
Which thus missed the point of the change: `rustdoc` already bundled documentation for methods accessible through one layer of `Deref`, it has now been enhanced to keep recursing 🙂

r? @jyn514 