### PR TITLE
Don't ICE when using `#[global_alloc]` on a non-item statement

### DIFF
--- a/src/test/ui/proc-macro/issue-83469-global-alloc-invalid-stmt.rs
+++ b/src/test/ui/proc-macro/issue-83469-global-alloc-invalid-stmt.rs
@@ -1,0 +1,10 @@
+// Regression test for issue #83469
+// Ensures that we recover from `#[global_alloc]` on an invalid
+// stmt without an ICE
+
+fn outer() {
+    #[global_allocator]
+    fn inner() {} //~ ERROR allocators must be statics
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-83469-global-alloc-invalid-stmt.stderr
+++ b/src/test/ui/proc-macro/issue-83469-global-alloc-invalid-stmt.stderr
@@ -1,0 +1,8 @@
+error: allocators must be statics
+  --> $DIR/issue-83469-global-alloc-invalid-stmt.rs:7:5
+   |
+LL |     fn inner() {}
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #83469

We need to return an `Annotatable::Stmt` if we were passed an
`Annotatable::Stmt`