### PR TITLE
Add `impl Into<!> for Infallible`

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -728,6 +728,13 @@ impl From<!> for Infallible {
     }
 }
 
+#[stable(feature = "convert_into_infallible", since = "1.53.0")]
+impl Into<!> for Infallible {
+    fn into(self) -> ! {
+        match self {}
+    }
+}
+
 #[stable(feature = "convert_infallible_hash", since = "1.44.0")]
 impl Hash for Infallible {
     fn hash<H: Hasher>(&self, _: &mut H) {

--- a/library/core/tests/result.rs
+++ b/library/core/tests/result.rs
@@ -1,3 +1,4 @@
+use core::convert::Infallible;
 use core::ops::DerefMut;
 use core::option::*;
 
@@ -208,8 +209,12 @@ pub fn test_into_ok() {
     fn infallible_op() -> Result<isize, !> {
         Ok(666)
     }
+    fn infallible_op_enum() -> Result<isize, Infallible> {
+        Ok(666)
+    }
 
     assert_eq!(infallible_op().into_ok(), 666);
+    assert_eq!(infallible_op_enum().into_ok(), 666);
 
     enum MyNeverToken {}
     impl From<MyNeverToken> for ! {
@@ -230,8 +235,12 @@ pub fn test_into_err() {
     fn until_error_op() -> Result<!, isize> {
         Err(666)
     }
+    fn until_error_op_enum() -> Result<Infallible, isize> {
+        Err(666)
+    }
 
     assert_eq!(until_error_op().into_err(), 666);
+    assert_eq!(until_error_op_enum().into_err(), 666);
 
     enum MyNeverToken {}
     impl From<MyNeverToken> for ! {


### PR DESCRIPTION
It's currently possible to convert a never (`!`) type instance into `Infallible` (`impl From<!> for Infallible`). But not the other way around. That means that the (unstable) methods `Result::into_ok` and `Result::into_err` (tracking issue: #61695) that use the trait bounds `Into<!>` will currently not work when you have a `Result<Infallible, _>` or `Result<_, Infallible>`.

I tried to implement `impl From<Infallible> for !` and ended up with a number of compilation errors like these:
```
error[E0277]: `?` couldn't convert the error to `!`
   --> compiler/rustc_serialize/src/opaque.rs:151:33
    |
151 |         self.emit_usize(v.len())?;
    |                                 ^ the trait `From<()>` is not implemented for `!`
```

I found in the git history that this was attempted previously, in commit b2cf9a02b2bce6ed984b0c967e2daf0af7b13629 in PR #58302 by @SimonSapin. And the problem is brought up in comment https://github.com/rust-lang/rust/pull/58302#issuecomment-463316054 but no solution or discussion followed. I also don't understand the error. Is this the same inference problem that is currently preventing the never type from becoming stable? Clearly, [custom never tokens can implement conversion into `!`](https://github.com/rust-lang/rust/blob/master/library/core/tests/result.rs#L214-L219), just not the standard `Infallible` one?

I then tried `impl Into<!> for Infallible` instead. And it seems to work. In the future when `!` is (hopefully) stabilized, this impl can just be removed, as it will be covered by by the blanket implementation `impl<T> From<T> for T`. I know that manually implementing `Into` is not recommended. But as far as I know it's also not forbidden? This might be a legitimate case where we need it, since the corresponding `From` does not work?

I'm not sure if this could complicate the stabilization of the never type maybe? If so, we should likely not merge this. As I'm really hoping to get the proper never type on stable sometime. Ping @nikomatsakis, since I think you are still looking into that?

I tagged it as `#[stable]` directly. My understanding is that trait impls can't be unstable? Please advice on how to proceed here if this is wrong. Is an RFC needed?

### Alternative solution (for Result::{into_ok, into_err} specifically)

For the `into_ok` and `into_err` methods specifically there is another way to make them work on stable before `!` is stabilized. The trait bounds can be changed from `Into<!>` to `Into<Infallible`. Since the conversion between the types work that way it will continue to be usable on nightly for the real never type, and it will allow stable to use the methods with `Infallible`. But unless there are reasons we don't want `Infallible` to be convertible to the real never type, I think this is cleaner and more useful for `Infallible` in general.