### PR TITLE
Add char::code_point

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -687,7 +687,7 @@ impl char {
     /// Basic usage:
     ///
     /// ```
-    /// assert_eq!('💯'.code_point(), 65);
+    /// assert_eq!('💯'.code_point(), 0x1F4AF);
     /// assert_eq!('❤'.code_point(), 0x2764);
     /// assert_eq!('a'.code_point(), 97);
     /// ```

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -699,6 +699,7 @@ impl char {
     /// assert_eq!('ß'.code_point(), 'ß' as u32);
     /// assert_eq!('\n'.code_point(), '\n' as u32);
     /// ```
+    #[stable(feature = "char_code_point", since = "1.53.0")]
     #[inline]
     pub const fn code_point(self) -> u32 {
         // Casting a `char` to a `u32` gives the underlying scalar value, and all scalar values are

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -700,6 +700,7 @@ impl char {
     /// assert_eq!('\n'.code_point(), '\n' as u32);
     /// ```
     #[stable(feature = "char_code_point", since = "1.53.0")]
+    #[rustc_const_stable(feature = "char_code_point", since = "1.53.0")]
     #[inline]
     pub const fn code_point(self) -> u32 {
         // Casting a `char` to a `u32` gives the underlying scalar value, and all scalar values are

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -673,6 +673,39 @@ impl char {
         encode_utf16_raw(self as u32, dst)
     }
 
+    /// Returns the ["Unicode code point"][codepoint] associated with this `char`.
+    ///
+    /// Although ["Unicode scalar values"][scalar] and ["code points"][codepoint] are different,
+    /// all scalar values are code points. Because a `char` is a scalar value, it therefore is also
+    /// a valid code point. This method provides that code point as a `u32`.
+    ///
+    /// [scalar]: http://www.unicode.org/glossary/#unicode_scalar_value
+    /// [codepoint]: http://www.unicode.org/glossary/#code_point
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// assert_eq!('💯'.code_point(), 65);
+    /// assert_eq!('❤'.code_point(), 0x2764);
+    /// assert_eq!('a'.code_point(), 97);
+    /// ```
+    ///
+    /// This method is equivalent to casting via `as`, but with a more descriptive name:
+    ///
+    /// ```
+    /// assert_eq!('a'.code_point(), 'a' as u32);
+    /// assert_eq!('ß'.code_point(), 'ß' as u32);
+    /// assert_eq!('\n'.code_point(), '\n' as u32);
+    /// ```
+    #[inline]
+    pub const fn code_point(self) -> u32 {
+        // Casting a `char` to a `u32` gives the underlying scalar value, and all scalar values are
+        // valid code points
+        self as u32
+    }
+
     /// Returns `true` if this `char` has the `Alphabetic` property.
     ///
     /// `Alphabetic` is described in Chapter 4 (Character Properties) of the [Unicode Standard] and


### PR DESCRIPTION
In rust-lang/rust#79502, which introduced `From<char> for u{64,128}`, some desire for a dedicated code point method on `char` was expressed. This PR implements `char::code_point` (where the underscore comes from the fact that the documentation and Unicode both stylize it as two words, i.e., "code point" instead of "codepoint"). The method is simply implemented as `self as u32`.