### PR TITLE
rustdoc: Add unstable CLI option to show basic type layout information

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -649,6 +649,7 @@ impl Step for Rustdoc {
 
         cargo.rustdocflag("--document-private-items");
         cargo.rustdocflag("--enable-index-page");
+        cargo.rustdocflag("--show-type-layout");
         cargo.rustdocflag("-Zunstable-options");
         builder.run(&mut cargo.into());
     }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -549,6 +549,7 @@ impl Step for Rustc {
         cargo.rustdocflag("--enable-index-page");
         cargo.rustdocflag("-Zunstable-options");
         cargo.rustdocflag("-Znormalize-docs");
+        cargo.rustdocflag("--show-type-layout");
         compile::rustc_cargo(builder, &mut cargo, target);
 
         // Only include compiler crates, no dependencies of those, such as `libc`.

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -267,6 +267,8 @@ crate struct RenderOptions {
     crate document_hidden: bool,
     /// If `true`, generate a JSON file in the crate folder instead of HTML redirection files.
     crate generate_redirect_map: bool,
+    /// Show the memory layout of types in the docs.
+    crate show_type_layout: bool,
     crate unstable_features: rustc_feature::UnstableFeatures,
     crate emit: Vec<EmitType>,
 }
@@ -636,6 +638,7 @@ impl Options {
         let document_hidden = matches.opt_present("document-hidden-items");
         let run_check = matches.opt_present("check");
         let generate_redirect_map = matches.opt_present("generate-redirect-map");
+        let show_type_layout = matches.opt_present("show-type-layout");
 
         let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(matches, error_format);
 
@@ -695,6 +698,7 @@ impl Options {
                 document_private,
                 document_hidden,
                 generate_redirect_map,
+                show_type_layout,
                 unstable_features: rustc_feature::UnstableFeatures::from_environment(
                     crate_name.as_deref(),
                 ),

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -91,6 +91,8 @@ crate struct SharedContext<'tcx> {
     crate include_sources: bool,
     /// The local file sources we've emitted and their respective url-paths.
     crate local_sources: FxHashMap<PathBuf, String>,
+    /// Show the memory layout of types in the docs.
+    pub(super) show_type_layout: bool,
     /// Whether the collapsed pass ran
     collapsed: bool,
     /// The base-URL of the issue tracker for when an item has been tagged with
@@ -373,6 +375,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             generate_search_filter,
             unstable_features,
             generate_redirect_map,
+            show_type_layout,
             ..
         } = options;
 
@@ -446,6 +449,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             all: RefCell::new(AllTypes::new()),
             errors: receiver,
             redirections: if generate_redirect_map { Some(Default::default()) } else { None },
+            show_type_layout,
         };
 
         // Add the default themes to the `Vec` of stylepaths

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1540,9 +1540,10 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
         return;
     }
 
-    let param_env = cx.tcx().param_env(ty_def_id);
-    let ty = cx.tcx().type_of(ty_def_id);
-    match cx.tcx().layout_of(param_env.and(ty)) {
+    let tcx = cx.tcx();
+    let param_env = tcx.param_env(ty_def_id);
+    let ty = tcx.type_of(ty_def_id);
+    match tcx.layout_of(param_env.and(ty)) {
         Ok(ty_layout) => {
             writeln!(w, "<h2 class=\"small-section-header\">Layout</h2>");
             writeln!(w, "<div class=\"docblock\">");

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -837,7 +837,7 @@ fn item_typedef(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::T
     // we need #14072 to make sense of the generics.
     render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
 
-    document_ty_layout(w, cx, def_id);
+    document_type_layout(w, cx, def_id);
 }
 
 fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Union) {
@@ -886,7 +886,7 @@ fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Uni
     }
     let def_id = it.def_id.expect_real();
     render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
-    document_ty_layout(w, cx, def_id);
+    document_type_layout(w, cx, def_id);
 }
 
 fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) {
@@ -1023,7 +1023,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
     }
     let def_id = it.def_id.expect_real();
     render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
-    document_ty_layout(w, cx, def_id);
+    document_type_layout(w, cx, def_id);
 }
 
 fn item_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Macro) {
@@ -1164,7 +1164,7 @@ fn item_struct(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::St
     }
     let def_id = it.def_id.expect_real();
     render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
-    document_ty_layout(w, cx, def_id);
+    document_type_layout(w, cx, def_id);
 }
 
 fn item_static(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Static) {
@@ -1535,7 +1535,7 @@ fn document_non_exhaustive(w: &mut Buffer, item: &clean::Item) {
     }
 }
 
-fn document_ty_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
+fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
     if !cx.shared.show_type_layout {
         return;
     }
@@ -1560,7 +1560,7 @@ fn document_ty_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
             } else {
                 writeln!(
                     w,
-                    "<strong>Size:</strong> {size} byte{pl}",
+                    "<p><strong>Size:</strong> {size} byte{pl}</p>",
                     size = ty_layout.layout.size.bytes(),
                     pl = if ty_layout.layout.size.bytes() == 1 { "" } else { "s" },
                 );

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -846,6 +846,7 @@ fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Uni
     });
 
     document(w, cx, it, None);
+
     let mut fields = s
         .fields
         .iter()
@@ -880,7 +881,9 @@ fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Uni
             document(w, cx, field, Some(it));
         }
     }
-    render_assoc_items(w, cx, it, it.def_id.expect_real(), AssocItemRender::All)
+    let def_id = it.def_id.expect_real();
+    render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
+    document_ty_layout(w, cx, def_id);
 }
 
 fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum) {
@@ -940,6 +943,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
     });
 
     document(w, cx, it, None);
+
     if !e.variants.is_empty() {
         write!(
             w,
@@ -1014,7 +1018,9 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
             render_stability_since(w, variant, it, cx.tcx());
         }
     }
-    render_assoc_items(w, cx, it, it.def_id.expect_real(), AssocItemRender::All)
+    let def_id = it.def_id.expect_real();
+    render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
+    document_ty_layout(w, cx, def_id);
 }
 
 fn item_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Macro) {
@@ -1114,6 +1120,7 @@ fn item_struct(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::St
     });
 
     document(w, cx, it, None);
+
     let mut fields = s
         .fields
         .iter()
@@ -1152,7 +1159,9 @@ fn item_struct(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::St
             }
         }
     }
-    render_assoc_items(w, cx, it, it.def_id.expect_real(), AssocItemRender::All)
+    let def_id = it.def_id.expect_real();
+    render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
+    document_ty_layout(w, cx, def_id);
 }
 
 fn item_static(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Static) {
@@ -1520,5 +1529,29 @@ fn document_non_exhaustive(w: &mut Buffer, item: &clean::Item) {
         }
 
         w.write_str("</div></details>");
+    }
+}
+
+fn document_ty_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
+    let param_env = cx.tcx().param_env(ty_def_id);
+    let ty = cx.tcx().type_of(ty_def_id);
+    match cx.tcx().layout_of(param_env.and(ty)) {
+        Ok(ty_layout) => {
+            writeln!(w, r#"<h2 class="small-section-header">Layout</h2>"#);
+            writeln!(w, "<div>");
+            if ty_layout.layout.abi.is_unsized() {
+                writeln!(w, "<strong>Sized:</strong> (unsized)");
+            } else {
+                writeln!(
+                    w,
+                    "<strong>Size:</strong> {size} byte{pl}",
+                    size = ty_layout.layout.size.bytes(),
+                    pl = if ty_layout.layout.size.bytes() == 1 { "" } else { "s" },
+                );
+            }
+            writeln!(w, "</div>");
+        }
+        // FIXME: should we crash instead? or report an error?
+        Err(_layout_err) => {}
     }
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1550,7 +1550,7 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
             writeln!(
                 w,
                 "<div class=\"warning\"><p><strong>Note:</strong> Most layout information is \
-                 completely unstable and may be different between compiler versions. \
+                 completely unstable and may be different between compiler versions and platforms. \
                  The only exception is types with certain <code>repr(...)</code> attributes. \
                  Please see the Rust Reference’s \
                  <a href=\"https://doc.rust-lang.org/reference/type-layout.html\">“Type Layout”</a> \
@@ -1559,11 +1559,12 @@ fn document_type_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
             if ty_layout.layout.abi.is_unsized() {
                 writeln!(w, "<p><strong>Size:</strong> (unsized)</p>");
             } else {
+                let bytes = ty_layout.layout.size.bytes();
                 writeln!(
                     w,
                     "<p><strong>Size:</strong> {size} byte{pl}</p>",
-                    size = ty_layout.layout.size.bytes(),
-                    pl = if ty_layout.layout.size.bytes() == 1 { "" } else { "s" },
+                    size = bytes,
+                    pl = if bytes == 1 { "" } else { "s" },
                 );
             }
             writeln!(w, "</div>");

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1536,6 +1536,10 @@ fn document_non_exhaustive(w: &mut Buffer, item: &clean::Item) {
 }
 
 fn document_ty_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
+    if !cx.shared.show_type_layout {
+        return;
+    }
+
     let param_env = cx.tcx().param_env(ty_def_id);
     let ty = cx.tcx().type_of(ty_def_id);
     match cx.tcx().layout_of(param_env.and(ty)) {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -837,8 +837,6 @@ fn item_typedef(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::T
     // associated items from the aliased type (see discussion in #32077), but
     // we need #14072 to make sense of the generics.
     render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
-
-    document_type_layout(w, cx, def_id);
 }
 
 fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Union) {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1551,7 +1551,9 @@ fn document_ty_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
             }
             writeln!(w, "</div>");
         }
-        // FIXME: should we crash instead? or report an error?
-        Err(_layout_err) => {}
+        // Layout errors can occur with valid code, e.g. if you try to get the layout
+        // of a generic type such as `Vec<T>`. In case of a layout error, we just
+        // don't show any layout information.
+        Err(_) => {}
     }
 }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -830,11 +830,14 @@ fn item_typedef(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::T
 
     document(w, cx, it, None);
 
+    let def_id = it.def_id.expect_real();
     // Render any items associated directly to this alias, as otherwise they
     // won't be visible anywhere in the docs. It would be nice to also show
     // associated items from the aliased type (see discussion in #32077), but
     // we need #14072 to make sense of the generics.
-    render_assoc_items(w, cx, it, it.def_id.expect_real(), AssocItemRender::All)
+    render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
+
+    document_ty_layout(w, cx, def_id);
 }
 
 fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Union) {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1537,10 +1537,19 @@ fn document_ty_layout(w: &mut Buffer, cx: &Context<'_>, ty_def_id: DefId) {
     let ty = cx.tcx().type_of(ty_def_id);
     match cx.tcx().layout_of(param_env.and(ty)) {
         Ok(ty_layout) => {
-            writeln!(w, r#"<h2 class="small-section-header">Layout</h2>"#);
-            writeln!(w, "<div>");
+            writeln!(w, "<h2 class=\"small-section-header\">Layout</h2>");
+            writeln!(w, "<div class=\"docblock\">");
+            writeln!(
+                w,
+                "<div class=\"warning\"><p><strong>Note:</strong> Most layout information is \
+                 completely unstable and may be different between compiler versions. \
+                 The only exception is types with certain <code>repr(...)</code> attributes. \
+                 Please see the Rust Reference’s \
+                 <a href=\"https://doc.rust-lang.org/reference/type-layout.html\">“Type Layout”</a> \
+                 chapter for details on type layout guarantees.</p></div>"
+            );
             if ty_layout.layout.abi.is_unsized() {
-                writeln!(w, "<strong>Sized:</strong> (unsized)");
+                writeln!(w, "<p><strong>Size:</strong> (unsized)</p>");
             } else {
                 writeln!(
                     w,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -594,6 +594,9 @@ fn opts() -> Vec<RustcOptGroup> {
             )
         }),
         unstable("no-run", |o| o.optflag("", "no-run", "Compile doctests without running them")),
+        unstable("show-type-layout", |o| {
+            o.optflag("", "show-type-layout", "Include the memory layout of types in the docs")
+        }),
     ]
 }
 

--- a/src/test/rustdoc/type-layout-flag-required.rs
+++ b/src/test/rustdoc/type-layout-flag-required.rs
@@ -1,0 +1,4 @@
+// Tests that `--show-type-layout` is required in order to show layout info.
+
+// @!has type_layout_flag_required/struct.Foo.html 'Size: '
+pub struct Foo(usize);

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -1,0 +1,43 @@
+// @has type_layout/struct.Foo.html 'Size: '
+// @has - ' bytes'
+pub struct Foo {
+    pub a: usize,
+    b: Vec<String>,
+}
+
+// @has type_layout/enum.Bar.html 'Size: '
+// @has - ' bytes'
+pub enum Bar<'a> {
+    A(String),
+    B(&'a str, (std::collections::HashMap<String, usize>, Foo)),
+}
+
+// @has type_layout/union.Baz.html 'Size: '
+// @has - ' bytes'
+pub union Baz {
+    a: &'static str,
+    b: usize,
+    c: &'static [u8],
+}
+
+// @has type_layout/struct.X.html 'Size: '
+// @has - ' bytes'
+pub struct X(usize);
+
+// @has type_layout/struct.Y.html 'Size: '
+// @has - ' byte'
+// @!has - ' bytes'
+pub struct Y(u8);
+
+// @!has type_layout/struct.Generic.html 'Size: '
+pub struct Generic<T>(T);
+
+// @has type_layout/struct.Unsized.html 'Size: '
+// @has - '(unsized)'
+pub struct Unsized([u8]);
+
+// @!has type_layout/type.TypeAlias.html 'Size: '
+pub type TypeAlias = X;
+
+// @!has type_layout/trait.MyTrait.html 'Size: '
+pub trait MyTrait {}

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -36,7 +36,8 @@ pub struct Generic<T>(T);
 // @has - '(unsized)'
 pub struct Unsized([u8]);
 
-// @!has type_layout/type.TypeAlias.html 'Size: '
+// @has type_layout/type.TypeAlias.html 'Size: '
+// @has - ' bytes'
 pub type TypeAlias = X;
 
 // @!has type_layout/trait.MyTrait.html 'Size: '

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -1,3 +1,5 @@
+// compile-flags: --show-type-layout -Z unstable-options
+
 // @has type_layout/struct.Foo.html 'Size: '
 // @has - ' bytes'
 pub struct Foo {

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -50,9 +50,5 @@ pub struct GenericLifetimes<'a>(&'a str);
 // @has - '(unsized)'
 pub struct Unsized([u8]);
 
-// @has type_layout/type.TypeAlias.html 'Size: '
-// @has - ' bytes'
-pub type TypeAlias = X;
-
 // @!has type_layout/trait.MyTrait.html 'Size: '
 pub trait MyTrait {}

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -27,7 +27,7 @@ pub union Baz {
 pub struct X(usize);
 
 // @has type_layout/struct.Y.html 'Size: '
-// @has - ' byte'
+// @has - '1 byte'
 // @!has - ' bytes'
 pub struct Y(u8);
 

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -35,8 +35,16 @@ pub struct Y(u8);
 // @has - '0 bytes'
 pub struct Z;
 
-// @!has type_layout/struct.Generic.html 'Size: '
+// We can't compute layout for generic types.
+// @has type_layout/struct.Generic.html 'Unable to compute type layout, possibly due to this type having generic parameters'
+// @!has - 'Size: '
 pub struct Generic<T>(T);
+
+// We *can*, however, compute layout for types that are only generic over lifetimes,
+// because lifetimes are a type-system construct.
+// @has type_layout/struct.GenericLifetimes.html 'Size: '
+// @has - ' bytes'
+pub struct GenericLifetimes<'a>(&'a str);
 
 // @has type_layout/struct.Unsized.html 'Size: '
 // @has - '(unsized)'

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -31,6 +31,10 @@ pub struct X(usize);
 // @!has - ' bytes'
 pub struct Y(u8);
 
+// @has type_layout/struct.Z.html 'Size: '
+// @has - '0 bytes'
+pub struct Z;
+
 // @!has type_layout/struct.Generic.html 'Size: '
 pub struct Generic<T>(T);
 


### PR DESCRIPTION
Closes #75988.

Right now it just shows the size.
