### PR TITLE
compiletest: handle llvm_version with suffix like "12.0.0libcxx"

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -973,7 +973,11 @@ fn parse_normalization_string(line: &mut &str) -> Option<String> {
 }
 
 pub fn extract_llvm_version(version: &str) -> Option<u32> {
-    let version_without_suffix = version.trim_end_matches("git").split('-').next().unwrap();
+    let pat = |c: char| !c.is_ascii_digit() && c != '.';
+    let version_without_suffix = match version.find(pat) {
+        Some(pos) => &version[..pos],
+        None => version,
+    };
     let components: Vec<u32> = version_without_suffix
         .split('.')
         .map(|s| s.parse().expect("Malformed version component"))

--- a/src/tools/compiletest/src/tests.rs
+++ b/src/tools/compiletest/src/tests.rs
@@ -68,4 +68,8 @@ fn test_extract_llvm_version() {
     assert_eq!(extract_llvm_version("9.0.1-rust-1.43.0-dev"), Some(90001));
     assert_eq!(extract_llvm_version("9.3.1-rust-1.43.0-dev"), Some(90301));
     assert_eq!(extract_llvm_version("10.0.0-rust"), Some(100000));
+    assert_eq!(extract_llvm_version("11.1.0"), Some(110100));
+    assert_eq!(extract_llvm_version("12.0.0libcxx"), Some(120000));
+    assert_eq!(extract_llvm_version("12.0.0-rc3"), Some(120000));
+    assert_eq!(extract_llvm_version("13.0.0git"), Some(130000));
 }


### PR DESCRIPTION
The previous code only remove the suffix begin with `-`, but Gentoo Linux [define `LLVM_VERSION_SUFFIX="libcxx"`](https://github.com/gentoo/gentoo/blob/604d79f327176eecb05293d7154e24231229cb31/sys-devel/llvm/llvm-11.1.0.ebuild#L378) when llvm is linked to libc++ and lead to a panic: 

```
thread 'main' panicked at 'Malformed version component: ParseIntError { kind: InvalidDigit }', src/tools/compiletest/src/header.rs:968:28
```

This new code will handle all suffix not beginning with digit or dot.