### PR TITLE
Implement bool.take()

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -31,7 +31,7 @@ impl bool {
     pub fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
         if self { Some(f()) } else { None }
     }
-    
+
     /// Sets the `bool` to `false`, and returns the original value.
     ///
     /// # Examples

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -37,6 +37,8 @@ impl bool {
     /// # Examples
     ///
     /// ```
+    /// #![feature(bool_take)]
+    ///
     /// let mut b = true;
     /// assert_eq!(b.take(), true);
     /// assert_eq!(b.take(), false);

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -31,4 +31,19 @@ impl bool {
     pub fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
         if self { Some(f()) } else { None }
     }
+    
+    /// Sets the `bool` to `false`, and returns the original value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mut b = true;
+    /// assert_eq!(b.take(), true);
+    /// assert_eq!(b.take(), false);
+    /// ```
+    #[unstable(feature = "bool_take", issue = "none")]
+    #[inline]
+    pub fn take(&mut self) -> bool {
+        crate::mem::replace(self, false)
+    }
 }


### PR DESCRIPTION
I found myself wanting to write code using this method on `bool`. It essentially mirrors `Option::<()>::take`

This would make it easy to both check and reset a `bool` value in one line, ex `if need_stuff.take() { // do stuff }` 

If this seems reasonable, I will open a tracking issue. If not, feel free to just close this.