### PR TITLE
[beta] backports

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -66,7 +66,7 @@ pub use iter::{EscapeDebug, EscapeDefault, EscapeUnicode};
 pub use iter::SplitAsciiWhitespace;
 
 #[stable(feature = "split_inclusive", since = "1.51.0")]
-use iter::SplitInclusive;
+pub use iter::SplitInclusive;
 
 #[unstable(feature = "str_internals", issue = "none")]
 pub use validations::next_code_point;

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # stable release's version number. `date` is the date where the release we're
 # bootstrapping off was released.
 
-date: 2021-03-23
+date: 2021-03-25
 rustc: 1.51.0
 
 # We use a nightly rustfmt to format the source because it solves some
@@ -39,4 +39,4 @@ rustc: 1.51.0
 # looking at a beta source tarball and it's uncommented we'll shortly comment it
 # out.
 
-dev: 1
+#dev: 1


### PR DESCRIPTION
Initial round of beta backports, with 1 PR:

* SplitInclusive is public API #83372 

This also includes a bump to the released stable compiler.

r? @Mark-Simulacrum 