### PR TITLE
Break when there is a mismatch in the type count

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/type_check/input_output.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/input_output.rs
@@ -70,6 +70,12 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
         // Equate expected input tys with those in the MIR.
         for (argument_index, &normalized_input_ty) in normalized_input_tys.iter().enumerate() {
+            if argument_index + 1 >= body.local_decls.len() {
+                self.tcx()
+                    .sess
+                    .delay_span_bug(body.span, "found more normalized_input_ty than local_decls");
+                break;
+            }
             // In MIR, argument N is stored in local N+1.
             let local = Local::new(argument_index + 1);
 

--- a/src/test/ui/mir/issue-83499-input-output-iteration-ice.rs
+++ b/src/test/ui/mir/issue-83499-input-output-iteration-ice.rs
@@ -1,0 +1,10 @@
+// Test that when in MIR the amount of local_decls and amount of normalized_input_tys don't match
+// that an out-of-bounds access does not occur.
+#![feature(c_variadic)]
+
+fn main() {}
+
+fn foo(_: Bar, ...) -> impl {}
+//~^ ERROR only foreign or `unsafe extern "C" functions may be C-variadic
+//~| ERROR cannot find type `Bar` in this scope
+//~| ERROR at least one trait must be specified

--- a/src/test/ui/mir/issue-83499-input-output-iteration-ice.stderr
+++ b/src/test/ui/mir/issue-83499-input-output-iteration-ice.stderr
@@ -1,0 +1,21 @@
+error: only foreign or `unsafe extern "C" functions may be C-variadic
+  --> $DIR/issue-83499-input-output-iteration-ice.rs:7:16
+   |
+LL | fn foo(_: Bar, ...) -> impl {}
+   |                ^^^
+
+error: at least one trait must be specified
+  --> $DIR/issue-83499-input-output-iteration-ice.rs:7:24
+   |
+LL | fn foo(_: Bar, ...) -> impl {}
+   |                        ^^^^
+
+error[E0412]: cannot find type `Bar` in this scope
+  --> $DIR/issue-83499-input-output-iteration-ice.rs:7:11
+   |
+LL | fn foo(_: Bar, ...) -> impl {}
+   |           ^^^ not found in this scope
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
When other errors are generated, there can be a mismatch between the
amount of input types in MIR, and the amount in the function itself.
Break from the comparative loop if this is the case to prevent
out-of-bounds.
Fixes #83499