### PR TITLE
Suggest `i += 1` when we see `i++` or `++i`

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1777,6 +1777,7 @@ impl<'a> Parser<'a> {
         err.span_label(span, "expected expression");
         if self.prev_token.kind == TokenKind::BinOp(token::Plus)
             && self.token.kind == TokenKind::BinOp(token::Plus)
+            && self.look_ahead(1, |t| !t.is_lit())
         {
             let span = self.prev_token.span.to(self.token.span);
             err.note("Rust has no dedicated increment and decrement operators");
@@ -1788,6 +1789,7 @@ impl<'a> Parser<'a> {
             );
         } else if self.token.kind == TokenKind::BinOp(token::Plus)
             && self.look_ahead(1, |t| t.kind == TokenKind::BinOp(token::Plus))
+            && self.look_ahead(2, |t| !t.is_lit())
         {
             err.note("Rust has no dedicated increment and decrement operators");
             err.help("try using `+= 1` instead");

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1775,6 +1775,23 @@ impl<'a> Parser<'a> {
             self.sess.expr_parentheses_needed(&mut err, *sp, None);
         }
         err.span_label(span, "expected expression");
+        if self.prev_token.kind == TokenKind::BinOp(token::Plus)
+            && self.token.kind == TokenKind::BinOp(token::Plus)
+        {
+            let span = self.prev_token.span.to(self.token.span);
+            err.note("Rust has no dedicated increment and decrement operators");
+            err.span_suggestion_verbose(
+                span,
+                "try using `+= 1` instead",
+                " += 1".into(),
+                Applicability::Unspecified,
+            );
+        } else if self.token.kind == TokenKind::BinOp(token::Plus)
+            && self.look_ahead(1, |t| t.kind == TokenKind::BinOp(token::Plus))
+        {
+            err.note("Rust has no dedicated increment and decrement operators");
+            err.help("try using `+= 1` instead");
+        }
         err
     }
 

--- a/src/test/ui/parser/increment.rs
+++ b/src/test/ui/parser/increment.rs
@@ -1,0 +1,11 @@
+fn test1() {
+    let i = 0;
+    i++; //~ ERROR
+}
+
+fn test2() {
+    let i = 0;
+    ++i; //~ ERROR
+}
+
+fn main() {}

--- a/src/test/ui/parser/increment.stderr
+++ b/src/test/ui/parser/increment.stderr
@@ -1,0 +1,23 @@
+error: expected expression, found `+`
+  --> $DIR/increment.rs:3:7
+   |
+LL |     i++;
+   |       ^ expected expression
+   |
+   = note: Rust has no dedicated increment and decrement operators
+help: try using `+= 1` instead
+   |
+LL |     i += 1;
+   |       ^^^^
+
+error: expected expression, found `+`
+  --> $DIR/increment.rs:8:5
+   |
+LL |     ++i;
+   |     ^ expected expression
+   |
+   = note: Rust has no dedicated increment and decrement operators
+   = help: try using `+= 1` instead
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Closes #83502 (for `i++` and `++i`; `--i` should be covered by #82987 and `i--`
is tricky to handle).
