### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 src/etc/installer/gfx/* binary
 src/vendor/** -text
 Cargo.lock linguist-generated=false
+config.toml.example linguist-language=TOML
 
 # Older git versions try to fix line endings on images and fonts, this prevents it.
 *.png binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,11 +252,11 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecount"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 dependencies = [
- "packed_simd",
+ "packed_simd_2",
 ]
 
 [[package]]
@@ -1902,6 +1902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.4+1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,12 +2441,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_simd"
-version = "0.3.3"
+name = "packed_simd_2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220"
+checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
 dependencies = [
  "cfg-if 0.1.10",
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,15 +614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",
@@ -2503,15 +2494,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall 0.2.5",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,9 +1889,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -213,11 +213,13 @@ impl<'a> Iterator for Parser<'a> {
                         Some(String(self.string(pos + 1)))
                     } else {
                         let arg = self.argument();
-                        if let Some(end) = self.must_consume('}') {
-                            let start = self.to_span_index(pos);
-                            let end = self.to_span_index(end + 1);
+                        if let Some(rbrace_byte_idx) = self.must_consume('}') {
+                            let lbrace_inner_offset = self.to_span_index(pos);
+                            let rbrace_inner_offset = self.to_span_index(rbrace_byte_idx);
                             if self.is_literal {
-                                self.arg_places.push(start.to(end));
+                                self.arg_places.push(
+                                    lbrace_inner_offset.to(InnerOffset(rbrace_inner_offset.0 + 1)),
+                                );
                             }
                         }
                         Some(NextArgument(arg))

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -735,25 +735,24 @@ fn find_skips_from_snippet(
     };
 
     fn find_skips(snippet: &str, is_raw: bool) -> Vec<usize> {
-        let mut eat_ws = false;
         let mut s = snippet.char_indices().peekable();
         let mut skips = vec![];
         while let Some((pos, c)) = s.next() {
             match (c, s.peek()) {
                 // skip whitespace and empty lines ending in '\\'
                 ('\\', Some((next_pos, '\n'))) if !is_raw => {
-                    eat_ws = true;
                     skips.push(pos);
                     skips.push(*next_pos);
                     let _ = s.next();
-                }
-                ('\\', Some((next_pos, '\n' | 'n' | 't'))) if eat_ws => {
-                    skips.push(pos);
-                    skips.push(*next_pos);
-                    let _ = s.next();
-                }
-                (' ' | '\n' | '\t', _) if eat_ws => {
-                    skips.push(pos);
+
+                    while let Some((pos, c)) = s.peek() {
+                        if matches!(c, ' ' | '\n' | '\t') {
+                            skips.push(*pos);
+                            let _ = s.next();
+                        } else {
+                            break;
+                        }
+                    }
                 }
                 ('\\', Some((next_pos, 'n' | 't' | 'r' | '0' | '\\' | '\'' | '\"'))) => {
                     skips.push(*next_pos);
@@ -803,10 +802,6 @@ fn find_skips_from_snippet(
                             }
                         }
                     }
-                }
-                _ if eat_ws => {
-                    // `take_while(|c| c.is_whitespace())`
-                    eat_ws = false;
                 }
                 _ => {}
             }

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -19,6 +19,10 @@
 //! format!("{value}", value=4);      // => "4"
 //! format!("{} {}", 1, 2);           // => "1 2"
 //! format!("{:04}", 42);             // => "0042" with leading zeros
+//! format!("{:#?}", (100, 200));     // => "(
+//!                                   //       100,
+//!                                   //       200,
+//!                                   //     )"
 //! ```
 //!
 //! From these, you can see that the first argument is a format string. It is
@@ -163,7 +167,7 @@
 //! * `-` - Currently not used
 //! * `#` - This flag indicates that the "alternate" form of printing should
 //!         be used. The alternate forms are:
-//!     * `#?` - pretty-print the [`Debug`] formatting
+//!     * `#?` - pretty-print the [`Debug`] formatting (newline and indent)
 //!     * `#x` - precedes the argument with a `0x`
 //!     * `#X` - precedes the argument with a `0x`
 //!     * `#b` - precedes the argument with a `0b`

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -167,7 +167,7 @@
 //! * `-` - Currently not used
 //! * `#` - This flag indicates that the "alternate" form of printing should
 //!         be used. The alternate forms are:
-//!     * `#?` - pretty-print the [`Debug`] formatting (newline and indent)
+//!     * `#?` - pretty-print the [`Debug`] formatting (adds linebreaks and indentation)
 //!     * `#x` - precedes the argument with a `0x`
 //!     * `#X` - precedes the argument with a `0x`
 //!     * `#b` - precedes the argument with a `0b`

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.88", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { version = "0.2.89", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.39" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }

--- a/library/std/src/os/linux/mod.rs
+++ b/library/std/src/os/linux/mod.rs
@@ -3,4 +3,5 @@
 #![stable(feature = "raw_ext", since = "1.1.0")]
 
 pub mod fs;
+pub mod process;
 pub mod raw;

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -1,6 +1,6 @@
 //! Linux-specific extensions to primitives in the `std::process` module.
 
-#![unstable(feature = "linux_pidfd", issue = "none")]
+#![unstable(feature = "linux_pidfd", issue = "82971")]
 
 use crate::io::Result;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
@@ -31,13 +31,14 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 ///
 /// // The file descriptor will be closed when `pidfd` is dropped.
 /// ```
-/// Refer to the man page of `pidfd_open(2)` for further details.
+/// Refer to the man page of [`pidfd_open(2)`] for further details.
 ///
 /// [`Command`]: process::Command
 /// [`create_pidfd`]: CommandExt::create_pidfd
 /// [`Child`]: process::Child
 /// [`pidfd`]: fn@ChildExt::pidfd
 /// [`take_pidfd`]: ChildExt::take_pidfd
+/// [`pidfd_open(2)`]: https://man7.org/linux/man-pages/man2/pidfd_open.2.html
 #[derive(Debug)]
 pub struct PidFd {
     inner: FileDesc,

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -1,0 +1,47 @@
+//! Linux-specific extensions to primitives in the `std::process` module.
+
+#![unstable(feature = "linux_pidfd", issue = "none")]
+
+use crate::process;
+use crate::sys_common::AsInnerMut;
+use crate::io::Result;
+
+/// Os-specific extensions to [`process::Child`]
+///
+/// [`process::Child`]: crate::process::Child
+pub trait ChildExt {
+    /// Obtains the pidfd created for this child process, if available.
+    ///
+    /// A pidfd will only ever be available if `create_pidfd(true)` was called
+    /// when the corresponding `Command` was created.
+    ///
+    /// Even if `create_pidfd(true)` is called, a pidfd may not be available
+    /// due to an older version of Linux being in use, or if
+    /// some other error occured.
+    ///
+    /// See `man pidfd_open` for more details about pidfds.
+    fn pidfd(&self) -> Result<i32>;
+}
+
+/// Os-specific extensions to [`process::Command`]
+///
+/// [`process::Command`]: crate::process::Command
+pub trait CommandExt {
+    /// Sets whether or this `Command` will attempt to create a pidfd
+    /// for the child. If this method is never called, a pidfd will
+    /// not be crated.
+    ///
+    /// The pidfd can be retrieved from the child via [`ChildExt::pidfd`]
+    ///
+    /// A pidfd will only be created if it is possible to do so
+    /// in a guaranteed race-free manner (e.g. if the `clone3` system call is
+    /// supported). Otherwise, [`ChildExit::pidfd`] will return an error.
+    fn create_pidfd(&mut self, val: bool) -> &mut process::Command;
+}
+
+impl CommandExt for process::Command {
+    fn create_pidfd(&mut self, val: bool) -> &mut process::Command {
+        self.as_inner_mut().create_pidfd(val);
+        self
+    }
+}

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -2,40 +2,142 @@
 
 #![unstable(feature = "linux_pidfd", issue = "none")]
 
-use crate::process;
-use crate::sys_common::AsInnerMut;
 use crate::io::Result;
+use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use crate::process;
+use crate::sys::fd::FileDesc;
+use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 
-/// Os-specific extensions to [`process::Child`]
+/// This type represents a file descriptor that refers to a process.
 ///
-/// [`process::Child`]: crate::process::Child
-pub trait ChildExt {
-    /// Obtains the pidfd created for this child process, if available.
-    ///
-    /// A pidfd will only ever be available if `create_pidfd(true)` was called
-    /// when the corresponding `Command` was created.
-    ///
-    /// Even if `create_pidfd(true)` is called, a pidfd may not be available
-    /// due to an older version of Linux being in use, or if
-    /// some other error occured.
-    ///
-    /// See `man pidfd_open` for more details about pidfds.
-    fn pidfd(&self) -> Result<i32>;
+/// A `PidFd` can be obtained by setting the corresponding option on [`Command`]
+/// with [`create_pidfd`]. Subsequently, the created pidfd can be retrieved
+/// from the [`Child`] by calling [`pidfd`] or [`take_pidfd`].
+///
+/// Example:
+/// ```no_run
+/// #![feature(linux_pidfd)]
+/// use std::os::linux::process::{CommandExt, ChildExt};
+/// use std::process::Command;
+///
+/// let mut child = Command::new("echo")
+///     .create_pidfd(true)
+///     .spawn()
+///     .expect("Failed to spawn child");
+///
+/// let pidfd = child
+///     .take_pidfd()
+///     .expect("Failed to retrieve pidfd");
+///
+/// // The file descriptor will be closed when `pidfd` is dropped.
+/// ```
+/// Refer to the man page of `pidfd_open(2)` for further details.
+///
+/// [`Command`]: process::Command
+/// [`create_pidfd`]: CommandExt::create_pidfd
+/// [`Child`]: process::Child
+/// [`pidfd`]: fn@ChildExt::pidfd
+/// [`take_pidfd`]: ChildExt::take_pidfd
+#[derive(Debug)]
+pub struct PidFd {
+    inner: FileDesc,
 }
 
-/// Os-specific extensions to [`process::Command`]
+impl AsInner<FileDesc> for PidFd {
+    fn as_inner(&self) -> &FileDesc {
+        &self.inner
+    }
+}
+
+impl FromInner<FileDesc> for PidFd {
+    fn from_inner(inner: FileDesc) -> PidFd {
+        PidFd { inner }
+    }
+}
+
+impl IntoInner<FileDesc> for PidFd {
+    fn into_inner(self) -> FileDesc {
+        self.inner
+    }
+}
+
+impl AsRawFd for PidFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_inner().raw()
+    }
+}
+
+impl FromRawFd for PidFd {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self::from_inner(FileDesc::new(fd))
+    }
+}
+
+impl IntoRawFd for PidFd {
+    fn into_raw_fd(self) -> RawFd {
+        self.into_inner().into_raw()
+    }
+}
+
+mod private_child_ext {
+    pub trait Sealed {}
+    impl Sealed for crate::process::Child {}
+}
+
+/// Os-specific extensions for [`Child`]
 ///
-/// [`process::Command`]: crate::process::Command
-pub trait CommandExt {
-    /// Sets whether or this `Command` will attempt to create a pidfd
-    /// for the child. If this method is never called, a pidfd will
-    /// not be crated.
+/// [`Child`]: process::Child
+pub trait ChildExt: private_child_ext::Sealed {
+    /// Obtains a reference to the [`PidFd`] created for this [`Child`], if available.
     ///
-    /// The pidfd can be retrieved from the child via [`ChildExt::pidfd`]
+    /// A pidfd will only be available if its creation was requested with
+    /// [`create_pidfd`] when the corresponding [`Command`] was created.
+    ///
+    /// Even if requested, a pidfd may not be available due to an older
+    /// version of Linux being in use, or if some other error occurred.
+    ///
+    /// [`Command`]: process::Command
+    /// [`create_pidfd`]: CommandExt::create_pidfd
+    /// [`Child`]: process::Child
+    fn pidfd(&self) -> Result<&PidFd>;
+
+    /// Takes ownership of the [`PidFd`] created for this [`Child`], if available.
+    ///
+    /// A pidfd will only be available if its creation was requested with
+    /// [`create_pidfd`] when the corresponding [`Command`] was created.
+    ///
+    /// Even if requested, a pidfd may not be available due to an older
+    /// version of Linux being in use, or if some other error occurred.
+    ///
+    /// [`Command`]: process::Command
+    /// [`create_pidfd`]: CommandExt::create_pidfd
+    /// [`Child`]: process::Child
+    fn take_pidfd(&mut self) -> Result<PidFd>;
+}
+
+mod private_command_ext {
+    pub trait Sealed {}
+    impl Sealed for crate::process::Command {}
+}
+
+/// Os-specific extensions for [`Command`]
+///
+/// [`Command`]: process::Command
+pub trait CommandExt: private_command_ext::Sealed {
+    /// Sets whether a [`PidFd`](struct@PidFd) should be created for the [`Child`]
+    /// spawned by this [`Command`].
+    /// By default, no pidfd will be created.
+    ///
+    /// The pidfd can be retrieved from the child with [`pidfd`] or [`take_pidfd`].
     ///
     /// A pidfd will only be created if it is possible to do so
-    /// in a guaranteed race-free manner (e.g. if the `clone3` system call is
-    /// supported). Otherwise, [`ChildExit::pidfd`] will return an error.
+    /// in a guaranteed race-free manner (e.g. if the `clone3` system call
+    /// is supported). Otherwise, [`pidfd`] will return an error.
+    ///
+    /// [`Command`]: process::Command
+    /// [`Child`]: process::Child
+    /// [`pidfd`]: fn@ChildExt::pidfd
+    /// [`take_pidfd`]: ChildExt::take_pidfd
     fn create_pidfd(&mut self, val: bool) -> &mut process::Command;
 }
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -165,7 +165,7 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 /// [`wait`]: Child::wait
 #[stable(feature = "process", since = "1.0.0")]
 pub struct Child {
-    handle: imp::Process,
+    pub(crate) handle: imp::Process,
 
     /// The handle for writing to the child's standard input (stdin), if it has
     /// been captured. To avoid partially moving

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -79,6 +79,7 @@ pub struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
+    pub(crate) make_pidfd: bool,
 }
 
 // Create a new type for argv, so that we can make it `Send` and `Sync`
@@ -141,6 +142,7 @@ impl Command {
             stdin: None,
             stdout: None,
             stderr: None,
+            make_pidfd: false,
         }
     }
 
@@ -175,6 +177,10 @@ impl Command {
     }
     pub fn groups(&mut self, groups: &[gid_t]) {
         self.groups = Some(Box::from(groups));
+    }
+    
+    pub fn create_pidfd(&mut self, val: bool) {
+        self.make_pidfd = val;
     }
 
     pub fn saw_nul(&self) -> bool {

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -79,7 +79,7 @@ pub struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
-    pub(crate) make_pidfd: bool,
+    pub(crate) create_pidfd: bool,
 }
 
 // Create a new type for argv, so that we can make it `Send` and `Sync`
@@ -142,7 +142,7 @@ impl Command {
             stdin: None,
             stdout: None,
             stderr: None,
-            make_pidfd: false,
+            create_pidfd: false,
         }
     }
 
@@ -178,9 +178,9 @@ impl Command {
     pub fn groups(&mut self, groups: &[gid_t]) {
         self.groups = Some(Box::from(groups));
     }
-    
+
     pub fn create_pidfd(&mut self, val: bool) {
-        self.make_pidfd = val;
+        self.create_pidfd = val;
     }
 
     pub fn saw_nul(&self) -> bool {

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -79,6 +79,7 @@ pub struct Command {
     stdin: Option<Stdio>,
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
+    #[cfg(target_os = "linux")]
     pub(crate) create_pidfd: bool,
 }
 
@@ -125,6 +126,28 @@ pub enum Stdio {
 }
 
 impl Command {
+    #[cfg(not(target_os = "linux"))]
+    pub fn new(program: &OsStr) -> Command {
+        let mut saw_nul = false;
+        let program = os2c(program, &mut saw_nul);
+        Command {
+            argv: Argv(vec![program.as_ptr(), ptr::null()]),
+            args: vec![program.clone()],
+            program,
+            env: Default::default(),
+            cwd: None,
+            uid: None,
+            gid: None,
+            saw_nul,
+            closures: Vec::new(),
+            groups: None,
+            stdin: None,
+            stdout: None,
+            stderr: None,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
     pub fn new(program: &OsStr) -> Command {
         let mut saw_nul = false;
         let program = os2c(program, &mut saw_nul);
@@ -179,6 +202,7 @@ impl Command {
         self.groups = Some(Box::from(groups));
     }
 
+    #[cfg(target_os = "linux")]
     pub fn create_pidfd(&mut self, val: bool) {
         self.create_pidfd = val;
     }

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -80,7 +80,7 @@ pub struct Command {
     stdout: Option<Stdio>,
     stderr: Option<Stdio>,
     #[cfg(target_os = "linux")]
-    pub(crate) create_pidfd: bool,
+    create_pidfd: bool,
 }
 
 // Create a new type for argv, so that we can make it `Send` and `Sync`
@@ -205,6 +205,17 @@ impl Command {
     #[cfg(target_os = "linux")]
     pub fn create_pidfd(&mut self, val: bool) {
         self.create_pidfd = val;
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[allow(dead_code)]
+    pub fn get_create_pidfd(&self) -> bool {
+        false
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn get_create_pidfd(&self) -> bool {
+        self.create_pidfd
     }
 
     pub fn saw_nul(&self) -> bool {

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -3,16 +3,20 @@ use crate::fmt;
 use crate::io::{self, Error, ErrorKind};
 use crate::mem;
 use crate::ptr;
+use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys;
 use crate::sys::cvt;
 use crate::sys::process::process_common::*;
-use crate::sync::atomic::{AtomicBool, Ordering};
+use crate::sys_common::FromInner;
+
+#[cfg(target_os = "linux")]
+use crate::os::linux::process::PidFd;
 
 #[cfg(target_os = "vxworks")]
 use libc::RTP_ID as pid_t;
 
 #[cfg(not(target_os = "vxworks"))]
-use libc::{c_int, gid_t, pid_t, uid_t};
+use libc::{c_int, c_long, gid_t, pid_t, uid_t};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Command
@@ -78,12 +82,12 @@ impl Command {
                 }
                 n => {
                     drop(env_lock);
-                    n as pid_t
+                    n
                 }
             }
         };
 
-        let mut p = Process { pid, status: None, pidfd };
+        let mut p = Process::new(pid, pidfd);
         drop(output);
         let mut bytes = [0; 8];
 
@@ -118,82 +122,84 @@ impl Command {
 
     // Attempts to fork the process. If successful, returns
     // Ok((0, -1)) in the child, and Ok((child_pid, child_pidfd)) in the parent.
-    fn do_fork(&mut self) -> Result<(libc::c_long, libc::pid_t), io::Error> {
+    fn do_fork(&mut self) -> Result<(pid_t, pid_t), io::Error> {
         // If we fail to create a pidfd for any reason, this will
         // stay as -1, which indicates an error
-        let mut pidfd: libc::pid_t = -1;
+        let mut pidfd: pid_t = -1;
 
         // On Linux, attempt to use the `clone3` syscall, which
-        // supports more argument (in particular, the ability to create a pidfd).
+        // supports more arguments (in particular, the ability to create a pidfd).
         // If this fails, we will fall through this block to a call to `fork()`
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                static HAS_CLONE3: AtomicBool = AtomicBool::new(true);
+        #[cfg(target_os = "linux")]
+        {
+            static HAS_CLONE3: AtomicBool = AtomicBool::new(true);
 
-                const CLONE_PIDFD: u64 = 0x00001000;
+            const CLONE_PIDFD: u64 = 0x00001000;
 
-                #[repr(C)]
-                struct clone_args {
-                    flags: u64,
-                    pidfd: u64,
-                    child_tid: u64,
-                    parent_tid: u64,
-                    exit_signal: u64,
-                    stack: u64,
-                    stack_size: u64,
-                    tls: u64,
-                    set_tid: u64,
-                    set_tid_size: u64,
-                    cgroup: u64,
+            #[repr(C)]
+            struct clone_args {
+                flags: u64,
+                pidfd: u64,
+                child_tid: u64,
+                parent_tid: u64,
+                exit_signal: u64,
+                stack: u64,
+                stack_size: u64,
+                tls: u64,
+                set_tid: u64,
+                set_tid_size: u64,
+                cgroup: u64,
+            }
+
+            syscall! {
+                fn clone3(cl_args: *mut clone_args, len: libc::size_t) -> c_long
+            }
+
+            if HAS_CLONE3.load(Ordering::Relaxed) {
+                let mut flags = 0;
+                if self.create_pidfd {
+                    flags |= CLONE_PIDFD;
                 }
 
-                syscall! {
-                    fn clone3(cl_args: *mut clone_args, len: libc::size_t) -> libc::c_long
-                }
+                let mut args = clone_args {
+                    flags,
+                    pidfd: &mut pidfd as *mut pid_t as u64,
+                    child_tid: 0,
+                    parent_tid: 0,
+                    exit_signal: libc::SIGCHLD as u64,
+                    stack: 0,
+                    stack_size: 0,
+                    tls: 0,
+                    set_tid: 0,
+                    set_tid_size: 0,
+                    cgroup: 0,
+                };
 
-                if HAS_CLONE3.load(Ordering::Relaxed) {
-                    let mut flags = 0;
-                    if self.make_pidfd {
-                        flags |= CLONE_PIDFD;
-                    }
+                let args_ptr = &mut args as *mut clone_args;
+                let args_size = crate::mem::size_of::<clone_args>();
 
-                    let mut args = clone_args {
-                        flags,
-                        pidfd: &mut pidfd as *mut libc::pid_t as u64,
-                        child_tid: 0,
-                        parent_tid: 0,
-                        exit_signal: libc::SIGCHLD as u64,
-                        stack: 0,
-                        stack_size: 0,
-                        tls: 0,
-                        set_tid: 0,
-                        set_tid_size: 0,
-                        cgroup: 0
-                    };
-
-                    let args_ptr = &mut args as *mut clone_args;
-                    let args_size = crate::mem::size_of::<clone_args>();
-
-                    let res = cvt(unsafe { clone3(args_ptr, args_size) });
-                    match res {
-                        Ok(n) => return Ok((n, pidfd)),
-                        Err(e) => match e.raw_os_error() {
-                            // Multiple threads can race to execute this store,
-                            // but that's fine - that just means that multiple threads
-                            // will have tried and failed to execute the same syscall,
-                            // with no other side effects.
-                            Some(libc::ENOSYS) => HAS_CLONE3.store(false, Ordering::Relaxed),
-                            _ => return Err(e)
-                        }
-                    }
+                let res = cvt(unsafe { clone3(args_ptr, args_size) });
+                match res {
+                    Ok(n) => return Ok((n as pid_t, pidfd)),
+                    Err(e) => match e.raw_os_error() {
+                        // Multiple threads can race to execute this store,
+                        // but that's fine - that just means that multiple threads
+                        // will have tried and failed to execute the same syscall,
+                        // with no other side effects.
+                        Some(libc::ENOSYS) => HAS_CLONE3.store(false, Ordering::Relaxed),
+                        // Fallback to fork if `EPERM` is returned. (e.g. blocked by seccomp)
+                        Some(libc::EPERM) => {}
+                        _ => return Err(e),
+                    },
                 }
             }
         }
+
         // If we get here, we are either not on Linux,
         // or we are on Linux and the 'clone3' syscall does not exist
-        cvt(unsafe { libc::fork() }.into()).map(|res| (res, pidfd))
+        // or we do not have permission to call it
+        cvt(unsafe { libc::fork() }).map(|res| (res, pidfd))
     }
-
 
     pub fn exec(&mut self, default: Stdio) -> io::Error {
         let envp = self.capture_env();
@@ -346,6 +352,8 @@ impl Command {
     #[cfg(not(any(
         target_os = "macos",
         target_os = "freebsd",
+        all(target_os = "linux", target_env = "gnu"),
+        all(target_os = "linux", target_env = "musl"),
     )))]
     fn posix_spawn(
         &mut self,
@@ -360,6 +368,8 @@ impl Command {
     #[cfg(any(
         target_os = "macos",
         target_os = "freebsd",
+        all(target_os = "linux", target_env = "gnu"),
+        all(target_os = "linux", target_env = "musl"),
     ))]
     fn posix_spawn(
         &mut self,
@@ -374,6 +384,7 @@ impl Command {
             || (self.env_saw_path() && !self.program_is_path())
             || !self.get_closures().is_empty()
             || self.get_groups().is_some()
+            || self.create_pidfd
         {
             return Ok(None);
         }
@@ -418,7 +429,7 @@ impl Command {
             None => None,
         };
 
-        let mut p = Process { pid: 0, status: None };
+        let mut p = Process::new(0, -1);
 
         struct PosixSpawnFileActions<'a>(&'a mut MaybeUninit<libc::posix_spawn_file_actions_t>);
 
@@ -508,14 +519,25 @@ pub struct Process {
     pid: pid_t,
     status: Option<ExitStatus>,
     // On Linux, stores the pidfd created for this child.
-    // This is -1 if the user did not request pidfd creation,
+    // This is None if the user did not request pidfd creation,
     // or if the pidfd could not be created for some reason
     // (e.g. the `clone3` syscall was not available).
     #[cfg(target_os = "linux")]
-    pidfd: libc::c_int,
+    pidfd: Option<PidFd>,
 }
 
 impl Process {
+    #[cfg(target_os = "linux")]
+    fn new(pid: pid_t, pidfd: pid_t) -> Self {
+        let pidfd = (pidfd >= 0).then(|| PidFd::from_inner(sys::fd::FileDesc::new(pidfd)));
+        Process { pid, status: None, pidfd }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn new(pid: pid_t, _pidfd: pid_t) -> Self {
+        Process { pid, status: None }
+    }
+
     pub fn id(&self) -> u32 {
         self.pid as u32
     }
@@ -632,12 +654,18 @@ impl fmt::Display for ExitStatus {
 #[cfg(target_os = "linux")]
 #[unstable(feature = "linux_pidfd", issue = "none")]
 impl crate::os::linux::process::ChildExt for crate::process::Child {
-    fn pidfd(&self) -> crate::io::Result<i32> {
-        if self.handle.pidfd > 0 {
-            Ok(self.handle.pidfd)
-        } else {
-            Err(crate::io::Error::from(crate::io::ErrorKind::Other))
-        }
+    fn pidfd(&self) -> io::Result<&PidFd> {
+        self.handle
+            .pidfd
+            .as_ref()
+            .ok_or_else(|| Error::new(ErrorKind::Other, "No pidfd was created."))
+    }
+
+    fn take_pidfd(&mut self) -> io::Result<PidFd> {
+        self.handle
+            .pidfd
+            .take()
+            .ok_or_else(|| Error::new(ErrorKind::Other, "No pidfd was created."))
     }
 }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -652,7 +652,7 @@ impl fmt::Display for ExitStatus {
 }
 
 #[cfg(target_os = "linux")]
-#[unstable(feature = "linux_pidfd", issue = "none")]
+#[unstable(feature = "linux_pidfd", issue = "82971")]
 impl crate::os::linux::process::ChildExt for crate::process::Child {
     fn pidfd(&self) -> io::Result<&PidFd> {
         self.handle

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -162,7 +162,7 @@ impl Command {
         // we will fall through this block to a call to `fork()`
         if HAS_CLONE3.load(Ordering::Relaxed) {
             let mut flags = 0;
-            if self.create_pidfd {
+            if self.get_create_pidfd() {
                 flags |= CLONE_PIDFD;
             }
 
@@ -387,7 +387,7 @@ impl Command {
             || (self.env_saw_path() && !self.program_is_path())
             || !self.get_closures().is_empty()
             || self.get_groups().is_some()
-            || self.create_pidfd
+            || self.get_create_pidfd()
         {
             return Ok(None);
         }

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -6,6 +6,7 @@ use crate::ptr;
 use crate::sys;
 use crate::sys::cvt;
 use crate::sys::process::process_common::*;
+use crate::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_os = "vxworks")]
 use libc::RTP_ID as pid_t;
@@ -48,7 +49,8 @@ impl Command {
         // a lock any more because the parent won't do anything and the child is
         // in its own process. Thus the parent drops the lock guard while the child
         // forgets it to avoid unlocking it on a new thread, which would be invalid.
-        let (env_lock, result) = unsafe { (sys::os::env_read_lock(), cvt(libc::fork())?) };
+        let env_lock = sys::os::env_read_lock();
+        let (result, pidfd) = self.do_fork()?;
 
         let pid = unsafe {
             match result {
@@ -76,12 +78,12 @@ impl Command {
                 }
                 n => {
                     drop(env_lock);
-                    n
+                    n as pid_t
                 }
             }
         };
 
-        let mut p = Process { pid, status: None };
+        let mut p = Process { pid, status: None, pidfd };
         drop(output);
         let mut bytes = [0; 8];
 
@@ -113,6 +115,85 @@ impl Command {
             }
         }
     }
+
+    // Attempts to fork the process. If successful, returns
+    // Ok((0, -1)) in the child, and Ok((child_pid, child_pidfd)) in the parent.
+    fn do_fork(&mut self) -> Result<(libc::c_long, libc::pid_t), io::Error> {
+        // If we fail to create a pidfd for any reason, this will
+        // stay as -1, which indicates an error
+        let mut pidfd: libc::pid_t = -1;
+
+        // On Linux, attempt to use the `clone3` syscall, which
+        // supports more argument (in prarticular, the ability to create a pidfd).
+        // If this fails, we will fall through this block to a call to `fork()`
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                static HAS_CLONE3: AtomicBool = AtomicBool::new(true);
+
+                const CLONE_PIDFD: u64 = 0x00001000;
+
+                #[repr(C)]
+                struct clone_args {
+                    flags: u64,
+                    pidfd: u64,
+                    child_tid: u64,
+                    parent_tid: u64,
+                    exit_signal: u64,
+                    stack: u64,
+                    stack_size: u64,
+                    tls: u64,
+                    set_tid: u64,
+                    set_tid_size: u64,
+                    cgroup: u64,
+                }
+
+                syscall! {
+                    fn clone3(cl_args: *mut clone_args, len: libc::size_t) -> libc::c_long
+                }
+
+                if HAS_CLONE3.load(Ordering::Relaxed) {
+                    let mut flags = 0;
+                    if self.make_pidfd {
+                        flags |= CLONE_PIDFD;
+                    }
+
+                    let mut args = clone_args {
+                        flags,
+                        pidfd: &mut pidfd as *mut libc::pid_t as u64,
+                        child_tid: 0,
+                        parent_tid: 0,
+                        exit_signal: libc::SIGCHLD as u64,
+                        stack: 0,
+                        stack_size: 0,
+                        tls: 0,
+                        set_tid: 0,
+                        set_tid_size: 0,
+                        cgroup: 0
+                    };
+
+                    let args_ptr = &mut args as *mut clone_args;
+                    let args_size = crate::mem::size_of::<clone_args>();
+
+                    let res = cvt(unsafe { clone3(args_ptr, args_size) });
+                    match res {
+                        Ok(n) => return Ok((n, pidfd)),
+                        Err(e) => match e.raw_os_error() {
+                            // Multiple threads can race to execute this store,
+                            // but that's fine - that just means that multiple threads
+                            // will have tried and failed to execute the same syscall,
+                            // with no other side effects.
+                            Some(libc::ENOSYS) => HAS_CLONE3.store(false, Ordering::Relaxed),
+                            _ => return Err(e)
+                        }
+                    }
+                }
+            }
+        }
+        // If we get here, we are either not on Linux,
+        // or we are on Linux and the 'clone3' syscall does not exist
+        cvt(unsafe { libc::fork() }.into()).map(|res| (res, pidfd))
+    }
+
 
     pub fn exec(&mut self, default: Stdio) -> io::Error {
         let envp = self.capture_env();
@@ -265,8 +346,6 @@ impl Command {
     #[cfg(not(any(
         target_os = "macos",
         target_os = "freebsd",
-        all(target_os = "linux", target_env = "gnu"),
-        all(target_os = "linux", target_env = "musl"),
     )))]
     fn posix_spawn(
         &mut self,
@@ -281,8 +360,6 @@ impl Command {
     #[cfg(any(
         target_os = "macos",
         target_os = "freebsd",
-        all(target_os = "linux", target_env = "gnu"),
-        all(target_os = "linux", target_env = "musl"),
     ))]
     fn posix_spawn(
         &mut self,
@@ -430,6 +507,12 @@ impl Command {
 pub struct Process {
     pid: pid_t,
     status: Option<ExitStatus>,
+    // On Linux, stores the pidfd created for this child.
+    // This is -1 if the user did not request pidfd creation,
+    // or if the pidfd could not be created for some reason
+    // (e.g. the `clone3` syscall was not available).
+    #[cfg(target_os = "linux")]
+    pidfd: libc::c_int,
 }
 
 impl Process {
@@ -542,6 +625,18 @@ impl fmt::Display for ExitStatus {
             write!(f, "continued (WIFCONTINUED)")
         } else {
             write!(f, "unrecognised wait status: {} {:#x}", self.0, self.0)
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[unstable(feature = "linux_pidfd", issue = "none")]
+impl crate::os::linux::process::ChildExt for crate::process::Child {
+    fn pidfd(&self) -> crate::io::Result<i32> {
+        if self.handle.pidfd > 0 {
+            Ok(self.handle.pidfd)
+        } else {
+            Err(crate::io::Error::from(crate::io::ErrorKind::Other))
         }
     }
 }

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -124,7 +124,7 @@ impl Command {
         let mut pidfd: libc::pid_t = -1;
 
         // On Linux, attempt to use the `clone3` syscall, which
-        // supports more argument (in prarticular, the ability to create a pidfd).
+        // supports more argument (in particular, the ability to create a pidfd).
         // If this fails, we will fall through this block to a call to `fork()`
         cfg_if::cfg_if! {
             if #[cfg(target_os = "linux")] {

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -54,12 +54,10 @@ impl DocFolder for SourceCollector<'_, '_> {
             self.scx.include_sources = match self.emit_source(&filename) {
                 Ok(()) => true,
                 Err(e) => {
-                    println!(
-                        "warning: source code was requested to be rendered, \
-                         but processing `{}` had an error: {}",
-                        filename, e
+                    self.scx.tcx.sess.span_err(
+                        item.span.inner(),
+                        &format!("failed to render source code for `{}`: {}", filename, e),
                     );
-                    println!("         skipping rendering of source code");
                     false
                 }
             };

--- a/src/test/ui/asm/srcloc.rs
+++ b/src/test/ui/asm/srcloc.rs
@@ -1,7 +1,7 @@
 // no-system-llvm
 // only-x86_64
 // build-fail
-
+// compile-flags: -Ccodegen-units=1
 #![feature(asm)]
 
 // Checks that inline asm errors are mapped to the correct line in the source code.

--- a/src/test/ui/asm/sym.rs
+++ b/src/test/ui/asm/sym.rs
@@ -76,5 +76,5 @@ fn main() {
     std::thread::spawn(|| {
         assert_eq!(static_addr!(S1), &S1 as *const u32);
         assert_eq!(static_tls_addr!(S2), &S2 as *const u32);
-    });
+    }).join().unwrap();
 }

--- a/src/test/ui/command/command-create-pidfd.rs
+++ b/src/test/ui/command/command-create-pidfd.rs
@@ -1,5 +1,5 @@
 // run-pass
-// linux-only - pidfds are a linux-specific concept
+// only-linux - pidfds are a linux-specific concept
 
 #![feature(linux_pidfd)]
 use std::os::linux::process::{CommandExt, ChildExt};

--- a/src/test/ui/command/command-create-pidfd.rs
+++ b/src/test/ui/command/command-create-pidfd.rs
@@ -1,0 +1,27 @@
+// run-pass
+// linux-only - pidfds are a linux-specific concept
+
+#![feature(linux_pidfd)]
+use std::os::linux::process::{CommandExt, ChildExt};
+use std::process::Command;
+
+fn main() {
+    // We don't assert the precise value, since the standard libarary
+    // may be opened other file descriptors before our code ran.
+    let _ = Command::new("echo")
+        .create_pidfd(true)
+        .spawn()
+        .unwrap()
+        .pidfd().expect("failed to obtain pidfd");
+
+    let _ = Command::new("echo")
+        .create_pidfd(false)
+        .spawn()
+        .unwrap()
+        .pidfd().expect_err("pidfd should not have been created when create_pid(false) is set");
+
+    let _ = Command::new("echo")
+        .spawn()
+        .unwrap()
+        .pidfd().expect_err("pidfd should not have been created");
+}

--- a/src/test/ui/command/command-create-pidfd.rs
+++ b/src/test/ui/command/command-create-pidfd.rs
@@ -6,8 +6,8 @@ use std::os::linux::process::{CommandExt, ChildExt};
 use std::process::Command;
 
 fn main() {
-    // We don't assert the precise value, since the standard libarary
-    // may be opened other file descriptors before our code ran.
+    // We don't assert the precise value, since the standard library
+    // might have opened other file descriptors before our code runs.
     let _ = Command::new("echo")
         .create_pidfd(true)
         .spawn()

--- a/src/test/ui/command/command-pre-exec.rs
+++ b/src/test/ui/command/command-pre-exec.rs
@@ -66,24 +66,6 @@ fn main() {
     };
     assert_eq!(output.raw_os_error(), Some(102));
 
-    let pid = unsafe { libc::getpid() };
-    assert!(pid >= 0);
-    let output = unsafe {
-        Command::new(&me)
-            .arg("empty")
-            .pre_exec(move || {
-                let child = libc::getpid();
-                assert!(child >= 0);
-                assert!(pid != child);
-                Ok(())
-            })
-            .output()
-            .unwrap()
-    };
-    assert!(output.status.success());
-    assert!(output.stderr.is_empty());
-    assert!(output.stdout.is_empty());
-
     let mem = Arc::new(AtomicUsize::new(0));
     let mem2 = mem.clone();
     let output = unsafe {

--- a/src/test/ui/macros/issue-83340.rs
+++ b/src/test/ui/macros/issue-83340.rs
@@ -1,0 +1,8 @@
+// check-fail
+
+fn main() {
+    println!(
+        "\
+\n {} │", //~ ERROR: 1 positional argument in format string, but no arguments were given
+    );
+}

--- a/src/test/ui/macros/issue-83340.stderr
+++ b/src/test/ui/macros/issue-83340.stderr
@@ -1,0 +1,8 @@
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/issue-83340.rs:6:4
+   |
+LL | \n {} │",
+   |    ^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/macros/issue-83344.rs
+++ b/src/test/ui/macros/issue-83344.rs
@@ -1,0 +1,6 @@
+// chekc-fail
+
+fn main() {
+    println!("{}\
+"); //~^ ERROR: 1 positional argument in format string, but no arguments were given
+}

--- a/src/test/ui/macros/issue-83344.stderr
+++ b/src/test/ui/macros/issue-83344.stderr
@@ -1,0 +1,8 @@
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/issue-83344.rs:4:15
+   |
+LL |     println!("{}\
+   |               ^^
+
+error: aborting due to previous error
+

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -32,7 +32,6 @@ const EXCEPTIONS: &[(&str, &str)] = &[
     ("fuchsia-zircon", "BSD-3-Clause"), // rustdoc, rustc, cargo (jobserver & tempdir)
     ("colored", "MPL-2.0"),             // rustfmt
     ("ordslice", "Apache-2.0"),         // rls
-    ("cloudabi", "BSD-2-Clause"),       // (rls -> crossbeam-channel 0.2 -> rand 0.5)
     ("ryu", "Apache-2.0 OR BSL-1.0"),   // rls/cargo/... (because of serde)
     ("bytesize", "Apache-2.0"),         // cargo
     ("im-rc", "MPL-2.0+"),              // cargo
@@ -76,7 +75,6 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "cfg-if",
     "chalk-derive",
     "chalk-ir",
-    "cloudabi",
     "cmake",
     "compiler_builtins",
     "cpuid-bool",


### PR DESCRIPTION
Successful merges:

 - #81825 (Add Linux-specific pidfd process extensions (take 2))
 - #82993 (rustdoc: Use diagnostics for error when including sources)
 - #83239 (Remove/replace some outdated crates from the dependency tree)
 - #83328 (Fixes to inline assmebly tests)
 - #83343 (Simplify and fix byte skipping in format! string parser)
 - #83348 (format macro argument parsing fix)
 - #83388 (Make # pretty print format easier to discover)
 - #83431 (Tell GitHub to highlight `config.toml.example` as TOML)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=81825,82993,83239,83328,83343,83348,83388,83431)
<!-- homu-ignore:end -->