### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@
 src/etc/installer/gfx/* binary
 src/vendor/** -text
 Cargo.lock linguist-generated=false
+config.toml.example linguist-language=TOML
 
 # Older git versions try to fix line endings on images and fonts, this prevents it.
 *.png binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,11 +252,11 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecount"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e"
+checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 dependencies = [
- "packed_simd",
+ "packed_simd_2",
 ]
 
 [[package]]
@@ -1902,6 +1902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.4+1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,12 +2441,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "packed_simd"
-version = "0.3.3"
+name = "packed_simd_2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85ea9fc0d4ac0deb6fe7911d38786b32fc11119afd9e9d38b84ff691ce64220"
+checksum = "3278e0492f961fd4ae70909f56b2723a7e8d01a228427294e19cdfdebda89a17"
 dependencies = [
  "cfg-if 0.1.10",
+ "libm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,15 +614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",
@@ -2503,15 +2494,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall 0.2.5",
  "smallvec 1.6.1",
  "winapi 0.3.9",
 ]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -35,7 +35,7 @@ Compiler
 - [Added tier 3 support for `i386-unknown-linux-gnu` and `i486-unknown-linux-gnu` targets.][80662]
 - [The `target-cpu=native` option will now detect individual features of CPUs.][80749]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -183,7 +183,7 @@ Compiler
 - [The `x86_64-unknown-freebsd` is now built with the full toolset.][79484]
 - [Dropped support for all cloudabi targets.][78439]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -360,7 +360,7 @@ Compiler
 - [Output from threads spawned in tests is now captured.][78227]
 - [Change os and vendor values to "none" and "unknown" for some targets][78951]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -465,7 +465,7 @@ Compiler
   Note: If you're using cargo you must explicitly pass the `--target` flag.
 - [Added tier 2\* support for `aarch64-unknown-linux-musl`.][76420]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -604,7 +604,7 @@ Compiler
 - [Upgrade the FreeBSD toolchain to version 11.4][75204]
 - [`RUST_BACKTRACE`'s output is now more compact.][75048]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -889,7 +889,7 @@ Compiler
 - [Added tier 3 support for the `thumbv7a-uwp-windows-msvc` target.][72133]
 - [Upgraded to LLVM 10.][67759]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 
@@ -1398,7 +1398,7 @@ Compiler
    pointing to the location where they were called, rather than
    `core`'s internals. ][67887]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -1496,7 +1496,7 @@ Compiler
 - [You can now provide `--extern` flag without a path, indicating that it is
   available from the search path or specified with an `-L` flag.][64882]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 [argfile-docs]: https://doc.rust-lang.org/nightly/rustc/command-line-arguments.html#path-load-command-line-flags-from-a-path
@@ -1620,7 +1620,7 @@ Compiler
 - [Added tier 3 support for the `mips64-unknown-linux-muslabi64`, and
   `mips64el-unknown-linux-muslabi64` targets.][65843]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
   information on Rust's tiered platform support.
 
 Libraries
@@ -1770,7 +1770,7 @@ Compiler
   output of successful tests.][62600]
 
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -1864,7 +1864,7 @@ Compiler
 - [Added tier 3 support for the `riscv32i-unknown-none-elf` target.][62784]
 - [Upgraded to LLVM 9.][62592]
 
-\* Refer to Rust's [platform support page][forge-platform-support] for more
+\* Refer to Rust's [platform support page][platform-support-doc] for more
 information on Rust's tiered platform support.
 
 Libraries
@@ -1951,7 +1951,7 @@ Compatibility Notes
 [`Duration::mul_f32`]: https://doc.rust-lang.org/std/time/struct.Duration.html#method.mul_f32
 [`Duration::mul_f64`]: https://doc.rust-lang.org/std/time/struct.Duration.html#method.mul_f64
 [`any::type_name`]: https://doc.rust-lang.org/std/any/fn.type_name.html
-[forge-platform-support]: https://forge.rust-lang.org/release/platform-support.html
+[platform-support-doc]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 [pipeline-internals]: https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199
 
 Version 1.37.0 (2019-08-15)

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -160,7 +160,7 @@ pub enum TyKind<'tcx> {
     /// ```
     FnPtr(PolyFnSig<'tcx>),
 
-    /// A trait, defined with `trait`.
+    /// A trait object. Written as `dyn for<'b> Trait<'b, Assoc = u32> + Send + 'a`.
     Dynamic(&'tcx List<Binder<ExistentialPredicate<'tcx>>>, ty::Region<'tcx>),
 
     /// The anonymous type of a closure. Used to represent the type of

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -213,11 +213,13 @@ impl<'a> Iterator for Parser<'a> {
                         Some(String(self.string(pos + 1)))
                     } else {
                         let arg = self.argument();
-                        if let Some(end) = self.must_consume('}') {
-                            let start = self.to_span_index(pos);
-                            let end = self.to_span_index(end + 1);
+                        if let Some(rbrace_byte_idx) = self.must_consume('}') {
+                            let lbrace_inner_offset = self.to_span_index(pos);
+                            let rbrace_inner_offset = self.to_span_index(rbrace_byte_idx);
                             if self.is_literal {
-                                self.arg_places.push(start.to(end));
+                                self.arg_places.push(
+                                    lbrace_inner_offset.to(InnerOffset(rbrace_inner_offset.0 + 1)),
+                                );
                             }
                         }
                         Some(NextArgument(arg))

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -735,25 +735,24 @@ fn find_skips_from_snippet(
     };
 
     fn find_skips(snippet: &str, is_raw: bool) -> Vec<usize> {
-        let mut eat_ws = false;
         let mut s = snippet.char_indices().peekable();
         let mut skips = vec![];
         while let Some((pos, c)) = s.next() {
             match (c, s.peek()) {
                 // skip whitespace and empty lines ending in '\\'
                 ('\\', Some((next_pos, '\n'))) if !is_raw => {
-                    eat_ws = true;
                     skips.push(pos);
                     skips.push(*next_pos);
                     let _ = s.next();
-                }
-                ('\\', Some((next_pos, '\n' | 'n' | 't'))) if eat_ws => {
-                    skips.push(pos);
-                    skips.push(*next_pos);
-                    let _ = s.next();
-                }
-                (' ' | '\n' | '\t', _) if eat_ws => {
-                    skips.push(pos);
+
+                    while let Some((pos, c)) = s.peek() {
+                        if matches!(c, ' ' | '\n' | '\t') {
+                            skips.push(*pos);
+                            let _ = s.next();
+                        } else {
+                            break;
+                        }
+                    }
                 }
                 ('\\', Some((next_pos, 'n' | 't' | 'r' | '0' | '\\' | '\'' | '\"'))) => {
                     skips.push(*next_pos);
@@ -803,10 +802,6 @@ fn find_skips_from_snippet(
                             }
                         }
                     }
-                }
-                _ if eat_ws => {
-                    // `take_while(|c| c.is_whitespace())`
-                    eat_ws = false;
                 }
                 _ => {}
             }

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -19,6 +19,10 @@
 //! format!("{value}", value=4);      // => "4"
 //! format!("{} {}", 1, 2);           // => "1 2"
 //! format!("{:04}", 42);             // => "0042" with leading zeros
+//! format!("{:#?}", (100, 200));     // => "(
+//!                                   //       100,
+//!                                   //       200,
+//!                                   //     )"
 //! ```
 //!
 //! From these, you can see that the first argument is a format string. It is
@@ -163,7 +167,7 @@
 //! * `-` - Currently not used
 //! * `#` - This flag indicates that the "alternate" form of printing should
 //!         be used. The alternate forms are:
-//!     * `#?` - pretty-print the [`Debug`] formatting
+//!     * `#?` - pretty-print the [`Debug`] formatting (newline and indent)
 //!     * `#x` - precedes the argument with a `0x`
 //!     * `#X` - precedes the argument with a `0x`
 //!     * `#b` - precedes the argument with a `0b`

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -167,7 +167,7 @@
 //! * `-` - Currently not used
 //! * `#` - This flag indicates that the "alternate" form of printing should
 //!         be used. The alternate forms are:
-//!     * `#?` - pretty-print the [`Debug`] formatting (newline and indent)
+//!     * `#?` - pretty-print the [`Debug`] formatting (adds linebreaks and indentation)
 //!     * `#x` - precedes the argument with a `0x`
 //!     * `#X` - precedes the argument with a `0x`
 //!     * `#b` - precedes the argument with a `0b`

--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -57,7 +57,8 @@ pub enum SocketAddr {
 /// See [`SocketAddr`] for a type encompassing both IPv4 and IPv6 socket addresses.
 ///
 /// The size of a `SocketAddrV4` struct may vary depending on the target operating
-/// system.
+/// system. Do not assume that this type has the same memory layout as the underlying
+/// system representation.
 ///
 /// [IETF RFC 793]: https://tools.ietf.org/html/rfc793
 /// [`IPv4` address]: Ipv4Addr
@@ -76,6 +77,8 @@ pub enum SocketAddr {
 #[derive(Copy)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SocketAddrV4 {
+    // Do not assume that this struct is implemented as the underlying system representation.
+    // The memory layout is not part of the stable interface that std exposes.
     inner: c::sockaddr_in,
 }
 
@@ -88,7 +91,8 @@ pub struct SocketAddrV4 {
 /// See [`SocketAddr`] for a type encompassing both IPv4 and IPv6 socket addresses.
 ///
 /// The size of a `SocketAddrV6` struct may vary depending on the target operating
-/// system.
+/// system. Do not assume that this type has the same memory layout as the underlying
+/// system representation.
 ///
 /// [IETF RFC 2553, Section 3.3]: https://tools.ietf.org/html/rfc2553#section-3.3
 /// [`IPv6` address]: Ipv6Addr
@@ -107,6 +111,8 @@ pub struct SocketAddrV4 {
 #[derive(Copy)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SocketAddrV6 {
+    // Do not assume that this struct is implemented as the underlying system representation.
+    // The memory layout is not part of the stable interface that std exposes.
     inner: c::sockaddr_in6,
 }
 

--- a/src/test/ui/asm/srcloc.rs
+++ b/src/test/ui/asm/srcloc.rs
@@ -1,7 +1,7 @@
 // no-system-llvm
 // only-x86_64
 // build-fail
-
+// compile-flags: -Ccodegen-units=1
 #![feature(asm)]
 
 // Checks that inline asm errors are mapped to the correct line in the source code.

--- a/src/test/ui/asm/sym.rs
+++ b/src/test/ui/asm/sym.rs
@@ -76,5 +76,5 @@ fn main() {
     std::thread::spawn(|| {
         assert_eq!(static_addr!(S1), &S1 as *const u32);
         assert_eq!(static_tls_addr!(S2), &S2 as *const u32);
-    });
+    }).join().unwrap();
 }

--- a/src/test/ui/macros/issue-83340.rs
+++ b/src/test/ui/macros/issue-83340.rs
@@ -1,0 +1,8 @@
+// check-fail
+
+fn main() {
+    println!(
+        "\
+\n {} │", //~ ERROR: 1 positional argument in format string, but no arguments were given
+    );
+}

--- a/src/test/ui/macros/issue-83340.stderr
+++ b/src/test/ui/macros/issue-83340.stderr
@@ -1,0 +1,8 @@
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/issue-83340.rs:6:4
+   |
+LL | \n {} │",
+   |    ^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/macros/issue-83344.rs
+++ b/src/test/ui/macros/issue-83344.rs
@@ -1,0 +1,6 @@
+// chekc-fail
+
+fn main() {
+    println!("{}\
+"); //~^ ERROR: 1 positional argument in format string, but no arguments were given
+}

--- a/src/test/ui/macros/issue-83344.stderr
+++ b/src/test/ui/macros/issue-83344.stderr
@@ -1,0 +1,8 @@
+error: 1 positional argument in format string, but no arguments were given
+  --> $DIR/issue-83344.rs:4:15
+   |
+LL |     println!("{}\
+   |               ^^
+
+error: aborting due to previous error
+

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -973,7 +973,11 @@ fn parse_normalization_string(line: &mut &str) -> Option<String> {
 }
 
 pub fn extract_llvm_version(version: &str) -> Option<u32> {
-    let version_without_suffix = version.trim_end_matches("git").split('-').next().unwrap();
+    let pat = |c: char| !c.is_ascii_digit() && c != '.';
+    let version_without_suffix = match version.find(pat) {
+        Some(pos) => &version[..pos],
+        None => version,
+    };
     let components: Vec<u32> = version_without_suffix
         .split('.')
         .map(|s| s.parse().expect("Malformed version component"))

--- a/src/tools/compiletest/src/tests.rs
+++ b/src/tools/compiletest/src/tests.rs
@@ -68,4 +68,8 @@ fn test_extract_llvm_version() {
     assert_eq!(extract_llvm_version("9.0.1-rust-1.43.0-dev"), Some(90001));
     assert_eq!(extract_llvm_version("9.3.1-rust-1.43.0-dev"), Some(90301));
     assert_eq!(extract_llvm_version("10.0.0-rust"), Some(100000));
+    assert_eq!(extract_llvm_version("11.1.0"), Some(110100));
+    assert_eq!(extract_llvm_version("12.0.0libcxx"), Some(120000));
+    assert_eq!(extract_llvm_version("12.0.0-rc3"), Some(120000));
+    assert_eq!(extract_llvm_version("13.0.0git"), Some(130000));
 }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -32,7 +32,6 @@ const EXCEPTIONS: &[(&str, &str)] = &[
     ("fuchsia-zircon", "BSD-3-Clause"), // rustdoc, rustc, cargo (jobserver & tempdir)
     ("colored", "MPL-2.0"),             // rustfmt
     ("ordslice", "Apache-2.0"),         // rls
-    ("cloudabi", "BSD-2-Clause"),       // (rls -> crossbeam-channel 0.2 -> rand 0.5)
     ("ryu", "Apache-2.0 OR BSL-1.0"),   // rls/cargo/... (because of serde)
     ("bytesize", "Apache-2.0"),         // cargo
     ("im-rc", "MPL-2.0+"),              // cargo
@@ -76,7 +75,6 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "cfg-if",
     "chalk-derive",
     "chalk-ir",
-    "cloudabi",
     "cmake",
     "compiler_builtins",
     "cpuid-bool",


### PR DESCRIPTION
Successful merges:

 - #83239 (Remove/replace some outdated crates from the dependency tree)
 - #83328 (Fixes to inline assmebly tests)
 - #83343 (Simplify and fix byte skipping in format! string parser)
 - #83348 (format macro argument parsing fix)
 - #83388 (Make # pretty print format easier to discover)
 - #83431 (Tell GitHub to highlight `config.toml.example` as TOML)
 - #83508 (Use the direct link to the platform support page)
 - #83511 (compiletest: handle llvm_version with suffix like "12.0.0libcxx")
 - #83524 (Document that the SocketAddr memory representation is not stable)
 - #83525 (fix doc comment for `ty::Dynamic`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83239,83328,83343,83348,83388,83431,83508,83511,83524,83525)
<!-- homu-ignore:end -->