### PR TITLE
Add intra-doc `field@` disambiguator

### DIFF
--- a/src/test/rustdoc/intra-doc/field-disambiguator.rs
+++ b/src/test/rustdoc/intra-doc/field-disambiguator.rs
@@ -1,15 +1,29 @@
 #![crate_name = "foo"]
 
-pub struct Foo {
-    pub bar: i32,
+pub struct MyStruct {
+    pub my_field: i32,
 }
 
-impl Foo {
-    /// [`Foo::bar()`] gets a reference to [`field@Foo::bar`].
-    /// What about [without disambiguators](Foo::bar)?
-    // @has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#method.bar"]' 'Foo::bar()'
-    // @has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#structfield.bar"]' 'Foo::bar'
-    // @!has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#structfield.bar"]' 'field'
-    // @has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#method.bar"]' 'without disambiguators'
+impl MyStruct {
+    /// [`MyStruct::my_field()`] gets a reference to [`field@MyStruct::my_field`].
+    /// What about [without disambiguators](MyStruct::my_field)?
+    // @has foo/struct.MyStruct.html '//a[@href="../foo/struct.MyStruct.html#method.my_field"]' 'MyStruct::my_field()'
+    // @has - '//a[@href="../foo/struct.MyStruct.html#structfield.my_field"]' 'MyStruct::my_field'
+    // @!has - '//a' 'field'
+    // @has - '//a[@href="../foo/struct.MyStruct.html#method.my_field"]' 'without disambiguators'
+    pub fn my_field(&self) -> i32 { self.bar }
+}
+
+pub enum MyEnum {
+    MyVariant { my_field: i32 },
+}
+
+impl MyEnum {
+    /// [`MyEnum::my_field()`] gets a reference to [`field@MyEnum::MyVariant::my_field`].
+    /// What about [without disambiguators](MyEnum::MyVariant::my_field)?
+    // @has foo/enum.MyEnum.html '//a[@href="../foo/enum.MyEnum.html#method.my_field"]' 'MyEnum::MyVariant::my_field()'
+    // @has - '//a[@href="../foo/enum.MyEnum.html#enumfield.my_field"]' 'MyEnum::MyVariant::my_field'
+    // @!has - '//a' 'field'
+    // @has - '//a[@href="../foo/enum.MyEnum.html#method.my_field"]' 'without disambiguators'
     pub fn bar(&self) -> i32 { self.bar }
 }

--- a/src/test/rustdoc/intra-doc/field-disambiguator.rs
+++ b/src/test/rustdoc/intra-doc/field-disambiguator.rs
@@ -1,0 +1,15 @@
+#![crate_name = "foo"]
+
+pub struct Foo {
+    pub bar: i32,
+}
+
+impl Foo {
+    /// [`Foo::bar()`] gets a reference to [`field@Foo::bar`].
+    /// What about [without disambiguators](Foo::bar)?
+    // @has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#method.bar"]' 'Foo::bar()'
+    // @has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#structfield.bar"]' 'Foo::bar'
+    // @!has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#structfield.bar"]' 'field'
+    // @has foo/struct.Foo.html '//a[@href="../foo/struct.Foo.html#method.bar"]' 'without disambiguators'
+    pub fn bar(&self) -> i32 { self.bar }
+}


### PR DESCRIPTION
This change required some refactoring because fields (1) don't get their
own `Res` (instead they seem to use the `Res` of their parent node) and
(2) `DefKind::Field::ns()` returns `None`, so rustdoc has to
special-case fields. For some reason, we treat fields as if they're in
the value namespace - I'm not sure why that is.

Fixes https://github.com/rust-lang/rust/issues/80283.