### PR TITLE
Always preserve `None`-delimited groups in a captured `TokenStream`

### DIFF
--- a/src/test/ui/proc-macro/auxiliary/nested-macro-rules.rs
+++ b/src/test/ui/proc-macro/auxiliary/nested-macro-rules.rs
@@ -2,14 +2,15 @@ pub struct FirstStruct;
 
 #[macro_export]
 macro_rules! outer_macro {
-    ($name:ident) => {
+    ($name:ident, $attr_struct_name:ident) => {
         #[macro_export]
         macro_rules! inner_macro {
-            ($wrapper:ident) => {
-                $wrapper!($name)
+            ($bang_macro:ident, $attr_macro:ident) => {
+                $bang_macro!($name);
+                #[$attr_macro] struct $attr_struct_name {}
             }
         }
     }
 }
 
-outer_macro!(FirstStruct);
+outer_macro!(FirstStruct, FirstAttrStruct);

--- a/src/test/ui/proc-macro/nested-macro-rules.rs
+++ b/src/test/ui/proc-macro/nested-macro-rules.rs
@@ -1,7 +1,7 @@
 // run-pass
 // aux-build:nested-macro-rules.rs
 // aux-build:test-macros.rs
-// compile-flags: -Z span-debug
+// compile-flags: -Z span-debug -Z macro-backtrace
 // edition:2018
 
 #![no_std] // Don't load unnecessary hygiene information from std
@@ -10,14 +10,14 @@ extern crate std;
 extern crate nested_macro_rules;
 extern crate test_macros;
 
-use test_macros::print_bang;
+use test_macros::{print_bang, print_attr};
 
 use nested_macro_rules::FirstStruct;
 struct SecondStruct;
 
 fn main() {
-    nested_macro_rules::inner_macro!(print_bang);
+    nested_macro_rules::inner_macro!(print_bang, print_attr);
 
-    nested_macro_rules::outer_macro!(SecondStruct);
-    inner_macro!(print_bang);
+    nested_macro_rules::outer_macro!(SecondStruct, SecondAttrStruct);
+    inner_macro!(print_bang, print_attr);
 }

--- a/src/test/ui/proc-macro/nested-macro-rules.stdout
+++ b/src/test/ui/proc-macro/nested-macro-rules.stdout
@@ -5,10 +5,32 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         stream: TokenStream [
             Ident {
                 ident: "FirstStruct",
-                span: $DIR/auxiliary/nested-macro-rules.rs:15:14: 15:25 (#7),
+                span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#7),
             },
         ],
-        span: $DIR/auxiliary/nested-macro-rules.rs:9:27: 9:32 (#6),
+        span: $DIR/auxiliary/nested-macro-rules.rs:9:30: 9:35 (#6),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): struct FirstAttrStruct { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "struct",
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#6),
+    },
+    Group {
+        delimiter: None,
+        stream: TokenStream [
+            Ident {
+                ident: "FirstAttrStruct",
+                span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#7),
+            },
+        ],
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:39: 10:56 (#6),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#6),
     },
 ]
 PRINT-BANG INPUT (DISPLAY): SecondStruct
@@ -18,9 +40,31 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
         stream: TokenStream [
             Ident {
                 ident: "SecondStruct",
-                span: $DIR/nested-macro-rules.rs:21:38: 21:50 (#13),
+                span: $DIR/nested-macro-rules.rs:21:38: 21:50 (#16),
             },
         ],
-        span: $DIR/auxiliary/nested-macro-rules.rs:9:27: 9:32 (#12),
+        span: $DIR/auxiliary/nested-macro-rules.rs:9:30: 9:35 (#15),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): struct SecondAttrStruct { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "struct",
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#15),
+    },
+    Group {
+        delimiter: None,
+        stream: TokenStream [
+            Ident {
+                ident: "SecondAttrStruct",
+                span: $DIR/nested-macro-rules.rs:21:52: 21:68 (#16),
+            },
+        ],
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:39: 10:56 (#15),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/auxiliary/nested-macro-rules.rs:10:57: 10:59 (#15),
     },
 ]


### PR DESCRIPTION
Previously, we would silently remove any `None`-delimiters when
capturing a `TokenStream`, 'flattenting' them to their inner tokens.
This was not normally visible, since we usually have
`TokenKind::Interpolated` (which gets converted to a `None`-delimited
group during macro invocation) instead of an actual `None`-delimited
group.

However, there are a couple of cases where this becomes visible to
proc-macros:
1. A cross-crate `macro_rules!` macro has a `None`-delimited group
   stored in its body (as a result of being produced by another
   `macro_rules!` macro). The cross-crate `macro_rules!` invocation
   can then expand to an attribute macro invocation, which needs
   to be able to see the `None`-delimited group.
2. A proc-macro can invoke an attribute proc-macro with its re-collected
   input. If there are any nonterminals present in the input, they will
   get re-collected to `None`-delimited groups, which will then get
   captured as part of the attribute macro invocation.

Both of these cases are incredibly obscure, so there hopefully won't be
any breakage. This change will allow more agressive 'flattenting' of
nonterminals in #82608 without losing `None`-delimited groups.