### PR TITLE
Fix Debug implementation for RwLock{Read,Write}Guard.

### DIFF
--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -473,7 +473,7 @@ impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl<T: fmt::Debug> fmt::Debug for RwLockReadGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RwLockReadGuard").field("lock", &self.lock).finish()
+        (**self).fmt(f)
     }
 }
 
@@ -487,7 +487,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RwLockReadGuard<'_, T> {
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl<T: fmt::Debug> fmt::Debug for RwLockWriteGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("RwLockWriteGuard").field("lock", &self.lock).finish()
+        (**self).fmt(f)
     }
 }
 


### PR DESCRIPTION
This would attempt to print the Debug representation of the lock that the guard has locked, which will try to lock again, fail, and just print `"<locked>"` unhelpfully.

After this change, this just prints the contents of the mutex, like the other smart pointers (and MutexGuard) do.

MutexGuard had this problem too: https://github.com/rust-lang/rust/issues/57702