### PR TITLE
update Miri, and also run test suite with mir-opt-level=4

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -452,7 +452,14 @@ impl Step for Miri {
 
             cargo.add_rustc_lib_path(builder, compiler);
 
-            if !try_run(builder, &mut cargo.into()) {
+            let mut cargo = Command::from(cargo);
+            if !try_run(builder, &mut cargo) {
+                return;
+            }
+
+            // # Run `cargo test` with `-Zmir-opt-level=4`.
+            cargo.env("MIRIFLAGS", "-O -Zmir-opt-level=4");
+            if !try_run(builder, &mut cargo) {
                 return;
             }
 


### PR DESCRIPTION
In the Miri repo, we run the Miri test suite once with default flags and once with `-O -Zmir-opt-level=4`. This helps identify and document situations where MIR optimizations mask UB -- it is okay for that to happen, but it might be god to look into it when it does happen. Recently these tests failed fairly frequently as new MIR optimizations were added, and since we only run them on the Miri side, it is not even clear which rustc PR introduced the change. So I propose we also run these tests in the rustc repo, such that toolstate tracking will tell us the exact PR (or at least the rollup) that caused the change.

r? @oli-obk 
Fixes https://github.com/rust-lang/rust/issues/83590