### PR TITLE
Add `core::array::from_fn`

### DIFF
--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -307,6 +307,15 @@ fn empty_array_is_always_default() {
 }
 
 #[test]
+fn array_from_fn() {
+    let a = array::from_fn(|i| 2 * i + 1);
+    assert_eq!(a, [1, 3, 5, 7]);
+
+    let b = array::from_fn(|i| i.to_string());
+    assert_eq!(b, [String::from("0"), String::from("1")]);
+}
+
+#[test]
 fn array_map() {
     let a = [1, 2, 3];
     let b = a.map(|v| v + 1);

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -1,5 +1,6 @@
 #![feature(alloc_layout_extra)]
 #![feature(array_chunks)]
+#![feature(array_from_fn)]
 #![feature(array_from_ref)]
 #![feature(array_methods)]
 #![feature(array_map)]


### PR DESCRIPTION
This adds `core::array::from_fn` for initializing an array from a closure. The API is meant to closely resemble `core::iter::from_fn` with the difference that the array dictates the amount of elements produced as opposed to the function.

This should also cover a lot of cases where one might want to reach for collecting into an array, but without all the associated problems that this would have, such as providing too few or too many elements.

# Example Usage

```rust
let array = std::array::from_fn(|index| 2 * index);
assert_eq!(array, [0, 2, 4, 6]);
```