### PR TITLE
Remove dead or useless code from Session

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1236,9 +1236,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             (Some(..), Some(..), HalfOpen) => hir::LangItem::Range,
             (None, Some(..), Closed) => hir::LangItem::RangeToInclusive,
             (Some(..), Some(..), Closed) => unreachable!(),
-            (_, None, Closed) => {
-                self.diagnostic().span_fatal(span, "inclusive range with no end").raise()
-            }
+            (_, None, Closed) => self.diagnostic().span_fatal(span, "inclusive range with no end"),
         };
 
         let fields = self.arena.alloc_from_iter(

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -692,6 +692,7 @@ impl Handler {
         db
     }
 
+    // NOTE: intentionally doesn't raise an error so rustc_codegen_ssa only reports fatal errors in the main thread
     pub fn fatal(&self, msg: &str) -> FatalError {
         self.inner.borrow_mut().fatal(msg)
     }

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -634,9 +634,9 @@ impl Handler {
         DiagnosticBuilder::new(self, Level::Note, msg)
     }
 
-    pub fn span_fatal(&self, span: impl Into<MultiSpan>, msg: &str) -> FatalError {
+    pub fn span_fatal(&self, span: impl Into<MultiSpan>, msg: &str) -> ! {
         self.emit_diag_at_span(Diagnostic::new(Fatal, msg), span);
-        FatalError
+        FatalError.raise()
     }
 
     pub fn span_fatal_with_code(
@@ -644,9 +644,9 @@ impl Handler {
         span: impl Into<MultiSpan>,
         msg: &str,
         code: DiagnosticId,
-    ) -> FatalError {
+    ) -> ! {
         self.emit_diag_at_span(Diagnostic::new_with_code(Fatal, Some(code), msg), span);
-        FatalError
+        FatalError.raise()
     }
 
     pub fn span_err(&self, span: impl Into<MultiSpan>, msg: &str) {

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -315,57 +315,41 @@ impl<'a> StringReader<'a> {
         let (lit_kind, mode, prefix_len, postfix_len) = match kind {
             rustc_lexer::LiteralKind::Char { terminated } => {
                 if !terminated {
-                    self.sess
-                        .span_diagnostic
-                        .struct_span_fatal_with_code(
-                            self.mk_sp(start, suffix_start),
-                            "unterminated character literal",
-                            error_code!(E0762),
-                        )
-                        .emit();
-                    FatalError.raise();
+                    self.sess.span_diagnostic.span_fatal_with_code(
+                        self.mk_sp(start, suffix_start),
+                        "unterminated character literal",
+                        error_code!(E0762),
+                    )
                 }
                 (token::Char, Mode::Char, 1, 1) // ' '
             }
             rustc_lexer::LiteralKind::Byte { terminated } => {
                 if !terminated {
-                    self.sess
-                        .span_diagnostic
-                        .struct_span_fatal_with_code(
-                            self.mk_sp(start + BytePos(1), suffix_start),
-                            "unterminated byte constant",
-                            error_code!(E0763),
-                        )
-                        .emit();
-                    FatalError.raise();
+                    self.sess.span_diagnostic.span_fatal_with_code(
+                        self.mk_sp(start + BytePos(1), suffix_start),
+                        "unterminated byte constant",
+                        error_code!(E0763),
+                    )
                 }
                 (token::Byte, Mode::Byte, 2, 1) // b' '
             }
             rustc_lexer::LiteralKind::Str { terminated } => {
                 if !terminated {
-                    self.sess
-                        .span_diagnostic
-                        .struct_span_fatal_with_code(
-                            self.mk_sp(start, suffix_start),
-                            "unterminated double quote string",
-                            error_code!(E0765),
-                        )
-                        .emit();
-                    FatalError.raise();
+                    self.sess.span_diagnostic.span_fatal_with_code(
+                        self.mk_sp(start, suffix_start),
+                        "unterminated double quote string",
+                        error_code!(E0765),
+                    )
                 }
                 (token::Str, Mode::Str, 1, 1) // " "
             }
             rustc_lexer::LiteralKind::ByteStr { terminated } => {
                 if !terminated {
-                    self.sess
-                        .span_diagnostic
-                        .struct_span_fatal_with_code(
-                            self.mk_sp(start + BytePos(1), suffix_start),
-                            "unterminated double quote byte string",
-                            error_code!(E0766),
-                        )
-                        .emit();
-                    FatalError.raise();
+                    self.sess.span_diagnostic.span_fatal_with_code(
+                        self.mk_sp(start + BytePos(1), suffix_start),
+                        "unterminated double quote byte string",
+                        error_code!(E0766),
+                    )
                 }
                 (token::ByteStr, Mode::ByteStr, 2, 1) // b" "
             }

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -148,15 +148,11 @@ impl<'a> StringReader<'a> {
                         None => "unterminated block comment",
                     };
                     let last_bpos = self.pos;
-                    self.sess
-                        .span_diagnostic
-                        .struct_span_fatal_with_code(
-                            self.mk_sp(start, last_bpos),
-                            msg,
-                            error_code!(E0758),
-                        )
-                        .emit();
-                    FatalError.raise();
+                    self.sess.span_diagnostic.span_fatal_with_code(
+                        self.mk_sp(start, last_bpos),
+                        msg,
+                        error_code!(E0758),
+                    );
                 }
 
                 // Skip non-doc comments

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -144,11 +144,7 @@ impl AttemptLocalParseRecovery {
 }
 
 impl<'a> Parser<'a> {
-    pub(super) fn span_fatal_err<S: Into<MultiSpan>>(
-        &self,
-        sp: S,
-        err: Error,
-    ) -> DiagnosticBuilder<'a> {
+    pub(super) fn span_err<S: Into<MultiSpan>>(&self, sp: S, err: Error) -> DiagnosticBuilder<'a> {
         err.span_err(sp, self.diagnostic())
     }
 

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1326,7 +1326,7 @@ impl<'a> Parser<'a> {
             token::CloseDelim(token::Brace) => {}
             token::DocComment(..) => {
                 let previous_span = self.prev_token.span;
-                let mut err = self.span_fatal_err(self.token.span, Error::UselessDocComment);
+                let mut err = self.span_err(self.token.span, Error::UselessDocComment);
                 self.bump(); // consume the doc comment
                 let comma_after_doc_seen = self.eat(&token::Comma);
                 // `seen_comma` is always false, because we are inside doc block

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -525,7 +525,7 @@ impl<'a> Parser<'a> {
     fn ident_or_err(&mut self) -> PResult<'a, (Ident, /* is_raw */ bool)> {
         self.token.ident().ok_or_else(|| match self.prev_token.kind {
             TokenKind::DocComment(..) => {
-                self.span_fatal_err(self.prev_token.span, Error::UselessDocComment)
+                self.span_err(self.prev_token.span, Error::UselessDocComment)
             }
             _ => self.expected_ident_found(),
         })

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -168,7 +168,7 @@ impl<'a> Parser<'a> {
     fn error_outer_attrs(&self, attrs: &[Attribute]) {
         if let [.., last] = attrs {
             if last.is_doc_comment() {
-                self.span_fatal_err(last.span, Error::UselessDocComment).emit();
+                self.span_err(last.span, Error::UselessDocComment).emit();
             } else if attrs.iter().any(|a| a.style == AttrStyle::Outer) {
                 self.struct_span_err(last.span, "expected statement after outer attribute").emit();
             }

--- a/compiler/rustc_session/src/cgu_reuse_tracker.rs
+++ b/compiler/rustc_session/src/cgu_reuse_tracker.rs
@@ -112,7 +112,7 @@ impl CguReuseTracker {
                                        not recorded",
                         cgu_user_name, cgu_name
                     );
-                    diag.span_fatal(error_span.0, &msg).raise();
+                    diag.span_fatal(error_span.0, &msg)
                 }
             }
         }

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -421,7 +421,7 @@ impl Session {
     }
 
     pub fn span_fatal<S: Into<MultiSpan>>(&self, sp: S, msg: &str) -> ! {
-        self.diagnostic().span_fatal(sp, msg).raise()
+        self.diagnostic().span_fatal(sp, msg)
     }
     pub fn span_fatal_with_code<S: Into<MultiSpan>>(
         &self,
@@ -429,7 +429,7 @@ impl Session {
         msg: &str,
         code: DiagnosticId,
     ) -> ! {
-        self.diagnostic().span_fatal_with_code(sp, msg, code).raise()
+        self.diagnostic().span_fatal_with_code(sp, msg, code)
     }
     pub fn fatal(&self, msg: &str) -> ! {
         self.diagnostic().fatal(msg).raise()

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -492,12 +492,6 @@ impl Session {
     pub fn warn(&self, msg: &str) {
         self.diagnostic().warn(msg)
     }
-    pub fn opt_span_warn<S: Into<MultiSpan>>(&self, opt_sp: Option<S>, msg: &str) {
-        match opt_sp {
-            Some(sp) => self.span_warn(sp, msg),
-            None => self.warn(msg),
-        }
-    }
     /// Delay a span_bug() call until abort_if_errors()
     #[track_caller]
     pub fn delay_span_bug<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {


### PR DESCRIPTION
This is a more principled follow-up to https://github.com/rust-lang/rust/pull/83185#discussion_r601753839.

- Rename `Parser::span_fatal_err` -> `Parser::span_err`
- Remove some unnecessary uses of `struct_span_fatal`
- Make `Diagnostic::span_fatal` unconditionally raise an error
- Add `impl Deref<Target = Handler>` for Session and remove all functions that are exactly the same as their Handler counterparts
- Note why `Handler::fatal` is different from `Sesssion::fatal`
- Remove unused `opt_span_warn` function

r? @oli-obk or @estebank