### PR TITLE
Remove unnecessary `ignore-cloudabi` flag

### DIFF
--- a/src/test/ui/command/command-setgroups.rs
+++ b/src/test/ui/command/command-setgroups.rs
@@ -1,6 +1,5 @@
 // run-pass
 // ignore-windows - this is a unix-specific test
-// ignore-cloudabi
 // ignore-emscripten
 // ignore-sgx
 // ignore-musl - returns dummy result for _SC_NGROUPS_MAX


### PR DESCRIPTION
...since we dropped the CloudABI support.