### PR TITLE
Add case insensitive file systems support in rustdoc

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -265,6 +265,9 @@ crate struct RenderOptions {
     crate document_hidden: bool,
     /// If `true`, generate a JSON file in the crate folder instead of HTML redirection files.
     crate generate_redirect_map: bool,
+    /// If this option is set to `true`, HTML files will be generated as it would on a
+    /// case-insensitive file system.
+    crate generate_case_insensitive: bool,
     crate unstable_features: rustc_feature::UnstableFeatures,
 }
 
@@ -580,6 +583,7 @@ impl Options {
         let document_hidden = matches.opt_present("document-hidden-items");
         let run_check = matches.opt_present("check");
         let generate_redirect_map = matches.opt_present("generate-redirect-map");
+        let generate_case_insensitive = matches.opt_present("generate-case-insensitive");
 
         let (lint_opts, describe_lints, lint_cap) = get_cmd_lint_options(matches, error_format);
 
@@ -638,6 +642,7 @@ impl Options {
                 document_private,
                 document_hidden,
                 generate_redirect_map,
+                generate_case_insensitive,
                 unstable_features: rustc_feature::UnstableFeatures::from_environment(
                     crate_name.as_deref(),
                 ),

--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -1,10 +1,16 @@
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{edition::Edition, Symbol};
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
 
 use crate::clean;
 use crate::config::RenderOptions;
 use crate::error::Error;
 use crate::formats::cache::Cache;
+use crate::html::render::print_item::item_path;
 
 /// Allows for different backends to rustdoc to be used with the `run_format()` function. Each
 /// backend renderer has hooks for initialization, documenting an item, entering and exiting a
@@ -26,6 +32,7 @@ crate trait FormatRenderer<'tcx>: Sized {
         edition: Edition,
         cache: Cache,
         tcx: TyCtxt<'tcx>,
+        case_insensitive_conflicts: Option<FxHashSet<String>>,
     ) -> Result<(Self, clean::Crate), Error>;
 
     /// Make a new renderer to render a child of the item currently being rendered.
@@ -52,6 +59,71 @@ crate trait FormatRenderer<'tcx>: Sized {
     fn cache(&self) -> &Cache;
 }
 
+fn handle_module(dst: &Path, item: &clean::Item, paths_map: &mut FxHashMap<String, usize>) {
+    // modules are special because they add a namespace. We also need to
+    // recurse into the items of the module as well.
+    let name = item.name.as_ref().unwrap().to_string();
+    if name.is_empty() {
+        panic!("Unexpected module with empty name");
+    }
+    let module = match *item.kind {
+        clean::StrippedItem(box clean::ModuleItem(ref m)) | clean::ModuleItem(ref m) => m,
+        _ => unreachable!(),
+    };
+    let mod_path = dst.join(&name);
+    for it in &module.items {
+        if it.is_mod() {
+            handle_module(&mod_path, it, paths_map);
+        } else if it.name.is_some() && !it.is_extern_crate() {
+            let name = it.name.as_ref().unwrap();
+            let item_type = it.type_();
+            let file_name = &item_path(item_type, &name.as_str());
+            let insensitive_path = mod_path.join(file_name).display().to_string();
+
+            let entry = paths_map.entry(insensitive_path.to_lowercase()).or_insert(0);
+            *entry += 1;
+        }
+    }
+}
+
+fn build_case_insensitive_map(
+    krate: &clean::Crate,
+    options: &RenderOptions,
+) -> Option<FxHashSet<String>> {
+    let mut paths_map: FxHashMap<String, usize> = FxHashMap::default();
+
+    handle_module(&options.output, &krate.module, &mut paths_map);
+    Some(paths_map.into_iter().filter(|(_, count)| *count > 1).map(|(path, _)| path).collect())
+}
+
+fn check_if_case_insensitive(dst: &Path) -> bool {
+    fn create_and_write(dst: &Path, content: &str) {
+        if let Ok(mut f) = fs::OpenOptions::new().write(true).create(true).truncate(true).open(dst)
+        {
+            // Ignoring potential errors.
+            let _ = f.write(content.as_bytes());
+        }
+    }
+    fn compare_content(dst: &Path, content: &str) -> bool {
+        fs::read_to_string(dst).unwrap_or_else(|_| String::new()).as_str() == content
+    }
+
+    let path1 = dst.join("___a.tmp");
+    let content1 = "a";
+    let path2 = dst.join("___A.tmp");
+    let content2 = "A";
+
+    create_and_write(&path1, content1);
+    create_and_write(&path1, content2);
+
+    let res = compare_content(&path1, content1) && compare_content(&path2, content2);
+    // We ignore the errors when removing the files.
+    let _ = fs::remove_file(&path1);
+    let _ = fs::remove_file(&path2);
+
+    res
+}
+
 /// Main method for rendering a crate.
 crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
     krate: clean::Crate,
@@ -63,9 +135,16 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
 ) -> Result<(), Error> {
     let prof = &tcx.sess.prof;
 
+    let case_insensitive_conflicts =
+        if options.generate_case_insensitive || check_if_case_insensitive(&options.output) {
+            build_case_insensitive_map(&krate, &options)
+        } else {
+            None
+        };
+
     let (mut format_renderer, krate) = prof
         .extra_verbose_generic_activity("create_renderer", T::descr())
-        .run(|| T::init(krate, options, edition, cache, tcx))?;
+        .run(|| T::init(krate, options, edition, cache, tcx, case_insensitive_conflicts))?;
 
     // Render the crate documentation
     let crate_name = krate.name;

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1138,7 +1138,7 @@ pub(super) fn full_path(cx: &Context<'_>, item: &clean::Item) -> String {
     s
 }
 
-pub(super) fn item_path(ty: ItemType, name: &str) -> String {
+crate fn item_path(ty: ItemType, name: &str) -> String {
     match ty {
         ItemType::Module => format!("{}index.html", ensure_trailing_slash(name)),
         _ => format!("{}.{}.html", ty, name),

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2,7 +2,7 @@
 // Local js definitions:
 /* global addClass, getSettingValue, hasClass */
 /* global onEach, onEachLazy, hasOwnProperty, removeClass, updateLocalStorage */
-/* global switchTheme, useSystemTheme */
+/* global switchTheme, useSystemTheme, getNakedUrl */
 
 if (!String.prototype.startsWith) {
     String.prototype.startsWith = function(searchString, position) {
@@ -38,13 +38,7 @@ if (!DOMTokenList.prototype.remove) {
     };
 }
 
-(function () {
-    var rustdocVars = document.getElementById("rustdoc-vars");
-    if (rustdocVars) {
-        window.rootPath = rustdocVars.attributes["data-root-path"].value;
-        window.currentCrate = rustdocVars.attributes["data-current-crate"].value;
-        window.searchJS = rustdocVars.attributes["data-search-js"].value;
-    }
+function initSidebarVars() {
     var sidebarVars = document.getElementById("sidebar-vars");
     if (sidebarVars) {
         window.sidebarCurrent = {
@@ -53,6 +47,16 @@ if (!DOMTokenList.prototype.remove) {
             relpath: sidebarVars.attributes["data-relpath"].value,
         };
     }
+}
+
+(function () {
+    var rustdocVars = document.getElementById("rustdoc-vars");
+    if (rustdocVars) {
+        window.rootPath = rustdocVars.attributes["data-root-path"].value;
+        window.currentCrate = rustdocVars.attributes["data-current-crate"].value;
+        window.searchJS = rustdocVars.attributes["data-search-js"].value;
+    }
+    initSidebarVars();
 }());
 
 // Gets the human-readable string for the virtual-key code of the
@@ -94,11 +98,6 @@ function getThemesElement() {
 
 function getThemePickerElement() {
     return document.getElementById(THEME_PICKER_ELEMENT_ID);
-}
-
-// Returns the current URL without any query parameter or hash.
-function getNakedUrl() {
-    return window.location.href.split("?")[0].split("#")[0];
 }
 
 // Sets the focus on the search bar at the top of the page
@@ -170,7 +169,7 @@ function hideThemeButtonState() {
     });
 }());
 
-(function() {
+function rustdocInit() {
     "use strict";
 
     // This mapping table should match the discriminants of
@@ -2149,7 +2148,7 @@ function hideThemeButtonState() {
                 sidebar.appendChild(div);
             }
         }
-    }
+    };
 
     // delayed sidebar rendering.
     window.initSidebarItems = function(items) {
@@ -3060,4 +3059,6 @@ function hideThemeButtonState() {
     onHashChange(null);
     window.onhashchange = onHashChange;
     setupSearchLoader();
-}());
+}
+
+rustdocInit();

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -31,6 +31,11 @@ function getSettingValue(settingName) {
     return null;
 }
 
+// Returns the current URL without any query parameter or hash.
+function getNakedUrl() {
+    return window.location.href.split("?")[0].split("#")[0];
+}
+
 var localStoredTheme = getSettingValue("theme");
 
 var savedHref = [];

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::{edition::Edition, Symbol};
@@ -137,6 +137,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         _edition: Edition,
         cache: Cache,
         tcx: TyCtxt<'tcx>,
+        _case_insensitive_conflicts: Option<FxHashSet<String>>,
     ) -> Result<(Self, clean::Crate), Error> {
         debug!("Initializing json renderer");
         Ok((

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -527,6 +527,13 @@ fn opts() -> Vec<RustcOptGroup> {
         unstable("print", |o| {
             o.optmulti("", "print", "Rustdoc information to print on stdout", "[unversioned-files]")
         }),
+        unstable("generate-case-insensitive", |o| {
+            o.optflag(
+                "",
+                "generate-case-insensitive",
+                "Force the generation of HTML to be case insensitive",
+            )
+        }),
     ]
 }
 

--- a/src/test/rustdoc-gui/basic-code.goml
+++ b/src/test/rustdoc-gui/basic-code.goml
@@ -1,3 +1,3 @@
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 click: ".srclink"
 assert: (".line-numbers", 1)

--- a/src/test/rustdoc-gui/basic.goml
+++ b/src/test/rustdoc-gui/basic.goml
@@ -1,4 +1,4 @@
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 assert: ("#functions")
 goto: ./struct.Foo.html
 assert: ("div.type-decl")

--- a/src/test/rustdoc-gui/check_info_sign_position.goml
+++ b/src/test/rustdoc-gui/check_info_sign_position.goml
@@ -1,4 +1,4 @@
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 goto: ./fn.check_list_code_block.html
 // If the codeblock is the first element of the docblock, the information tooltip must have
 // have some top margin to avoid going over the toggle (the "[+]").

--- a/src/test/rustdoc-gui/code-sidebar-toggle.goml
+++ b/src/test/rustdoc-gui/code-sidebar-toggle.goml
@@ -1,4 +1,4 @@
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 click: ".srclink"
 click: "#sidebar-toggle"
 wait-for: 500

--- a/src/test/rustdoc-gui/insensitive-case-check.goml
+++ b/src/test/rustdoc-gui/insensitive-case-check.goml
@@ -1,0 +1,7 @@
+goto: file://|DOC_PATH|/insensitive_case_docs/struct.ab.html
+// Checks that the sidebar was filled.
+wait-for: ".sidebar-elems > .items > .sidebar-title"
+// Checks that the content has been loaded
+assert: ".impl-items > h4"
+// Checks that the collapse toggles have been generated as expected
+assert: ".impl-items > h4 > .collapse-toggle"

--- a/src/test/rustdoc-gui/insensitive-test.rs
+++ b/src/test/rustdoc-gui/insensitive-test.rs
@@ -1,0 +1,19 @@
+//! The point of this crate is to test the insensitive case handling.
+
+#![crate_name = "insensitive_case_docs"]
+
+#![allow(non_camel_case_types)]
+
+/// This is ab.
+pub struct ab;
+
+impl ab {
+    pub fn foo(&self) {}
+}
+
+/// This is another Ab!
+pub struct Ab;
+
+impl Ab {
+    pub fn bar(&self) {}
+}

--- a/src/test/rustdoc-gui/list_code_block.goml
+++ b/src/test/rustdoc-gui/list_code_block.goml
@@ -1,3 +1,3 @@
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 goto: ./fn.check_list_code_block.html
 assert: ("pre.rust.fn")

--- a/src/test/rustdoc-gui/nojs-attr-pos.goml
+++ b/src/test/rustdoc-gui/nojs-attr-pos.goml
@@ -1,5 +1,5 @@
 // Check that the attributes are well positioned when javascript is disabled (since
 // there is no toggle to display)
 javascript: false
-goto: file://|DOC_PATH|/struct.Foo.html
+goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 assert: (".attributes", {"margin-left": "0px"})

--- a/src/test/rustdoc-gui/search-input-mobile.goml
+++ b/src/test/rustdoc-gui/search-input-mobile.goml
@@ -1,6 +1,6 @@
 // Test to ensure that you can click on the search input, whatever the width.
 // The PR which fixed it is: https://github.com/rust-lang/rust/pull/81592
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 size: (463, 700)
 // We first check that the search input isn't already focused.
 assert-false: ("input.search-input:focus")

--- a/src/test/rustdoc-gui/shortcuts.goml
+++ b/src/test/rustdoc-gui/shortcuts.goml
@@ -1,5 +1,5 @@
 // Check that the various shortcuts are working.
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 // We first check that the search input isn't already focused.
 assert-false: "input.search-input:focus"
 press-key: "s"

--- a/src/test/rustdoc-gui/theme-change.goml
+++ b/src/test/rustdoc-gui/theme-change.goml
@@ -1,4 +1,4 @@
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 click: "#theme-picker"
 click: "#theme-choices > button:first-child"
 wait-for: 500

--- a/src/test/rustdoc-gui/toggle-docs.goml
+++ b/src/test/rustdoc-gui/toggle-docs.goml
@@ -1,4 +1,4 @@
-goto: file://|DOC_PATH|/index.html
+goto: file://|DOC_PATH|/test_docs/index.html
 click: "#toggle-all-docs"
 wait-for: 5000
 assert: ("#main > div.docblock.hidden-by-usual-hider")

--- a/src/test/rustdoc-gui/trait-sidebar-item-order.goml
+++ b/src/test/rustdoc-gui/trait-sidebar-item-order.goml
@@ -1,4 +1,4 @@
-goto: file://|DOC_PATH|/trait.AnotherOne.html
+goto: file://|DOC_PATH|/test_docs/trait.AnotherOne.html
 assert: (".sidebar-links a:nth-of-type(1)", "another")
 assert: (".sidebar-links a:nth-of-type(2)", "func1")
 assert: (".sidebar-links a:nth-of-type(3)", "func2")

--- a/src/test/rustdoc/insensitive-case.rs
+++ b/src/test/rustdoc/insensitive-case.rs
@@ -1,0 +1,18 @@
+// compile-flags: -Zunstable-options --generate-case-insensitive
+
+#![crate_name = "foo"]
+
+// @!has 'foo/struct.Aa.html'
+// @has 'foo/struct.aa.html'
+// @!has 'foo/struct.aa.html' '//h4[@id="method.new"]'
+pub struct aa;
+
+impl aa {
+   pub fn foo(&self) {}
+}
+
+pub struct Aa;
+
+impl Aa {
+   pub fn foo(&self) {}
+}


### PR DESCRIPTION
Fixes #25879.
Fixes #80504.

This PR adds the support for case insensitive file system. To do so, we first detect if we are on a case insensitive file system (writing in files with same "name" if lowercased and then check if we have both different content or just one). This can be overriden with the `--generate-case-insensitive` option (which I used to test and for the tests).

Now for the front-end: we generate a file for the conflicted URL which contains JS which will load the expected file. The conflicted files are put in non-conflict file paths (simply adding a number depending on their position in the vector).

If you want to test it locally even on linux, you can check the `Self` and `self` keywords.