### PR TITLE
Use `span_suggestion_verbose` for redundant semicolons lint

### DIFF
--- a/compiler/rustc_lint/src/redundant_semicolon.rs
+++ b/compiler/rustc_lint/src/redundant_semicolon.rs
@@ -55,7 +55,7 @@ fn maybe_lint_redundant_semis(cx: &EarlyContext<'_>, seq: &mut Option<(Span, boo
                 ("unnecessary trailing semicolon", "remove this semicolon")
             };
             lint.build(msg)
-                .span_suggestion(span, rem, String::new(), Applicability::MaybeIncorrect)
+                .span_suggestion_verbose(span, rem, String::new(), Applicability::MaybeIncorrect)
                 .emit();
         });
     }


### PR DESCRIPTION
This should prevent weird inline suggestions that look like

    help: remove these semicolons: ``

and instead ensure that the suggestion gets its own diagnostic window.
I think it's helpful to see the change if it's in a diagnostic window,
which is why I didn't use `span_suggestion_hidden`.
