### PR TITLE
Add SockAddrsIter

### DIFF
--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -747,6 +747,43 @@ impl hash::Hash for SocketAddrV6 {
     }
 }
 
+#[stable(feature = "LazySocketAddrs", since = "1.52.0")]
+#[derive(Debug, Clone)]
+/// Wrapper struct that allows Iterators of SocketAddr to be used where
+/// ToSocketAddrs is a trait bound
+pub struct SocketAddrsIter<I, S>
+where
+    S: Into<SocketAddr> + Clone,
+    I: Iterator<Item = S> + Clone,
+{
+    inner: I,
+}
+
+impl<I, S> SocketAddrsIter<I, S>
+where
+    S: Into<SocketAddr> + Clone,
+    I: Iterator<Item = S> + Clone,
+{
+    #[stable(feature = "LazySocketAddrs", since = "1.52.0")]
+    /// Make a new SocketAddrsIter
+    pub fn new(iter: I) -> Self {
+        SocketAddrsIter { inner: iter }
+    }
+}
+
+#[stable(feature = "LazySocketAddrs", since = "1.52.0")]
+impl<I, S> Iterator for SocketAddrsIter<I, S>
+where
+    S: Into<SocketAddr> + Clone,
+    I: Iterator<Item = S> + Clone,
+{
+    type Item = SocketAddr;
+
+    fn next(&mut self) -> Option<SocketAddr> {
+        self.inner.next().map(S::into)
+    }
+}
+
 /// A trait for objects which can be converted or resolved to one or more
 /// [`SocketAddr`] values.
 ///
@@ -878,6 +915,19 @@ impl ToSocketAddrs for SocketAddr {
     type Iter = option::IntoIter<SocketAddr>;
     fn to_socket_addrs(&self) -> io::Result<option::IntoIter<SocketAddr>> {
         Ok(Some(*self).into_iter())
+    }
+}
+
+#[stable(feature = "LazySocketAddrs", since = "1.52.0")]
+impl<I, S> ToSocketAddrs for SocketAddrsIter<I, S>
+where
+    S: Into<SocketAddr> + Clone,
+    I: Iterator<Item = S> + Clone,
+{
+    type Iter = Self;
+
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        Ok((*self).clone())
     }
 }
 

--- a/library/std/src/net/addr/tests.rs
+++ b/library/std/src/net/addr/tests.rs
@@ -52,6 +52,16 @@ fn to_socket_addr_string() {
 }
 
 #[test]
+fn to_socket_addr_iter() {
+    let ports = 1000..1005;
+    let sock_iter = ports.map(|port| sa4(Ipv4Addr::new(77, 88, 21, 11), port));
+    let sock_vec: Vec<SocketAddr> = tsa(SocketAddrsIter::new(sock_iter.clone())).unwrap();
+    let sock_vec2: Vec<SocketAddr> = sock_iter.map(SocketAddr::from).collect();
+
+    assert_eq!(sock_vec, sock_vec2);
+}
+
+#[test]
 fn bind_udp_socket_bad() {
     // rust-lang/rust#53957: This is a regression test for a parsing problem
     // discovered as part of issue rust-lang/rust#23076, where we were

--- a/library/std/src/net/mod.rs
+++ b/library/std/src/net/mod.rs
@@ -20,7 +20,7 @@
 use crate::io::{self, Error, ErrorKind};
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use self::addr::{SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
+pub use self::addr::{SocketAddr, SocketAddrV4, SocketAddrV6, SocketAddrsIter, ToSocketAddrs};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::ip::{IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope};
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
SocketAddrsIter wraps Iterators of `Into<SocketAddr>` and implements
ToSocketAddrs. fixes #83323.