### PR TITLE
Replace tabs in err messages before rendering

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1258,7 +1258,7 @@ impl EmitterWriter {
                 buffer.append(0, ": ", header_style);
             }
             for &(ref text, _) in msg.iter() {
-                buffer.append(0, text, header_style);
+                buffer.append(0, &replace_tabs(text), header_style);
             }
         }
 

--- a/src/test/ui/issue-83639.rs
+++ b/src/test/ui/issue-83639.rs
@@ -1,0 +1,6 @@
+// check-fail
+// ignore-tidy-tab
+
+fn main() {
+    """	" //~ ERROR
+}

--- a/src/test/ui/issue-83639.stderr
+++ b/src/test/ui/issue-83639.stderr
@@ -1,0 +1,8 @@
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `"    "`
+  --> $DIR/issue-83639.rs:5:7
+   |
+LL |     """    "
+   |       ^^^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This is done in other call sites, but was missing in one place.

Fixes #83638