### PR TITLE
Wrap non-pre code blocks

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -424,7 +424,9 @@ nav.sub {
 	text-overflow: ellipsis;
 	margin: 0;
 }
-.docblock-short code {
+/* Wrap non-pre code blocks (`text`) but not (```text```). */
+.docblock > :not(pre) > code,
+.docblock-short > :not(pre) > code {
 	white-space: pre-wrap;
 }
 


### PR DESCRIPTION
Fix #83550 regression

```
$ cargo new --lib whitespace && cd whitespace && echo '//! `"   foo   "`' > src/lib.rs && cargo doc --open
```

Before

![](https://user-images.githubusercontent.com/89623/112713498-c0dfc200-8ed5-11eb-8c57-efdf26372e74.png)

After

![](https://user-images.githubusercontent.com/89623/112713538-f08eca00-8ed5-11eb-8a98-675179f60ae2.png)

r? @GuillaumeGomez 
cc @mgeisler