### PR TITLE
make `Sized` predicates coinductive

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -843,7 +843,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
     fn coinductive_predicate(&self, predicate: ty::Predicate<'tcx>) -> bool {
         let result = match predicate.kind().skip_binder() {
-            ty::PredicateKind::Trait(ref data, _) => self.tcx().trait_is_auto(data.def_id()),
+            ty::PredicateKind::Trait(ref data, _) => {
+                self.tcx().trait_is_auto(data.def_id())
+                    || self.tcx().lang_items().sized_trait() == Some(data.def_id())
+            }
             _ => false,
         };
         debug!(?predicate, ?result, "coinductive_predicate");

--- a/src/test/ui/generic-associated-types/projection-bound-cycle-generic.rs
+++ b/src/test/ui/generic-associated-types/projection-bound-cycle-generic.rs
@@ -24,6 +24,7 @@ impl<T> Foo for Number<T> {
     // ```
     // which it is :)
     type Item where [T]: Sized = [T];
+    //~^ ERROR overflow evaluating the requirement `<Number<T> as Foo>::Item == _
 }
 
 struct OnlySized<T> where T: Sized { f: T }
@@ -43,7 +44,6 @@ impl<T> Bar for T where T: Foo {
     // can use the bound on `Foo::Item` for this, but that requires
     // `wf(<T as Foo>::Item)`, which is an invalid cycle.
     type Assoc = OnlySized<<T as Foo>::Item>;
-    //~^ ERROR overflow evaluating the requirement `<T as Foo>::Item: Sized`
 }
 
 fn foo<T: Print>() {

--- a/src/test/ui/generic-associated-types/projection-bound-cycle-generic.stderr
+++ b/src/test/ui/generic-associated-types/projection-bound-cycle-generic.stderr
@@ -7,14 +7,11 @@ LL | #![feature(generic_associated_types)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
-error[E0275]: overflow evaluating the requirement `<T as Foo>::Item: Sized`
-  --> $DIR/projection-bound-cycle-generic.rs:45:5
+error[E0275]: overflow evaluating the requirement `<Number<T> as Foo>::Item == _`
+  --> $DIR/projection-bound-cycle-generic.rs:26:5
    |
-LL | struct OnlySized<T> where T: Sized { f: T }
-   |                  - required by this bound in `OnlySized`
-...
-LL |     type Assoc = OnlySized<<T as Foo>::Item>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     type Item where [T]: Sized = [T];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/generic-associated-types/projection-bound-cycle.rs
+++ b/src/test/ui/generic-associated-types/projection-bound-cycle.rs
@@ -26,6 +26,7 @@ impl Foo for Number {
     // ```
     // which it is :)
     type Item where str: Sized = str;
+    //~^ ERROR overflow evaluating the requirement `<Number as Foo>::Item == _
 }
 
 struct OnlySized<T> where T: Sized { f: T }
@@ -45,7 +46,6 @@ impl<T> Bar for T where T: Foo {
     // can use the bound on `Foo::Item` for this, but that requires
     // `wf(<T as Foo>::Item)`, which is an invalid cycle.
     type Assoc = OnlySized<<T as Foo>::Item>;
-    //~^ ERROR overflow evaluating the requirement `<T as Foo>::Item: Sized`
 }
 
 fn foo<T: Print>() {

--- a/src/test/ui/generic-associated-types/projection-bound-cycle.stderr
+++ b/src/test/ui/generic-associated-types/projection-bound-cycle.stderr
@@ -7,14 +7,11 @@ LL | #![feature(generic_associated_types)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #44265 <https://github.com/rust-lang/rust/issues/44265> for more information
 
-error[E0275]: overflow evaluating the requirement `<T as Foo>::Item: Sized`
-  --> $DIR/projection-bound-cycle.rs:47:5
+error[E0275]: overflow evaluating the requirement `<Number as Foo>::Item == _`
+  --> $DIR/projection-bound-cycle.rs:28:5
    |
-LL | struct OnlySized<T> where T: Sized { f: T }
-   |                  - required by this bound in `OnlySized`
-...
-LL |     type Assoc = OnlySized<<T as Foo>::Item>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     type Item where str: Sized = str;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/sized/coinductive-1.rs
+++ b/src/test/ui/sized/coinductive-1.rs
@@ -1,0 +1,14 @@
+// check-pass
+struct Node<C: Trait<Self>>(C::Assoc);
+
+trait Trait<T> {
+    type Assoc;
+}
+
+impl<T> Trait<T> for Vec<()> {
+    type Assoc = Vec<T>;
+}
+
+fn main() {
+    let _ = Node::<Vec<()>>(Vec::new());
+}

--- a/src/test/ui/sized/coinductive-2.rs
+++ b/src/test/ui/sized/coinductive-2.rs
@@ -1,0 +1,28 @@
+// run-pass
+struct Node<C: CollectionFactory<Self>> {
+    _children: C::Collection,
+}
+
+trait CollectionFactory<T> {
+    type Collection;
+}
+
+impl<T> CollectionFactory<T> for Vec<()> {
+    type Collection = Vec<T>;
+}
+
+trait Collection<T>: Sized {
+    fn push(&mut self, v: T);
+}
+
+impl<T> Collection<T> for Vec<T> {
+    fn push(&mut self, v: T) {
+        self.push(v)
+    }
+}
+
+fn main() {
+    let _ = Node::<Vec<()>> {
+        _children: Vec::new(),
+    };
+}

--- a/src/test/ui/sized/recursive-type-1.rs
+++ b/src/test/ui/sized/recursive-type-1.rs
@@ -1,0 +1,10 @@
+// check-pass
+trait A { type Assoc; }
+
+impl A for () {
+    // FIXME: it would be nice for this to at least cause a warning.
+    type Assoc = Foo<()>;
+}
+struct Foo<T: A>(T::Assoc);
+
+fn main() {}

--- a/src/test/ui/sized/recursive-type-2.rs
+++ b/src/test/ui/sized/recursive-type-2.rs
@@ -1,0 +1,13 @@
+// build-fail
+//~^ ERROR cycle detected when computing layout of `Foo<()>`
+
+trait A { type Assoc: ?Sized; }
+
+impl A for () {
+    type Assoc = Foo<()>;
+}
+struct Foo<T: A>(T::Assoc);
+
+fn main() {
+    let x: Foo<()>;
+}

--- a/src/test/ui/sized/recursive-type-2.stderr
+++ b/src/test/ui/sized/recursive-type-2.stderr
@@ -1,0 +1,12 @@
+error[E0391]: cycle detected when computing layout of `Foo<()>`
+   |
+   = note: ...which again requires computing layout of `Foo<()>`, completing the cycle
+note: cycle used when optimizing MIR for `main`
+  --> $DIR/recursive-type-2.rs:11:1
+   |
+LL | fn main() {
+   | ^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
:shrug:

needs either an MCP/RFC and `wg-traits` signoff. While I think this is sound, I am not too knowledgeable about coinduction so I might be wrong here.

r? @nikomatsakis 