### PR TITLE
Disallow octal format in Ipv4 string

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -67,7 +67,9 @@ pub enum IpAddr {
 ///
 /// `Ipv4Addr` provides a [`FromStr`] implementation. The four octets are in decimal
 /// notation, divided by `.` (this is called "dot-decimal notation").
+/// Notably, octal numbers and hexadecimal numbers are not allowed per [IETF RFC 6943].
 ///
+/// [IETF RFC 6943]: https://tools.ietf.org/html/rfc6943#section-3.1.1
 /// [`FromStr`]: crate::str::FromStr
 ///
 /// # Examples

--- a/library/std/src/net/parser/tests.rs
+++ b/library/std/src/net/parser/tests.rs
@@ -8,11 +8,15 @@ const SCOPE_ID: u32 = 1337;
 const IPV4: Ipv4Addr = Ipv4Addr::new(192, 168, 0, 1);
 const IPV4_STR: &str = "192.168.0.1";
 const IPV4_STR_PORT: &str = "192.168.0.1:8080";
+const IPV4_STR_WITH_OCTAL: &str = "0127.0.0.1";
+const IPV4_STR_WITH_HEX: &str = "0x10.0.0.1";
 
 const IPV6: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0xc0a8, 0x1);
 const IPV6_STR_FULL: &str = "2001:db8:0:0:0:0:c0a8:1";
 const IPV6_STR_COMPRESS: &str = "2001:db8::c0a8:1";
 const IPV6_STR_V4: &str = "2001:db8::192.168.0.1";
+const IPV6_STR_V4_WITH_OCTAL: &str = "2001:db8::0127.0.0.1";
+const IPV6_STR_V4_WITH_HEX: &str = "2001:db8::0x10.0.0.1";
 const IPV6_STR_PORT: &str = "[2001:db8::c0a8:1]:8080";
 const IPV6_STR_PORT_SCOPE_ID: &str = "[2001:db8::c0a8:1%1337]:8080";
 
@@ -22,6 +26,8 @@ fn parse_ipv4() {
     assert_eq!(result, IPV4);
 
     assert!(Ipv4Addr::from_str(IPV4_STR_PORT).is_err());
+    assert!(Ipv4Addr::from_str(IPV4_STR_WITH_OCTAL).is_err());
+    assert!(Ipv4Addr::from_str(IPV4_STR_WITH_HEX).is_err());
     assert!(Ipv4Addr::from_str(IPV6_STR_FULL).is_err());
     assert!(Ipv4Addr::from_str(IPV6_STR_COMPRESS).is_err());
     assert!(Ipv4Addr::from_str(IPV6_STR_V4).is_err());
@@ -39,6 +45,8 @@ fn parse_ipv6() {
     let result: Ipv6Addr = IPV6_STR_V4.parse().unwrap();
     assert_eq!(result, IPV6);
 
+    assert!(Ipv6Addr::from_str(IPV6_STR_V4_WITH_OCTAL).is_err());
+    assert!(Ipv6Addr::from_str(IPV6_STR_V4_WITH_HEX).is_err());
     assert!(Ipv6Addr::from_str(IPV4_STR).is_err());
     assert!(Ipv6Addr::from_str(IPV4_STR_PORT).is_err());
     assert!(Ipv6Addr::from_str(IPV6_STR_PORT).is_err());


### PR DESCRIPTION
In its original specification, leading zero in Ipv4 string is interpreted
as octal literals. So a IP address 0127.0.0.1 actually means 87.0.0.1.

This confusion can lead to many security vulnerabilities. Therefore, in
[IETF RFC 6943], it suggests to disallow octal/hexadecimal format in Ipv4
string all together.

Existing implementation already disallows hexadecimal numbers. This commit
makes Parser reject octal numbers.

Fixes #83648.

[IETF RFC 6943]: https://tools.ietf.org/html/rfc6943#section-3.1.1