### PR TITLE
[aarch64] add target feature outline-atomics

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -416,6 +416,11 @@ pub fn llvm_global_features(sess: &Session) -> Vec<String> {
     // -Ctarget-features
     features.extend(sess.opts.cg.target_feature.split(',').flat_map(&filter));
 
+    // FIXME: Move outline-atomics to target definition when earliest supported LLVM is 12.
+    if get_version() >= (12, 0, 0) && sess.target.llvm_target.contains("aarch64-unknown-linux") {
+        features.push("+outline-atomics".to_string());
+    }
+
     features
 }
 

--- a/src/test/assembly/asm/aarch64-outline-atomics.rs
+++ b/src/test/assembly/asm/aarch64-outline-atomics.rs
@@ -1,0 +1,16 @@
+// min-llvm-version: 12.0
+// assembly-output: emit-asm
+// compile-flags: -O
+// compile-flags: --target aarch64-unknown-linux-gnu
+// needs-llvm-components: aarch64
+// only-aarch64
+
+#![crate_type = "rlib"]
+
+use std::sync::atomic::{AtomicI32, Ordering::*};
+
+pub fn compare_exchange(a: &AtomicI32) {
+    // On AArch64 LLVM should outline atomic operations.
+    // CHECK: __aarch64_cas4_relax
+    let _ = a.compare_exchange(0, 10, Relaxed, Relaxed);
+}


### PR DESCRIPTION
Enable outline-atomics by default as enabled in clang by the following commit
https://reviews.llvm.org/rGc5e7e649d537067dec7111f3de1430d0fc8a4d11

Performance improves by several orders of magnitude when using the LSE instructions
instead of the ARMv8.0 compatible load/store exclusive instructions.

Tested on Graviton2 aarch64-linux with
x.py build && x.py install && x.py test