### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -699,7 +699,6 @@ impl<'tcx> ty::TyS<'tcx> {
     /// optimization as well as the rules around static values. Note
     /// that the `Freeze` trait is not exposed to end users and is
     /// effectively an implementation detail.
-    // FIXME: use `TyCtxtAt` instead of separate `Span`.
     pub fn is_freeze(&'tcx self, tcx_at: TyCtxtAt<'tcx>, param_env: ty::ParamEnv<'tcx>) -> bool {
         self.is_trivially_freeze() || tcx_at.is_freeze_raw(param_env.and(self))
     }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -2,6 +2,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::ascii;
 use crate::intrinsics;
 use crate::mem;
 use crate::str::FromStr;
@@ -660,6 +661,31 @@ impl u8 {
     #[inline]
     pub const fn is_ascii_control(&self) -> bool {
         matches!(*self, b'\0'..=b'\x1F' | b'\x7F')
+    }
+
+    /// Returns an iterator that produces an escaped version of a `u8`,
+    /// treating it as an ASCII character.
+    ///
+    /// The behavior is identical to [`ascii::escape_default`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(inherent_ascii_escape)]
+    ///
+    /// assert_eq!("0", b'0'.escape_ascii().to_string());
+    /// assert_eq!("\\t", b'\t'.escape_ascii().to_string());
+    /// assert_eq!("\\r", b'\r'.escape_ascii().to_string());
+    /// assert_eq!("\\n", b'\n'.escape_ascii().to_string());
+    /// assert_eq!("\\'", b'\''.escape_ascii().to_string());
+    /// assert_eq!("\\\"", b'"'.escape_ascii().to_string());
+    /// assert_eq!("\\\\", b'\\'.escape_ascii().to_string());
+    /// assert_eq!("\\x9d", b'\x9d'.escape_ascii().to_string());
+    /// ```
+    #[unstable(feature = "inherent_ascii_escape", issue = "77174")]
+    #[inline]
+    pub fn escape_ascii(&self) -> ascii::EscapeDefault {
+        ascii::escape_default(*self)
     }
 }
 

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -81,6 +81,9 @@ pub use index::SliceIndex;
 #[unstable(feature = "slice_range", issue = "76393")]
 pub use index::range;
 
+#[unstable(feature = "inherent_ascii_escape", issue = "77174")]
+pub use ascii::EscapeAscii;
+
 #[lang = "slice"]
 #[cfg(not(test))]
 impl<T> [T] {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1162,6 +1162,7 @@ crate fn plain_text_summary(md: &str) -> String {
     s
 }
 
+#[derive(Debug)]
 crate struct MarkdownLink {
     pub kind: LinkType,
     pub link: String,

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -424,7 +424,9 @@ nav.sub {
 	text-overflow: ellipsis;
 	margin: 0;
 }
-.docblock-short code {
+/* Wrap non-pre code blocks (`text`) but not (```text```). */
+.docblock > :not(pre) > code,
+.docblock-short > :not(pre) > code {
 	white-space: pre-wrap;
 }
 

--- a/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.rs
+++ b/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.rs
@@ -1,10 +1,13 @@
+#![deny(warnings)]
+
 //! Linking to [foo@banana] and [`bar@banana!()`].
 //~^ ERROR unknown disambiguator `foo`
 //~| ERROR unknown disambiguator `bar`
 //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
 //~^ ERROR unknown disambiguator ``
 //~| ERROR unknown disambiguator ``
-
-#![deny(warnings)]
+//! And with weird backticks: [``foo@hello``] [foo`@`hello].
+//~^ ERROR unknown disambiguator `foo`
+//~| ERROR unknown disambiguator `foo`
 
 fn main() {}

--- a/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.rs
+++ b/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.rs
@@ -1,0 +1,10 @@
+//! Linking to [foo@banana] and [`bar@banana!()`].
+//~^ ERROR unknown disambiguator `foo`
+//~| ERROR unknown disambiguator `bar`
+//! And to [no disambiguator](@nectarine) and [another](@apricot!()).
+//~^ ERROR unknown disambiguator ``
+//~| ERROR unknown disambiguator ``
+
+#![deny(warnings)]
+
+fn main() {}

--- a/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
+++ b/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
@@ -2,7 +2,7 @@ error: unknown disambiguator `foo`
   --> $DIR/unknown-disambiguator.rs:1:17
    |
 LL | //! Linking to [foo@banana] and [`bar@banana!()`].
-   |                 ^^^^^^^^^^
+   |                 ^^^
    |
 note: the lint level is defined here
   --> $DIR/unknown-disambiguator.rs:8:9
@@ -10,31 +10,24 @@ note: the lint level is defined here
 LL | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(warnings)]`
-   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
 
 error: unknown disambiguator `bar`
-  --> $DIR/unknown-disambiguator.rs:1:34
+  --> $DIR/unknown-disambiguator.rs:1:35
    |
 LL | //! Linking to [foo@banana] and [`bar@banana!()`].
-   |                                  ^^^^^^^^^^^^^^^
-   |
-   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
+   |                                   ^^^
 
 error: unknown disambiguator ``
   --> $DIR/unknown-disambiguator.rs:4:31
    |
 LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
-   |                               ^^^^^^^^^^
-   |
-   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
+   |                               ^
 
 error: unknown disambiguator ``
   --> $DIR/unknown-disambiguator.rs:4:57
    |
 LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
-   |                                                         ^^^^^^^^^^^
-   |
-   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
+   |                                                         ^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
+++ b/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
@@ -1,33 +1,45 @@
 error: unknown disambiguator `foo`
-  --> $DIR/unknown-disambiguator.rs:1:17
+  --> $DIR/unknown-disambiguator.rs:3:17
    |
 LL | //! Linking to [foo@banana] and [`bar@banana!()`].
    |                 ^^^
    |
 note: the lint level is defined here
-  --> $DIR/unknown-disambiguator.rs:8:9
+  --> $DIR/unknown-disambiguator.rs:1:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(warnings)]`
 
 error: unknown disambiguator `bar`
-  --> $DIR/unknown-disambiguator.rs:1:35
+  --> $DIR/unknown-disambiguator.rs:3:35
    |
 LL | //! Linking to [foo@banana] and [`bar@banana!()`].
    |                                   ^^^
 
+error: unknown disambiguator `foo`
+  --> $DIR/unknown-disambiguator.rs:9:34
+   |
+LL | //! And with weird backticks: [``foo@hello``] [foo`@`hello].
+   |                                  ^^^
+
+error: unknown disambiguator `foo`
+  --> $DIR/unknown-disambiguator.rs:9:48
+   |
+LL | //! And with weird backticks: [``foo@hello``] [foo`@`hello].
+   |                                                ^^^
+
 error: unknown disambiguator ``
-  --> $DIR/unknown-disambiguator.rs:4:31
+  --> $DIR/unknown-disambiguator.rs:6:31
    |
 LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
    |                               ^
 
 error: unknown disambiguator ``
-  --> $DIR/unknown-disambiguator.rs:4:57
+  --> $DIR/unknown-disambiguator.rs:6:57
    |
 LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
    |                                                         ^
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
+++ b/src/test/rustdoc-ui/intra-doc/unknown-disambiguator.stderr
@@ -1,0 +1,40 @@
+error: unknown disambiguator `foo`
+  --> $DIR/unknown-disambiguator.rs:1:17
+   |
+LL | //! Linking to [foo@banana] and [`bar@banana!()`].
+   |                 ^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unknown-disambiguator.rs:8:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(warnings)]`
+   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
+
+error: unknown disambiguator `bar`
+  --> $DIR/unknown-disambiguator.rs:1:34
+   |
+LL | //! Linking to [foo@banana] and [`bar@banana!()`].
+   |                                  ^^^^^^^^^^^^^^^
+   |
+   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
+
+error: unknown disambiguator ``
+  --> $DIR/unknown-disambiguator.rs:4:31
+   |
+LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
+   |                               ^^^^^^^^^^
+   |
+   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
+
+error: unknown disambiguator ``
+  --> $DIR/unknown-disambiguator.rs:4:57
+   |
+LL | //! And to [no disambiguator](@nectarine) and [another](@apricot!()).
+   |                                                         ^^^^^^^^^^^
+   |
+   = note: the disambiguator is the part of the link before the `@` sign, or a suffix such as `()` for functions
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/const-generics/defaults/complex-unord-param.rs
+++ b/src/test/ui/const-generics/defaults/complex-unord-param.rs
@@ -6,16 +6,16 @@
 #![allow(dead_code)]
 
 struct NestedArrays<'a, const N: usize, A: 'a, const M: usize, T:'a =u32> {
-  //[min]~^ ERROR type parameters must be declared prior to const parameters
-  args: &'a [&'a [T; M]; N],
-  specifier: A,
+    //[min]~^ ERROR type parameters must be declared prior to const parameters
+    args: &'a [&'a [T; M]; N],
+    specifier: A,
 }
 
 fn main() {
-  let array = [1, 2, 3];
-  let nest = [&array];
-  let _ = NestedArrays {
-    args: &nest,
-    specifier: true,
-  };
+    let array = [1, 2, 3];
+    let nest = [&array];
+    let _ = NestedArrays {
+        args: &nest,
+        specifier: true,
+    };
 }

--- a/src/test/ui/const-generics/defaults/default-annotation.rs
+++ b/src/test/ui/const-generics/defaults/default-annotation.rs
@@ -13,8 +13,8 @@ pub struct ConstDefaultUnstable<const N: usize = 3>;
 
 #[stable(feature = "const_default_unstable", since="none")]
 pub struct ConstDefaultStable<const N: usize = {
-  #[stable(feature = "const_default_unstable_val", since="none")]
-  3
+    #[stable(feature = "const_default_unstable_val", since="none")]
+    3
 }>;
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/mismatch.rs
+++ b/src/test/ui/const-generics/defaults/mismatch.rs
@@ -8,16 +8,16 @@ pub struct Example3<const N: usize=13, T=u32>(T);
 pub struct Example4<const N: usize=13, const M: usize=4>;
 
 fn main() {
-  let e: Example::<13> = ();
-  //~^ Error: mismatched types
-  let e: Example2::<u32, 13> = ();
-  //~^ Error: mismatched types
-  let e: Example3::<13, u32> = ();
-  //~^ Error: mismatched types
-  let e: Example3::<7> = ();
-  //~^ Error: mismatched types
-  // FIXME(const_generics_defaults): There should be a note for the error below, but it is
-  // missing.
-  let e: Example4::<7> = ();
-  //~^ Error: mismatched types
+    let e: Example::<13> = ();
+    //~^ Error: mismatched types
+    let e: Example2::<u32, 13> = ();
+    //~^ Error: mismatched types
+    let e: Example3::<13, u32> = ();
+    //~^ Error: mismatched types
+    let e: Example3::<7> = ();
+    //~^ Error: mismatched types
+    // FIXME(const_generics_defaults): There should be a note for the error below, but it is
+    // missing.
+    let e: Example4::<7> = ();
+    //~^ Error: mismatched types
 }

--- a/src/test/ui/const-generics/defaults/mismatch.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.stderr
@@ -1,51 +1,51 @@
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:11:26
+  --> $DIR/mismatch.rs:11:28
    |
-LL |   let e: Example::<13> = ();
-   |          -------------   ^^ expected struct `Example`, found `()`
-   |          |
-   |          expected due to this
+LL |     let e: Example::<13> = ();
+   |            -------------   ^^ expected struct `Example`, found `()`
+   |            |
+   |            expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:13:32
+  --> $DIR/mismatch.rs:13:34
    |
-LL |   let e: Example2::<u32, 13> = ();
-   |          -------------------   ^^ expected struct `Example2`, found `()`
-   |          |
-   |          expected due to this
+LL |     let e: Example2::<u32, 13> = ();
+   |            -------------------   ^^ expected struct `Example2`, found `()`
+   |            |
+   |            expected due to this
    |
    = note: expected struct `Example2`
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:15:32
+  --> $DIR/mismatch.rs:15:34
    |
-LL |   let e: Example3::<13, u32> = ();
-   |          -------------------   ^^ expected struct `Example3`, found `()`
-   |          |
-   |          expected due to this
+LL |     let e: Example3::<13, u32> = ();
+   |            -------------------   ^^ expected struct `Example3`, found `()`
+   |            |
+   |            expected due to this
    |
    = note: expected struct `Example3`
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:17:26
+  --> $DIR/mismatch.rs:17:28
    |
-LL |   let e: Example3::<7> = ();
-   |          -------------   ^^ expected struct `Example3`, found `()`
-   |          |
-   |          expected due to this
+LL |     let e: Example3::<7> = ();
+   |            -------------   ^^ expected struct `Example3`, found `()`
+   |            |
+   |            expected due to this
    |
    = note: expected struct `Example3<7_usize>`
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:21:26
+  --> $DIR/mismatch.rs:21:28
    |
-LL |   let e: Example4::<7> = ();
-   |          -------------   ^^ expected struct `Example4`, found `()`
-   |          |
-   |          expected due to this
+LL |     let e: Example4::<7> = ();
+   |            -------------   ^^ expected struct `Example4`, found `()`
+   |            |
+   |            expected due to this
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/const-generics/defaults/needs-feature.rs
+++ b/src/test/ui/const-generics/defaults/needs-feature.rs
@@ -10,5 +10,5 @@ struct A<const N: usize, T=u32>(T);
 //[min]~^ ERROR type parameters must be declared prior
 
 fn main() {
-  let _: A<3> = A(0);
+    let _: A<3> = A(0);
 }

--- a/src/test/ui/const-generics/defaults/repr-c-issue-82792.rs
+++ b/src/test/ui/const-generics/defaults/repr-c-issue-82792.rs
@@ -1,0 +1,14 @@
+// Regression test for #82792.
+
+// run-pass
+
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
+
+#[repr(C)]
+pub struct Loaf<T: Sized, const N: usize = 1usize> {
+    head: [T; N],
+    slice: [T],
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/simple-defaults.rs
+++ b/src/test/ui/const-generics/defaults/simple-defaults.rs
@@ -6,12 +6,12 @@
 #![allow(dead_code)]
 
 struct FixedOutput<'a, const N: usize, T=u32> {
-  //[min]~^ ERROR type parameters must be declared prior to const parameters
-  out: &'a [T; N],
+    //[min]~^ ERROR type parameters must be declared prior to const parameters
+    out: &'a [T; N],
 }
 
 trait FixedOutputter {
-  fn out(&self) -> FixedOutput<'_, 10>;
+    fn out(&self) -> FixedOutput<'_, 10>;
 }
 
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - #83130 (escape_ascii take 2)
 - #83543 (Lint on unknown intra-doc link disambiguators)
 - #83636 (Add a regression test for issue-82792)
 - #83643 (Remove a FIXME resolved by #73578)
 - #83644 (:arrow_up: rust-analyzer)
 - #83645 (Wrap non-pre code blocks)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83130,83543,83636,83643,83644,83645)
<!-- homu-ignore:end -->