### PR TITLE
Introduce `Statements` abstraction

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -893,8 +893,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
         debug!("codegen_block({:?}={:?})", bb, data);
 
-        for statement in &data.statements {
-            bx = self.codegen_statement(bx, statement);
+        for (statement, source_info) in data.statements.statements_and_source_info_iter() {
+            bx = self.codegen_statement(bx, statement, source_info);
         }
 
         self.codegen_terminator(bx, bb, data.terminator());

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -32,6 +32,7 @@
 #![feature(const_fn)]
 #![feature(const_panic)]
 #![feature(core_intrinsics)]
+#![feature(destructuring_assignment)]
 #![feature(discriminant_kind)]
 #![feature(never_type)]
 #![feature(extern_types)]

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1186,14 +1186,17 @@ pub struct Statements<'tcx> {
 }
 
 impl<'tcx> Statements<'tcx> {
+    #[inline]
     pub fn new() -> Self {
         Self { statements: vec![], source_infos: vec![] }
     }
 
+    #[inline]
     pub fn one(stmt: Statement<'tcx>, source_info: SourceInfo) -> Self {
         Self { statements: vec![stmt], source_infos: vec![source_info] }
     }
 
+    #[inline]
     pub fn two(
         stmt1: Statement<'tcx>,
         source_info1: SourceInfo,
@@ -1203,89 +1206,109 @@ impl<'tcx> Statements<'tcx> {
         Self { statements: vec![stmt1, stmt2], source_infos: vec![source_info1, source_info2] }
     }
 
+    #[inline]
     pub fn from_iter(iter: impl IntoIterator<Item = (Statement<'tcx>, SourceInfo)>) -> Self {
         let (statements, source_infos) = iter.into_iter().unzip();
         Self { statements, source_infos }
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.statements.len()
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.statements.len() == 0
     }
 
+    #[inline]
     pub fn make_nop(&mut self, idx: usize) {
         self.statements[idx].make_nop()
     }
 
+    #[inline]
     pub fn source_info(&self, idx: usize) -> &SourceInfo {
         &self.source_infos[idx]
     }
 
+    #[inline]
     pub fn source_info_mut(&mut self, idx: usize) -> &mut SourceInfo {
         &mut self.source_infos[idx]
     }
 
+    #[inline]
     pub fn source_info_opt(&self, idx: usize) -> Option<&SourceInfo> {
         self.source_infos.get(idx)
     }
 
+    #[inline]
     pub fn source_info_iter(&self) -> impl Iterator<Item = &SourceInfo> {
         self.source_infos.iter()
     }
 
+    #[inline]
     pub fn source_info_iter_mut(&mut self) -> impl Iterator<Item = &mut SourceInfo> {
         self.source_infos.iter_mut()
     }
 
+    #[inline]
     pub fn statement(&self, idx: usize) -> &Statement<'tcx> {
         &self.statements[idx]
     }
 
+    #[inline]
     pub fn statement_opt(&self, idx: usize) -> Option<&Statement<'tcx>> {
         self.statements.get(idx)
     }
 
+    #[inline]
     pub fn last_stmt(&self) -> Option<&Statement<'tcx>> {
         self.statements.last()
     }
 
+    #[inline]
     pub fn statement_mut(&mut self, idx: usize) -> &mut Statement<'tcx> {
         &mut self.statements[idx]
     }
 
+    #[inline]
     pub fn statements_iter(&self) -> std::slice::Iter<'_, Statement<'tcx>> {
         self.statements.iter()
     }
 
+    #[inline]
     pub fn statements_iter_mut(&mut self) -> std::slice::IterMut<'_, Statement<'tcx>> {
         self.statements.iter_mut()
     }
 
+    #[inline]
     pub fn statements_and_source_info_iter(
         &self,
     ) -> impl Iterator<Item = (&Statement<'tcx>, &SourceInfo)> {
         self.statements.iter().zip(self.source_infos.iter())
     }
 
+    #[inline]
     pub fn statements_and_source_info_iter_mut(
         &mut self,
     ) -> impl Iterator<Item = (&mut Statement<'tcx>, &mut SourceInfo)> {
         self.statements.iter_mut().zip(self.source_infos.iter_mut())
     }
 
+    #[inline]
     pub fn push(&mut self, stmt: Statement<'tcx>, source_info: SourceInfo) {
         self.statements.push(stmt);
         self.source_infos.push(source_info);
     }
 
+    #[inline]
     pub fn insert(&mut self, at: usize, stmt: Statement<'tcx>, source_info: SourceInfo) {
         self.statements.insert(at, stmt);
         self.source_infos.insert(at, source_info);
     }
 
+    #[inline]
     pub fn extend(
         &mut self,
         stmts: impl Iterator<Item = Statement<'tcx>>,
@@ -1295,6 +1318,7 @@ impl<'tcx> Statements<'tcx> {
         self.source_infos.extend(source_infos);
     }
 
+    #[inline]
     pub fn rotate_right(&mut self, k: usize) {
         self.statements.rotate_right(k);
         self.source_infos.rotate_right(k);
@@ -1327,11 +1351,13 @@ impl<'tcx> Statements<'tcx> {
         }
     }
 
+    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         self.statements.reserve(additional);
         self.source_infos.reserve(additional);
     }
 
+    #[inline]
     pub fn append(&mut self, other: &mut Self) {
         self.statements.append(&mut other.statements);
         self.source_infos.append(&mut other.source_infos);

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/explain_borrow.rs
@@ -517,7 +517,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 let kind = if let Some(&Statement {
                     kind: StatementKind::FakeRead(box (FakeReadCause::ForLet(_), _)),
                     ..
-                }) = block.statements.get(location.statement_index)
+                }) = block.statements.statement_opt(location.statement_index)
                 {
                     LaterUseKind::FakeLetRead
                 } else if self.was_captured_by_trait_object(borrow) {
@@ -562,7 +562,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         // Start at the reserve location, find the place that we want to see cast to a trait object.
         let location = borrow.reserve_location;
         let block = &self.body[location.block];
-        let stmt = block.statements.get(location.statement_index);
+        let stmt = block.statements.statement_opt(location.statement_index);
         debug!("was_captured_by_trait_object: location={:?} stmt={:?}", location, stmt);
 
         // We make a `queue` vector that has the locations we want to visit. As of writing, this
@@ -590,7 +590,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             // We need to check the current location to find out if it is a terminator.
             let is_terminator = current_location.statement_index == block.statements.len();
             if !is_terminator {
-                let stmt = &block.statements[current_location.statement_index];
+                let stmt = block.statements.statement(current_location.statement_index);
                 debug!("was_captured_by_trait_object: stmt={:?}", stmt);
 
                 // The only kind of statement that we care about is assignments...

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/move_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/move_errors.rs
@@ -91,7 +91,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     Rvalue::Use(Operand::Move(move_from)),
                 ))) = self.body.basic_blocks()[location.block]
                     .statements
-                    .get(location.statement_index)
+                    .statement_opt(location.statement_index)
                     .map(|stmt| &stmt.kind)
                 {
                     if let Some(local) = place.as_local() {

--- a/compiler/rustc_mir/src/borrow_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/mod.rs
@@ -564,7 +564,7 @@ impl<'cx, 'tcx> dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtxt<'cx, 'tc
         location: Location,
     ) {
         debug!("MirBorrowckCtxt::process_statement({:?}, {:?}): {:?}", location, stmt, flow_state);
-        let span = stmt.source_info.span;
+        let span = self.body[location.block].statements.source_info(location.statement_index).span;
 
         self.check_activations(location, span, flow_state);
 
@@ -1441,7 +1441,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
                         let body = self.body;
                         let bbd = &body[loc.block];
-                        let stmt = &bbd.statements[loc.statement_index];
+                        let stmt = bbd.statements.statement(loc.statement_index);
                         debug!("temporary assigned in: stmt={:?}", stmt);
 
                         if let StatementKind::Assign(box (_, Rvalue::Ref(_, _, source))) = stmt.kind

--- a/compiler/rustc_mir/src/dataflow/framework/direction.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/direction.rs
@@ -83,7 +83,9 @@ impl Direction for Backward {
         analysis.apply_before_terminator_effect(state, terminator, location);
         analysis.apply_terminator_effect(state, terminator, location);
 
-        for (statement_index, statement) in block_data.statements.iter().enumerate().rev() {
+        for (statement_index, statement) in
+            block_data.statements.statements_iter().enumerate().rev()
+        {
             let location = Location { block, statement_index };
             analysis.apply_before_statement_effect(state, statement, location);
             analysis.apply_statement_effect(state, statement, location);
@@ -103,7 +105,9 @@ impl Direction for Backward {
         analysis.before_terminator_effect(trans, terminator, location);
         analysis.terminator_effect(trans, terminator, location);
 
-        for (statement_index, statement) in block_data.statements.iter().enumerate().rev() {
+        for (statement_index, statement) in
+            block_data.statements.statements_iter().enumerate().rev()
+        {
             let location = Location { block, statement_index };
             analysis.before_statement_effect(trans, statement, location);
             analysis.statement_effect(trans, statement, location);
@@ -152,7 +156,7 @@ impl Direction for Backward {
 
             Effect::Primary => {
                 let location = Location { block, statement_index: from.statement_index };
-                let statement = &block_data.statements[from.statement_index];
+                let statement = block_data.statements.statement(from.statement_index);
 
                 analysis.apply_statement_effect(state, statement, location);
                 if to == Effect::Primary.at_index(from.statement_index) {
@@ -169,7 +173,7 @@ impl Direction for Backward {
 
         for statement_index in (to.statement_index..next_effect).rev().map(|i| i + 1) {
             let location = Location { block, statement_index };
-            let statement = &block_data.statements[statement_index];
+            let statement = block_data.statements.statement(statement_index);
             analysis.apply_before_statement_effect(state, statement, location);
             analysis.apply_statement_effect(state, statement, location);
         }
@@ -177,7 +181,7 @@ impl Direction for Backward {
         // Handle the statement at `to`.
 
         let location = Location { block, statement_index: to.statement_index };
-        let statement = &block_data.statements[to.statement_index];
+        let statement = &block_data.statements.statement(to.statement_index);
         analysis.apply_before_statement_effect(state, statement, location);
 
         if to.effect == Effect::Before {
@@ -208,7 +212,7 @@ impl Direction for Backward {
         results.reconstruct_terminator_effect(state, term, loc);
         vis.visit_terminator_after_primary_effect(state, term, loc);
 
-        for (statement_index, stmt) in block_data.statements.iter().enumerate().rev() {
+        for (statement_index, stmt) in block_data.statements.statements_iter().enumerate().rev() {
             let loc = Location { block, statement_index };
             results.reconstruct_before_statement_effect(state, stmt, loc);
             vis.visit_statement_before_primary_effect(state, stmt, loc);
@@ -287,7 +291,7 @@ impl Direction for Forward {
     ) where
         A: Analysis<'tcx>,
     {
-        for (statement_index, statement) in block_data.statements.iter().enumerate() {
+        for (statement_index, statement) in block_data.statements.statements_iter().enumerate() {
             let location = Location { block, statement_index };
             analysis.apply_before_statement_effect(state, statement, location);
             analysis.apply_statement_effect(state, statement, location);
@@ -307,7 +311,7 @@ impl Direction for Forward {
     ) where
         A: GenKillAnalysis<'tcx>,
     {
-        for (statement_index, statement) in block_data.statements.iter().enumerate() {
+        for (statement_index, statement) in block_data.statements.statements_iter().enumerate() {
             let location = Location { block, statement_index };
             analysis.before_statement_effect(trans, statement, location);
             analysis.statement_effect(trans, statement, location);
@@ -351,7 +355,7 @@ impl Direction for Forward {
 
             Effect::Primary => {
                 let location = Location { block, statement_index: from.statement_index };
-                let statement = &block_data.statements[from.statement_index];
+                let statement = &block_data.statements.statement(from.statement_index);
                 analysis.apply_statement_effect(state, statement, location);
 
                 // If we only needed to apply the after effect of the statement at `idx`, we are done.
@@ -367,7 +371,7 @@ impl Direction for Forward {
 
         for statement_index in first_unapplied_index..to.statement_index {
             let location = Location { block, statement_index };
-            let statement = &block_data.statements[statement_index];
+            let statement = block_data.statements.statement(statement_index);
             analysis.apply_before_statement_effect(state, statement, location);
             analysis.apply_statement_effect(state, statement, location);
         }
@@ -383,7 +387,7 @@ impl Direction for Forward {
                 analysis.apply_terminator_effect(state, terminator, location);
             }
         } else {
-            let statement = &block_data.statements[to.statement_index];
+            let statement = &block_data.statements.statement(to.statement_index);
             analysis.apply_before_statement_effect(state, statement, location);
 
             if to.effect == Effect::Primary {
@@ -405,7 +409,7 @@ impl Direction for Forward {
 
         vis.visit_block_start(state, block_data, block);
 
-        for (statement_index, stmt) in block_data.statements.iter().enumerate() {
+        for (statement_index, stmt) in block_data.statements.statements_iter().enumerate() {
             let loc = Location { block, statement_index };
             results.reconstruct_before_statement_effect(state, stmt, loc);
             vis.visit_statement_before_primary_effect(state, stmt, loc);

--- a/compiler/rustc_mir/src/dataflow/framework/graphviz.rs
+++ b/compiler/rustc_mir/src/dataflow/framework/graphviz.rs
@@ -369,7 +369,7 @@ where
             if A::Direction::is_forward() { it.next().unwrap() } else { it.next_back().unwrap() }
         };
 
-        for (i, statement) in body[block].statements.iter().enumerate() {
+        for (i, statement) in body[block].statements.statements_iter().enumerate() {
             let statement_str = format!("{:?}", statement);
             let index_str = format!("{}", i);
 

--- a/compiler/rustc_mir/src/dataflow/impls/mod.rs
+++ b/compiler/rustc_mir/src/dataflow/impls/mod.rs
@@ -696,7 +696,7 @@ fn switch_on_enum_discriminant(
     block: &'mir mir::BasicBlockData<'tcx>,
     switch_on: mir::Place<'tcx>,
 ) -> Option<(mir::Place<'tcx>, &'tcx ty::AdtDef)> {
-    match block.statements.last().map(|stmt| &stmt.kind) {
+    match block.statements.last_stmt().map(|stmt| &stmt.kind) {
         Some(mir::StatementKind::Assign(box (lhs, mir::Rvalue::Discriminant(discriminated))))
             if *lhs == switch_on =>
         {

--- a/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
+++ b/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
@@ -232,7 +232,7 @@ pub(super) fn gather_moves<'tcx>(
     builder.gather_args();
 
     for (bb, block) in body.basic_blocks().iter_enumerated() {
-        for (i, stmt) in block.statements.iter().enumerate() {
+        for (i, stmt) in block.statements.statements_iter().enumerate() {
             let source = Location { block: bb, statement_index: i };
             builder.gather_statement(source, stmt);
         }
@@ -312,7 +312,10 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             }
             StatementKind::SetDiscriminant { .. } => {
                 span_bug!(
-                    stmt.source_info.span,
+                    self.builder.body.basic_blocks()[self.loc.block]
+                        .statements
+                        .source_info(self.loc.statement_index)
+                        .span,
                     "SetDiscriminant should not exist during borrowck"
                 );
             }

--- a/compiler/rustc_mir/src/interpret/step.rs
+++ b/compiler/rustc_mir/src/interpret/step.rs
@@ -61,7 +61,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         let old_frames = self.frame_idx();
 
-        if let Some(stmt) = basic_block.statements.get(loc.statement_index) {
+        if let Some(stmt) = basic_block.statements.statement_opt(loc.statement_index) {
             assert_eq!(old_frames, self.frame_idx());
             self.statement(stmt)?;
             return Ok(true);

--- a/compiler/rustc_mir/src/transform/add_call_guards.rs
+++ b/compiler/rustc_mir/src/transform/add_call_guards.rs
@@ -60,7 +60,7 @@ impl AddCallGuards {
                 {
                     // It's a critical edge, break it
                     let call_guard = BasicBlockData {
-                        statements: vec![],
+                        statements: Statements::new(),
                         is_cleanup: block.is_cleanup,
                         terminator: Some(Terminator {
                             source_info,

--- a/compiler/rustc_mir/src/transform/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir/src/transform/add_moves_for_packed_drops.rs
@@ -94,7 +94,10 @@ fn add_move_for_packed_drop<'tcx>(
     let temp = patch.new_temp(ty, terminator.source_info.span);
 
     let storage_dead_block = patch.new_block(BasicBlockData {
-        statements: vec![Statement { source_info, kind: StatementKind::StorageDead(temp) }],
+        statements: Statements::one(
+            Statement { kind: StatementKind::StorageDead(temp) },
+            source_info,
+        ),
         terminator: Some(Terminator { source_info, kind: TerminatorKind::Goto { target } }),
         is_cleanup,
     });

--- a/compiler/rustc_mir/src/transform/check_packed_ref.rs
+++ b/compiler/rustc_mir/src/transform/check_packed_ref.rs
@@ -75,7 +75,9 @@ impl<'a, 'tcx> Visitor<'tcx> for PackedRefChecker<'a, 'tcx> {
 
     fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
         // Make sure we know where in the MIR we are.
-        self.source_info = statement.source_info;
+        self.source_info = *self.body.basic_blocks()[location.block]
+            .statements
+            .source_info(location.statement_index);
         self.super_statement(statement, location);
     }
 

--- a/compiler/rustc_mir/src/transform/check_unsafety.rs
+++ b/compiler/rustc_mir/src/transform/check_unsafety.rs
@@ -103,7 +103,9 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
     }
 
     fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
-        self.source_info = statement.source_info;
+        self.source_info = *self.body.basic_blocks()[location.block]
+            .statements
+            .source_info(location.statement_index);
         match statement.kind {
             StatementKind::Assign(..)
             | StatementKind::FakeRead(..)

--- a/compiler/rustc_mir/src/transform/const_debuginfo.rs
+++ b/compiler/rustc_mir/src/transform/const_debuginfo.rs
@@ -77,10 +77,10 @@ fn find_optimization_oportunities<'tcx>(body: &Body<'tcx>) -> Vec<(Local, Consta
             }
 
             if let StatementKind::Assign(box (p, Rvalue::Use(Operand::Constant(box c)))) =
-                &bb.statements[location.statement_index].kind
+                bb.statements.statement(location.statement_index).kind
             {
                 if let Some(local) = p.as_local() {
-                    eligable_locals.push((local, *c));
+                    eligable_locals.push((local, c));
                 }
             }
         }

--- a/compiler/rustc_mir/src/transform/const_goto.rs
+++ b/compiler/rustc_mir/src/transform/const_goto.rs
@@ -58,7 +58,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ConstGotoOptimizationFinder<'a, 'tcx> {
         let _: Option<_> = try {
             let target = terminator.kind.as_goto()?;
             // We only apply this optimization if the last statement is a const assignment
-            let last_statement = self.body.basic_blocks()[location.block].statements.last()?;
+            let last_statement = self.body.basic_blocks()[location.block].statements.last_stmt()?;
 
             if let (place, Rvalue::Use(Operand::Constant(_const))) =
                 last_statement.kind.as_assign()?

--- a/compiler/rustc_mir/src/transform/deaggregator.rs
+++ b/compiler/rustc_mir/src/transform/deaggregator.rs
@@ -10,7 +10,7 @@ impl<'tcx> MirPass<'tcx> for Deaggregator {
         let (basic_blocks, local_decls) = body.basic_blocks_and_local_decls_mut();
         let local_decls = &*local_decls;
         for bb in basic_blocks {
-            bb.expand_statements(|stmt| {
+            bb.statements.expand_statements(|(stmt, source_info)| {
                 // FIXME(eddyb) don't match twice on `stmt.kind` (post-NLL).
                 match stmt.kind {
                     // FIXME(#48193) Deaggregate arrays when it's cheaper to do so.
@@ -25,7 +25,7 @@ impl<'tcx> MirPass<'tcx> for Deaggregator {
                 }
 
                 let stmt = stmt.replace_nop();
-                let source_info = stmt.source_info;
+                let source_info = *source_info;
                 let (lhs, kind, operands) = match stmt.kind {
                     StatementKind::Assign(box (lhs, Rvalue::Aggregate(kind, operands))) => {
                         (lhs, kind, operands)

--- a/compiler/rustc_mir/src/transform/deduplicate_blocks.rs
+++ b/compiler/rustc_mir/src/transform/deduplicate_blocks.rs
@@ -103,7 +103,7 @@ struct BasicBlockHashable<'tcx, 'a> {
 
 impl<'tcx, 'a> Hash for BasicBlockHashable<'tcx, 'a> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        hash_statements(state, self.basic_block_data.statements.iter());
+        hash_statements(state, self.basic_block_data.statements.statements_iter());
         // Note that since we only hash the kind, we lose span information if we deduplicate the blocks
         self.basic_block_data.terminator().kind.hash(state);
     }
@@ -115,8 +115,11 @@ impl<'tcx, 'a> PartialEq for BasicBlockHashable<'tcx, 'a> {
     fn eq(&self, other: &Self) -> bool {
         self.basic_block_data.statements.len() == other.basic_block_data.statements.len()
             && &self.basic_block_data.terminator().kind == &other.basic_block_data.terminator().kind
-            && iter::zip(&self.basic_block_data.statements, &other.basic_block_data.statements)
-                .all(|(x, y)| statement_eq(&x.kind, &y.kind))
+            && iter::zip(
+                self.basic_block_data.statements.statements_iter(),
+                other.basic_block_data.statements.statements_iter(),
+            )
+            .all(|(x, y)| statement_eq(&x.kind, &y.kind))
     }
 }
 

--- a/compiler/rustc_mir/src/transform/dest_prop.rs
+++ b/compiler/rustc_mir/src/transform/dest_prop.rs
@@ -499,7 +499,7 @@ impl Conflicts<'a> {
 
             // First, go forwards for `MaybeInitializedLocals` and apply intra-statement/terminator
             // conflicts.
-            for (i, statement) in data.statements.iter().enumerate() {
+            for (i, statement) in data.statements.statements_iter().enumerate() {
                 this.record_statement_conflicts(statement);
 
                 let loc = Location { block, statement_index: i };

--- a/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
+++ b/compiler/rustc_mir/src/transform/early_otherwise_branch.rs
@@ -347,7 +347,7 @@ impl<'a, 'tcx> Helper<'a, 'tcx> {
 
                 // find the place of the adt where the discriminant is being read from
                 // assume this is the last statement of the block
-                let place_of_adt_discr_read = match bb.statements.last()?.kind {
+                let place_of_adt_discr_read = match bb.statements.last_stmt()?.kind {
                     StatementKind::Assign(box (_, Rvalue::Discriminant(adt_place))) => {
                         Some(adt_place)
                     }

--- a/compiler/rustc_mir/src/transform/instcombine.rs
+++ b/compiler/rustc_mir/src/transform/instcombine.rs
@@ -15,12 +15,12 @@ impl<'tcx> MirPass<'tcx> for InstCombine {
         let (basic_blocks, local_decls) = body.basic_blocks_and_local_decls_mut();
         let ctx = InstCombineContext { tcx, local_decls };
         for block in basic_blocks.iter_mut() {
-            for statement in block.statements.iter_mut() {
+            for (statement, source_info) in block.statements.statements_and_source_info_iter_mut() {
                 match statement.kind {
                     StatementKind::Assign(box (_place, ref mut rvalue)) => {
-                        ctx.combine_bool_cmp(&statement.source_info, rvalue);
-                        ctx.combine_ref_deref(&statement.source_info, rvalue);
-                        ctx.combine_len(&statement.source_info, rvalue);
+                        ctx.combine_bool_cmp(source_info, rvalue);
+                        ctx.combine_ref_deref(source_info, rvalue);
+                        ctx.combine_len(source_info, rvalue);
                     }
                     _ => {}
                 }

--- a/compiler/rustc_mir/src/transform/lower_intrinsics.rs
+++ b/compiler/rustc_mir/src/transform/lower_intrinsics.rs
@@ -26,33 +26,38 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                     }
                     sym::forget => {
                         if let Some((destination, target)) = *destination {
-                            block.statements.push(Statement {
-                                source_info: terminator.source_info,
-                                kind: StatementKind::Assign(box (
-                                    destination,
-                                    Rvalue::Use(Operand::Constant(box Constant {
-                                        span: terminator.source_info.span,
-                                        user_ty: None,
-                                        literal: ty::Const::zero_sized(tcx, tcx.types.unit).into(),
-                                    })),
-                                )),
-                            });
+                            block.statements.push(
+                                Statement {
+                                    kind: StatementKind::Assign(box (
+                                        destination,
+                                        Rvalue::Use(Operand::Constant(box Constant {
+                                            span: terminator.source_info.span,
+                                            user_ty: None,
+                                            literal: ty::Const::zero_sized(tcx, tcx.types.unit)
+                                                .into(),
+                                        })),
+                                    )),
+                                },
+                                terminator.source_info,
+                            );
                             terminator.kind = TerminatorKind::Goto { target };
                         }
                     }
                     sym::copy_nonoverlapping => {
                         let target = destination.unwrap().1;
                         let mut args = args.drain(..);
-                        block.statements.push(Statement {
-                            source_info: terminator.source_info,
-                            kind: StatementKind::CopyNonOverlapping(
-                                box rustc_middle::mir::CopyNonOverlapping {
-                                    src: args.next().unwrap(),
-                                    dst: args.next().unwrap(),
-                                    count: args.next().unwrap(),
-                                },
-                            ),
-                        });
+                        block.statements.push(
+                            Statement {
+                                kind: StatementKind::CopyNonOverlapping(
+                                    box rustc_middle::mir::CopyNonOverlapping {
+                                        src: args.next().unwrap(),
+                                        dst: args.next().unwrap(),
+                                        count: args.next().unwrap(),
+                                    },
+                                ),
+                            },
+                            terminator.source_info,
+                        );
                         assert_eq!(
                             args.next(),
                             None,
@@ -76,13 +81,15 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                                 sym::wrapping_mul => BinOp::Mul,
                                 _ => bug!("unexpected intrinsic"),
                             };
-                            block.statements.push(Statement {
-                                source_info: terminator.source_info,
-                                kind: StatementKind::Assign(box (
-                                    destination,
-                                    Rvalue::BinaryOp(bin_op, box (lhs, rhs)),
-                                )),
-                            });
+                            block.statements.push(
+                                Statement {
+                                    kind: StatementKind::Assign(box (
+                                        destination,
+                                        Rvalue::BinaryOp(bin_op, box (lhs, rhs)),
+                                    )),
+                                },
+                                terminator.source_info,
+                            );
                             terminator.kind = TerminatorKind::Goto { target };
                         }
                     }
@@ -94,13 +101,15 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                     sym::size_of => {
                         if let Some((destination, target)) = *destination {
                             let tp_ty = substs.type_at(0);
-                            block.statements.push(Statement {
-                                source_info: terminator.source_info,
-                                kind: StatementKind::Assign(box (
-                                    destination,
-                                    Rvalue::NullaryOp(NullOp::SizeOf, tp_ty),
-                                )),
-                            });
+                            block.statements.push(
+                                Statement {
+                                    kind: StatementKind::Assign(box (
+                                        destination,
+                                        Rvalue::NullaryOp(NullOp::SizeOf, tp_ty),
+                                    )),
+                                },
+                                terminator.source_info,
+                            );
                             terminator.kind = TerminatorKind::Goto { target };
                         }
                     }
@@ -109,13 +118,15 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                             (*destination, args[0].place())
                         {
                             let arg = tcx.mk_place_deref(arg);
-                            block.statements.push(Statement {
-                                source_info: terminator.source_info,
-                                kind: StatementKind::Assign(box (
-                                    destination,
-                                    Rvalue::Discriminant(arg),
-                                )),
-                            });
+                            block.statements.push(
+                                Statement {
+                                    kind: StatementKind::Assign(box (
+                                        destination,
+                                        Rvalue::Discriminant(arg),
+                                    )),
+                                },
+                                terminator.source_info,
+                            );
                             terminator.kind = TerminatorKind::Goto { target };
                         }
                     }

--- a/compiler/rustc_mir/src/transform/nrvo.rs
+++ b/compiler/rustc_mir/src/transform/nrvo.rs
@@ -131,7 +131,11 @@ fn find_local_assigned_to_return_place(
     while seen.insert(block) {
         trace!("Looking for assignments to `_0` in {:?}", block);
 
-        let local = body[block].statements.iter().rev().find_map(as_local_assigned_to_return_place);
+        let local = body[block]
+            .statements
+            .statements_iter()
+            .rev()
+            .find_map(as_local_assigned_to_return_place);
         if local.is_some() {
             return local;
         }

--- a/compiler/rustc_mir/src/transform/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir/src/transform/remove_noop_landing_pads.rs
@@ -32,7 +32,7 @@ impl RemoveNoopLandingPads {
         body: &Body<'_>,
         nop_landing_pads: &BitSet<BasicBlock>,
     ) -> bool {
-        for stmt in &body[bb].statements {
+        for stmt in body[bb].statements.statements_iter() {
             match &stmt.kind {
                 StatementKind::FakeRead(..)
                 | StatementKind::StorageLive(_)

--- a/compiler/rustc_mir/src/transform/remove_zsts.rs
+++ b/compiler/rustc_mir/src/transform/remove_zsts.rs
@@ -15,7 +15,9 @@ impl<'tcx> MirPass<'tcx> for RemoveZsts {
         let param_env = tcx.param_env(body.source.def_id());
         let (basic_blocks, local_decls) = body.basic_blocks_and_local_decls_mut();
         for block in basic_blocks.iter_mut() {
-            for statement in block.statements.iter_mut() {
+            for (statement, statement_source_info) in
+                block.statements.statements_and_source_info_iter_mut()
+            {
                 match statement.kind {
                     StatementKind::Assign(box (place, _)) => {
                         let place_ty = place.ty(local_decls, tcx).ty;
@@ -35,7 +37,7 @@ impl<'tcx> MirPass<'tcx> for RemoveZsts {
                         if tcx.consider_optimizing(|| {
                             format!(
                                 "RemoveZsts - Place: {:?} SourceInfo: {:?}",
-                                place, statement.source_info
+                                place, statement_source_info
                             )
                         }) {
                             statement.make_nop();

--- a/compiler/rustc_mir/src/transform/rustc_peek.rs
+++ b/compiler/rustc_mir/src/transform/rustc_peek.rs
@@ -126,7 +126,7 @@ pub fn sanity_check_via_rustc_peek<'tcx, A>(
         //    rustc_peek(_2);
         let (statement_index, peek_rval) = block_data
             .statements
-            .iter()
+            .statements_iter()
             .enumerate()
             .find_map(|(i, stmt)| value_assigned_to_local(stmt, call.arg).map(|rval| (i, rval)))
             .expect(

--- a/compiler/rustc_mir/src/transform/uninhabited_enum_branching.rs
+++ b/compiler/rustc_mir/src/transform/uninhabited_enum_branching.rs
@@ -31,7 +31,7 @@ fn get_switched_on_type<'tcx>(
     // Only bother checking blocks which terminate by switching on a local.
     if let Some(local) = get_discriminant_local(&terminator.kind) {
         let stmt_before_term = (!block_data.statements.is_empty())
-            .then(|| &block_data.statements[block_data.statements.len() - 1].kind);
+            .then(|| &block_data.statements.statement(block_data.statements.len() - 1).kind);
 
         if let Some(StatementKind::Assign(box (l, Rvalue::Discriminant(place)))) = stmt_before_term
         {

--- a/compiler/rustc_mir/src/transform/unreachable_prop.rs
+++ b/compiler/rustc_mir/src/transform/unreachable_prop.rs
@@ -27,7 +27,7 @@ impl MirPass<'_> for UnreachablePropagation {
             // This is a temporary solution that handles possibly diverging asm statements.
             // Accompanying testcases: mir-opt/unreachable_asm.rs and mir-opt/unreachable_asm_2.rs
             let asm_stmt_in_block = || {
-                bb_data.statements.iter().any(|stmt: &Statement<'_>| match stmt.kind {
+                bb_data.statements.statements_iter().any(|stmt: &Statement<'_>| match stmt.kind {
                     StatementKind::LlvmInlineAsm(..) => true,
                     _ => false,
                 })

--- a/compiler/rustc_mir/src/util/generic_graph.rs
+++ b/compiler/rustc_mir/src/util/generic_graph.rs
@@ -49,7 +49,8 @@ fn bb_to_graph_node(block: BasicBlock, body: &Body<'_>, dark_mode: bool) -> Node
     };
 
     let style = NodeStyle { title_bg: Some(bgcolor.to_owned()), ..Default::default() };
-    let mut stmts: Vec<String> = data.statements.iter().map(|x| format!("{:?}", x)).collect();
+    let mut stmts: Vec<String> =
+        data.statements.statements_iter().map(|x| format!("{:?}", x)).collect();
 
     // add the terminator to the stmts, gsgdt can print it out seperately
     let mut terminator_head = String::new();

--- a/compiler/rustc_mir/src/util/pretty.rs
+++ b/compiler/rustc_mir/src/util/pretty.rs
@@ -352,7 +352,7 @@ where
 
     // List of statements in the middle.
     let mut current_location = Location { block, statement_index: 0 };
-    for statement in &data.statements {
+    for (statement, stmt_source_info) in data.statements.statements_and_source_info_iter() {
         extra_data(PassWhere::BeforeLocation(current_location), w)?;
         let indented_body = format!("{0}{0}{1:?};", INDENT, statement);
         writeln!(
@@ -360,7 +360,7 @@ where
             "{:A$} // {}{}",
             indented_body,
             if tcx.sess.verbose() { format!("{:?}: ", current_location) } else { String::new() },
-            comment(tcx, statement.source_info),
+            comment(tcx, *stmt_source_info),
             A = ALIGN,
         )?;
 

--- a/compiler/rustc_mir/src/util/storage.rs
+++ b/compiler/rustc_mir/src/util/storage.rs
@@ -15,7 +15,7 @@ impl AlwaysLiveLocals {
         let mut always_live_locals = AlwaysLiveLocals(BitSet::new_filled(body.local_decls.len()));
 
         for block in body.basic_blocks() {
-            for statement in &block.statements {
+            for statement in block.statements.statements_iter() {
                 use mir::StatementKind::{StorageDead, StorageLive};
                 if let StorageLive(l) | StorageDead(l) = statement.kind {
                     always_live_locals.0.remove(l);

--- a/compiler/rustc_mir_build/src/build/cfg.rs
+++ b/compiler/rustc_mir_build/src/build/cfg.rs
@@ -26,9 +26,14 @@ impl<'tcx> CFG<'tcx> {
         bb
     }
 
-    crate fn push(&mut self, block: BasicBlock, statement: Statement<'tcx>) {
+    crate fn push(
+        &mut self,
+        block: BasicBlock,
+        statement: Statement<'tcx>,
+        source_info: SourceInfo,
+    ) {
         debug!("push({:?}, {:?})", block, statement);
-        self.block_data_mut(block).statements.push(statement);
+        self.block_data_mut(block).statements.push(statement, source_info);
     }
 
     crate fn push_assign(
@@ -40,7 +45,8 @@ impl<'tcx> CFG<'tcx> {
     ) {
         self.push(
             block,
-            Statement { source_info, kind: StatementKind::Assign(box (place, rvalue)) },
+            Statement { kind: StatementKind::Assign(box (place, rvalue)) },
+            source_info,
         );
     }
 
@@ -81,8 +87,8 @@ impl<'tcx> CFG<'tcx> {
         place: Place<'tcx>,
     ) {
         let kind = StatementKind::FakeRead(box (cause, place));
-        let stmt = Statement { source_info, kind };
-        self.push(block, stmt);
+        let stmt = Statement { kind };
+        self.push(block, stmt, source_info);
     }
 
     crate fn terminate(

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -495,7 +495,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     this.cfg.push(
                         block,
                         Statement {
-                            source_info,
                             kind: StatementKind::AscribeUserType(
                                 box (
                                     place,
@@ -504,6 +503,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 Variance::Invariant,
                             ),
                         },
+                        source_info,
                     );
                 }
                 block.and(place_builder)
@@ -521,7 +521,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     this.cfg.push(
                         block,
                         Statement {
-                            source_info,
                             kind: StatementKind::AscribeUserType(
                                 box (
                                     Place::from(temp),
@@ -530,6 +529,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                                 Variance::Invariant,
                             ),
                         },
+                        source_info,
                     );
                 }
                 block.and(PlaceBuilder::from(temp))

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -90,7 +90,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 let result = this.local_decls.push(LocalDecl::new(expr.ty, expr_span).internal());
                 this.cfg.push(
                     block,
-                    Statement { source_info, kind: StatementKind::StorageLive(result) },
+                    Statement { kind: StatementKind::StorageLive(result) },
+                    source_info,
                 );
                 if let Some(scope) = scope {
                     // schedule a shallow free of that memory, lest we unwind:
@@ -405,7 +406,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let source_info = this.source_info(upvar_span);
         let temp = this.local_decls.push(LocalDecl::new(upvar_ty, upvar_span));
 
-        this.cfg.push(block, Statement { source_info, kind: StatementKind::StorageLive(temp) });
+        this.cfg.push(block, Statement { kind: StatementKind::StorageLive(temp) }, source_info);
 
         let arg_place_builder = unpack!(block = this.as_place_builder(block, arg));
 

--- a/compiler/rustc_mir_build/src/build/expr/as_temp.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_temp.rs
@@ -86,8 +86,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             ExprKind::Block { body: Block { expr: None, targeted_by_break: false, .. } }
                 if expr_ty.is_never() => {}
             _ => {
-                this.cfg
-                    .push(block, Statement { source_info, kind: StatementKind::StorageLive(temp) });
+                this.cfg.push(
+                    block,
+                    Statement { kind: StatementKind::StorageLive(temp) },
+                    source_info,
+                );
 
                 // In constants, `temp_lifetime` is `None` for temporaries that
                 // live for the `'static` lifetime. Thus we do not drop these

--- a/compiler/rustc_mir_build/src/build/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/build/expr/stmt.rs
@@ -112,13 +112,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.cfg.push(
                     block,
                     Statement {
-                        source_info,
                         kind: StatementKind::LlvmInlineAsm(box LlvmInlineAsm {
                             asm: asm.clone(),
                             outputs,
                             inputs,
                         }),
                     },
+                    source_info,
                 );
                 this.block_context.pop();
                 block.unit()

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -447,7 +447,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 self.cfg.push(
                     block,
                     Statement {
-                        source_info: ty_source_info,
                         kind: StatementKind::AscribeUserType(
                             box (place, user_ty),
                             // We always use invariant as the variance here. This is because the
@@ -467,6 +466,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             ty::Variance::Invariant,
                         ),
                     },
+                    ty_source_info,
                 );
 
                 self.schedule_drop_for_binding(var, irrefutable_pat.span, OutsideGuard);
@@ -600,7 +600,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> Place<'tcx> {
         let local_id = self.var_local_id(var, for_guard);
         let source_info = self.source_info(span);
-        self.cfg.push(block, Statement { source_info, kind: StatementKind::StorageLive(local_id) });
+        self.cfg.push(block, Statement { kind: StatementKind::StorageLive(local_id) }, source_info);
         let region_scope = self.region_scope_tree.var_scope(var.local_id);
         if schedule_drop {
             self.schedule_drop(span, region_scope, local_id, DropKind::Storage);
@@ -1955,12 +1955,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             self.cfg.push(
                 block,
                 Statement {
-                    source_info,
                     kind: StatementKind::AscribeUserType(
                         box (ascription.source, user_ty),
                         ascription.variance,
                     ),
                 },
+                source_info,
             );
         }
     }

--- a/compiler/rustc_mir_build/src/build/scope.rs
+++ b/compiler/rustc_mir_build/src/build/scope.rs
@@ -367,11 +367,8 @@ impl DropTree {
                 // Root nodes don't correspond to a drop.
                 DropKind::Storage if drop_idx == ROOT_NODE => {}
                 DropKind::Storage => {
-                    let stmt = Statement {
-                        source_info: drop_data.0.source_info,
-                        kind: StatementKind::StorageDead(drop_data.0.local),
-                    };
-                    cfg.push(block, stmt);
+                    let stmt = Statement { kind: StatementKind::StorageDead(drop_data.0.local) };
+                    cfg.push(block, stmt, drop_data.0.source_info);
                     let target = blocks[drop_data.1].unwrap();
                     if target != block {
                         // Diagnostics don't use this `Span` but debuginfo
@@ -949,11 +946,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             assert_eq!(local, cond_temp, "Drop scheduled on top of condition");
                             self.cfg.push(
                                 true_block,
-                                Statement { source_info, kind: StatementKind::StorageDead(local) },
+                                Statement { kind: StatementKind::StorageDead(local) },
+                                source_info,
                             );
                             self.cfg.push(
                                 false_block,
-                                Statement { source_info, kind: StatementKind::StorageDead(local) },
+                                Statement { kind: StatementKind::StorageDead(local) },
+                                source_info,
                             );
                         }
                     }
@@ -1177,7 +1176,7 @@ fn build_scope_drops<'tcx>(
                 }
                 // Only temps and vars need their storage dead.
                 assert!(local.index() > arg_count);
-                cfg.push(block, Statement { source_info, kind: StatementKind::StorageDead(local) });
+                cfg.push(block, Statement { kind: StatementKind::StorageDead(local) }, source_info);
             }
         }
     }


### PR DESCRIPTION
The abstraction allows for a memory layout where SourceInfo is not
stored alongside the Statement. Since Statement is often iterated
without accessing the SourceInfo, we can avoid loading the cacheline
with SourceInfo's that are not going to be accessed.