### PR TITLE
Fix Self keyword doc URL conflict on case insensitive file systems (until definitely fixed on rustdoc)

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1310,7 +1310,11 @@ mod return_keyword {}
 /// [Reference]: ../reference/items/associated-items.html#methods
 mod self_keyword {}
 
-#[doc(keyword = "Self")]
+// FIXME: Once rustdoc can handle URL conflicts on case insensitive file systems, we can remove the
+// three next lines and put back: `#[doc(keyword = "Self")]`.
+#[doc(alias = "Self")]
+#[allow(rustc::existing_doc_keyword)]
+#[doc(keyword = "SelfTy")]
 //
 /// The implementing type within a [`trait`] or [`impl`] block, or the current type within a type
 /// definition.


### PR DESCRIPTION
This is just a hack to allow rustup to work on macOS and windows again to distribute std documentation (hopefully once https://github.com/rust-lang/rfcs/pull/3097 or an equivalent is merged).

Fixes https://github.com/rust-lang/rust/issues/80504. Prevents https://github.com/rust-lang/rust/issues/83154 and https://github.com/rust-lang/rustup/issues/2694 in future releases.

cc @kinnison 
r? @jyn514 