### PR TITLE
rustdoc: Only look at blanket impls in `get_blanket_impls`

### DIFF
--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -69,6 +69,12 @@ pub struct TraitImpls {
     non_blanket_impls: FxHashMap<fast_reject::SimplifiedType, Vec<DefId>>,
 }
 
+impl TraitImpls {
+    pub fn blanket_impls(&self) -> &[DefId] {
+        self.blanket_impls.as_slice()
+    }
+}
+
 impl<'tcx> TraitDef {
     pub fn new(
         def_id: DefId,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -26,7 +26,9 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
             {
                 continue;
             }
-            self.cx.tcx.for_each_relevant_impl(trait_def_id, ty, |impl_def_id| {
+            // NOTE: doesn't use `for_each_relevant_impl` to avoid looking at anything besides blanket impls
+            let trait_impls = self.cx.tcx.trait_impls_of(trait_def_id);
+            for &impl_def_id in trait_impls.blanket_impls() {
                 debug!(
                     "get_blanket_impls: Considering impl for trait '{:?}' {:?}",
                     trait_def_id, impl_def_id
@@ -86,7 +88,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                     may_apply, trait_ref, ty
                 );
                 if !may_apply {
-                    return;
+                    continue;
                 }
 
                 self.cx.generated_synthetics.insert((ty, trait_def_id));
@@ -127,7 +129,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                         blanket_impl: Some(trait_ref.self_ty().clean(self.cx)),
                     }),
                 });
-            });
+            }
         }
         impls
     }


### PR DESCRIPTION
The idea here is that all the work in https://github.com/rust-lang/rust/blob/16156fb2787f745e57504197bd7fe38b69c6cbea/compiler/rustc_middle/src/ty/trait_def.rs#L172-L186 doesn't matter for `get_blanket_impls` - Rustdoc will already pick up on those blocks when it documents the item.