### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -28,6 +28,7 @@ use std::fmt;
 
 use super::InferCtxtPrivExt;
 use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
+use rustc_middle::ty::print::with_no_trimmed_paths;
 
 #[derive(Debug)]
 pub enum GeneratorInteriorOrUpvar {
@@ -440,7 +441,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 {
                     // Missing generic type parameter bound.
                     let param_name = self_ty.to_string();
-                    let constraint = trait_ref.print_only_trait_path().to_string();
+                    let constraint =
+                        with_no_trimmed_paths(|| trait_ref.print_only_trait_path().to_string());
                     if suggest_constraining_type_param(
                         self.tcx,
                         generics,

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1310,7 +1310,11 @@ mod return_keyword {}
 /// [Reference]: ../reference/items/associated-items.html#methods
 mod self_keyword {}
 
-#[doc(keyword = "Self")]
+// FIXME: Once rustdoc can handle URL conflicts on case insensitive file systems, we can remove the
+// three next lines and put back: `#[doc(keyword = "Self")]`.
+#[doc(alias = "Self")]
+#[allow(rustc::existing_doc_keyword)]
+#[doc(keyword = "SelfTy")]
 //
 /// The implementing type within a [`trait`] or [`impl`] block, or the current type within a type
 /// definition.

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -547,15 +547,18 @@ mod fn_keyword {}
 /// # fn code() { }
 /// # let iterator = 0..2;
 /// {
-///     let mut _iter = std::iter::IntoIterator::into_iter(iterator);
-///     loop {
-///         match _iter.next() {
-///             Some(loop_variable) => {
-///                 code()
-///             },
-///             None => break,
-///         }
-///     }
+///     let result = match IntoIterator::into_iter(iterator) {
+///         mut iter => loop {
+///             let next;
+///             match iter.next() {
+///                 Some(val) => next = val,
+///                 None => break,
+///             };
+///             let loop_variable = next;
+///             let () = { code(); };
+///         },
+///     };
+///     result
 /// }
 /// ```
 ///

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -1,4 +1,4 @@
-//! The Rust Prelude.
+//! # The Rust Prelude
 //!
 //! Rust comes with a variety of things in its standard library. However, if
 //! you had to manually import every single thing that you used, it would be

--- a/library/std/src/prelude/mod.rs
+++ b/library/std/src/prelude/mod.rs
@@ -1,4 +1,4 @@
-//! # The Rust Prelude
+//! The Rust Prelude.
 //!
 //! Rust comes with a variety of things in its standard library. However, if
 //! you had to manually import every single thing that you used, it would be
@@ -28,53 +28,53 @@
 //! The current version of the prelude (version 1) lives in
 //! [`std::prelude::v1`], and re-exports the following:
 //!
-//! * [`std::marker`]::{[`Copy`], [`Send`], [`Sized`], [`Sync`], [`Unpin`]}:
+//! * <code>[std::marker]::{[Copy], [Send], [Sized], [Sync], [Unpin]}</code>,
 //!   marker traits that indicate fundamental properties of types.
-//! * [`std::ops`]::{[`Drop`], [`Fn`], [`FnMut`], [`FnOnce`]}: various
+//! * <code>[std::ops]::{[Drop], [Fn], [FnMut], [FnOnce]}</code>, various
 //!   operations for both destructors and overloading `()`.
-//! * [`std::mem`]::[`drop`][`mem::drop`]: a convenience function for explicitly
+//! * <code>[std::mem]::[drop][mem::drop]</code>, a convenience function for explicitly
 //!   dropping a value.
-//! * [`std::boxed`]::[`Box`]: a way to allocate values on the heap.
-//! * [`std::borrow`]::[`ToOwned`]: the conversion trait that defines
+//! * <code>[std::boxed]::[Box]</code>, a way to allocate values on the heap.
+//! * <code>[std::borrow]::[ToOwned]</code>, the conversion trait that defines
 //!   [`to_owned`], the generic method for creating an owned type from a
 //!   borrowed type.
-//! * [`std::clone`]::[`Clone`]: the ubiquitous trait that defines
-//!   [`clone`][`Clone::clone`], the method for producing a copy of a value.
-//! * [`std::cmp`]::{[`PartialEq`], [`PartialOrd`], [`Eq`], [`Ord`]}: the
+//! * <code>[std::clone]::[Clone]</code>, the ubiquitous trait that defines
+//!   [`clone`][Clone::clone], the method for producing a copy of a value.
+//! * <code>[std::cmp]::{[PartialEq], [PartialOrd], [Eq], [Ord]}</code>, the
 //!   comparison traits, which implement the comparison operators and are often
 //!   seen in trait bounds.
-//! * [`std::convert`]::{[`AsRef`], [`AsMut`], [`Into`], [`From`]}: generic
+//! * <code>[std::convert]::{[AsRef], [AsMut], [Into], [From]}</code>, generic
 //!   conversions, used by savvy API authors to create overloaded methods.
-//! * [`std::default`]::[`Default`], types that have default values.
-//! * [`std::iter`]::{[`Iterator`], [`Extend`], [`IntoIterator`],
-//!   [`DoubleEndedIterator`], [`ExactSizeIterator`]}: iterators of various
+//! * <code>[std::default]::[Default]</code>, types that have default values.
+//! * <code>[std::iter]::{[Iterator], [Extend], [IntoIterator], [DoubleEndedIterator], [ExactSizeIterator]}</code>,
+//!   iterators of various
 //!   kinds.
-//! * [`std::option`]::[`Option`]::{[`self`][`Option`], [`Some`], [`None`]}, a
+//! * <code>[std::option]::[Option]::{[self][Option], [Some], [None]}</code>, a
 //!   type which expresses the presence or absence of a value. This type is so
 //!   commonly used, its variants are also exported.
-//! * [`std::result`]::[`Result`]::{[`self`][`Result`], [`Ok`], [`Err`]}: a type
+//! * <code>[std::result]::[Result]::{[self][Result], [Ok], [Err]}</code>, a type
 //!   for functions that may succeed or fail. Like [`Option`], its variants are
 //!   exported as well.
-//! * [`std::string`]::{[`String`], [`ToString`]}: heap-allocated strings.
-//! * [`std::vec`]::[`Vec`]: a growable, heap-allocated vector.
+//! * <code>[std::string]::{[String], [ToString]}</code>, heap-allocated strings.
+//! * <code>[std::vec]::[Vec]</code>, a growable, heap-allocated vector.
 //!
-//! [`mem::drop`]: crate::mem::drop
-//! [`std::borrow`]: crate::borrow
-//! [`std::boxed`]: crate::boxed
-//! [`std::clone`]: crate::clone
-//! [`std::cmp`]: crate::cmp
-//! [`std::convert`]: crate::convert
-//! [`std::default`]: crate::default
-//! [`std::iter`]: crate::iter
-//! [`std::marker`]: crate::marker
-//! [`std::mem`]: crate::mem
-//! [`std::ops`]: crate::ops
-//! [`std::option`]: crate::option
+//! [mem::drop]: crate::mem::drop
+//! [std::borrow]: crate::borrow
+//! [std::boxed]: crate::boxed
+//! [std::clone]: crate::clone
+//! [std::cmp]: crate::cmp
+//! [std::convert]: crate::convert
+//! [std::default]: crate::default
+//! [std::iter]: crate::iter
+//! [std::marker]: crate::marker
+//! [std::mem]: crate::mem
+//! [std::ops]: crate::ops
+//! [std::option]: crate::option
 //! [`std::prelude::v1`]: v1
-//! [`std::result`]: crate::result
-//! [`std::slice`]: crate::slice
-//! [`std::string`]: crate::string
-//! [`std::vec`]: mod@crate::vec
+//! [std::result]: crate::result
+//! [std::slice]: crate::slice
+//! [std::string]: crate::string
+//! [std::vec]: mod@crate::vec
 //! [`to_owned`]: crate::borrow::ToOwned::to_owned
 //! [book-closures]: ../../book/ch13-01-closures.html
 //! [book-dtor]: ../../book/ch15-03-drop.html

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -108,6 +108,19 @@ impl Step for Linkcheck {
     /// documentation to ensure we don't have a bunch of dead ones.
     fn run(self, builder: &Builder<'_>) {
         let host = self.host;
+        let hosts = &builder.hosts;
+        let targets = &builder.targets;
+
+        // if we have different hosts and targets, some things may be built for
+        // the host (e.g. rustc) and others for the target (e.g. std). The
+        // documentation built for each will contain broken links to
+        // docs built for the other platform (e.g. rustc linking to cargo)
+        if (hosts != targets) && !hosts.is_empty() && !targets.is_empty() {
+            panic!(
+                "Linkcheck currently does not support builds with different hosts and targets.
+You can skip linkcheck with --exclude src/tools/linkchecker"
+            );
+        }
 
         builder.info(&format!("Linkcheck ({})", host));
 
@@ -123,19 +136,6 @@ impl Step for Linkcheck {
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let builder = run.builder;
         let run = run.path("src/tools/linkchecker");
-        let hosts = &builder.hosts;
-        let targets = &builder.targets;
-
-        // if we have different hosts and targets, some things may be built for
-        // the host (e.g. rustc) and others for the target (e.g. std). The
-        // documentation built for each will contain broken links to
-        // docs built for the other platform (e.g. rustc linking to cargo)
-        if (hosts != targets) && !hosts.is_empty() && !targets.is_empty() {
-            panic!(
-                "Linkcheck currently does not support builds with different hosts and targets.
-You can skip linkcheck with --exclude src/tools/linkchecker"
-            );
-        }
         run.default_condition(builder.config.docs)
     }
 

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -31,8 +31,8 @@ LL |     type Bar: Clone = Vec<T>;
    = note: required because of the requirements on the impl of `Clone` for `Vec<T>`
 help: consider restricting type parameter `T`
    |
-LL | trait Foo<T: Clone> {
-   |            ^^^^^^^
+LL | trait Foo<T: std::clone::Clone> {
+   |            ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `(): Foo<Self>` is not satisfied
   --> $DIR/defaults-suitability.rs:34:5
@@ -99,8 +99,8 @@ LL |     type Baz = T;
    |
 help: consider further restricting type parameter `T`
    |
-LL |     Self::Baz: Clone, T: Clone
-   |                     ^^^^^^^^^^
+LL |     Self::Baz: Clone, T: std::clone::Clone
+   |                     ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/associated-types/issue-27675-unchecked-bounds.stderr
+++ b/src/test/ui/associated-types/issue-27675-unchecked-bounds.stderr
@@ -9,8 +9,8 @@ LL |     copy::<dyn Setup<From=T>>(t)
    |
 help: consider restricting type parameter `T`
    |
-LL | pub fn copy_any<T: Copy>(t: &T) -> T {
-   |                  ^^^^^^
+LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/issue-43784-associated-type.stderr
+++ b/src/test/ui/associated-types/issue-43784-associated-type.stderr
@@ -9,8 +9,8 @@ LL |     type Assoc = T;
    |
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Copy> Complete for T {
-   |       ^^^^^^
+LL | impl<T: std::marker::Copy> Complete for T {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-70818.stderr
+++ b/src/test/ui/async-await/issue-70818.stderr
@@ -11,8 +11,8 @@ LL |     async { (ty, ty1) }
    |                  ^^^ has type `U` which is not `Send`
 help: consider restricting type parameter `U`
    |
-LL | fn foo<T: Send, U: Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
-   |                  ^^^^^^
+LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/bad/bad-method-typaram-kind.stderr
+++ b/src/test/ui/bad/bad-method-typaram-kind.stderr
@@ -6,8 +6,8 @@ LL |     1.bar::<T>();
    |
 help: consider further restricting this bound
    |
-LL | fn foo<T:'static + Send>() {
-   |                  ^^^^^^
+LL | fn foo<T:'static + std::marker::Send>() {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/bound-suggestions.fixed
+++ b/src/test/ui/bound-suggestions.fixed
@@ -5,37 +5,37 @@ use std::fmt::Debug;
 // Rustfix should add this, or use `std::fmt::Debug` instead.
 
 #[allow(dead_code)]
-fn test_impl(t: impl Sized + Debug) {
+fn test_impl(t: impl Sized + std::fmt::Debug) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
 #[allow(dead_code)]
-fn test_no_bounds<T: Debug>(t: T) {
+fn test_no_bounds<T: std::fmt::Debug>(t: T) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
 #[allow(dead_code)]
-fn test_one_bound<T: Sized + Debug>(t: T) {
+fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
     println!("{:?}", t);
     //~^ ERROR doesn't implement
 }
 
 #[allow(dead_code)]
-fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: Debug {
+fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
     println!("{:?} {:?}", x, y);
     //~^ ERROR doesn't implement
 }
 
 #[allow(dead_code)]
-fn test_one_bound_where<X>(x: X) where X: Sized + Debug {
+fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
     println!("{:?}", x);
     //~^ ERROR doesn't implement
 }
 
 #[allow(dead_code)]
-fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized, X: Debug {
+fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized, X: std::fmt::Debug {
     println!("{:?}", x);
     //~^ ERROR doesn't implement
 }

--- a/src/test/ui/bound-suggestions.stderr
+++ b/src/test/ui/bound-suggestions.stderr
@@ -8,8 +8,8 @@ LL |     println!("{:?}", t);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
-LL | fn test_impl(t: impl Sized + Debug) {
-   |                            ^^^^^^^
+LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
+   |                            ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` doesn't implement `Debug`
   --> $DIR/bound-suggestions.rs:15:22
@@ -21,8 +21,8 @@ LL |     println!("{:?}", t);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
-LL | fn test_no_bounds<T: Debug>(t: T) {
-   |                    ^^^^^^^
+LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
+   |                    ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` doesn't implement `Debug`
   --> $DIR/bound-suggestions.rs:21:22
@@ -34,8 +34,8 @@ LL |     println!("{:?}", t);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
-LL | fn test_one_bound<T: Sized + Debug>(t: T) {
-   |                            ^^^^^^^
+LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
+   |                            ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `Y` doesn't implement `Debug`
   --> $DIR/bound-suggestions.rs:27:30
@@ -47,8 +47,8 @@ LL |     println!("{:?} {:?}", x, y);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `Y`
    |
-LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: Debug {
-   |                                                                   ^^^^^^^^^^
+LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `X` doesn't implement `Debug`
   --> $DIR/bound-suggestions.rs:33:22
@@ -60,8 +60,8 @@ LL |     println!("{:?}", x);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |
-LL | fn test_one_bound_where<X>(x: X) where X: Sized + Debug {
-   |                                                 ^^^^^^^
+LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
+   |                                                 ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `X` doesn't implement `Debug`
   --> $DIR/bound-suggestions.rs:39:22
@@ -73,8 +73,8 @@ LL |     println!("{:?}", x);
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `X`
    |
-LL | fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized, X: Debug {
-   |                                                            ^^^^^^^^^^
+LL | fn test_many_bounds_where<X>(x: X) where X: Sized, X: Sized, X: std::fmt::Debug {
+   |                                                            ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/bound-suggestions.rs:44:46

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -10,8 +10,8 @@ LL | impl <T: Sync+'static> Foo for (T,) { }
    = note: required because it appears within the type `(T,)`
 help: consider further restricting this bound
    |
-LL | impl <T: Sync+'static + Send> Foo for (T,) { }
-   |                       ^^^^^^
+LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
+   |                       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/builtin-superkinds-double-superkind.rs:9:16
@@ -25,8 +25,8 @@ LL | impl <T: Send> Foo for (T,T) { }
    = note: required because it appears within the type `(T, T)`
 help: consider further restricting this bound
    |
-LL | impl <T: Send + Sync> Foo for (T,T) { }
-   |               ^^^^^^
+LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }
+   |               ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -12,8 +12,8 @@ LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
    = note: required because it appears within the type `X<T>`
 help: consider further restricting this bound
    |
-LL | impl <T:Sync+'static + Send> RequiresRequiresShareAndSend for X<T> { }
-   |                      ^^^^^^
+LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }
+   |                      ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/src/test/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -9,8 +9,8 @@ LL | impl <T: Sync+'static> Foo for T { }
    |
 help: consider further restricting this bound
    |
-LL | impl <T: Sync+'static + Send> Foo for T { }
-   |                       ^^^^^^
+LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }
+   |                       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -9,8 +9,8 @@ LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
    |
 help: consider further restricting this bound
    |
-LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + Send {
-   |                                                       ^^^^^^
+LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
+   |                                                       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -9,8 +9,8 @@ LL |     take_const_owned(f);
    |
 help: consider further restricting this bound
    |
-LL | fn give_owned<F>(f: F) where F: FnOnce() + Send + Sync {
-   |                                                 ^^^^^^
+LL | fn give_owned<F>(f: F) where F: FnOnce() + Send + std::marker::Sync {
+   |                                                 ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-argument-if-length.full.stderr
+++ b/src/test/ui/const-generics/const-argument-if-length.full.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/const-argument-if-length.rs:7:28
    |
 LL | pub const fn is_zst<T: ?Sized>() -> usize {
-   |                     - this type parameter needs to be `Sized`
+   |                     - this type parameter needs to be `std::marker::Sized`
 LL |     if std::mem::size_of::<T>() == 0 {
    |                            ^ doesn't have a size known at compile-time
    | 
@@ -15,7 +15,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/const-argument-if-length.rs:16:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
-   |                        - this type parameter needs to be `Sized`
+   |                        - this type parameter needs to be `std::marker::Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/const-generics/const-argument-if-length.min.stderr
+++ b/src/test/ui/const-generics/const-argument-if-length.min.stderr
@@ -11,7 +11,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/const-argument-if-length.rs:16:12
    |
 LL | pub struct AtLeastByte<T: ?Sized> {
-   |                        - this type parameter needs to be `Sized`
+   |                        - this type parameter needs to be `std::marker::Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/const-generics/issues/issue-61336-2.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336-2.full.stderr
@@ -16,8 +16,8 @@ LL |     [x; { N }]
    = note: the `Copy` trait is required because the repeated element will be copied
 help: consider restricting type parameter `T`
    |
-LL | fn g<T: Copy, const N: usize>(x: T) -> [T; N] {
-   |       ^^^^^^
+LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-61336-2.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336-2.min.stderr
@@ -7,8 +7,8 @@ LL |     [x; { N }]
    = note: the `Copy` trait is required because the repeated element will be copied
 help: consider restricting type parameter `T`
    |
-LL | fn g<T: Copy, const N: usize>(x: T) -> [T; N] {
-   |       ^^^^^^
+LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-61336.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336.full.stderr
@@ -16,8 +16,8 @@ LL |     [x; N]
    = note: the `Copy` trait is required because the repeated element will be copied
 help: consider restricting type parameter `T`
    |
-LL | fn g<T: Copy, const N: usize>(x: T) -> [T; N] {
-   |       ^^^^^^
+LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/const-generics/issues/issue-61336.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-61336.min.stderr
@@ -7,8 +7,8 @@ LL |     [x; N]
    = note: the `Copy` trait is required because the repeated element will be copied
 help: consider restricting type parameter `T`
    |
-LL | fn g<T: Copy, const N: usize>(x: T) -> [T; N] {
-   |       ^^^^^^
+LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/dst/dst-object-from-unsized-type.stderr
+++ b/src/test/ui/dst/dst-object-from-unsized-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:8:23
    |
 LL | fn test1<T: ?Sized + Foo>(t: &T) {
-   |          - this type parameter needs to be `Sized`
+   |          - this type parameter needs to be `std::marker::Sized`
 LL |     let u: &dyn Foo = t;
    |                       ^ doesn't have a size known at compile-time
    |
@@ -12,7 +12,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/dst-object-from-unsized-type.rs:13:23
    |
 LL | fn test2<T: ?Sized + Foo>(t: &T) {
-   |          - this type parameter needs to be `Sized`
+   |          - this type parameter needs to be `std::marker::Sized`
 LL |     let v: &dyn Foo = t as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
@@ -69,8 +69,8 @@ LL |     type Pointer2<U32> = Box<U32>;
    |
 help: consider restricting type parameter `U32`
    |
-LL |     type Pointer2<U32: Clone> = Box<U32>;
-   |                      ^^^^^^^
+LL |     type Pointer2<U32: std::clone::Clone> = Box<U32>;
+   |                      ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/generic-associated-types/impl_bounds.stderr
+++ b/src/test/ui/generic-associated-types/impl_bounds.stderr
@@ -51,8 +51,8 @@ LL |     type C where Self: Copy = String;
    = note: the requirement `Fooy<T>: Copy` appears on the associated impl type but not on the corresponding associated trait type
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Copy> Foo for Fooy<T> {
-   |       ^^^^^^
+LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
+++ b/src/test/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
@@ -18,8 +18,8 @@ LL |     type Item<'a> = T;
    |
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Copy> UnsafeCopy for T {
-   |       ^^^^^^
+LL | impl<T: std::marker::Copy> UnsafeCopy for T {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/src/test/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -19,8 +19,8 @@ LL |     type F<'a> = Self;
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Fn<()>> Fun for T {
-   |       ^^^^^^^^
+LL | impl<T: std::ops::Fn<()>> Fun for T {
+   |       ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/src/test/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -19,8 +19,8 @@ LL |     type F<'a> = Self;
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Fn<()>> Fun for T {
-   |       ^^^^^^^^
+LL | impl<T: std::ops::Fn<()>> Fun for T {
+   |       ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/src/test/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -19,8 +19,8 @@ LL |     type F<'a> = Self;
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Fn<()>> Fun for T {
-   |       ^^^^^^^^
+LL | impl<T: std::ops::Fn<()>> Fun for T {
+   |       ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/src/test/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -19,8 +19,8 @@ LL |     type F<'a> = Self;
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Fn<()>> Fun for T {
-   |       ^^^^^^^^
+LL | impl<T: std::ops::Fn<()>> Fun for T {
+   |       ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/generic-associated-types/issue-74824.stderr
+++ b/src/test/ui/generic-associated-types/issue-74824.stderr
@@ -19,8 +19,8 @@ LL |     type Copy<T>: Copy = Box<T>;
    = note: required because of the requirements on the impl of `Clone` for `Box<T>`
 help: consider restricting type parameter `T`
    |
-LL |     type Copy<T: Clone>: Copy = Box<T>;
-   |                ^^^^^^^
+LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
+   |                ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/issue-55872-1.full_tait.stderr
+++ b/src/test/ui/impl-trait/issue-55872-1.full_tait.stderr
@@ -25,8 +25,8 @@ LL |     type E = impl Copy;
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound
    |
-LL | impl<S: Default + Copy> Bar for S {
-   |                 ^^^^^^
+LL | impl<S: Default + std::marker::Copy> Bar for S {
+   |                 ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: Copy` is not satisfied in `(S, T)`
   --> $DIR/issue-55872-1.rs:14:14
@@ -37,8 +37,8 @@ LL |     type E = impl Copy;
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound
    |
-LL |     fn foo<T: Default + Copy>() -> Self::E {
-   |                       ^^^^^^
+LL |     fn foo<T: Default + std::marker::Copy>() -> Self::E {
+   |                       ^^^^^^^^^^^^^^^^^^^
 
 error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
   --> $DIR/issue-55872-1.rs:18:37

--- a/src/test/ui/impl-trait/issue-55872-1.min_tait.stderr
+++ b/src/test/ui/impl-trait/issue-55872-1.min_tait.stderr
@@ -16,8 +16,8 @@ LL |     type E = impl Copy;
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound
    |
-LL | impl<S: Default + Copy> Bar for S {
-   |                 ^^^^^^
+LL | impl<S: Default + std::marker::Copy> Bar for S {
+   |                 ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: Copy` is not satisfied in `(S, T)`
   --> $DIR/issue-55872-1.rs:14:14
@@ -28,8 +28,8 @@ LL |     type E = impl Copy;
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound
    |
-LL |     fn foo<T: Default + Copy>() -> Self::E {
-   |                       ^^^^^^
+LL |     fn foo<T: Default + std::marker::Copy>() -> Self::E {
+   |                       ^^^^^^^^^^^^^^^^^^^
 
 error: type parameter `T` is part of concrete type but not used in parameter list for the `impl Trait` type alias
   --> $DIR/issue-55872-1.rs:18:37

--- a/src/test/ui/inference/issue-83606.rs
+++ b/src/test/ui/inference/issue-83606.rs
@@ -1,0 +1,10 @@
+// Regression test for #83606.
+
+fn foo<const N: usize>(_: impl std::fmt::Display) -> [usize; N] {
+    [0; N]
+}
+
+fn main() {
+    let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
+    //~^ ERROR: type annotations needed for `[usize; _]`
+}

--- a/src/test/ui/inference/issue-83606.stderr
+++ b/src/test/ui/inference/issue-83606.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed for `[usize; _]`
+  --> $DIR/issue-83606.rs:8:13
+   |
+LL |     let _ = foo("foo"); //<- Do not suggest `foo::<N>("foo");`!
+   |         -   ^^^ cannot infer the value of const parameter `N` declared on the function `foo`
+   |         |
+   |         consider giving this pattern the explicit type `[usize; _]`, where the type parameter `N` is specified
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/issues/issue-27060-2.stderr
+++ b/src/test/ui/issues/issue-27060-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/issue-27060-2.rs:3:11
    |
 LL | pub struct Bad<T: ?Sized> {
-   |                - this type parameter needs to be `Sized`
+   |                - this type parameter needs to be `std::marker::Sized`
 LL |     data: T,
    |           ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/issues/issue-43784-supertrait.stderr
+++ b/src/test/ui/issues/issue-43784-supertrait.stderr
@@ -9,8 +9,8 @@ LL | impl<T> Complete for T {}
    |
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Copy> Complete for T {}
-   |       ^^^^^^
+LL | impl<T: std::marker::Copy> Complete for T {}
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-impl-type-params.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.stderr
@@ -8,8 +8,8 @@ LL |     let a = &t as &dyn Gettable<T>;
    = note: required for the cast to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
-LL | fn f<T: Send>(val: T) {
-   |       ^^^^^^
+LL | fn f<T: std::marker::Send>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:18:13
@@ -21,8 +21,8 @@ LL |     let a = &t as &dyn Gettable<T>;
    = note: required for the cast to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
-LL | fn f<T: Copy>(val: T) {
-   |       ^^^^^^
+LL | fn f<T: std::marker::Copy>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be sent between threads safely
   --> $DIR/kindck-impl-type-params.rs:25:31
@@ -34,8 +34,8 @@ LL |     let a: &dyn Gettable<T> = &t;
    = note: required for the cast to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
-LL | fn g<T: Send>(val: T) {
-   |       ^^^^^^
+LL | fn g<T: std::marker::Send>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:25:31
@@ -47,8 +47,8 @@ LL |     let a: &dyn Gettable<T> = &t;
    = note: required for the cast to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
-LL | fn g<T: Copy>(val: T) {
-   |       ^^^^^^
+LL | fn g<T: std::marker::Copy>(val: T) {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error[E0477]: the type `&'a isize` does not fulfill the required lifetime
   --> $DIR/kindck-impl-type-params.rs:32:13

--- a/src/test/ui/phantom-auto-trait.stderr
+++ b/src/test/ui/phantom-auto-trait.stderr
@@ -12,8 +12,8 @@ LL |     is_zen(x)
    = note: required because it appears within the type `Guard<'_, T>`
 help: consider restricting type parameter `T`
    |
-LL | fn not_sync<T: Sync>(x: Guard<T>) {
-   |              ^^^^^^
+LL | fn not_sync<T: std::marker::Sync>(x: Guard<T>) {
+   |              ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-auto-trait.rs:26:12
@@ -30,8 +30,8 @@ LL |     is_zen(x)
    = note: required because it appears within the type `Nested<Guard<'_, T>>`
 help: consider restricting type parameter `T`
    |
-LL | fn nested_not_sync<T: Sync>(x: Nested<Guard<T>>) {
-   |                     ^^^^^^
+LL | fn nested_not_sync<T: std::marker::Sync>(x: Nested<Guard<T>>) {
+   |                     ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/auxiliary/issue-75801.rs
+++ b/src/test/ui/proc-macro/auxiliary/issue-75801.rs
@@ -1,0 +1,13 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn foo(_args: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}

--- a/src/test/ui/proc-macro/issue-75801.rs
+++ b/src/test/ui/proc-macro/issue-75801.rs
@@ -1,0 +1,19 @@
+// aux-build: issue-75801.rs
+
+// Regression test for #75801.
+
+#[macro_use]
+extern crate issue_75801;
+
+macro_rules! foo {
+    ($arg:expr) => {
+        #[foo]
+        fn bar() {
+            let _bar: u32 = $arg;
+        }
+    };
+}
+
+foo!("baz"); //~ ERROR: mismatched types [E0308]
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-75801.stderr
+++ b/src/test/ui/proc-macro/issue-75801.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-75801.rs:17:6
+   |
+LL |             let _bar: u32 = $arg;
+   |                       --- expected due to this
+...
+LL | foo!("baz");
+   |      ^^^^^ expected `u32`, found `&str`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/specialization/deafult-generic-associated-type-bound.stderr
+++ b/src/test/ui/specialization/deafult-generic-associated-type-bound.stderr
@@ -28,8 +28,8 @@ LL |     default type U<'a> = &'a T;
    = note: required because of the requirements on the impl of `PartialEq` for `&'a T`
 help: consider further restricting this bound
    |
-LL | impl<T: 'static + PartialEq> X for T {
-   |                 ^^^^^^^^^^^
+LL | impl<T: 'static + std::cmp::PartialEq> X for T {
+   |                 ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 2 warnings emitted
 

--- a/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -19,8 +19,8 @@ LL | default impl<U> Foo<'static, U> for () {}
    |
 help: consider restricting type parameter `U`
    |
-LL | default impl<U: Eq> Foo<'static, U> for () {}
-   |               ^^^^
+LL | default impl<U: std::cmp::Eq> Foo<'static, U> for () {}
+   |               ^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/src/test/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -5,7 +5,7 @@ LL | struct X<T>(T);
    |          - required by this bound in `X`
 ...
 LL | struct Struct5<T: ?Sized>{
-   |                - this type parameter needs to be `Sized`
+   |                - this type parameter needs to be `std::marker::Sized`
 LL |     _t: X<T>,
    |         ^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/suggestions/restrict-type-argument.stderr
+++ b/src/test/ui/suggestions/restrict-type-argument.stderr
@@ -9,8 +9,8 @@ LL |     is_send(val);
    |
 help: consider further restricting this bound
    |
-LL | fn use_impl_sync(val: impl Sync + Send) {
-   |                                 ^^^^^^
+LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
+   |                                 ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:8:13
@@ -23,8 +23,8 @@ LL |     is_send(val);
    |
 help: consider further restricting this bound
    |
-LL | fn use_where<S>(val: S) where S: Sync + Send {
-   |                                       ^^^^^^
+LL | fn use_where<S>(val: S) where S: Sync + std::marker::Send {
+   |                                       ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:12:13
@@ -37,8 +37,8 @@ LL |     is_send(val);
    |
 help: consider further restricting this bound
    |
-LL | fn use_bound<S: Sync + Send>(val: S) {
-   |                      ^^^^^^
+LL | fn use_bound<S: Sync + std::marker::Send>(val: S) {
+   |                      ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:20:13
@@ -51,8 +51,8 @@ LL |     is_send(val);
    |
 help: consider further restricting this bound
    |
-LL |     Sync + Send
-   |          ^^^^^^
+LL |     Sync + std::marker::Send
+   |          ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:24:13
@@ -65,8 +65,8 @@ LL |     is_send(val);
    |
 help: consider further restricting this bound
    |
-LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug + Send {
-   |                                                                  ^^^^^^
+LL | fn use_bound_and_where<S: Sync>(val: S) where S: std::fmt::Debug + std::marker::Send {
+   |                                                                  ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `S` cannot be sent between threads safely
   --> $DIR/restrict-type-argument.rs:28:13
@@ -79,8 +79,8 @@ LL |     is_send(val);
    |
 help: consider restricting type parameter `S`
    |
-LL | fn use_unbound<S: Send>(val: S) {
-   |                 ^^^^^^
+LL | fn use_unbound<S: std::marker::Send>(val: S) {
+   |                 ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/trait-impl-bound-suggestions.fixed
+++ b/src/test/ui/trait-impl-bound-suggestions.fixed
@@ -10,7 +10,7 @@ struct ConstrainedStruct<X: Copy> {
 }
 
 #[allow(dead_code)]
-trait InsufficientlyConstrainedGeneric<X=()> where X: Copy {
+trait InsufficientlyConstrainedGeneric<X=()> where X: std::marker::Copy {
     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
         //~^ ERROR the trait bound `X: Copy` is not satisfied
         ConstrainedStruct { x }

--- a/src/test/ui/trait-impl-bound-suggestions.stderr
+++ b/src/test/ui/trait-impl-bound-suggestions.stderr
@@ -9,8 +9,8 @@ LL |     fn return_the_constrained_type(&self, x: X) -> ConstrainedStruct<X> {
    |
 help: consider further restricting type parameter `X`
    |
-LL | trait InsufficientlyConstrainedGeneric<X=()> where X: Copy {
-   |                                              ^^^^^^^^^^^^^
+LL | trait InsufficientlyConstrainedGeneric<X=()> where X: std::marker::Copy {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/inductive-overflow/two-traits.stderr
+++ b/src/test/ui/traits/inductive-overflow/two-traits.stderr
@@ -9,8 +9,8 @@ LL |     type X = Self;
    |
 help: consider further restricting this bound
    |
-LL | impl<T: Magic + Sync> Magic for T {
-   |               ^^^^^^
+LL | impl<T: Magic + std::marker::Sync> Magic for T {
+   |               ^^^^^^^^^^^^^^^^^^^
 
 error[E0275]: overflow evaluating the requirement `*mut (): Magic`
   --> $DIR/two-traits.rs:20:5

--- a/src/test/ui/traits/suggest-where-clause.stderr
+++ b/src/test/ui/traits/suggest-where-clause.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/suggest-where-clause.rs:7:20
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       - this type parameter needs to be `Sized`
+   |                       - this type parameter needs to be `std::marker::Sized`
 LL |     // suggest a where-clause, if needed
 LL |     mem::size_of::<U>();
    |                    ^ doesn't have a size known at compile-time
@@ -16,7 +16,7 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
   --> $DIR/suggest-where-clause.rs:10:5
    |
 LL | fn check<T: Iterator, U: ?Sized>() {
-   |                       - this type parameter needs to be `Sized`
+   |                       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     mem::size_of::<Misc<U>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.full_tait.stderr
@@ -15,8 +15,8 @@ LL | type X<T> = impl Clone;
    |
 help: consider restricting type parameter `T`
    |
-LL | type X<T: Clone> = impl Clone;
-   |         ^^^^^^^
+LL | type X<T: std::clone::Clone> = impl Clone;
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.min_tait.stderr
@@ -6,8 +6,8 @@ LL | type X<T> = impl Clone;
    |
 help: consider restricting type parameter `T`
    |
-LL | type X<T: Clone> = impl Clone;
-   |         ^^^^^^^
+LL | type X<T: std::clone::Clone> = impl Clone;
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.full_tait.stderr
@@ -28,8 +28,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, U)`
 help: consider restricting type parameter `T`
    |
-LL | type Two<T: Debug, U> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `U` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use5.rs:11:18
@@ -40,8 +40,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, U)`
 help: consider restricting type parameter `U`
    |
-LL | type Two<T, U: Debug> = impl Debug;
-   |              ^^^^^^^
+LL | type Two<T, U: std::fmt::Debug> = impl Debug;
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.min_tait.stderr
@@ -19,8 +19,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, U)`
 help: consider restricting type parameter `T`
    |
-LL | type Two<T: Debug, U> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `U` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use5.rs:11:18
@@ -31,8 +31,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, U)`
 help: consider restricting type parameter `U`
    |
-LL | type Two<T, U: Debug> = impl Debug;
-   |              ^^^^^^^
+LL | type Two<T, U: std::fmt::Debug> = impl Debug;
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.full_tait.stderr
@@ -28,8 +28,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, T)`
 help: consider restricting type parameter `T`
    |
-LL | type Two<T: Debug, U> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.min_tait.stderr
@@ -19,8 +19,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, T)`
 help: consider restricting type parameter `T`
    |
-LL | type Two<T: Debug, U> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.full_tait.stderr
@@ -28,8 +28,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, u32)`
 help: consider restricting type parameter `T`
    |
-LL | type Two<T: Debug, U> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.min_tait.stderr
@@ -19,8 +19,8 @@ LL | type Two<T, U> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(T, u32)`
 help: consider restricting type parameter `T`
    |
-LL | type Two<T: Debug, U> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.full_tait.stderr
@@ -40,8 +40,8 @@ LL | type Two<A, B> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(A, B, <A as Foo>::Bar)`
 help: consider restricting type parameter `A`
    |
-LL | type Two<A: Debug, B> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<A: std::fmt::Debug, B> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `B` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use9.rs:10:18
@@ -52,8 +52,8 @@ LL | type Two<A, B> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(A, B, <A as Foo>::Bar)`
 help: consider restricting type parameter `B`
    |
-LL | type Two<A, B: Debug> = impl Debug;
-   |              ^^^^^^^
+LL | type Two<A, B: std::fmt::Debug> = impl Debug;
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.min_tait.stderr
@@ -31,8 +31,8 @@ LL | type Two<A, B> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(A, B, <A as Foo>::Bar)`
 help: consider restricting type parameter `A`
    |
-LL | type Two<A: Debug, B> = impl Debug;
-   |           ^^^^^^^
+LL | type Two<A: std::fmt::Debug, B> = impl Debug;
+   |           ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `B` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use9.rs:10:18
@@ -43,8 +43,8 @@ LL | type Two<A, B> = impl Debug;
    = note: required because of the requirements on the impl of `Debug` for `(A, B, <A as Foo>::Bar)`
 help: consider restricting type parameter `B`
    |
-LL | type Two<A, B: Debug> = impl Debug;
-   |              ^^^^^^^
+LL | type Two<A, B: std::fmt::Debug> = impl Debug;
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.full_tait.stderr
@@ -30,8 +30,8 @@ LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
    |
 help: consider restricting type parameter `U`
    |
-LL | fn underconstrained<U: Debug>(_: U) -> Underconstrained<U> {
-   |                      ^^^^^^^
+LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
+   |                      ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `V` doesn't implement `Debug`
   --> $DIR/generic_underconstrained2.rs:21:43
@@ -44,8 +44,8 @@ LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
    |
 help: consider restricting type parameter `V`
    |
-LL | fn underconstrained2<U, V: Debug>(_: U, _: V) -> Underconstrained2<V> {
-   |                          ^^^^^^^
+LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
+   |                          ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/generic_underconstrained2.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_underconstrained2.min_tait.stderr
@@ -21,8 +21,8 @@ LL | fn underconstrained<U>(_: U) -> Underconstrained<U> {
    |
 help: consider restricting type parameter `U`
    |
-LL | fn underconstrained<U: Debug>(_: U) -> Underconstrained<U> {
-   |                      ^^^^^^^
+LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
+   |                      ^^^^^^^^^^^^^^^^^
 
 error[E0277]: `V` doesn't implement `Debug`
   --> $DIR/generic_underconstrained2.rs:21:43
@@ -35,8 +35,8 @@ LL | fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {
    |
 help: consider restricting type parameter `V`
    |
-LL | fn underconstrained2<U, V: Debug>(_: U, _: V) -> Underconstrained2<V> {
-   |                          ^^^^^^^
+LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
+   |                          ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/issue-52843.full_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-52843.full_tait.stderr
@@ -15,8 +15,8 @@ LL | type Foo<T> = impl Default;
    |
 help: consider restricting type parameter `T`
    |
-LL | type Foo<T: Default> = impl Default;
-   |           ^^^^^^^^^
+LL | type Foo<T: std::default::Default> = impl Default;
+   |           ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/type-alias-impl-trait/issue-52843.min_tait.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-52843.min_tait.stderr
@@ -6,8 +6,8 @@ LL | type Foo<T> = impl Default;
    |
 help: consider restricting type parameter `T`
    |
-LL | type Foo<T: Default> = impl Default;
-   |           ^^^^^^^^^
+LL | type Foo<T: std::default::Default> = impl Default;
+   |           ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -56,8 +56,8 @@ LL | trait Base<T = String>: Super<T> { }
    |
 help: consider further restricting type parameter `T`
    |
-LL | trait Base<T = String>: Super<T> where T: Copy { }
-   |                                  ^^^^^^^^^^^^^
+LL | trait Base<T = String>: Super<T> where T: std::marker::Copy { }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot add `u8` to `i32`
   --> $DIR/type-check-defaults.rs:24:66

--- a/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -9,8 +9,8 @@ LL | fn is_send<T:Send>() {
    |
 help: consider restricting type parameter `T`
    |
-LL | fn foo<T: Send>() {
-   |         ^^^^^^
+LL | fn foo<T: std::marker::Send>() {
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:4:12
    |
 LL | union Foo<T: ?Sized> {
-   |           - this type parameter needs to be `Sized`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |
@@ -21,7 +21,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:9:12
    |
 LL | struct Foo2<T: ?Sized> {
-   |             - this type parameter needs to be `Sized`
+   |             - this type parameter needs to be `std::marker::Sized`
 LL |     value: T,
    |            ^ doesn't have a size known at compile-time
    |
@@ -40,7 +40,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/union-sized-field.rs:15:11
    |
 LL | enum Foo3<T: ?Sized> {
-   |           - this type parameter needs to be `Sized`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     Value(T),
    |           ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -6,7 +6,7 @@ LL | fn bar<T: Sized>() { }
 LL | fn foo<T: ?Sized>() { bar::<T>() }
    |        -                    ^ doesn't have a size known at compile-time
    |        |
-   |        this type parameter needs to be `Sized`
+   |        this type parameter needs to be `std::marker::Sized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -7,7 +7,7 @@ LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `Sized`
+   |         this type parameter needs to be `std::marker::Sized`
    |
 help: you could relax the implicit `Sized` bound on `U` if it were used through indirection like `&U` or `Box<U>`
   --> $DIR/unsized-enum.rs:4:10

--- a/src/test/ui/unsized/unsized-enum2.stderr
+++ b/src/test/ui/unsized/unsized-enum2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `W` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:23:8
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |        - this type parameter needs to be `Sized`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     // parameter
 LL |     VA(W),
    |        ^ doesn't have a size known at compile-time
@@ -22,7 +22,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:25:11
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                   - this type parameter needs to be `Sized`
+   |                   - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     VB{x: X},
    |           ^ doesn't have a size known at compile-time
@@ -42,7 +42,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:27:15
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                              - this type parameter needs to be `Sized`
+   |                              - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     VC(isize, Y),
    |               ^ doesn't have a size known at compile-time
@@ -62,7 +62,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized-enum2.rs:29:21
    |
 LL | enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   |                                         - this type parameter needs to be `Sized`
+   |                                         - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     VD{u: isize, x: Z},
    |                     ^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -7,7 +7,7 @@ LL |
 LL | impl<X: ?Sized> S5<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `Sized`
+   |      this type parameter needs to be `std::marker::Sized`
    |
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-inherent-impl-self-type.rs:5:11

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -7,7 +7,7 @@ LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |         -                          ^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `Sized`
+   |         this type parameter needs to be `std::marker::Sized`
    |
 help: you could relax the implicit `Sized` bound on `T` if it were used through indirection like `&T` or `Box<T>`
   --> $DIR/unsized-struct.rs:4:12
@@ -26,7 +26,7 @@ LL | fn is_sized<T:Sized>() { }
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |         -              ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |         |
-   |         this type parameter needs to be `Sized`
+   |         this type parameter needs to be `std::marker::Sized`
    |
    = note: required because it appears within the type `Bar<T>`
 

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -7,7 +7,7 @@ LL |
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |      -                    ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `Sized`
+   |      this type parameter needs to be `std::marker::Sized`
    |
 help: you could relax the implicit `Sized` bound on `Y` if it were used through indirection like `&Y` or `Box<Y>`
   --> $DIR/unsized-trait-impl-self-type.rs:8:11

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -7,7 +7,7 @@ LL | trait T2<Z> {
 LL | impl<X: ?Sized> T2<X> for S4<X> {
    |      -          ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `Sized`
+   |      this type parameter needs to be `std::marker::Sized`
    |
 help: consider relaxing the implicit `Sized` restriction
    |

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:7:13
    |
 LL | fn f1<X: ?Sized>(x: &X) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f2::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
@@ -18,7 +18,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:18:13
    |
 LL | fn f3<X: ?Sized + T>(x: &X) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f4::<X>(x);
    |             ^ doesn't have a size known at compile-time
 ...
@@ -37,7 +37,7 @@ LL | fn f5<Y>(x: &Y) {}
    |       - required by this bound in `f5`
 ...
 LL | fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f5(x1);
    |        ^^ doesn't have a size known at compile-time
    |
@@ -51,7 +51,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:40:8
    |
 LL | fn f9<X: ?Sized>(x1: Box<S<X>>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(*x1, 34));
    |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -62,7 +62,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:9
    |
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        - this type parameter needs to be `Sized`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(32, *x1));
    |         ^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -77,7 +77,7 @@ LL | fn f5<Y>(x: &Y) {}
    |       - required by this bound in `f5`
 ...
 LL | fn f10<X: ?Sized>(x1: Box<S<X>>) {
-   |        - this type parameter needs to be `Sized`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     f5(&(32, *x1));
    |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/unsized5.stderr
+++ b/src/test/ui/unsized5.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:4:9
    |
 LL | struct S1<X: ?Sized> {
-   |           - this type parameter needs to be `Sized`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     f1: X,
    |         ^ doesn't have a size known at compile-time
    |
@@ -21,7 +21,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:10:8
    |
 LL | struct S2<X: ?Sized> {
-   |           - this type parameter needs to be `Sized`
+   |           - this type parameter needs to be `std::marker::Sized`
 LL |     f: isize,
 LL |     g: X,
    |        ^ doesn't have a size known at compile-time
@@ -77,7 +77,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:25:8
    |
 LL | enum E<X: ?Sized> {
-   |        - this type parameter needs to be `Sized`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     V1(X, isize),
    |        ^ doesn't have a size known at compile-time
    |
@@ -96,7 +96,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized5.rs:29:12
    |
 LL | enum F<X: ?Sized> {
-   |        - this type parameter needs to be `Sized`
+   |        - this type parameter needs to be `std::marker::Sized`
 LL |     V2{f1: X, f: isize},
    |            ^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/unsized6.stderr
+++ b/src/test/ui/unsized6.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:9:9
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                             - this type parameter needs to be `Sized`
+   |                             - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y: Y;
    |         ^ doesn't have a size known at compile-time
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:7:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                  - this type parameter needs to be `Sized`
+   |                  - this type parameter needs to be `std::marker::Sized`
 LL |     let _: W; // <-- this is OK, no bindings created, no initializer.
 LL |     let _: (isize, (X, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -25,7 +25,7 @@ error[E0277]: the size for values of type `Z` cannot be known at compilation tim
   --> $DIR/unsized6.rs:11:12
    |
 LL | fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
-   |                                        - this type parameter needs to be `Sized`
+   |                                        - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y: (isize, (Z, usize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -36,7 +36,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:15:9
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     let y: X;
    |         ^ doesn't have a size known at compile-time
    |
@@ -47,7 +47,7 @@ error[E0277]: the size for values of type `Y` cannot be known at compilation tim
   --> $DIR/unsized6.rs:17:12
    |
 LL | fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
-   |                  - this type parameter needs to be `Sized`
+   |                  - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y: (isize, (Y, isize));
    |            ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -58,7 +58,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:22:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -69,7 +69,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:24:9
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -81,7 +81,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:26:10
    |
 LL | fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -93,7 +93,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:30:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 LL |     let y: X = *x1;
    |         ^ doesn't have a size known at compile-time
    |
@@ -104,7 +104,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:32:9
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let y = *x2;
    |         ^ doesn't have a size known at compile-time
@@ -116,7 +116,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized6.rs:34:10
    |
 LL | fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   |       - this type parameter needs to be `Sized`
+   |       - this type parameter needs to be `std::marker::Sized`
 ...
 LL |     let (y, z) = (*x3, 4);
    |          ^ doesn't have a size known at compile-time
@@ -130,7 +130,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn g1<X: ?Sized>(x: X) {}
    |       -          ^ doesn't have a size known at compile-time
    |       |
-   |       this type parameter needs to be `Sized`
+   |       this type parameter needs to be `std::marker::Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size
@@ -144,7 +144,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
 LL | fn g2<X: ?Sized + T>(x: X) {}
    |       -              ^ doesn't have a size known at compile-time
    |       |
-   |       this type parameter needs to be `Sized`
+   |       this type parameter needs to be `std::marker::Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: function arguments must have a statically known size, borrowed types always have a known size

--- a/src/test/ui/unsized7.stderr
+++ b/src/test/ui/unsized7.stderr
@@ -7,7 +7,7 @@ LL | trait T1<Z: T> {
 LL | impl<X: ?Sized + T> T1<X> for S3<X> {
    |      -              ^^^^^ doesn't have a size known at compile-time
    |      |
-   |      this type parameter needs to be `Sized`
+   |      this type parameter needs to be `std::marker::Sized`
    |
 help: consider relaxing the implicit `Sized` restriction
    |

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -9,8 +9,8 @@ LL |     where T: ExtraCopy<U>
    |
 help: consider further restricting type parameter `U`
    |
-LL |     where T: ExtraCopy<U>, U: Copy
-   |                          ^^^^^^^^^
+LL |     where T: ExtraCopy<U>, U: std::marker::Copy
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -9,8 +9,8 @@ LL |         f: IsCopy<A>
    |
 help: consider restricting type parameter `A`
    |
-LL | enum AnotherEnum<A: Copy> {
-   |                   ^^^^^^
+LL | enum AnotherEnum<A: std::marker::Copy> {
+   |                   ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -9,8 +9,8 @@ LL |     SomeVariant(IsCopy<A>)
    |
 help: consider restricting type parameter `A`
    |
-LL | enum SomeEnum<A: Copy> {
-   |                ^^^^^^
+LL | enum SomeEnum<A: std::marker::Copy> {
+   |                ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -9,8 +9,8 @@ LL | fn foo<T,U>() where T: ExtraCopy<U>
    |
 help: consider further restricting type parameter `U`
    |
-LL | fn foo<T,U>() where T: ExtraCopy<U>, U: Copy
-   |                                    ^^^^^^^^^
+LL | fn foo<T,U>() where T: ExtraCopy<U>, U: std::marker::Copy
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
   --> $DIR/wf-fn-where-clause.rs:12:16

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -9,8 +9,8 @@ LL | fn bar<T>(_: &MustBeCopy<T>)
    |
 help: consider restricting type parameter `T`
    |
-LL | fn bar<T: Copy>(_: &MustBeCopy<T>)
-   |         ^^^^^^
+LL | fn bar<T: std::marker::Copy>(_: &MustBeCopy<T>)
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -9,8 +9,8 @@ LL | fn bar<T>() -> MustBeCopy<T>
    |
 help: consider restricting type parameter `T`
    |
-LL | fn bar<T: Copy>() -> MustBeCopy<T>
-   |         ^^^^^^
+LL | fn bar<T: std::marker::Copy>() -> MustBeCopy<T>
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -9,8 +9,8 @@ LL |     x: fn(MustBeCopy<T>)
    |
 help: consider restricting type parameter `T`
    |
-LL | struct Bar<T: Copy> {
-   |             ^^^^^^
+LL | struct Bar<T: std::marker::Copy> {
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -9,8 +9,8 @@ LL |     x: fn() -> MustBeCopy<T>
    |
 help: consider restricting type parameter `T`
    |
-LL | struct Foo<T: Copy> {
-   |             ^^^^^^
+LL | struct Foo<T: std::marker::Copy> {
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -9,8 +9,8 @@ LL |     where T: MustBeCopy<U>
    |
 help: consider further restricting type parameter `U`
    |
-LL |     where T: MustBeCopy<U>, U: Copy
-   |                           ^^^^^^^^^
+LL |     where T: MustBeCopy<U>, U: std::marker::Copy
+   |                           ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -9,8 +9,8 @@ LL |     x: dyn Object<MustBeCopy<T>>
    |
 help: consider restricting type parameter `T`
    |
-LL | struct Bar<T: Copy> {
-   |             ^^^^^^
+LL | struct Bar<T: std::marker::Copy> {
+   |             ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -9,8 +9,8 @@ LL |     fn foo(self) where T: ExtraCopy<U>
    |
 help: consider restricting type parameter `U`
    |
-LL | impl<T,U: Copy> Foo<T,U> {
-   |         ^^^^^^
+LL | impl<T,U: std::marker::Copy> Foo<T,U> {
+   |         ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -9,8 +9,8 @@ LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>
    |
 help: consider further restricting type parameter `U`
    |
-LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>, U: Copy
-   |                                         ^^^^^^^^^
+LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>, U: std::marker::Copy
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -9,8 +9,8 @@ LL |     where T: ExtraCopy<U>
    |
 help: consider further restricting type parameter `U`
    |
-LL |     where T: ExtraCopy<U>, U: Copy
-   |                          ^^^^^^^^^
+LL |     where T: ExtraCopy<U>, U: std::marker::Copy
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -9,8 +9,8 @@ LL |     data: IsCopy<A>
    |
 help: consider restricting type parameter `A`
    |
-LL | struct SomeStruct<A: Copy> {
-   |                    ^^^^^^
+LL | struct SomeStruct<A: std::marker::Copy> {
+   |                    ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -9,8 +9,8 @@ LL |     type Type1: ExtraCopy<T>;
    |
 help: consider restricting type parameter `T`
    |
-LL | trait SomeTrait<T: Copy> {
-   |                  ^^^^^^
+LL | trait SomeTrait<T: std::marker::Copy> {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -9,8 +9,8 @@ LL |     where T: ExtraCopy<U>
    |
 help: consider further restricting type parameter `U`
    |
-LL |     where T: ExtraCopy<U>, U: Copy
-   |                          ^^^^^^^^^
+LL |     where T: ExtraCopy<U>, U: std::marker::Copy
+   |                          ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -9,8 +9,8 @@ LL | trait SomeTrait<T>: ExtraCopy<T> {
    |
 help: consider restricting type parameter `T`
    |
-LL | trait SomeTrait<T: Copy>: ExtraCopy<T> {
-   |                  ^^^^^^
+LL | trait SomeTrait<T: std::marker::Copy>: ExtraCopy<T> {
+   |                  ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -9,8 +9,8 @@ LL |         require_copy(self.x);
    |
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Copy> Foo<T> {
-   |       ^^^^^^
+LL | impl<T: std::marker::Copy> Foo<T> {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -9,8 +9,8 @@ LL |         require_copy(self.x);
    |
 help: consider restricting type parameter `T`
    |
-LL | impl<T: Copy> Foo<T> for Bar<T> {
-   |       ^^^^^^
+LL | impl<T: std::marker::Copy> Foo<T> for Bar<T> {
+   |       ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #80720 (Make documentation of which items the prelude exports more readable.)
 - #83654 (Do not emit a suggestion that causes the E0632 error)
 - #83671 (Add a regression test for issue-75801)
 - #83673 (give full path of constraint in suggest_constraining_type_param)
 - #83678 (Fix Self keyword doc URL conflict on case insensitive file systems (until definitely fixed on rustdoc))
 - #83680 (Update for loop desugaring docs)
 - #83683 (bootstrap: don't complain about linkcheck if it is excluded)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=80720,83654,83671,83673,83678,83680,83683)
<!-- homu-ignore:end -->