### PR TITLE
Give a better error when --theme is not a CSS file

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -439,7 +439,9 @@ impl Options {
                     return Err(1);
                 }
                 if theme_file.extension() != Some(OsStr::new("css")) {
-                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s)).emit();
+                    diag.struct_err(&format!("invalid argument: \"{}\"", theme_s))
+                        .help("arguments to --theme must have a .css extension")
+                        .emit();
                     return Err(1);
                 }
                 let (success, ret) = theme::test_theme_against(&theme_file, &paths, &diag);

--- a/src/test/rustdoc-ui/invalid-theme-name.rs
+++ b/src/test/rustdoc-ui/invalid-theme-name.rs
@@ -1,0 +1,3 @@
+// compile-flags:--theme {{src-base}}/invalid-theme-name.rs
+// error-pattern: invalid argument
+// error-pattern: must have a .css extension

--- a/src/test/rustdoc-ui/invalid-theme-name.stderr
+++ b/src/test/rustdoc-ui/invalid-theme-name.stderr
@@ -1,0 +1,4 @@
+error: invalid argument: "$DIR/invalid-theme-name.rs"
+   |
+   = help: arguments to --theme must have a .css extension
+

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1909,8 +1909,7 @@ impl<'test> TestCx<'test> {
         } else {
             Command::new(&self.config.rustdoc_path.clone().expect("no rustdoc built yet"))
         };
-        // FIXME Why is -L here?
-        rustc.arg(input_file); //.arg("-L").arg(&self.config.build_base);
+        rustc.arg(input_file);
 
         // Use a single thread for efficiency and a deterministic error message order
         rustc.arg("-Zthreads=1");


### PR DESCRIPTION
Before:

```
error: invalid argument: "bacon.toml"
```

After:
```
error: invalid argument: "bacon.toml"
  |
  = help: arguments to --theme must be CSS files
```

cc https://github.com/rust-lang/rust/pull/83478