### PR TITLE
Fix a layout possible miscalculation in `alloc::RawVec`

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -425,10 +425,11 @@ impl<T, A: Allocator> RawVec<T, A> {
         assert!(cap <= self.capacity(), "Tried to shrink to a larger capacity");
 
         let (ptr, layout) = if let Some(mem) = self.current_memory() { mem } else { return Ok(()) };
-        let new_size = cap * mem::size_of::<T>();
 
         let ptr = unsafe {
-            let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
+            // `Layout::array` cannot overflow here because it would have
+            // owerflown earlier when capacity was larger.
+            let new_layout = Layout::array::<T>(cap).unwrap_unchecked();
             self.alloc
                 .shrink(ptr, layout, new_layout)
                 .map_err(|_| AllocError { layout: new_layout, non_exhaustive: () })?

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -244,9 +244,7 @@ impl<T, A: Allocator> RawVec<T, A> {
             // We have an allocated chunk of memory, so we can bypass runtime
             // checks to get our current layout.
             unsafe {
-                let align = mem::align_of::<T>();
-                let size = mem::size_of::<T>() * self.cap;
-                let layout = Layout::from_size_align_unchecked(size, align);
+                let layout = Layout::array::<T>(self.cap).unwrap_unchecked();
                 Some((self.ptr.cast().into(), layout))
             }
         }

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -428,7 +428,7 @@ impl<T, A: Allocator> RawVec<T, A> {
 
         let ptr = unsafe {
             // `Layout::array` cannot overflow here because it would have
-            // owerflown earlier when capacity was larger.
+            // overflowed earlier when capacity was larger.
             let new_layout = Layout::array::<T>(cap).unwrap_unchecked();
             self.alloc
                 .shrink(ptr, layout, new_layout)

--- a/src/test/ui/sanitize/hwaddress.rs
+++ b/src/test/ui/sanitize/hwaddress.rs
@@ -1,6 +1,9 @@
 // needs-sanitizer-support
 // needs-sanitizer-hwaddress
 //
+// FIXME(#83706): this test triggers errors on aarch64-gnu
+// ignore-aarch64-unknown-linux-gnu
+//
 // FIXME(#83989): codegen-units=1 triggers linker errors on aarch64-gnu
 // compile-flags: -Z sanitizer=hwaddress -O -g -C codegen-units=16
 //


### PR DESCRIPTION
A layout miscalculation could happen in `RawVec` when used with a type whose size isn't a multiple of its alignment. I don't know if such type can exist in Rust, but the Layout API provides ways to manipulate such types. Anyway, it is better to calculate memory size in a consistent way.