### PR TITLE
[DO NOT MERGE] Measure the performance impact of removing intrinsic wrappers

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -492,10 +492,7 @@ impl TypeId {
 /// );
 /// ```
 #[stable(feature = "type_name", since = "1.38.0")]
-#[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
-pub const fn type_name<T: ?Sized>() -> &'static str {
-    intrinsics::type_name::<T>()
-}
+pub use intrinsics::type_name;
 
 /// Returns the name of the type of the pointed-to value as a string slice.
 /// This is the same as `type_name::<T>()`, but can be used where the type of a

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -42,14 +42,8 @@ use crate::intrinsics;
 /// assert_eq!(div_1(9, 1), 4);
 /// assert_eq!(div_1(11, u32::MAX), 0);
 /// ```
-#[inline]
 #[stable(feature = "unreachable", since = "1.27.0")]
-#[rustc_const_unstable(feature = "const_unreachable_unchecked", issue = "53188")]
-pub const unsafe fn unreachable_unchecked() -> ! {
-    // SAFETY: the safety contract for `intrinsics::unreachable` must
-    // be upheld by the caller.
-    unsafe { intrinsics::unreachable() }
-}
+pub use intrinsics::unreachable as unreachable_unchecked;
 
 /// Emits a machine instruction to signal the processor that it is running in
 /// a busy-wait spin-loop ("spin lock").

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -724,6 +724,7 @@ extern "rust-intrinsic" {
     /// reach code marked with this function.
     ///
     /// The stabilized version of this intrinsic is [`core::hint::unreachable_unchecked`](crate::hint::unreachable_unchecked).
+    #[stable(feature = "unreachable", since = "1.27.0")]
     #[rustc_const_unstable(feature = "const_unreachable_unchecked", issue = "53188")]
     pub fn unreachable() -> !;
 
@@ -769,13 +770,17 @@ extern "rust-intrinsic" {
     /// items of the same type, including alignment padding.
     ///
     /// The stabilized version of this intrinsic is [`core::mem::size_of`](crate::mem::size_of).
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_size_of", since = "1.40.0")]
+    #[rustc_promotable]
     pub fn size_of<T>() -> usize;
 
     /// The minimum alignment of a type.
     ///
     /// The stabilized version of this intrinsic is [`core::mem::align_of`](crate::mem::align_of).
+    #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_min_align_of", since = "1.40.0")]
+    #[rustc_promotable]
     pub fn min_align_of<T>() -> usize;
     /// The preferred alignment of a type.
     ///
@@ -797,6 +802,7 @@ extern "rust-intrinsic" {
     /// Gets a static string slice containing the name of a type.
     ///
     /// The stabilized version of this intrinsic is [`core::any::type_name`](crate::any::type_name).
+    #[stable(feature = "type_name", since = "1.38.0")]
     #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
     pub fn type_name<T: ?Sized>() -> &'static str;
 
@@ -805,6 +811,7 @@ extern "rust-intrinsic" {
     /// crate it is invoked in.
     ///
     /// The stabilized version of this intrinsic is [`core::any::TypeId::of`](crate::any::TypeId::of).
+    #[stable(feature = "type_name", since = "1.38.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
@@ -1091,6 +1098,7 @@ extern "rust-intrinsic" {
     /// `Copy`, then the return value of this function is unspecified.
     ///
     /// The stabilized version of this intrinsic is [`mem::needs_drop`](crate::mem::needs_drop).
+    #[stable(feature = "needs_drop", since = "1.21.0")]
     #[rustc_const_stable(feature = "const_needs_drop", since = "1.40.0")]
     pub fn needs_drop<T>() -> bool;
 
@@ -1159,10 +1167,12 @@ extern "rust-intrinsic" {
     /// Performs a volatile load from the `src` pointer.
     ///
     /// The stabilized version of this intrinsic is [`core::ptr::read_volatile`](crate::ptr::read_volatile).
+    #[stable(feature = "volatile", since = "1.9.0")]
     pub fn volatile_load<T>(src: *const T) -> T;
     /// Performs a volatile store to the `dst` pointer.
     ///
     /// The stabilized version of this intrinsic is [`core::ptr::write_volatile`](crate::ptr::write_volatile).
+    #[stable(feature = "volatile", since = "1.9.0")]
     pub fn volatile_store<T>(dst: *mut T, val: T);
 
     /// Performs a volatile load from the `src` pointer

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -148,11 +148,8 @@ pub const fn forget<T>(t: T) {
 ///
 /// This function is just a shim intended to be removed when the `unsized_locals` feature gets
 /// stabilized.
-#[inline]
 #[unstable(feature = "forget_unsized", issue = "none")]
-pub fn forget_unsized<T: ?Sized>(t: T) {
-    intrinsics::forget(t)
-}
+pub use intrinsics::forget as forget_unsized;
 
 /// Returns the size of a type in bytes.
 ///
@@ -294,13 +291,8 @@ pub fn forget_unsized<T: ?Sized>(t: T) {
 /// ```
 ///
 /// [alignment]: align_of
-#[inline(always)]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_promotable]
-#[rustc_const_stable(feature = "const_size_of", since = "1.24.0")]
-pub const fn size_of<T>() -> usize {
-    intrinsics::size_of::<T>()
-}
+pub use intrinsics::size_of;
 
 /// Returns the size of the pointed-to value in bytes.
 ///
@@ -369,13 +361,8 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 /// let y: &[u8] = &x;
 /// assert_eq!(13, unsafe { mem::size_of_val_raw(y) });
 /// ```
-#[inline]
 #[unstable(feature = "layout_for_ptr", issue = "69835")]
-#[rustc_const_unstable(feature = "const_size_of_val_raw", issue = "46571")]
-pub const unsafe fn size_of_val_raw<T: ?Sized>(val: *const T) -> usize {
-    // SAFETY: the caller must provide a valid raw pointer
-    unsafe { intrinsics::size_of_val(val) }
-}
+pub use intrinsics::size_of_val as size_of_val_raw;
 
 /// Returns the [ABI]-required minimum alignment of a type.
 ///
@@ -393,12 +380,9 @@ pub const unsafe fn size_of_val_raw<T: ?Sized>(val: *const T) -> usize {
 ///
 /// assert_eq!(4, mem::min_align_of::<i32>());
 /// ```
-#[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_deprecated(reason = "use `align_of` instead", since = "1.2.0")]
-pub fn min_align_of<T>() -> usize {
-    intrinsics::min_align_of::<T>()
-}
+pub use intrinsics::min_align_of;
 
 /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to.
 ///
@@ -437,13 +421,8 @@ pub fn min_align_of_val<T: ?Sized>(val: &T) -> usize {
 ///
 /// assert_eq!(4, mem::align_of::<i32>());
 /// ```
-#[inline(always)]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_promotable]
-#[rustc_const_stable(feature = "const_align_of", since = "1.24.0")]
-pub const fn align_of<T>() -> usize {
-    intrinsics::min_align_of::<T>()
-}
+pub use intrinsics::min_align_of as align_of;
 
 /// Returns the [ABI]-required minimum alignment of the type of the value that `val` points to.
 ///
@@ -567,13 +546,9 @@ pub const unsafe fn align_of_val_raw<T: ?Sized>(val: *const T) -> usize {
 ///     }
 /// }
 /// ```
-#[inline]
 #[stable(feature = "needs_drop", since = "1.21.0")]
-#[rustc_const_stable(feature = "const_needs_drop", since = "1.36.0")]
 #[rustc_diagnostic_item = "needs_drop"]
-pub const fn needs_drop<T>() -> bool {
-    intrinsics::needs_drop::<T>()
-}
+pub use intrinsics::needs_drop;
 
 /// Returns the value of type `T` represented by the all-zero byte-pattern.
 ///
@@ -1043,9 +1018,5 @@ pub const fn discriminant<T>(v: &T) -> Discriminant<T> {
 /// assert_eq!(mem::variant_count::<Option<!>>(), 2);
 /// assert_eq!(mem::variant_count::<Result<!, !>>(), 2);
 /// ```
-#[inline(always)]
 #[unstable(feature = "variant_count", issue = "73662")]
-#[rustc_const_unstable(feature = "variant_count", issue = "73662")]
-pub const fn variant_count<T>() -> usize {
-    intrinsics::variant_count::<T>()
-}
+pub use intrinsics::variant_count;

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -75,7 +75,7 @@
 use crate::cmp::Ordering;
 use crate::fmt;
 use crate::hash;
-use crate::intrinsics::{self, abort, is_aligned_and_not_null};
+use crate::intrinsics;
 use crate::mem::{self, MaybeUninit};
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1077,16 +1077,8 @@ pub const unsafe fn write_unaligned<T>(dst: *mut T, src: T) {
 ///     assert_eq!(std::ptr::read_volatile(y), 12);
 /// }
 /// ```
-#[inline]
 #[stable(feature = "volatile", since = "1.9.0")]
-pub unsafe fn read_volatile<T>(src: *const T) -> T {
-    if cfg!(debug_assertions) && !is_aligned_and_not_null(src) {
-        // Not panicking to keep codegen impact smaller.
-        abort();
-    }
-    // SAFETY: the caller must uphold the safety contract for `volatile_load`.
-    unsafe { intrinsics::volatile_load(src) }
-}
+pub use intrinsics::volatile_load as read_volatile;
 
 /// Performs a volatile write of a memory location with the given value without
 /// reading or dropping the old value.
@@ -1148,18 +1140,8 @@ pub unsafe fn read_volatile<T>(src: *const T) -> T {
 ///     assert_eq!(std::ptr::read_volatile(y), 12);
 /// }
 /// ```
-#[inline]
 #[stable(feature = "volatile", since = "1.9.0")]
-pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
-    if cfg!(debug_assertions) && !is_aligned_and_not_null(dst) {
-        // Not panicking to keep codegen impact smaller.
-        abort();
-    }
-    // SAFETY: the caller must uphold the safety contract for `volatile_store`.
-    unsafe {
-        intrinsics::volatile_store(dst, src);
-    }
-}
+pub use intrinsics::volatile_store as write_volatile;
 
 /// Align pointer `p`.
 ///


### PR DESCRIPTION
This is currently a breaking change as the intrinsic wrappers use the "Rust" abi, while intrinsics use the "rust-intrinsic" abi, but I want to see this changed in the future. For now this will only measure the compile time difference of removing the wrappers.