### PR TITLE
rustc_apfloat: fix typo in is_denormal

### DIFF
--- a/compiler/rustc_apfloat/src/ppc.rs
+++ b/compiler/rustc_apfloat/src/ppc.rs
@@ -398,7 +398,7 @@ where
 
     fn is_denormal(self) -> bool {
         self.category() == Category::Normal
-            && (self.0.is_denormal() || self.0.is_denormal() ||
+            && (self.0.is_denormal() || self.1.is_denormal() ||
           // (double)(Hi + Lo) == Hi defines a normal number.
           !(self.0 + self.1).value.bitwise_eq(self.0))
     }


### PR DESCRIPTION
Sources:
https://github.com/llvm-mirror/llvm/blob/23efab2bbd424ed13495a420ad8641cb2c6c28f9/lib/Support/APFloat.cpp#L4341..L4346
