### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -953,7 +953,7 @@ pub fn build_target_config(opts: &Options, target_override: Option<Target>) -> T
             opts.error_format,
             &format!(
                 "Error loading target specification: {}. \
-            Use `--print target-list` for a list of built-in targets",
+                 Run `rustc --print target-list` for a list of built-in targets",
                 e
             ),
         )

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -858,7 +858,7 @@ impl From<Cow<'_, OsStr>> for Box<OsStr> {
 
 #[stable(feature = "os_string_from_box", since = "1.18.0")]
 impl From<Box<OsStr>> for OsString {
-    /// Converts a [`Box`]`<`[`OsStr`]`>` into a `OsString` without copying or
+    /// Converts a [`Box`]`<`[`OsStr`]`>` into an [`OsString`] without copying or
     /// allocating.
     #[inline]
     fn from(boxed: Box<OsStr>) -> OsString {

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -361,7 +361,7 @@ impl OsString {
 impl From<String> for OsString {
     /// Converts a [`String`] into a [`OsString`].
     ///
-    /// The conversion copies the data, and includes an allocation on the heap.
+    /// This conversion does not allocate or copy memory.
     #[inline]
     fn from(s: String) -> OsString {
         OsString { inner: Buf::from_string(s) }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1467,7 +1467,7 @@ impl<T: ?Sized + AsRef<OsStr>> From<&T> for PathBuf {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl From<OsString> for PathBuf {
-    /// Converts a `OsString` into a `PathBuf`
+    /// Converts a [`OsString`] into a [`PathBuf`]
     ///
     /// This conversion does not allocate or copy memory.
     #[inline]
@@ -1478,7 +1478,7 @@ impl From<OsString> for PathBuf {
 
 #[stable(feature = "from_path_buf_for_os_string", since = "1.14.0")]
 impl From<PathBuf> for OsString {
-    /// Converts a `PathBuf` into a `OsString`
+    /// Converts a [`PathBuf`] into a [`OsString`]
     ///
     /// This conversion does not allocate or copy memory.
     #[inline]
@@ -1489,7 +1489,7 @@ impl From<PathBuf> for OsString {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl From<String> for PathBuf {
-    /// Converts a `String` into a `PathBuf`
+    /// Converts a [`String`] into a [`PathBuf`]
     ///
     /// This conversion does not allocate or copy memory.
     #[inline]
@@ -1595,7 +1595,7 @@ impl<'a> From<Cow<'a, Path>> for PathBuf {
 
 #[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<PathBuf> for Arc<Path> {
-    /// Converts a `PathBuf` into an `Arc` by moving the `PathBuf` data into a new `Arc` buffer.
+    /// Converts a [`PathBuf`] into an [`Arc`] by moving the [`PathBuf`] data into a new [`Arc`] buffer.
     #[inline]
     fn from(s: PathBuf) -> Arc<Path> {
         let arc: Arc<OsStr> = Arc::from(s.into_os_string());
@@ -1605,7 +1605,7 @@ impl From<PathBuf> for Arc<Path> {
 
 #[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<&Path> for Arc<Path> {
-    /// Converts a `Path` into an `Arc` by copying the `Path` data into a new `Arc` buffer.
+    /// Converts a [`Path`] into an [`Arc`] by copying the [`Path`] data into a new [`Arc`] buffer.
     #[inline]
     fn from(s: &Path) -> Arc<Path> {
         let arc: Arc<OsStr> = Arc::from(s.as_os_str());
@@ -1615,7 +1615,7 @@ impl From<&Path> for Arc<Path> {
 
 #[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<PathBuf> for Rc<Path> {
-    /// Converts a `PathBuf` into an `Rc` by moving the `PathBuf` data into a new `Rc` buffer.
+    /// Converts a [`PathBuf`] into an [`Rc`] by moving the [`PathBuf`] data into a new `Rc` buffer.
     #[inline]
     fn from(s: PathBuf) -> Rc<Path> {
         let rc: Rc<OsStr> = Rc::from(s.into_os_string());
@@ -1625,7 +1625,7 @@ impl From<PathBuf> for Rc<Path> {
 
 #[stable(feature = "shared_from_slice2", since = "1.24.0")]
 impl From<&Path> for Rc<Path> {
-    /// Converts a `Path` into an `Rc` by copying the `Path` data into a new `Rc` buffer.
+    /// Converts a [`Path`] into an [`Rc`] by copying the [`Path`] data into a new `Rc` buffer.
     #[inline]
     fn from(s: &Path) -> Rc<Path> {
         let rc: Rc<OsStr> = Rc::from(s.as_os_str());

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1467,7 +1467,7 @@ impl<T: ?Sized + AsRef<OsStr>> From<&T> for PathBuf {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl From<OsString> for PathBuf {
-    /// Converts a [`OsString`] into a [`PathBuf`]
+    /// Converts an [`OsString`] into a [`PathBuf`]
     ///
     /// This conversion does not allocate or copy memory.
     #[inline]
@@ -1478,7 +1478,7 @@ impl From<OsString> for PathBuf {
 
 #[stable(feature = "from_path_buf_for_os_string", since = "1.14.0")]
 impl From<PathBuf> for OsString {
-    /// Converts a [`PathBuf`] into a [`OsString`]
+    /// Converts a [`PathBuf`] into an [`OsString`]
     ///
     /// This conversion does not allocate or copy memory.
     #[inline]

--- a/src/test/ui/proc-macro/auxiliary/issue-79825.rs
+++ b/src/test/ui/proc-macro/auxiliary/issue-79825.rs
@@ -1,0 +1,14 @@
+// force-host
+// no-prefer-dynamic
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn assert_input(args: TokenStream, input: TokenStream) -> TokenStream {
+    assert_eq!(input.to_string(), "trait Alias = Sized ;");
+    assert!(args.is_empty());
+    TokenStream::new()
+}

--- a/src/test/ui/proc-macro/issue-79825.rs
+++ b/src/test/ui/proc-macro/issue-79825.rs
@@ -1,0 +1,10 @@
+// check-pass
+// aux-build:issue-79825.rs
+#![feature(trait_alias)]
+
+extern crate issue_79825;
+
+#[issue_79825::assert_input]
+trait Alias = Sized;
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-81555.rs
+++ b/src/test/ui/proc-macro/issue-81555.rs
@@ -1,0 +1,15 @@
+// check-pass
+// aux-build:test-macros.rs
+#![feature(stmt_expr_attributes, proc_macro_hygiene)]
+
+extern crate test_macros;
+
+use test_macros::identity_attr;
+
+#[identity_attr]
+fn main() {
+    let _x;
+    let y = ();
+    #[identity_attr]
+    _x = y;
+}

--- a/src/test/ui/specialization/issue-68830-spurious-diagnostics.rs
+++ b/src/test/ui/specialization/issue-68830-spurious-diagnostics.rs
@@ -1,0 +1,23 @@
+// A regression test for #68830. This checks we don't emit
+// a verbose `conflicting implementations` error.
+
+#![feature(specialization)]
+#![allow(incomplete_features)]
+
+struct BadStruct {
+    err: MissingType //~ ERROR: cannot find type `MissingType` in this scope
+}
+
+trait MyTrait<T> {
+    fn foo();
+}
+
+impl<T, D> MyTrait<T> for D {
+    default fn foo() {}
+}
+
+impl<T> MyTrait<T> for BadStruct {
+    fn foo() {}
+}
+
+fn main() {}

--- a/src/test/ui/specialization/issue-68830-spurious-diagnostics.stderr
+++ b/src/test/ui/specialization/issue-68830-spurious-diagnostics.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `MissingType` in this scope
+  --> $DIR/issue-68830-spurious-diagnostics.rs:8:10
+   |
+LL |     err: MissingType
+   |          ^^^^^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Successful merges:

 - #83015 (Add regression tests for #79825 and #81555)
 - #83699 (Add a regression test for issue-68830)
 - #83700 (Fix documentation of conversion from String to OsString)
 - #83711 (Clarify `--print target-list` is a rustc's option)
 - #83712 (Update LLVM with another wasm simd fix)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83015,83699,83700,83711,83712)
<!-- homu-ignore:end -->