### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "cargo"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -326,6 +326,7 @@ dependencies = [
  "serde",
  "serde_ignored",
  "serde_json",
+ "shell-escape",
  "strip-ansi-escapes",
  "tar",
  "tempfile",


### PR DESCRIPTION
5 commits in 1e8703890f285befb5e32627ad4e0a0454dde1fb..3c44c3c4b7900b8b13c85ead25ccaa8abb7d8989
2021-03-26 16:59:39 +0000 to 2021-03-31 21:21:15 +0000
- Fix semver docs for 1.51. (rust-lang/cargo#9316)
- Add `cargo config` subcommand. (rust-lang/cargo#9302)
- Give one more example for the --featuers CLI (rust-lang/cargo#9313)
- Bump to 0.54.0, update changelog (rust-lang/cargo#9308)
- Make the URL to the tracking issue for `--out-dir` into a link (rust-lang/cargo#9309)