### PR TITLE
2229: Support migration via rustfix

### DIFF
--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -511,8 +511,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         };
 
                     let diagnostic_msg = format!(
-                        "`{}` causes {} to be fully captured",
-                        migration_string, migrated_variables_concat
+                        "add a dummy let to cause {} to be fully captured",
+                        migrated_variables_concat
                     );
 
                     diagnostics_builder.span_suggestion(

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -12,14 +12,14 @@ fn test1_all_need_migration() {
     let t1 = (String::new(), String::new());
     let t2 = (String::new(), String::new());
 
-    let c = || {
+    let c = || { let _ = (&t, &t1, &t2); {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
-    };
+    } };
 
     c();
 }
@@ -31,13 +31,13 @@ fn test2_only_precise_paths_need_migration() {
     let t1 = (String::new(), String::new());
     let t2 = (String::new(), String::new());
 
-    let c = || {
+    let c = || { let _ = (&t, &t1); {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
-    };
+    } };
 
     c();
 }
@@ -47,12 +47,12 @@ fn test2_only_precise_paths_need_migration() {
 fn test3_only_by_value_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
-    };
+    } };
 
     c();
 }
@@ -65,12 +65,12 @@ fn test4_only_non_copy_types_need_migration() {
     // `t1` is Copy because all of its elements are Copy
     let t1 = (0i32, 0i32);
 
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
-    };
+    } };
 
     c();
 }
@@ -83,12 +83,12 @@ fn test5_only_drop_types_need_migration() {
     // `s` doesn't implement Drop or any elements within it, and doesn't need migration
     let s = S(0i32, 0i32);
 
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
-    };
+    } };
 
     c();
 }
@@ -98,11 +98,11 @@ fn test5_only_drop_types_need_migration() {
 fn test6_move_closures_non_copy_types_might_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
-    let c = move || {
+    let c = move || { let _ = (&t1, &t); {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
-    };
+    } };
 
     c();
 }
@@ -113,11 +113,11 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
 fn test7_drop_non_drop_aggregate_need_migration() {
     let t = (String::new(), String::new(), 0i32);
 
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
-    };
+    } };
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -14,7 +14,7 @@ fn test1_all_need_migration() {
 
     let c = || { let _ = (&t, &t1, &t2); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
         let _t1 = t1.0;
@@ -33,7 +33,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || { let _ = (&t, &t1); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -49,7 +49,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (String::new(), String::new());
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
     };
@@ -67,7 +67,7 @@ fn test4_only_non_copy_types_need_migration() {
 
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
     };
@@ -85,7 +85,7 @@ fn test5_only_drop_types_need_migration() {
 
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
     };
@@ -100,7 +100,7 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t1 = (String::new(), String::new());
     let c = move || { let _ = (&t1, &t); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
     };
 
@@ -115,7 +115,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
 
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.fixed
@@ -12,14 +12,14 @@ fn test1_all_need_migration() {
     let t1 = (String::new(), String::new());
     let t2 = (String::new(), String::new());
 
-    let c = || { let _ = (&t, &t1, &t2); {
+    let c = || { let _ = (&t, &t1, &t2); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
-    } };
+    };
 
     c();
 }
@@ -31,13 +31,13 @@ fn test2_only_precise_paths_need_migration() {
     let t1 = (String::new(), String::new());
     let t2 = (String::new(), String::new());
 
-    let c = || { let _ = (&t, &t1); {
+    let c = || { let _ = (&t, &t1); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
-    } };
+    };
 
     c();
 }
@@ -47,12 +47,12 @@ fn test2_only_precise_paths_need_migration() {
 fn test3_only_by_value_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
-    } };
+    };
 
     c();
 }
@@ -65,12 +65,12 @@ fn test4_only_non_copy_types_need_migration() {
     // `t1` is Copy because all of its elements are Copy
     let t1 = (0i32, 0i32);
 
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
-    } };
+    };
 
     c();
 }
@@ -83,12 +83,12 @@ fn test5_only_drop_types_need_migration() {
     // `s` doesn't implement Drop or any elements within it, and doesn't need migration
     let s = S(0i32, 0i32);
 
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
-    } };
+    };
 
     c();
 }
@@ -98,11 +98,11 @@ fn test5_only_drop_types_need_migration() {
 fn test6_move_closures_non_copy_types_might_need_migration() {
     let t = (String::new(), String::new());
     let t1 = (String::new(), String::new());
-    let c = move || { let _ = (&t1, &t); {
+    let c = move || { let _ = (&t1, &t); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
-    } };
+    };
 
     c();
 }
@@ -113,11 +113,11 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
 fn test7_drop_non_drop_aggregate_need_migration() {
     let t = (String::new(), String::new(), 0i32);
 
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
-    } };
+    };
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.rs
@@ -14,7 +14,7 @@ fn test1_all_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
 
         let _t = t.0;
         let _t1 = t1.0;
@@ -33,7 +33,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -49,7 +49,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (String::new(), String::new());
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{}", t1.1);
     };
@@ -67,7 +67,7 @@ fn test4_only_non_copy_types_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
     };
@@ -85,7 +85,7 @@ fn test5_only_drop_types_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _s = s.0;
     };
@@ -100,7 +100,7 @@ fn test6_move_closures_non_copy_types_might_need_migration() {
     let t1 = (String::new(), String::new());
     let c = move || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{} {}", t1.1, t.1);
     };
 
@@ -115,7 +115,7 @@ fn test7_drop_non_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: `let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1, &t2); 
 LL |
@@ -39,7 +39,7 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-help: `let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1); 
 LL |
@@ -61,7 +61,7 @@ LL | |         println!("{}", t1.1);
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -83,7 +83,7 @@ LL | |         let _t1 = t1.0;
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -105,7 +105,7 @@ LL | |         let _s = s.0;
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -126,7 +126,7 @@ LL | |         println!("{} {}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-help: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL |     let c = move || { let _ = (&t1, &t); 
 LL |
@@ -146,7 +146,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -1,25 +1,33 @@
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:13:13
+  --> $DIR/insignificant_drop.rs:15:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
-LL | |         let _t = t.0;
-LL | |         let _t1 = t1.0;
+LL | |
+...  |
 LL | |         let _t2 = t2.0;
 LL | |     };
    | |_____^
    |
 note: the lint level is defined here
-  --> $DIR/insignificant_drop.rs:1:9
+  --> $DIR/insignificant_drop.rs:3:9
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: drop(&(t, t1, t2));
+help: `let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+   |
+LL |     let c = || { let _ = (&t, &t1, &t2); {
+LL |
+LL |
+LL | 
+LL |         let _t = t.0;
+LL |         let _t1 = t1.0;
+ ...
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:31:13
+  --> $DIR/insignificant_drop.rs:34:13
    |
 LL |       let c = || {
    |  _____________^
@@ -31,10 +39,18 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t, t1));
+help: `let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+   |
+LL |     let c = || { let _ = (&t, &t1); {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         let _t1 = t1.0;
+LL |         let _t2 = t2;
+ ...
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:47:13
+  --> $DIR/insignificant_drop.rs:50:13
    |
 LL |       let c = || {
    |  _____________^
@@ -45,10 +61,18 @@ LL | |         println!("{}", t1.1);
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         println!("{}", t1.1);
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:65:13
+  --> $DIR/insignificant_drop.rs:68:13
    |
 LL |       let c = || {
    |  _____________^
@@ -59,10 +83,18 @@ LL | |         let _t1 = t1.0;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         let _t1 = t1.0;
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:83:13
+  --> $DIR/insignificant_drop.rs:86:13
    |
 LL |       let c = || {
    |  _____________^
@@ -73,10 +105,18 @@ LL | |         let _s = s.0;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         let _s = s.0;
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:98:13
+  --> $DIR/insignificant_drop.rs:101:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -86,10 +126,17 @@ LL | |         println!("{} {}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t1, t));
+help: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+   |
+LL |     let c = move || { let _ = (&t1, &t); {
+LL |
+LL |
+LL |         println!("{} {}", t1.1, t.1);
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/insignificant_drop.rs:113:13
+  --> $DIR/insignificant_drop.rs:116:13
    |
 LL |       let c = || {
    |  _____________^
@@ -99,7 +146,14 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |     } };
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/insignificant_drop.stderr
@@ -18,7 +18,7 @@ LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: `let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
    |
-LL |     let c = || { let _ = (&t, &t1, &t2); {
+LL |     let c = || { let _ = (&t, &t1, &t2); 
 LL |
 LL |
 LL | 
@@ -41,7 +41,7 @@ LL | |     };
    |
 help: `let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
    |
-LL |     let c = || { let _ = (&t, &t1); {
+LL |     let c = || { let _ = (&t, &t1); 
 LL |
 LL |
 LL |         let _t = t.0;
@@ -63,12 +63,12 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.0;
 LL |         println!("{}", t1.1);
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -85,12 +85,12 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.0;
 LL |         let _t1 = t1.0;
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -107,12 +107,12 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.0;
 LL |         let _s = s.0;
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -128,11 +128,11 @@ LL | |     };
    |
 help: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
    |
-LL |     let c = move || { let _ = (&t1, &t); {
+LL |     let c = move || { let _ = (&t1, &t); 
 LL |
 LL |
 LL |         println!("{} {}", t1.1, t.1);
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -148,11 +148,11 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     } };
+LL |     };
    |
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
@@ -18,7 +18,7 @@ fn closure_contains_block() {
     let t = (Foo(0), Foo(0));
     let c = || { let _ = &t; 
         //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-        //~| HELP: `let _ = &t` causes `t` to be fully captured
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -29,7 +29,7 @@ fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
     let c = || { let _ = &t; t.0 };
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.fixed
@@ -1,0 +1,40 @@
+// run-rustfix
+#![deny(disjoint_capture_drop_reorder)]
+//~^ NOTE: the lint level is defined here
+
+// Test the two possible cases for automated migartion using rustfix
+// - Closure contains a block i.e.  `|| { .. };`
+// - Closure contains just an expr `|| ..;`
+
+#[derive(Debug)]
+struct Foo(i32);
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("{:?} dropped", self.0);
+    }
+}
+
+fn closure_contains_block() {
+    let t = (Foo(0), Foo(0));
+    let c = || { let _ = &t; 
+        //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+        //~| HELP: `let _ = &t` causes `t` to be fully captured
+        let _t = t.0;
+    };
+
+    c();
+}
+
+fn closure_doesnt_contain_block() {
+    let t = (Foo(0), Foo(0));
+    let c = || { let _ = &t; t.0 };
+    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| HELP: `let _ = &t` causes `t` to be fully captured
+
+    c();
+}
+
+fn main() {
+    closure_contains_block();
+    closure_doesnt_contain_block();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
@@ -1,0 +1,40 @@
+// run-rustfix
+#![deny(disjoint_capture_drop_reorder)]
+//~^ NOTE: the lint level is defined here
+
+// Test the two possible cases for automated migartion using rustfix
+// - Closure contains a block i.e.  `|| { .. };`
+// - Closure contains just an expr `|| ..;`
+
+#[derive(Debug)]
+struct Foo(i32);
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("{:?} dropped", self.0);
+    }
+}
+
+fn closure_contains_block() {
+    let t = (Foo(0), Foo(0));
+    let c = || {
+        //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+        //~| HELP: `let _ = &t` causes `t` to be fully captured
+        let _t = t.0;
+    };
+
+    c();
+}
+
+fn closure_doesnt_contain_block() {
+    let t = (Foo(0), Foo(0));
+    let c = || t.0;
+    //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
+    //~| HELP: `let _ = &t` causes `t` to be fully captured
+
+    c();
+}
+
+fn main() {
+    closure_contains_block();
+    closure_doesnt_contain_block();
+}

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.rs
@@ -18,7 +18,7 @@ fn closure_contains_block() {
     let t = (Foo(0), Foo(0));
     let c = || {
         //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-        //~| HELP: `let _ = &t` causes `t` to be fully captured
+        //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -29,7 +29,7 @@ fn closure_doesnt_contain_block() {
     let t = (Foo(0), Foo(0));
     let c = || t.0;
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -1,17 +1,16 @@
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/precise.rs:19:13
+  --> $DIR/migrations_rustfix.rs:19:13
    |
 LL |       let c = || {
    |  _____________^
 LL | |
 LL | |
 LL | |         let _t = t.0;
-LL | |         let _t = &t.1;
 LL | |     };
    | |_____^
    |
 note: the lint level is defined here
-  --> $DIR/precise.rs:3:9
+  --> $DIR/migrations_rustfix.rs:2:9
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -21,32 +20,19 @@ LL |     let c = || { let _ = &t;
 LL |
 LL |
 LL |         let _t = t.0;
-LL |         let _t = &t.1;
 LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/precise.rs:42:13
+  --> $DIR/migrations_rustfix.rs:30:13
    |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |         let _x = u.0.0;
-LL | |         let _x = u.0.1;
-LL | |         let _x = u.1.0;
-LL | |     };
-   | |_____^
+LL |     let c = || t.0;
+   |             ^^^^^^
    |
-help: `let _ = &u` causes `u` to be fully captured
+help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &u; 
-LL |
-LL |
-LL |         let _x = u.0.0;
-LL |         let _x = u.0.1;
-LL |         let _x = u.1.0;
- ...
+LL |     let c = || { let _ = &t; t.0 };
+   |                ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/migrations_rustfix.stderr
@@ -14,7 +14,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -29,7 +29,7 @@ error: drop order affected for closure because of `capture_disjoint_fields`
 LL |     let c = || t.0;
    |             ^^^^^^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; t.0 };
    |                ^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -18,7 +18,7 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
 
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
     };
@@ -41,7 +41,7 @@ fn test_precise_analysis_long_path_missing() {
 
     let c = || { let _ = &u; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &u` causes `u` to be fully captured
+    //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;
         let _x = u.1.0;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -16,12 +16,12 @@ struct ConstainsDropField(Foo, Foo);
 fn test_precise_analysis_drop_paths_not_captured_by_move() {
     let t = ConstainsDropField(Foo(10), Foo(20));
 
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
-    };
+    } };
 
     c();
 }
@@ -39,13 +39,13 @@ struct U(T, T);
 fn test_precise_analysis_long_path_missing() {
     let u = U(T(S, S), T(S, S));
 
-    let c = || {
+    let c = || { let _ = &u; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &u` causes `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;
         let _x = u.1.0;
-    };
+    } };
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.fixed
@@ -16,12 +16,12 @@ struct ConstainsDropField(Foo, Foo);
 fn test_precise_analysis_drop_paths_not_captured_by_move() {
     let t = ConstainsDropField(Foo(10), Foo(20));
 
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
-    } };
+    };
 
     c();
 }
@@ -39,13 +39,13 @@ struct U(T, T);
 fn test_precise_analysis_long_path_missing() {
     let u = U(T(S, S), T(S, S));
 
-    let c = || { let _ = &u; {
+    let c = || { let _ = &u; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &u` causes `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;
         let _x = u.1.0;
-    } };
+    };
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.rs
@@ -18,7 +18,7 @@ fn test_precise_analysis_drop_paths_not_captured_by_move() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         let _t = &t.1;
     };
@@ -41,7 +41,7 @@ fn test_precise_analysis_long_path_missing() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &u` causes `u` to be fully captured
+    //~| HELP: add a dummy let to cause `u` to be fully captured
         let _x = u.0.0;
         let _x = u.0.1;
         let _x = u.1.0;

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -1,23 +1,5 @@
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/precise.rs:27:13
-   |
-LL |       let c = || {
-   |  _____________^
-LL | |
-LL | |
-LL | |         let _t = t.0;
-LL | |     };
-   | |_____^
-   |
-note: the lint level is defined here
-  --> $DIR/precise.rs:1:9
-   |
-LL | #![deny(disjoint_capture_drop_reorder)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: drop(&(t));
-
-error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/precise.rs:40:13
+  --> $DIR/precise.rs:19:13
    |
 LL |       let c = || {
    |  _____________^
@@ -28,10 +10,23 @@ LL | |         let _t = &t.1;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+note: the lint level is defined here
+  --> $DIR/precise.rs:3:9
+   |
+LL | #![deny(disjoint_capture_drop_reorder)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         let _t = &t.1;
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/precise.rs:63:13
+  --> $DIR/precise.rs:42:13
    |
 LL |       let c = || {
    |  _____________^
@@ -43,7 +38,15 @@ LL | |         let _x = u.1.0;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(u));
+help: `let _ = &u` causes `u` to be fully captured
+   |
+LL |     let c = || { let _ = &u; {
+LL |
+LL |
+LL |         let _x = u.0.0;
+LL |         let _x = u.0.1;
+LL |         let _x = u.1.0;
+ ...
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/precise.stderr
@@ -15,7 +15,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -38,7 +38,7 @@ LL | |         let _x = u.1.0;
 LL | |     };
    | |_____^
    |
-help: `let _ = &u` causes `u` to be fully captured
+help: add a dummy let to cause `u` to be fully captured
    |
 LL |     let c = || { let _ = &u; 
 LL |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -24,7 +24,7 @@ fn test1_all_need_migration() {
 
     let c = || { let _ = (&t, &t1, &t2); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -42,7 +42,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || { let _ = (&t, &t1); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -58,7 +58,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
     };
@@ -75,7 +75,7 @@ fn test4_type_contains_drop_need_migration() {
 
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -90,7 +90,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -103,7 +103,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
 
     let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
 
@@ -118,7 +118,7 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
 
     let c = move || { let _ = (&t1, &t); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -22,13 +22,13 @@ fn test1_all_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let t2 = (Foo(0), Foo(0));
 
-    let c = || {
+    let c = || { let _ = (&t, &t1, &t2); {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
-    };
+    } };
 
     c();
 }
@@ -40,13 +40,13 @@ fn test2_only_precise_paths_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let t2 = (Foo(0), Foo(0));
 
-    let c = || {
+    let c = || { let _ = (&t, &t1); {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
-    };
+    } };
 
     c();
 }
@@ -56,12 +56,12 @@ fn test2_only_precise_paths_need_migration() {
 fn test3_only_by_value_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0));
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
-    };
+    } };
 
     c();
 }
@@ -73,11 +73,11 @@ fn test3_only_by_value_need_migration() {
 fn test4_type_contains_drop_need_migration() {
     let t = ConstainsDropField(Foo(0), Foo(0));
 
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
-    };
+    } };
 
     c();
 }
@@ -88,11 +88,11 @@ fn test4_type_contains_drop_need_migration() {
 fn test5_drop_non_drop_aggregate_need_migration() {
     let t = (Foo(0), Foo(0), 0i32);
 
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
-    };
+    } };
 
     c();
 }
@@ -101,11 +101,11 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 fn test6_significant_insignificant_drop_aggregate_need_migration() {
     let t = (Foo(0), String::new());
 
-    let c = || {
+    let c = || { let _ = &t; {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.1;
-    };
+    } };
 
     c();
 }
@@ -116,11 +116,11 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0), Foo(0));
 
-    let c = move || {
+    let c = move || { let _ = (&t1, &t); {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
-    };
+    } };
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.fixed
@@ -22,13 +22,13 @@ fn test1_all_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let t2 = (Foo(0), Foo(0));
 
-    let c = || { let _ = (&t, &t1, &t2); {
+    let c = || { let _ = (&t, &t1, &t2); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
-    } };
+    };
 
     c();
 }
@@ -40,13 +40,13 @@ fn test2_only_precise_paths_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let t2 = (Foo(0), Foo(0));
 
-    let c = || { let _ = (&t, &t1); {
+    let c = || { let _ = (&t, &t1); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
-    } };
+    };
 
     c();
 }
@@ -56,12 +56,12 @@ fn test2_only_precise_paths_need_migration() {
 fn test3_only_by_value_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0));
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
-    } };
+    };
 
     c();
 }
@@ -73,11 +73,11 @@ fn test3_only_by_value_need_migration() {
 fn test4_type_contains_drop_need_migration() {
     let t = ConstainsDropField(Foo(0), Foo(0));
 
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
-    } };
+    };
 
     c();
 }
@@ -88,11 +88,11 @@ fn test4_type_contains_drop_need_migration() {
 fn test5_drop_non_drop_aggregate_need_migration() {
     let t = (Foo(0), Foo(0), 0i32);
 
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.0;
-    } };
+    };
 
     c();
 }
@@ -101,11 +101,11 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 fn test6_significant_insignificant_drop_aggregate_need_migration() {
     let t = (Foo(0), String::new());
 
-    let c = || { let _ = &t; {
+    let c = || { let _ = &t; 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = &t` causes `t` to be fully captured
         let _t = t.1;
-    } };
+    };
 
     c();
 }
@@ -116,11 +116,11 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
     let t = (Foo(0), Foo(0));
     let t1 = (Foo(0), Foo(0), Foo(0));
 
-    let c = move || { let _ = (&t1, &t); {
+    let c = move || { let _ = (&t1, &t); 
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
     //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
-    } };
+    };
 
     c();
 }

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.rs
@@ -24,7 +24,7 @@ fn test1_all_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2.0;
@@ -42,7 +42,7 @@ fn test2_only_precise_paths_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP:` let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+    //~| HELP: add a dummy let to cause `t`, `t1` to be fully captured
         let _t = t.0;
         let _t1 = t1.0;
         let _t2 = t2;
@@ -58,7 +58,7 @@ fn test3_only_by_value_need_migration() {
     let t1 = (Foo(0), Foo(0));
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
         println!("{:?}", t1.1);
     };
@@ -75,7 +75,7 @@ fn test4_type_contains_drop_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -90,7 +90,7 @@ fn test5_drop_non_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.0;
     };
 
@@ -103,7 +103,7 @@ fn test6_significant_insignificant_drop_aggregate_need_migration() {
 
     let c = || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = &t` causes `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t` to be fully captured
         let _t = t.1;
     };
 
@@ -118,7 +118,7 @@ fn test7_move_closures_non_copy_types_might_need_migration() {
 
     let c = move || {
     //~^ ERROR: drop order affected for closure because of `capture_disjoint_fields`
-    //~| HELP: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+    //~| HELP: add a dummy let to cause `t1`, `t` to be fully captured
         println!("{:?} {:?}", t1.1, t.1);
     };
 

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -18,7 +18,7 @@ LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: `let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
    |
-LL |     let c = || { let _ = (&t, &t1, &t2); {
+LL |     let c = || { let _ = (&t, &t1, &t2); 
 LL |
 LL |
 LL |         let _t = t.0;
@@ -41,7 +41,7 @@ LL | |     };
    |
 help: `let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
    |
-LL |     let c = || { let _ = (&t, &t1); {
+LL |     let c = || { let _ = (&t, &t1); 
 LL |
 LL |
 LL |         let _t = t.0;
@@ -63,12 +63,12 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.0;
 LL |         println!("{:?}", t1.1);
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -84,11 +84,11 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -104,11 +104,11 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.0;
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -124,11 +124,11 @@ LL | |     };
    |
 help: `let _ = &t` causes `t` to be fully captured
    |
-LL |     let c = || { let _ = &t; {
+LL |     let c = || { let _ = &t; 
 LL |
 LL |
 LL |         let _t = t.1;
-LL |     } };
+LL |     };
    |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
@@ -144,11 +144,11 @@ LL | |     };
    |
 help: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
    |
-LL |     let c = move || { let _ = (&t1, &t); {
+LL |     let c = move || { let _ = (&t1, &t); 
 LL |
 LL |
 LL |         println!("{:?} {:?}", t1.1, t.1);
-LL |     } };
+LL |     };
    |
 
 error: aborting due to 7 previous errors

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -16,7 +16,7 @@ note: the lint level is defined here
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: `let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+help: add a dummy let to cause `t`, `t1`, `t2` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1, &t2); 
 LL |
@@ -39,7 +39,7 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-help: `let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+help: add a dummy let to cause `t`, `t1` to be fully captured
    |
 LL |     let c = || { let _ = (&t, &t1); 
 LL |
@@ -61,7 +61,7 @@ LL | |         println!("{:?}", t1.1);
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -82,7 +82,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -102,7 +102,7 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -122,7 +122,7 @@ LL | |         let _t = t.1;
 LL | |     };
    | |_____^
    |
-help: `let _ = &t` causes `t` to be fully captured
+help: add a dummy let to cause `t` to be fully captured
    |
 LL |     let c = || { let _ = &t; 
 LL |
@@ -142,7 +142,7 @@ LL | |         println!("{:?} {:?}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-help: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+help: add a dummy let to cause `t1`, `t` to be fully captured
    |
 LL |     let c = move || { let _ = (&t1, &t); 
 LL |

--- a/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/significant_drop.stderr
@@ -1,5 +1,5 @@
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:24:13
+  --> $DIR/significant_drop.rs:25:13
    |
 LL |       let c = || {
    |  _____________^
@@ -12,14 +12,22 @@ LL | |     };
    | |_____^
    |
 note: the lint level is defined here
-  --> $DIR/significant_drop.rs:1:9
+  --> $DIR/significant_drop.rs:2:9
    |
 LL | #![deny(disjoint_capture_drop_reorder)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: drop(&(t, t1, t2));
+help: `let _ = (&t, &t1, &t2)` causes `t`, `t1`, `t2` to be fully captured
+   |
+LL |     let c = || { let _ = (&t, &t1, &t2); {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         let _t1 = t1.0;
+LL |         let _t2 = t2.0;
+ ...
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:42:13
+  --> $DIR/significant_drop.rs:43:13
    |
 LL |       let c = || {
    |  _____________^
@@ -31,10 +39,18 @@ LL | |         let _t2 = t2;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t, t1));
+help: `let _ = (&t, &t1)` causes `t`, `t1` to be fully captured
+   |
+LL |     let c = || { let _ = (&t, &t1); {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         let _t1 = t1.0;
+LL |         let _t2 = t2;
+ ...
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:58:13
+  --> $DIR/significant_drop.rs:59:13
    |
 LL |       let c = || {
    |  _____________^
@@ -45,10 +61,18 @@ LL | |         println!("{:?}", t1.1);
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |         println!("{:?}", t1.1);
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:75:13
+  --> $DIR/significant_drop.rs:76:13
    |
 LL |       let c = || {
    |  _____________^
@@ -58,10 +82,17 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:90:13
+  --> $DIR/significant_drop.rs:91:13
    |
 LL |       let c = || {
    |  _____________^
@@ -71,10 +102,17 @@ LL | |         let _t = t.0;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.0;
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:105:13
+  --> $DIR/significant_drop.rs:104:13
    |
 LL |       let c = || {
    |  _____________^
@@ -84,10 +122,17 @@ LL | |         let _t = t.1;
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t));
+help: `let _ = &t` causes `t` to be fully captured
+   |
+LL |     let c = || { let _ = &t; {
+LL |
+LL |
+LL |         let _t = t.1;
+LL |     } };
+   |
 
 error: drop order affected for closure because of `capture_disjoint_fields`
-  --> $DIR/significant_drop.rs:120:13
+  --> $DIR/significant_drop.rs:119:13
    |
 LL |       let c = move || {
    |  _____________^
@@ -97,7 +142,14 @@ LL | |         println!("{:?} {:?}", t1.1, t.1);
 LL | |     };
    | |_____^
    |
-   = note: drop(&(t1, t));
+help: `let _ = (&t1, &t)` causes `t1`, `t` to be fully captured
+   |
+LL |     let c = move || { let _ = (&t1, &t); {
+LL |
+LL |
+LL |         println!("{:?} {:?}", t1.1, t.1);
+LL |     } };
+   |
 
 error: aborting due to 7 previous errors
 


### PR DESCRIPTION
- Adds support of machine applicable suggestions for `disjoint_capture_drop_reorder`.
- Doesn't migrate in the case of pre-existing bugs in user code


r? @nikomatsakis 