### PR TITLE
Add explanatory note to `bare_urls` lint

### DIFF
--- a/src/librustdoc/passes/bare_urls.rs
+++ b/src/librustdoc/passes/bare_urls.rs
@@ -73,6 +73,7 @@ impl<'a, 'tcx> DocFolder for BareUrlsLinter<'a, 'tcx> {
                     .unwrap_or(item.span.inner());
                 cx.tcx.struct_span_lint_hir(crate::lint::BARE_URLS, hir_id, sp, |lint| {
                     lint.build(msg)
+                        .note("bare URLs are not automatically turned into clickable links")
                         .span_suggestion(
                             sp,
                             "use an automatic link instead",

--- a/src/test/rustdoc-ui/bare-urls.stderr
+++ b/src/test/rustdoc-ui/bare-urls.stderr
@@ -9,102 +9,135 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc::bare_urls)]
    |         ^^^^^^^^^^^^^^^^^^
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:7:5
    |
 LL | /// https://somewhere.com/a
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:9:5
    |
 LL | /// https://www.somewhere.com
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://www.somewhere.com>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:11:5
    |
 LL | /// https://www.somewhere.com/a
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://www.somewhere.com/a>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:13:5
    |
 LL | /// https://subdomain.example.com
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://subdomain.example.com>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:15:5
    |
 LL | /// https://somewhere.com?
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:17:5
    |
 LL | /// https://somewhere.com/a?
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:19:5
    |
 LL | /// https://somewhere.com?hello=12
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?hello=12>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:21:5
    |
 LL | /// https://somewhere.com/a?hello=12
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?hello=12>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:23:5
    |
 LL | /// https://example.com?hello=12#xyz
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com?hello=12#xyz>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:25:5
    |
 LL | /// https://example.com/a?hello=12#xyz
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com/a?hello=12#xyz>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:27:5
    |
 LL | /// https://example.com#xyz
    |     ^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com#xyz>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:29:5
    |
 LL | /// https://example.com/a#xyz
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://example.com/a#xyz>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:31:5
    |
 LL | /// https://somewhere.com?hello=12&bye=11
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?hello=12&bye=11>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:33:5
    |
 LL | /// https://somewhere.com/a?hello=12&bye=11
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?hello=12&bye=11>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:35:5
    |
 LL | /// https://somewhere.com?hello=12&bye=11#xyz
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com?hello=12&bye=11#xyz>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: this URL is not a hyperlink
   --> $DIR/bare-urls.rs:37:10
    |
 LL | /// hey! https://somewhere.com/a?hello=12&bye=11#xyz
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://somewhere.com/a?hello=12&bye=11#xyz>`
+   |
+   = note: bare URLs are not automatically turned into clickable links
 
 error: aborting due to 17 previous errors
 

--- a/src/test/rustdoc-ui/renamed-lint-still-applies.stderr
+++ b/src/test/rustdoc-ui/renamed-lint-still-applies.stderr
@@ -31,6 +31,7 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc::non_autolinks)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: bare URLs are not automatically turned into clickable links
 
 error: aborting due to 2 previous errors; 1 warning emitted
 


### PR DESCRIPTION
I think the lint is confusing otherwise since it doesn't fully explain
what the problem is.
