### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -286,7 +286,7 @@ Xuefeng Wu <benewu@gmail.com> Xuefeng Wu <xfwu@thoughtworks.com>
 Xuefeng Wu <benewu@gmail.com> XuefengWu <benewu@gmail.com>
 York Xiang <bombless@126.com>
 Youngsoo Son <ysson83@gmail.com> <ysoo.son@samsung.com>
-Yuki Okushi <huyuumi.dev@gmail.com>
+Yuki Okushi <jtitor@2k36.org> <huyuumi.dev@gmail.com>
 Zach Pomerantz <zmp@umich.edu>
 Zack Corr <zack@z0w0.me> <zackcorr95@gmail.com>
 Zack Slayton <zack.slayton@gmail.com>

--- a/compiler/rustc_mir/src/borrow_check/type_check/input_output.rs
+++ b/compiler/rustc_mir/src/borrow_check/type_check/input_output.rs
@@ -70,6 +70,12 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
         // Equate expected input tys with those in the MIR.
         for (argument_index, &normalized_input_ty) in normalized_input_tys.iter().enumerate() {
+            if argument_index + 1 >= body.local_decls.len() {
+                self.tcx()
+                    .sess
+                    .delay_span_bug(body.span, "found more normalized_input_ty than local_decls");
+                break;
+            }
             // In MIR, argument N is stored in local N+1.
             let local = Local::new(argument_index + 1);
 

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -471,7 +471,7 @@ fn wait(state_and_queue: &AtomicUsize, mut current_state: usize) {
             // If the managing thread happens to signal and unpark us before we
             // can park ourselves, the result could be this thread never gets
             // unparked. Luckily `park` comes with the guarantee that if it got
-            // an `unpark` just before on an unparked thread is does not park.
+            // an `unpark` just before on an unparked thread it does not park.
             thread::park();
         }
         break;

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1354,6 +1354,7 @@ fn init_id_map() -> FxHashMap<String, usize> {
     map.insert("default-settings".to_owned(), 1);
     map.insert("rustdoc-vars".to_owned(), 1);
     map.insert("sidebar-vars".to_owned(), 1);
+    map.insert("copy-path".to_owned(), 1);
     // This is the list of IDs used by rustdoc sections.
     map.insert("fields".to_owned(), 1);
     map.insert("variants".to_owned(), 1);

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -73,6 +73,7 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer)
         }
     }
     write!(buf, "<a class=\"{}\" href=\"\">{}</a>", item.type_(), item.name.as_ref().unwrap());
+    write!(buf, "<button id=\"copy-path\" onclick=\"copy_path(this)\">⎘</button>");
 
     buf.write_str("</span>"); // in-band
     buf.write_str("<span class=\"out-of-band\">");

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -3061,3 +3061,28 @@ function hideThemeButtonState() {
     window.onhashchange = onHashChange;
     setupSearchLoader();
 }());
+
+function copy_path(but) {
+    var parent = but.parentElement;
+    var path = [];
+
+    onEach(parent.childNodes, function(child) {
+        if (child.tagName === 'A') {
+            path.push(child.textContent);
+        }
+    });
+
+    var el = document.createElement('textarea');
+    el.value = 'use ' + path.join('::') + ';';
+    el.setAttribute('readonly', '');
+    // To not make it appear on the screen.
+    el.style.position = 'absolute';
+    el.style.left = '-9999px';
+
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+
+    but.textContent = '✓';
+}

--- a/src/librustdoc/html/static/noscript.css
+++ b/src/librustdoc/html/static/noscript.css
@@ -33,3 +33,8 @@ rules.
 	/* Since there is no toggle (the "[-]") when JS is disabled, no need for this margin either. */
 	margin-left: 0 !important;
 }
+
+#copy-path {
+	/* It requires JS to work so no need to display it in this case. */
+	display: none;
+}

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1316,20 +1316,29 @@ h4 > .notable-traits {
 	outline: none;
 }
 
-.help-button {
-	right: 30px;
-	font-family: "Fira Sans", Arial, sans-serif;
-	text-align: center;
-	font-size: 17px;
-}
-
-#theme-picker, #settings-menu, .help-button {
+#theme-picker, #settings-menu, .help-button, #copy-path {
 	padding: 4px;
 	width: 27px;
 	height: 29px;
 	border: 1px solid;
 	border-radius: 3px;
 	cursor: pointer;
+}
+
+.help-button {
+	right: 30px;
+	font-family: "Fira Sans", Arial, sans-serif;
+	text-align: center;
+	font-size: 17px;
+	padding-top: 2px;
+}
+
+#copy-path {
+	height: 30px;
+	font-size: 18px;
+	margin-left: 10px;
+	padding: 0 6px;
+	width: 28px;
 }
 
 #theme-choices {

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -498,7 +498,7 @@ kbd {
 	box-shadow-color: #c6cbd1;
 }
 
-#theme-picker, #settings-menu, .help-button {
+#theme-picker, #settings-menu, .help-button, #copy-path {
 	border-color: #5c6773;
 	background-color: #0f1419;
 	color: #fff;
@@ -510,7 +510,8 @@ kbd {
 
 #theme-picker:hover, #theme-picker:focus,
 #settings-menu:hover, #settings-menu:focus,
-.help-button:hover, .help-button:focus {
+.help-button:hover, .help-button:focus,
+#copy-path:hover, #copy-path:focus {
 	border-color: #e0e0e0;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -388,7 +388,7 @@ kbd {
 	box-shadow-color: #c6cbd1;
 }
 
-#theme-picker, #settings-menu, .help-button {
+#theme-picker, #settings-menu, .help-button, #copy-path {
 	border-color: #e0e0e0;
 	background: #f0f0f0;
 	color: #000;
@@ -396,7 +396,8 @@ kbd {
 
 #theme-picker:hover, #theme-picker:focus,
 #settings-menu:hover, #settings-menu:focus,
-.help-button:hover, .help-button:focus {
+.help-button:hover, .help-button:focus,
+#copy-path:hover, #copy-path:focus {
 	border-color: #ffb900;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -380,14 +380,15 @@ kbd {
 	box-shadow-color: #c6cbd1;
 }
 
-#theme-picker, #settings-menu, .help-button {
+#theme-picker, #settings-menu, .help-button, #copy-path {
 	border-color: #e0e0e0;
 	background-color: #fff;
 }
 
 #theme-picker:hover, #theme-picker:focus,
 #settings-menu:hover, #settings-menu:focus,
-.help-button:hover, .help-button:focus {
+.help-button:hover, .help-button:focus,
+#copy-path:hover, #copy-path:focus {
 	border-color: #717171;
 }
 

--- a/src/test/rustdoc-gui/search-tab-selection-if-current-is-empty.goml
+++ b/src/test/rustdoc-gui/search-tab-selection-if-current-is-empty.goml
@@ -1,0 +1,21 @@
+goto: file://|DOC_PATH|/index.html
+write: (".search-input", "Foo")
+// Waiting for the search results to appear...
+wait-for: "#titles"
+assert: ("#titles > button:nth-of-type(1)", "class", "selected")
+
+// To go back to the original "state"
+goto: file://|DOC_PATH|/index.html
+write: (".search-input", "-> String")
+// Waiting for the search results to appear...
+wait-for: "#titles"
+// With this search, only the last tab shouldn't be empty so it should be selected.
+assert: ("#titles > button:nth-of-type(3)", "class", "selected")
+
+// To go back to the original "state"
+goto: file://|DOC_PATH|/index.html
+write: (".search-input", "-> Something")
+// Waiting for the search results to appear...
+wait-for: "#titles"
+// With this search, all the tabs are empty so the first one should remain selected.
+assert: ("#titles > button:nth-of-type(1)", "class", "selected")

--- a/src/test/ui/mir/issue-83499-input-output-iteration-ice.rs
+++ b/src/test/ui/mir/issue-83499-input-output-iteration-ice.rs
@@ -1,0 +1,10 @@
+// Test that when in MIR the amount of local_decls and amount of normalized_input_tys don't match
+// that an out-of-bounds access does not occur.
+#![feature(c_variadic)]
+
+fn main() {}
+
+fn foo(_: Bar, ...) -> impl {}
+//~^ ERROR only foreign or `unsafe extern "C" functions may be C-variadic
+//~| ERROR cannot find type `Bar` in this scope
+//~| ERROR at least one trait must be specified

--- a/src/test/ui/mir/issue-83499-input-output-iteration-ice.stderr
+++ b/src/test/ui/mir/issue-83499-input-output-iteration-ice.stderr
@@ -1,0 +1,21 @@
+error: only foreign or `unsafe extern "C" functions may be C-variadic
+  --> $DIR/issue-83499-input-output-iteration-ice.rs:7:16
+   |
+LL | fn foo(_: Bar, ...) -> impl {}
+   |                ^^^
+
+error: at least one trait must be specified
+  --> $DIR/issue-83499-input-output-iteration-ice.rs:7:24
+   |
+LL | fn foo(_: Bar, ...) -> impl {}
+   |                        ^^^^
+
+error[E0412]: cannot find type `Bar` in this scope
+  --> $DIR/issue-83499-input-output-iteration-ice.rs:7:11
+   |
+LL | fn foo(_: Bar, ...) -> impl {}
+   |           ^^^ not found in this scope
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Successful merges:

 - #83535 (Break when there is a mismatch in the type count)
 - #83721 (Add a button to copy the "use statement")
 - #83740 (Fix comment typo in once.rs)
 - #83745 (Add my new email address to .mailmap)
 - #83754 (Add test to ensure search tabs behaviour)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83535,83721,83740,83745,83754)
<!-- homu-ignore:end -->