### PR TITLE
Add drop_leak and drop_leak_mut

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1046,7 +1046,7 @@ impl<T: ?Sized> RefCell<T> {
     /// Ref::leak(c.borrow());
     ///
     /// assert!(c.try_borrow_mut().is_err());
-    /// c.drop_leak();
+    /// unsafe { c.drop_leak() };
     /// assert!(c.try_borrow_mut().is_ok());
     /// ```
     #[unstable(feature = "cell_leak", issue = "69099")]
@@ -1069,7 +1069,7 @@ impl<T: ?Sized> RefCell<T> {
     /// RefMut::leak(c.borrow_mut());
     ///
     /// assert!(c.try_borrow().is_err());
-    /// c.drop_leak_mut();
+    /// unsafe { c.drop_leak_mut() };
     /// assert!(c.try_borrow().is_ok());
     /// ```
     #[unstable(feature = "cell_leak", issue = "69099")]


### PR DESCRIPTION
I'm trying to implement a `StaticRef` type which can be built from `Rc<RefCell<T>>` without needing a lifetime (when dropped, it decrements the refcount _and_ the borrow count). But I find that `undo_leak` doesn't quite do what I want it to do in the presence of multiple `StaticRef`s, so I'd like to add `drop_leak`.

Here's the implementation of `StaticRef`:

```
#![feature(cell_leak)]

use std::{
    cell::{Ref, RefCell},
    ops::Deref,
    rc::Rc,
};

pub struct StaticRef<T, S = T>(Holder<S>, *const T);

impl<T> StaticRef<T> {
    pub fn borrow_from(orig: Rc<RefCell<T>>) -> Self {
        let x: *const T = Ref::leak(orig.borrow());
        StaticRef(Holder(orig), x)
    }
}
impl<S, T> StaticRef<T, S> {
    pub fn map<T2, F: for<'b> FnOnce(&'b T) -> &'b T2>(self, op: F) -> StaticRef<T2, S> {
        let StaticRef(holder, x) = self;
        StaticRef(holder, op(unsafe { &*x }))
    }
}

struct Holder<S>(Rc<RefCell<S>>);

impl<S> Drop for Holder<S> {
    fn drop(&mut self) {
        unsafe { self.0.drop_leak() }
    }
}

impl<S, T> Deref for StaticRef<T, S> {
    type Target = T;

    fn deref<'b>(&'b self) -> &'b T {
        unsafe { &*self.1 }
    }
}
```
