### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -26,6 +26,7 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("vfp2", Some(sym::arm_target_feature)),
     ("vfp3", Some(sym::arm_target_feature)),
     ("vfp4", Some(sym::arm_target_feature)),
+    ("fp-armv8", Some(sym::arm_target_feature)),
     // This is needed for inline assembly, but shouldn't be stabilized as-is
     // since it should be enabled per-function using #[instruction_set], not
     // #[target_feature].

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -124,7 +124,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v const fn from_usize(value: usize) -> Self {
-                assert!(value <= ($max as usize));
+                [()][(value > ($max as usize)) as usize];
                 unsafe {
                     Self::from_u32_unchecked(value as u32)
                 }
@@ -132,7 +132,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v const fn from_u32(value: u32) -> Self {
-                assert!(value <= $max);
+                [()][(value > $max) as usize];
                 unsafe {
                     Self::from_u32_unchecked(value)
                 }

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -124,6 +124,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v const fn from_usize(value: usize) -> Self {
+                // FIXME: replace with `assert!(value <= ($max as usize));` once `const_panic` is stable
                 [()][(value > ($max as usize)) as usize];
                 unsafe {
                     Self::from_u32_unchecked(value as u32)
@@ -132,6 +133,7 @@ macro_rules! newtype_index {
 
             #[inline]
             $v const fn from_u32(value: u32) -> Self {
+                // FIXME: replace with `assert!(value <= $max);` once `const_panic` is stable
                 [()][(value > $max) as usize];
                 unsafe {
                     Self::from_u32_unchecked(value)

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -547,7 +547,7 @@ declare_lint! {
     /// Also consider if you intended to use an _inner attribute_ (with a `!`
     /// such as `#![allow(unused)]`) which applies to the item the attribute
     /// is within, or an _outer attribute_ (without a `!` such as
-    /// `#[allow(unsued)]`) which applies to the item *following* the
+    /// `#[allow(unused)]`) which applies to the item *following* the
     /// attribute.
     ///
     /// [attributes]: https://doc.rust-lang.org/reference/attributes.html

--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -66,7 +66,8 @@
 //! consider non-generic items, an empty type-substitution set. (In eager
 //! collection mode, during incremental compilation, all non-generic functions
 //! are considered as roots, as well as when the `-Clink-dead-code` option is
-//! specified. Functions marked `#[no_mangle]` also always act as roots.)
+//! specified. Functions marked `#[no_mangle]` and functions called by inlinable
+//! functions also always act as roots.)
 //!
 //! ### Finding neighbor nodes
 //! Given a mono item node, we can discover neighbors by inspecting its

--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -61,9 +61,12 @@
 //!
 //! The roots of the mono item graph correspond to the public non-generic
 //! syntactic items in the source code. We find them by walking the HIR of the
-//! crate, and whenever we hit upon a public function, method, or static item, we
-//! create a mono item consisting of the items DefId and, since we only
-//! consider non-generic items, an empty type-substitution set.
+//! crate, and whenever we hit upon a public function, method, or static item,
+//! we create a mono item consisting of the items DefId and, since we only
+//! consider non-generic items, an empty type-substitution set. (In eager
+//! collection mode, during incremental compilation, all non-generic functions
+//! are considered as roots, as well as when the `-Clink-dead-code` option is
+//! specified. Functions marked `#[no_mangle]` also always act as roots.)
 //!
 //! ### Finding neighbor nodes
 //! Given a mono item node, we can discover neighbors by inspecting its

--- a/compiler/rustc_mir/src/monomorphize/collector.rs
+++ b/compiler/rustc_mir/src/monomorphize/collector.rs
@@ -59,9 +59,9 @@
 //!
 //! ### Discovering roots
 //!
-//! The roots of the mono item graph correspond to the non-generic
+//! The roots of the mono item graph correspond to the public non-generic
 //! syntactic items in the source code. We find them by walking the HIR of the
-//! crate, and whenever we hit upon a function, method, or static item, we
+//! crate, and whenever we hit upon a public function, method, or static item, we
 //! create a mono item consisting of the items DefId and, since we only
 //! consider non-generic items, an empty type-substitution set.
 //!

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(never_type)]
-#![feature(const_panic)]
-#![feature(control_flow_enum)]
-
 #[macro_use]
 extern crate bitflags;
 #[macro_use]

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -33,15 +33,22 @@ use crate::string;
 use crate::sync::Arc;
 
 /// `Error` is a trait representing the basic expectations for error values,
-/// i.e., values of type `E` in [`Result<T, E>`]. Errors must describe
-/// themselves through the [`Display`] and [`Debug`] traits, and may provide
-/// cause chain information:
+/// i.e., values of type `E` in [`Result<T, E>`].
 ///
-/// [`Error::source()`] is generally used when errors cross
-/// "abstraction boundaries". If one module must report an error that is caused
-/// by an error from a lower-level module, it can allow accessing that error
-/// via [`Error::source()`]. This makes it possible for the high-level
-/// module to provide its own errors while also revealing some of the
+/// Errors must describe themselves through the [`Display`] and [`Debug`]
+/// traits. Error messages are typically concise lowercase sentences without
+/// trailing punctuation:
+///
+/// ```
+/// let err = "NaN".parse::<u32>().unwrap_err();
+/// assert_eq!(err.to_string(), "invalid digit found in string");
+/// ```
+///
+/// Errors may provide cause chain information. [`Error::source()`] is generally
+/// used when errors cross "abstraction boundaries". If one module must report
+/// an error that is caused by an error from a lower-level module, it can allow
+/// accessing that error via [`Error::source()`]. This makes it possible for the
+/// high-level module to provide its own errors while also revealing some of the
 /// implementation for debugging via `source` chains.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Error: Debug + Display {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -247,6 +247,7 @@
 #![feature(const_ip)]
 #![feature(const_ipv6)]
 #![feature(const_raw_ptr_deref)]
+#![feature(const_socketaddr)]
 #![feature(const_ipv4)]
 #![feature(container_error_extra)]
 #![feature(core_intrinsics)]

--- a/library/std/src/net/addr.rs
+++ b/library/std/src/net/addr.rs
@@ -143,7 +143,8 @@ impl SocketAddr {
     /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
     /// ```
     #[stable(feature = "ip_addr", since = "1.7.0")]
-    pub fn ip(&self) -> IpAddr {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn ip(&self) -> IpAddr {
         match *self {
             SocketAddr::V4(ref a) => IpAddr::V4(*a.ip()),
             SocketAddr::V6(ref a) => IpAddr::V6(*a.ip()),
@@ -182,7 +183,8 @@ impl SocketAddr {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn port(&self) -> u16 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn port(&self) -> u16 {
         match *self {
             SocketAddr::V4(ref a) => a.port(),
             SocketAddr::V6(ref a) => a.port(),
@@ -224,7 +226,8 @@ impl SocketAddr {
     /// assert_eq!(socket.is_ipv6(), false);
     /// ```
     #[stable(feature = "sockaddr_checker", since = "1.16.0")]
-    pub fn is_ipv4(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn is_ipv4(&self) -> bool {
         matches!(*self, SocketAddr::V4(_))
     }
 
@@ -244,7 +247,8 @@ impl SocketAddr {
     /// assert_eq!(socket.is_ipv6(), true);
     /// ```
     #[stable(feature = "sockaddr_checker", since = "1.16.0")]
-    pub fn is_ipv6(&self) -> bool {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn is_ipv6(&self) -> bool {
         matches!(*self, SocketAddr::V6(_))
     }
 }
@@ -284,7 +288,8 @@ impl SocketAddrV4 {
     /// assert_eq!(socket.ip(), &Ipv4Addr::new(127, 0, 0, 1));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn ip(&self) -> &Ipv4Addr {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn ip(&self) -> &Ipv4Addr {
         // SAFETY: `Ipv4Addr` is `#[repr(C)] struct { _: in_addr; }`.
         // It is safe to cast from `&in_addr` to `&Ipv4Addr`.
         unsafe { &*(&self.inner.sin_addr as *const c::in_addr as *const Ipv4Addr) }
@@ -317,7 +322,8 @@ impl SocketAddrV4 {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn port(&self) -> u16 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn port(&self) -> u16 {
         ntohs(self.inner.sin_port)
     }
 
@@ -380,7 +386,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.ip(), &Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn ip(&self) -> &Ipv6Addr {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn ip(&self) -> &Ipv6Addr {
         unsafe { &*(&self.inner.sin6_addr as *const c::in6_addr as *const Ipv6Addr) }
     }
 
@@ -411,7 +418,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.port(), 8080);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn port(&self) -> u16 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn port(&self) -> u16 {
         ntohs(self.inner.sin6_port)
     }
 
@@ -452,7 +460,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.flowinfo(), 10);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn flowinfo(&self) -> u32 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn flowinfo(&self) -> u32 {
         self.inner.sin6_flowinfo
     }
 
@@ -490,7 +499,8 @@ impl SocketAddrV6 {
     /// assert_eq!(socket.scope_id(), 78);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn scope_id(&self) -> u32 {
+    #[rustc_const_unstable(feature = "const_socketaddr", issue = "82485")]
+    pub const fn scope_id(&self) -> u32 {
         self.inner.sin6_scope_id
     }
 

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -624,7 +624,7 @@ crate fn record_extern_trait(cx: &mut DocContext<'_>, did: DefId) {
 
     let trait_ = clean::TraitWithExtraInfo {
         trait_,
-        is_spotlight: clean::utils::has_doc_flag(cx.tcx.get_attrs(did), sym::notable_trait),
+        is_notable: clean::utils::has_doc_flag(cx.tcx.get_attrs(did), sym::notable_trait),
     };
     cx.external_traits.borrow_mut().insert(did, trait_);
     cx.active_extern_traits.remove(&did);

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -65,7 +65,7 @@ crate struct Crate {
 #[derive(Clone, Debug)]
 crate struct TraitWithExtraInfo {
     crate trait_: Trait,
-    crate is_spotlight: bool,
+    crate is_notable: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -464,10 +464,9 @@ crate fn run_global_ctxt(
     if let Some(sized_trait_did) = ctxt.tcx.lang_items().sized_trait() {
         let mut sized_trait = build_external_trait(&mut ctxt, sized_trait_did);
         sized_trait.is_auto = true;
-        ctxt.external_traits.borrow_mut().insert(
-            sized_trait_did,
-            TraitWithExtraInfo { trait_: sized_trait, is_spotlight: false },
-        );
+        ctxt.external_traits
+            .borrow_mut()
+            .insert(sized_trait_did, TraitWithExtraInfo { trait_: sized_trait, is_notable: false });
     }
 
     debug!("crate: {:?}", tcx.hir().krate());

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -116,7 +116,7 @@ crate struct Cache {
     // even though the trait itself is not exported. This can happen if a trait
     // was defined in function/expression scope, since the impl will be picked
     // up by `collect-trait-impls` but the trait won't be scraped out in the HIR
-    // crawl. In order to prevent crashes when looking for spotlight traits or
+    // crawl. In order to prevent crashes when looking for notable traits or
     // when gathering trait documentation on a type, hold impls here while
     // folding and add them to the cache later on if we find the trait.
     orphan_trait_impls: Vec<(DefId, FxHashSet<DefId>, Impl)>,
@@ -227,7 +227,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
         if let clean::TraitItem(ref t) = *item.kind {
             self.cache.traits.entry(item.def_id).or_insert_with(|| clean::TraitWithExtraInfo {
                 trait_: t.clone(),
-                is_spotlight: item.attrs.has_doc_flag(sym::notable_trait),
+                is_notable: item.attrs.has_doc_flag(sym::notable_trait),
             });
         }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1045,7 +1045,7 @@ fn render_assoc_item(
         write!(
             w,
             "{}{}{}{}{}{}{}fn <a href=\"{href}\" class=\"fnname\">{name}</a>\
-             {generics}{decl}{spotlight}{where_clause}",
+             {generics}{decl}{notable_traits}{where_clause}",
             if parent == ItemType::Trait { "    " } else { "" },
             vis,
             constness,
@@ -1057,7 +1057,7 @@ fn render_assoc_item(
             name = name,
             generics = g.print(cache, tcx),
             decl = d.full_print(cache, tcx, header_len, indent, header.asyncness),
-            spotlight = spotlight_decl(&d, cache, tcx),
+            notable_traits = notable_traits_decl(&d, cache, tcx),
             where_clause = print_where_clause(g, cache, tcx, indent, end_newline),
         )
     }
@@ -1341,7 +1341,7 @@ fn should_render_item(item: &clean::Item, deref_mut_: bool, cache: &Cache) -> bo
     }
 }
 
-fn spotlight_decl(decl: &clean::FnDecl, cache: &Cache, tcx: TyCtxt<'_>) -> String {
+fn notable_traits_decl(decl: &clean::FnDecl, cache: &Cache, tcx: TyCtxt<'_>) -> String {
     let mut out = Buffer::html();
     let mut trait_ = String::new();
 
@@ -1349,9 +1349,11 @@ fn spotlight_decl(decl: &clean::FnDecl, cache: &Cache, tcx: TyCtxt<'_>) -> Strin
         if let Some(impls) = cache.impls.get(&did) {
             for i in impls {
                 let impl_ = i.inner_impl();
-                if impl_.trait_.def_id().map_or(false, |d| {
-                    cache.traits.get(&d).map(|t| t.is_spotlight).unwrap_or(false)
-                }) {
+                if impl_
+                    .trait_
+                    .def_id()
+                    .map_or(false, |d| cache.traits.get(&d).map(|t| t.is_notable).unwrap_or(false))
+                {
                     if out.is_empty() {
                         write!(
                             &mut out,

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -10,9 +10,9 @@ use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{kw, sym, Symbol};
 
 use super::{
-    collect_paths_for_type, document, ensure_trailing_slash, item_ty_to_strs, render_assoc_item,
-    render_assoc_items, render_attributes, render_impl, render_stability_since_raw, spotlight_decl,
-    write_srclink, AssocItemLink, Context,
+    collect_paths_for_type, document, ensure_trailing_slash, item_ty_to_strs, notable_traits_decl,
+    render_assoc_item, render_assoc_items, render_attributes, render_impl,
+    render_stability_since_raw, write_srclink, AssocItemLink, Context,
 };
 use crate::clean::{self, GetDefId};
 use crate::formats::cache::Cache;
@@ -381,7 +381,7 @@ fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::
     write!(
         w,
         "{vis}{constness}{asyncness}{unsafety}{abi}fn \
-         {name}{generics}{decl}{spotlight}{where_clause}</pre>",
+         {name}{generics}{decl}{notable_traits}{where_clause}</pre>",
         vis = it.visibility.print_with_space(cx.tcx(), it.def_id, cx.cache()),
         constness = f.header.constness.print_with_space(),
         asyncness = f.header.asyncness.print_with_space(),
@@ -391,7 +391,7 @@ fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::
         generics = f.generics.print(cx.cache(), cx.tcx()),
         where_clause = print_where_clause(&f.generics, cx.cache(), cx.tcx(), 0, true),
         decl = f.decl.full_print(cx.cache(), cx.tcx(), header_len, 0, f.header.asyncness),
-        spotlight = spotlight_decl(&f.decl, cx.cache(), cx.tcx()),
+        notable_traits = notable_traits_decl(&f.decl, cx.cache(), cx.tcx()),
     );
     document(w, cx, it, None)
 }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -173,12 +173,9 @@ code, pre, a.test-arrow {
 	border-radius: 3px;
 	padding: 0 0.1em;
 }
-.docblock pre code, .docblock-short pre code, .docblock code.spotlight {
+.docblock pre code, .docblock-short pre code {
 	padding: 0;
 	padding-right: 1ex;
-}
-.docblock code.spotlight :last-child {
-	padding-bottom: 0.6em;
 }
 pre {
 	padding: 14px;


### PR DESCRIPTION
Successful merges:

 - #82487 (Constify methods of `std::net::SocketAddr`, `SocketAddrV4` and `SocketAddrV6`)
 - #83756 (rustdoc: Rename internal uses of `spotlight`)
 - #83780 (Document "standard" conventions for error messages)
 - #83787 (Monomorphization doc fix)
 - #83803 (add fp-armv8 for ARM_ALLOWED_FEATURES)
 - #83804 (Remove nightly features in rustc_type_ir)
 - #83810 (Fix rustc_lint_defs documentation typo)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=82487,83756,83780,83787,83803,83804,83810)
<!-- homu-ignore:end -->