### PR TITLE
expand: Do not ICE when a legacy AST-based macro attribute produces and empty expression

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -735,7 +735,14 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                     });
                                 }
                             };
-                            fragment_kind.expect_from_annotatables(items)
+                            if fragment_kind == AstFragmentKind::Expr && items.is_empty() {
+                                let msg =
+                                    "removing an expression is not supported in this position";
+                                self.cx.span_err(span, msg);
+                                fragment_kind.dummy(span)
+                            } else {
+                                fragment_kind.expect_from_annotatables(items)
+                            }
                         }
                         Err(mut err) => {
                             err.emit();

--- a/src/test/ui/macros/attr-empty-expr.rs
+++ b/src/test/ui/macros/attr-empty-expr.rs
@@ -1,0 +1,11 @@
+// AST-based macro attributes expanding to an empty expression produce an error and not ICE.
+
+#![feature(custom_test_frameworks)]
+#![feature(stmt_expr_attributes)]
+#![feature(test)]
+
+fn main() {
+    let _ = #[test] 0; //~ ERROR removing an expression is not supported in this position
+    let _ = #[bench] 1; //~ ERROR removing an expression is not supported in this position
+    let _ = #[test_case] 2; //~ ERROR removing an expression is not supported in this position
+}

--- a/src/test/ui/macros/attr-empty-expr.stderr
+++ b/src/test/ui/macros/attr-empty-expr.stderr
@@ -1,0 +1,20 @@
+error: removing an expression is not supported in this position
+  --> $DIR/attr-empty-expr.rs:8:13
+   |
+LL |     let _ = #[test] 0;
+   |             ^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/attr-empty-expr.rs:9:13
+   |
+LL |     let _ = #[bench] 1;
+   |             ^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/attr-empty-expr.rs:10:13
+   |
+LL |     let _ = #[test_case] 2;
+   |             ^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/80251

The reported error is the same as for `let _ = #[cfg(FALSE)] EXPR;`