### PR TITLE
Add `#[inline]` to IpAddr methods

### DIFF
--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -993,6 +993,7 @@ impl Ord for Ipv4Addr {
 }
 
 impl IntoInner<c::in_addr> for Ipv4Addr {
+    #[inline]
     fn into_inner(self) -> c::in_addr {
         self.inner
     }
@@ -1800,11 +1801,13 @@ impl Ord for Ipv6Addr {
 }
 
 impl AsInner<c::in6_addr> for Ipv6Addr {
+    #[inline]
     fn as_inner(&self) -> &c::in6_addr {
         &self.inner
     }
 }
 impl FromInner<c::in6_addr> for Ipv6Addr {
+    #[inline]
     fn from_inner(addr: c::in6_addr) -> Ipv6Addr {
         Ipv6Addr { inner: addr }
     }


### PR DESCRIPTION
Add some inlines to trivial methods of IpAddr
Closes https://github.com/rust-lang/rust/issues/77583