### PR TITLE
rustdoc: Cleanup handling of associated items for intra-doc links

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(nll)]
 #![cfg_attr(bootstrap, feature(or_patterns))]
 #![recursion_limit = "256"]
+#![allow(rustdoc::private_intra_doc_links)]
 
 pub use rustc_hir::def::{Namespace, PerNS};
 

--- a/src/test/rustdoc-ui/intra-doc/private.private.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private.private.stderr
@@ -1,19 +1,27 @@
 warning: public documentation for `DocMe` links to private item `DontDocMe`
-  --> $DIR/private.rs:5:11
+  --> $DIR/private.rs:7:11
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |           ^^^^^^^^^ this item is private
    |
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: public documentation for `DocMe` links to private item `DontDocMe::f`
-  --> $DIR/private.rs:5:23
+  --> $DIR/private.rs:7:23
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |                       ^^^^^^^^^^^^ this item is private
    |
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
-warning: 2 warnings emitted
+warning: public documentation for `DocMe` links to private item `DontDocMe::x`
+  --> $DIR/private.rs:7:38
+   |
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
+   |                                      ^^^^^^^^^^^^ this item is private
+   |
+   = note: this link resolves only because you passed `--document-private-items`, but will break without
+
+warning: 3 warnings emitted
 

--- a/src/test/rustdoc-ui/intra-doc/private.public.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private.public.stderr
@@ -1,19 +1,27 @@
 warning: public documentation for `DocMe` links to private item `DontDocMe`
-  --> $DIR/private.rs:5:11
+  --> $DIR/private.rs:7:11
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |           ^^^^^^^^^ this item is private
    |
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: public documentation for `DocMe` links to private item `DontDocMe::f`
-  --> $DIR/private.rs:5:23
+  --> $DIR/private.rs:7:23
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |                       ^^^^^^^^^^^^ this item is private
    |
    = note: this link will resolve properly if you pass `--document-private-items`
 
-warning: 2 warnings emitted
+warning: public documentation for `DocMe` links to private item `DontDocMe::x`
+  --> $DIR/private.rs:7:38
+   |
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
+   |                                      ^^^^^^^^^^^^ this item is private
+   |
+   = note: this link will resolve properly if you pass `--document-private-items`
+
+warning: 3 warnings emitted
 

--- a/src/test/rustdoc-ui/intra-doc/private.rs
+++ b/src/test/rustdoc-ui/intra-doc/private.rs
@@ -2,12 +2,16 @@
 // revisions: public private
 // [private]compile-flags: --document-private-items
 
-/// docs [DontDocMe] [DontDocMe::f]
+// make sure to update `rustdoc/intra-doc/private.rs` if you update this file
+
+/// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
 //~^ WARNING public documentation for `DocMe` links to private item `DontDocMe`
+//~| WARNING public documentation for `DocMe` links to private item `DontDocMe::x`
 //~| WARNING public documentation for `DocMe` links to private item `DontDocMe::f`
-// FIXME: for [private] we should also make sure the link was actually generated
 pub struct DocMe;
-struct DontDocMe;
+struct DontDocMe {
+    x: usize,
+}
 
 impl DontDocMe {
     fn f() {}

--- a/src/test/rustdoc/intra-doc/private.rs
+++ b/src/test/rustdoc/intra-doc/private.rs
@@ -1,6 +1,17 @@
 #![crate_name = "private"]
 // compile-flags: --document-private-items
-/// docs [DontDocMe]
+
+// make sure to update `rustdoc-ui/intra-doc/private.rs` if you update this file
+
+/// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
 // @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html"]' 'DontDocMe'
+// @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html#method.f"]' 'DontDocMe::f'
+// @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html#structfield.x"]' 'DontDocMe::x'
 pub struct DocMe;
-struct DontDocMe;
+struct DontDocMe {
+    x: usize,
+}
+
+impl DontDocMe {
+    fn f() {}
+}


### PR DESCRIPTION
Helps with https://github.com/rust-lang/rust/issues/83761 (right now the uses of the resolver are all intermingled with uses of the tyctxt). Best reviewed one commit at a time.

r? @bugadani maybe? Feel free to reassign :)