### PR TITLE
Don't report disambiguator error if link would have been ignored

### DIFF
--- a/src/test/rustdoc-ui/intra-doc/email-address-localhost.rs
+++ b/src/test/rustdoc-ui/intra-doc/email-address-localhost.rs
@@ -1,0 +1,6 @@
+#![deny(warnings)]
+
+//! Email me at <hello@localhost>.
+//~^ ERROR unknown disambiguator `hello`
+
+//! This should *not* warn: <hello@example.com>.

--- a/src/test/rustdoc-ui/intra-doc/email-address-localhost.stderr
+++ b/src/test/rustdoc-ui/intra-doc/email-address-localhost.stderr
@@ -1,0 +1,15 @@
+error: unknown disambiguator `hello`
+  --> $DIR/email-address-localhost.rs:3:18
+   |
+LL | //! Email me at <hello@localhost>.
+   |                  ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/email-address-localhost.rs:1:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(warnings)]`
+
+error: aborting due to previous error
+

--- a/src/test/rustdoc/intra-doc/email-address.rs
+++ b/src/test/rustdoc/intra-doc/email-address.rs
@@ -1,0 +1,6 @@
+//! Email me at <hello@example.com>.
+//! Email me at <hello-world@example.com>.
+//! Email me at <hello@localhost> (this warns but will still become a link).
+// @has email_address/index.html '//a[@href="mailto:hello@example.com"]' 'hello@example.com'
+// @has email_address/index.html '//a[@href="mailto:hello-world@example.com"]' 'hello-world@example.com'
+// @has email_address/index.html '//a[@href="mailto:hello@localhost"]' 'hello@localhost'


### PR DESCRIPTION
Fixes #83859.

This prevents us from warning on links such as `<hello@example.com>`.
Note that we still warn on links such as `<hello@localhost>` because
they have no dots in them. However, the links will still work, even
though a warning is reported.

r? @jyn514
