### PR TITLE
rustdoc: Use DiagnosticInfo in more parts of intra-doc links

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -984,7 +984,7 @@ impl LinkCollector<'_, '_> {
                     // See issue #83859.
                     let disambiguator_range = (no_backticks_range.start + relative_range.start)
                         ..(no_backticks_range.start + relative_range.end);
-                    disambiguator_error(self.cx, &item, dox, disambiguator_range, &err_msg);
+                    disambiguator_error(self.cx, diag_info, disambiguator_range, &err_msg);
                 }
                 return None;
             }
@@ -1973,8 +1973,7 @@ fn anchor_failure(
 /// Report an error in the link disambiguator.
 fn disambiguator_error(
     cx: &DocContext<'_>,
-    item: &Item,
-    dox: &str,
+    DiagnosticInfo { item, ori_link: _, dox, link_range: _ }: DiagnosticInfo<'_>,
     disambiguator_range: Range<usize>,
     msg: &str,
 ) {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1192,7 +1192,7 @@ impl LinkCollector<'_, '_> {
                 if self.cx.tcx.privacy_access_levels(LOCAL_CRATE).is_exported(hir_src)
                     && !self.cx.tcx.privacy_access_levels(LOCAL_CRATE).is_exported(hir_dst)
                 {
-                    privacy_error(self.cx, &item, &path_str, dox, &ori_link);
+                    privacy_error(self.cx, diag_info, &path_str);
                 }
             }
 
@@ -2045,7 +2045,11 @@ fn suggest_disambiguator(
 }
 
 /// Report a link from a public item to a private one.
-fn privacy_error(cx: &DocContext<'_>, item: &Item, path_str: &str, dox: &str, link: &MarkdownLink) {
+fn privacy_error(
+    cx: &DocContext<'_>,
+    DiagnosticInfo { item, ori_link: _, dox, link_range }: DiagnosticInfo<'_>,
+    path_str: &str,
+) {
     let sym;
     let item_name = match item.name {
         Some(name) => {
@@ -2057,7 +2061,7 @@ fn privacy_error(cx: &DocContext<'_>, item: &Item, path_str: &str, dox: &str, li
     let msg =
         format!("public documentation for `{}` links to private item `{}`", item_name, path_str);
 
-    report_diagnostic(cx.tcx, PRIVATE_INTRA_DOC_LINKS, &msg, item, dox, &link.range, |diag, sp| {
+    report_diagnostic(cx.tcx, PRIVATE_INTRA_DOC_LINKS, &msg, item, dox, &link_range, |diag, sp| {
         if let Some(sp) = sp {
             diag.span_label(sp, "this item is private");
         }

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1023,11 +1023,9 @@ impl LinkCollector<'_, '_> {
             debug!("attempting to resolve item without parent module: {}", path_str);
             resolution_failure(
                 self,
-                &item,
+                diag_info,
                 path_str,
                 disambiguator,
-                dox,
-                ori_link.range,
                 smallvec![ResolutionFailure::NoParentItem],
             );
             return None;
@@ -1073,11 +1071,9 @@ impl LinkCollector<'_, '_> {
                     debug!("link has malformed generics: {}", path_str);
                     resolution_failure(
                         self,
-                        &item,
+                        diag_info,
                         path_str,
                         disambiguator,
-                        dox,
-                        ori_link.range,
                         smallvec![err_kind],
                     );
                     return None;
@@ -1337,15 +1333,7 @@ impl LinkCollector<'_, '_> {
                                 }
                             }
                         }
-                        resolution_failure(
-                            self,
-                            diag.item,
-                            path_str,
-                            disambiguator,
-                            diag.dox,
-                            diag.link_range,
-                            smallvec![kind],
-                        );
+                        resolution_failure(self, diag, path_str, disambiguator, smallvec![kind]);
                         // This could just be a normal link or a broken link
                         // we could potentially check if something is
                         // "intra-doc-link-like" and warn in that case.
@@ -1406,11 +1394,9 @@ impl LinkCollector<'_, '_> {
                 if len == 0 {
                     resolution_failure(
                         self,
-                        diag.item,
+                        diag,
                         path_str,
                         disambiguator,
-                        diag.dox,
-                        diag.link_range,
                         candidates.into_iter().filter_map(|res| res.err()).collect(),
                     );
                     // this could just be a normal link
@@ -1452,15 +1438,7 @@ impl LinkCollector<'_, '_> {
                                 break;
                             }
                         }
-                        resolution_failure(
-                            self,
-                            diag.item,
-                            path_str,
-                            disambiguator,
-                            diag.dox,
-                            diag.link_range,
-                            smallvec![kind],
-                        );
+                        resolution_failure(self, diag, path_str, disambiguator, smallvec![kind]);
                         None
                     }
                 }
@@ -1750,11 +1728,9 @@ fn report_diagnostic(
 /// `std::io::Error::x`, this will resolve `std::io::Error`.
 fn resolution_failure(
     collector: &mut LinkCollector<'_, '_>,
-    item: &Item,
+    DiagnosticInfo { item, ori_link: _, dox, link_range }: DiagnosticInfo<'_>,
     path_str: &str,
     disambiguator: Option<Disambiguator>,
-    dox: &str,
-    link_range: Range<usize>,
     kinds: SmallVec<[ResolutionFailure<'_>; 3]>,
 ) {
     let tcx = collector.cx.tcx;

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1124,7 +1124,7 @@ impl LinkCollector<'_, '_> {
                 } else {
                     // `[char]` when a `char` module is in scope
                     let candidates = vec![res, prim];
-                    ambiguity_error(self.cx, &item, path_str, dox, ori_link.range, candidates);
+                    ambiguity_error(self.cx, diag_info, path_str, candidates);
                     return None;
                 }
             }
@@ -1413,14 +1413,7 @@ impl LinkCollector<'_, '_> {
                     }
                     // If we're reporting an ambiguity, don't mention the namespaces that failed
                     let candidates = candidates.map(|candidate| candidate.ok().map(|(res, _)| res));
-                    ambiguity_error(
-                        self.cx,
-                        diag.item,
-                        path_str,
-                        diag.dox,
-                        diag.link_range,
-                        candidates.present_items().collect(),
-                    );
+                    ambiguity_error(self.cx, diag, path_str, candidates.present_items().collect());
                     None
                 }
             }
@@ -1983,10 +1976,8 @@ fn disambiguator_error(
 /// Report an ambiguity error, where there were multiple possible resolutions.
 fn ambiguity_error(
     cx: &DocContext<'_>,
-    item: &Item,
+    DiagnosticInfo { item, ori_link: _, dox, link_range }: DiagnosticInfo<'_>,
     path_str: &str,
-    dox: &str,
-    link_range: Range<usize>,
     candidates: Vec<Res>,
 ) {
     let mut msg = format!("`{}` is ", path_str);

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -2005,16 +2005,16 @@ fn resolution_failure(
 fn anchor_failure(
     cx: &DocContext<'_>,
     item: &Item,
-    path_str: &str,
+    ori_link: &str,
     dox: &str,
     link_range: Range<usize>,
     failure: AnchorFailure,
 ) {
     let msg = match failure {
-        AnchorFailure::MultipleAnchors => format!("`{}` contains multiple anchors", path_str),
+        AnchorFailure::MultipleAnchors => format!("`{}` contains multiple anchors", ori_link),
         AnchorFailure::RustdocAnchorConflict(res) => format!(
             "`{}` contains an anchor, but links to {kind}s are already anchored",
-            path_str,
+            ori_link,
             kind = res.descr(),
         ),
     };

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1975,10 +1975,10 @@ fn disambiguator_error(
     cx: &DocContext<'_>,
     item: &Item,
     dox: &str,
-    link_range: Range<usize>,
+    disambiguator_range: Range<usize>,
     msg: &str,
 ) {
-    report_diagnostic(cx.tcx, BROKEN_INTRA_DOC_LINKS, msg, item, dox, &link_range, |_diag, _sp| {});
+    report_diagnostic(cx.tcx, BROKEN_INTRA_DOC_LINKS, msg, item, dox, &disambiguator_range, |_diag, _sp| {});
 }
 
 /// Report an ambiguity error, where there were multiple possible resolutions.

--- a/src/test/rustdoc-ui/intra-doc/anchors.rs
+++ b/src/test/rustdoc-ui/intra-doc/anchors.rs
@@ -43,3 +43,7 @@ pub fn enum_link() {}
 /// [u32#hello]
 //~^ ERROR `u32#hello` contains an anchor
 pub fn x() {}
+
+/// [prim@usize#x]
+//~^ ERROR `prim@usize#x` contains an anchor
+pub mod usize {}

--- a/src/test/rustdoc-ui/intra-doc/anchors.stderr
+++ b/src/test/rustdoc-ui/intra-doc/anchors.stderr
@@ -1,14 +1,20 @@
-error: `Foo::f#hola` contains an anchor, but links to fields are already anchored
-  --> $DIR/anchors.rs:25:15
+error: `prim@usize#x` contains an anchor, but links to builtin types are already anchored
+  --> $DIR/anchors.rs:47:6
    |
-LL | /// Or maybe [Foo::f#hola].
-   |               ^^^^^^^^^^^ contains invalid anchor
+LL | /// [prim@usize#x]
+   |      ^^^^^^^^^^^^ contains invalid anchor
    |
 note: the lint level is defined here
   --> $DIR/anchors.rs:1:9
    |
 LL | #![deny(rustdoc::broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `Foo::f#hola` contains an anchor, but links to fields are already anchored
+  --> $DIR/anchors.rs:25:15
+   |
+LL | /// Or maybe [Foo::f#hola].
+   |               ^^^^^^^^^^^ contains invalid anchor
 
 error: `hello#people#!` contains multiple anchors
   --> $DIR/anchors.rs:31:28
@@ -28,5 +34,5 @@ error: `u32#hello` contains an anchor, but links to builtin types are already an
 LL | /// [u32#hello]
    |      ^^^^^^^^^ contains invalid anchor
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This makes the code a lot less verbose.

This is separated into lots of tiny commits because it was easier for me that way, but the overall diff isn't that big if you want to read it at once.

r? @bugadani 