### PR TITLE
Fix racing file access in tidy

### DIFF
--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -53,6 +53,7 @@ pub mod unstable_book;
 
 fn filter_dirs(path: &Path) -> bool {
     let skip = [
+        "tidy-test-file",
         "compiler/rustc_codegen_cranelift",
         "src/llvm-project",
         "library/backtrace",


### PR DESCRIPTION
That should fix the failure in https://github.com/rust-lang/rust/pull/83776#issuecomment-813311289 

The file is only created for a brief moment during the bins checks in the source directories while other checks may also be visiting the same directory. By skipping it we avoid file not found errors.