### PR TITLE
Document compiler/ with -Aprivate-intra-doc-links

### DIFF
--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -45,9 +45,6 @@ macro_rules! forward {
         pub fn $n:ident(&self, $($name:ident: $ty:ty),* $(,)?) -> &Self
     ) => {
         $(#[$attrs])*
-        // we always document with --document-private-items
-        #[cfg_attr(not(bootstrap), allow(rustdoc::private_intra_doc_links))]
-        #[cfg_attr(bootstrap, allow(private_intra_doc_links))]
         #[doc = concat!("See [`Diagnostic::", stringify!($n), "()`].")]
         pub fn $n(&self, $($name: $ty),*) -> &Self {
             self.diagnostic.$n($($name),*);
@@ -62,9 +59,6 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         #[doc = concat!("See [`Diagnostic::", stringify!($n), "()`].")]
-        // we always document with --document-private-items
-        #[cfg_attr(not(bootstrap), allow(rustdoc::private_intra_doc_links))]
-        #[cfg_attr(bootstrap, allow(private_intra_doc_links))]
         pub fn $n(&mut self, $($name: $ty),*) -> &mut Self {
             self.0.diagnostic.$n($($name),*);
             self
@@ -82,9 +76,6 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         #[doc = concat!("See [`Diagnostic::", stringify!($n), "()`].")]
-        // we always document with --document-private-items
-        #[cfg_attr(not(bootstrap), allow(rustdoc::private_intra_doc_links))]
-        #[cfg_attr(bootstrap, allow(private_intra_doc_links))]
         pub fn $n<$($generic: $bound),*>(&mut self, $($name: $ty),*) -> &mut Self {
             self.0.diagnostic.$n($($name),*);
             self

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -549,6 +549,8 @@ impl Step for Rustc {
         // Build cargo command.
         let mut cargo = builder.cargo(compiler, Mode::Rustc, SourceType::InTree, target, "doc");
         cargo.rustdocflag("--document-private-items");
+        // Since we always pass --document-private-items, there's no need to warn about linking to private items.
+        cargo.rustdocflag("-Arustdoc::private-intra-doc-links");
         cargo.rustdocflag("--enable-index-page");
         cargo.rustdocflag("-Zunstable-options");
         cargo.rustdocflag("-Znormalize-docs");


### PR DESCRIPTION
Since compiler/ always passes --document-private-items, it's ok to link to items that are private.