### PR TITLE
Emit an error if trying to use Intel syntax asm! with an old LLVM

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -879,7 +879,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             })
             .collect();
 
-        bx.codegen_inline_asm(template, &operands, options, line_spans);
+        bx.codegen_inline_asm(
+            template,
+            &operands,
+            options,
+            line_spans,
+            terminator.source_info.span,
+        );
 
         if let Some(target) = destination {
             helper.funclet_br(self, &mut bx, target);

--- a/compiler/rustc_codegen_ssa/src/traits/asm.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/asm.rs
@@ -53,6 +53,7 @@ pub trait AsmBuilderMethods<'tcx>: BackendTypes {
         operands: &[InlineAsmOperandRef<'tcx, Self>],
         options: InlineAsmOptions,
         line_spans: &[Span],
+        span: Span,
     );
 }
 


### PR DESCRIPTION
asm! with Intel syntax requires LLVM 10.0.1.

cc #76738

r? @nagisa 