### PR TITLE
Add listing of lints (eg via `-W help`) to rustdoc

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -845,7 +845,8 @@ the command line flag directly.
     );
 }
 
-fn describe_lints(sess: &Session, lint_store: &LintStore, loaded_plugins: bool) {
+/// Write to stdout lint command options, together with a list of all available lints
+pub fn describe_lints(sess: &Session, lint_store: &LintStore, loaded_plugins: bool) {
     println!(
         "
 Available lint options:

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -97,8 +97,7 @@ crate struct Options {
     crate maybe_sysroot: Option<PathBuf>,
     /// Lint information passed over the command-line.
     crate lint_opts: Vec<(String, Level)>,
-    /// Whether to ask rustc to describe the lints it knows. Practically speaking, this will not be
-    /// used, since we abort if we have no input file, but it's included for completeness.
+    /// Whether to ask rustc to describe the lints it knows.
     crate describe_lints: bool,
     /// What level to cap lints at.
     crate lint_cap: Option<Level>,

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -74,7 +74,7 @@ use std::default::Default;
 use std::env;
 use std::process;
 
-use rustc_driver::abort_on_err;
+use rustc_driver::{abort_on_err, describe_lints};
 use rustc_errors::ErrorReported;
 use rustc_interface::interface;
 use rustc_middle::ty::TyCtxt;
@@ -704,6 +704,12 @@ fn main_options(options: config::Options) -> MainResult {
     interface::create_compiler_and_run(config, |compiler| {
         compiler.enter(|queries| {
             let sess = compiler.session();
+
+            if sess.opts.describe_lints {
+                let (_, lint_store) = &*queries.register_plugins()?.peek();
+                describe_lints(sess, lint_store, true);
+                return Ok(());
+            }
 
             // We need to hold on to the complete resolver, so we cause everything to be
             // cloned for the analysis passes to use. Suboptimal, but necessary in the

--- a/src/test/rustdoc-ui/issue-83883-describe-lints.rs
+++ b/src/test/rustdoc-ui/issue-83883-describe-lints.rs
@@ -1,0 +1,8 @@
+// compile-flags: -W help
+// check-pass
+//
+// ignore-tidy-linelength
+//
+// normalize-stdout-test: "( +name  default  meaning\n +----  -------  -------\n)?( *[[:word:]:-]+  (allow  |warn   |deny   |forbid )  [^\n]+\n)+" -> "    $$NAMES  $$LEVELS  $$MEANINGS"
+// normalize-stdout-test: " +name  sub-lints\n +----  ---------\n( *[[:word:]:-]+  [^\n]+\n)+" -> "    $$NAMES  $$SUB_LINTS"
+// normalize-stdout-test: " +rustdoc::all(  (rustdoc::[[:word:]-]+, )*rustdoc::[[:word:]-]+)?" -> "    rustdoc::all  $$GROUPS$4"

--- a/src/test/rustdoc-ui/issue-83883-describe-lints.stdout
+++ b/src/test/rustdoc-ui/issue-83883-describe-lints.stdout
@@ -1,0 +1,25 @@
+
+Available lint options:
+    -W <foo>           Warn about <foo>
+    -A <foo>           Allow <foo>
+    -D <foo>           Deny <foo>
+    -F <foo>           Forbid <foo> (deny <foo> and all attempts to override)
+
+
+Lint checks provided by rustc:
+
+    $NAMES  $LEVELS  $MEANINGS
+
+Lint groups provided by rustc:
+
+    $NAMES  $SUB_LINTS
+
+Lint checks provided by plugins loaded by this crate:
+
+    $NAMES  $LEVELS  $MEANINGS
+
+Lint groups provided by plugins loaded by this crate:
+
+    rustdoc::all  $GROUPS
+
+


### PR DESCRIPTION
Fixes #83883

r? @jyn514