### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_errors/src/diagnostic_builder.rs
+++ b/compiler/rustc_errors/src/diagnostic_builder.rs
@@ -45,9 +45,6 @@ macro_rules! forward {
         pub fn $n:ident(&self, $($name:ident: $ty:ty),* $(,)?) -> &Self
     ) => {
         $(#[$attrs])*
-        // we always document with --document-private-items
-        #[cfg_attr(not(bootstrap), allow(rustdoc::private_intra_doc_links))]
-        #[cfg_attr(bootstrap, allow(private_intra_doc_links))]
         #[doc = concat!("See [`Diagnostic::", stringify!($n), "()`].")]
         pub fn $n(&self, $($name: $ty),*) -> &Self {
             self.diagnostic.$n($($name),*);
@@ -62,9 +59,6 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         #[doc = concat!("See [`Diagnostic::", stringify!($n), "()`].")]
-        // we always document with --document-private-items
-        #[cfg_attr(not(bootstrap), allow(rustdoc::private_intra_doc_links))]
-        #[cfg_attr(bootstrap, allow(private_intra_doc_links))]
         pub fn $n(&mut self, $($name: $ty),*) -> &mut Self {
             self.0.diagnostic.$n($($name),*);
             self
@@ -82,9 +76,6 @@ macro_rules! forward {
     ) => {
         $(#[$attrs])*
         #[doc = concat!("See [`Diagnostic::", stringify!($n), "()`].")]
-        // we always document with --document-private-items
-        #[cfg_attr(not(bootstrap), allow(rustdoc::private_intra_doc_links))]
-        #[cfg_attr(bootstrap, allow(private_intra_doc_links))]
         pub fn $n<$($generic: $bound),*>(&mut self, $($name: $ty),*) -> &mut Self {
             self.0.diagnostic.$n($($name),*);
             self

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -735,7 +735,14 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                                     });
                                 }
                             };
-                            fragment_kind.expect_from_annotatables(items)
+                            if fragment_kind == AstFragmentKind::Expr && items.is_empty() {
+                                let msg =
+                                    "removing an expression is not supported in this position";
+                                self.cx.span_err(span, msg);
+                                fragment_kind.dummy(span)
+                            } else {
+                                fragment_kind.expect_from_annotatables(items)
+                            }
                         }
                         Err(mut err) => {
                             err.emit();

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(nll)]
 #![cfg_attr(bootstrap, feature(or_patterns))]
 #![recursion_limit = "256"]
+#![allow(rustdoc::private_intra_doc_links)]
 
 pub use rustc_hir::def::{Namespace, PerNS};
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -735,8 +735,14 @@ fn convert_item(tcx: TyCtxt<'_>, item_id: hir::ItemId) {
                 tcx.ensure().generics_of(item.def_id);
                 tcx.ensure().type_of(item.def_id);
                 tcx.ensure().predicates_of(item.def_id);
-                if let hir::ForeignItemKind::Fn(..) = item.kind {
-                    tcx.ensure().fn_sig(item.def_id);
+                match item.kind {
+                    hir::ForeignItemKind::Fn(..) => tcx.ensure().fn_sig(item.def_id),
+                    hir::ForeignItemKind::Static(..) => {
+                        let mut visitor = PlaceholderHirTyCollector::default();
+                        visitor.visit_foreign_item(item);
+                        placeholder_type_error(tcx, None, &[], visitor.0, false, None);
+                    }
+                    _ => (),
                 }
             }
         }

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -1,4 +1,5 @@
-# These defaults are meant for contributors to the compiler who do not modify codegen or LLVM
+# These defaults are meant for contributors to tools which build on the
+# compiler, but do not modify it directly.
 [rust]
 # This enables `RUSTC_LOG=debug`, avoiding confusing situations
 # where adding `debug!()` appears to do nothing.
@@ -6,6 +7,9 @@
 debug-logging = true
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Download rustc from CI instead of building it from source.
+# This cuts compile times by almost 60x, but means you can't modify the compiler.
+download-rustc = "if-unchanged"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -549,6 +549,8 @@ impl Step for Rustc {
         // Build cargo command.
         let mut cargo = builder.cargo(compiler, Mode::Rustc, SourceType::InTree, target, "doc");
         cargo.rustdocflag("--document-private-items");
+        // Since we always pass --document-private-items, there's no need to warn about linking to private items.
+        cargo.rustdocflag("-Arustdoc::private-intra-doc-links");
         cargo.rustdocflag("--enable-index-page");
         cargo.rustdocflag("-Zunstable-options");
         cargo.rustdocflag("-Znormalize-docs");

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -914,7 +914,7 @@ impl Attributes {
             .collect()
     }
 
-    crate fn get_doc_aliases(&self) -> FxHashSet<String> {
+    crate fn get_doc_aliases(&self) -> Box<[String]> {
         let mut aliases = FxHashSet::default();
 
         for attr in self.other_attrs.lists(sym::doc).filter(|a| a.has_name(sym::alias)) {
@@ -931,7 +931,7 @@ impl Attributes {
                 aliases.insert(attr.value_str().map(|s| s.to_string()).unwrap());
             }
         }
-        aliases
+        aliases.into_iter().collect::<Vec<String>>().into()
     }
 }
 

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -120,10 +120,6 @@ crate struct Cache {
     // when gathering trait documentation on a type, hold impls here while
     // folding and add them to the cache later on if we find the trait.
     orphan_trait_impls: Vec<(DefId, FxHashSet<DefId>, Impl)>,
-
-    /// Aliases added through `#[doc(alias = "...")]`. Since a few items can have the same alias,
-    /// we need the alias element to have an array of items.
-    crate aliases: BTreeMap<String, Vec<usize>>,
 }
 
 /// This struct is used to wrap the `cache` and `tcx` in order to run `DocFolder`.

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -309,15 +309,8 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                             parent,
                             parent_idx: None,
                             search_type: get_index_search_type(&item, &self.empty_cache, self.tcx),
+                            aliases: item.attrs.get_doc_aliases(),
                         });
-
-                        for alias in item.attrs.get_doc_aliases() {
-                            self.cache
-                                .aliases
-                                .entry(alias.to_lowercase())
-                                .or_insert(Vec::new())
-                                .push(self.cache.search_index.len() - 1);
-                        }
                     }
                 }
                 (Some(parent), None) if is_inherent_impl_item => {

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -82,18 +82,27 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
                 parent: Some(did),
                 parent_idx: None,
                 search_type: get_index_search_type(&item, cache, tcx),
+                aliases: item.attrs.get_doc_aliases(),
             });
-            for alias in item.attrs.get_doc_aliases() {
-                cache
-                    .aliases
-                    .entry(alias.to_lowercase())
-                    .or_insert(Vec::new())
-                    .push(cache.search_index.len() - 1);
-            }
         }
     }
 
     let Cache { ref mut search_index, ref paths, ref mut aliases, .. } = *cache;
+
+    // Sort search index items. This improves the compressibility of the search index.
+    search_index.sort_unstable_by(|k1, k2| {
+        // `sort_unstable_by_key` produces lifetime errors
+        let k1 = (&k1.path, &k1.name, &k1.ty, &k1.parent);
+        let k2 = (&k2.path, &k2.name, &k2.ty, &k2.parent);
+        std::cmp::Ord::cmp(&k1, &k2)
+    });
+
+    // Set up alias indexes.
+    for (i, item) in search_index.iter().enumerate() {
+        for alias in &item.aliases[..] {
+            aliases.entry(alias.to_lowercase()).or_insert(Vec::new()).push(i);
+        }
+    }
 
     // Reduce `DefId` in paths into smaller sequential numbers,
     // and prune the paths that do not appear in the index.

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -87,7 +87,11 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
         }
     }
 
-    let Cache { ref mut search_index, ref paths, ref mut aliases, .. } = *cache;
+    let Cache { ref mut search_index, ref paths, .. } = *cache;
+
+    // Aliases added through `#[doc(alias = "...")]`. Since a few items can have the same alias,
+    // we need the alias element to have an array of items.
+    let mut aliases: BTreeMap<String, Vec<usize>> = BTreeMap::new();
 
     // Sort search index items. This improves the compressibility of the search index.
     search_index.sort_unstable_by(|k1, k2| {
@@ -210,7 +214,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
             doc: crate_doc,
             items: crate_items,
             paths: crate_paths,
-            aliases,
+            aliases: &aliases,
         })
         .expect("failed serde conversion")
         // All these `replace` calls are because we have to go through JS string for JSON content.

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -164,6 +164,7 @@ crate struct IndexItem {
     crate parent: Option<DefId>,
     crate parent_idx: Option<usize>,
     crate search_type: Option<IndexItemFunctionType>,
+    crate aliases: Box<[String]>,
 }
 
 /// A type used for the search index.

--- a/src/test/rustdoc-ui/intra-doc/private.private.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private.private.stderr
@@ -1,19 +1,27 @@
 warning: public documentation for `DocMe` links to private item `DontDocMe`
-  --> $DIR/private.rs:5:11
+  --> $DIR/private.rs:7:11
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |           ^^^^^^^^^ this item is private
    |
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
 warning: public documentation for `DocMe` links to private item `DontDocMe::f`
-  --> $DIR/private.rs:5:23
+  --> $DIR/private.rs:7:23
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |                       ^^^^^^^^^^^^ this item is private
    |
    = note: this link resolves only because you passed `--document-private-items`, but will break without
 
-warning: 2 warnings emitted
+warning: public documentation for `DocMe` links to private item `DontDocMe::x`
+  --> $DIR/private.rs:7:38
+   |
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
+   |                                      ^^^^^^^^^^^^ this item is private
+   |
+   = note: this link resolves only because you passed `--document-private-items`, but will break without
+
+warning: 3 warnings emitted
 

--- a/src/test/rustdoc-ui/intra-doc/private.public.stderr
+++ b/src/test/rustdoc-ui/intra-doc/private.public.stderr
@@ -1,19 +1,27 @@
 warning: public documentation for `DocMe` links to private item `DontDocMe`
-  --> $DIR/private.rs:5:11
+  --> $DIR/private.rs:7:11
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |           ^^^^^^^^^ this item is private
    |
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
    = note: this link will resolve properly if you pass `--document-private-items`
 
 warning: public documentation for `DocMe` links to private item `DontDocMe::f`
-  --> $DIR/private.rs:5:23
+  --> $DIR/private.rs:7:23
    |
-LL | /// docs [DontDocMe] [DontDocMe::f]
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
    |                       ^^^^^^^^^^^^ this item is private
    |
    = note: this link will resolve properly if you pass `--document-private-items`
 
-warning: 2 warnings emitted
+warning: public documentation for `DocMe` links to private item `DontDocMe::x`
+  --> $DIR/private.rs:7:38
+   |
+LL | /// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
+   |                                      ^^^^^^^^^^^^ this item is private
+   |
+   = note: this link will resolve properly if you pass `--document-private-items`
+
+warning: 3 warnings emitted
 

--- a/src/test/rustdoc-ui/intra-doc/private.rs
+++ b/src/test/rustdoc-ui/intra-doc/private.rs
@@ -2,12 +2,16 @@
 // revisions: public private
 // [private]compile-flags: --document-private-items
 
-/// docs [DontDocMe] [DontDocMe::f]
+// make sure to update `rustdoc/intra-doc/private.rs` if you update this file
+
+/// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
 //~^ WARNING public documentation for `DocMe` links to private item `DontDocMe`
+//~| WARNING public documentation for `DocMe` links to private item `DontDocMe::x`
 //~| WARNING public documentation for `DocMe` links to private item `DontDocMe::f`
-// FIXME: for [private] we should also make sure the link was actually generated
 pub struct DocMe;
-struct DontDocMe;
+struct DontDocMe {
+    x: usize,
+}
 
 impl DontDocMe {
     fn f() {}

--- a/src/test/rustdoc/intra-doc/private.rs
+++ b/src/test/rustdoc/intra-doc/private.rs
@@ -1,6 +1,17 @@
 #![crate_name = "private"]
 // compile-flags: --document-private-items
-/// docs [DontDocMe]
+
+// make sure to update `rustdoc-ui/intra-doc/private.rs` if you update this file
+
+/// docs [DontDocMe] [DontDocMe::f] [DontDocMe::x]
 // @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html"]' 'DontDocMe'
+// @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html#method.f"]' 'DontDocMe::f'
+// @has private/struct.DocMe.html '//*a[@href="../private/struct.DontDocMe.html#structfield.x"]' 'DontDocMe::x'
 pub struct DocMe;
-struct DontDocMe;
+struct DontDocMe {
+    x: usize,
+}
+
+impl DontDocMe {
+    fn f() {}
+}

--- a/src/test/ui/deref-suggestion.rs
+++ b/src/test/ui/deref-suggestion.rs
@@ -63,4 +63,12 @@ fn main() {
         b
         //~^ ERROR mismatched types
     };
+    let val = if true {
+        *a
+    } else if true {
+    //~^ ERROR incompatible types
+        b
+    } else {
+        &0
+    };
 }

--- a/src/test/ui/deref-suggestion.rs
+++ b/src/test/ui/deref-suggestion.rs
@@ -45,4 +45,14 @@ fn main() {
     //~^ ERROR mismatched types
     let r = R { i: i };
     //~^ ERROR mismatched types
+
+
+    let a = &1;
+    let b = &2;
+    let val: i32 = if true {
+        a + 1
+    } else {
+        b
+        //~^ ERROR mismatched types
+    };
 }

--- a/src/test/ui/deref-suggestion.rs
+++ b/src/test/ui/deref-suggestion.rs
@@ -55,4 +55,12 @@ fn main() {
         b
         //~^ ERROR mismatched types
     };
+    let val: i32 = if true {
+        let _ = 2;
+        a + 1
+    } else {
+        let _ = 2;
+        b
+        //~^ ERROR mismatched types
+    };
 }

--- a/src/test/ui/deref-suggestion.stderr
+++ b/src/test/ui/deref-suggestion.stderr
@@ -125,16 +125,6 @@ LL | ||     };
    | ||_____|
    | |______`if` and `else` have incompatible types
    |        expected `i32`, found `&{integer}`
-   |
-help: consider dereferencing the borrow
-   |
-LL |     } else *if true {
-LL |
-LL |         b
-LL |     } else {
-LL |         &0
-LL |     };
-   |
 
 error: aborting due to 13 previous errors
 

--- a/src/test/ui/deref-suggestion.stderr
+++ b/src/test/ui/deref-suggestion.stderr
@@ -107,6 +107,35 @@ LL |         b
    |         expected `i32`, found `&{integer}`
    |         help: consider dereferencing the borrow: `*b`
 
-error: aborting due to 12 previous errors
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/deref-suggestion.rs:68:12
+   |
+LL |        let val = if true {
+   |   _______________-
+LL |  |         *a
+   |  |         -- expected because of this
+LL |  |     } else if true {
+   |  |____________^
+LL | ||
+LL | ||         b
+LL | ||     } else {
+LL | ||         &0
+LL | ||     };
+   | ||     ^
+   | ||_____|
+   | |______`if` and `else` have incompatible types
+   |        expected `i32`, found `&{integer}`
+   |
+help: consider dereferencing the borrow
+   |
+LL |     } else *if true {
+LL |
+LL |         b
+LL |     } else {
+LL |         &0
+LL |     };
+   |
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/deref-suggestion.stderr
+++ b/src/test/ui/deref-suggestion.stderr
@@ -89,6 +89,15 @@ LL |     let r = R { i: i };
    |                    expected `u32`, found `&{integer}`
    |                    help: consider dereferencing the borrow: `*i`
 
-error: aborting due to 10 previous errors
+error[E0308]: mismatched types
+  --> $DIR/deref-suggestion.rs:55:9
+   |
+LL |         b
+   |         ^
+   |         |
+   |         expected `i32`, found `&{integer}`
+   |         help: consider dereferencing the borrow: `*b`
+
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/deref-suggestion.stderr
+++ b/src/test/ui/deref-suggestion.stderr
@@ -98,6 +98,15 @@ LL |         b
    |         expected `i32`, found `&{integer}`
    |         help: consider dereferencing the borrow: `*b`
 
-error: aborting due to 11 previous errors
+error[E0308]: mismatched types
+  --> $DIR/deref-suggestion.rs:63:9
+   |
+LL |         b
+   |         ^
+   |         |
+   |         expected `i32`, found `&{integer}`
+   |         help: consider dereferencing the borrow: `*b`
+
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/macros/attr-empty-expr.rs
+++ b/src/test/ui/macros/attr-empty-expr.rs
@@ -1,0 +1,11 @@
+// AST-based macro attributes expanding to an empty expression produce an error and not ICE.
+
+#![feature(custom_test_frameworks)]
+#![feature(stmt_expr_attributes)]
+#![feature(test)]
+
+fn main() {
+    let _ = #[test] 0; //~ ERROR removing an expression is not supported in this position
+    let _ = #[bench] 1; //~ ERROR removing an expression is not supported in this position
+    let _ = #[test_case] 2; //~ ERROR removing an expression is not supported in this position
+}

--- a/src/test/ui/macros/attr-empty-expr.stderr
+++ b/src/test/ui/macros/attr-empty-expr.stderr
@@ -1,0 +1,20 @@
+error: removing an expression is not supported in this position
+  --> $DIR/attr-empty-expr.rs:8:13
+   |
+LL |     let _ = #[test] 0;
+   |             ^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/attr-empty-expr.rs:9:13
+   |
+LL |     let _ = #[bench] 1;
+   |             ^^^^^^^^
+
+error: removing an expression is not supported in this position
+  --> $DIR/attr-empty-expr.rs:10:13
+   |
+LL |     let _ = #[test_case] 2;
+   |             ^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/typeck/issue-83621-placeholder-static-in-extern.rs
+++ b/src/test/ui/typeck/issue-83621-placeholder-static-in-extern.rs
@@ -1,0 +1,7 @@
+// Regression test for #83621.
+
+extern "C" {
+    static x: _; //~ ERROR: [E0121]
+}
+
+fn main() {}

--- a/src/test/ui/typeck/issue-83621-placeholder-static-in-extern.stderr
+++ b/src/test/ui/typeck/issue-83621-placeholder-static-in-extern.stderr
@@ -1,0 +1,9 @@
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/issue-83621-placeholder-static-in-extern.rs:4:15
+   |
+LL |     static x: _;
+   |               ^ not allowed in type signatures
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
Successful merges:

 - #83370 (Add `x.py setup tools` which enables `download-rustc` by default)
 - #83489 (Properly suggest deref in else block)
 - #83734 (Catch a bad placeholder type error for statics in `extern`s)
 - #83814 (expand: Do not ICE when a legacy AST-based macro attribute produces and empty expression)
 - #83835 (rustdoc: sort search index items for compression)
 - #83849 (rustdoc: Cleanup handling of associated items for intra-doc links)
 - #83881 (:arrow_up: rust-analyzer)
 - #83885 (Document compiler/ with -Aprivate-intra-doc-links)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83370,83489,83734,83814,83835,83849,83881,83885)
<!-- homu-ignore:end -->