### PR TITLE
Fix HashMap/HashSet LLDB pretty-printer on Rust <= 1.51

### DIFF
--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -563,7 +563,11 @@ class StdHashMapSyntheticProvider:
             # HashSet wraps either std HashMap or hashbrown::HashSet, which both
             # wrap hashbrown::HashMap, so either way we "unwrap" twice.
             hashbrown_hashmap = self.valobj.GetChildAtIndex(0).GetChildAtIndex(0)
-        return hashbrown_hashmap.GetChildMemberWithName("table").GetChildMemberWithName("table")
+        table = hashbrown_hashmap.GetChildMemberWithName("table")
+        # BACKCOMPAT: rust 1.51. Drop this condition (https://github.com/rust-lang/rust/pull/77566)
+        if table.GetChildMemberWithName("table").IsValid():
+            table = table.GetChildMemberWithName("table")
+        return table
 
     def has_children(self):
         # type: () -> bool


### PR DESCRIPTION
The pretty-printer was broken in https://github.com/rust-lang/rust/pull/77566 after updating to Rust 1.52.
Now it is compatible with older Rust versions as well.

Fixes #83891