### PR TITLE
Use `EvaluatedToOkModuloRegions` when we get a coinductive match

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -736,7 +736,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 cycle.map(|stack| stack.obligation.predicate.without_const().to_predicate(tcx));
             if self.coinductive_match(cycle) {
                 debug!("evaluate_stack --> recursive, coinductive");
-                Some(EvaluatedToOk)
+                Some(EvaluatedToOkModuloRegions)
             } else {
                 debug!("evaluate_stack --> recursive, inductive");
                 Some(EvaluatedToRecur)


### PR DESCRIPTION
This forces every participant in the cycle to have a result
`EvaluatedToOkModuloRegions` (or an error) as well, since their result
will be influenced by the coinductive result.

While I'm confident that this is sound (AFAIK, it's always sound to
replace `EvaluatedToOk` with `EvaluatedToOkModuloRegions`), I don't
really understand the coinductive cycle logic. This appears to fix the
`syn` incremental crash, but there could be a different way of fixing it
as well.