### PR TITLE
Enforce `Sized` return types on `Fn*` bounds

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -538,7 +538,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         {
             // Do not allow `foo::<fn() -> A>();` for `A: !Sized` (#82633)
             let fn_sig = obligation.predicate.self_ty().skip_binder().fn_sig(self.tcx());
-            let ty = fn_sig.output().skip_binder();
+            let ty = self.infcx.replace_bound_vars_with_placeholders(fn_sig.output());
             let trait_ref = ty::TraitRef {
                 def_id: lang_items.sized_trait().unwrap(),
                 substs: self.tcx().mk_substs_trait(ty, &[]),

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -34,7 +34,7 @@ use crate::traits::{
     ImplSourceUserDefinedData,
 };
 use crate::traits::{ObjectCastObligation, PredicateObligation, TraitObligation};
-use crate::traits::{Obligation, ObligationCause};
+use crate::traits::{Obligation, ObligationCause, ObligationCauseCode};
 use crate::traits::{SelectionError, Unimplemented};
 
 use super::BuiltinImplConditions;
@@ -533,6 +533,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let lang_items = self.tcx().lang_items();
         if [lang_items.fn_once_trait(), lang_items.fn_trait(), lang_items.fn_mut_trait()]
             .contains(&Some(obligation.predicate.def_id()))
+            // Skip `MiscObligation`s for better output.
+            && matches!(obligation.cause.code, ObligationCauseCode::BindingObligation(_, _))
         {
             // Do not allow `foo::<fn() -> A>();` for `A: !Sized` (#82633)
             let fn_sig = obligation.predicate.self_ty().skip_binder().fn_sig(self.tcx());

--- a/src/test/ui/closures/closure-return-type-must-be-sized.rs
+++ b/src/test/ui/closures/closure-return-type-must-be-sized.rs
@@ -1,0 +1,72 @@
+#![feature(unboxed_closures)]
+
+trait A {
+    fn a() where Self: Sized;
+}
+
+mod a {
+    use A;
+
+    pub fn foo<F: FnOnce<()>>() where F::Output: A {
+        F::Output::a()
+    }
+
+    pub fn bar<F: FnOnce() -> R, R: ?Sized>() {}
+
+    pub fn baz<F: FnOnce<()>>() where F::Output: A, F::Output: Sized {
+        F::Output::a()
+    }
+}
+
+mod b {
+    use A;
+
+    pub fn foo<F: Fn<()>>() where F::Output: A {
+        F::Output::a()
+    }
+
+    pub fn bar<F: Fn() -> R, R: ?Sized>() {}
+
+    pub fn baz<F: Fn<()>>() where F::Output: A, F::Output: Sized {
+        F::Output::a()
+    }
+}
+
+mod c {
+    use A;
+
+    pub fn foo<F: FnMut<()>>() where F::Output: A {
+        F::Output::a()
+    }
+
+    pub fn bar<F: FnMut() -> R, R: ?Sized>() {}
+
+    pub fn baz<F: FnMut<()>>() where F::Output: A, F::Output: Sized {
+        F::Output::a()
+    }
+}
+
+impl A for Box<dyn A> {
+    fn a() {}
+}
+
+fn main() {
+    a::foo::<fn() -> dyn A>();         //~ERROR E0277
+    a::bar::<fn() -> dyn A, _>();      //~ERROR E0277
+    a::baz::<fn() -> dyn A>();         //~ERROR E0277
+    a::foo::<fn() -> Box<dyn A>>();    // ok
+    a::bar::<fn() -> Box<dyn A>, _>(); // ok
+    a::baz::<fn() -> Box<dyn A>>();    // ok
+    b::foo::<fn() -> dyn A>();         //~ERROR E0277
+    b::bar::<fn() -> dyn A, _>();      //~ERROR E0277
+    b::baz::<fn() -> dyn A>();         //~ERROR E0277
+    b::foo::<fn() -> Box<dyn A>>();    // ok
+    b::bar::<fn() -> Box<dyn A>, _>(); // ok
+    b::baz::<fn() -> Box<dyn A>>();    // ok
+    c::foo::<fn() -> dyn A>();         //~ERROR E0277
+    c::bar::<fn() -> dyn A, _>();      //~ERROR E0277
+    c::baz::<fn() -> dyn A>();         //~ERROR E0277
+    c::foo::<fn() -> Box<dyn A>>();    // ok
+    c::bar::<fn() -> Box<dyn A>, _>(); // ok
+    c::baz::<fn() -> Box<dyn A>>();    // ok
+}

--- a/src/test/ui/closures/closure-return-type-must-be-sized.stderr
+++ b/src/test/ui/closures/closure-return-type-must-be-sized.stderr
@@ -1,0 +1,99 @@
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:54:5
+   |
+LL |     a::foo::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:55:5
+   |
+LL |     pub fn bar<F: FnOnce() -> R, R: ?Sized>() {}
+   |                   ------------- required by this bound in `a::bar`
+...
+LL |     a::bar::<fn() -> dyn A, _>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:56:5
+   |
+LL |     pub fn baz<F: FnOnce<()>>() where F::Output: A, F::Output: Sized {
+   |                                                                ----- required by this bound in `a::baz`
+...
+LL |     a::baz::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:60:5
+   |
+LL |     pub fn foo<F: Fn<()>>() where F::Output: A {
+   |                   ------ required by this bound in `b::foo`
+...
+LL |     b::foo::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:61:5
+   |
+LL |     pub fn bar<F: Fn() -> R, R: ?Sized>() {}
+   |                   --------- required by this bound in `b::bar`
+...
+LL |     b::bar::<fn() -> dyn A, _>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:62:5
+   |
+LL |     pub fn baz<F: Fn<()>>() where F::Output: A, F::Output: Sized {
+   |                                                            ----- required by this bound in `b::baz`
+...
+LL |     b::baz::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:66:5
+   |
+LL |     pub fn foo<F: FnMut<()>>() where F::Output: A {
+   |                   --------- required by this bound in `c::foo`
+...
+LL |     c::foo::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:67:5
+   |
+LL |     pub fn bar<F: FnMut() -> R, R: ?Sized>() {}
+   |                   ------------ required by this bound in `c::bar`
+...
+LL |     c::bar::<fn() -> dyn A, _>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
+  --> $DIR/closure-return-type-must-be-sized.rs:68:5
+   |
+LL |     pub fn baz<F: FnMut<()>>() where F::Output: A, F::Output: Sized {
+   |                                                               ----- required by this bound in `c::baz`
+...
+LL |     c::baz::<fn() -> dyn A>();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/closures/closure-return-type-must-be-sized.stderr
+++ b/src/test/ui/closures/closure-return-type-must-be-sized.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
   --> $DIR/closure-return-type-must-be-sized.rs:54:5
    |
+LL |     pub fn foo<F: FnOnce<()>>() where F::Output: A {
+   |                   ---------- required by this bound in `a::foo`
+...
 LL |     a::foo::<fn() -> dyn A>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |


### PR DESCRIPTION
In a `fn() -> Out` bound, enforce `Out: Sized` to avoid unsoundness.

Fix #82633.

r? @pnkfelix cc @nikomatsakis 