### PR TITLE
update ToString impl for T: Display to use format macro

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2272,11 +2272,7 @@ impl<T: fmt::Display + ?Sized> ToString for T {
     // to try to remove it.
     #[inline]
     default fn to_string(&self) -> String {
-        use fmt::Write;
-        let mut buf = String::new();
-        buf.write_fmt(format_args!("{}", self))
-            .expect("a Display implementation returned an error unexpectedly");
-        buf
+        format!("{}", self)
     }
 }
 


### PR DESCRIPTION
I believe that using `format!()` directly could potentially result in less allocations as it will allocate an estimated capacity up front.