### PR TITLE
Add copy_sign() as doc alias for f32/f64::copysign()

### DIFF
--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -196,6 +196,7 @@ impl f32 {
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]
     #[stable(feature = "copysign", since = "1.35.0")]
+    #[doc(alias = "copy_sign")]
     pub fn copysign(self, sign: f32) -> f32 {
         unsafe { intrinsics::copysignf32(self, sign) }
     }

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -194,8 +194,9 @@ impl f64 {
     /// assert!(f64::NAN.copysign(1.0).is_nan());
     /// ```
     #[must_use = "method returns a new number and does not mutate the original value"]
-    #[stable(feature = "copysign", since = "1.35.0")]
     #[inline]
+    #[stable(feature = "copysign", since = "1.35.0")]
+    #[doc(alias = "copy_sign")]
     pub fn copysign(self, sign: f64) -> f64 {
         unsafe { intrinsics::copysignf64(self, sign) }
     }


### PR DESCRIPTION
This should help the compiler emit a more helpful error message when the
function is spelled the way it should have been.

cc #58046