### PR TITLE
Disable using non-ascii identifiers in extern blocks.

### DIFF
--- a/src/test/ui/feature-gates/feature-gate-non_ascii_idents.rs
+++ b/src/test/ui/feature-gates/feature-gate-non_ascii_idents.rs
@@ -28,6 +28,7 @@ enum Bär { //~ ERROR non-ascii idents
 
 extern "C" {
     fn qüx();  //~ ERROR non-ascii idents
+    //~^ ERROR items in `extern` blocks
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-non_ascii_idents.stderr
+++ b/src/test/ui/feature-gates/feature-gate-non_ascii_idents.stderr
@@ -1,3 +1,13 @@
+error: items in `extern` blocks cannot use non-ascii identifiers
+  --> $DIR/feature-gate-non_ascii_idents.rs:30:8
+   |
+LL | extern "C" {
+   | ---------- in this `extern` block
+LL |     fn qüx();
+   |        ^^^
+   |
+   = note: This limitation may be lifted in the future; see issue #83942 <https://github.com/rust-lang/rust/issues/83942> for more information
+
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:1:22
    |
@@ -115,6 +125,6 @@ LL |     fn qüx();
    = note: see issue #55467 <https://github.com/rust-lang/rust/issues/55467> for more information
    = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
-error: aborting due to 13 previous errors
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/rfc-2457/extern_block_nonascii_forbidden.rs
+++ b/src/test/ui/rfc-2457/extern_block_nonascii_forbidden.rs
@@ -1,0 +1,10 @@
+#![feature(extern_types)]
+#![feature(non_ascii_idents)]
+
+extern "C" {
+    type 一; //~ items in `extern` blocks cannot use non-ascii identifiers
+    fn 二(); //~ items in `extern` blocks cannot use non-ascii identifiers
+    static 三: usize; //~ items in `extern` blocks cannot use non-ascii identifiers
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2457/extern_block_nonascii_forbidden.stderr
+++ b/src/test/ui/rfc-2457/extern_block_nonascii_forbidden.stderr
@@ -1,0 +1,34 @@
+error: items in `extern` blocks cannot use non-ascii identifiers
+  --> $DIR/extern_block_nonascii_forbidden.rs:5:10
+   |
+LL | extern "C" {
+   | ---------- in this `extern` block
+LL |     type 一;
+   |          ^^
+   |
+   = note: This limitation may be lifted in the future; see issue #83942 <https://github.com/rust-lang/rust/issues/83942> for more information
+
+error: items in `extern` blocks cannot use non-ascii identifiers
+  --> $DIR/extern_block_nonascii_forbidden.rs:6:8
+   |
+LL | extern "C" {
+   | ---------- in this `extern` block
+LL |     type 一;
+LL |     fn 二();
+   |        ^^
+   |
+   = note: This limitation may be lifted in the future; see issue #83942 <https://github.com/rust-lang/rust/issues/83942> for more information
+
+error: items in `extern` blocks cannot use non-ascii identifiers
+  --> $DIR/extern_block_nonascii_forbidden.rs:7:12
+   |
+LL | extern "C" {
+   | ---------- in this `extern` block
+...
+LL |     static 三: usize;
+   |            ^^
+   |
+   = note: This limitation may be lifted in the future; see issue #83942 <https://github.com/rust-lang/rust/issues/83942> for more information
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/rfc-2457/mod_file_nonascii_forbidden.stderr
+++ b/src/test/ui/rfc-2457/mod_file_nonascii_forbidden.stderr
@@ -6,7 +6,7 @@ LL | mod řųśť;
    |
    = help: to create the module `řųśť`, create file "$DIR/řųśť.rs"
 
-error[E0754]: trying to load file for module `řųśť` with non ascii identifer name
+error[E0754]: trying to load file for module `řųśť` with non-ascii identifier name
   --> $DIR/mod_file_nonascii_forbidden.rs:3:5
    |
 LL | mod řųśť;


### PR DESCRIPTION
Fixes #83923.