### PR TITLE
Account for `ExprKind::Block` when suggesting .into() and deref

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -205,6 +205,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         found: Ty<'tcx>,
         expected_ty_expr: Option<&'tcx hir::Expr<'tcx>>,
     ) {
+        let expr = expr.peel_blocks();
         if let Some((sp, msg, suggestion, applicability)) = self.check_ref(expr, found, expected) {
             err.span_suggestion(sp, msg, suggestion, applicability);
         } else if let (ty::FnDef(def_id, ..), true) =

--- a/src/test/ui/suggestions/issue-82361.stderr
+++ b/src/test/ui/suggestions/issue-82361.stderr
@@ -21,10 +21,10 @@ LL | |         1
    | |         - expected because of this
 LL | |     } else {
 LL | |         &1
-   | |         -^
+   | |         ^^
    | |         |
    | |         expected integer, found `&{integer}`
-   | |         help: consider removing the `&`
+   | |         help: consider removing the borrow: `1`
 LL | |     };
    | |_____- `if` and `else` have incompatible types
 
@@ -36,10 +36,10 @@ LL | |         1
    | |         - expected because of this
 LL | |     } else {
 LL | |         &mut 1
-   | |         -----^
+   | |         ^^^^^^
    | |         |
    | |         expected integer, found `&mut {integer}`
-   | |         help: consider removing the `&mut`
+   | |         help: consider removing the borrow: `1`
 LL | |     };
    | |_____- `if` and `else` have incompatible types
 

--- a/src/test/ui/suggestions/issue-83943.fixed
+++ b/src/test/ui/suggestions/issue-83943.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+
+fn main() {
+    if true {
+        "A".to_string()
+    } else {
+        "B".to_string() //~ ERROR `if` and `else` have incompatible types
+    };
+}

--- a/src/test/ui/suggestions/issue-83943.rs
+++ b/src/test/ui/suggestions/issue-83943.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+
+fn main() {
+    if true {
+        "A".to_string()
+    } else {
+        "B" //~ ERROR `if` and `else` have incompatible types
+    };
+}

--- a/src/test/ui/suggestions/issue-83943.stderr
+++ b/src/test/ui/suggestions/issue-83943.stderr
@@ -1,0 +1,18 @@
+error[E0308]: `if` and `else` have incompatible types
+  --> $DIR/issue-83943.rs:7:9
+   |
+LL | /     if true {
+LL | |         "A".to_string()
+   | |         --------------- expected because of this
+LL | |     } else {
+LL | |         "B"
+   | |         ^^^
+   | |         |
+   | |         expected struct `String`, found `&str`
+   | |         help: try using a conversion method: `"B".to_string()`
+LL | |     };
+   | |_____- `if` and `else` have incompatible types
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #83943.