### PR TITLE
Add `free` as a doc alias for `drop`

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -886,7 +886,7 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// ```
 ///
 /// [`RefCell`]: crate::cell::RefCell
-#[doc(alias = "delete")]
+#[doc(alias("delete", "free"))]
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn drop<T>(_x: T) {}


### PR DESCRIPTION
This is the absolute smallest version of #81988. I think we should at least add this one.