### PR TITLE
faster check contains on some ascii strings

### DIFF
--- a/compiler/rustc_ast/src/util/comments.rs
+++ b/compiler/rustc_ast/src/util/comments.rs
@@ -55,7 +55,7 @@ pub fn beautify_doc_string(data: Symbol) -> Symbol {
 
         for line in lines {
             for (j, c) in line.chars().enumerate() {
-                if j > i || !"* \t".contains(c) {
+                if j > i || !(c.is_ascii() && "* \t".contains(c)) {
                     return None;
                 }
                 if c == '*' {

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -221,8 +221,9 @@ fn check_panic_str<'tcx>(
 /// and the type of (opening) delimiter used.
 fn find_delimiters<'tcx>(cx: &LateContext<'tcx>, span: Span) -> Option<(Span, Span, char)> {
     let snippet = cx.sess().parse_sess.source_map().span_to_snippet(span).ok()?;
-    let (open, open_ch) = snippet.char_indices().find(|&(_, c)| "([{".contains(c))?;
-    let close = snippet.rfind(|c| ")]}".contains(c))?;
+    let (open, open_ch) =
+        snippet.char_indices().find(|&(_, c)| c.is_ascii() && "([{".contains(c))?;
+    let close = snippet.rfind(|c: char| c.is_ascii() && ")]}".contains(c))?;
     Some((
         span.from_inner(InnerSpan { start: open, end: open + 1 }),
         span.from_inner(InnerSpan { start: close, end: close + 1 }),

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1427,13 +1427,17 @@ fn range_between_backticks(ori_link: &MarkdownLink) -> Range<usize> {
 /// The difference between this and [`should_ignore_link()`] is that this
 /// check should only be used on links that still have disambiguators.
 fn should_ignore_link_with_disambiguators(link: &str) -> bool {
-    link.contains(|ch: char| !(ch.is_alphanumeric() || ":_<>, !*&;@()".contains(ch)))
+    link.contains(|ch: char| {
+        !(ch.is_alphanumeric() || (ch.is_ascii() && ":_<>, !*&;@()".contains(ch)))
+    })
 }
 
 /// Returns true if we should ignore `path_str` due to it being unlikely
 /// that it is an intra-doc link.
 fn should_ignore_link(path_str: &str) -> bool {
-    path_str.contains(|ch: char| !(ch.is_alphanumeric() || ":_<>, !*&;".contains(ch)))
+    path_str.contains(|ch: char| {
+        !(ch.is_alphanumeric() || (ch.is_ascii() && ":_<>, !*&;".contains(ch)))
+    })
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Fail fast if non ascii char found. For example to evade things like https://godbolt.org/z/q13z7EKqc
