### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -98,7 +98,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum FnKind<'a> {
     /// `#[xxx] pub async/const/extern "Abi" fn foo()`
     ItemFn(Ident, &'a Generics<'a>, FnHeader, &'a Visibility<'a>),

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -1,6 +1,6 @@
 //! Throughout the compiler tree, there are several places which want to have
 //! access to state or queries while being inside crates that are dependencies
-//! of librustc_middle. To facilitate this, we have the
+//! of `rustc_middle`. To facilitate this, we have the
 //! `rustc_data_structures::AtomicRef` type, which allows us to setup a global
 //! static which can then be set in this file at program startup.
 //!
@@ -13,8 +13,8 @@ use rustc_errors::{Diagnostic, TRACK_DIAGNOSTICS};
 use rustc_middle::ty::tls;
 use std::fmt;
 
-/// This is a callback from librustc_ast as it cannot access the implicit state
-/// in librustc_middle otherwise.
+/// This is a callback from `rustc_ast` as it cannot access the implicit state
+/// in `rustc_middle` otherwise.
 fn span_debug(span: rustc_span::Span, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     tls::with_opt(|tcx| {
         if let Some(tcx) = tcx {
@@ -25,8 +25,8 @@ fn span_debug(span: rustc_span::Span, f: &mut fmt::Formatter<'_>) -> fmt::Result
     })
 }
 
-/// This is a callback from librustc_ast as it cannot access the implicit state
-/// in librustc_middle otherwise. It is used to when diagnostic messages are
+/// This is a callback from `rustc_ast` as it cannot access the implicit state
+/// in `rustc_middle` otherwise. It is used to when diagnostic messages are
 /// emitted and stores them in the current query, if there is one.
 fn track_diagnostic(diagnostic: &Diagnostic) {
     tls::with_context_opt(|icx| {
@@ -39,8 +39,8 @@ fn track_diagnostic(diagnostic: &Diagnostic) {
     })
 }
 
-/// This is a callback from librustc_hir as it cannot access the implicit state
-/// in librustc_middle otherwise.
+/// This is a callback from `rustc_hir` as it cannot access the implicit state
+/// in `rustc_middle` otherwise.
 fn def_id_debug(def_id: rustc_hir::def_id::DefId, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(f, "DefId({}:{}", def_id.krate, def_id.index.index())?;
     tls::with_opt(|opt_tcx| {

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -379,6 +379,17 @@ impl Options {
             }
         }
 
+        // check for `--output-format=json`
+        if !matches!(matches.opt_str("output-format").as_deref(), None | Some("html"))
+            && !matches.opt_present("show-coverage")
+            && !nightly_options::is_unstable_enabled(matches)
+        {
+            rustc_session::early_error(
+                error_format,
+                "the -Z unstable-options flag must be passed to enable --output-format for documentation generation (see https://github.com/rust-lang/rust/issues/76578)",
+            );
+        }
+
         let to_check = matches.opt_strs("check-theme");
         if !to_check.is_empty() {
             let paths = theme::load_css_paths(static_files::themes::LIGHT.as_bytes());
@@ -575,13 +586,7 @@ impl Options {
         let output_format = match matches.opt_str("output-format") {
             Some(s) => match OutputFormat::try_from(s.as_str()) {
                 Ok(out_fmt) => {
-                    if out_fmt.is_json()
-                        && !(show_coverage || nightly_options::match_is_nightly_build(matches))
-                    {
-                        diag.struct_err("json output format isn't supported for doc generation")
-                            .emit();
-                        return Err(1);
-                    } else if !out_fmt.is_json() && show_coverage {
+                    if !out_fmt.is_json() && show_coverage {
                         diag.struct_err(
                             "html output format isn't supported for the --show-coverage option",
                         )
@@ -703,16 +708,10 @@ impl Options {
 
 /// Prints deprecation warnings for deprecated options
 fn check_deprecated_options(matches: &getopts::Matches, diag: &rustc_errors::Handler) {
-    let deprecated_flags = ["input-format", "output-format", "no-defaults", "passes"];
+    let deprecated_flags = ["input-format", "no-defaults", "passes"];
 
     for flag in deprecated_flags.iter() {
         if matches.opt_present(flag) {
-            if *flag == "output-format"
-                && (matches.opt_present("show-coverage")
-                    || nightly_options::match_is_nightly_build(matches))
-            {
-                continue;
-            }
             let mut err = diag.struct_warn(&format!("the `{}` flag is deprecated", flag));
             err.note(
                 "see issue #44136 <https://github.com/rust-lang/rust/issues/44136> \

--- a/src/test/run-make/unstable-flag-required/Makefile
+++ b/src/test/run-make/unstable-flag-required/Makefile
@@ -1,0 +1,4 @@
+-include ../../run-make-fulldeps/tools.mk
+
+all:
+	$(RUSTDOC) --output-format=json x.html 2>&1 | diff - output-format-json.stderr

--- a/src/test/run-make/unstable-flag-required/README.md
+++ b/src/test/run-make/unstable-flag-required/README.md
@@ -1,0 +1,3 @@
+This is a collection of tests that verify `--unstable-options` is required.
+It should eventually be removed in favor of UI tests once compiletest stops
+passing --unstable-options by default (#82639).

--- a/src/test/run-make/unstable-flag-required/output-format-json.stderr
+++ b/src/test/run-make/unstable-flag-required/output-format-json.stderr
@@ -1,0 +1,2 @@
+error: the -Z unstable-options flag must be passed to enable --output-format for documentation generation (see https://github.com/rust-lang/rust/issues/76578)
+

--- a/src/test/run-make/unstable-flag-required/x.rs
+++ b/src/test/run-make/unstable-flag-required/x.rs
@@ -1,0 +1,1 @@
+// nothing to see here

--- a/src/test/rustdoc-ui/output-format-html-stable.rs
+++ b/src/test/rustdoc-ui/output-format-html-stable.rs
@@ -1,0 +1,4 @@
+// compile-flags: --output-format html
+// check-pass
+// This tests that `--output-format html` is accepted without `-Z unstable-options`,
+// since it has been stable since 1.0.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1600,7 +1600,7 @@ impl<'test> TestCx<'test> {
             .args(&self.props.compile_flags);
 
         if self.config.mode == RustdocJson {
-            rustdoc.arg("--output-format").arg("json");
+            rustdoc.arg("--output-format").arg("json").arg("-Zunstable-options");
         }
 
         if let Some(ref linker) = self.config.linker {


### PR DESCRIPTION
Successful merges:

 - #82497 (Fix handling of `--output-format json` flag)
 - #83965 (Add Debug implementation for hir::intravisit::FnKind)
 - #83974 (Fix outdated crate names in `rustc_interface::callbacks`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=82497,83965,83974)
<!-- homu-ignore:end -->