### PR TITLE
Remove the insta-stable `cfg(wasm)`

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -822,9 +822,6 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
         }
     }
     ret.insert((sym::target_arch, Some(Symbol::intern(arch))));
-    if sess.target.is_like_wasm {
-        ret.insert((sym::wasm, None));
-    }
     ret.insert((sym::target_endian, Some(Symbol::intern(end.as_str()))));
     ret.insert((sym::target_pointer_width, Some(Symbol::intern(&wordsz))));
     ret.insert((sym::target_env, Some(Symbol::intern(env))));

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1295,7 +1295,6 @@ symbols! {
         vreg,
         vreg_low16,
         warn,
-        wasm,
         wasm_import_module,
         wasm_target_feature,
         while_let,

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -487,7 +487,6 @@ impl<'a> fmt::Display for Display<'a> {
                         "windows" => "Windows",
                         _ => "",
                     },
-                    (sym::wasm, None) => "WebAssembly",
                     (sym::target_arch, Some(arch)) => match &*arch.as_str() {
                         "aarch64" => "AArch64",
                         "arm" => "ARM",


### PR DESCRIPTION
The addition of `cfg(wasm)` was an oversight on my end that turns out to have a number
of downsides:

* It was introduced as an insta-stable addition, forgoing the usual
  staging mechanism we use for potentially far-reaching changes;
* It is a breaking change for people who are using `--cfg wasm` either
  directly or via cargo for other purposes;
* It is not entirely clear if a bare `wasm` cfg is a right option or
  whether `wasm` family of targets are special enough to warrant
  special-casing these targets specifically.

As for the last point, there appears to be a fair amount of support for
reducing the boilerplate in specifying architectures from the same
family, while ignoring their pointer width. The suggested way forward
would be to propose such a change as a separate RFC as it is potentially
a quite contentious addition.

cc #83879 @devsnek 