### PR TITLE
call to_owned directly in str::to_string

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2292,7 +2292,7 @@ impl ToString for char {
 impl ToString for str {
     #[inline]
     fn to_string(&self) -> String {
-        String::from(self)
+        self.to_owned()
     }
 }
 


### PR DESCRIPTION
This is a very minor change. The current flow is: `str::to_string -> String::from(str) -> str.to_owned()`, which is harder to follow.