### PR TITLE
Expand derive invocations in left-to-right order

### DIFF
--- a/src/test/ui/macros/builtin-std-paths-fail.stderr
+++ b/src/test/ui/macros/builtin-std-paths-fail.stderr
@@ -10,6 +10,18 @@ error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
 LL |     core::RustcDecodable,
    |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
 
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:2:11
+   |
+LL |     core::RustcDecodable,
+   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:4:11
+   |
+LL |     core::RustcDecodable,
+   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+
 error[E0433]: failed to resolve: could not find `bench` in `core`
   --> $DIR/builtin-std-paths-fail.rs:7:9
    |
@@ -34,17 +46,17 @@ error[E0433]: failed to resolve: could not find `test` in `core`
 LL | #[core::test]
    |         ^^^^ could not find `test` in `core`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
-  --> $DIR/builtin-std-paths-fail.rs:4:11
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:14:10
    |
-LL |     core::RustcDecodable,
-   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+LL |     std::RustcDecodable,
+   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
 
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
-  --> $DIR/builtin-std-paths-fail.rs:2:11
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:16:10
    |
-LL |     core::RustcDecodable,
-   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+LL |     std::RustcDecodable,
+   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
 
 error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
   --> $DIR/builtin-std-paths-fail.rs:14:10
@@ -81,18 +93,6 @@ error[E0433]: failed to resolve: could not find `test` in `std`
    |
 LL | #[std::test]
    |        ^^^^ could not find `test` in `std`
-
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
-  --> $DIR/builtin-std-paths-fail.rs:16:10
-   |
-LL |     std::RustcDecodable,
-   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
-
-error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
-  --> $DIR/builtin-std-paths-fail.rs:14:10
-   |
-LL |     std::RustcDecodable,
-   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/proc-macro/attribute-after-derive.stdout
+++ b/src/test/ui/proc-macro/attribute-after-derive.stdout
@@ -99,22 +99,6 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: $DIR/attribute-after-derive.rs:18:1: 21:2 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): struct DeriveAttribute { }
-PRINT-ATTR INPUT (DEBUG): TokenStream [
-    Ident {
-        ident: "struct",
-        span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),
-    },
-    Ident {
-        ident: "DeriveAttribute",
-        span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),
-    },
-    Group {
-        delimiter: Brace,
-        stream: TokenStream [],
-        span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),
-    },
-]
 PRINT-DERIVE INPUT (DISPLAY): #[print_attr] struct DeriveAttribute { }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Punct {
@@ -132,6 +116,22 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         ],
         span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),
     },
+    Ident {
+        ident: "struct",
+        span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),
+    },
+    Ident {
+        ident: "DeriveAttribute",
+        span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),
+    },
+    Group {
+        delimiter: Brace,
+        stream: TokenStream [],
+        span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),
+    },
+]
+PRINT-ATTR INPUT (DISPLAY): struct DeriveAttribute { }
+PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
         span: $DIR/attribute-after-derive.rs:25:1: 28:2 (#0),

--- a/src/test/ui/proc-macro/auxiliary/multiple-derives.rs
+++ b/src/test/ui/proc-macro/auxiliary/multiple-derives.rs
@@ -1,0 +1,22 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+macro_rules! make_derives {
+    ($($name:ident),*) => {
+        $(
+            #[proc_macro_derive($name)]
+            pub fn $name(input: TokenStream) -> TokenStream {
+                println!("Derive {}: {}", stringify!($name), input);
+                TokenStream::new()
+            }
+        )*
+    }
+}
+
+make_derives!(First, Second, Third, Fourth, Fifth);

--- a/src/test/ui/proc-macro/derive-expand-order.rs
+++ b/src/test/ui/proc-macro/derive-expand-order.rs
@@ -1,0 +1,14 @@
+// run-pass
+// aux-build:multiple-derives.rs
+
+extern crate multiple_derives;
+
+use multiple_derives::*;
+
+#[derive(First)]
+#[derive(Second)]
+#[derive(Third, Fourth)]
+#[derive(Fifth)]
+pub struct Foo {}
+
+fn main() {}

--- a/src/test/ui/proc-macro/derive-expand-order.stdout
+++ b/src/test/ui/proc-macro/derive-expand-order.stdout
@@ -1,0 +1,5 @@
+Derive First: #[derive(Second)] #[derive(Third, Fourth)] #[derive(Fifth)] pub struct Foo { }
+Derive Second: #[derive(Third, Fourth)] #[derive(Fifth)] pub struct Foo { }
+Derive Third: #[derive(Fifth)] pub struct Foo { }
+Derive Fourth: #[derive(Fifth)] pub struct Foo { }
+Derive Fifth: pub struct Foo { }

--- a/src/test/ui/proc-macro/issue-36935.stderr
+++ b/src/test/ui/proc-macro/issue-36935.stderr
@@ -1,11 +1,3 @@
-error: proc-macro derive panicked
-  --> $DIR/issue-36935.rs:6:20
-   |
-LL | #[derive(Identity, Panic)]
-   |                    ^^^^^
-   |
-   = help: message: panic-derive
-
 error[E0428]: the name `Baz` is defined multiple times
   --> $DIR/issue-36935.rs:7:1
    |
@@ -16,6 +8,14 @@ LL | struct Baz {
    | previous definition of the type `Baz` here
    |
    = note: `Baz` must be defined only once in the type namespace of this module
+
+error: proc-macro derive panicked
+  --> $DIR/issue-36935.rs:6:20
+   |
+LL | #[derive(Identity, Panic)]
+   |                    ^^^^^
+   |
+   = help: message: panic-derive
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/union/union-derive.stderr
+++ b/src/test/ui/union/union-derive.stderr
@@ -1,26 +1,8 @@
 error: this trait cannot be derived for unions
-  --> $DIR/union-derive.rs:9:5
+  --> $DIR/union-derive.rs:4:5
    |
-LL |     Debug,
-   |     ^^^^^
-
-error: this trait cannot be derived for unions
-  --> $DIR/union-derive.rs:8:5
-   |
-LL |     Default,
-   |     ^^^^^^^
-
-error: this trait cannot be derived for unions
-  --> $DIR/union-derive.rs:7:5
-   |
-LL |     Hash,
-   |     ^^^^
-
-error: this trait cannot be derived for unions
-  --> $DIR/union-derive.rs:6:5
-   |
-LL |     Ord,
-   |     ^^^
+LL |     PartialEq,
+   |     ^^^^^^^^^
 
 error: this trait cannot be derived for unions
   --> $DIR/union-derive.rs:5:5
@@ -29,10 +11,28 @@ LL |     PartialOrd,
    |     ^^^^^^^^^^
 
 error: this trait cannot be derived for unions
-  --> $DIR/union-derive.rs:4:5
+  --> $DIR/union-derive.rs:6:5
    |
-LL |     PartialEq,
-   |     ^^^^^^^^^
+LL |     Ord,
+   |     ^^^
+
+error: this trait cannot be derived for unions
+  --> $DIR/union-derive.rs:7:5
+   |
+LL |     Hash,
+   |     ^^^^
+
+error: this trait cannot be derived for unions
+  --> $DIR/union-derive.rs:8:5
+   |
+LL |     Default,
+   |     ^^^^^^^
+
+error: this trait cannot be derived for unions
+  --> $DIR/union-derive.rs:9:5
+   |
+LL |     Debug,
+   |     ^^^^^
 
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
While derives were being collected in left-to-order order, the
corresponding `Invocation`s were being pushed in the wrong order.