### PR TITLE
Avoid `;` -> `,` recovery and unclosed `}` recovery from being too verbose

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -703,6 +703,8 @@ impl<'a> Parser<'a> {
         let mut recovered = false;
         let mut trailing = false;
         let mut v = vec![];
+        let unclosed_delims = !self.unclosed_delims.is_empty();
+
         while !self.expect_any_with_type(kets, expect) {
             if let token::CloseDelim(..) | token::Eof = self.token.kind {
                 break;
@@ -723,7 +725,7 @@ impl<'a> Parser<'a> {
 
                             // Attempt to keep parsing if it was a similar separator.
                             if let Some(ref tokens) = t.similar_tokens() {
-                                if tokens.contains(&self.token.kind) {
+                                if tokens.contains(&self.token.kind) && !unclosed_delims {
                                     self.bump();
                                 }
                             }

--- a/src/test/ui/parser/issue-63116.stderr
+++ b/src/test/ui/parser/issue-63116.stderr
@@ -12,11 +12,11 @@ error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `;`
 LL | impl W <s(f;Y(;]
    |            ^ expected one of 7 possible tokens
 
-error: expected one of `!`, `&&`, `&`, `(`, `)`, `*`, `+`, `,`, `->`, `...`, `::`, `:`, `<`, `=`, `>`, `?`, `[`, `_`, `async`, `const`, `dyn`, `extern`, `fn`, `for`, `impl`, `unsafe`, lifetime, or path, found `;`
-  --> $DIR/issue-63116.rs:3:15
+error: mismatched closing delimiter: `]`
+  --> $DIR/issue-63116.rs:3:16
    |
 LL | impl W <s(f;Y(;]
-   |              -^ help: `)` may belong here
+   |              - ^ mismatched closing delimiter
    |              |
    |              unclosed delimiter
 

--- a/src/test/ui/parser/use-unclosed-brace.rs
+++ b/src/test/ui/parser/use-unclosed-brace.rs
@@ -1,26 +1,12 @@
+// error-pattern: expected one of `,`, `::`, `as`, or `}`, found `;`
+// error-pattern: this file contains an unclosed delimiter
+// error-pattern: expected item, found `}`
 use foo::{bar, baz;
-//~^ ERROR expected one of `,`, `::`, `as`, or `}`, found `;`
 
 use std::fmt::Display;
-//~^ ERROR expected identifier, found keyword `use`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `std`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `;`
 
 mod bar { }
-//~^ ERROR expected identifier, found keyword `mod`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `bar`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `{`
 
 mod baz { }
-//~^ ERROR expected identifier, found keyword `mod`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `{`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `baz`
-//~| ERROR expected one of `,` or `}`, found keyword `mod`
 
 fn main() {}
-//~^ ERROR expected identifier, found keyword `fn`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `(`
-//~| ERROR expected one of `,` or `}`, found keyword `fn`
-//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `main`
-
-//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/use-unclosed-brace.rs
+++ b/src/test/ui/parser/use-unclosed-brace.rs
@@ -1,0 +1,26 @@
+use foo::{bar, baz;
+//~^ ERROR expected one of `,`, `::`, `as`, or `}`, found `;`
+
+use std::fmt::Display;
+//~^ ERROR expected identifier, found keyword `use`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `std`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `;`
+
+mod bar { }
+//~^ ERROR expected identifier, found keyword `mod`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `bar`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `{`
+
+mod baz { }
+//~^ ERROR expected identifier, found keyword `mod`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `{`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `baz`
+//~| ERROR expected one of `,` or `}`, found keyword `mod`
+
+fn main() {}
+//~^ ERROR expected identifier, found keyword `fn`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `(`
+//~| ERROR expected one of `,` or `}`, found keyword `fn`
+//~| ERROR expected one of `,`, `::`, `as`, or `}`, found `main`
+
+//~ ERROR this file contains an unclosed delimiter

--- a/src/test/ui/parser/use-unclosed-brace.stderr
+++ b/src/test/ui/parser/use-unclosed-brace.stderr
@@ -1,0 +1,139 @@
+error: this file contains an unclosed delimiter
+  --> $DIR/use-unclosed-brace.rs:26:51
+   |
+LL | use foo::{bar, baz;
+   |          - unclosed delimiter
+...
+LL |
+   |                                                   ^
+
+error: expected identifier, found keyword `use`
+  --> $DIR/use-unclosed-brace.rs:4:1
+   |
+LL | use std::fmt::Display;
+   | ^^^ expected identifier, found keyword
+
+error: expected one of `,`, `::`, `as`, or `}`, found `;`
+  --> $DIR/use-unclosed-brace.rs:1:19
+   |
+LL | use foo::{bar, baz;
+   |          -        ^ expected one of `,`, `::`, `as`, or `}`
+   |          |
+   |          unclosed delimiter
+   |
+help: `}` may belong here
+   |
+LL | use foo::{bar, baz};
+   |                   ^
+help: missing `,`
+   |
+LL | use foo::{bar, baz,;
+   |                   ^
+
+error: expected one of `,`, `::`, `as`, or `}`, found `std`
+  --> $DIR/use-unclosed-brace.rs:4:5
+   |
+LL | use std::fmt::Display;
+   |    -^^^ expected one of `,`, `::`, `as`, or `}`
+   |    |
+   |    help: missing `,`
+
+error: expected identifier, found keyword `mod`
+  --> $DIR/use-unclosed-brace.rs:9:1
+   |
+LL | mod bar { }
+   | ^^^ expected identifier, found keyword
+
+error: expected one of `,`, `::`, `as`, or `}`, found `;`
+  --> $DIR/use-unclosed-brace.rs:4:22
+   |
+LL | use std::fmt::Display;
+   |                      ^
+   |                      |
+   |                      expected one of `,`, `::`, `as`, or `}`
+   |                      help: missing `,`
+
+error: expected one of `,`, `::`, `as`, or `}`, found `bar`
+  --> $DIR/use-unclosed-brace.rs:9:5
+   |
+LL | mod bar { }
+   |    -^^^ expected one of `,`, `::`, `as`, or `}`
+   |    |
+   |    help: missing `,`
+
+error: expected one of `,`, `::`, `as`, or `}`, found `{`
+  --> $DIR/use-unclosed-brace.rs:9:9
+   |
+LL | mod bar { }
+   |        -^ expected one of `,`, `::`, `as`, or `}`
+   |        |
+   |        help: missing `,`
+
+error: expected identifier, found keyword `mod`
+  --> $DIR/use-unclosed-brace.rs:14:1
+   |
+LL | mod baz { }
+   | ^^^ expected identifier, found keyword
+
+error: expected one of `,` or `}`, found keyword `mod`
+  --> $DIR/use-unclosed-brace.rs:14:1
+   |
+LL | mod bar { }
+   |            -
+   |            |
+   |            expected one of `,` or `}`
+   |            help: missing `,`
+...
+LL | mod baz { }
+   | ^^^ unexpected token
+
+error: expected one of `,`, `::`, `as`, or `}`, found `baz`
+  --> $DIR/use-unclosed-brace.rs:14:5
+   |
+LL | mod baz { }
+   |    -^^^ expected one of `,`, `::`, `as`, or `}`
+   |    |
+   |    help: missing `,`
+
+error: expected one of `,`, `::`, `as`, or `}`, found `{`
+  --> $DIR/use-unclosed-brace.rs:14:9
+   |
+LL | mod baz { }
+   |        -^ expected one of `,`, `::`, `as`, or `}`
+   |        |
+   |        help: missing `,`
+
+error: expected identifier, found keyword `fn`
+  --> $DIR/use-unclosed-brace.rs:20:1
+   |
+LL | fn main() {}
+   | ^^ expected identifier, found keyword
+
+error: expected one of `,` or `}`, found keyword `fn`
+  --> $DIR/use-unclosed-brace.rs:20:1
+   |
+LL | mod baz { }
+   |            -
+   |            |
+   |            expected one of `,` or `}`
+   |            help: missing `,`
+...
+LL | fn main() {}
+   | ^^ unexpected token
+
+error: expected one of `,`, `::`, `as`, or `}`, found `main`
+  --> $DIR/use-unclosed-brace.rs:20:4
+   |
+LL | fn main() {}
+   |   -^^^^ expected one of `,`, `::`, `as`, or `}`
+   |   |
+   |   help: missing `,`
+
+error: expected one of `,`, `::`, `as`, or `}`, found `(`
+  --> $DIR/use-unclosed-brace.rs:20:8
+   |
+LL | fn main() {}
+   |        ^ expected one of `,`, `::`, `as`, or `}`
+
+error: aborting due to 16 previous errors
+

--- a/src/test/ui/parser/use-unclosed-brace.stderr
+++ b/src/test/ui/parser/use-unclosed-brace.stderr
@@ -1,139 +1,27 @@
 error: this file contains an unclosed delimiter
-  --> $DIR/use-unclosed-brace.rs:26:51
+  --> $DIR/use-unclosed-brace.rs:12:14
    |
 LL | use foo::{bar, baz;
    |          - unclosed delimiter
 ...
-LL |
-   |                                                   ^
-
-error: expected identifier, found keyword `use`
-  --> $DIR/use-unclosed-brace.rs:4:1
-   |
-LL | use std::fmt::Display;
-   | ^^^ expected identifier, found keyword
+LL | fn main() {}
+   |              ^
 
 error: expected one of `,`, `::`, `as`, or `}`, found `;`
-  --> $DIR/use-unclosed-brace.rs:1:19
+  --> $DIR/use-unclosed-brace.rs:4:19
    |
 LL | use foo::{bar, baz;
-   |          -        ^ expected one of `,`, `::`, `as`, or `}`
-   |          |
+   |          -        ^
+   |          |        |
+   |          |        expected one of `,`, `::`, `as`, or `}`
+   |          |        help: `}` may belong here
    |          unclosed delimiter
-   |
-help: `}` may belong here
-   |
-LL | use foo::{bar, baz};
-   |                   ^
-help: missing `,`
-   |
-LL | use foo::{bar, baz,;
-   |                   ^
 
-error: expected one of `,`, `::`, `as`, or `}`, found `std`
-  --> $DIR/use-unclosed-brace.rs:4:5
-   |
-LL | use std::fmt::Display;
-   |    -^^^ expected one of `,`, `::`, `as`, or `}`
-   |    |
-   |    help: missing `,`
-
-error: expected identifier, found keyword `mod`
-  --> $DIR/use-unclosed-brace.rs:9:1
-   |
-LL | mod bar { }
-   | ^^^ expected identifier, found keyword
-
-error: expected one of `,`, `::`, `as`, or `}`, found `;`
-  --> $DIR/use-unclosed-brace.rs:4:22
-   |
-LL | use std::fmt::Display;
-   |                      ^
-   |                      |
-   |                      expected one of `,`, `::`, `as`, or `}`
-   |                      help: missing `,`
-
-error: expected one of `,`, `::`, `as`, or `}`, found `bar`
-  --> $DIR/use-unclosed-brace.rs:9:5
-   |
-LL | mod bar { }
-   |    -^^^ expected one of `,`, `::`, `as`, or `}`
-   |    |
-   |    help: missing `,`
-
-error: expected one of `,`, `::`, `as`, or `}`, found `{`
-  --> $DIR/use-unclosed-brace.rs:9:9
-   |
-LL | mod bar { }
-   |        -^ expected one of `,`, `::`, `as`, or `}`
-   |        |
-   |        help: missing `,`
-
-error: expected identifier, found keyword `mod`
-  --> $DIR/use-unclosed-brace.rs:14:1
-   |
-LL | mod baz { }
-   | ^^^ expected identifier, found keyword
-
-error: expected one of `,` or `}`, found keyword `mod`
-  --> $DIR/use-unclosed-brace.rs:14:1
-   |
-LL | mod bar { }
-   |            -
-   |            |
-   |            expected one of `,` or `}`
-   |            help: missing `,`
-...
-LL | mod baz { }
-   | ^^^ unexpected token
-
-error: expected one of `,`, `::`, `as`, or `}`, found `baz`
-  --> $DIR/use-unclosed-brace.rs:14:5
-   |
-LL | mod baz { }
-   |    -^^^ expected one of `,`, `::`, `as`, or `}`
-   |    |
-   |    help: missing `,`
-
-error: expected one of `,`, `::`, `as`, or `}`, found `{`
-  --> $DIR/use-unclosed-brace.rs:14:9
-   |
-LL | mod baz { }
-   |        -^ expected one of `,`, `::`, `as`, or `}`
-   |        |
-   |        help: missing `,`
-
-error: expected identifier, found keyword `fn`
-  --> $DIR/use-unclosed-brace.rs:20:1
+error: expected item, found `}`
+  --> $DIR/use-unclosed-brace.rs:12:14
    |
 LL | fn main() {}
-   | ^^ expected identifier, found keyword
+   |              ^ expected item
 
-error: expected one of `,` or `}`, found keyword `fn`
-  --> $DIR/use-unclosed-brace.rs:20:1
-   |
-LL | mod baz { }
-   |            -
-   |            |
-   |            expected one of `,` or `}`
-   |            help: missing `,`
-...
-LL | fn main() {}
-   | ^^ unexpected token
-
-error: expected one of `,`, `::`, `as`, or `}`, found `main`
-  --> $DIR/use-unclosed-brace.rs:20:4
-   |
-LL | fn main() {}
-   |   -^^^^ expected one of `,`, `::`, `as`, or `}`
-   |   |
-   |   help: missing `,`
-
-error: expected one of `,`, `::`, `as`, or `}`, found `(`
-  --> $DIR/use-unclosed-brace.rs:20:8
-   |
-LL | fn main() {}
-   |        ^ expected one of `,`, `::`, `as`, or `}`
-
-error: aborting due to 16 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Those two recovery attempts have a very bad interaction that causes too
unnecessary output. Add a simple gate to avoid interpreting a `;` as a
`,` when there are unclosed braces.

Fix #83498.