### PR TITLE
Fix perf regression in rustdoc::bare_urls

### DIFF
--- a/src/librustdoc/passes/bare_urls.rs
+++ b/src/librustdoc/passes/bare_urls.rs
@@ -16,7 +16,7 @@ crate const CHECK_BARE_URLS: Pass = Pass {
     description: "detects URLs that are not hyperlinks",
 };
 
-const URL_REGEX: SyncLazy<Regex> = SyncLazy::new(|| {
+static URL_REGEX: SyncLazy<Regex> = SyncLazy::new(|| {
     Regex::new(concat!(
         r"https?://",                          // url scheme
         r"([-a-zA-Z0-9@:%._\+~#=]{2,256}\.)+", // one or more subdomains


### PR DESCRIPTION
This regressed in #81764. After that PR, rustdoc compiled the regex for every single item in the crate: https://perf.rust-lang.org/compare.html?start=125505306744a0a5bb01d62337260a95d9ff8d57&end=2e495d2e845cf27740e3665f718acfd3aa17253e&stat=instructions%3Au

This would have been caught by `clippy::declare_interior_mutable_const` (cc https://github.com/rust-lang/rust/issues/77983).