### PR TITLE
Error on Reserved Syntax for Raw Keywords: `k#foo`

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -408,6 +408,8 @@ impl<'a> Classifier<'a> {
                 c => c,
             },
             TokenKind::RawIdent => Class::Ident,
+            //TODO How do I test this?
+            TokenKind::RawKeyword => Class::KeyWord,
             TokenKind::Lifetime { .. } => Class::Lifetime,
         };
         // Anything that didn't return above is the simple case where we the

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -408,7 +408,6 @@ impl<'a> Classifier<'a> {
                 c => c,
             },
             TokenKind::RawIdent => Class::Ident,
-            //TODO How do I test this?
             TokenKind::RawKeyword => Class::KeyWord,
             TokenKind::Lifetime { .. } => Class::Lifetime,
         };

--- a/src/test/ui/parser/raw/raw_keywords.rs
+++ b/src/test/ui/parser/raw/raw_keywords.rs
@@ -1,0 +1,82 @@
+// check-fail
+
+macro_rules! one_token   { ( $a:tt ) => { }; }
+macro_rules! two_tokens { ( $a:tt $b:tt ) => { }; }
+macro_rules! three_tokens { ( $a:tt $b:tt $c:tt) => { }; }
+macro_rules! four_tokens { ( $a:tt $b:tt $c:tt $d:tt ) => { }; }
+
+fn main() {
+    // Intended raw keyword syntax
+    one_token!(k#ident);
+    //~^ ERROR raw keyword syntax is reserved for future use
+    one_token!(k#fn);
+    //~^ ERROR raw keyword syntax is reserved for future use
+    one_token!(k#Self);
+    //~^ ERROR raw keyword syntax is reserved for future use
+    one_token!(k#dyn);
+    //~^ ERROR raw keyword syntax is reserved for future use
+    one_token!(k#await);
+    //~^ ERROR raw keyword syntax is reserved for future use
+
+    // This was previously valid in `quote!` macros, where `k` was a variable.
+    two_tokens!(#k#other_variable);
+    //~^ ERROR raw keyword syntax is reserved for future use
+
+    // weird interactions with raw literals.
+    two_tokens!(k#r"raw string");
+    //~^ ERROR raw keyword syntax is reserved for future use
+    two_tokens!(k#r "raw string");
+    //~^ ERROR raw keyword syntax is reserved for future use
+    two_tokens!(k#br"raw byte string");
+    //~^ ERROR raw keyword syntax is reserved for future use
+    three_tokens!(k#r"raw string"#);
+    //~^ ERROR raw keyword syntax is reserved for future use
+    four_tokens!(k#r#"raw string"#);
+    //~^ ERROR raw keyword syntax is reserved for future use
+    two_tokens!(k#b'-');
+    //~^ ERROR raw keyword syntax is reserved for future use
+    two_tokens!(k#b '-');
+    //~^ ERROR raw keyword syntax is reserved for future use
+
+    // weird raw idents
+    one_token!(r#k);
+    two_tokens!(r#k#);
+    three_tokens!(r#k#ident);
+    two_tokens!(r#k ident);
+    three_tokens!(r#k#r);
+    three_tokens!(r#k#r#ident);
+
+    // Inserting a whitespace gets you the previous lexing behaviour
+    three_tokens!(k# ident);
+    three_tokens!(k #ident);
+    three_tokens!(k # ident);
+
+    // These should work anyway
+    two_tokens!(k#);
+    two_tokens!(k #);
+    three_tokens!(k#123);
+    three_tokens!(k#"normal string");
+    three_tokens!(k#'c');
+    three_tokens!(k#'lifetime);
+    three_tokens!(k#[doc("doc attribute")]);
+
+    #[cfg(False)]
+    mod inside_cfg_false {
+        const k#SOMETHING: i32 = 42;
+        //~^ ERROR raw keyword syntax is reserved for future use
+    }
+
+    fn returns_k() -> i32 {
+        let k = 42;
+        k#k
+        //~^ ERROR raw keyword syntax is reserved for future use
+    }
+
+
+    // Test that the token counting macros actually count the right amount of tokens.
+    two_tokens!(k#knampf);
+    //~^ ERROR unexpected end of macro invocation
+    //~^^ ERROR raw keyword syntax is reserved for future use
+    two_tokens!(k # knampf);
+    //~^ ERROR no rules expected the token `knampf`
+}

--- a/src/test/ui/parser/raw/raw_keywords.stderr
+++ b/src/test/ui/parser/raw/raw_keywords.stderr
@@ -1,0 +1,116 @@
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:10:16
+   |
+LL |     one_token!(k#ident);
+   |                ^^^^^^^ help: insert a whitespace: `k #ident`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:12:16
+   |
+LL |     one_token!(k#fn);
+   |                ^^^^ help: insert a whitespace: `k #fn`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:14:16
+   |
+LL |     one_token!(k#Self);
+   |                ^^^^^^ help: insert a whitespace: `k #Self`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:16:16
+   |
+LL |     one_token!(k#dyn);
+   |                ^^^^^ help: insert a whitespace: `k #dyn`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:18:16
+   |
+LL |     one_token!(k#await);
+   |                ^^^^^^^ help: insert a whitespace: `k #await`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:22:18
+   |
+LL |     two_tokens!(#k#other_variable);
+   |                  ^^^^^^^^^^^^^^^^ help: insert a whitespace: `k #other_variable`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:26:17
+   |
+LL |     two_tokens!(k#r"raw string");
+   |                 ^^^ help: insert a whitespace: `k #r`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:28:17
+   |
+LL |     two_tokens!(k#r "raw string");
+   |                 ^^^ help: insert a whitespace: `k #r`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:30:17
+   |
+LL |     two_tokens!(k#br"raw byte string");
+   |                 ^^^^ help: insert a whitespace: `k #br`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:32:19
+   |
+LL |     three_tokens!(k#r"raw string"#);
+   |                   ^^^ help: insert a whitespace: `k #r`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:34:18
+   |
+LL |     four_tokens!(k#r#"raw string"#);
+   |                  ^^^ help: insert a whitespace: `k #r`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:36:17
+   |
+LL |     two_tokens!(k#b'-');
+   |                 ^^^ help: insert a whitespace: `k #b`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:38:17
+   |
+LL |     two_tokens!(k#b '-');
+   |                 ^^^ help: insert a whitespace: `k #b`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:65:15
+   |
+LL |         const k#SOMETHING: i32 = 42;
+   |               ^^^^^^^^^^^ help: insert a whitespace: `k #SOMETHING`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:71:9
+   |
+LL |         k#k
+   |         ^^^ help: insert a whitespace: `k #k`
+
+error: raw keyword syntax is reserved for future use
+  --> $DIR/raw_keywords.rs:77:17
+   |
+LL |     two_tokens!(k#knampf);
+   |                 ^^^^^^^^ help: insert a whitespace: `k #knampf`
+
+error: unexpected end of macro invocation
+  --> $DIR/raw_keywords.rs:77:25
+   |
+LL | macro_rules! two_tokens { ( $a:tt $b:tt ) => { }; }
+   | ----------------------- when calling this macro
+...
+LL |     two_tokens!(k#knampf);
+   |                         ^ missing tokens in macro arguments
+
+error: no rules expected the token `knampf`
+  --> $DIR/raw_keywords.rs:80:21
+   |
+LL | macro_rules! two_tokens { ( $a:tt $b:tt ) => { }; }
+   | ----------------------- when calling this macro
+...
+LL |     two_tokens!(k # knampf);
+   |                     ^^^^^^ no rules expected this token in macro call
+
+error: aborting due to 18 previous errors
+


### PR DESCRIPTION
This PR makes the raw keyword syntax from rust-lang/rfcs#3098 a hard error on all editions. (In contrast to what the RFC currently says.)

```
error: raw keyword syntax is reserved for future use
   |
LL |     one_token!(k#ident);
   |                ^^^^^^^ help: insert a whitespace: `k #ident`
```

More specifically, it becomes a tokenization error, so macros cannot use it. `k#ident` is now lexed as one token, similar to `r#ident`, although this could be changed later without breaking anything. 

Note that this is a breaking change, since macros previously interpreted it as three tokens, so something like `quote!{ #k#other_variable }` was valid. The [crater run](https://github.com/rust-lang/rust/pull/84037#issuecomment-830840063) showed no real regressions though.  You can easily get the old behavior by inserting a whitespace between `k` and `#`. 

The actual raw keywords feature for things like `k#async` is _not_ implemented here.


Previously, this PR was inteded to do a crater run for all reserved prefixes from  rust-lang/rfcs#3101, but even the try build ran into breakage in the ecosystem, so only `k#...` was tested.
