### PR TITLE
Deny float matches

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1682,7 +1682,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```rust,compile_fail
     /// let x = 42.0;
     ///
     /// match x {
@@ -1717,7 +1717,7 @@ declare_lint! {
     /// [match guard]: https://doc.rust-lang.org/reference/expressions/match-expr.html#match-guards
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub ILLEGAL_FLOATING_POINT_LITERAL_PATTERN,
-    Warn,
+    Deny,
     "floating-point literals cannot be used in patterns",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #41620 <https://github.com/rust-lang/rust/issues/41620>",

--- a/src/test/ui/deduplicate-diagnostics-2.deduplicate.stderr
+++ b/src/test/ui/deduplicate-diagnostics-2.deduplicate.stderr
@@ -1,15 +1,15 @@
-warning: floating-point types cannot be used in patterns
-  --> $DIR/deduplicate-diagnostics-2.rs:7:9
+error: floating-point types cannot be used in patterns
+  --> $DIR/deduplicate-diagnostics-2.rs:6:9
    |
 LL |         1.0 => {}
    |         ^^^
    |
-   = note: `#[warn(illegal_floating_point_literal_pattern)]` on by default
+   = note: `#[deny(illegal_floating_point_literal_pattern)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: floating-point types cannot be used in patterns
-  --> $DIR/deduplicate-diagnostics-2.rs:11:9
+error: floating-point types cannot be used in patterns
+  --> $DIR/deduplicate-diagnostics-2.rs:10:9
    |
 LL |         2.0 => {}
    |         ^^^
@@ -17,8 +17,8 @@ LL |         2.0 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: floating-point types cannot be used in patterns
-  --> $DIR/deduplicate-diagnostics-2.rs:7:9
+error: floating-point types cannot be used in patterns
+  --> $DIR/deduplicate-diagnostics-2.rs:6:9
    |
 LL |         1.0 => {}
    |         ^^^
@@ -26,5 +26,5 @@ LL |         1.0 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: 3 warnings emitted
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/deduplicate-diagnostics-2.duplicate.stderr
+++ b/src/test/ui/deduplicate-diagnostics-2.duplicate.stderr
@@ -1,15 +1,15 @@
-warning: floating-point types cannot be used in patterns
-  --> $DIR/deduplicate-diagnostics-2.rs:7:9
+error: floating-point types cannot be used in patterns
+  --> $DIR/deduplicate-diagnostics-2.rs:6:9
    |
 LL |         1.0 => {}
    |         ^^^
    |
-   = note: `#[warn(illegal_floating_point_literal_pattern)]` on by default
+   = note: `#[deny(illegal_floating_point_literal_pattern)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: floating-point types cannot be used in patterns
-  --> $DIR/deduplicate-diagnostics-2.rs:11:9
+error: floating-point types cannot be used in patterns
+  --> $DIR/deduplicate-diagnostics-2.rs:10:9
    |
 LL |         2.0 => {}
    |         ^^^
@@ -17,8 +17,8 @@ LL |         2.0 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: floating-point types cannot be used in patterns
-  --> $DIR/deduplicate-diagnostics-2.rs:7:9
+error: floating-point types cannot be used in patterns
+  --> $DIR/deduplicate-diagnostics-2.rs:6:9
    |
 LL |         1.0 => {}
    |         ^^^
@@ -26,8 +26,8 @@ LL |         1.0 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: floating-point types cannot be used in patterns
-  --> $DIR/deduplicate-diagnostics-2.rs:11:9
+error: floating-point types cannot be used in patterns
+  --> $DIR/deduplicate-diagnostics-2.rs:10:9
    |
 LL |         2.0 => {}
    |         ^^^
@@ -35,5 +35,5 @@ LL |         2.0 => {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: 4 warnings emitted
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/deduplicate-diagnostics-2.rs
+++ b/src/test/ui/deduplicate-diagnostics-2.rs
@@ -1,16 +1,15 @@
-// build-pass
 // revisions: duplicate deduplicate
 //[deduplicate] compile-flags: -Z deduplicate-diagnostics=yes
 
 fn main() {
     match 0.0 {
-        1.0 => {} //~ WARNING floating-point types cannot be used in patterns
+        1.0 => {} //~ ERROR floating-point types cannot be used in patterns
                   //~| WARNING this was previously accepted
-                  //~| WARNING floating-point types cannot be used in patterns
+                  //~| ERROR floating-point types cannot be used in patterns
                   //~| WARNING this was previously accepted
-        2.0 => {} //~ WARNING floating-point types cannot be used in patterns
+        2.0 => {} //~ ERROR floating-point types cannot be used in patterns
                   //~| WARNING this was previously accepted
-                  //[duplicate]~| WARNING floating-point types cannot be used in patterns
+                  //[duplicate]~| ERROR floating-point types cannot be used in patterns
                   //[duplicate]~| WARNING this was previously accepted
         _ => {}
     }

--- a/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.rs
+++ b/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.rs
@@ -16,9 +16,9 @@ fn main() {
     let x = 0.0;
     match x {
         f32::INFINITY => { }
-        //~^ WARNING floating-point types cannot be used in patterns
+        //~^ ERROR floating-point types cannot be used in patterns
         //~| WARNING will become a hard error in a future release
-        //~| WARNING floating-point types cannot be used in patterns
+        //~| ERROR floating-point types cannot be used in patterns
         //~| WARNING this was previously accepted by the compiler but is being phased out
         _ => { }
     }

--- a/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc-1445-restrict-constants-in-patterns/match-forbidden-without-eq.stderr
@@ -4,17 +4,17 @@ error: to use a constant of type `Foo` in a pattern, `Foo` must be annotated wit
 LL |         FOO => { }
    |         ^^^
 
-warning: floating-point types cannot be used in patterns
+error: floating-point types cannot be used in patterns
   --> $DIR/match-forbidden-without-eq.rs:18:9
    |
 LL |         f32::INFINITY => { }
    |         ^^^^^^^^^^^^^
    |
-   = note: `#[warn(illegal_floating_point_literal_pattern)]` on by default
+   = note: `#[deny(illegal_floating_point_literal_pattern)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-warning: floating-point types cannot be used in patterns
+error: floating-point types cannot be used in patterns
   --> $DIR/match-forbidden-without-eq.rs:18:9
    |
 LL |         f32::INFINITY => { }
@@ -23,5 +23,5 @@ LL |         f32::INFINITY => { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-error: aborting due to previous error; 2 warnings emitted
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
This upgrades the "warn on float literals in patterns" lint tracked in https://github.com/rust-lang/rust/issues/41620 to "deny". It's been quite enough time since rustc started issuing the warning.

I believe this probably should be run against crater first. Though it's not like it hasn't been an entire edition since the warning went up.