### PR TITLE
fix incorrect Box::from_raw_in doctest

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -793,7 +793,7 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     /// use std::alloc::{Allocator, Layout, System};
     ///
     /// unsafe {
-    ///     let ptr = System.allocate(Layout::new::<i32>())?.as_mut_ptr();
+    ///     let ptr = System.allocate(Layout::new::<i32>())?.as_mut_ptr() as *mut i32;
     ///     // In general .write is required to avoid attempting to destruct
     ///     // the (uninitialized) previous contents of `ptr`, though for this
     ///     // simple example `*ptr = 5` would have worked as well.


### PR DESCRIPTION
Now that Miri can run doctests, I ran it on liballoc, and found exactly one problem: this test creates a `Box<u8>` to deallocate a 4-byte allocation!

Introduced by https://github.com/rust-lang/rust/pull/80310 so r? @Manishearth @kennytm 