### PR TITLE
Add unstable <[T]>::{position, rposition} functions

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1965,6 +1965,69 @@ impl<T> [T] {
         cmp::SliceContains::slice_contains(x, self)
     }
 
+    /// If the slice contains at least one element with the given
+    /// value, returns the first index of that value. Otherwise,
+    /// returns `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_position)]
+    /// let v = [10, 40, 30, 20, 30];
+    /// assert_eq!(v.position(&30), Some(2));
+    /// assert!(v.position(&50).is_none());
+    /// ```
+    ///
+    /// If you do not have an `&T`, but just an `&U` such that `T: Borrow<U>`
+    /// (e.g. `String: Borrow<str>`), you can use `iter().position`:
+    ///
+    /// ```
+    /// // slice of `String`
+    /// let v = [String::from("hello"), String::from("world")];
+    /// // search with `&str`
+    /// assert_eq!(v.iter().position(|e| e == "hello"), Some(0));
+    /// assert_eq!(v.iter().position(|e| e == "hi"), None);
+    /// ```
+    #[unstable(feature = "slice_position", issue = "none", reason = "recently added")]
+    #[inline]
+    pub fn position(&self, x: &T) -> Option<usize>
+    where
+        T: PartialEq,
+    {
+        cmp::SlicePosition::slice_position(x, self)
+    }
+
+    /// If the slice contains at element with the given value, returns
+    /// the last index of that value. Otherwise, returns `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(slice_position)]
+    /// let v = [10, 40, 30, 20, 30];
+    /// assert_eq!(v.rposition(&30), Some(4));
+    /// assert!(v.rposition(&50).is_none());
+    /// ```
+    ///
+    /// If you do not have an `&T`, but just an `&U` such that `T: Borrow<U>`
+    /// (e.g. `String: Borrow<str>`), you can use `iter().rposition`:
+    ///
+    /// ```
+    /// // slice of `String`
+    /// let v = [String::from("hello"), String::from("world")];
+    /// // search with `&str`
+    /// assert_eq!(v.iter().rposition(|e| e == "hello"), Some(0));
+    /// assert_eq!(v.iter().rposition(|e| e == "hi"), None);
+    /// ```
+    #[unstable(feature = "slice_position", issue = "none", reason = "recently added")]
+    #[inline]
+    pub fn rposition(&self, x: &T) -> Option<usize>
+    where
+        T: PartialEq,
+    {
+        cmp::SlicePosition::slice_rposition(x, self)
+    }
+
     /// Returns `true` if `needle` is a prefix of the slice.
     ///
     /// # Examples

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -73,6 +73,7 @@
 #![feature(const_option)]
 #![feature(integer_atomics)]
 #![feature(slice_group_by)]
+#![feature(slice_position)]
 #![feature(trusted_random_access)]
 #![feature(unsize)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2026,6 +2026,37 @@ fn test_is_sorted() {
 }
 
 #[test]
+fn test_iter_position() {
+    // unspecialized
+    assert_eq!([1u32, 2, 2, 9].position(&2), Some(1));
+    assert_eq!([1u32, 2, 2, 9].rposition(&2), Some(2));
+    assert_eq!([1u32, 2, 2, 9].position(&1), Some(0));
+    assert_eq!([1u32, 2, 2, 9].rposition(&1), Some(0));
+    assert_eq!([1u32, 2, 2, 9].position(&9), Some(3));
+    assert_eq!([1u32, 2, 2, 9].rposition(&9), Some(3));
+    assert_eq!([1u32, 2, 2, 9].rposition(&6), None);
+    assert_eq!([1u32, 2, 2, 9].position(&6), None);
+    // specialized
+    assert_eq!([1u8, 2, 2, 9].position(&2), Some(1));
+    assert_eq!([1u8, 2, 2, 9].rposition(&2), Some(2));
+    assert_eq!([1u8, 2, 2, 9].position(&1), Some(0));
+    assert_eq!([1u8, 2, 2, 9].rposition(&1), Some(0));
+    assert_eq!([1u8, 2, 2, 9].position(&9), Some(3));
+    assert_eq!([1u8, 2, 2, 9].rposition(&9), Some(3));
+    assert_eq!([1u8, 2, 2, 9].rposition(&6), None);
+    assert_eq!([1u8, 2, 2, 9].position(&6), None);
+    // also specilaized
+    assert_eq!([1i8, 2, 2, 9].position(&2), Some(1));
+    assert_eq!([1i8, 2, 2, 9].rposition(&2), Some(2));
+    assert_eq!([1i8, 2, 2, 9].position(&1), Some(0));
+    assert_eq!([1i8, 2, 2, 9].rposition(&1), Some(0));
+    assert_eq!([1i8, 2, 2, 9].position(&9), Some(3));
+    assert_eq!([1i8, 2, 2, 9].rposition(&9), Some(3));
+    assert_eq!([1i8, 2, 2, 9].rposition(&6), None);
+    assert_eq!([1i8, 2, 2, 9].position(&6), None);
+}
+
+#[test]
 fn test_slice_run_destructors() {
     // Make sure that destructors get run on slice literals
     struct Foo<'a> {


### PR DESCRIPTION
These are essentially analogous to what `<[T]>::contains` is to `slice::Iter::any`.

The APIs in question are (see the commit diff for the doc comments and such, ofc)
```rust
impl [T] {
    pub fn position(&self, x: &T) -> Option<usize> where T: PartialEq;

    pub fn rposition(&self, x: &T) -> Option<usize> where T: PartialEq;
}
```

The primary reason for adding these when the iterator methods already exist, is that for primitives they can be specialized to use significantly faster search operations. Right now, this is done for `u8` and `i8`, since we already have a serviceable implementation of `memchr` right there (even if it's not the fastest, it will likely eventually be improved, and it's easily faster than `iter().position()`).

Note however, that i8/u8 are not the only reasons to add these. Eventually (such as when portable simd is more usable) a specialization for  `u16`, `i16`, `u32`, `i32` `f32`, `char`... (and really, all the primitives) could be provided with simd and give slices of those types a substantial performance boost.

Regarding the name, I'm not really that tied to this one, but it seems unambiguous given that it mirrors the name on iterators.

I'll file a tracking issue once I have a better idea if these will land or not.