### PR TITLE
clean up example on read_to_string

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -265,8 +265,9 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// ```no_run
 /// use std::fs;
 /// use std::net::SocketAddr;
+/// use std::error::Error;
 ///
-/// fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
+/// fn main() -> Result<(), Box<dyn Error>> {
 ///     let foo: SocketAddr = fs::read_to_string("address.txt")?.parse()?;
 ///     Ok(())
 /// }


### PR DESCRIPTION
This is the same thing, but simpler.

This came out of a comment from a user: https://news.ycombinator.com/item?id=25318117 but rather than hide the signature of main, I think a `use` plus not including the `'static` makes more sense.