### PR TITLE
Allow setting `target_family` to multiple values, and implement `target_family="wasm"`

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -813,7 +813,7 @@ pub fn default_configuration(sess: &Session) -> CrateConfig {
     ret.reserve(6); // the minimum number of insertions
     // Target bindings.
     ret.insert((sym::target_os, Some(Symbol::intern(os))));
-    if let Some(ref fam) = sess.target.os_family {
+    for fam in &sess.target.families {
         ret.insert((sym::target_family, Some(Symbol::intern(fam))));
         if fam == "windows" {
             ret.insert((sym::windows, None));

--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -23,7 +23,7 @@ pub fn opts(os: &str) -> TargetOptions {
         function_sections: false,
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         is_like_osx: true,
         dwarf_version: Some(2),
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/dragonfly_base.rs
+++ b/compiler/rustc_target/src/spec/dragonfly_base.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
         os: "dragonfly".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         linker_is_gnu: true,
         has_rpath: true,
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/freebsd_base.rs
+++ b/compiler/rustc_target/src/spec/freebsd_base.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
         os: "freebsd".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         linker_is_gnu: true,
         has_rpath: true,
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/fuchsia_base.rs
+++ b/compiler/rustc_target/src/spec/fuchsia_base.rs
@@ -25,7 +25,7 @@ pub fn opts() -> TargetOptions {
         linker: Some("rust-lld".to_owned()),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         is_like_fuchsia: true,
         linker_is_gnu: true,
         pre_link_args,

--- a/compiler/rustc_target/src/spec/haiku_base.rs
+++ b/compiler/rustc_target/src/spec/haiku_base.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
         os: "haiku".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         relro_level: RelroLevel::Full,
         linker_is_gnu: true,
         ..Default::default()

--- a/compiler/rustc_target/src/spec/illumos_base.rs
+++ b/compiler/rustc_target/src/spec/illumos_base.rs
@@ -20,7 +20,7 @@ pub fn opts() -> TargetOptions {
         dynamic_linking: true,
         executables: true,
         has_rpath: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         is_like_solaris: true,
         limit_rdylib_exports: false, // Linker doesn't support this
         eliminate_frame_pointer: false,

--- a/compiler/rustc_target/src/spec/l4re_base.rs
+++ b/compiler/rustc_target/src/spec/l4re_base.rs
@@ -20,7 +20,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         panic_strategy: PanicStrategy::Abort,
         linker: Some("ld".to_string()),
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/linux_base.rs
+++ b/compiler/rustc_target/src/spec/linux_base.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
         os: "linux".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         linker_is_gnu: true,
         has_rpath: true,
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1042,8 +1042,12 @@ pub struct TargetOptions {
     pub staticlib_prefix: String,
     /// String to append to the name of every static library. Defaults to ".a".
     pub staticlib_suffix: String,
-    /// OS family to use for conditional compilation. Valid options: "unix", "windows".
-    pub os_family: Option<String>,
+    /// Values of the `target_family` cfg set for this target.
+    ///
+    /// Common options are: "unix", "windows". Defaults to no families.
+    ///
+    /// See https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
+    pub families: Vec<String>,
     /// Whether the target toolchain's ABI supports returning small structs as an integer.
     pub abi_return_struct_as_int: bool,
     /// Whether the target toolchain is like macOS's. Only useful for compiling against iOS/macOS,
@@ -1293,7 +1297,7 @@ impl Default for TargetOptions {
             exe_suffix: String::new(),
             staticlib_prefix: "lib".to_string(),
             staticlib_suffix: ".a".to_string(),
-            os_family: None,
+            families: Vec::new(),
             abi_return_struct_as_int: false,
             is_like_osx: false,
             is_like_solaris: false,
@@ -1605,14 +1609,6 @@ impl Target {
                         .map(|s| s.to_string() );
                 }
             } );
-            ($key_name:ident = $json_name:expr, optional) => ( {
-                let name = $json_name;
-                if let Some(o) = obj.find(name) {
-                    base.$key_name = o
-                        .as_string()
-                        .map(|s| s.to_string() );
-                }
-            } );
             ($key_name:ident, LldFlavor) => ( {
                 let name = (stringify!($key_name)).replace("_", "-");
                 obj.find(&name[..]).and_then(|o| o.as_string().and_then(|s| {
@@ -1759,6 +1755,16 @@ impl Target {
                     Some(Ok(()))
                 })).unwrap_or(Ok(()))
             } );
+            ($key_name:ident, TargetFamilies) => ( {
+                let value = obj.find("target-family");
+                if let Some(v) = value.and_then(Json::as_array) {
+                    base.$key_name = v.iter()
+                        .map(|a| a.as_string().unwrap().to_string())
+                        .collect();
+                } else if let Some(v) = value.and_then(Json::as_string) {
+                    base.$key_name = vec![v.to_string()];
+                }
+            } );
         }
 
         if let Some(s) = obj.find("target-endian").and_then(Json::as_string) {
@@ -1802,7 +1808,7 @@ impl Target {
         key!(exe_suffix);
         key!(staticlib_prefix);
         key!(staticlib_suffix);
-        key!(os_family = "target-family", optional);
+        key!(families, TargetFamilies);
         key!(abi_return_struct_as_int, bool);
         key!(is_like_osx, bool);
         key!(is_like_solaris, bool);
@@ -2042,7 +2048,7 @@ impl ToJson for Target {
         target_option_val!(exe_suffix);
         target_option_val!(staticlib_prefix);
         target_option_val!(staticlib_suffix);
-        target_option_val!(os_family, "target-family");
+        target_option_val!(families, "target-family");
         target_option_val!(abi_return_struct_as_int);
         target_option_val!(is_like_osx);
         target_option_val!(is_like_solaris);

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1046,7 +1046,7 @@ pub struct TargetOptions {
     ///
     /// Common options are: "unix", "windows". Defaults to no families.
     ///
-    /// See https://doc.rust-lang.org/reference/conditional-compilation.html#target_family
+    /// See <https://doc.rust-lang.org/reference/conditional-compilation.html#target_family>.
     pub families: Vec<String>,
     /// Whether the target toolchain's ABI supports returning small structs as an integer.
     pub abi_return_struct_as_int: bool,

--- a/compiler/rustc_target/src/spec/netbsd_base.rs
+++ b/compiler/rustc_target/src/spec/netbsd_base.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
         os: "netbsd".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         linker_is_gnu: true,
         no_default_libraries: false,
         has_rpath: true,

--- a/compiler/rustc_target/src/spec/openbsd_base.rs
+++ b/compiler/rustc_target/src/spec/openbsd_base.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
         os: "openbsd".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         linker_is_gnu: true,
         has_rpath: true,
         abi_return_struct_as_int: true,

--- a/compiler/rustc_target/src/spec/redox_base.rs
+++ b/compiler/rustc_target/src/spec/redox_base.rs
@@ -6,7 +6,7 @@ pub fn opts() -> TargetOptions {
         env: "relibc".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         linker_is_gnu: true,
         has_rpath: true,
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/solaris_base.rs
+++ b/compiler/rustc_target/src/spec/solaris_base.rs
@@ -6,7 +6,7 @@ pub fn opts() -> TargetOptions {
         dynamic_linking: true,
         executables: true,
         has_rpath: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         is_like_solaris: true,
         limit_rdylib_exports: false, // Linker doesn't support this
         eh_frame_header: false,

--- a/compiler/rustc_target/src/spec/vxworks_base.rs
+++ b/compiler/rustc_target/src/spec/vxworks_base.rs
@@ -9,7 +9,7 @@ pub fn opts() -> TargetOptions {
         exe_suffix: ".vxe".to_string(),
         dynamic_linking: true,
         executables: true,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         linker_is_gnu: true,
         has_rpath: true,
         has_elf_tls: true,

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -38,7 +38,7 @@ pub fn target() -> Target {
         is_like_emscripten: true,
         panic_strategy: PanicStrategy::Unwind,
         post_link_args,
-        os_family: Some("unix".to_string()),
+        families: vec!["unix".to_string()],
         ..options
     };
     Target {

--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -61,6 +61,7 @@ pub fn options() -> TargetOptions {
 
     TargetOptions {
         is_like_wasm: true,
+        families: vec!["wasm".to_string()],
 
         // we allow dynamic linking, but only cdylibs. Basically we allow a
         // final library artifact that exports some symbols (a wasm module) but

--- a/compiler/rustc_target/src/spec/windows_gnu_base.rs
+++ b/compiler/rustc_target/src/spec/windows_gnu_base.rs
@@ -71,7 +71,7 @@ pub fn opts() -> TargetOptions {
         dll_prefix: String::new(),
         dll_suffix: ".dll".to_string(),
         exe_suffix: ".exe".to_string(),
-        os_family: Some("windows".to_string()),
+        families: vec!["windows".to_string()],
         is_like_windows: true,
         allows_weak_linkage: false,
         pre_link_args,

--- a/compiler/rustc_target/src/spec/windows_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/windows_msvc_base.rs
@@ -13,7 +13,7 @@ pub fn opts() -> TargetOptions {
         exe_suffix: ".exe".to_string(),
         staticlib_prefix: String::new(),
         staticlib_suffix: ".lib".to_string(),
-        os_family: Some("windows".to_string()),
+        families: vec!["windows".to_string()],
         crt_static_allows_dylibs: true,
         crt_static_respected: true,
         requires_uwtable: true,

--- a/src/test/ui/cfg/cfg-family.rs
+++ b/src/test/ui/cfg/cfg-family.rs
@@ -1,6 +1,6 @@
-// run-pass
+// build-pass
 // pretty-expanded FIXME #23616
-// ignore-wasm32-bare no target_family
+// ignore-wasm32-bare no bare family
 // ignore-sgx
 
 #[cfg(windows)]

--- a/src/test/ui/cfg/cfg-target-family.rs
+++ b/src/test/ui/cfg/cfg-target-family.rs
@@ -1,5 +1,4 @@
-// run-pass
-// ignore-wasm32-bare no target_family
+// build-pass
 // ignore-sgx
 
 // pretty-expanded FIXME #23616
@@ -9,5 +8,9 @@ pub fn main() {
 }
 
 #[cfg(target_family = "unix")]
+pub fn main() {
+}
+
+#[cfg(target_family="wasm")]
 pub fn main() {
 }


### PR DESCRIPTION
As per the conclusion in [this thread](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Are.20we.20comfortable.20with.20adding.20an.20insta-stable.20cfg.28wasm.29.3F/near/233158441), this implements an ability to specify any number of `target_family` values, allowing for more flexible generic groups, or "families", to be created than just the OS-based unix/windows dichotomy.

cc https://github.com/rust-lang/reference/pull/1006