### PR TITLE
rustdoc: clean up and test macro visibility print

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2287,14 +2287,14 @@ impl Clean<Item> for (&hir::MacroDef<'_>, Option<Symbol>) {
             if matchers.len() <= 1 {
                 format!(
                     "{}macro {}{} {{\n    ...\n}}",
-                    vis.print_with_space(cx.tcx, def_id, &cx.cache),
+                    vis.to_src_with_space(cx.tcx, def_id),
                     name,
                     matchers.iter().map(|span| span.to_src(cx)).collect::<String>(),
                 )
             } else {
                 format!(
                     "{}macro {} {{\n{}}}",
-                    vis.print_with_space(cx.tcx, def_id, &cx.cache),
+                    vis.to_src_with_space(cx.tcx, def_id),
                     name,
                     matchers
                         .iter()

--- a/src/test/rustdoc/decl_macro.rs
+++ b/src/test/rustdoc/decl_macro.rs
@@ -1,3 +1,5 @@
+// compile-flags: --document-private-items
+
 #![feature(decl_macro)]
 
 // @has decl_macro/macro.my_macro.html //pre 'pub macro my_macro() {'
@@ -36,4 +38,19 @@ pub macro my_macro_multi {
 // @has - //pre '}'
 pub macro by_example_single {
     ($foo:expr) => {}
+}
+
+mod a {
+    mod b {
+        // @has decl_macro/a/b/macro.by_example_vis.html //pre 'pub(super) macro by_example_vis($foo:expr) {'
+        pub(in super) macro by_example_vis {
+            ($foo:expr) => {}
+        }
+        mod c {
+            // @has decl_macro/a/b/c/macro.by_example_vis_named.html //pre 'pub(in a) macro by_example_vis_named($foo:expr) {'
+            pub(in a) macro by_example_vis_named {
+                ($foo:expr) => {}
+            }
+        }
+    }
 }


### PR DESCRIPTION
This fixes the overly-complex invariant mentioned in <https://github.com/rust-lang/rust/pull/83237#issuecomment-815346570>, where the macro source can't have any links in it only because the cache hasn't been populated yet.