### PR TITLE
Stabilize nonzero_leading_trailing_zeros

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1543,7 +1543,7 @@ extern "rust-intrinsic" {
     /// let num_trailing = unsafe { cttz_nonzero(x) };
     /// assert_eq!(num_trailing, 3);
     /// ```
-    #[rustc_const_unstable(feature = "const_cttz", issue = "none")]
+    #[rustc_const_stable(feature = "const_cttz", since = "1.53.0")]
     pub fn cttz_nonzero<T: Copy>(x: T) -> T;
 
     /// Reverses the bytes in an integer type `T`.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -79,7 +79,6 @@
 #![feature(const_int_unchecked_arith)]
 #![feature(const_mut_refs)]
 #![feature(const_refs_to_cell)]
-#![feature(const_cttz)]
 #![feature(const_panic)]
 #![feature(const_pin)]
 #![feature(const_fn)]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -191,13 +191,12 @@ macro_rules! nonzero_leading_trailing_zeros {
                 /// Basic usage:
                 ///
                 /// ```
-                /// #![feature(nonzero_leading_trailing_zeros)]
                 #[doc = concat!("let n = std::num::", stringify!($Ty), "::new(", stringify!($LeadingTestExpr), ").unwrap();")]
                 ///
                 /// assert_eq!(n.leading_zeros(), 0);
                 /// ```
-                #[unstable(feature = "nonzero_leading_trailing_zeros", issue = "79143")]
-                #[rustc_const_unstable(feature = "nonzero_leading_trailing_zeros", issue = "79143")]
+                #[stable(feature = "nonzero_leading_trailing_zeros", since = "1.53.0")]
+                #[rustc_const_stable(feature = "nonzero_leading_trailing_zeros", since = "1.53.0")]
                 #[inline]
                 pub const fn leading_zeros(self) -> u32 {
                     // SAFETY: since `self` can not be zero it is safe to call ctlz_nonzero
@@ -214,13 +213,12 @@ macro_rules! nonzero_leading_trailing_zeros {
                 /// Basic usage:
                 ///
                 /// ```
-                /// #![feature(nonzero_leading_trailing_zeros)]
                 #[doc = concat!("let n = std::num::", stringify!($Ty), "::new(0b0101000).unwrap();")]
                 ///
                 /// assert_eq!(n.trailing_zeros(), 3);
                 /// ```
-                #[unstable(feature = "nonzero_leading_trailing_zeros", issue = "79143")]
-                #[rustc_const_unstable(feature = "nonzero_leading_trailing_zeros", issue = "79143")]
+                #[stable(feature = "nonzero_leading_trailing_zeros", since = "1.53.0")]
+                #[rustc_const_stable(feature = "nonzero_leading_trailing_zeros", since = "1.53.0")]
                 #[inline]
                 pub const fn trailing_zeros(self) -> u32 {
                     // SAFETY: since `self` can not be zero it is safe to call cttz_nonzero

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -69,7 +69,6 @@
 #![feature(ptr_metadata)]
 #![feature(once_cell)]
 #![feature(unsized_tuple_coercion)]
-#![feature(nonzero_leading_trailing_zeros)]
 #![feature(const_option)]
 #![feature(integer_atomics)]
 #![feature(slice_group_by)]

--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -186,4 +186,13 @@ const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
 //~^ ERROR any use of this value will cause an error
 //~| WARN this was previously accepted by the compiler but is being phased out
 
+// capture fault with zero value
+
+const _: u32 = unsafe { std::intrinsics::ctlz_nonzero(0) };
+//~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
+const _: u32 = unsafe { std::intrinsics::cttz_nonzero(0) };
+//~^ ERROR any use of this value will cause an error
+//~| WARN this was previously accepted by the compiler but is being phased out
+
 fn main() {}

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -516,5 +516,27 @@ LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error: aborting due to 47 previous errors
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:191:25
+   |
+LL | const _: u32 = unsafe { std::intrinsics::ctlz_nonzero(0) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         `ctlz_nonzero` called on 0
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: any use of this value will cause an error
+  --> $DIR/const-int-unchecked.rs:194:25
+   |
+LL | const _: u32 = unsafe { std::intrinsics::cttz_nonzero(0) };
+   | ------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                         |
+   |                         `cttz_nonzero` called on 0
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 49 previous errors
 


### PR DESCRIPTION
Stabilizing nonzero_leading_trailing_zeros and due to this also stabilizing the intrinsic cttz_nonzero

FCP finished here: https://github.com/rust-lang/rust/issues/79143#issuecomment-817216153
@rustbot modify labels: +T-libs

Closes #79143