### PR TITLE
Stabilize const_cell_into_inner.

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -416,7 +416,7 @@ impl<T> Cell<T> {
     /// assert_eq!(five, 5);
     /// ```
     #[stable(feature = "move_cell", since = "1.17.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+    #[rustc_const_stable(feature = "const_cell_into_inner", since = "1.59.0")]
     pub const fn into_inner(self) -> T {
         self.value.into_inner()
     }
@@ -731,7 +731,7 @@ impl<T> RefCell<T> {
     /// let five = c.into_inner();
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+    #[rustc_const_stable(feature = "const_cell_into_inner", since = "1.59.0")]
     #[inline]
     pub const fn into_inner(self) -> T {
         // Since this function takes `self` (the `RefCell`) by value, the
@@ -1884,7 +1884,7 @@ impl<T> UnsafeCell<T> {
     /// ```
     #[inline(always)]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+    #[rustc_const_stable(feature = "const_cell_into_inner", since = "1.59.0")]
     pub const fn into_inner(self) -> T {
         self.value
     }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -103,7 +103,6 @@
 #![feature(const_arguments_as_str)]
 #![feature(const_bigint_helper_methods)]
 #![feature(const_caller_location)]
-#![feature(const_cell_into_inner)]
 #![feature(const_char_convert)]
 #![feature(const_discriminant)]
 #![feature(const_eval_select)]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -354,7 +354,7 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+    #[rustc_const_stable(feature = "const_cell_into_inner", since = "1.59.0")]
     pub const fn into_inner(self) -> bool {
         self.v.into_inner() != 0
     }
@@ -960,7 +960,7 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "atomic_access", since = "1.15.0")]
-    #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+    #[rustc_const_stable(feature = "const_cell_into_inner", since = "1.59.0")]
     pub const fn into_inner(self) -> *mut T {
         self.p.into_inner()
     }
@@ -1472,7 +1472,7 @@ macro_rules! atomic_int {
             /// ```
             #[inline]
             #[$stable_access]
-            #[rustc_const_unstable(feature = "const_cell_into_inner", issue = "78729")]
+            #[rustc_const_stable(feature = "const_cell_into_inner", since = "1.59.0")]
             pub const fn into_inner(self) -> $int_type {
                 self.v.into_inner()
             }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -8,7 +8,6 @@
 #![feature(cfg_panic)]
 #![feature(cfg_target_has_atomic)]
 #![feature(const_assume)]
-#![feature(const_cell_into_inner)]
 #![feature(const_convert)]
 #![feature(const_maybe_uninit_as_mut_ptr)]
 #![feature(const_maybe_uninit_assume_init)]


### PR DESCRIPTION
FCP finished here: https://github.com/rust-lang/rust/issues/78729#issuecomment-817201304

blocked on "precise drop analysis" unstable const feature (https://github.com/rust-lang/rust/issues/73255).

closes #78729