### PR TITLE
Use BCryptGenRandom instead of RtlGenRandom on Windows.

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -262,6 +262,8 @@ pub const STACK_SIZE_PARAM_IS_A_RESERVATION: DWORD = 0x00010000;
 
 pub const STATUS_SUCCESS: NTSTATUS = 0x00000000;
 
+pub const BCRYPT_USE_SYSTEM_PREFERRED_RNG: DWORD = 0x00000002;
+
 #[repr(C)]
 #[cfg(not(target_pointer_width = "64"))]
 pub struct WSADATA {
@@ -678,10 +680,6 @@ if #[cfg(not(target_vendor = "uwp"))] {
 
     #[link(name = "advapi32")]
     extern "system" {
-        // Forbidden when targeting UWP
-        #[link_name = "SystemFunction036"]
-        pub fn RtlGenRandom(RandomBuffer: *mut u8, RandomBufferLength: ULONG) -> BOOLEAN;
-
         // Allowed but unused by UWP
         pub fn OpenProcessToken(
             ProcessHandle: HANDLE,
@@ -743,8 +741,6 @@ if #[cfg(not(target_vendor = "uwp"))] {
 // UWP specific functions & types
 cfg_if::cfg_if! {
 if #[cfg(target_vendor = "uwp")] {
-    pub const BCRYPT_USE_SYSTEM_PREFERRED_RNG: DWORD = 0x00000002;
-
     #[repr(C)]
     pub struct FILE_STANDARD_INFO {
         pub AllocationSize: LARGE_INTEGER,
@@ -754,15 +750,6 @@ if #[cfg(target_vendor = "uwp")] {
         pub Directory: BOOLEAN,
     }
 
-    #[link(name = "bcrypt")]
-    extern "system" {
-        pub fn BCryptGenRandom(
-            hAlgorithm: LPVOID,
-            pBuffer: *mut u8,
-            cbBuffer: ULONG,
-            dwFlags: ULONG,
-        ) -> LONG;
-    }
     #[link(name = "kernel32")]
     extern "system" {
         pub fn GetFileInformationByHandleEx(
@@ -1083,6 +1070,18 @@ extern "system" {
         exceptfds: *mut fd_set,
         timeout: *const timeval,
     ) -> c_int;
+}
+
+#[link(name = "bcrypt")]
+extern "system" {
+    // >= Vista / Server 2008
+    // https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom
+    pub fn BCryptGenRandom(
+        hAlgorithm: LPVOID,
+        pBuffer: *mut u8,
+        cbBuffer: ULONG,
+        dwFlags: ULONG,
+    ) -> NTSTATUS;
 }
 
 // Functions that aren't available on every version of Windows that we support,

--- a/library/std/src/sys/windows/rand.rs
+++ b/library/std/src/sys/windows/rand.rs
@@ -2,18 +2,6 @@ use crate::io;
 use crate::mem;
 use crate::sys::c;
 
-#[cfg(not(target_vendor = "uwp"))]
-pub fn hashmap_random_keys() -> (u64, u64) {
-    let mut v = (0, 0);
-    let ret =
-        unsafe { c::RtlGenRandom(&mut v as *mut _ as *mut u8, mem::size_of_val(&v) as c::ULONG) };
-    if ret == 0 {
-        panic!("couldn't generate random bytes: {}", io::Error::last_os_error());
-    }
-    v
-}
-
-#[cfg(target_vendor = "uwp")]
 pub fn hashmap_random_keys() -> (u64, u64) {
     use crate::ptr;
 

--- a/src/test/run-make-fulldeps/tools.mk
+++ b/src/test/run-make-fulldeps/tools.mk
@@ -101,9 +101,9 @@ endif
 # Extra flags needed to compile a working executable with the standard library
 ifdef IS_WINDOWS
 ifdef IS_MSVC
-	EXTRACFLAGS := ws2_32.lib userenv.lib advapi32.lib
+	EXTRACFLAGS := ws2_32.lib userenv.lib advapi32.lib bcrypt.lib
 else
-	EXTRACFLAGS := -lws2_32 -luserenv
+	EXTRACFLAGS := -lws2_32 -luserenv -lbcrypt
 	EXTRACXXFLAGS := -lstdc++
 	# So this is a bit hacky: we can't use the DLL version of libstdc++ because
 	# it pulls in the DLL version of libgcc, which means that we end up with 2


### PR DESCRIPTION
This removes usage of RtlGenRandom on Windows, in favour of BCryptGenRandom.

BCryptGenRandom isn't available on XP, but we dropped XP support a while ago.