### PR TITLE
Check for asm support in UI tests that require it

### DIFF
--- a/src/test/ui/asm/naked-invalid-attr.rs
+++ b/src/test/ui/asm/naked-invalid-attr.rs
@@ -1,6 +1,6 @@
 // Checks that #[naked] attribute can be placed on function definitions only.
 //
-// ignore-wasm32 asm unsupported
+// needs-asm-support
 #![feature(asm)]
 #![feature(naked_functions)]
 #![naked] //~ ERROR should be applied to a function definition

--- a/src/test/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/src/test/ui/feature-gates/feature-gate-naked_functions.rs
@@ -1,3 +1,4 @@
+// needs-asm-support
 #![feature(asm)]
 
 #[naked]

--- a/src/test/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the `#[naked]` attribute is an experimental feature
-  --> $DIR/feature-gate-naked_functions.rs:3:1
+  --> $DIR/feature-gate-naked_functions.rs:4:1
    |
 LL | #[naked]
    | ^^^^^^^^
@@ -8,7 +8,7 @@ LL | #[naked]
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
 
 error[E0658]: the `#[naked]` attribute is an experimental feature
-  --> $DIR/feature-gate-naked_functions.rs:9:1
+  --> $DIR/feature-gate-naked_functions.rs:10:1
    |
 LL | #[naked]
    | ^^^^^^^^

--- a/src/test/ui/rfc-2091-track-caller/error-with-naked.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-naked.rs
@@ -1,3 +1,4 @@
+// needs-asm-support
 #![feature(asm, naked_functions)]
 
 #[track_caller] //~ ERROR cannot use `#[track_caller]` with `#[naked]`

--- a/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
@@ -1,11 +1,11 @@
 error[E0736]: cannot use `#[track_caller]` with `#[naked]`
-  --> $DIR/error-with-naked.rs:3:1
+  --> $DIR/error-with-naked.rs:4:1
    |
 LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 
 error[E0736]: cannot use `#[track_caller]` with `#[naked]`
-  --> $DIR/error-with-naked.rs:12:5
+  --> $DIR/error-with-naked.rs:13:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -44,6 +44,7 @@ impl EarlyProps {
         let mut props = EarlyProps::default();
         let rustc_has_profiler_support = env::var_os("RUSTC_PROFILER_SUPPORT").is_some();
         let rustc_has_sanitizer_support = env::var_os("RUSTC_SANITIZER_SUPPORT").is_some();
+        let has_asm_support = util::has_asm_support(&config.target);
         let has_asan = util::ASAN_SUPPORTED_TARGETS.contains(&&*config.target);
         let has_lsan = util::LSAN_SUPPORTED_TARGETS.contains(&&*config.target);
         let has_msan = util::MSAN_SUPPORTED_TARGETS.contains(&&*config.target);
@@ -73,6 +74,10 @@ impl EarlyProps {
                 if config.run_clang_based_tests_with.is_none()
                     && config.parse_needs_matching_clang(ln)
                 {
+                    props.ignore = true;
+                }
+
+                if !has_asm_support && config.parse_name_directive(ln, "needs-asm-support") {
                     props.ignore = true;
                 }
 

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -224,6 +224,17 @@ fn sanitizers() {
 }
 
 #[test]
+fn asm_support() {
+    let mut config = config();
+
+    config.target = "avr-unknown-gnu-atmega328".to_owned();
+    assert!(parse_rs(&config, "// needs-asm-support").ignore);
+
+    config.target = "i686-unknown-netbsd".to_owned();
+    assert!(!parse_rs(&config, "// needs-asm-support").ignore);
+}
+
+#[test]
 fn test_extract_version_range() {
     use super::{extract_llvm_version, extract_version_range};
 

--- a/src/tools/compiletest/src/util.rs
+++ b/src/tools/compiletest/src/util.rs
@@ -128,6 +128,15 @@ const BIG_ENDIAN: &[&str] = &[
     "sparcv9",
 ];
 
+static ASM_SUPPORTED_ARCHS: &[&str] = &[
+    "x86", "x86_64", "arm", "aarch64", "riscv32", "riscv64", "nvptx64", "hexagon", "mips",
+    "mips64", "spirv", "wasm32",
+];
+
+pub fn has_asm_support(triple: &str) -> bool {
+    ASM_SUPPORTED_ARCHS.contains(&get_arch(triple))
+}
+
 pub fn matches_os(triple: &str, name: &str) -> bool {
     // For the wasm32 bare target we ignore anything also ignored on emscripten
     // and then we also recognize `wasm32-bare` as the os for the target


### PR DESCRIPTION
Add `needs-asm-support` compiletest directive, and use it in asm tests
that require asm support without relying on any architecture specific
features.

Closes #84038.