### PR TITLE
stabilize `core::array::{from_ref,from_mut}` in `1.53.0`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -23,14 +23,14 @@ mod iter;
 pub use iter::IntoIter;
 
 /// Converts a reference to `T` into a reference to an array of length 1 (without copying).
-#[unstable(feature = "array_from_ref", issue = "77101")]
+#[stable(feature = "array_from_ref", since = "1.53.0")]
 pub fn from_ref<T>(s: &T) -> &[T; 1] {
     // SAFETY: Converting `&T` to `&[T; 1]` is sound.
     unsafe { &*(s as *const T).cast::<[T; 1]>() }
 }
 
 /// Converts a mutable reference to `T` into a mutable reference to an array of length 1 (without copying).
-#[unstable(feature = "array_from_ref", issue = "77101")]
+#[stable(feature = "array_from_ref", since = "1.53.0")]
 pub fn from_mut<T>(s: &mut T) -> &mut [T; 1] {
     // SAFETY: Converting `&mut T` to `&mut [T; 1]` is sound.
     unsafe { &mut *(s as *mut T).cast::<[T; 1]>() }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -1,6 +1,5 @@
 #![feature(alloc_layout_extra)]
 #![feature(array_chunks)]
-#![feature(array_from_ref)]
 #![feature(array_methods)]
 #![feature(array_map)]
 #![feature(array_windows)]


### PR DESCRIPTION
I didn't get any response in https://github.com/rust-lang/rust/issues/77101#issuecomment-761831104, so I figured out I can try opening stabilization pr.

---

This PR stabilizes following functions:
```rust
// core::array
pub fn from_ref<T>(s: &T) -> &[T; 1];
pub fn from_mut<T>(s: &mut T) -> &mut [T; 1];
```

Functions are similar to already stabilized `core::slice::{`[`from_ref`](https://doc.rust-lang.org/std/slice/fn.from_ref.html),[`from_mut`](https://doc.rust-lang.org/std/slice/fn.from_mut.html)`}` and were unstable without any problems/questions for a while now.

---

resolves #77101

@rustbot modify labels: +T-libs
