### PR TITLE
Remove `#[cfg]` attributes during cfg-expansion

### DIFF
--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.rs
@@ -29,7 +29,6 @@ macro_rules! generate_s10 {
     ($expr: expr) => {
         #[cfg(feature = $expr)]
         //~^ ERROR expected unsuffixed literal or identifier, found `concat!("nonexistent")`
-        //~| ERROR expected unsuffixed literal or identifier, found `concat!("nonexistent")`
         struct S10;
     }
 }

--- a/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-syntax-validation.stderr
@@ -63,18 +63,7 @@ LL | generate_s10!(concat!("nonexistent"));
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: expected unsuffixed literal or identifier, found `concat!("nonexistent")`
-  --> $DIR/cfg-attr-syntax-validation.rs:30:25
-   |
-LL |         #[cfg(feature = $expr)]
-   |                         ^^^^^
-...
-LL | generate_s10!(concat!("nonexistent"));
-   | -------------------------------------- in this macro invocation
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 11 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0537, E0565.
 For more information about an error, try `rustc --explain E0537`.

--- a/src/test/ui/proc-macro/cfg-eval.stdout
+++ b/src/test/ui/proc-macro/cfg-eval.stdout
@@ -1,4 +1,4 @@
-PRINT-ATTR INPUT (DISPLAY): struct S1 { #[cfg(all())] #[allow()] field_true : u8, }
+PRINT-ATTR INPUT (DISPLAY): struct S1 { #[allow()] field_true : u8, }
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -11,36 +11,6 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Brace,
         stream: TokenStream [
-            Punct {
-                ch: '#',
-                spacing: Alone,
-                span: $DIR/cfg-eval.rs:20:5: 20:6 (#0),
-            },
-            Group {
-                delimiter: Bracket,
-                stream: TokenStream [
-                    Ident {
-                        ident: "cfg",
-                        span: $DIR/cfg-eval.rs:20:7: 20:10 (#0),
-                    },
-                    Group {
-                        delimiter: Parenthesis,
-                        stream: TokenStream [
-                            Ident {
-                                ident: "all",
-                                span: $DIR/cfg-eval.rs:20:11: 20:14 (#0),
-                            },
-                            Group {
-                                delimiter: Parenthesis,
-                                stream: TokenStream [],
-                                span: $DIR/cfg-eval.rs:20:14: 20:24 (#0),
-                            },
-                        ],
-                        span: $DIR/cfg-eval.rs:20:10: 20:25 (#0),
-                    },
-                ],
-                span: $DIR/cfg-eval.rs:20:6: 20:26 (#0),
-            },
             Punct {
                 ch: '#',
                 spacing: Alone,
@@ -83,7 +53,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: $DIR/cfg-eval.rs:17:11: 24:2 (#0),
     },
 ]
-PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] (#[cfg(all())] 1,)
+PRINT-ATTR INPUT (DISPLAY): #[rustc_dummy] (1,)
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
@@ -103,36 +73,6 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
-            Punct {
-                ch: '#',
-                spacing: Alone,
-                span: $DIR/cfg-eval.rs:36:23: 36:24 (#0),
-            },
-            Group {
-                delimiter: Bracket,
-                stream: TokenStream [
-                    Ident {
-                        ident: "cfg",
-                        span: $DIR/cfg-eval.rs:36:25: 36:28 (#0),
-                    },
-                    Group {
-                        delimiter: Parenthesis,
-                        stream: TokenStream [
-                            Ident {
-                                ident: "all",
-                                span: $DIR/cfg-eval.rs:36:29: 36:32 (#0),
-                            },
-                            Group {
-                                delimiter: Parenthesis,
-                                stream: TokenStream [],
-                                span: $DIR/cfg-eval.rs:36:32: 36:42 (#0),
-                            },
-                        ],
-                        span: $DIR/cfg-eval.rs:36:28: 36:43 (#0),
-                    },
-                ],
-                span: $DIR/cfg-eval.rs:36:24: 36:44 (#0),
-            },
             Literal {
                 kind: Integer,
                 symbol: "1",

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -1278,12 +1278,10 @@ PRINT-DERIVE INPUT (DISPLAY): #[print_helper(a)] #[allow(dead_code)] #[print_hel
     second : bool, third :
     [u8 ;
      {
-         #[cfg(not(FALSE))] struct Inner ; match true
-         { #[allow(warnings)] false => { }, _ => { } } ; #[print_helper(c)]
-         #[cfg(not(FALSE))] fn kept_fn()
-         { # ! [cfg(not(FALSE))] let my_val = true ; } enum TupleEnum
-         { Foo(#[cfg(not(FALSE))] i32, u8) } struct
-         TupleStruct(#[cfg(not(FALSE))] i32, u8) ; 0
+         struct Inner ; match true
+         { #[allow(warnings)] false => { }, _ => { } } ; #[print_helper(c)] fn
+         kept_fn() { let my_val = true ; } enum TupleEnum { Foo(i32, u8) }
+         struct TupleStruct(i32, u8) ; 0
      }], #[print_helper(d)] fourth : B
 }
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
@@ -1429,41 +1427,6 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                     Group {
                         delimiter: Brace,
                         stream: TokenStream [
-                            Punct {
-                                ch: '#',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:30:9: 30:10 (#0),
-                            },
-                            Group {
-                                delimiter: Bracket,
-                                stream: TokenStream [
-                                    Ident {
-                                        ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:11: 30:14 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "not",
-                                                span: $DIR/issue-75930-derive-cfg.rs:30:15: 30:18 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:30:19: 30:24 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:30:18: 30:25 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:30:14: 30:26 (#0),
-                                    },
-                                ],
-                                span: $DIR/issue-75930-derive-cfg.rs:30:10: 30:27 (#0),
-                            },
                             Ident {
                                 ident: "struct",
                                 span: $DIR/issue-75930-derive-cfg.rs:30:28: 30:34 (#0),
@@ -1589,41 +1552,6 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                 ],
                                 span: $DIR/issue-75930-derive-cfg.rs:43:10: 43:27 (#0),
                             },
-                            Punct {
-                                ch: '#',
-                                spacing: Alone,
-                                span: $DIR/issue-75930-derive-cfg.rs:43:28: 43:29 (#0),
-                            },
-                            Group {
-                                delimiter: Bracket,
-                                stream: TokenStream [
-                                    Ident {
-                                        ident: "cfg",
-                                        span: $DIR/issue-75930-derive-cfg.rs:43:30: 43:33 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "not",
-                                                span: $DIR/issue-75930-derive-cfg.rs:43:34: 43:37 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "FALSE",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:43:38: 43:43 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:43:37: 43:44 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:43:33: 43:45 (#0),
-                                    },
-                                ],
-                                span: $DIR/issue-75930-derive-cfg.rs:43:29: 43:46 (#0),
-                            },
                             Ident {
                                 ident: "fn",
                                 span: $DIR/issue-75930-derive-cfg.rs:43:47: 43:49 (#0),
@@ -1640,46 +1568,6 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                             Group {
                                 delimiter: Brace,
                                 stream: TokenStream [
-                                    Punct {
-                                        ch: '#',
-                                        spacing: Joint,
-                                        span: $DIR/issue-75930-derive-cfg.rs:44:13: 44:14 (#0),
-                                    },
-                                    Punct {
-                                        ch: '!',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:44:14: 44:15 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Bracket,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:44:16: 44:19 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "not",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:44:20: 44:23 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:44:24: 44:29 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:44:23: 44:30 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:44:19: 44:31 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:44:15: 44:32 (#0),
-                                    },
                                     Ident {
                                         ident: "let",
                                         span: $DIR/issue-75930-derive-cfg.rs:45:13: 45:16 (#0),
@@ -1723,41 +1611,6 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
-                                            Punct {
-                                                ch: '#',
-                                                spacing: Alone,
-                                                span: $DIR/issue-75930-derive-cfg.rs:52:17: 52:18 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Bracket,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "cfg",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:52:19: 52:22 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "not",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:52:23: 52:26 (#0),
-                                                            },
-                                                            Group {
-                                                                delimiter: Parenthesis,
-                                                                stream: TokenStream [
-                                                                    Ident {
-                                                                        ident: "FALSE",
-                                                                        span: $DIR/issue-75930-derive-cfg.rs:52:27: 52:32 (#0),
-                                                                    },
-                                                                ],
-                                                                span: $DIR/issue-75930-derive-cfg.rs:52:26: 52:33 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:52:22: 52:34 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:52:18: 52:35 (#0),
-                                            },
                                             Ident {
                                                 ident: "i32",
                                                 span: $DIR/issue-75930-derive-cfg.rs:52:36: 52:39 (#0),
@@ -1788,41 +1641,6 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                             Group {
                                 delimiter: Parenthesis,
                                 stream: TokenStream [
-                                    Punct {
-                                        ch: '#',
-                                        spacing: Alone,
-                                        span: $DIR/issue-75930-derive-cfg.rs:59:13: 59:14 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Bracket,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "cfg",
-                                                span: $DIR/issue-75930-derive-cfg.rs:59:15: 59:18 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "not",
-                                                        span: $DIR/issue-75930-derive-cfg.rs:59:19: 59:22 (#0),
-                                                    },
-                                                    Group {
-                                                        delimiter: Parenthesis,
-                                                        stream: TokenStream [
-                                                            Ident {
-                                                                ident: "FALSE",
-                                                                span: $DIR/issue-75930-derive-cfg.rs:59:23: 59:28 (#0),
-                                                            },
-                                                        ],
-                                                        span: $DIR/issue-75930-derive-cfg.rs:59:22: 59:29 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/issue-75930-derive-cfg.rs:59:18: 59:30 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:59:14: 59:31 (#0),
-                                    },
                                     Ident {
                                         ident: "i32",
                                         span: $DIR/issue-75930-derive-cfg.rs:59:32: 59:35 (#0),

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.fixed
@@ -8,7 +8,8 @@
 
 // The suggestion span should include the attribute.
 
-
+#[cfg(blandiloquence)]
+ //~ HELP remove it
 //~^ ERROR unused extern crate
 
 fn main() {}

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
@@ -8,8 +8,8 @@
 
 // The suggestion span should include the attribute.
 
-#[cfg(blandiloquence)] //~ HELP remove it
-extern crate edition_lint_paths;
+#[cfg(blandiloquence)]
+extern crate edition_lint_paths; //~ HELP remove it
 //~^ ERROR unused extern crate
 
 fn main() {}

--- a/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/src/test/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,11 +1,8 @@
 error: unused extern crate
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:12:1
    |
-LL | / #[cfg(blandiloquence)]
-LL | | extern crate edition_lint_paths;
-   | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   | |________________________________|
-   |                                  help: remove it
+LL | extern crate edition_lint_paths;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
    |
 note: the lint level is defined here
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:6:9


### PR DESCRIPTION
Currently, we don't remove `#[cfg]` attributes from a target when the
predicates pass. This PR removes all 'passing' `#[cfg]` attributes
during cfg-expansion, which causes derive proc-macros to never see any
`#[cfg]` attributes in the input token stream.

With https://github.com/rust-lang/rust/pull/82608 merged, we can now do
this without losing spans.