### PR TITLE
Detect when suggested paths enter extern crates more rigorously

### DIFF
--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -758,17 +758,14 @@ impl<'a> Resolver<'a> {
     {
         let mut candidates = Vec::new();
         let mut seen_modules = FxHashSet::default();
-        let not_local_module = crate_name.name != kw::Crate;
-        let mut worklist =
-            vec![(start_module, Vec::<ast::PathSegment>::new(), true, not_local_module)];
+        let mut worklist = vec![(start_module, Vec::<ast::PathSegment>::new(), true)];
         let mut worklist_via_import = vec![];
 
-        while let Some((in_module, path_segments, accessible, in_module_is_extern)) =
-            match worklist.pop() {
-                None => worklist_via_import.pop(),
-                Some(x) => Some(x),
-            }
-        {
+        while let Some((in_module, path_segments, accessible)) = match worklist.pop() {
+            None => worklist_via_import.pop(),
+            Some(x) => Some(x),
+        } {
+            let in_module_is_extern = !in_module.def_id().unwrap().is_local();
             // We have to visit module children in deterministic order to avoid
             // instabilities in reported imports (#43552).
             in_module.for_each_child(self, |this, ident, ns, name_binding| {
@@ -850,11 +847,10 @@ impl<'a> Resolver<'a> {
                         name_binding.is_extern_crate() && lookup_ident.span.rust_2018();
 
                     if !is_extern_crate_that_also_appears_in_prelude {
-                        let is_extern = in_module_is_extern || name_binding.is_extern_crate();
                         // add the module to the lookup
                         if seen_modules.insert(module.def_id().unwrap()) {
                             if via_import { &mut worklist_via_import } else { &mut worklist }
-                                .push((module, path_segments, child_accessible, is_extern));
+                                .push((module, path_segments, child_accessible));
                         }
                     }
                 }

--- a/src/test/ui/resolve/auxiliary/issue-80079.rs
+++ b/src/test/ui/resolve/auxiliary/issue-80079.rs
@@ -1,0 +1,18 @@
+#![crate_type = "lib"]
+
+pub mod public {
+    use private_import;
+
+    // should not be suggested since it is private
+    struct Foo;
+
+    mod private_module {
+        // should not be suggested since it is private
+        pub struct Foo;
+    }
+}
+
+mod private_import {
+    // should not be suggested since it is private
+    pub struct Foo;
+}

--- a/src/test/ui/resolve/issue-80079.rs
+++ b/src/test/ui/resolve/issue-80079.rs
@@ -1,0 +1,12 @@
+// aux-build:issue-80079.rs
+
+// using a module from another crate should not cause errors to suggest private
+// items in that module
+
+extern crate issue_80079;
+
+use issue_80079::public;
+
+fn main() {
+    let _ = Foo; //~ ERROR cannot find value `Foo` in this scope
+}

--- a/src/test/ui/resolve/issue-80079.stderr
+++ b/src/test/ui/resolve/issue-80079.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `Foo` in this scope
+  --> $DIR/issue-80079.rs:11:13
+   |
+LL |     let _ = Foo;
+   |             ^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
When reporting resolution errors, the compiler tries to avoid suggesting importing inaccessible paths from other crates. However, the search for suggestions only recognized when it was entering a crate root directly, and so failed to recognize a path like `crate::module::private_item`, where `module` was imported from another crate with `use other_crate::module`, as entering another crate.

Fixes #80079
Fixes #84081