### PR TITLE
Stabilize Duration::MAX

### DIFF
--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -146,7 +146,7 @@ impl Duration {
     ///
     /// assert_eq!(Duration::MAX, Duration::new(u64::MAX, 1_000_000_000 - 1));
     /// ```
-    #[unstable(feature = "duration_constants", issue = "57391")]
+    #[stable(feature = "duration_saturating_ops", since = "1.53.0")]
     pub const MAX: Duration = Duration::new(u64::MAX, NANOS_PER_SEC - 1);
 
     /// Creates a new `Duration` from the specified number of whole seconds and

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -136,9 +136,10 @@ impl Duration {
 
     /// The maximum duration.
     ///
-    /// May vary by platform. At least equal to the number of seconds
-    /// difference between the minimum and maximum [`std::time::Instant`].
-    /// On many platforms this is roughly 584,942,417,355 years.
+    /// May vary by platform as necessary. Must be able to contain the difference between
+    /// two instances of [`Instant`] or two instances of [`SystemTime`].
+    /// This constraint gives it a value of about 584,942,417,355 years in practice,
+    /// which is currently used on all platforms.
     ///
     /// # Examples
     ///
@@ -147,7 +148,8 @@ impl Duration {
     ///
     /// assert_eq!(Duration::MAX, Duration::new(u64::MAX, 1_000_000_000 - 1));
     /// ```
-    /// [`std::time::Instant`]: ../../std/time/struct.Instant.html
+    /// [`Instant`]: ../../std/time/struct.Instant.html
+    /// [`SystemTime`]: ../../std/time/struct.SystemTime.html
     #[stable(feature = "duration_saturating_ops", since = "1.53.0")]
     pub const MAX: Duration = Duration::new(u64::MAX, NANOS_PER_SEC - 1);
 

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -136,16 +136,18 @@ impl Duration {
 
     /// The maximum duration.
     ///
-    /// It is roughly equal to a duration of 584,942,417,355 years.
+    /// May vary by platform. At least equal to the number of seconds
+    /// difference between the minimum and maximum [`std::time::Instant`].
+    /// On many platforms this is roughly 584,942,417,355 years.
     ///
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_constants)]
     /// use std::time::Duration;
     ///
     /// assert_eq!(Duration::MAX, Duration::new(u64::MAX, 1_000_000_000 - 1));
     /// ```
+    /// [`std::time::Instant`]: ../../std/time/struct.Instant.html
     #[stable(feature = "duration_saturating_ops", since = "1.53.0")]
     pub const MAX: Duration = Duration::new(u64::MAX, NANOS_PER_SEC - 1);
 


### PR DESCRIPTION
Following the suggested direction from https://github.com/rust-lang/rust/issues/76416#issuecomment-817278338, this PR proposes that `Duration::MAX` should have been part of the `duration_saturating_ops` feature flag all along, having been

0. heavily referenced by that feature flag
1. an odd duck next to most of `duration_constants`, as I expressed in https://github.com/rust-lang/rust/issues/57391#issuecomment-717681193
2. introduced in #76114 which added `duration_saturating_ops`

and accordingly should be folded into `duration_saturating_ops` and therefore stabilized.

r? @m-ou-se