### PR TITLE
Fix lookahead with None-delimited group

### DIFF
--- a/src/test/ui/macros/none-delim-lookahead.rs
+++ b/src/test/ui/macros/none-delim-lookahead.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+macro_rules! make_struct {
+    ($name:ident) => {
+        #[derive(Debug)]
+        struct Foo {
+            #[cfg(not(FALSE))]
+            field: fn($name: bool)
+        }
+    }
+}
+
+make_struct!(param_name);
+
+fn main() {}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/84162, a regression introduced by https://github.com/rust-lang/rust/pull/82608.