### PR TITLE
Fix typo in error message

### DIFF
--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -82,7 +82,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         if param_type.is_suggestable() {
                             err.span_suggestion(
                                 tcx.def_span(src_def_id),
-                                "consider changing this type paramater to a `const`-generic",
+                                "consider changing this type parameter to be a `const` generic",
                                 format!("const {}: {}", param_name, param_type),
                                 Applicability::MaybeIncorrect,
                             );

--- a/src/test/ui/const-generics/diagnostics.stderr
+++ b/src/test/ui/const-generics/diagnostics.stderr
@@ -31,9 +31,12 @@ error[E0747]: type provided when a constant was expected
   --> $DIR/diagnostics.rs:12:19
    |
 LL | impl<N> Foo for B<N> {}
-   |      -            ^
-   |      |
-   |      help: consider changing this type paramater to a `const`-generic: `const N: u8`
+   |                   ^
+   |
+help: consider changing this type parameter to be a `const` generic
+   |
+LL | impl<const N: u8> Foo for B<N> {}
+   |      ^^^^^^^^^^^
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/diagnostics.rs:16:32


### PR DESCRIPTION
Also tweaked the message a bit by

- removing the hyphen, because in my opinion the hyphen makes the
  message a bit harder to read, especially combined with the backticks;
- adding the word "be", because I think it's a bit clearer that way.
