### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,6 +50,8 @@ Libraries
 - [`io::Empty` now implements `io::Seek`.][78044]
 - [`rc::Weak<T>` and `sync::Weak<T>`'s methods such as `as_ptr` are now implemented for
   `T: ?Sized` types.][80764]
+- [`Div` and `Rem` by their `NonZero` variant is now implemented for all unsigned integers.][79134]
+
 
 Stabilized APIs
 ---------------
@@ -72,6 +74,8 @@ Stabilized APIs
 - [`str::split_inclusive`]
 - [`sync::OnceState`]
 - [`task::Wake`]
+- [`VecDeque::range`]
+- [`VecDeque::range_mut`]
 
 Cargo
 -----
@@ -115,6 +119,7 @@ Compatibility Notes
     - `thumbv7neon-unknown-linux-gnueabihf`
     - `armv7-unknown-linux-gnueabi`
     - `x86_64-unknown-linux-gnux32`
+- [`atomic::spin_loop_hint` has been deprecated.][80966] It's recommended to use `hint::spin_loop` instead.
 
 Internal Only
 -------------
@@ -145,6 +150,8 @@ Internal Only
 [80764]: https://github.com/rust-lang/rust/pull/80764
 [80749]: https://github.com/rust-lang/rust/pull/80749
 [80662]: https://github.com/rust-lang/rust/pull/80662
+[79134]: https://github.com/rust-lang/rust/pull/79134
+[80966]: https://github.com/rust-lang/rust/pull/80966
 [cargo/8997]: https://github.com/rust-lang/cargo/pull/8997
 [cargo/9112]: https://github.com/rust-lang/cargo/pull/9112
 [feature-resolver@2.0]: https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2
@@ -166,6 +173,8 @@ Internal Only
 [`Seek::stream_position`]: https://doc.rust-lang.org/nightly/std/io/trait.Seek.html#method.stream_position
 [`Peekable::next_if`]: https://doc.rust-lang.org/nightly/std/iter/struct.Peekable.html#method.next_if
 [`Peekable::next_if_eq`]: https://doc.rust-lang.org/nightly/std/iter/struct.Peekable.html#method.next_if_eq
+[`VecDeque::range`]: https://doc.rust-lang.org/nightly/std/collections/struct.VecDeque.html#method.range
+[`VecDeque::range_mut`]: https://doc.rust-lang.org/nightly/std/collections/struct.VecDeque.html#method.range_mut
 
 Version 1.50.0 (2021-02-11)
 ============================

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -666,21 +666,23 @@ impl<'a> Parser<'a> {
                     );
                     match x {
                         Ok((_, _, false)) => {
-                            self.bump(); // `>`
-                            match self.parse_expr() {
-                                Ok(_) => {
-                                    e.span_suggestion_verbose(
-                                        binop.span.shrink_to_lo(),
-                                        TURBOFISH_SUGGESTION_STR,
-                                        "::".to_string(),
-                                        Applicability::MaybeIncorrect,
-                                    );
-                                    e.emit();
-                                    *expr = self.mk_expr_err(expr.span.to(self.prev_token.span));
-                                    return Ok(());
-                                }
-                                Err(mut err) => {
-                                    err.cancel();
+                            if self.eat(&token::Gt) {
+                                match self.parse_expr() {
+                                    Ok(_) => {
+                                        e.span_suggestion_verbose(
+                                            binop.span.shrink_to_lo(),
+                                            TURBOFISH_SUGGESTION_STR,
+                                            "::".to_string(),
+                                            Applicability::MaybeIncorrect,
+                                        );
+                                        e.emit();
+                                        *expr =
+                                            self.mk_expr_err(expr.span.to(self.prev_token.span));
+                                        return Ok(());
+                                    }
+                                    Err(mut err) => {
+                                        err.cancel();
+                                    }
                                 }
                             }
                         }

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -82,7 +82,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         if param_type.is_suggestable() {
                             err.span_suggestion(
                                 tcx.def_span(src_def_id),
-                                "consider changing this type paramater to a `const`-generic",
+                                "consider changing this type parameter to be a `const` generic",
                                 format!("const {}: {}", param_name, param_type),
                                 Applicability::MaybeIncorrect,
                             );

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -940,7 +940,6 @@ impl<K, V> BTreeMap<K, V> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(btree_retain)]
     /// use std::collections::BTreeMap;
     ///
     /// let mut map: BTreeMap<i32, i32> = (0..8).map(|x| (x, x*10)).collect();
@@ -949,7 +948,7 @@ impl<K, V> BTreeMap<K, V> {
     /// assert!(map.into_iter().eq(vec![(0, 0), (2, 20), (4, 40), (6, 60)]));
     /// ```
     #[inline]
-    #[unstable(feature = "btree_retain", issue = "79025")]
+    #[stable(feature = "btree_retain", since = "1.53.0")]
     pub fn retain<F>(&mut self, mut f: F)
     where
         K: Ord,

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -851,7 +851,6 @@ impl<T> BTreeSet<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(btree_retain)]
     /// use std::collections::BTreeSet;
     ///
     /// let xs = [1, 2, 3, 4, 5, 6];
@@ -860,7 +859,7 @@ impl<T> BTreeSet<T> {
     /// set.retain(|&k| k % 2 == 0);
     /// assert!(set.iter().eq([2, 4, 6].iter()));
     /// ```
-    #[unstable(feature = "btree_retain", issue = "79025")]
+    #[stable(feature = "btree_retain", since = "1.53.0")]
     pub fn retain<F>(&mut self, mut f: F)
     where
         T: Ord,

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2268,7 +2268,7 @@ impl<T: ?Sized + Debug> Debug for RefMut<'_, T> {
 }
 
 #[stable(feature = "core_impl_debug", since = "1.9.0")]
-impl<T: ?Sized + Debug> Debug for UnsafeCell<T> {
+impl<T: ?Sized> Debug for UnsafeCell<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.pad("UnsafeCell")
     }

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -280,6 +280,7 @@ impl Duration {
     /// assert!(!Duration::from_secs(1).is_zero());
     /// ```
     #[stable(feature = "duration_zero", since = "1.53.0")]
+    #[rustc_const_stable(feature = "duration_zero", since = "1.53.0")]
     #[inline]
     pub const fn is_zero(&self) -> bool {
         self.secs == 0 && self.nanos == 0

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -124,14 +124,13 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_zero)]
     /// use std::time::Duration;
     ///
     /// let duration = Duration::ZERO;
     /// assert!(duration.is_zero());
     /// assert_eq!(duration.as_nanos(), 0);
     /// ```
-    #[unstable(feature = "duration_zero", issue = "73544")]
+    #[stable(feature = "duration_zero", since = "1.53.0")]
     pub const ZERO: Duration = Duration::from_nanos(0);
 
     /// The maximum duration.
@@ -269,7 +268,6 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_zero)]
     /// use std::time::Duration;
     ///
     /// assert!(Duration::ZERO.is_zero());
@@ -281,7 +279,7 @@ impl Duration {
     /// assert!(!Duration::from_nanos(1).is_zero());
     /// assert!(!Duration::from_secs(1).is_zero());
     /// ```
-    #[unstable(feature = "duration_zero", issue = "73544")]
+    #[stable(feature = "duration_zero", since = "1.53.0")]
     #[inline]
     pub const fn is_zero(&self) -> bool {
         self.secs == 0 && self.nanos == 0
@@ -536,7 +534,6 @@ impl Duration {
     /// # Examples
     ///
     /// ```
-    /// #![feature(duration_zero)]
     /// use std::time::Duration;
     ///
     /// assert_eq!(Duration::new(0, 1).saturating_sub(Duration::new(0, 0)), Duration::new(0, 1));

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -24,7 +24,6 @@
 #![feature(div_duration)]
 #![feature(duration_consts_2)]
 #![feature(duration_constants)]
-#![feature(duration_zero)]
 #![feature(exact_size_is_empty)]
 #![feature(extern_types)]
 #![feature(flt2dec)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -261,7 +261,6 @@
 #![cfg_attr(not(bootstrap), feature(doc_notable_trait))]
 #![feature(dropck_eyepatch)]
 #![feature(duration_constants)]
-#![feature(duration_zero)]
 #![feature(edition_panic)]
 #![feature(exact_size_is_empty)]
 #![feature(exhaustive_patterns)]

--- a/src/test/ui/const-generics/diagnostics.stderr
+++ b/src/test/ui/const-generics/diagnostics.stderr
@@ -31,9 +31,12 @@ error[E0747]: type provided when a constant was expected
   --> $DIR/diagnostics.rs:12:19
    |
 LL | impl<N> Foo for B<N> {}
-   |      -            ^
-   |      |
-   |      help: consider changing this type paramater to a `const`-generic: `const N: u8`
+   |                   ^
+   |
+help: consider changing this type parameter to be a `const` generic
+   |
+LL | impl<const N: u8> Foo for B<N> {}
+   |      ^^^^^^^^^^^
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/diagnostics.rs:16:32

--- a/src/test/ui/parser/issue-84117.rs
+++ b/src/test/ui/parser/issue-84117.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
+    //~^ ERROR expected one of `>`, a const expression
+    //~| ERROR expected one of `>`, a const expression, lifetime, or type, found `}`
+    //~| ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
+    //~| ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
+    //~| ERROR expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
+}
+//~^ ERROR expected one of `,`, `:`, `=`, or `>`, found `}`

--- a/src/test/ui/parser/issue-84117.stderr
+++ b/src/test/ui/parser/issue-84117.stderr
@@ -1,0 +1,49 @@
+error: expected one of `>`, a const expression, lifetime, or type, found `}`
+  --> $DIR/issue-84117.rs:2:67
+   |
+LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
+   |                                         ------------              ^ expected one of `>`, a const expression, lifetime, or type
+   |                                         |          |
+   |                                         |          help: use `=` if you meant to assign
+   |                                         while parsing the type for `inner_local`
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
+  --> $DIR/issue-84117.rs:2:65
+   |
+LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
+   |                                                                 ^ expected one of 7 possible tokens
+
+error: expected one of `,`, `:`, `=`, or `>`, found `}`
+  --> $DIR/issue-84117.rs:8:1
+   |
+LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
+   |         ------------ help: use `=` if you meant to assign          - expected one of `,`, `:`, `=`, or `>`
+   |         |
+   |         while parsing the type for `outer_local`
+...
+LL | }
+   | ^ unexpected token
+
+error: expected one of `>`, a const expression, lifetime, or type, found `}`
+  --> $DIR/issue-84117.rs:2:67
+   |
+LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
+   |                                         ------------              ^ expected one of `>`, a const expression, lifetime, or type
+   |                                         |          |
+   |                                         |          help: use `=` if you meant to assign
+   |                                         while parsing the type for `inner_local`
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
+  --> $DIR/issue-84117.rs:2:65
+   |
+LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
+   |                                                                 ^ expected one of 7 possible tokens
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, or an operator, found `,`
+  --> $DIR/issue-84117.rs:2:33
+   |
+LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
+   |                                 ^ expected one of 7 possible tokens
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #83438 (Update RELEASES.md)
 - #83707 (Remove `T: Debug` bound on UnsafeCell Debug impl)
 - #84084 (Stabilize duration_zero.)
 - #84121 (Stabilize BTree{Map,Set}::retain)
 - #84140 (Don't call bump in check_mistyped_turbofish_with_multiple_type_params)
 - #84141 (Fix typo in error message)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83438,83707,84084,84121,84140,84141)
<!-- homu-ignore:end -->