### PR TITLE
Remove slice diagnostic item

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -222,7 +222,6 @@ mod hack {
 }
 
 #[lang = "slice_alloc"]
-#[cfg_attr(not(test), rustc_diagnostic_item = "slice")]
 #[cfg(not(test))]
 impl<T> [T] {
     /// Sorts the slice.


### PR DESCRIPTION
...because it is unusally placed on an impl and is redundant with a lang item.

Depends on rust-lang/rust-clippy#7074 (next clippy sync). ~I expect clippy tests to fail in the meantime.~ Nope tests passed...

CC @flip1995