### PR TITLE
Generate links to definition in rustdoc source code pages

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -500,6 +500,10 @@ impl Session {
         &self.parse_sess.span_diagnostic
     }
 
+    pub fn with_disabled_diagnostic<T, F: FnOnce() -> T>(&self, f: F) -> T {
+        self.parse_sess.span_diagnostic.with_disabled_diagnostic(f)
+    }
+
     /// Analogous to calling methods on the given `DiagnosticBuilder`, but
     /// deduplicates on lint ID, span (if any), and message for this `Session`
     fn diag_once<'a, 'b>(

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -98,7 +98,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                     visibility: Inherited,
                     def_id: ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
                     kind: box ImplItem(Impl {
-                        span: Span::from_rustc_span(self.cx.tcx.def_span(impl_def_id)),
+                        span: Span::new(self.cx.tcx.def_span(impl_def_id)),
                         unsafety: hir::Unsafety::Normal,
                         generics: (
                             self.cx.tcx.generics_of(impl_def_id),

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -517,7 +517,7 @@ fn build_module(
         }
     }
 
-    let span = clean::Span::from_rustc_span(cx.tcx.def_span(did));
+    let span = clean::Span::new(cx.tcx.def_span(did));
     clean::Module { items, span }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -95,7 +95,8 @@ impl Clean<Item> for doctree::Module<'_> {
 
         // determine if we should display the inner contents or
         // the outer `mod` item for the source code.
-        let span = Span::from_rustc_span({
+
+        let span = Span::new({
             let where_outer = self.where_outer(cx.tcx);
             let sm = cx.sess().source_map();
             let outer = sm.lookup_char_pos(where_outer.lo());

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -343,7 +343,7 @@ crate struct Item {
 rustc_data_structures::static_assert_size!(Item, 56);
 
 crate fn rustc_span(def_id: DefId, tcx: TyCtxt<'_>) -> Span {
-    Span::from_rustc_span(def_id.as_local().map_or_else(
+    Span::new(def_id.as_local().map_or_else(
         || tcx.def_span(def_id),
         |local| {
             let hir = tcx.hir();
@@ -1947,15 +1947,15 @@ impl Span {
     /// span will be updated to point to the macro invocation instead of the macro definition.
     ///
     /// (See rust-lang/rust#39726)
-    crate fn from_rustc_span(sp: rustc_span::Span) -> Self {
+    crate fn new(sp: rustc_span::Span) -> Self {
         Self(sp.source_callsite())
     }
 
-    /// Unless you know what you're doing, use [`Self::from_rustc_span`] instead!
+    /// Unless you know what you're doing, use [`Self::new`] instead!
     ///
-    /// Contrary to [`Self::from_rustc_span`], this constructor wraps the span as is and don't
-    /// perform any operation on it, even if it's from a macro expansion.
-    crate fn wrap(sp: rustc_span::Span) -> Span {
+    /// This function doesn't clean the span at all. Compare with [`Self::new`]'s body to see the
+    /// difference.
+    crate fn wrap_raw(sp: rustc_span::Span) -> Span {
         Self(sp)
     }
 

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1951,14 +1951,6 @@ impl Span {
         Self(sp.source_callsite())
     }
 
-    /// Unless you know what you're doing, use [`Self::new`] instead!
-    ///
-    /// This function doesn't clean the span at all. Compare with [`Self::new`]'s body to see the
-    /// difference.
-    crate fn wrap_raw(sp: rustc_span::Span) -> Span {
-        Self(sp)
-    }
-
     crate fn inner(&self) -> rustc_span::Span {
         self.0
     }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1950,6 +1950,11 @@ impl Span {
         Self(sp.source_callsite())
     }
 
+    /// Unless you know what you're doing, use [`Self::from_rustc_span`] instead!
+    crate fn wrap(sp: rustc_span::Span) -> Span {
+        Self(sp)
+    }
+
     crate fn inner(&self) -> rustc_span::Span {
         self.0
     }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1943,14 +1943,18 @@ crate enum Variant {
 crate struct Span(rustc_span::Span);
 
 impl Span {
+    /// Wraps a [`rustc_span::Span`]. In case this span is the result of a macro expansion, the
+    /// span will be updated to point to the macro invocation instead of the macro definition.
+    ///
+    /// (See rust-lang/rust#39726)
     crate fn from_rustc_span(sp: rustc_span::Span) -> Self {
-        // Get the macro invocation instead of the definition,
-        // in case the span is result of a macro expansion.
-        // (See rust-lang/rust#39726)
         Self(sp.source_callsite())
     }
 
     /// Unless you know what you're doing, use [`Self::from_rustc_span`] instead!
+    ///
+    /// Contrary to [`Self::from_rustc_span`], this constructor wraps the span as is and don't
+    /// perform any operation on it, even if it's from a macro expansion.
     crate fn wrap(sp: rustc_span::Span) -> Span {
         Self(sp)
     }

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -659,6 +659,14 @@ impl Options {
         let nocapture = matches.opt_present("nocapture");
         let generate_link_to_definition = matches.opt_present("generate-link-to-definition");
 
+        if generate_link_to_definition && (show_coverage || output_format != OutputFormat::Html) {
+            diag.struct_err(
+                "--generate-link-to-definition option can only be used with HTML output format",
+            )
+            .emit();
+            return Err(1);
+        }
+
         let (lint_opts, describe_lints, lint_cap) =
             get_cmd_lint_options(matches, error_format, &debugging_opts);
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -276,6 +276,8 @@ crate struct RenderOptions {
     crate show_type_layout: bool,
     crate unstable_features: rustc_feature::UnstableFeatures,
     crate emit: Vec<EmitType>,
+    /// If `true`, HTML source pages will generate links for items to their definition.
+    crate generate_link_to_definition: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -655,6 +657,7 @@ impl Options {
         let generate_redirect_map = matches.opt_present("generate-redirect-map");
         let show_type_layout = matches.opt_present("show-type-layout");
         let nocapture = matches.opt_present("nocapture");
+        let generate_link_to_definition = matches.opt_present("generate-link-to-definition");
 
         let (lint_opts, describe_lints, lint_cap) =
             get_cmd_lint_options(matches, error_format, &debugging_opts);
@@ -721,6 +724,7 @@ impl Options {
                     crate_name.as_deref(),
                 ),
                 emit,
+                generate_link_to_definition,
             },
             crate_name,
             output_format,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -484,7 +484,11 @@ crate enum HrefError {
     NotInExternalCache,
 }
 
-crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<String>), HrefError> {
+crate fn href_with_root_path(
+    did: DefId,
+    cx: &Context<'_>,
+    root_path: Option<&str>,
+) -> Result<(String, ItemType, Vec<String>), HrefError> {
     let cache = &cx.cache();
     let relative_to = &cx.current;
     fn to_module_fqp(shortty: ItemType, fqp: &[String]) -> &[String] {
@@ -495,6 +499,7 @@ crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<Str
         return Err(HrefError::Private);
     }
 
+    let mut is_remote = false;
     let (fqp, shortty, mut url_parts) = match cache.paths.get(&did) {
         Some(&(ref fqp, shortty)) => (fqp, shortty, {
             let module_fqp = to_module_fqp(shortty, fqp);
@@ -508,6 +513,7 @@ crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<Str
                     shortty,
                     match cache.extern_locations[&did.krate] {
                         ExternalLocation::Remote(ref s) => {
+                            is_remote = true;
                             let s = s.trim_end_matches('/');
                             let mut s = vec![s];
                             s.extend(module_fqp[..].iter().map(String::as_str));
@@ -522,6 +528,12 @@ crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<Str
             }
         }
     };
+    if !is_remote {
+        if let Some(root_path) = root_path {
+            let root = root_path.trim_end_matches('/');
+            url_parts.insert(0, root);
+        }
+    }
     let last = &fqp.last().unwrap()[..];
     let filename;
     match shortty {
@@ -534,6 +546,10 @@ crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<Str
         }
     }
     Ok((url_parts.join("/"), shortty, fqp.to_vec()))
+}
+
+crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<String>), HrefError> {
+    href_with_root_path(did, cx, None)
 }
 
 /// Both paths should only be modules.

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -494,7 +494,10 @@ crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<Str
     if !did.is_local() && !cache.access_levels.is_public(did) && !cache.document_private {
         return Err(HrefError::Private);
     }
-
+    // href_with_depth_inner(did, cache, || {
+    //     let depth = CURRENT_DEPTH.with(|l| l.get());
+    //     "../".repeat(depth)
+    // })
     let (fqp, shortty, mut url_parts) = match cache.paths.get(&did) {
         Some(&(ref fqp, shortty)) => (fqp, shortty, {
             let module_fqp = to_module_fqp(shortty, fqp);

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -494,10 +494,7 @@ crate fn href(did: DefId, cx: &Context<'_>) -> Result<(String, ItemType, Vec<Str
     if !did.is_local() && !cache.access_levels.is_public(did) && !cache.document_private {
         return Err(HrefError::Private);
     }
-    // href_with_depth_inner(did, cache, || {
-    //     let depth = CURRENT_DEPTH.with(|l| l.get());
-    //     "../".repeat(depth)
-    // })
+
     let (fqp, shortty, mut url_parts) = match cache.paths.get(&did) {
         Some(&(ref fqp, shortty)) => (fqp, shortty, {
             let module_fqp = to_module_fqp(shortty, fqp);

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -573,24 +573,20 @@ fn string<T: Display>(
             });
         }
         if let Some(context_info) = context_info {
-            if let Some(href) = context_info
-                .context
-                .shared
-                .span_correspondance_map
-                .get(&def_span)
-                .and_then(|href| {
-                    let context = context_info.context;
-                    match href {
-                        LinkFromSrc::Local(span) => {
-                            context
+            if let Some(href) =
+                context_info.context.shared.span_correspondance_map.get(&def_span).and_then(
+                    |href| {
+                        let context = context_info.context;
+                        match href {
+                            LinkFromSrc::Local(span) => context
                                 .href_from_span(*span)
-                                .map(|s| format!("{}{}", context_info.root_path, s))
+                                .map(|s| format!("{}{}", context_info.root_path, s)),
+                            LinkFromSrc::External(def_id) => {
+                                format::href(*def_id, context).map(|(url, _, _)| url)
+                            }
                         }
-                        LinkFromSrc::External(def_id) => {
-                            format::href(*def_id, context).map(|(url, _, _)| url)
-                        }
-                    }
-                })
+                    },
+                )
             {
                 write!(out, "<a class=\"{}\" href=\"{}\">{}</a>", klass.as_html(), href, text);
                 return;

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -597,7 +597,7 @@ fn string<T: Display>(
                                 LinkFromSrc::Local(span) => {
                                     eprintln!("==> {:?}:{:?}", span.lo(), span.hi());
                                     context
-                                        .href_from_span(clean::Span::wrap(*span))
+                                        .href_from_span(clean::Span::wrap_raw(*span))
                                         .map(|s| format!("{}{}", root_path, s))
                                 }
                                 LinkFromSrc::External(def_id) => {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -547,9 +547,9 @@ fn string<T: Display>(
                                 LinkFromSrc::Local(span) => {
                                     eprintln!("==> {:?}:{:?}", span.lo(), span.hi());
                                     context
-                                    .href_from_span(clean::Span::wrap(*span))
-                                    .map(|s| format!("{}{}", root_path, s))
-                                },
+                                        .href_from_span(clean::Span::wrap(*span))
+                                        .map(|s| format!("{}{}", root_path, s))
+                                }
                                 LinkFromSrc::External(def_id) => {
                                     format::href(*def_id, context).map(|(url, _, _)| url)
                                 }

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -5,7 +5,6 @@
 //!
 //! Use the `render_with_highlighting` to highlight some rust code.
 
-use crate::clean;
 use crate::html::escape::Escape;
 use crate::html::render::Context;
 
@@ -584,7 +583,7 @@ fn string<T: Display>(
                     match href {
                         LinkFromSrc::Local(span) => {
                             context
-                                .href_from_span(clean::Span::wrap_raw(*span))
+                                .href_from_span(*span)
                                 .map(|s| format!("{}{}", context_info.root_path, s))
                         }
                         LinkFromSrc::External(def_id) => {

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -580,12 +580,19 @@ fn string<T: Display>(
         if let Some(href) =
             context_info.context.shared.span_correspondance_map.get(&def_span).and_then(|href| {
                 let context = context_info.context;
+                // FIXME: later on, it'd be nice to provide two links (if possible) for all items:
+                // one to the documentation page and one to the source definition.
+                // FIXME: currently, external items only generate a link to their documentation,
+                // a link to their definition can be generated using this:
+                // https://github.com/rust-lang/rust/blob/60f1a2fc4b535ead9c85ce085fdce49b1b097531/src/librustdoc/html/render/context.rs#L315-L338
                 match href {
                     LinkFromSrc::Local(span) => context
                         .href_from_span(*span)
                         .map(|s| format!("{}{}", context_info.root_path, s)),
                     LinkFromSrc::External(def_id) => {
-                        format::href(*def_id, context).map(|(url, _, _)| url)
+                        format::href_with_root_path(*def_id, context, Some(context_info.root_path))
+                            .ok()
+                            .map(|(url, _, _)| url)
                     }
                 }
             })

--- a/src/librustdoc/html/highlight/fixtures/highlight.html
+++ b/src/librustdoc/html/highlight/fixtures/highlight.html
@@ -1,0 +1,4 @@
+<span class="kw">use</span> <span class="ident"><span class="kw">crate</span>::a::foo</span>;
+<span class="kw">use</span> <span class="ident"><span class="self">self</span>::whatever</span>;
+<span class="kw">let</span> <span class="ident">x</span> <span class="op">=</span> <span class="ident"><span class="kw">super</span>::b::foo</span>;
+<span class="kw">let</span> <span class="ident">y</span> <span class="op">=</span> <span class="ident"><span class="self">Self</span>::whatever</span>;

--- a/src/librustdoc/html/highlight/fixtures/sample.html
+++ b/src/librustdoc/html/highlight/fixtures/sample.html
@@ -23,7 +23,7 @@
     <span class="macro">assert!</span>(<span class="self">self</span>.<span class="ident">length</span> <span class="op">&lt;</span> <span class="ident">N</span> <span class="op">&amp;&amp;</span> <span class="ident">index</span> <span class="op">&lt;</span><span class="op">=</span> <span class="self">self</span>.<span class="ident">length</span>);
     <span class="ident">::std::env::var</span>(<span class="string">&quot;gateau&quot;</span>).<span class="ident">is_ok</span>();
     <span class="attribute">#[<span class="ident">rustfmt::skip</span>]</span>
-    <span class="kw">let</span> <span class="ident">s</span>:<span class="ident">std</span><span class="ident">::path::PathBuf</span> <span class="op">=</span> <span class="ident">std::path::PathBuf::new</span>();
+    <span class="kw">let</span> <span class="ident">s</span>:<span class="ident">std::path::PathBuf</span> <span class="op">=</span> <span class="ident">std::path::PathBuf::new</span>();
     <span class="kw">let</span> <span class="kw-2">mut</span> <span class="ident">s</span> <span class="op">=</span> <span class="ident">String::new</span>();
 
     <span class="kw">match</span> <span class="kw-2">&amp;</span><span class="ident">s</span> {

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -40,3 +40,17 @@ fn test_dos_backline() {
         expect_file!["fixtures/dos_line.html"].assert_eq(&html.into_inner());
     });
 }
+
+#[test]
+fn test_keyword_highlight() {
+    create_default_session_globals_then(|| {
+        let src = "use crate::a::foo;
+use self::whatever;
+let x = super::b::foo;
+let y = Self::whatever;";
+
+        let mut html = Buffer::new();
+        write_code(&mut html, src, Edition::Edition2018, None);
+        expect_file!["fixtures/highlight.html"].assert_eq(&html.into_inner());
+    });
+}

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -22,7 +22,7 @@ fn test_html_highlighting() {
         let src = include_str!("fixtures/sample.rs");
         let html = {
             let mut out = Buffer::new();
-            write_code(&mut out, src, Edition::Edition2018, 0, None, "");
+            write_code(&mut out, src, Edition::Edition2018, None);
             format!("{}<pre><code>{}</code></pre>\n", STYLE, out.into_inner())
         };
         expect_file!["fixtures/sample.html"].assert_eq(&html);
@@ -36,7 +36,7 @@ fn test_dos_backline() {
     println!(\"foo\");\r\n\
 }\r\n";
         let mut html = Buffer::new();
-        write_code(&mut html, src, Edition::Edition2018, 0, None, "");
+        write_code(&mut html, src, Edition::Edition2018, None);
         expect_file!["fixtures/dos_line.html"].assert_eq(&html.into_inner());
     });
 }

--- a/src/librustdoc/html/highlight/tests.rs
+++ b/src/librustdoc/html/highlight/tests.rs
@@ -22,7 +22,7 @@ fn test_html_highlighting() {
         let src = include_str!("fixtures/sample.rs");
         let html = {
             let mut out = Buffer::new();
-            write_code(&mut out, src, Edition::Edition2018);
+            write_code(&mut out, src, Edition::Edition2018, 0, None, "");
             format!("{}<pre><code>{}</code></pre>\n", STYLE, out.into_inner())
         };
         expect_file!["fixtures/sample.html"].assert_eq(&html);
@@ -36,7 +36,7 @@ fn test_dos_backline() {
     println!(\"foo\");\r\n\
 }\r\n";
         let mut html = Buffer::new();
-        write_code(&mut html, src, Edition::Edition2018);
+        write_code(&mut html, src, Edition::Edition2018, 0, None, "");
         expect_file!["fixtures/dos_line.html"].assert_eq(&html.into_inner());
     });
 }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -330,9 +330,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
             tooltip,
             edition,
             None,
-            0,
             None,
-            "",
         );
         Some(Event::Html(s.into_inner().into()))
     }

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -330,6 +330,9 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
             tooltip,
             edition,
             None,
+            0,
+            None,
+            "",
         );
         Some(Event::Html(s.into_inner().into()))
     }

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -18,8 +18,8 @@ use super::cache::{build_index, ExternalLocation};
 use super::print_item::{full_path, item_path, print_item};
 use super::write_shared::write_shared;
 use super::{
-    collect_spans_and_sources, print_sidebar, settings, AllTypes, LinkFromSrc, NameDoc, StylePath,
-    BASIC_KEYWORDS,
+    collect_spans_and_sources, print_sidebar, settings, AllTypes, LightSpan, LinkFromSrc, NameDoc,
+    StylePath, BASIC_KEYWORDS,
 };
 
 use crate::clean;
@@ -131,7 +131,7 @@ crate struct SharedContext<'tcx> {
 
     /// Correspondance map used to link types used in the source code pages to allow to click on
     /// links to jump to the type's definition.
-    crate span_correspondance_map: FxHashMap<(u32, u32), LinkFromSrc>,
+    crate span_correspondance_map: FxHashMap<LightSpan, LinkFromSrc>,
 }
 
 impl SharedContext<'_> {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -396,6 +396,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             unstable_features,
             generate_redirect_map,
             show_type_layout,
+            generate_link_to_definition,
             ..
         } = options;
 
@@ -456,8 +457,13 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             }
         }
 
-        let (mut krate, local_sources, matches) =
-            collect_spans_and_sources(tcx, krate, &src_root, include_sources);
+        let (mut krate, local_sources, matches) = collect_spans_and_sources(
+            tcx,
+            krate,
+            &src_root,
+            include_sources,
+            generate_link_to_definition,
+        );
 
         let (sender, receiver) = channel();
         let mut scx = SharedContext {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -17,7 +17,10 @@ use rustc_span::symbol::sym;
 use super::cache::{build_index, ExternalLocation};
 use super::print_item::{full_path, item_path, print_item};
 use super::write_shared::write_shared;
-use super::{print_sidebar, settings, AllTypes, NameDoc, StylePath, BASIC_KEYWORDS};
+use super::{
+    collect_spans_and_sources, print_sidebar, settings, AllTypes, LinkFromSrc, NameDoc, StylePath,
+    BASIC_KEYWORDS,
+};
 
 use crate::clean;
 use crate::clean::ExternalCrate;
@@ -46,7 +49,7 @@ crate struct Context<'tcx> {
     pub(crate) current: Vec<String>,
     /// The current destination folder of where HTML artifacts should be placed.
     /// This changes as the context descends into the module hierarchy.
-    pub(super) dst: PathBuf,
+    crate dst: PathBuf,
     /// A flag, which when `true`, will render pages which redirect to the
     /// real location of an item. This is used to allow external links to
     /// publicly reused items to redirect to the right location.
@@ -58,7 +61,7 @@ crate struct Context<'tcx> {
     /// Issue for improving the situation: [#82381][]
     ///
     /// [#82381]: https://github.com/rust-lang/rust/issues/82381
-    pub(super) shared: Rc<SharedContext<'tcx>>,
+    crate shared: Rc<SharedContext<'tcx>>,
     /// The [`Cache`] used during rendering.
     ///
     /// Ideally the cache would be in [`SharedContext`], but it's mutated
@@ -68,7 +71,11 @@ crate struct Context<'tcx> {
     /// It's immutable once in `Context`, so it's not as bad that it's not in
     /// `SharedContext`.
     // FIXME: move `cache` to `SharedContext`
-    pub(super) cache: Rc<Cache>,
+    crate cache: Rc<Cache>,
+    /// This flag indicates whether `[src]` links should be generated or not. If
+    /// the source files are present in the html rendering, then this will be
+    /// `true`.
+    crate include_sources: bool,
 }
 
 // `Context` is cloned a lot, so we don't want the size to grow unexpectedly.
@@ -84,10 +91,6 @@ crate struct SharedContext<'tcx> {
     /// This describes the layout of each page, and is not modified after
     /// creation of the context (contains info like the favicon and added html).
     crate layout: layout::Layout,
-    /// This flag indicates whether `[src]` links should be generated or not. If
-    /// the source files are present in the html rendering, then this will be
-    /// `true`.
-    crate include_sources: bool,
     /// The local file sources we've emitted and their respective url-paths.
     crate local_sources: FxHashMap<PathBuf, String>,
     /// Show the memory layout of types in the docs.
@@ -125,6 +128,10 @@ crate struct SharedContext<'tcx> {
     redirections: Option<RefCell<FxHashMap<String, String>>>,
 
     pub(crate) templates: tera::Tera,
+
+    /// Correspondance map used to link types used in the source code pages to allow to click on
+    /// links to jump to the type's definition.
+    crate span_correspondance_map: FxHashMap<(u32, u32), LinkFromSrc>,
 }
 
 impl SharedContext<'_> {
@@ -293,15 +300,19 @@ impl<'tcx> Context<'tcx> {
     /// may happen, for example, with externally inlined items where the source
     /// of their crate documentation isn't known.
     pub(super) fn src_href(&self, item: &clean::Item) -> Option<String> {
-        if item.span(self.tcx()).is_dummy() {
+        self.href_from_span(item.span(self.tcx()))
+    }
+
+    crate fn href_from_span(&self, span: clean::Span) -> Option<String> {
+        if span.is_dummy() {
             return None;
         }
         let mut root = self.root_path();
         let mut path = String::new();
-        let cnum = item.span(self.tcx()).cnum(self.sess());
+        let cnum = span.cnum(self.sess());
 
         // We can safely ignore synthetic `SourceFile`s.
-        let file = match item.span(self.tcx()).filename(self.sess()) {
+        let file = match span.filename(self.sess()) {
             FileName::Real(ref path) => path.local_path_if_available().to_path_buf(),
             _ => return None,
         };
@@ -339,8 +350,8 @@ impl<'tcx> Context<'tcx> {
             (&*symbol, &path)
         };
 
-        let loline = item.span(self.tcx()).lo(self.sess()).line;
-        let hiline = item.span(self.tcx()).hi(self.sess()).line;
+        let loline = span.lo(self.sess()).line;
+        let hiline = span.hi(self.sess()).line;
         let lines =
             if loline == hiline { loline.to_string() } else { format!("{}-{}", loline, hiline) };
         Some(format!(
@@ -362,9 +373,9 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
     const RUN_ON_MODULE: bool = true;
 
     fn init(
-        mut krate: clean::Crate,
+        krate: clean::Crate,
         options: RenderOptions,
-        mut cache: Cache,
+        cache: Cache,
         tcx: TyCtxt<'tcx>,
     ) -> Result<(Self, clean::Crate), Error> {
         // need to save a copy of the options for rendering the index page
@@ -444,13 +455,16 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                 _ => {}
             }
         }
+
+        let (mut krate, local_sources, matches) =
+            collect_spans_and_sources(tcx, krate, &src_root, include_sources);
+
         let (sender, receiver) = channel();
         let mut scx = SharedContext {
             tcx,
             collapsed: krate.collapsed,
             src_root,
-            include_sources,
-            local_sources: Default::default(),
+            local_sources,
             issue_tracker_base_url,
             layout,
             created_dirs: Default::default(),
@@ -466,6 +480,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             redirections: if generate_redirect_map { Some(Default::default()) } else { None },
             show_type_layout,
             templates,
+            span_correspondance_map: matches,
         };
 
         // Add the default themes to the `Vec` of stylepaths
@@ -483,12 +498,6 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
 
         let dst = output;
         scx.ensure_dir(&dst)?;
-        if emit_crate {
-            krate = sources::render(&dst, &mut scx, krate)?;
-        }
-
-        // Build our search index
-        let index = build_index(&krate, &mut cache, tcx);
 
         let mut cx = Context {
             current: Vec::new(),
@@ -497,7 +506,15 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             id_map: RefCell::new(id_map),
             shared: Rc::new(scx),
             cache: Rc::new(cache),
+            include_sources,
         };
+
+        if emit_crate {
+            krate = sources::render(&mut cx, krate)?;
+        }
+
+        // Build our search index
+        let index = build_index(&krate, Rc::get_mut(&mut cx.cache).unwrap(), tcx);
 
         // Write shared runs within a flock; disable thread dispatching of IO temporarily.
         Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);
@@ -514,6 +531,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             id_map: RefCell::new(IdMap::new()),
             shared: Rc::clone(&self.shared),
             cache: Rc::clone(&self.cache),
+            include_sources: self.include_sources,
         }
     }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -18,8 +18,8 @@ use super::cache::{build_index, ExternalLocation};
 use super::print_item::{full_path, item_path, print_item};
 use super::write_shared::write_shared;
 use super::{
-    collect_spans_and_sources, print_sidebar, settings, AllTypes, LightSpan, LinkFromSrc, NameDoc,
-    StylePath, BASIC_KEYWORDS,
+    collect_spans_and_sources, print_sidebar, settings, AllTypes, LinkFromSrc, NameDoc, StylePath,
+    BASIC_KEYWORDS,
 };
 
 use crate::clean;
@@ -131,7 +131,7 @@ crate struct SharedContext<'tcx> {
 
     /// Correspondance map used to link types used in the source code pages to allow to click on
     /// links to jump to the type's definition.
-    crate span_correspondance_map: FxHashMap<LightSpan, LinkFromSrc>,
+    crate span_correspondance_map: FxHashMap<rustc_span::Span, LinkFromSrc>,
 }
 
 impl SharedContext<'_> {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -30,9 +30,11 @@ mod tests;
 
 mod context;
 mod print_item;
+mod span_map;
 mod write_shared;
 
 crate use context::*;
+crate use span_map::{collect_spans_and_sources, LinkFromSrc};
 
 use std::collections::VecDeque;
 use std::default::Default;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -34,7 +34,7 @@ mod span_map;
 mod write_shared;
 
 crate use context::*;
-crate use span_map::{collect_spans_and_sources, LinkFromSrc};
+crate use span_map::{collect_spans_and_sources, LightSpan, LinkFromSrc};
 
 use std::collections::VecDeque;
 use std::default::Default;

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -34,7 +34,7 @@ mod span_map;
 mod write_shared;
 
 crate use context::*;
-crate use span_map::{collect_spans_and_sources, LightSpan, LinkFromSrc};
+crate use span_map::{collect_spans_and_sources, LinkFromSrc};
 
 use std::collections::VecDeque;
 use std::default::Default;

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -119,7 +119,7 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer,
     // [src] link in the downstream documentation will actually come back to
     // this page, and this link will be auto-clicked. The `id` attribute is
     // used to find the link to auto-click.
-    if cx.shared.include_sources && !item.is_primitive() {
+    if cx.include_sources && !item.is_primitive() {
         write_srclink(cx, item, buf);
     }
 
@@ -1081,6 +1081,9 @@ fn item_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Mac
             None,
             it.span(cx.tcx()).inner().edition(),
             None,
+            0,
+            None,
+            "",
         );
     });
     document(w, cx, it, None)

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1081,9 +1081,7 @@ fn item_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Mac
             None,
             it.span(cx.tcx()).inner().edition(),
             None,
-            0,
             None,
-            "",
         );
     });
     document(w, cx, it, None)

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -110,6 +110,7 @@ impl<'tcx> SpanMapVisitor<'tcx> {
                 Some(def_id)
             }
             Res::Local(_) => None,
+            Res::Err => return,
             _ => return,
         };
         if let Some(span) = self.tcx.hir().res_span(path.res) {

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -183,20 +183,13 @@ impl Visitor<'tcx> for SpanMapVisitor<'tcx> {
                         hir.maybe_body_owned_by(body_id).expect("a body which isn't a body"),
                     );
                     if let Some(def_id) = typeck_results.type_dependent_def_id(expr.hir_id) {
-                        match hir.span_if_local(def_id) {
-                            Some(span) => {
-                                self.matches.insert(
-                                    LightSpan::new_from_span(method_span),
-                                    LinkFromSrc::Local(clean::Span::new(span)),
-                                );
-                            }
-                            None => {
-                                self.matches.insert(
-                                    LightSpan::new_from_span(method_span),
-                                    LinkFromSrc::External(def_id),
-                                );
-                            }
-                        }
+                        self.matches.insert(
+                            LightSpan::new_from_span(method_span),
+                            match hir.span_if_local(def_id) {
+                                Some(span) => LinkFromSrc::Local(clean::Span::new(span)),
+                                None => LinkFromSrc::External(def_id),
+                            },
+                        );
                     }
                 }
             }

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -20,11 +20,14 @@ crate fn collect_spans_and_sources(
     krate: clean::Crate,
     src_root: &std::path::Path,
     include_sources: bool,
+    generate_link_to_definition: bool,
 ) -> (clean::Crate, FxHashMap<std::path::PathBuf, String>, FxHashMap<(u32, u32), LinkFromSrc>) {
     let mut visitor = SpanMapVisitor { tcx, matches: FxHashMap::default() };
 
     if include_sources {
-        intravisit::walk_crate(&mut visitor, tcx.hir().krate());
+        if generate_link_to_definition {
+            intravisit::walk_crate(&mut visitor, tcx.hir().krate());
+        }
         let (krate, sources) = sources::collect_local_sources(tcx, src_root, krate);
         (krate, sources, visitor.matches)
     } else {

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -1,0 +1,110 @@
+use crate::clean;
+use crate::html::sources;
+
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::DefId;
+use rustc_hir::intravisit::{self, NestedVisitorMap, Visitor};
+use rustc_hir::{/*ExprKind, */ GenericParam, GenericParamKind, HirId};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+
+#[derive(Debug)]
+crate enum LinkFromSrc {
+    Local(Span),
+    External(DefId),
+}
+
+crate fn collect_spans_and_sources(
+    tcx: TyCtxt<'_>,
+    krate: clean::Crate,
+    src_root: &std::path::Path,
+    include_sources: bool,
+) -> (clean::Crate, FxHashMap<std::path::PathBuf, String>, FxHashMap<(u32, u32), LinkFromSrc>) {
+    let mut visitor = SpanMapVisitor { tcx, matches: FxHashMap::default() };
+
+    if include_sources {
+        intravisit::walk_crate(&mut visitor, tcx.hir().krate());
+        let (krate, sources) = sources::collect_local_sources(tcx, src_root, krate);
+        (krate, sources, visitor.matches)
+    } else {
+        (krate, Default::default(), Default::default())
+    }
+}
+
+fn span_to_tuple(span: Span) -> (u32, u32) {
+    (span.lo().0, span.hi().0)
+}
+
+struct SpanMapVisitor<'tcx> {
+    crate tcx: TyCtxt<'tcx>,
+    crate matches: FxHashMap<(u32, u32), LinkFromSrc>,
+}
+
+impl<'tcx> SpanMapVisitor<'tcx> {
+    fn handle_path(&mut self, path: &rustc_hir::Path<'_>, path_span: Option<Span>) -> bool {
+        let info = match path.res {
+            Res::Def(kind, def_id) if kind != DefKind::TyParam => {
+                if matches!(kind, DefKind::Macro(_)) {
+                    return false;
+                }
+                Some(def_id)
+            }
+            Res::Local(_) => None,
+            _ => return true,
+        };
+        if let Some(span) = self.tcx.hir().res_span(path.res) {
+            self.matches.insert(
+                path_span.map(span_to_tuple).unwrap_or_else(|| span_to_tuple(path.span)),
+                LinkFromSrc::Local(span),
+            );
+        } else if let Some(def_id) = info {
+            self.matches.insert(
+                path_span.map(span_to_tuple).unwrap_or_else(|| span_to_tuple(path.span)),
+                LinkFromSrc::External(def_id),
+            );
+        }
+        true
+    }
+}
+
+impl Visitor<'tcx> for SpanMapVisitor<'tcx> {
+    type Map = rustc_middle::hir::map::Map<'tcx>;
+
+    fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
+        NestedVisitorMap::All(self.tcx.hir())
+    }
+
+    fn visit_generic_param(&mut self, p: &'tcx GenericParam<'tcx>) {
+        if !matches!(p.kind, GenericParamKind::Type { .. }) {
+            return;
+        }
+        for bound in p.bounds {
+            if let Some(trait_ref) = bound.trait_ref() {
+                self.handle_path(&trait_ref.path, None);
+            }
+        }
+    }
+
+    fn visit_path(&mut self, path: &'tcx rustc_hir::Path<'tcx>, _id: HirId) {
+        self.handle_path(path, None);
+        intravisit::walk_path(self, path);
+    }
+
+    // fn visit_expr(&mut self, expr: &'tcx rustc_hir::Expr<'tcx>) {
+    //     match expr.kind {
+    //         ExprKind::MethodCall(segment, method_span, _, _) => {
+    //             if let Some(hir_id) = segment.hir_id {
+    //                 // call https://doc.rust-lang.org/beta/nightly-rustc/rustc_middle/ty/context/struct.TypeckResults.html#method.type_dependent_def_id
+    //             }
+    //         }
+    //         _ => {}
+    //     }
+    //     intravisit::walk_expr(self, expr);
+    // }
+
+    fn visit_use(&mut self, path: &'tcx rustc_hir::Path<'tcx>, id: HirId) {
+        self.handle_path(path, None);
+        intravisit::walk_use(self, path, id);
+    }
+}

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -9,12 +9,29 @@ use rustc_hir::{ExprKind, GenericParam, GenericParamKind, HirId, Mod, Node};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
+/// This enum allows us to store two different kinds of information:
+///
+/// In case the `span` definition comes from the same crate, we can simply get the `span` and use
+/// it as is.
+///
+/// Otherwise, we store the definition `DefId` and will generate a link to the documentation page
+/// instead of the source code directly.
 #[derive(Debug)]
 crate enum LinkFromSrc {
     Local(Span),
     External(DefId),
 }
 
+/// This function will do at most two things:
+///
+/// 1. Generate a `span` correspondance map which links an item `span` to its definition `span`.
+/// 2. Collect the source code files.
+///
+/// It returns the `krate`, the source code files and the `span` correspondance map.
+///
+/// Note about the `span` correspondance map: the keys are actually `(lo, hi)` of `span`s. We don't
+/// need the `span` context later on, only their position, so instead of keep a whole `Span`, we
+/// only keep the `lo` and `hi`.
 crate fn collect_spans_and_sources(
     tcx: TyCtxt<'_>,
     krate: clean::Crate,

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -51,7 +51,7 @@ impl LightSpan {
         Self { lo: lo + file_span_lo, hi: hi + file_span_lo }
     }
 
-    crate fn empty() -> Self {
+    crate fn dummy() -> Self {
         Self { lo: 0, hi: 0 }
     }
 

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 /// instead of the source code directly.
 #[derive(Debug)]
 crate enum LinkFromSrc {
-    Local(Span),
+    Local(clean::Span),
     External(DefId),
 }
 
@@ -113,7 +113,7 @@ impl<'tcx> SpanMapVisitor<'tcx> {
                 path_span
                     .map(LightSpan::new_from_span)
                     .unwrap_or_else(|| LightSpan::new_from_span(path.span)),
-                LinkFromSrc::Local(span),
+                LinkFromSrc::Local(clean::Span::new(span)),
             );
         } else if let Some(def_id) = info {
             self.matches.insert(
@@ -161,7 +161,7 @@ impl Visitor<'tcx> for SpanMapVisitor<'tcx> {
                     Node::Item(item) => {
                         self.matches.insert(
                             LightSpan::new_from_span(item.ident.span),
-                            LinkFromSrc::Local(m.inner),
+                            LinkFromSrc::Local(clean::Span::new(m.inner)),
                         );
                     }
                     _ => {}
@@ -187,7 +187,7 @@ impl Visitor<'tcx> for SpanMapVisitor<'tcx> {
                             Some(span) => {
                                 self.matches.insert(
                                     LightSpan::new_from_span(method_span),
-                                    LinkFromSrc::Local(span),
+                                    LinkFromSrc::Local(clean::Span::new(span)),
                                 );
                             }
                             None => {

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -9,6 +9,8 @@ use rustc_hir::{ExprKind, GenericParam, GenericParamKind, HirId, Mod, Node};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
 
+use std::path::{Path, PathBuf};
+
 /// This enum allows us to store two different kinds of information:
 ///
 /// In case the `span` definition comes from the same crate, we can simply get the `span` and use
@@ -35,10 +37,10 @@ crate enum LinkFromSrc {
 crate fn collect_spans_and_sources(
     tcx: TyCtxt<'_>,
     krate: clean::Crate,
-    src_root: &std::path::Path,
+    src_root: &Path,
     include_sources: bool,
     generate_link_to_definition: bool,
-) -> (clean::Crate, FxHashMap<std::path::PathBuf, String>, FxHashMap<(u32, u32), LinkFromSrc>) {
+) -> (clean::Crate, FxHashMap<PathBuf, String>, FxHashMap<(u32, u32), LinkFromSrc>) {
     let mut visitor = SpanMapVisitor { tcx, matches: FxHashMap::default() };
 
     if include_sources {

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -181,11 +181,11 @@ impl Visitor<'tcx> for SpanMapVisitor<'tcx> {
                 if let Some(hir_id) = segment.hir_id {
                     let hir = self.tcx.hir();
                     let body_id = hir.enclosing_body_owner(hir_id);
-                    // FIXME: this is showing error messages for parts of the code that are not
-                    // compiled (because of cfg)!
-                    let typeck_results = self.tcx.typeck_body(
-                        hir.maybe_body_owned_by(body_id).expect("a body which isn't a body"),
-                    );
+                    let typeck_results = self.tcx.sess.with_disabled_diagnostic(|| {
+                        self.tcx.typeck_body(
+                            hir.maybe_body_owned_by(body_id).expect("a body which isn't a body"),
+                        )
+                    });
                     if let Some(def_id) = typeck_results.type_dependent_def_id(expr.hir_id) {
                         self.matches.insert(
                             LightSpan::new_from_span(method_span),

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -272,7 +272,7 @@ pub(super) fn write_shared(
     write_minify("search.js", static_files::SEARCH_JS)?;
     write_minify("settings.js", static_files::SETTINGS_JS)?;
 
-    if cx.shared.include_sources {
+    if cx.include_sources {
         write_minify("source-script.js", static_files::sidebar::SOURCE_SCRIPT)?;
     }
 
@@ -398,7 +398,7 @@ pub(super) fn write_shared(
         }
     }
 
-    if cx.shared.include_sources {
+    if cx.include_sources {
         let mut hierarchy = Hierarchy::new(OsString::new());
         for source in cx
             .shared

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -5,8 +5,10 @@ use crate::fold::DocFolder;
 use crate::html::format::Buffer;
 use crate::html::highlight;
 use crate::html::layout;
-use crate::html::render::{SharedContext, BASIC_KEYWORDS};
+use crate::html::render::{Context, BASIC_KEYWORDS};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::LOCAL_CRATE;
+use rustc_middle::ty::TyCtxt;
 use rustc_session::Session;
 use rustc_span::edition::Edition;
 use rustc_span::source_map::FileName;
@@ -14,52 +16,116 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-crate fn render(
-    dst: &Path,
-    scx: &mut SharedContext<'_>,
-    krate: clean::Crate,
-) -> Result<clean::Crate, Error> {
+crate fn render(cx: &mut Context<'_>, krate: clean::Crate) -> Result<clean::Crate, Error> {
     info!("emitting source files");
-    let dst = dst.join("src").join(&*krate.name.as_str());
-    scx.ensure_dir(&dst)?;
-    let mut folder = SourceCollector { dst, scx };
+    let dst = cx.dst.join("src").join(&*krate.name.as_str());
+    cx.shared.ensure_dir(&dst)?;
+    let mut folder = SourceCollector { dst, cx, emitted_local_sources: FxHashSet::default() };
     Ok(folder.fold_crate(krate))
+}
+
+crate fn collect_local_sources<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    src_root: &Path,
+    krate: clean::Crate,
+) -> (clean::Crate, FxHashMap<PathBuf, String>) {
+    let mut lsc = LocalSourcesCollector { tcx, local_sources: FxHashMap::default(), src_root };
+
+    let krate = lsc.fold_crate(krate);
+    (krate, lsc.local_sources)
+}
+
+struct LocalSourcesCollector<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    local_sources: FxHashMap<PathBuf, String>,
+    src_root: &'a Path,
+}
+
+fn is_real_and_local(span: clean::Span, sess: &Session) -> bool {
+    span.filename(sess).is_real() && span.cnum(sess) == LOCAL_CRATE
+}
+
+impl LocalSourcesCollector<'_, '_> {
+    fn add_local_source(&mut self, item: &clean::Item) {
+        let sess = self.tcx.sess;
+        let span = item.span(self.tcx);
+        // skip all synthetic "files"
+        if !is_real_and_local(span, sess) {
+            return;
+        }
+        let filename = span.filename(sess);
+        let p = match filename {
+            FileName::Real(ref file) => match file.local_path() {
+                Some(p) => p.to_path_buf(),
+                _ => return,
+            },
+            _ => return,
+        };
+        if self.local_sources.contains_key(&*p) {
+            // We've already emitted this source
+            return;
+        }
+
+        let mut href = String::new();
+        clean_path(&self.src_root, &p, false, |component| {
+            href.push_str(&component.to_string_lossy());
+            href.push('/');
+        });
+
+        let src_fname = p.file_name().expect("source has no filename").to_os_string();
+        let mut fname = src_fname.clone();
+        fname.push(".html");
+        href.push_str(&fname.to_string_lossy());
+        self.local_sources.insert(p, href);
+    }
+}
+
+impl DocFolder for LocalSourcesCollector<'_, '_> {
+    fn fold_item(&mut self, item: clean::Item) -> Option<clean::Item> {
+        self.add_local_source(&item);
+
+        // FIXME: if `include_sources` isn't set and DocFolder didn't require consuming the crate by value,
+        // we could return None here without having to walk the rest of the crate.
+        Some(self.fold_item_recur(item))
+    }
 }
 
 /// Helper struct to render all source code to HTML pages
 struct SourceCollector<'a, 'tcx> {
-    scx: &'a mut SharedContext<'tcx>,
+    cx: &'a mut Context<'tcx>,
 
     /// Root destination to place all HTML output into
     dst: PathBuf,
+    emitted_local_sources: FxHashSet<PathBuf>,
 }
 
 impl DocFolder for SourceCollector<'_, '_> {
     fn fold_item(&mut self, item: clean::Item) -> Option<clean::Item> {
+        let tcx = self.cx.tcx();
+        let span = item.span(tcx);
+        let sess = tcx.sess;
+
         // If we're not rendering sources, there's nothing to do.
         // If we're including source files, and we haven't seen this file yet,
         // then we need to render it out to the filesystem.
-        if self.scx.include_sources
-            // skip all synthetic "files"
-            && item.span(self.scx.tcx).filename(self.sess()).is_real()
-            // skip non-local files
-            && item.span(self.scx.tcx).cnum(self.sess()) == LOCAL_CRATE
-        {
-            let filename = item.span(self.scx.tcx).filename(self.sess());
+        if self.cx.include_sources && is_real_and_local(span, sess) {
+            let filename = span.filename(sess);
+            let span = span.inner();
+            let start_pos = sess.source_map().lookup_source_file(span.lo()).start_pos;
             // If it turns out that we couldn't read this file, then we probably
             // can't read any of the files (generating html output from json or
             // something like that), so just don't include sources for the
             // entire crate. The other option is maintaining this mapping on a
             // per-file basis, but that's probably not worth it...
-            self.scx.include_sources = match self.emit_source(&filename) {
+            self.cx.include_sources = match self.emit_source(&filename, start_pos.0) {
                 Ok(()) => true,
                 Err(e) => {
-                    self.scx.tcx.sess.span_err(
-                        item.span(self.scx.tcx).inner(),
+                    self.cx.shared.tcx.sess.span_err(
+                        span,
                         &format!(
                             "failed to render source code for `{}`: {}",
                             filename.prefer_local(),
-                            e
+                            e,
                         ),
                     );
                     false
@@ -73,12 +139,8 @@ impl DocFolder for SourceCollector<'_, '_> {
 }
 
 impl SourceCollector<'_, 'tcx> {
-    fn sess(&self) -> &'tcx Session {
-        &self.scx.tcx.sess
-    }
-
     /// Renders the given filename into its corresponding HTML source file.
-    fn emit_source(&mut self, filename: &FileName) -> Result<(), Error> {
+    fn emit_source(&mut self, filename: &FileName, file_span_lo: u32) -> Result<(), Error> {
         let p = match *filename {
             FileName::Real(ref file) => {
                 if let Some(local_path) = file.local_path() {
@@ -89,7 +151,7 @@ impl SourceCollector<'_, 'tcx> {
             }
             _ => return Ok(()),
         };
-        if self.scx.local_sources.contains_key(&*p) {
+        if self.emitted_local_sources.contains(&*p) {
             // We've already emitted this source
             return Ok(());
         }
@@ -107,20 +169,17 @@ impl SourceCollector<'_, 'tcx> {
         // Create the intermediate directories
         let mut cur = self.dst.clone();
         let mut root_path = String::from("../../");
-        let mut href = String::new();
-        clean_path(&self.scx.src_root, &p, false, |component| {
+        clean_path(&self.cx.shared.src_root, &p, false, |component| {
             cur.push(component);
             root_path.push_str("../");
-            href.push_str(&component.to_string_lossy());
-            href.push('/');
         });
-        self.scx.ensure_dir(&cur)?;
+
+        self.cx.shared.ensure_dir(&cur)?;
 
         let src_fname = p.file_name().expect("source has no filename").to_os_string();
         let mut fname = src_fname.clone();
         fname.push(".html");
         cur.push(&fname);
-        href.push_str(&fname.to_string_lossy());
 
         let title = format!("{} - source", src_fname.to_string_lossy());
         let desc = format!("Source of the Rust file `{}`.", filename.prefer_remapped());
@@ -128,23 +187,32 @@ impl SourceCollector<'_, 'tcx> {
             title: &title,
             css_class: "source",
             root_path: &root_path,
-            static_root_path: self.scx.static_root_path.as_deref(),
+            static_root_path: self.cx.shared.static_root_path.as_deref(),
             description: &desc,
             keywords: BASIC_KEYWORDS,
-            resource_suffix: &self.scx.resource_suffix,
-            extra_scripts: &[&format!("source-files{}", self.scx.resource_suffix)],
-            static_extra_scripts: &[&format!("source-script{}", self.scx.resource_suffix)],
+            resource_suffix: &self.cx.shared.resource_suffix,
+            extra_scripts: &[&format!("source-files{}", self.cx.shared.resource_suffix)],
+            static_extra_scripts: &[&format!("source-script{}", self.cx.shared.resource_suffix)],
         };
         let v = layout::render(
-            &self.scx.templates,
-            &self.scx.layout,
+            &self.cx.shared.templates,
+            &self.cx.shared.layout,
             &page,
             "",
-            |buf: &mut _| print_src(buf, contents, self.scx.edition()),
-            &self.scx.style_files,
+            |buf: &mut _| {
+                print_src(
+                    buf,
+                    contents,
+                    self.cx.shared.edition(),
+                    file_span_lo,
+                    &self.cx,
+                    &root_path,
+                )
+            },
+            &self.cx.shared.style_files,
         );
-        self.scx.fs.write(&cur, v.as_bytes())?;
-        self.scx.local_sources.insert(p, href);
+        self.cx.shared.fs.write(&cur, v.as_bytes())?;
+        self.emitted_local_sources.insert(p);
         Ok(())
     }
 }
@@ -178,7 +246,14 @@ where
 
 /// Wrapper struct to render the source code of a file. This will do things like
 /// adding line numbers to the left-hand side.
-fn print_src(buf: &mut Buffer, s: &str, edition: Edition) {
+fn print_src(
+    buf: &mut Buffer,
+    s: &str,
+    edition: Edition,
+    file_span_lo: u32,
+    context: &Context<'_>,
+    root_path: &str,
+) {
     let lines = s.lines().count();
     let mut line_numbers = Buffer::empty_from(buf);
     let mut cols = 0;
@@ -192,5 +267,16 @@ fn print_src(buf: &mut Buffer, s: &str, edition: Edition) {
         writeln!(line_numbers, "<span id=\"{0}\">{0:1$}</span>", i, cols);
     }
     line_numbers.write_str("</pre>");
-    highlight::render_with_highlighting(s, buf, None, None, None, edition, Some(line_numbers));
+    highlight::render_with_highlighting(
+        s,
+        buf,
+        None,
+        None,
+        None,
+        edition,
+        Some(line_numbers),
+        file_span_lo,
+        Some(context),
+        root_path,
+    );
 }

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -275,8 +275,6 @@ fn print_src(
         None,
         edition,
         Some(line_numbers),
-        file_span_lo,
-        Some(context),
-        root_path,
+        Some(highlight::ContextInfo { context, file_span_lo, root_path }),
     );
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -450,6 +450,10 @@ nav.sub {
 	border-bottom-left-radius: 5px;
 }
 
+.example-wrap > pre.rust a:hover {
+	text-decoration: underline;
+}
+
 .rustdoc:not(.source) .example-wrap > pre:not(.line-number) {
 	width: 100%;
 	overflow-x: auto;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -607,6 +607,13 @@ fn opts() -> Vec<RustcOptGroup> {
         unstable("nocapture", |o| {
             o.optflag("", "nocapture", "Don't capture stdout and stderr of tests")
         }),
+        unstable("generate-link-to-definition", |o| {
+            o.optflag(
+                "",
+                "generate-link-to-definition",
+                "Make the identifiers in the HTML source code pages navigable",
+            )
+        }),
     ]
 }
 

--- a/src/test/rustdoc-ui/generate-link-to-definition-opt-unstable.rs
+++ b/src/test/rustdoc-ui/generate-link-to-definition-opt-unstable.rs
@@ -1,0 +1,6 @@
+// This test purpose is to check that the "--generate-link-to-definition"
+// option can only be used on nightly.
+
+// compile-flags: --generate-link-to-definition
+
+pub fn f() {}

--- a/src/test/rustdoc-ui/generate-link-to-definition-opt-unstable.stderr
+++ b/src/test/rustdoc-ui/generate-link-to-definition-opt-unstable.stderr
@@ -1,0 +1,2 @@
+error: the `-Z unstable-options` flag must also be passed to enable the flag `generate-link-to-definition`
+

--- a/src/test/rustdoc-ui/generate-link-to-definition-opt.rs
+++ b/src/test/rustdoc-ui/generate-link-to-definition-opt.rs
@@ -1,0 +1,6 @@
+// This test purpose is to check that the "--generate-link-to-definition"
+// option can only be used with HTML generation.
+
+// compile-flags: -Zunstable-options --generate-link-to-definition --output-format json
+
+pub fn f() {}

--- a/src/test/rustdoc-ui/generate-link-to-definition-opt.stderr
+++ b/src/test/rustdoc-ui/generate-link-to-definition-opt.stderr
@@ -1,0 +1,2 @@
+error: --generate-link-to-definition option can only be used with HTML output format
+

--- a/src/test/rustdoc-ui/generate-link-to-definition-opt2.rs
+++ b/src/test/rustdoc-ui/generate-link-to-definition-opt2.rs
@@ -1,0 +1,6 @@
+// This test purpose is to check that the "--generate-link-to-definition"
+// option can only be used with HTML generation.
+
+// compile-flags: -Zunstable-options --generate-link-to-definition --show-coverage
+
+pub fn f() {}

--- a/src/test/rustdoc-ui/generate-link-to-definition-opt2.stderr
+++ b/src/test/rustdoc-ui/generate-link-to-definition-opt2.stderr
@@ -1,0 +1,2 @@
+error: --generate-link-to-definition option can only be used with HTML output format
+

--- a/src/test/rustdoc/auxiliary/source-code-bar.rs
+++ b/src/test/rustdoc/auxiliary/source-code-bar.rs
@@ -1,0 +1,17 @@
+//! just some other file. :)
+
+use crate::Foo;
+
+pub struct Bar {
+    field: Foo,
+}
+
+pub struct Bar2 {
+    field: crate::Foo,
+}
+
+pub mod sub {
+    pub trait Trait {
+        fn tadam() {}
+    }
+}

--- a/src/test/rustdoc/auxiliary/source_code.rs
+++ b/src/test/rustdoc/auxiliary/source_code.rs
@@ -1,0 +1,1 @@
+pub struct SourceCode;

--- a/src/test/rustdoc/check-source-code-urls-to-def.rs
+++ b/src/test/rustdoc/check-source-code-urls-to-def.rs
@@ -2,10 +2,11 @@
 
 #![crate_name = "foo"]
 
+// @has 'src/foo/check-source-code-urls-to-def.rs.html'
+
+// @has - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#1-17"]' 'bar'
 #[path = "auxiliary/source-code-bar.rs"]
 pub mod bar;
-
-// @has 'src/foo/check-source-code-urls-to-def.rs.html'
 
 // @count - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#5-7"]' 4
 use bar::Bar;
@@ -22,13 +23,13 @@ impl Foo {
 fn babar() {}
 
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/alloc/string/struct.String.html"]' 'String'
-// @count - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#16"]' 5
+// @count - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#17"]' 5
 pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar) {
     let x = 12;
     let y: Foo = Foo;
     let z: Bar = bar::Bar { field: Foo };
     babar();
-    // @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#19"]' 'hello'
+    // @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#20"]' 'hello'
     y.hello();
 }
 

--- a/src/test/rustdoc/check-source-code-urls-to-def.rs
+++ b/src/test/rustdoc/check-source-code-urls-to-def.rs
@@ -1,6 +1,10 @@
 // compile-flags: -Zunstable-options --generate-link-to-definition
+// aux-build:source_code.rs
+// build-aux-docs
 
 #![crate_name = "foo"]
+
+extern crate source_code;
 
 // @has 'src/foo/check-source-code-urls-to-def.rs.html'
 
@@ -23,13 +27,14 @@ impl Foo {
 fn babar() {}
 
 // @has - '//a[@href="https://doc.rust-lang.org/nightly/alloc/string/struct.String.html"]' 'String'
-// @count - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#17"]' 5
-pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar) {
+// @count - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#21"]' 5
+// @has - '//a[@href="../../source_code/struct.SourceCode.html"]' 'source_code::SourceCode'
+pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar, f: source_code::SourceCode) {
     let x = 12;
     let y: Foo = Foo;
     let z: Bar = bar::Bar { field: Foo };
     babar();
-    // @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#20"]' 'hello'
+    // @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#24"]' 'hello'
     y.hello();
 }
 

--- a/src/test/rustdoc/check-source-code-urls-to-def.rs
+++ b/src/test/rustdoc/check-source-code-urls-to-def.rs
@@ -1,0 +1,38 @@
+// compile-flags: -Zunstable-options --generate-link-to-definition
+
+#![crate_name = "foo"]
+
+#[path = "auxiliary/source-code-bar.rs"]
+pub mod bar;
+
+// @has 'src/foo/check-source-code-urls-to-def.rs.html'
+
+// @count - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#5-7"]' 4
+use bar::Bar;
+// @has - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#13-17"]' 'self'
+// @has - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#14-16"]' 'Trait'
+use bar::sub::{self, Trait};
+
+pub struct Foo;
+
+impl Foo {
+    fn hello(&self) {}
+}
+
+fn babar() {}
+
+// @has - '//a[@href="https://doc.rust-lang.org/nightly/alloc/string/struct.String.html"]' 'String'
+// @count - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#16"]' 5
+pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar) {
+    let x = 12;
+    let y: Foo = Foo;
+    let z: Bar = bar::Bar { field: Foo };
+    babar();
+    // @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#19"]' 'hello'
+    y.hello();
+}
+
+// @has - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#14-16"]' 'bar::sub::Trait'
+// @has - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#14-16"]' 'Trait'
+pub fn foo2<T: bar::sub::Trait, V: Trait>(t: &T, v: &V) {
+}

--- a/src/test/rustdoc/check-source-code-urls-to-def.rs
+++ b/src/test/rustdoc/check-source-code-urls-to-def.rs
@@ -26,7 +26,7 @@ impl Foo {
 
 fn babar() {}
 
-// @has - '//a[@href="https://doc.rust-lang.org/nightly/alloc/string/struct.String.html"]' 'String'
+// @has - '//a/@href' '/struct.String.html'
 // @count - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#21"]' 5
 // @has - '//a[@href="../../source_code/struct.SourceCode.html"]' 'source_code::SourceCode'
 pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar, f: source_code::SourceCode) {


### PR DESCRIPTION
## Description

This PR adds an option (disabled by default) to add links in the source code page on ident. So for for example:

```rust
mod other_module;
struct Foo;
fn bar() {}

fn x<T: other_module::Trait>(f: Foo, g: other_module::Whatever, t: &T) {
    let f: Foo = Foo;
    bar();
    f.some_method();
}
```

In the example (mostly in the `x` function), `other_module::Trait`, `Foo`, `other_module::Whatever`, `bar` and `some_method` are now links (and `other_module` at the top too).

In case there is a type coming from another crate, it'll link to its documentation page and not its definition (but you can then click on `[src]` so I guess it's fine).

Another important detail: I voluntarily didn't add links for primitive types. I think we can discuss about adding links on them or not in a later PR (adding the support for them would require only a few lines).

Here is a video summing up everything I wrote above:

https://user-images.githubusercontent.com/3050060/114622354-21307b00-9cae-11eb-834d-f6d8178a37bd.mp4

## Performance impact

So, on my computer, the performance remains more or less the same (which is quite surprising but that's a nice surprise). Here are the numbers:

Without the option:
 * core:  1m 21s
 * alloc: 26.78s
 * std: 27.30s
 * proc_macro: 4.50s

With source to definition links generation (I enabled by default the option):
 * core: 1m 25s
 * alloc: 25.76s
 * std: 27.07s
 * proc_macro: 4.66s

So no real change here (again, I'm very surprised by this fact).

For the size of the generated source files (only taking into account the `src` folder here since it's the only one impacted) by running `du -shc .` (when I am in the source folder).

Without the option: 11.939 MB
With the option: 12.611 MB

So not a big change here either. In all those docs, I ran `grep -nR '<a class=' . | wc -l` and got 43917. So there are quite a lot of links added. :)

cc @rust-lang/rustdoc 
r? @jyn514 