### PR TITLE
Fix join_paths error display.

### DIFF
--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -223,7 +223,7 @@ where
 
 impl fmt::Display for JoinPathsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "path segment contains separator `{}`", PATH_SEPARATOR)
+        write!(f, "path segment contains separator `{}`", char::from(PATH_SEPARATOR))
     }
 }
 


### PR DESCRIPTION
On unix, the error from `join_paths` looked like this:

```
path segment contains separator `58`
```

This PR changes it to look like this:

```
path segment contains separator `:`
```
