### PR TITLE
Explicitly implement `!Send` and `!Sync` for `sys::{Args, Env}`

### DIFF
--- a/library/std/src/sys/hermit/args.rs
+++ b/library/std/src/sys/hermit/args.rs
@@ -1,6 +1,5 @@
 use crate::ffi::OsString;
 use crate::fmt;
-use crate::marker::PhantomData;
 use crate::vec;
 
 /// One-time global initialization.
@@ -20,7 +19,6 @@ pub fn args() -> Args {
 
 pub struct Args {
     iter: vec::IntoIter<OsString>,
-    _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
 
 impl fmt::Debug for Args {
@@ -28,6 +26,9 @@ impl fmt::Debug for Args {
         self.iter.as_slice().fmt(f)
     }
 }
+
+impl !Send for Args {}
+impl !Sync for Args {}
 
 impl Iterator for Args {
     type Item = OsString;
@@ -54,7 +55,6 @@ impl DoubleEndedIterator for Args {
 mod imp {
     use super::Args;
     use crate::ffi::{CStr, OsString};
-    use crate::marker::PhantomData;
     use crate::ptr;
     use crate::sys_common::os_str_bytes::*;
 
@@ -77,7 +77,7 @@ mod imp {
     }
 
     pub fn args() -> Args {
-        Args { iter: clone().into_iter(), _dont_send_or_sync_me: PhantomData }
+        Args { iter: clone().into_iter() }
     }
 
     fn clone() -> Vec<OsString> {

--- a/library/std/src/sys/hermit/os.rs
+++ b/library/std/src/sys/hermit/os.rs
@@ -110,8 +110,10 @@ pub fn init_environment(env: *const *const i8) {
 
 pub struct Env {
     iter: vec::IntoIter<(OsString, OsString)>,
-    _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
+
+impl !Send for Env {}
+impl !Sync for Env {}
 
 impl Iterator for Env {
     type Item = (OsString, OsString);
@@ -134,7 +136,7 @@ pub fn env() -> Env {
             result.push((key.clone(), value.clone()));
         }
 
-        return Env { iter: result.into_iter(), _dont_send_or_sync_me: PhantomData };
+        return Env { iter: result.into_iter() };
     }
 }
 

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -12,7 +12,6 @@ use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
 use crate::io;
 use crate::iter;
-use crate::marker::PhantomData;
 use crate::mem;
 use crate::memchr;
 use crate::path::{self, PathBuf};
@@ -460,8 +459,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
 
 pub struct Env {
     iter: vec::IntoIter<(OsString, OsString)>,
-    _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
+
+impl !Send for Env {}
+impl !Sync for Env {}
 
 impl Iterator for Env {
     type Item = (OsString, OsString);
@@ -510,7 +511,7 @@ pub fn env() -> Env {
                 environ = environ.add(1);
             }
         }
-        return Env { iter: result.into_iter(), _dont_send_or_sync_me: PhantomData };
+        return Env { iter: result.into_iter() };
     }
 
     fn parse(input: &[u8]) -> Option<(OsString, OsString)> {

--- a/library/std/src/sys/wasi/args.rs
+++ b/library/std/src/sys/wasi/args.rs
@@ -2,7 +2,6 @@
 
 use crate::ffi::{CStr, OsStr, OsString};
 use crate::fmt;
-use crate::marker::PhantomData;
 use crate::os::wasi::ffi::OsStrExt;
 use crate::vec;
 
@@ -12,15 +11,14 @@ pub unsafe fn cleanup() {}
 
 pub struct Args {
     iter: vec::IntoIter<OsString>,
-    _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
+
+impl !Send for Args {}
+impl !Sync for Args {}
 
 /// Returns the command line arguments
 pub fn args() -> Args {
-    Args {
-        iter: maybe_args().unwrap_or(Vec::new()).into_iter(),
-        _dont_send_or_sync_me: PhantomData,
-    }
+    Args { iter: maybe_args().unwrap_or(Vec::new()).into_iter() }
 }
 
 fn maybe_args() -> Option<Vec<OsString>> {

--- a/library/std/src/sys/wasi/os.rs
+++ b/library/std/src/sys/wasi/os.rs
@@ -129,8 +129,10 @@ pub fn current_exe() -> io::Result<PathBuf> {
 }
 pub struct Env {
     iter: vec::IntoIter<(OsString, OsString)>,
-    _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
+
+impl !Send for Env {}
+impl !Sync for Env {}
 
 impl Iterator for Env {
     type Item = (OsString, OsString);
@@ -155,7 +157,7 @@ pub fn env() -> Env {
                 environ = environ.add(1);
             }
         }
-        return Env { iter: result.into_iter(), _dont_send_or_sync_me: PhantomData };
+        return Env { iter: result.into_iter() };
     }
 
     // See src/libstd/sys/unix/os.rs, same as that

--- a/library/std/src/sys/wasm/args.rs
+++ b/library/std/src/sys/wasm/args.rs
@@ -1,6 +1,5 @@
 use crate::ffi::OsString;
 use crate::fmt;
-use crate::marker::PhantomData;
 use crate::vec;
 
 pub unsafe fn init(_argc: isize, _argv: *const *const u8) {
@@ -10,13 +9,15 @@ pub unsafe fn init(_argc: isize, _argv: *const *const u8) {
 pub unsafe fn cleanup() {}
 
 pub fn args() -> Args {
-    Args { iter: Vec::new().into_iter(), _dont_send_or_sync_me: PhantomData }
+    Args { iter: Vec::new().into_iter() }
 }
 
 pub struct Args {
     iter: vec::IntoIter<OsString>,
-    _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
+
+impl !Send for Args {}
+impl !Sync for Args {}
 
 impl fmt::Debug for Args {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Remove the field `_dont_send_or_sync_me: PhantomData<*mut ()>` in favor of an explicit implementation of `!Send` and `!Sync`.