### PR TITLE
Update docs for unsafe_op_in_unsafe_fn stability.

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2522,9 +2522,10 @@ declare_lint! {
     ///
     /// The fix to this is to wrap the unsafe code in an `unsafe` block.
     ///
-    /// This lint is "allow" by default because it has not yet been
-    /// stabilized, and is not yet complete. See [RFC #2585] and [issue
-    /// #71668] for more details
+    /// This lint is "allow" by default since this will affect a large amount
+    /// of existing code, and the exact plan for increasing the severity is
+    /// still being considered. See [RFC #2585] and [issue #71668] for more
+    /// details.
     ///
     /// [`unsafe fn`]: https://doc.rust-lang.org/reference/unsafe-functions.html
     /// [`unsafe` block]: https://doc.rust-lang.org/reference/expressions/block-expr.html#unsafe-blocks


### PR DESCRIPTION
The unsafe_op_in_unsafe_fn lint was stabilized in #79208, but the bottom of this documentation wasn't updated.

I'm just guessing at the reason here, hopefully it is close to correct. The only discussion I found is https://github.com/rust-lang/rust/issues/71668#issuecomment-730399862 which didn't really explain the thought process behind the decision.
