### PR TITLE
rustdoc: Note that forbidding anchors in links to primitives is a bug

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1913,6 +1913,10 @@ fn anchor_failure(cx: &DocContext<'_>, diag_info: DiagnosticInfo<'_>, failure: A
         if let Some(sp) = sp {
             diag.span_label(sp, "contains invalid anchor");
         }
+        if let AnchorFailure::RustdocAnchorConflict(Res::Primitive(_)) = failure {
+            diag.note("this restriction may be lifted in a future release");
+            diag.note("see https://github.com/rust-lang/rust/issues/83083 for more information");
+        }
     });
 }
 

--- a/src/test/rustdoc-ui/intra-doc/anchors.stderr
+++ b/src/test/rustdoc-ui/intra-doc/anchors.stderr
@@ -9,6 +9,8 @@ note: the lint level is defined here
    |
 LL | #![deny(rustdoc::broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this restriction may be lifted in a future release
+   = note: see https://github.com/rust-lang/rust/issues/83083 for more information
 
 error: `Foo::f#hola` contains an anchor, but links to fields are already anchored
   --> $DIR/anchors.rs:25:15
@@ -33,6 +35,9 @@ error: `u32#hello` contains an anchor, but links to builtin types are already an
    |
 LL | /// [u32#hello]
    |      ^^^^^^^^^ contains invalid anchor
+   |
+   = note: this restriction may be lifted in a future release
+   = note: see https://github.com/rust-lang/rust/issues/83083 for more information
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/83083, https://github.com/rust-lang/rust/pull/84147#discussion_r613518820

r? @cuviper