### PR TITLE
Deprecate the core::raw / std::raw module

### DIFF
--- a/library/core/src/raw.rs
+++ b/library/core/src/raw.rs
@@ -1,5 +1,9 @@
 #![allow(missing_docs)]
 #![unstable(feature = "raw", issue = "27751")]
+#![rustc_deprecated(
+    since = "1.53.0",
+    reason = "use pointer metadata APIs instead https://github.com/rust-lang/rust/issues/81513"
+)]
 
 //! Contains struct definitions for the layout of compiler built-in types.
 //!

--- a/library/core/tests/mem.rs
+++ b/library/core/tests/mem.rs
@@ -97,6 +97,9 @@ fn test_transmute_copy() {
     assert_eq!(1, unsafe { transmute_copy(&1) });
 }
 
+// Remove this test when `std::raw` is removed.
+// The replacement pointer metadata APIs are tested in library/core/tests/ptr.rs
+#[allow(deprecated)]
 #[test]
 fn test_transmute() {
     trait Foo {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -456,6 +456,7 @@ pub use core::pin;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::ptr;
 #[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated_in_future)]
 pub use core::raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -456,7 +456,7 @@ pub use core::pin;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::ptr;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated)]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -456,7 +456,7 @@ pub use core::pin;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::ptr;
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated_in_future)]
+#[allow(deprecated)]
 pub use core::raw;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;

--- a/src/test/ui/cast/fat-ptr-cast-rpass.rs
+++ b/src/test/ui/cast/fat-ptr-cast-rpass.rs
@@ -1,5 +1,8 @@
 // run-pass
 
+// Remove this file when `std::raw` is removed.
+// The replacement pointer metadata APIs are tested in library/core/tests/ptr.rs
+#![allow(deprecated)]
 #![feature(raw)]
 
 use std::mem;
@@ -37,5 +40,4 @@ fn main() {
 
     assert_eq!(b, d);
     assert_eq!(c, d as usize);
-
 }


### PR DESCRIPTION
It only contains the `TraitObject` struct which exposes components of wide pointer. Pointer metadata APIs are designed to replace this: https://github.com/rust-lang/rust/issues/81513