### PR TITLE
move core::hint::black_box under its own feature gate

### DIFF
--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(allow_internal_unstable)]
 #![feature(bench_black_box)]
-#![feature(const_fn)]
 #![feature(const_panic)]
 #![feature(extend_one)]
 #![feature(iter_zip)]

--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(allow_internal_unstable)]
+#![feature(bench_black_box)]
+#![feature(const_fn)]
 #![feature(const_panic)]
 #![feature(extend_one)]
 #![feature(iter_zip)]

--- a/library/core/benches/fmt.rs
+++ b/library/core/benches/fmt.rs
@@ -112,7 +112,7 @@ fn write_str_macro_debug(bh: &mut Bencher) {
 #[bench]
 fn write_u128_max(bh: &mut Bencher) {
     bh.iter(|| {
-        std::hint::black_box(format!("{}", u128::MAX));
+        test::black_box(format!("{}", u128::MAX));
     });
 }
 
@@ -120,20 +120,20 @@ fn write_u128_max(bh: &mut Bencher) {
 fn write_u128_min(bh: &mut Bencher) {
     bh.iter(|| {
         let s = format!("{}", 0u128);
-        std::hint::black_box(s);
+        test::black_box(s);
     });
 }
 
 #[bench]
 fn write_u64_max(bh: &mut Bencher) {
     bh.iter(|| {
-        std::hint::black_box(format!("{}", u64::MAX));
+        test::black_box(format!("{}", u64::MAX));
     });
 }
 
 #[bench]
 fn write_u64_min(bh: &mut Bencher) {
     bh.iter(|| {
-        std::hint::black_box(format!("{}", 0u64));
+        test::black_box(format!("{}", 0u64));
     });
 }

--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -154,7 +154,7 @@ pub fn spin_loop() {
 /// [`std::convert::identity`]: crate::convert::identity
 #[cfg_attr(not(miri), inline)]
 #[cfg_attr(miri, inline(never))]
-#[unstable(feature = "test", issue = "50297")]
+#[unstable(feature = "bench_black_box", issue = "64102")]
 #[cfg_attr(miri, allow(unused_mut))]
 pub fn black_box<T>(mut dummy: T) -> T {
     // We need to "use" the argument in some way LLVM can't introspect, and on

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -233,6 +233,7 @@
 #![feature(assert_matches)]
 #![feature(associated_type_bounds)]
 #![feature(atomic_mut_ptr)]
+#![feature(bench_black_box)]
 #![feature(box_syntax)]
 #![feature(c_variadic)]
 #![feature(cfg_accessible)]

--- a/library/test/src/bench.rs
+++ b/library/test/src/bench.rs
@@ -1,6 +1,4 @@
 //! Benchmarking module.
-pub use std::hint::black_box;
-
 use super::{
     event::CompletedTest,
     options::BenchMode,
@@ -15,6 +13,15 @@ use std::io;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+/// An identity function that *__hints__* to the compiler to be maximally pessimistic about what
+/// `black_box` could do.
+///
+/// See [`std::hint::black_box`] for details.
+#[inline(always)]
+pub fn black_box<T>(dummy: T) -> T {
+    std::hint::black_box(dummy)
+}
 
 /// Manager of the benchmarking runs.
 ///

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -24,6 +24,7 @@
 #![feature(rustc_private)]
 #![feature(nll)]
 #![feature(available_concurrency)]
+#![feature(bench_black_box)]
 #![feature(internal_output_capture)]
 #![feature(panic_unwind)]
 #![feature(staged_api)]

--- a/src/test/ui/consts/cast-discriminant-zst-enum.rs
+++ b/src/test/ui/consts/cast-discriminant-zst-enum.rs
@@ -1,6 +1,6 @@
 // run-pass
 // Test a ZST enum whose dicriminant is ~0i128. This caused an ICE when casting to a i32.
-#![feature(test)]
+#![feature(bench_black_box)]
 use std::hint::black_box;
 
 #[derive(Copy, Clone)]

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -1,6 +1,6 @@
 // run-pass
 #![feature(const_discriminant)]
-#![feature(test)]
+#![feature(bench_black_box)]
 #![allow(dead_code)]
 
 use std::mem::{discriminant, Discriminant};

--- a/src/test/ui/sanitize/address.rs
+++ b/src/test/ui/sanitize/address.rs
@@ -7,7 +7,7 @@
 // error-pattern: AddressSanitizer: stack-buffer-overflow
 // error-pattern: 'xs' (line 15) <== Memory access at offset
 
-#![feature(test)]
+#![feature(bench_black_box)]
 
 use std::hint::black_box;
 

--- a/src/test/ui/sanitize/hwaddress.rs
+++ b/src/test/ui/sanitize/hwaddress.rs
@@ -7,7 +7,7 @@
 // run-fail
 // error-pattern: HWAddressSanitizer: tag-mismatch
 
-#![feature(test)]
+#![feature(bench_black_box)]
 
 use std::hint::black_box;
 

--- a/src/test/ui/sanitize/leak.rs
+++ b/src/test/ui/sanitize/leak.rs
@@ -6,7 +6,7 @@
 // run-fail
 // error-pattern: LeakSanitizer: detected memory leaks
 
-#![feature(test)]
+#![feature(bench_black_box)]
 
 use std::hint::black_box;
 use std::mem;

--- a/src/test/ui/sanitize/memory.rs
+++ b/src/test/ui/sanitize/memory.rs
@@ -13,7 +13,7 @@
 
 #![feature(core_intrinsics)]
 #![feature(start)]
-#![feature(test)]
+#![feature(bench_black_box)]
 
 use std::hint::black_box;
 use std::mem::MaybeUninit;


### PR DESCRIPTION
The `black_box` function had its own RFC and is tracked separately from the `test` feature at https://github.com/rust-lang/rust/issues/64102. Let's reflect this in the feature gate.

To avoid breaking all the benchmarks, libtest's `test::black_box` is a wrapping definition, not a reexport -- this means it is still under the `test` feature gate.