### PR TITLE
[WIP] Switch StableHasher from SipHash to HighwayHash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "highway"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66920f2e905206a4aca271ae71f1638f10854e3739f162fc465fb8aecce44446"
+
+[[package]]
 name = "home"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,6 +3851,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "ena",
+ "highway",
  "indexmap",
  "jobserver",
  "libc",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -29,6 +29,7 @@ measureme = "9.1.0"
 libc = "0.2"
 stacker = "0.1.12"
 tempfile = "3.0.5"
+highway = "0.6.3"
 
 [dependencies.parking_lot]
 version = "0.11"

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -105,6 +105,7 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "gsgdt",
     "hashbrown",
     "hermit-abi",
+    "highway",
     "humantime",
     "indexmap",
     "instant",


### PR DESCRIPTION
This changes the hash in the legacy symbol mangling format - if this is
undesired, we could use SipHash just for symbol mangling.

r? @ghost