### PR TITLE
Builtin derive macros: fix error with const generics default

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -541,7 +541,7 @@ impl<'a> TraitDef<'a> {
             self.generics.to_generics(cx, self.span, type_ident, generics);
 
         // Create the generic parameters
-        params.extend(generics.params.iter().map(|param| match param.kind {
+        params.extend(generics.params.iter().map(|param| match &param.kind {
             GenericParamKind::Lifetime { .. } => param.clone(),
             GenericParamKind::Type { .. } => {
                 // I don't think this can be moved out of the loop, since
@@ -561,7 +561,18 @@ impl<'a> TraitDef<'a> {
 
                 cx.typaram(self.span, param.ident, vec![], bounds, None)
             }
-            GenericParamKind::Const { .. } => param.clone(),
+            GenericParamKind::Const { ty, kw_span, .. } => {
+                let const_nodefault_kind = GenericParamKind::Const {
+                    ty: ty.clone(),
+                    kw_span: kw_span.clone(),
+
+                    // We can't have default values inside impl block
+                    default: None,
+                };
+                let mut param_clone = param.clone();
+                param_clone.kind = const_nodefault_kind;
+                param_clone
+            }
         }));
 
         // and similarly for where clauses

--- a/src/test/ui/derives/derive-macro-const-default.rs
+++ b/src/test/ui/derives/derive-macro-const-default.rs
@@ -1,0 +1,14 @@
+// check-pass
+#![allow(incomplete_features)]
+#![feature(const_generics_defaults)]
+
+#[derive(Clone, PartialEq, Debug)]
+struct Example<T, const N: usize = 1usize>([T; N]);
+
+fn main() {
+    let a = Example([(); 16]);
+    let b = a.clone();
+    if a != b {
+        let _c = format!("{:?}", a);
+    }
+}


### PR DESCRIPTION
This fixes a bug where builtin derive macros (like Clone, Debug) would basically copy-paste the default from a const generic, causing a compile error with very confusing message - it would say defaults are not allowed in impl blocks, while pointing at struct/enum/union definition.