### PR TITLE
rustdoc: get rid of unused path printing code

### DIFF
--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -401,7 +401,7 @@ crate fn resolve_type(cx: &mut DocContext<'_>, path: Path, id: hir::HirId) -> Ty
             return Generic(kw::SelfUpper);
         }
         Res::Def(DefKind::TyParam, _) if path.segments.len() == 1 => {
-            return Generic(Symbol::intern(&format!("{:#}", path.print(&cx.cache, cx.tcx))));
+            return Generic(Symbol::intern(&path.whole_name()));
         }
         Res::SelfTy(..) | Res::Def(DefKind::TyParam | DefKind::AssocTy, _) => true,
         _ => false,

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -453,48 +453,6 @@ impl clean::GenericArgs {
     }
 }
 
-impl clean::PathSegment {
-    crate fn print<'a, 'tcx: 'a>(
-        &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
-        display_fn(move |f| {
-            if f.alternate() {
-                write!(f, "{}{:#}", self.name, self.args.print(cache, tcx))
-            } else {
-                write!(f, "{}{}", self.name, self.args.print(cache, tcx))
-            }
-        })
-    }
-}
-
-impl clean::Path {
-    crate fn print<'a, 'tcx: 'a>(
-        &'a self,
-        cache: &'a Cache,
-        tcx: TyCtxt<'tcx>,
-    ) -> impl fmt::Display + 'a + Captures<'tcx> {
-        display_fn(move |f| {
-            if self.global {
-                f.write_str("::")?
-            }
-
-            for (i, seg) in self.segments.iter().enumerate() {
-                if i > 0 {
-                    f.write_str("::")?
-                }
-                if f.alternate() {
-                    write!(f, "{:#}", seg.print(cache, tcx))?;
-                } else {
-                    write!(f, "{}", seg.print(cache, tcx))?;
-                }
-            }
-            Ok(())
-        })
-    }
-}
-
 crate fn href(did: DefId, cache: &Cache) -> Option<(String, ItemType, Vec<String>)> {
     if !did.is_local() && !cache.access_levels.is_public(did) && !cache.document_private {
         return None;


### PR DESCRIPTION
The code for printing a raw path is only used in utils.rs, which only prints the alternative (non-HTML) format. Path has
a function that does the same thing without HTML support, so use that instead.