### PR TITLE
extract code path shared between FromIterator and Extend

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2637,6 +2637,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// The bound `I: TrustedLen` ensures that the caller can safely know
     /// how much needs to be allocated.
     #[cfg(not(no_global_oom_handling))]
+    #[inline]
     unsafe fn extend_prealloc_trusted_len<I: TrustedLen<Item = T>>(&mut self, iterator: I) {
         unsafe {
             let mut ptr = self.as_mut_ptr().add(self.len());

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -62,7 +62,7 @@ use core::hash::{Hash, Hasher};
 use core::intrinsics::{arith_offset, assume};
 use core::iter;
 #[cfg(not(no_global_oom_handling))]
-use core::iter::FromIterator;
+use core::iter::{FromIterator, TrustedLen};
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::{self, Index, IndexMut, Range, RangeBounds};
@@ -2624,6 +2624,31 @@ impl<T, A: Allocator> Vec<T, A> {
                 // NB can't overflow since we would have had to alloc the address space
                 self.set_len(len + 1);
             }
+        }
+    }
+
+    /// Appends the iterator's items to the vec without allocating.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `self` has sufficient spare capacity
+    /// to hold the items returned by the iterator.
+    ///
+    /// The bound `I: TrustedLen` ensures that the caller can safely know
+    /// how much needs to be allocated.
+    #[cfg(not(no_global_oom_handling))]
+    unsafe fn extend_prealloc_trustedlen<I: TrustedLen<Item = T>>(&mut self, iterator: I) {
+        unsafe {
+            let mut ptr = self.as_mut_ptr().add(self.len());
+            let mut local_len = SetLenOnDrop::new(&mut self.len);
+            iterator.for_each(move |element| {
+                ptr::write(ptr, element);
+                ptr = ptr.offset(1);
+                // Since the loop executes user code which can panic we have to bump the length
+                // after each step.
+                // NB can't overflow since we would have had to alloc the address space
+                local_len.increment_len(1);
+            });
         }
     }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2637,7 +2637,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// The bound `I: TrustedLen` ensures that the caller can safely know
     /// how much needs to be allocated.
     #[cfg(not(no_global_oom_handling))]
-    unsafe fn extend_prealloc_trustedlen<I: TrustedLen<Item = T>>(&mut self, iterator: I) {
+    unsafe fn extend_prealloc_trusted_len<I: TrustedLen<Item = T>>(&mut self, iterator: I) {
         unsafe {
             let mut ptr = self.as_mut_ptr().add(self.len());
             let mut local_len = SetLenOnDrop::new(&mut self.len);

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -36,7 +36,7 @@ where
             // Safety: We rely on the TrustedLen contract to know how much capacity needs to be
             // reserved. And we reserved at least that amount above.
             unsafe {
-                self.extend_prealloc_trustedlen(iterator);
+                self.extend_prealloc_trusted_len(iterator);
             }
         } else {
             // Per TrustedLen contract a `None` upper bound means that the iterator length

--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -55,7 +55,7 @@ where
         // Safety: The TrustedLen contract together with the `with_capacity`
         // above guarantee that no further allocations should be needed to collect the iterator
         unsafe {
-            vector.extend_prealloc_trustedlen(iterator);
+            vector.extend_prealloc_trusted_len(iterator);
         }
         vector
     }

--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -52,8 +52,11 @@ where
             // (via `with_capacity`) we do the same here.
             _ => panic!("capacity overflow"),
         };
-        // reuse extend specialization for TrustedLen
-        vector.spec_extend(iterator);
+        // Safety: The TrustedLen contract together with the `with_capacity`
+        // above guarantee that no further allocations should be needed to collect the iterator
+        unsafe {
+            vector.extend_prealloc_trustedlen(iterator);
+        }
         vector
     }
 }


### PR DESCRIPTION
This should eliminate the call to `reserve` on the `FromIterator` code path since that's redundant after the `with_capacity` call. So it should result in reduced IR.

I hope this will result in better compile times by itself, but if not it may still improve the numbers combined with the revert in #83797 which would increase the code weight of `reserve()`

@rustbot label T-libs-impl