### PR TITLE
Mark `has_global_allocator` query as `eval_always`

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1055,6 +1055,8 @@ rustc_queries! {
         desc { "checking if the crate is_compiler_builtins" }
     }
     query has_global_allocator(_: CrateNum) -> bool {
+        // This query depends on untracked global state in CStore
+        eval_always
         fatal_cycle
         desc { "checking if the crate has_global_allocator" }
     }

--- a/src/test/incremental/issue-84252-global-alloc.rs
+++ b/src/test/incremental/issue-84252-global-alloc.rs
@@ -1,0 +1,12 @@
+// revisions: cfail1 cfail2
+// build-pass
+
+#![crate_type="lib"]
+#![crate_type="cdylib"]
+
+#[allow(unused_imports)]
+use std::alloc::System;
+
+#[cfg(cfail1)]
+#[global_allocator]
+static ALLOC: System = System;


### PR DESCRIPTION
Fixes #84252

This query reads from untracked global state in `CStore`.