### PR TITLE
Inform the msvc linker about local and upstream native libraries

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1809,9 +1809,9 @@ fn add_local_native_libraries(
             None => continue,
         };
         match lib.kind {
-            NativeLibKind::Dylib | NativeLibKind::Unspecified => cmd.link_dylib(name),
+            NativeLibKind::Dylib | NativeLibKind::Unspecified => cmd.link_local_dylib(name),
             NativeLibKind::Framework => cmd.link_framework(name),
-            NativeLibKind::StaticNoBundle => cmd.link_staticlib(name),
+            NativeLibKind::StaticNoBundle => cmd.link_local_staticlib(name),
             NativeLibKind::StaticBundle => cmd.link_whole_staticlib(name, &search_path),
             NativeLibKind::RawDylib => {
                 // FIXME(#58713): Proper handling for raw dylibs.


### PR DESCRIPTION
This gives downstream crates the ability to override upstream native libraries.

In the MSVC linker there are two ways to specify a library:

* as a standalone argument on the command line
* using [`/DEFAULTLIB:`](https://docs.microsoft.com/en-us/cpp/build/reference/defaultlib-specify-default-library?view=msvc-160)

The first way cannot be overridden, except by a library that appears earlier on the command line. There is no way to remove such a library. On the other hand, using `/DEFAULTLIB:` allows overriding or removing a library using `/NODEFAULTLIB:`. Thus using `/DEFAULTLIB:` for upstream native libraries grants more control over linking. This is especially useful for overriding standard library imports which isn't as easy to patch as third party crates. It is also consistent with the behaviour of Visual C++'s `#pragma comment(lib, "libname")`. Such consistency is useful in mixed Rust/C++ code bases.

This PR does effectively de-prioritise upstream libraries but crate local libraries were always favoured.