### PR TITLE
Don't set fast-math for the SIMD operations we set it for previously

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -261,7 +261,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn fadd_fast(&mut self, lhs: &'ll Value, rhs: &'ll Value) -> &'ll Value {
         unsafe {
             let instr = llvm::LLVMBuildFAdd(self.llbuilder, lhs, rhs, UNNAMED);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
@@ -269,7 +269,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn fsub_fast(&mut self, lhs: &'ll Value, rhs: &'ll Value) -> &'ll Value {
         unsafe {
             let instr = llvm::LLVMBuildFSub(self.llbuilder, lhs, rhs, UNNAMED);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
@@ -277,7 +277,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn fmul_fast(&mut self, lhs: &'ll Value, rhs: &'ll Value) -> &'ll Value {
         unsafe {
             let instr = llvm::LLVMBuildFMul(self.llbuilder, lhs, rhs, UNNAMED);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
@@ -285,7 +285,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn fdiv_fast(&mut self, lhs: &'ll Value, rhs: &'ll Value) -> &'ll Value {
         unsafe {
             let instr = llvm::LLVMBuildFDiv(self.llbuilder, lhs, rhs, UNNAMED);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
@@ -293,7 +293,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn frem_fast(&mut self, lhs: &'ll Value, rhs: &'ll Value) -> &'ll Value {
         unsafe {
             let instr = llvm::LLVMBuildFRem(self.llbuilder, lhs, rhs, UNNAMED);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
@@ -1242,14 +1242,14 @@ impl Builder<'a, 'll, 'tcx> {
     pub fn vector_reduce_fadd_fast(&mut self, acc: &'ll Value, src: &'ll Value) -> &'ll Value {
         unsafe {
             let instr = llvm::LLVMRustBuildVectorReduceFAdd(self.llbuilder, acc, src);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
     pub fn vector_reduce_fmul_fast(&mut self, acc: &'ll Value, src: &'ll Value) -> &'ll Value {
         unsafe {
             let instr = llvm::LLVMRustBuildVectorReduceFMul(self.llbuilder, acc, src);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
@@ -1282,7 +1282,7 @@ impl Builder<'a, 'll, 'tcx> {
         unsafe {
             let instr =
                 llvm::LLVMRustBuildVectorReduceFMin(self.llbuilder, src, /*NoNaNs:*/ true);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }
@@ -1290,7 +1290,7 @@ impl Builder<'a, 'll, 'tcx> {
         unsafe {
             let instr =
                 llvm::LLVMRustBuildVectorReduceFMax(self.llbuilder, src, /*NoNaNs:*/ true);
-            llvm::LLVMRustSetHasUnsafeAlgebra(instr);
+            llvm::LLVMRustSetFastMath(instr);
             instr
         }
     }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1053,50 +1053,48 @@ fn generic_simd_intrinsic(
         let vec_ty = bx.type_vector(elem_ty, in_len);
 
         let (intr_name, fn_ty) = match name {
-            sym::simd_fsqrt => ("sqrt", bx.type_func(&[vec_ty], vec_ty)),
-            sym::simd_fsin => ("sin", bx.type_func(&[vec_ty], vec_ty)),
-            sym::simd_fcos => ("cos", bx.type_func(&[vec_ty], vec_ty)),
-            sym::simd_fabs => ("fabs", bx.type_func(&[vec_ty], vec_ty)),
             sym::simd_ceil => ("ceil", bx.type_func(&[vec_ty], vec_ty)),
-            sym::simd_floor => ("floor", bx.type_func(&[vec_ty], vec_ty)),
-            sym::simd_round => ("round", bx.type_func(&[vec_ty], vec_ty)),
-            sym::simd_trunc => ("trunc", bx.type_func(&[vec_ty], vec_ty)),
-            sym::simd_fexp => ("exp", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_fabs => ("fabs", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_fcos => ("cos", bx.type_func(&[vec_ty], vec_ty)),
             sym::simd_fexp2 => ("exp2", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_fexp => ("exp", bx.type_func(&[vec_ty], vec_ty)),
             sym::simd_flog10 => ("log10", bx.type_func(&[vec_ty], vec_ty)),
             sym::simd_flog2 => ("log2", bx.type_func(&[vec_ty], vec_ty)),
             sym::simd_flog => ("log", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_floor => ("floor", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_fma => ("fma", bx.type_func(&[vec_ty, vec_ty, vec_ty], vec_ty)),
             sym::simd_fpowi => ("powi", bx.type_func(&[vec_ty, bx.type_i32()], vec_ty)),
             sym::simd_fpow => ("pow", bx.type_func(&[vec_ty, vec_ty], vec_ty)),
-            sym::simd_fma => ("fma", bx.type_func(&[vec_ty, vec_ty, vec_ty], vec_ty)),
+            sym::simd_fsin => ("sin", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_fsqrt => ("sqrt", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_round => ("round", bx.type_func(&[vec_ty], vec_ty)),
+            sym::simd_trunc => ("trunc", bx.type_func(&[vec_ty], vec_ty)),
             _ => return_error!("unrecognized intrinsic `{}`", name),
         };
-
         let llvm_name = &format!("llvm.{0}.v{1}{2}", intr_name, in_len, elem_ty_str);
         let f = bx.declare_cfn(&llvm_name, llvm::UnnamedAddr::No, fn_ty);
         let c = bx.call(f, &args.iter().map(|arg| arg.immediate()).collect::<Vec<_>>(), None);
-        unsafe { llvm::LLVMRustSetHasUnsafeAlgebra(c) };
         Ok(c)
     }
 
     if std::matches!(
         name,
-        sym::simd_fsqrt
-            | sym::simd_fsin
-            | sym::simd_fcos
+        sym::simd_ceil
             | sym::simd_fabs
-            | sym::simd_ceil
-            | sym::simd_floor
-            | sym::simd_round
-            | sym::simd_trunc
-            | sym::simd_fexp
+            | sym::simd_fcos
             | sym::simd_fexp2
+            | sym::simd_fexp
             | sym::simd_flog10
             | sym::simd_flog2
             | sym::simd_flog
-            | sym::simd_fpowi
-            | sym::simd_fpow
+            | sym::simd_floor
             | sym::simd_fma
+            | sym::simd_fpow
+            | sym::simd_fpowi
+            | sym::simd_fsin
+            | sym::simd_fsqrt
+            | sym::simd_round
+            | sym::simd_trunc
     ) {
         return simd_simple_float_intrinsic(name, in_elem, in_ty, in_len, bx, span, args);
     }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1354,7 +1354,7 @@ extern "C" {
     pub fn LLVMBuildNeg(B: &Builder<'a>, V: &'a Value, Name: *const c_char) -> &'a Value;
     pub fn LLVMBuildFNeg(B: &Builder<'a>, V: &'a Value, Name: *const c_char) -> &'a Value;
     pub fn LLVMBuildNot(B: &Builder<'a>, V: &'a Value, Name: *const c_char) -> &'a Value;
-    pub fn LLVMRustSetHasUnsafeAlgebra(Instr: &Value);
+    pub fn LLVMRustSetFastMath(Instr: &Value);
 
     // Memory
     pub fn LLVMBuildAlloca(B: &Builder<'a>, Ty: &'a Type, Name: *const c_char) -> &'a Value;

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -349,8 +349,10 @@ extern "C" void LLVMRustRemoveFunctionAttributes(LLVMValueRef Fn,
   F->setAttributes(PALNew);
 }
 
-// enable fpmath flag UnsafeAlgebra
-extern "C" void LLVMRustSetHasUnsafeAlgebra(LLVMValueRef V) {
+// Enable a fast-math flag
+//
+// https://llvm.org/docs/LangRef.html#fast-math-flags
+extern "C" void LLVMRustSetFastMath(LLVMValueRef V) {
   if (auto I = dyn_cast<Instruction>(unwrap<Value>(V))) {
     I->setFast(true);
   }

--- a/src/test/codegen/issue-84268.rs
+++ b/src/test/codegen/issue-84268.rs
@@ -1,0 +1,23 @@
+// compile-flags: -O --crate-type=rlib
+#![feature(platform_intrinsics, repr_simd)]
+
+extern "platform-intrinsic" {
+    fn simd_fabs<T>(x: T) -> T;
+    fn simd_eq<T, U>(x: T, y: T) -> U;
+}
+
+#[repr(simd)]
+pub struct V([f32; 4]);
+
+#[repr(simd)]
+pub struct M([i32; 4]);
+
+#[no_mangle]
+// CHECK-LABEL: @is_infinite
+pub fn is_infinite(v: V) -> M {
+    // CHECK: fabs
+    // CHECK: cmp oeq
+    unsafe {
+        simd_eq(simd_fabs(v), V([f32::INFINITY; 4]))
+    }
+}

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @fabs_32x2
 #[no_mangle]
 pub unsafe fn fabs_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.fabs.v2f32
+    // CHECK: call <2 x float> @llvm.fabs.v2f32
     simd_fabs(a)
 }
 
 // CHECK-LABEL: @fabs_32x4
 #[no_mangle]
 pub unsafe fn fabs_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.fabs.v4f32
+    // CHECK: call <4 x float> @llvm.fabs.v4f32
     simd_fabs(a)
 }
 
 // CHECK-LABEL: @fabs_32x8
 #[no_mangle]
 pub unsafe fn fabs_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.fabs.v8f32
+    // CHECK: call <8 x float> @llvm.fabs.v8f32
     simd_fabs(a)
 }
 
 // CHECK-LABEL: @fabs_32x16
 #[no_mangle]
 pub unsafe fn fabs_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.fabs.v16f32
+    // CHECK: call <16 x float> @llvm.fabs.v16f32
     simd_fabs(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @fabs_64x4
 #[no_mangle]
 pub unsafe fn fabs_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.fabs.v4f64
+    // CHECK: call <4 x double> @llvm.fabs.v4f64
     simd_fabs(a)
 }
 
 // CHECK-LABEL: @fabs_64x2
 #[no_mangle]
 pub unsafe fn fabs_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.fabs.v2f64
+    // CHECK: call <2 x double> @llvm.fabs.v2f64
     simd_fabs(a)
 }
 
 // CHECK-LABEL: @fabs_64x8
 #[no_mangle]
 pub unsafe fn fabs_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.fabs.v8f64
+    // CHECK: call <8 x double> @llvm.fabs.v8f64
     simd_fabs(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @ceil_32x2
 #[no_mangle]
 pub unsafe fn ceil_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.ceil.v2f32
+    // CHECK: call <2 x float> @llvm.ceil.v2f32
     simd_ceil(a)
 }
 
 // CHECK-LABEL: @ceil_32x4
 #[no_mangle]
 pub unsafe fn ceil_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.ceil.v4f32
+    // CHECK: call <4 x float> @llvm.ceil.v4f32
     simd_ceil(a)
 }
 
 // CHECK-LABEL: @ceil_32x8
 #[no_mangle]
 pub unsafe fn ceil_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.ceil.v8f32
+    // CHECK: call <8 x float> @llvm.ceil.v8f32
     simd_ceil(a)
 }
 
 // CHECK-LABEL: @ceil_32x16
 #[no_mangle]
 pub unsafe fn ceil_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.ceil.v16f32
+    // CHECK: call <16 x float> @llvm.ceil.v16f32
     simd_ceil(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @ceil_64x4
 #[no_mangle]
 pub unsafe fn ceil_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.ceil.v4f64
+    // CHECK: call <4 x double> @llvm.ceil.v4f64
     simd_ceil(a)
 }
 
 // CHECK-LABEL: @ceil_64x2
 #[no_mangle]
 pub unsafe fn ceil_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.ceil.v2f64
+    // CHECK: call <2 x double> @llvm.ceil.v2f64
     simd_ceil(a)
 }
 
 // CHECK-LABEL: @ceil_64x8
 #[no_mangle]
 pub unsafe fn ceil_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.ceil.v8f64
+    // CHECK: call <8 x double> @llvm.ceil.v8f64
     simd_ceil(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @fcos_32x2
 #[no_mangle]
 pub unsafe fn fcos_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.cos.v2f32
+    // CHECK: call <2 x float> @llvm.cos.v2f32
     simd_fcos(a)
 }
 
 // CHECK-LABEL: @fcos_32x4
 #[no_mangle]
 pub unsafe fn fcos_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.cos.v4f32
+    // CHECK: call <4 x float> @llvm.cos.v4f32
     simd_fcos(a)
 }
 
 // CHECK-LABEL: @fcos_32x8
 #[no_mangle]
 pub unsafe fn fcos_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.cos.v8f32
+    // CHECK: call <8 x float> @llvm.cos.v8f32
     simd_fcos(a)
 }
 
 // CHECK-LABEL: @fcos_32x16
 #[no_mangle]
 pub unsafe fn fcos_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.cos.v16f32
+    // CHECK: call <16 x float> @llvm.cos.v16f32
     simd_fcos(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @fcos_64x4
 #[no_mangle]
 pub unsafe fn fcos_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.cos.v4f64
+    // CHECK: call <4 x double> @llvm.cos.v4f64
     simd_fcos(a)
 }
 
 // CHECK-LABEL: @fcos_64x2
 #[no_mangle]
 pub unsafe fn fcos_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.cos.v2f64
+    // CHECK: call <2 x double> @llvm.cos.v2f64
     simd_fcos(a)
 }
 
 // CHECK-LABEL: @fcos_64x8
 #[no_mangle]
 pub unsafe fn fcos_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.cos.v8f64
+    // CHECK: call <8 x double> @llvm.cos.v8f64
     simd_fcos(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @exp_32x2
 #[no_mangle]
 pub unsafe fn exp_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.exp.v2f32
+    // CHECK: call <2 x float> @llvm.exp.v2f32
     simd_fexp(a)
 }
 
 // CHECK-LABEL: @exp_32x4
 #[no_mangle]
 pub unsafe fn exp_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.exp.v4f32
+    // CHECK: call <4 x float> @llvm.exp.v4f32
     simd_fexp(a)
 }
 
 // CHECK-LABEL: @exp_32x8
 #[no_mangle]
 pub unsafe fn exp_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.exp.v8f32
+    // CHECK: call <8 x float> @llvm.exp.v8f32
     simd_fexp(a)
 }
 
 // CHECK-LABEL: @exp_32x16
 #[no_mangle]
 pub unsafe fn exp_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.exp.v16f32
+    // CHECK: call <16 x float> @llvm.exp.v16f32
     simd_fexp(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @exp_64x4
 #[no_mangle]
 pub unsafe fn exp_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.exp.v4f64
+    // CHECK: call <4 x double> @llvm.exp.v4f64
     simd_fexp(a)
 }
 
 // CHECK-LABEL: @exp_64x2
 #[no_mangle]
 pub unsafe fn exp_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.exp.v2f64
+    // CHECK: call <2 x double> @llvm.exp.v2f64
     simd_fexp(a)
 }
 
 // CHECK-LABEL: @exp_64x8
 #[no_mangle]
 pub unsafe fn exp_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.exp.v8f64
+    // CHECK: call <8 x double> @llvm.exp.v8f64
     simd_fexp(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @exp2_32x2
 #[no_mangle]
 pub unsafe fn exp2_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.exp2.v2f32
+    // CHECK: call <2 x float> @llvm.exp2.v2f32
     simd_fexp2(a)
 }
 
 // CHECK-LABEL: @exp2_32x4
 #[no_mangle]
 pub unsafe fn exp2_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.exp2.v4f32
+    // CHECK: call <4 x float> @llvm.exp2.v4f32
     simd_fexp2(a)
 }
 
 // CHECK-LABEL: @exp2_32x8
 #[no_mangle]
 pub unsafe fn exp2_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.exp2.v8f32
+    // CHECK: call <8 x float> @llvm.exp2.v8f32
     simd_fexp2(a)
 }
 
 // CHECK-LABEL: @exp2_32x16
 #[no_mangle]
 pub unsafe fn exp2_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.exp2.v16f32
+    // CHECK: call <16 x float> @llvm.exp2.v16f32
     simd_fexp2(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @exp2_64x4
 #[no_mangle]
 pub unsafe fn exp2_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.exp2.v4f64
+    // CHECK: call <4 x double> @llvm.exp2.v4f64
     simd_fexp2(a)
 }
 
 // CHECK-LABEL: @exp2_64x2
 #[no_mangle]
 pub unsafe fn exp2_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.exp2.v2f64
+    // CHECK: call <2 x double> @llvm.exp2.v2f64
     simd_fexp2(a)
 }
 
 // CHECK-LABEL: @exp2_64x8
 #[no_mangle]
 pub unsafe fn exp2_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.exp2.v8f64
+    // CHECK: call <8 x double> @llvm.exp2.v8f64
     simd_fexp2(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @floor_32x2
 #[no_mangle]
 pub unsafe fn floor_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.floor.v2f32
+    // CHECK: call <2 x float> @llvm.floor.v2f32
     simd_floor(a)
 }
 
 // CHECK-LABEL: @floor_32x4
 #[no_mangle]
 pub unsafe fn floor_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.floor.v4f32
+    // CHECK: call <4 x float> @llvm.floor.v4f32
     simd_floor(a)
 }
 
 // CHECK-LABEL: @floor_32x8
 #[no_mangle]
 pub unsafe fn floor_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.floor.v8f32
+    // CHECK: call <8 x float> @llvm.floor.v8f32
     simd_floor(a)
 }
 
 // CHECK-LABEL: @floor_32x16
 #[no_mangle]
 pub unsafe fn floor_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.floor.v16f32
+    // CHECK: call <16 x float> @llvm.floor.v16f32
     simd_floor(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @floor_64x4
 #[no_mangle]
 pub unsafe fn floor_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.floor.v4f64
+    // CHECK: call <4 x double> @llvm.floor.v4f64
     simd_floor(a)
 }
 
 // CHECK-LABEL: @floor_64x2
 #[no_mangle]
 pub unsafe fn floor_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.floor.v2f64
+    // CHECK: call <2 x double> @llvm.floor.v2f64
     simd_floor(a)
 }
 
 // CHECK-LABEL: @floor_64x8
 #[no_mangle]
 pub unsafe fn floor_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.floor.v8f64
+    // CHECK: call <8 x double> @llvm.floor.v8f64
     simd_floor(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @fma_32x2
 #[no_mangle]
 pub unsafe fn fma_32x2(a: f32x2, b: f32x2, c: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.fma.v2f32
+    // CHECK: call <2 x float> @llvm.fma.v2f32
     simd_fma(a, b, c)
 }
 
 // CHECK-LABEL: @fma_32x4
 #[no_mangle]
 pub unsafe fn fma_32x4(a: f32x4, b: f32x4, c: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.fma.v4f32
+    // CHECK: call <4 x float> @llvm.fma.v4f32
     simd_fma(a, b, c)
 }
 
 // CHECK-LABEL: @fma_32x8
 #[no_mangle]
 pub unsafe fn fma_32x8(a: f32x8, b: f32x8, c: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.fma.v8f32
+    // CHECK: call <8 x float> @llvm.fma.v8f32
     simd_fma(a, b, c)
 }
 
 // CHECK-LABEL: @fma_32x16
 #[no_mangle]
 pub unsafe fn fma_32x16(a: f32x16, b: f32x16, c: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.fma.v16f32
+    // CHECK: call <16 x float> @llvm.fma.v16f32
     simd_fma(a, b, c)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @fma_64x4
 #[no_mangle]
 pub unsafe fn fma_64x4(a: f64x4, b: f64x4, c: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.fma.v4f64
+    // CHECK: call <4 x double> @llvm.fma.v4f64
     simd_fma(a, b, c)
 }
 
 // CHECK-LABEL: @fma_64x2
 #[no_mangle]
 pub unsafe fn fma_64x2(a: f64x2, b: f64x2, c: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.fma.v2f64
+    // CHECK: call <2 x double> @llvm.fma.v2f64
     simd_fma(a, b, c)
 }
 
 // CHECK-LABEL: @fma_64x8
 #[no_mangle]
 pub unsafe fn fma_64x8(a: f64x8, b: f64x8, c: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.fma.v8f64
+    // CHECK: call <8 x double> @llvm.fma.v8f64
     simd_fma(a, b, c)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @fsqrt_32x2
 #[no_mangle]
 pub unsafe fn fsqrt_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.sqrt.v2f32
+    // CHECK: call <2 x float> @llvm.sqrt.v2f32
     simd_fsqrt(a)
 }
 
 // CHECK-LABEL: @fsqrt_32x4
 #[no_mangle]
 pub unsafe fn fsqrt_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.sqrt.v4f32
+    // CHECK: call <4 x float> @llvm.sqrt.v4f32
     simd_fsqrt(a)
 }
 
 // CHECK-LABEL: @fsqrt_32x8
 #[no_mangle]
 pub unsafe fn fsqrt_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.sqrt.v8f32
+    // CHECK: call <8 x float> @llvm.sqrt.v8f32
     simd_fsqrt(a)
 }
 
 // CHECK-LABEL: @fsqrt_32x16
 #[no_mangle]
 pub unsafe fn fsqrt_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.sqrt.v16f32
+    // CHECK: call <16 x float> @llvm.sqrt.v16f32
     simd_fsqrt(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @fsqrt_64x4
 #[no_mangle]
 pub unsafe fn fsqrt_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.sqrt.v4f64
+    // CHECK: call <4 x double> @llvm.sqrt.v4f64
     simd_fsqrt(a)
 }
 
 // CHECK-LABEL: @fsqrt_64x2
 #[no_mangle]
 pub unsafe fn fsqrt_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.sqrt.v2f64
+    // CHECK: call <2 x double> @llvm.sqrt.v2f64
     simd_fsqrt(a)
 }
 
 // CHECK-LABEL: @fsqrt_64x8
 #[no_mangle]
 pub unsafe fn fsqrt_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.sqrt.v8f64
+    // CHECK: call <8 x double> @llvm.sqrt.v8f64
     simd_fsqrt(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @log_32x2
 #[no_mangle]
 pub unsafe fn log_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.log.v2f32
+    // CHECK: call <2 x float> @llvm.log.v2f32
     simd_flog(a)
 }
 
 // CHECK-LABEL: @log_32x4
 #[no_mangle]
 pub unsafe fn log_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.log.v4f32
+    // CHECK: call <4 x float> @llvm.log.v4f32
     simd_flog(a)
 }
 
 // CHECK-LABEL: @log_32x8
 #[no_mangle]
 pub unsafe fn log_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.log.v8f32
+    // CHECK: call <8 x float> @llvm.log.v8f32
     simd_flog(a)
 }
 
 // CHECK-LABEL: @log_32x16
 #[no_mangle]
 pub unsafe fn log_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.log.v16f32
+    // CHECK: call <16 x float> @llvm.log.v16f32
     simd_flog(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @log_64x4
 #[no_mangle]
 pub unsafe fn log_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.log.v4f64
+    // CHECK: call <4 x double> @llvm.log.v4f64
     simd_flog(a)
 }
 
 // CHECK-LABEL: @log_64x2
 #[no_mangle]
 pub unsafe fn log_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.log.v2f64
+    // CHECK: call <2 x double> @llvm.log.v2f64
     simd_flog(a)
 }
 
 // CHECK-LABEL: @log_64x8
 #[no_mangle]
 pub unsafe fn log_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.log.v8f64
+    // CHECK: call <8 x double> @llvm.log.v8f64
     simd_flog(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @log10_32x2
 #[no_mangle]
 pub unsafe fn log10_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.log10.v2f32
+    // CHECK: call <2 x float> @llvm.log10.v2f32
     simd_flog10(a)
 }
 
 // CHECK-LABEL: @log10_32x4
 #[no_mangle]
 pub unsafe fn log10_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.log10.v4f32
+    // CHECK: call <4 x float> @llvm.log10.v4f32
     simd_flog10(a)
 }
 
 // CHECK-LABEL: @log10_32x8
 #[no_mangle]
 pub unsafe fn log10_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.log10.v8f32
+    // CHECK: call <8 x float> @llvm.log10.v8f32
     simd_flog10(a)
 }
 
 // CHECK-LABEL: @log10_32x16
 #[no_mangle]
 pub unsafe fn log10_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.log10.v16f32
+    // CHECK: call <16 x float> @llvm.log10.v16f32
     simd_flog10(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @log10_64x4
 #[no_mangle]
 pub unsafe fn log10_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.log10.v4f64
+    // CHECK: call <4 x double> @llvm.log10.v4f64
     simd_flog10(a)
 }
 
 // CHECK-LABEL: @log10_64x2
 #[no_mangle]
 pub unsafe fn log10_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.log10.v2f64
+    // CHECK: call <2 x double> @llvm.log10.v2f64
     simd_flog10(a)
 }
 
 // CHECK-LABEL: @log10_64x8
 #[no_mangle]
 pub unsafe fn log10_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.log10.v8f64
+    // CHECK: call <8 x double> @llvm.log10.v8f64
     simd_flog10(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @log2_32x2
 #[no_mangle]
 pub unsafe fn log2_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.log2.v2f32
+    // CHECK: call <2 x float> @llvm.log2.v2f32
     simd_flog2(a)
 }
 
 // CHECK-LABEL: @log2_32x4
 #[no_mangle]
 pub unsafe fn log2_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.log2.v4f32
+    // CHECK: call <4 x float> @llvm.log2.v4f32
     simd_flog2(a)
 }
 
 // CHECK-LABEL: @log2_32x8
 #[no_mangle]
 pub unsafe fn log2_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.log2.v8f32
+    // CHECK: call <8 x float> @llvm.log2.v8f32
     simd_flog2(a)
 }
 
 // CHECK-LABEL: @log2_32x16
 #[no_mangle]
 pub unsafe fn log2_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.log2.v16f32
+    // CHECK: call <16 x float> @llvm.log2.v16f32
     simd_flog2(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @log2_64x4
 #[no_mangle]
 pub unsafe fn log2_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.log2.v4f64
+    // CHECK: call <4 x double> @llvm.log2.v4f64
     simd_flog2(a)
 }
 
 // CHECK-LABEL: @log2_64x2
 #[no_mangle]
 pub unsafe fn log2_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.log2.v2f64
+    // CHECK: call <2 x double> @llvm.log2.v2f64
     simd_flog2(a)
 }
 
 // CHECK-LABEL: @log2_64x8
 #[no_mangle]
 pub unsafe fn log2_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.log2.v8f64
+    // CHECK: call <8 x double> @llvm.log2.v8f64
     simd_flog2(a)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-pow.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-pow.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @fpow_32x2
 #[no_mangle]
 pub unsafe fn fpow_32x2(a: f32x2, b: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.pow.v2f32
+    // CHECK: call <2 x float> @llvm.pow.v2f32
     simd_fpow(a, b)
 }
 
 // CHECK-LABEL: @fpow_32x4
 #[no_mangle]
 pub unsafe fn fpow_32x4(a: f32x4, b: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.pow.v4f32
+    // CHECK: call <4 x float> @llvm.pow.v4f32
     simd_fpow(a, b)
 }
 
 // CHECK-LABEL: @fpow_32x8
 #[no_mangle]
 pub unsafe fn fpow_32x8(a: f32x8, b: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.pow.v8f32
+    // CHECK: call <8 x float> @llvm.pow.v8f32
     simd_fpow(a, b)
 }
 
 // CHECK-LABEL: @fpow_32x16
 #[no_mangle]
 pub unsafe fn fpow_32x16(a: f32x16, b: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.pow.v16f32
+    // CHECK: call <16 x float> @llvm.pow.v16f32
     simd_fpow(a, b)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @fpow_64x4
 #[no_mangle]
 pub unsafe fn fpow_64x4(a: f64x4, b: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.pow.v4f64
+    // CHECK: call <4 x double> @llvm.pow.v4f64
     simd_fpow(a, b)
 }
 
 // CHECK-LABEL: @fpow_64x2
 #[no_mangle]
 pub unsafe fn fpow_64x2(a: f64x2, b: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.pow.v2f64
+    // CHECK: call <2 x double> @llvm.pow.v2f64
     simd_fpow(a, b)
 }
 
 // CHECK-LABEL: @fpow_64x8
 #[no_mangle]
 pub unsafe fn fpow_64x8(a: f64x8, b: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.pow.v8f64
+    // CHECK: call <8 x double> @llvm.pow.v8f64
     simd_fpow(a, b)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-powi.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-powi.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @fpowi_32x2
 #[no_mangle]
 pub unsafe fn fpowi_32x2(a: f32x2, b: i32) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.powi.v2f32
+    // CHECK: call <2 x float> @llvm.powi.v2f32
     simd_fpowi(a, b)
 }
 
 // CHECK-LABEL: @fpowi_32x4
 #[no_mangle]
 pub unsafe fn fpowi_32x4(a: f32x4, b: i32) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.powi.v4f32
+    // CHECK: call <4 x float> @llvm.powi.v4f32
     simd_fpowi(a, b)
 }
 
 // CHECK-LABEL: @fpowi_32x8
 #[no_mangle]
 pub unsafe fn fpowi_32x8(a: f32x8, b: i32) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.powi.v8f32
+    // CHECK: call <8 x float> @llvm.powi.v8f32
     simd_fpowi(a, b)
 }
 
 // CHECK-LABEL: @fpowi_32x16
 #[no_mangle]
 pub unsafe fn fpowi_32x16(a: f32x16, b: i32) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.powi.v16f32
+    // CHECK: call <16 x float> @llvm.powi.v16f32
     simd_fpowi(a, b)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @fpowi_64x4
 #[no_mangle]
 pub unsafe fn fpowi_64x4(a: f64x4, b: i32) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.powi.v4f64
+    // CHECK: call <4 x double> @llvm.powi.v4f64
     simd_fpowi(a, b)
 }
 
 // CHECK-LABEL: @fpowi_64x2
 #[no_mangle]
 pub unsafe fn fpowi_64x2(a: f64x2, b: i32) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.powi.v2f64
+    // CHECK: call <2 x double> @llvm.powi.v2f64
     simd_fpowi(a, b)
 }
 
 // CHECK-LABEL: @fpowi_64x8
 #[no_mangle]
 pub unsafe fn fpowi_64x8(a: f64x8, b: i32) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.powi.v8f64
+    // CHECK: call <8 x double> @llvm.powi.v8f64
     simd_fpowi(a, b)
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
@@ -32,28 +32,28 @@ extern "platform-intrinsic" {
 // CHECK-LABEL: @fsin_32x2
 #[no_mangle]
 pub unsafe fn fsin_32x2(a: f32x2) -> f32x2 {
-    // CHECK: call fast <2 x float> @llvm.sin.v2f32
+    // CHECK: call <2 x float> @llvm.sin.v2f32
     simd_fsin(a)
 }
 
 // CHECK-LABEL: @fsin_32x4
 #[no_mangle]
 pub unsafe fn fsin_32x4(a: f32x4) -> f32x4 {
-    // CHECK: call fast <4 x float> @llvm.sin.v4f32
+    // CHECK: call <4 x float> @llvm.sin.v4f32
     simd_fsin(a)
 }
 
 // CHECK-LABEL: @fsin_32x8
 #[no_mangle]
 pub unsafe fn fsin_32x8(a: f32x8) -> f32x8 {
-    // CHECK: call fast <8 x float> @llvm.sin.v8f32
+    // CHECK: call <8 x float> @llvm.sin.v8f32
     simd_fsin(a)
 }
 
 // CHECK-LABEL: @fsin_32x16
 #[no_mangle]
 pub unsafe fn fsin_32x16(a: f32x16) -> f32x16 {
-    // CHECK: call fast <16 x float> @llvm.sin.v16f32
+    // CHECK: call <16 x float> @llvm.sin.v16f32
     simd_fsin(a)
 }
 
@@ -73,20 +73,20 @@ pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
 // CHECK-LABEL: @fsin_64x4
 #[no_mangle]
 pub unsafe fn fsin_64x4(a: f64x4) -> f64x4 {
-    // CHECK: call fast <4 x double> @llvm.sin.v4f64
+    // CHECK: call <4 x double> @llvm.sin.v4f64
     simd_fsin(a)
 }
 
 // CHECK-LABEL: @fsin_64x2
 #[no_mangle]
 pub unsafe fn fsin_64x2(a: f64x2) -> f64x2 {
-    // CHECK: call fast <2 x double> @llvm.sin.v2f64
+    // CHECK: call <2 x double> @llvm.sin.v2f64
     simd_fsin(a)
 }
 
 // CHECK-LABEL: @fsin_64x8
 #[no_mangle]
 pub unsafe fn fsin_64x8(a: f64x8) -> f64x8 {
-    // CHECK: call fast <8 x double> @llvm.sin.v8f64
+    // CHECK: call <8 x double> @llvm.sin.v8f64
     simd_fsin(a)
 }


### PR DESCRIPTION
`fast-math` implies things like functions not being able to accept as an
argument or return as a result, say, `inf` which made these functions
confusingly named or behaving incorrectly, depending on how you
interpret it. Since the time when these intrinsics have been implemented
the intrinsics user's (stdsimd) approach has changed significantly and
so now it is required that these intrinsics operate normally rather than
in "whatever" way.

Fixes #84268