### PR TITLE
bootstrap: Restore missing --bulk-dirs for rust-docs, rustc-docs

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -74,7 +74,7 @@ impl Step for Docs {
 
         let mut tarball = Tarball::new(builder, "rust-docs", &host.triple);
         tarball.set_product_name("Rust Documentation");
-        tarball.add_dir(&builder.doc_out(host), dest);
+        tarball.add_bulk_dir(&builder.doc_out(host), dest);
         tarball.add_file(&builder.src.join("src/doc/robots.txt"), dest, 0o644);
         Some(tarball.generate())
     }
@@ -107,7 +107,7 @@ impl Step for RustcDocs {
 
         let mut tarball = Tarball::new(builder, "rustc-docs", &host.triple);
         tarball.set_product_name("Rustc Documentation");
-        tarball.add_dir(&builder.compiler_doc_out(host), "share/doc/rust/html/rustc");
+        tarball.add_bulk_dir(&builder.compiler_doc_out(host), "share/doc/rust/html/rustc");
         Some(tarball.generate())
     }
 }


### PR DESCRIPTION
The `--bulk-dirs` argument was removed for rust-docs in commit c768ce138427b1844c1f6594daba9c0e33928032 and rustc-docs in commit 8ca46fc7a83734c9622f11f25d16b82316f44bcc (#79788), presumably by mistake; that slowed down installation of rust-docs from under a second to some twenty *minutes*.  Restoring `--bulk-dirs` reverses this slowdown.

Fixes #80684.

Cc @pietroalbini.