### PR TITLE
Allow longer spans in the short format.

### DIFF
--- a/compiler/rustc_span/src/span_encoding.rs
+++ b/compiler/rustc_span/src/span_encoding.rs
@@ -62,8 +62,8 @@ pub struct Span {
     ctxt_or_zero: u16,
 }
 
-const LEN_TAG: u16 = 0b1000_0000_0000_0000;
-const MAX_LEN: u32 = 0b0111_1111_1111_1111;
+const LEN_TAG: u16 = 0b1111_1111_1111_1111;
+const MAX_LEN: u32 = (LEN_TAG as u32) - 1;
 const MAX_CTXT: u32 = 0b1111_1111_1111_1111;
 
 /// Dummy span, both position and length are zero, syntax context is zero as well.


### PR DESCRIPTION
I could not find a reason why the maximum length was this small.
