### PR TITLE
various const parameter defaults improvements

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -754,7 +754,7 @@ fn validate_generic_param_order(
             GenericParamKind::Type { default: _ } => (ParamKindOrd::Type, ident),
             GenericParamKind::Const { ref ty, kw_span: _, default: _ } => {
                 let ty = pprust::ty_to_string(ty);
-                let unordered = sess.features_untracked().const_generics;
+                let unordered = sess.features_untracked().unordered_const_ty_params();
                 (ParamKindOrd::Const { unordered }, Some(format!("const {}: {}", param.ident, ty)))
             }
         };

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -63,6 +63,10 @@ macro_rules! declare_features {
                     _ => panic!("`{}` was not listed in `declare_features`", feature),
                 }
             }
+
+            pub fn unordered_const_ty_params(&self) -> bool {
+                self.const_generics || self.const_generics_defaults
+            }
         }
     };
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -296,7 +296,9 @@ impl GenericArg<'_> {
         match self {
             GenericArg::Lifetime(_) => ast::ParamKindOrd::Lifetime,
             GenericArg::Type(_) => ast::ParamKindOrd::Type,
-            GenericArg::Const(_) => ast::ParamKindOrd::Const { unordered: feats.const_generics },
+            GenericArg::Const(_) => {
+                ast::ParamKindOrd::Const { unordered: feats.unordered_const_ty_params() }
+            }
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -36,7 +36,7 @@ impl GenericParamDefKind {
             GenericParamDefKind::Lifetime => ast::ParamKindOrd::Lifetime,
             GenericParamDefKind::Type { .. } => ast::ParamKindOrd::Type,
             GenericParamDefKind::Const { .. } => {
-                ast::ParamKindOrd::Const { unordered: tcx.features().const_generics }
+                ast::ParamKindOrd::Const { unordered: tcx.features().unordered_const_ty_params() }
             }
         }
     }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -472,17 +472,6 @@ impl<'a> Resolver<'a> {
                 );
                 err
             }
-            ResolutionError::ParamInAnonConstInTyDefault(name) => {
-                let mut err = self.session.struct_span_err(
-                    span,
-                    "constant values inside of type parameter defaults must not depend on generic parameters",
-                );
-                err.span_label(
-                    span,
-                    format!("the anonymous constant must not depend on the parameter `{}`", name),
-                );
-                err
-            }
             ResolutionError::ParamInNonTrivialAnonConst { name, is_type } => {
                 let mut err = self.session.struct_span_err(
                     span,

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -286,7 +286,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                                         ParamKindOrd::Const {
                                                             unordered: tcx
                                                                 .features()
-                                                                .const_generics,
+                                                                .unordered_const_ty_params(),
                                                         }
                                                     }
                                                 },
@@ -309,7 +309,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                             GenericArg::Lifetime(_) => ParamKindOrd::Lifetime,
                                             GenericArg::Type(_) => ParamKindOrd::Type,
                                             GenericArg::Const(_) => ParamKindOrd::Const {
-                                                unordered: tcx.features().const_generics,
+                                                unordered: tcx
+                                                    .features()
+                                                    .unordered_const_ty_params(),
                                             },
                                         }),
                                         Some(&format!(

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -513,7 +513,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     GenericParamDefKind::Const { has_default } => {
                         let ty = tcx.at(self.span).type_of(param.def_id);
                         if !infer_args && has_default {
-                            tcx.const_param_default(param.def_id).into()
+                            tcx.const_param_default(param.def_id)
+                                .subst_spanned(tcx, substs.unwrap(), Some(self.span))
+                                .into()
                         } else {
                             if infer_args {
                                 self.astconv.ct_infer(ty, Some(param), self.span).into()

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1446,7 +1446,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     GenericParamDefKind::Const { has_default, .. } => {
                         if !infer_args && has_default {
-                            tcx.const_param_default(param.def_id).into()
+                            tcx.const_param_default(param.def_id)
+                                .subst_spanned(tcx, substs.unwrap(), Some(self.span))
+                                .into()
                         } else {
                             self.fcx.var_for_def(self.span, param)
                         }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -1316,13 +1316,13 @@ fn has_late_bound_regions<'tcx>(tcx: TyCtxt<'tcx>, node: Node<'tcx>) -> Option<S
     }
 }
 
-struct AnonConstInParamListDetector {
-    in_param_list: bool,
-    found_anon_const_in_list: bool,
+struct AnonConstInParamTyDetector {
+    in_param_ty: bool,
+    found_anon_const_in_param_ty: bool,
     ct: HirId,
 }
 
-impl<'v> Visitor<'v> for AnonConstInParamListDetector {
+impl<'v> Visitor<'v> for AnonConstInParamTyDetector {
     type Map = intravisit::ErasedMap<'v>;
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
@@ -1330,15 +1330,17 @@ impl<'v> Visitor<'v> for AnonConstInParamListDetector {
     }
 
     fn visit_generic_param(&mut self, p: &'v hir::GenericParam<'v>) {
-        let prev = self.in_param_list;
-        self.in_param_list = true;
-        intravisit::walk_generic_param(self, p);
-        self.in_param_list = prev;
+        if let GenericParamKind::Const { ref ty, default: _ } = p.kind {
+            let prev = self.in_param_ty;
+            self.in_param_ty = true;
+            self.visit_ty(ty);
+            self.in_param_ty = prev;
+        }
     }
 
     fn visit_anon_const(&mut self, c: &'v hir::AnonConst) {
-        if self.in_param_list && self.ct == c.hir_id {
-            self.found_anon_const_in_list = true;
+        if self.in_param_ty && self.ct == c.hir_id {
+            self.found_anon_const_in_param_ty = true;
         } else {
             intravisit::walk_anon_const(self, c)
         }
@@ -1366,27 +1368,24 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
             let parent_id = tcx.hir().get_parent_item(hir_id);
             let parent_def_id = tcx.hir().local_def_id(parent_id);
 
-            let mut in_param_list = false;
+            let mut in_param_ty = false;
             for (_parent, node) in tcx.hir().parent_iter(hir_id) {
                 if let Some(generics) = node.generics() {
-                    let mut visitor = AnonConstInParamListDetector {
-                        in_param_list: false,
-                        found_anon_const_in_list: false,
+                    let mut visitor = AnonConstInParamTyDetector {
+                        in_param_ty: false,
+                        found_anon_const_in_param_ty: false,
                         ct: hir_id,
                     };
 
                     visitor.visit_generics(generics);
-                    in_param_list = visitor.found_anon_const_in_list;
+                    in_param_ty = visitor.found_anon_const_in_param_ty;
                     break;
                 }
             }
 
-            if in_param_list {
+            if in_param_ty {
                 // We do not allow generic parameters in anon consts if we are inside
-                // of a param list.
-                //
-                // This affects both default type bindings, e.g. `struct<T, U = [u8; std::mem::size_of::<T>()]>(T, U)`,
-                // and the types of const parameters, e.g. `struct V<const N: usize, const M: [u8; N]>();`.
+                // of a const parameter type, e.g. `struct Foo<const N: usize, const M: [u8; N]>` is not allowed.
                 None
             } else if tcx.lazy_normalization() {
                 // HACK(eddyb) this provides the correct generics when

--- a/src/test/ui/const-generics/defaults/auxiliary/const_defaulty.rs
+++ b/src/test/ui/const-generics/defaults/auxiliary/const_defaulty.rs
@@ -1,4 +1,4 @@
-#![feature(const_generics)]
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
@@ -1,16 +1,18 @@
-error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/complex-generic-default-expr.rs:9:62
+error: constant expression depends on a generic parameter
+  --> $DIR/complex-generic-default-expr.rs:6:34
+   |
+LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
+   |                                  ^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/complex-generic-default-expr.rs:10:21
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
-   |            -                                                 ^ doesn't have a size known at compile-time
-   |            |
-   |            this type parameter needs to be `std::marker::Sized`
-   | 
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |                     ^^^^^^^^^
    |
-LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
+   = note: this may fail depending on what value the parameter takes
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/complex-generic-default-expr.rs:6:62
+  --> $DIR/complex-generic-default-expr.rs:9:62
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |            -                                                 ^ doesn't have a size known at compile-time

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -1,0 +1,20 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-generic-default-expr.rs:6:47
+   |
+LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
+   |                                               ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-generic-default-expr.rs:9:62
+   |
+LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
+   |                                                              ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:10:47
+  --> $DIR/complex-generic-default-expr.rs:6:47
    |
 LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |                                               ^ cannot perform const operation using `N`
@@ -8,7 +8,7 @@ LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:13:62
+  --> $DIR/complex-generic-default-expr.rs:10:62
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |                                                              ^ cannot perform const operation using `T`

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:6:47
+  --> $DIR/complex-generic-default-expr.rs:10:47
    |
 LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |                                               ^ cannot perform const operation using `N`
@@ -8,7 +8,7 @@ LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:9:62
+  --> $DIR/complex-generic-default-expr.rs:13:62
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |                                                              ^ cannot perform const operation using `T`

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,4 +1,8 @@
-// revisions: full min
+// revisions: min
+// FIXME(const_generics): add the `full` revision,
+// currently causes an ICE as we don't supply substs to
+// anon consts in the parameter listing, as that would
+// cause that anon const to reference itself.
 #![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
@@ -8,6 +12,6 @@ struct Foo<const N: usize, const M: usize = { N + 1 }>;
 
 struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
 //[min]~^ ERROR generic parameters may not be used in const operations
-//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time 
+//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,9 +1,13 @@
-#![feature(const_generics, const_generics_defaults)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct Foo<const N: usize, const M: usize = { N + 1 }>;
+//[min]~^ ERROR generic parameters may not be used in const operations
 
 struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
-//~^ ERROR the size for values of type `T` cannot be known at compilation time 
+//[min]~^ ERROR generic parameters may not be used in const operations
+//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time 
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,0 +1,9 @@
+#![feature(const_generics, const_generics_defaults)]
+#![allow(incomplete_features)]
+
+struct Foo<const N: usize, const M: usize = { N + 1 }>;
+
+struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
+//~^ ERROR the size for values of type `T` cannot be known at compilation time 
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,17 +1,14 @@
-// revisions: min
-// FIXME(const_generics): add the `full` revision,
-// currently causes an ICE as we don't supply substs to
-// anon consts in the parameter listing, as that would
-// cause that anon const to reference itself.
+// revisions: full min
 #![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct Foo<const N: usize, const M: usize = { N + 1 }>;
-//[min]~^ ERROR generic parameters may not be used in const operations
+//[full]~^ ERROR constant expression depends on a generic parameter
+//[min]~^^ ERROR generic parameters may not be used in const operations
 
 struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
-//[min]~^ ERROR generic parameters may not be used in const operations
-//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time
+//[full]~^ ERROR constant expression depends on a generic parameter
+//[min]~^^ ERROR generic parameters may not be used in const operations
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/complex-generic-default-expr.rs:6:62
+   |
+LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
+   |            -                                                 ^ doesn't have a size known at compile-time
+   |            |
+   |            this type parameter needs to be `std::marker::Sized`
+   | 
+  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/defaults/const-default.rs
+++ b/src/test/ui/const-generics/defaults/const-default.rs
@@ -1,6 +1,6 @@
 // run-pass
-
-#![feature(const_generics)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
+++ b/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
@@ -8,7 +8,16 @@ fn foo<const N: usize>() -> Foo<N> {
     Foo(x, x)
 }
 
+// To check that we actually apply the correct substs for const param defaults.
+fn concrete_foo() -> Foo<13> {
+    Foo(Default::default(), Default::default())
+}
+
+
 fn main() {
     let val = foo::<13>();
+    assert_eq!(val.0, val.1);
+
+    let val = concrete_foo();
     assert_eq!(val.0, val.1);
 }

--- a/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
+++ b/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
@@ -1,0 +1,14 @@
+// run-pass
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
+struct Foo<const N: usize, const M: usize = N>([u8; N], [u8; M]);
+
+fn foo<const N: usize>() -> Foo<N> {
+    let x = [0; N];
+    Foo(x, x)
+}
+
+fn main() {
+    let val = foo::<13>();
+    assert_eq!(val.0, val.1);
+}

--- a/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
+++ b/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
@@ -1,0 +1,18 @@
+// run-pass
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
+// FIXME(const_generics_defaults): while we can allow this,
+// we probably won't easily allow this with more complex const operations.
+//
+// So we have to make a conscious decision here when stabilizing a relaxed parameter ordering.
+struct Foo<const N: usize, T = [u8; N]>(T);
+
+impl<const N: usize> Foo<N> {
+    fn new() -> Self {
+        Foo([0; N])
+    }
+}
+
+fn main() {
+    assert_eq!(Foo::new().0, [0; 10]);
+}

--- a/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
+++ b/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
@@ -1,10 +1,6 @@
 // run-pass
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
-// FIXME(const_generics_defaults): while we can allow this,
-// we probably won't easily allow this with more complex const operations.
-//
-// So we have to make a conscious decision here when stabilizing a relaxed parameter ordering.
 struct Foo<const N: usize, T = [u8; N]>(T);
 
 impl<const N: usize> Foo<N> {

--- a/src/test/ui/const-generics/defaults/default-on-impl.full.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.full.stderr
@@ -1,5 +1,5 @@
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/default-on-impl.rs:6:12
+  --> $DIR/default-on-impl.rs:8:12
    |
 LL | impl<const N: usize = 1> Foo<N> {}
    |            ^

--- a/src/test/ui/const-generics/defaults/default-on-impl.min.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.min.stderr
@@ -1,0 +1,8 @@
+error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/default-on-impl.rs:8:12
+   |
+LL | impl<const N: usize = 1> Foo<N> {}
+   |            ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/defaults/default-on-impl.rs
+++ b/src/test/ui/const-generics/defaults/default-on-impl.rs
@@ -1,4 +1,6 @@
-#![feature(const_generics, const_generics_defaults)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct Foo<const N: usize>;

--- a/src/test/ui/const-generics/defaults/default-on-impl.rs
+++ b/src/test/ui/const-generics/defaults/default-on-impl.rs
@@ -1,0 +1,9 @@
+#![feature(const_generics, const_generics_defaults)]
+#![allow(incomplete_features)]
+
+struct Foo<const N: usize>;
+
+impl<const N: usize = 1> Foo<N> {}
+//~^ ERROR defaults for const parameters are only allowed
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/default-on-impl.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.stderr
@@ -1,0 +1,8 @@
+error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/default-on-impl.rs:6:12
+   |
+LL | impl<const N: usize = 1> Foo<N> {}
+   |            ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/defaults/default-param-wf-concrete.rs
+++ b/src/test/ui/const-generics/defaults/default-param-wf-concrete.rs
@@ -1,0 +1,5 @@
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
+struct Foo<const N: u8 = { 255 + 1 }>;
+//~^ ERROR evaluation of constant value failed
+fn main() {}

--- a/src/test/ui/const-generics/defaults/default-param-wf-concrete.stderr
+++ b/src/test/ui/const-generics/defaults/default-param-wf-concrete.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/default-param-wf-concrete.rs:3:28
+   |
+LL | struct Foo<const N: u8 = { 255 + 1 }>;
+   |                            ^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/const-generics/defaults/external.rs
+++ b/src/test/ui/const-generics/defaults/external.rs
@@ -1,5 +1,7 @@
 // aux-build:const_defaulty.rs
 // check-pass
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/intermixed-lifetime.full.stderr
+++ b/src/test/ui/const-generics/defaults/intermixed-lifetime.full.stderr
@@ -1,5 +1,5 @@
 error: lifetime parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:6:28
+  --> $DIR/intermixed-lifetime.rs:7:28
    |
 LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
    |           -----------------^^---------- help: reorder the parameters: lifetimes, then consts and types: `<'a, const N: usize, T = u32>`

--- a/src/test/ui/const-generics/defaults/intermixed-lifetime.min.stderr
+++ b/src/test/ui/const-generics/defaults/intermixed-lifetime.min.stderr
@@ -1,26 +1,14 @@
 error: lifetime parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:6:28
+  --> $DIR/intermixed-lifetime.rs:7:28
    |
 LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
-   |           -----------------^^---------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
+   |           -----------------^^---------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const N: usize, T = u32>`
 
-error: type parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:6:32
-   |
-LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
-   |           ---------------------^------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
-
-error: lifetime parameters must be declared prior to const parameters
+error: lifetime parameters must be declared prior to type parameters
   --> $DIR/intermixed-lifetime.rs:10:37
    |
 LL | struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-   |           --------------------------^^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
+   |           --------------------------^^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const N: usize, T = u32>`
 
-error: type parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:10:28
-   |
-LL | struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-   |           -----------------^----------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/defaults/intermixed-lifetime.rs
+++ b/src/test/ui/const-generics/defaults/intermixed-lifetime.rs
@@ -1,15 +1,13 @@
-// revisions: full min
 // Checks that lifetimes cannot be interspersed between consts and types.
+// revisions: full min
 #![cfg_attr(full, feature(const_generics))]
-#![cfg_attr(full, allow(incomplete_features))]
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
 
 struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
 //~^ Error lifetime parameters must be declared prior to const parameters
-//[min]~^^ Error type parameters must be declared prior to const parameters
 
 struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-//[full]~^ Error lifetime parameters must be declared prior to type parameters
-//[min]~^^ Error type parameters must be declared prior to const parameters
-//[min]~| Error lifetime parameters must be declared prior to const parameters
+//~^ Error lifetime parameters must be declared prior to type parameters
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/mismatch.full.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.full.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:11:28
+  --> $DIR/mismatch.rs:12:28
    |
 LL |     let e: Example::<13> = ();
    |            -------------   ^^ expected struct `Example`, found `()`
@@ -7,7 +7,7 @@ LL |     let e: Example::<13> = ();
    |            expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:13:34
+  --> $DIR/mismatch.rs:14:34
    |
 LL |     let e: Example2::<u32, 13> = ();
    |            -------------------   ^^ expected struct `Example2`, found `()`
@@ -18,7 +18,7 @@ LL |     let e: Example2::<u32, 13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:15:34
+  --> $DIR/mismatch.rs:16:34
    |
 LL |     let e: Example3::<13, u32> = ();
    |            -------------------   ^^ expected struct `Example3`, found `()`
@@ -29,7 +29,7 @@ LL |     let e: Example3::<13, u32> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:17:28
+  --> $DIR/mismatch.rs:18:28
    |
 LL |     let e: Example3::<7> = ();
    |            -------------   ^^ expected struct `Example3`, found `()`
@@ -40,7 +40,7 @@ LL |     let e: Example3::<7> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:21:28
+  --> $DIR/mismatch.rs:22:28
    |
 LL |     let e: Example4::<7> = ();
    |            -------------   ^^ expected struct `Example4`, found `()`

--- a/src/test/ui/const-generics/defaults/mismatch.min.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.min.stderr
@@ -1,0 +1,52 @@
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:12:28
+   |
+LL |     let e: Example::<13> = ();
+   |            -------------   ^^ expected struct `Example`, found `()`
+   |            |
+   |            expected due to this
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:14:34
+   |
+LL |     let e: Example2::<u32, 13> = ();
+   |            -------------------   ^^ expected struct `Example2`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Example2`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:16:34
+   |
+LL |     let e: Example3::<13, u32> = ();
+   |            -------------------   ^^ expected struct `Example3`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Example3`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:18:28
+   |
+LL |     let e: Example3::<7> = ();
+   |            -------------   ^^ expected struct `Example3`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Example3<7_usize>`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:22:28
+   |
+LL |     let e: Example4::<7> = ();
+   |            -------------   ^^ expected struct `Example4`, found `()`
+   |            |
+   |            expected due to this
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/defaults/mismatch.rs
+++ b/src/test/ui/const-generics/defaults/mismatch.rs
@@ -1,4 +1,5 @@
-#![feature(const_generics)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
@@ -11,4 +11,3 @@ trait Foo<const KIND: bool = true> {}
 fn foo<const SIZE: usize = 5>() {}
 
 struct Range<const FROM: usize = 0, const LEN: usize = 0, const TO: usize = FROM>;
-

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
@@ -10,4 +10,5 @@ trait Foo<const KIND: bool = true> {}
 
 fn foo<const SIZE: usize = 5>() {}
 
-struct Range<const FROM: usize = 0, const LEN: usize = 0, const TO: usize = {FROM + LEN}>;
+struct Range<const FROM: usize = 0, const LEN: usize = 0, const TO: usize = FROM>;
+

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -17,4 +17,5 @@ trait Foo<const KIND : bool = true> { }
 fn foo<const SIZE : usize = 5>() { }
 
 struct Range<const FROM : usize = 0, const LEN : usize = 0, const TO : usize =
-             { FROM + LEN }>;
+             FROM>;
+

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -18,4 +18,3 @@ fn foo<const SIZE : usize = 5>() { }
 
 struct Range<const FROM : usize = 0, const LEN : usize = 0, const TO : usize =
              FROM>;
-

--- a/src/test/ui/const-generics/defaults/repr-c-issue-82792.rs
+++ b/src/test/ui/const-generics/defaults/repr-c-issue-82792.rs
@@ -6,7 +6,7 @@
 #![allow(incomplete_features)]
 
 #[repr(C)]
-pub struct Loaf<T: Sized, const N: usize = 1usize> {
+pub struct Loaf<T: Sized, const N: usize = 1> {
     head: [T; N],
     slice: [T],
 }

--- a/src/test/ui/const-generics/defaults/simple-defaults.min.stderr
+++ b/src/test/ui/const-generics/defaults/simple-defaults.min.stderr
@@ -1,8 +1,0 @@
-error: type parameters must be declared prior to const parameters
-  --> $DIR/simple-defaults.rs:8:40
-   |
-LL | struct FixedOutput<'a, const N: usize, T=u32> {
-   |                   ---------------------^----- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
-
-error: aborting due to previous error
-

--- a/src/test/ui/const-generics/defaults/simple-defaults.rs
+++ b/src/test/ui/const-generics/defaults/simple-defaults.rs
@@ -1,12 +1,12 @@
-// [full] run-pass
-// revisions: min full
-// Checks some basic test cases for defaults.
+// run-pass
+// Checks that type param defaults are allowed after const params.
+// revisions: full min
 #![cfg_attr(full, feature(const_generics))]
-#![cfg_attr(full, allow(incomplete_features))]
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
 #![allow(dead_code)]
 
 struct FixedOutput<'a, const N: usize, T=u32> {
-    //[min]~^ ERROR type parameters must be declared prior to const parameters
     out: &'a [T; N],
 }
 

--- a/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
+++ b/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
@@ -1,5 +1,7 @@
 // check-pass
-#![feature(const_generics, const_generics_defaults)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct N;

--- a/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
+++ b/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
@@ -1,0 +1,17 @@
+// check-pass
+#![feature(const_generics, const_generics_defaults)]
+#![allow(incomplete_features)]
+
+struct N;
+
+struct Foo<const N: usize = 1, T = N>(T);
+
+impl Foo {
+    fn new() -> Self {
+        Foo(N)
+    }
+}
+
+fn main() {
+    let Foo::<1, N>(N) = Foo::new();
+}

--- a/src/test/ui/const-generics/defaults/wrong-order.full.stderr
+++ b/src/test/ui/const-generics/defaults/wrong-order.full.stderr
@@ -1,19 +1,8 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/wrong-order.rs:4:10
+  --> $DIR/wrong-order.rs:6:10
    |
 LL | struct A<T = u32, const N: usize> {
    |          ^
-   |
-   = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
-warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/wrong-order.rs:2:27
-   |
-LL | #![cfg_attr(full, feature(const_generics))]
-   |                           ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
-
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/wrong-order.min.stderr
+++ b/src/test/ui/const-generics/defaults/wrong-order.min.stderr
@@ -1,10 +1,8 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/wrong-order.rs:4:10
+  --> $DIR/wrong-order.rs:6:10
    |
 LL | struct A<T = u32, const N: usize> {
    |          ^
-   |
-   = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/wrong-order.rs
+++ b/src/test/ui/const-generics/defaults/wrong-order.rs
@@ -1,5 +1,7 @@
 // revisions: full min
-#![cfg_attr(full, feature(const_generics))] //[full]~WARN the feature `const_generics` is incomplete
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
 
 struct A<T = u32, const N: usize> {
     //~^ ERROR generic parameters with a default must be trailing

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
@@ -6,17 +6,26 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    |
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
-error: constant values inside of type parameter defaults must not depend on generic parameters
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
-   |
-LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-   |                                            ^ the anonymous constant must not depend on the parameter `T`
-
-error: constant values inside of type parameter defaults must not depend on generic parameters
+error[E0128]: generic parameters with a default cannot use forward declared identifiers
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
-   |                     ^ the anonymous constant must not depend on the parameter `N`
+   |                     ^ defaulted generic parameters cannot be forward declared
+
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
+   |
+LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
+   |            -                               ^ doesn't have a size known at compile-time
+   |            |
+   |            this type parameter needs to be `std::marker::Sized`
+   | 
+  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
 
 error: aborting due to 3 previous errors
 
+Some errors have detailed explanations: E0128, E0277.
+For more information about an error, try `rustc --explain E0128`.

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -7,25 +7,11 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared
 
-error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
-   |
-LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-   |            -                               ^ doesn't have a size known at compile-time
-   |            |
-   |            this type parameter needs to be `std::marker::Sized`
-   | 
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0128, E0277.
-For more information about an error, try `rustc --explain E0128`.
+For more information about this error, try `rustc --explain E0128`.

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -7,7 +7,7 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -16,7 +16,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -7,7 +7,7 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error: generic parameters may not be used in const operations
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:5:44
    |
 LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    |                                            ^ cannot perform const operation using `T`
@@ -16,7 +16,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -15,11 +15,12 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    = note: type parameters may not be used in const expressions
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
-error: constant values inside of type parameter defaults must not depend on generic parameters
+error[E0128]: generic parameters with a default cannot use forward declared identifiers
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
-   |                     ^ the anonymous constant must not depend on the parameter `N`
+   |                     ^ defaulted generic parameters cannot be forward declared
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0128`.

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -7,7 +7,6 @@ struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
 //[full]~^ ERROR the size for values of type `T` cannot be known at compilation time
 //[min]~^^ ERROR generic parameters may not be used in const operations
 
-// FIXME(const_generics_defaults): We still don't know how to deal with type defaults.
 struct Bar<T = [u8; N], const N: usize>(T);
 //~^ ERROR generic parameters with a default cannot use forward declared identifiers
 //~| ERROR generic parameters with a default

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -1,11 +1,9 @@
 // revisions: full min
-
 #![cfg_attr(full, feature(const_generics))]
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-//[full]~^ ERROR the size for values of type `T` cannot be known at compilation time
-//[min]~^^ ERROR generic parameters may not be used in const operations
+//[min]~^ ERROR generic parameters may not be used in const operations
 
 struct Bar<T = [u8; N], const N: usize>(T);
 //~^ ERROR generic parameters with a default cannot use forward declared identifiers

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -4,12 +4,12 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-//[full]~^ ERROR constant values inside of type parameter defaults
+//[full]~^ ERROR the size for values of type `T` cannot be known at compilation time
 //[min]~^^ ERROR generic parameters may not be used in const operations
 
 // FIXME(const_generics_defaults): We still don't know how to deal with type defaults.
 struct Bar<T = [u8; N], const N: usize>(T);
-//~^ ERROR constant values inside of type parameter defaults
+//~^ ERROR generic parameters with a default cannot use forward declared identifiers
 //~| ERROR generic parameters with a default
 
 fn main() {}

--- a/src/test/ui/generics/generic-non-trailing-defaults.rs
+++ b/src/test/ui/generics/generic-non-trailing-defaults.rs
@@ -5,5 +5,6 @@ struct Vec<A = Heap, T>(A, T);
 
 struct Foo<A, B = Vec<C>, C>(A, B, C);
 //~^ ERROR generic parameters with a default must be trailing
+//~| ERROR generic parameters with a default cannot use
 
 fn main() {}

--- a/src/test/ui/generics/generic-non-trailing-defaults.stderr
+++ b/src/test/ui/generics/generic-non-trailing-defaults.stderr
@@ -10,5 +10,12 @@ error: generic parameters with a default must be trailing
 LL | struct Foo<A, B = Vec<C>, C>(A, B, C);
    |               ^
 
-error: aborting due to 2 previous errors
+error[E0128]: generic parameters with a default cannot use forward declared identifiers
+  --> $DIR/generic-non-trailing-defaults.rs:6:23
+   |
+LL | struct Foo<A, B = Vec<C>, C>(A, B, C);
+   |                       ^ defaulted generic parameters cannot be forward declared
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0128`.


### PR DESCRIPTION
Actually resolve names in const parameter defaults, fixing `struct Foo<const N: usize = { usize::MAX }>`.

---
Split generic parameter ban rib for types and consts, allowing
```rust
#![feature(const_generics_defaults)]
struct Q;
struct Foo<T = Q, const Q: usize = 3>(T);
```

---
Remove the type/const ordering restriction if `const_generics_defaults` is active, even if `const_generics` is not. allowing us to stabilize and test const param defaults separately.

---
Check well formedness of const parameter defaults, eagerly emitting an error for `struct Foo<const N: usize = { 0 - 1 }>`

---
Do not forbid const parameters in param defaults, allowing `struct Foo<const N: usize, T = [u8; N]>(T)` and `struct Foo<const N: usize, const M: usize = N>`. Note that this should not change anything which is stabilized, as on stable, type parameters must be in front of const parameters, which means that type parameter defaults are only allowed if no const parameters exist.

We still forbid generic parameters inside of const param types.

r? @varkor @petrochenkov 