### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2041,7 +2041,7 @@ impl<T, A: Allocator> Vec<T, A> {
 
     /// Safety: changing returned .2 (&mut usize) is considered the same as calling `.set_len(_)`.
     ///
-    /// This method is used to have unique access to all vec parts at once in `extend_from_within`.
+    /// This method provides unique access to all vec parts at once in `extend_from_within`.
     unsafe fn split_at_spare_mut_with_len(
         &mut self,
     ) -> (&mut [T], &mut [MaybeUninit<T>], &mut usize) {
@@ -2279,7 +2279,7 @@ impl<T: Clone, A: Allocator> ExtendFromWithinSpec for Vec<T, A> {
         iter::zip(to_clone, spare)
             .map(|(src, dst)| dst.write(src.clone()))
             // Note:
-            // - Element was just initialized with `MaybeUninit::write`, so it's ok to increace len
+            // - Element was just initialized with `MaybeUninit::write`, so it's ok to increase len
             // - len is increased after each element to prevent leaks (see issue #82533)
             .for_each(|_| *len += 1);
     }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1329,7 +1329,9 @@ fn metadata_access_times() {
         match (a.created(), b.created()) {
             (Ok(t1), Ok(t2)) => assert!(t1 <= t2),
             (Err(e1), Err(e2))
-                if e1.kind() == ErrorKind::Other && e2.kind() == ErrorKind::Other => {}
+                if e1.kind() == ErrorKind::Other && e2.kind() == ErrorKind::Other
+                    || e1.kind() == ErrorKind::Unsupported
+                        && e2.kind() == ErrorKind::Unsupported => {}
             (a, b) => {
                 panic!("creation time must be always supported or not supported: {:?} {:?}", a, b,)
             }

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -181,9 +181,11 @@ pub enum ErrorKind {
     #[stable(feature = "read_exact", since = "1.6.0")]
     UnexpectedEof,
 
-    /// This operation is not supported on this platform.
-    #[stable(feature = "not_supported_error", since = "1.52.0")]
-    NotSupported,
+    /// This operation is unsupported on this platform.
+    ///
+    /// This means that the operation can never succeed.
+    #[stable(feature = "unsupported_error", since = "1.52.0")]
+    Unsupported,
 }
 
 impl ErrorKind {
@@ -207,7 +209,7 @@ impl ErrorKind {
             ErrorKind::Interrupted => "operation interrupted",
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
-            ErrorKind::NotSupported => "not supported",
+            ErrorKind::Unsupported => "unsupported",
         }
     }
 }

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -184,7 +184,7 @@ pub enum ErrorKind {
     /// This operation is unsupported on this platform.
     ///
     /// This means that the operation can never succeed.
-    #[stable(feature = "unsupported_error", since = "1.52.0")]
+    #[stable(feature = "unsupported_error", since = "1.53.0")]
     Unsupported,
 }
 

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -182,7 +182,7 @@ pub enum ErrorKind {
     UnexpectedEof,
 
     /// This operation is not supported on this platform.
-    #[stable(feature = "not_supported_error", since = "1.50.0")]
+    #[stable(feature = "not_supported_error", since = "1.52.0")]
     NotSupported,
 }
 

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -180,6 +180,10 @@ pub enum ErrorKind {
     /// read.
     #[stable(feature = "read_exact", since = "1.6.0")]
     UnexpectedEof,
+
+    /// This operation is not supported on this platform.
+    #[stable(feature = "not_supported_error", since = "1.50.0")]
+    NotSupported,
 }
 
 impl ErrorKind {
@@ -203,6 +207,7 @@ impl ErrorKind {
             ErrorKind::Interrupted => "operation interrupted",
             ErrorKind::Other => "other os error",
             ErrorKind::UnexpectedEof => "unexpected end of file",
+            ErrorKind::NotSupported => "not supported",
         }
     }
 }

--- a/library/std/src/sys/hermit/fd.rs
+++ b/library/std/src/sys/hermit/fd.rs
@@ -1,9 +1,10 @@
 #![unstable(reason = "not public", issue = "none", feature = "fd")]
 
-use crate::io::{self, ErrorKind, Read};
+use crate::io::{self, Read};
 use crate::mem;
 use crate::sys::cvt;
 use crate::sys::hermit::abi;
+use crate::sys::unsupported;
 use crate::sys_common::AsInner;
 
 #[derive(Debug)]
@@ -46,7 +47,7 @@ impl FileDesc {
         self.duplicate_path(&[])
     }
     pub fn duplicate_path(&self, _path: &[u8]) -> io::Result<FileDesc> {
-        Err(io::Error::new_const(ErrorKind::Other, &"duplicate isn't supported"))
+        unsupported()
     }
 
     pub fn nonblocking(&self) -> io::Result<bool> {
@@ -54,11 +55,11 @@ impl FileDesc {
     }
 
     pub fn set_cloexec(&self) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"cloexec isn't supported"))
+        unsupported()
     }
 
     pub fn set_nonblocking(&self, _nonblocking: bool) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"nonblocking isn't supported"))
+        unsupported()
     }
 }
 

--- a/library/std/src/sys/hermit/mod.rs
+++ b/library/std/src/sys/hermit/mod.rs
@@ -56,7 +56,7 @@ pub fn unsupported<T>() -> crate::io::Result<T> {
 
 pub fn unsupported_err() -> crate::io::Error {
     crate::io::Error::new_const(
-        crate::io::ErrorKind::NotSupported,
+        crate::io::ErrorKind::Unsupported,
         &"operation not supported on HermitCore yet",
     )
 }

--- a/library/std/src/sys/hermit/mod.rs
+++ b/library/std/src/sys/hermit/mod.rs
@@ -56,7 +56,7 @@ pub fn unsupported<T>() -> crate::io::Result<T> {
 
 pub fn unsupported_err() -> crate::io::Error {
     crate::io::Error::new_const(
-        crate::io::ErrorKind::Other,
+        crate::io::ErrorKind::NotSupported,
         &"operation not supported on HermitCore yet",
     )
 }

--- a/library/std/src/sys/hermit/net.rs
+++ b/library/std/src/sys/hermit/net.rs
@@ -166,7 +166,7 @@ impl TcpStream {
     }
 
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
-        Err(io::Error::new_const(ErrorKind::Other, &"socket_addr isn't supported"))
+        unsupported()
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
@@ -199,7 +199,7 @@ impl TcpStream {
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
-        Err(io::Error::new_const(ErrorKind::Other, &"take_error isn't supported"))
+        unsupported()
     }
 
     pub fn set_nonblocking(&self, mode: bool) -> io::Result<()> {
@@ -247,27 +247,27 @@ impl TcpListener {
     }
 
     pub fn set_ttl(&self, _: u32) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_only_v6(&self, _: bool) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn only_v6(&self) -> io::Result<bool> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 }
 
@@ -281,127 +281,127 @@ pub struct UdpSocket(abi::Handle);
 
 impl UdpSocket {
     pub fn bind(_: io::Result<&SocketAddr>) -> io::Result<UdpSocket> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn recv_from(&self, _: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn peek_from(&self, _: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn send_to(&self, _: &[u8], _: &SocketAddr) -> io::Result<usize> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn duplicate(&self) -> io::Result<UdpSocket> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_broadcast(&self, _: bool) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn broadcast(&self) -> io::Result<bool> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_multicast_loop_v4(&self, _: bool) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn multicast_loop_v4(&self) -> io::Result<bool> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_multicast_ttl_v4(&self, _: u32) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_multicast_loop_v6(&self, _: bool) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn multicast_loop_v6(&self) -> io::Result<bool> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_ttl(&self, _: u32) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn recv(&self, _: &mut [u8]) -> io::Result<usize> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn send(&self, _: &[u8]) -> io::Result<usize> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 
     pub fn connect(&self, _: io::Result<&SocketAddr>) -> io::Result<()> {
-        Err(io::Error::new_const(ErrorKind::Other, &"not supported"))
+        unsupported()
     }
 }
 

--- a/library/std/src/sys/sgx/mod.rs
+++ b/library/std/src/sys/sgx/mod.rs
@@ -50,7 +50,7 @@ pub fn unsupported<T>() -> crate::io::Result<T> {
 }
 
 pub fn unsupported_err() -> crate::io::Error {
-    crate::io::Error::new_const(ErrorKind::NotSupported, &"operation not supported on SGX yet")
+    crate::io::Error::new_const(ErrorKind::Unsupported, &"operation not supported on SGX yet")
 }
 
 /// This function is used to implement various functions that doesn't exist,

--- a/library/std/src/sys/sgx/mod.rs
+++ b/library/std/src/sys/sgx/mod.rs
@@ -50,7 +50,7 @@ pub fn unsupported<T>() -> crate::io::Result<T> {
 }
 
 pub fn unsupported_err() -> crate::io::Error {
-    crate::io::Error::new_const(ErrorKind::Other, &"operation not supported on SGX yet")
+    crate::io::Error::new_const(ErrorKind::NotSupported, &"operation not supported on SGX yet")
 }
 
 /// This function is used to implement various functions that doesn't exist,

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -366,7 +366,7 @@ impl FileAttr {
         }
 
         Err(io::Error::new_const(
-            io::ErrorKind::Other,
+            io::ErrorKind::NotSupported,
             &"creation time is not available on this platform \
                             currently",
         ))

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -366,7 +366,7 @@ impl FileAttr {
         }
 
         Err(io::Error::new_const(
-            io::ErrorKind::NotSupported,
+            io::ErrorKind::Unsupported,
             &"creation time is not available on this platform \
                             currently",
         ))

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -1,6 +1,6 @@
 macro_rules! unimpl {
     () => {
-        return Err(io::Error::new_const(io::ErrorKind::Other, &"No networking available on L4Re."));
+        return Err(io::Error::new_const(io::ErrorKind::NotSupported, &"No networking available on L4Re."));
     };
 }
 

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -1,6 +1,9 @@
 macro_rules! unimpl {
     () => {
-        return Err(io::Error::new_const(io::ErrorKind::NotSupported, &"No networking available on L4Re."));
+        return Err(io::Error::new_const(
+            io::ErrorKind::Unsupported,
+            &"No networking available on L4Re.",
+        ));
     };
 }
 

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -148,6 +148,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::EINVAL => ErrorKind::InvalidInput,
         libc::ETIMEDOUT => ErrorKind::TimedOut,
         libc::EEXIST => ErrorKind::AlreadyExists,
+        libc::ENOSYS => ErrorKind::NotSupported,
 
         // These two constants can have the same value on some systems,
         // but different values on others, so we can't use a match

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -148,7 +148,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::EINVAL => ErrorKind::InvalidInput,
         libc::ETIMEDOUT => ErrorKind::TimedOut,
         libc::EEXIST => ErrorKind::AlreadyExists,
-        libc::ENOSYS => ErrorKind::NotSupported,
+        libc::ENOSYS => ErrorKind::Unsupported,
 
         // These two constants can have the same value on some systems,
         // but different values on others, so we can't use a match

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -447,7 +447,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 #[cfg(any(target_os = "fuchsia", target_os = "l4re"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     use crate::io::ErrorKind;
-    Err(io::Error::new_const(ErrorKind::NotSupported, &"Not yet implemented!"))
+    Err(io::Error::new_const(ErrorKind::Unsupported, &"Not yet implemented!"))
 }
 
 #[cfg(target_os = "vxworks")]

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -447,7 +447,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
 #[cfg(any(target_os = "fuchsia", target_os = "l4re"))]
 pub fn current_exe() -> io::Result<PathBuf> {
     use crate::io::ErrorKind;
-    Err(io::Error::new_const(ErrorKind::Other, &"Not yet implemented!"))
+    Err(io::Error::new_const(ErrorKind::NotSupported, &"Not yet implemented!"))
 }
 
 #[cfg(target_os = "vxworks")]

--- a/library/std/src/sys/unsupported/common.rs
+++ b/library/std/src/sys/unsupported/common.rs
@@ -18,7 +18,10 @@ pub fn unsupported<T>() -> std_io::Result<T> {
 }
 
 pub fn unsupported_err() -> std_io::Error {
-    std_io::Error::new_const(std_io::ErrorKind::NotSupported, &"operation not supported on this platform")
+    std_io::Error::new_const(
+        std_io::ErrorKind::Unsupported,
+        &"operation not supported on this platform",
+    )
 }
 
 pub fn decode_error_kind(_code: i32) -> crate::io::ErrorKind {

--- a/library/std/src/sys/unsupported/common.rs
+++ b/library/std/src/sys/unsupported/common.rs
@@ -18,7 +18,7 @@ pub fn unsupported<T>() -> std_io::Result<T> {
 }
 
 pub fn unsupported_err() -> std_io::Error {
-    std_io::Error::new_const(std_io::ErrorKind::Other, &"operation not supported on this platform")
+    std_io::Error::new_const(std_io::ErrorKind::NotSupported, &"operation not supported on this platform")
 }
 
 pub fn decode_error_kind(_code: i32) -> crate::io::ErrorKind {

--- a/library/std/src/sys/unsupported/os.rs
+++ b/library/std/src/sys/unsupported/os.rs
@@ -80,11 +80,11 @@ pub fn getenv(_: &OsStr) -> io::Result<Option<OsString>> {
 }
 
 pub fn setenv(_: &OsStr, _: &OsStr) -> io::Result<()> {
-    Err(io::Error::new_const(io::ErrorKind::NotSupported, &"cannot set env vars on this platform"))
+    Err(io::Error::new_const(io::ErrorKind::Unsupported, &"cannot set env vars on this platform"))
 }
 
 pub fn unsetenv(_: &OsStr) -> io::Result<()> {
-    Err(io::Error::new_const(io::ErrorKind::NotSupported, &"cannot unset env vars on this platform"))
+    Err(io::Error::new_const(io::ErrorKind::Unsupported, &"cannot unset env vars on this platform"))
 }
 
 pub fn temp_dir() -> PathBuf {

--- a/library/std/src/sys/unsupported/os.rs
+++ b/library/std/src/sys/unsupported/os.rs
@@ -80,11 +80,11 @@ pub fn getenv(_: &OsStr) -> io::Result<Option<OsString>> {
 }
 
 pub fn setenv(_: &OsStr, _: &OsStr) -> io::Result<()> {
-    Err(io::Error::new_const(io::ErrorKind::Other, &"cannot set env vars on this platform"))
+    Err(io::Error::new_const(io::ErrorKind::NotSupported, &"cannot set env vars on this platform"))
 }
 
 pub fn unsetenv(_: &OsStr) -> io::Result<()> {
-    Err(io::Error::new_const(io::ErrorKind::Other, &"cannot unset env vars on this platform"))
+    Err(io::Error::new_const(io::ErrorKind::NotSupported, &"cannot unset env vars on this platform"))
 }
 
 pub fn temp_dir() -> PathBuf {

--- a/library/std/src/sys/vxworks/mod.rs
+++ b/library/std/src/sys/vxworks/mod.rs
@@ -83,6 +83,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::EINVAL => ErrorKind::InvalidInput,
         libc::ETIMEDOUT => ErrorKind::TimedOut,
         libc::EEXIST => ErrorKind::AlreadyExists,
+        libc::ENOSYS => ErrorKind::NotSupported,
 
         // These two constants can have the same value on some systems,
         // but different values on others, so we can't use a match

--- a/library/std/src/sys/vxworks/mod.rs
+++ b/library/std/src/sys/vxworks/mod.rs
@@ -83,7 +83,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::EINVAL => ErrorKind::InvalidInput,
         libc::ETIMEDOUT => ErrorKind::TimedOut,
         libc::EEXIST => ErrorKind::AlreadyExists,
-        libc::ENOSYS => ErrorKind::NotSupported,
+        libc::ENOSYS => ErrorKind::Unsupported,
 
         // These two constants can have the same value on some systems,
         // but different values on others, so we can't use a match

--- a/library/std/src/sys/wasi/mod.rs
+++ b/library/std/src/sys/wasi/mod.rs
@@ -78,6 +78,7 @@ pub fn decode_error_kind(errno: i32) -> std_io::ErrorKind {
         wasi::ERRNO_TIMEDOUT => TimedOut,
         wasi::ERRNO_EXIST => AlreadyExists,
         wasi::ERRNO_AGAIN => WouldBlock,
+        wasi::ERRNO_NOSYS => NotSupported,
         _ => Other,
     }
 }

--- a/library/std/src/sys/wasi/mod.rs
+++ b/library/std/src/sys/wasi/mod.rs
@@ -78,7 +78,7 @@ pub fn decode_error_kind(errno: i32) -> std_io::ErrorKind {
         wasi::ERRNO_TIMEDOUT => TimedOut,
         wasi::ERRNO_EXIST => AlreadyExists,
         wasi::ERRNO_AGAIN => WouldBlock,
-        wasi::ERRNO_NOSYS => NotSupported,
+        wasi::ERRNO_NOSYS => Unsupported,
         _ => Other,
     }
 }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -802,7 +802,7 @@ pub fn link(original: &Path, link: &Path) -> io::Result<()> {
 
 #[cfg(target_vendor = "uwp")]
 pub fn link(_original: &Path, _link: &Path) -> io::Result<()> {
-    return Err(io::Error::new_const(io::ErrorKind::Other, &"hard link are not supported on UWP"));
+    return Err(io::Error::new_const(io::ErrorKind::NotSupported, &"hard link are not supported on UWP"));
 }
 
 pub fn stat(path: &Path) -> io::Result<FileAttr> {

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -802,7 +802,10 @@ pub fn link(original: &Path, link: &Path) -> io::Result<()> {
 
 #[cfg(target_vendor = "uwp")]
 pub fn link(_original: &Path, _link: &Path) -> io::Result<()> {
-    return Err(io::Error::new_const(io::ErrorKind::NotSupported, &"hard link are not supported on UWP"));
+    return Err(io::Error::new_const(
+        io::ErrorKind::Unsupported,
+        &"hard link are not supported on UWP",
+    ));
 }
 
 pub fn stat(path: &Path) -> io::Result<FileAttr> {

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -78,6 +78,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         | c::ERROR_IPSEC_IKE_TIMED_OUT
         | c::ERROR_RUNLEVEL_SWITCH_TIMEOUT
         | c::ERROR_RUNLEVEL_SWITCH_AGENT_TIMEOUT => return ErrorKind::TimedOut,
+        c::ERROR_CALL_NOT_IMPLEMENTED => return ErrorKind::NotSupported,
         _ => {}
     }
 

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -78,7 +78,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         | c::ERROR_IPSEC_IKE_TIMED_OUT
         | c::ERROR_RUNLEVEL_SWITCH_TIMEOUT
         | c::ERROR_RUNLEVEL_SWITCH_AGENT_TIMEOUT => return ErrorKind::TimedOut,
-        c::ERROR_CALL_NOT_IMPLEMENTED => return ErrorKind::NotSupported,
+        c::ERROR_CALL_NOT_IMPLEMENTED => return ErrorKind::Unsupported,
         _ => {}
     }
 

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -370,7 +370,7 @@ impl Socket {
 
     #[cfg(target_vendor = "uwp")]
     fn set_no_inherit(&self) -> io::Result<()> {
-        Err(io::Error::new_const(io::ErrorKind::NotSupported, &"Unavailable on UWP"))
+        Err(io::Error::new_const(io::ErrorKind::Unsupported, &"Unavailable on UWP"))
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -370,7 +370,7 @@ impl Socket {
 
     #[cfg(target_vendor = "uwp")]
     fn set_no_inherit(&self) -> io::Result<()> {
-        Err(io::Error::new_const(io::ErrorKind::Other, &"Unavailable on UWP"))
+        Err(io::Error::new_const(io::ErrorKind::NotSupported, &"Unavailable on UWP"))
     }
 
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -477,6 +477,7 @@ fn build_module(
                                 }],
                             },
                             did: None,
+                            attrs: None,
                         },
                         true,
                     )),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2081,6 +2081,7 @@ crate enum ImportKind {
 crate struct ImportSource {
     crate path: Path,
     crate did: Option<DefId>,
+    crate attrs: Option<Attributes>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -468,10 +468,10 @@ crate fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
 }
 
 crate fn resolve_use_source(cx: &mut DocContext<'_>, path: Path) -> ImportSource {
-    ImportSource {
-        did: if path.res.opt_def_id().is_none() { None } else { Some(register_res(cx, path.res)) },
-        path,
-    }
+    let did = if path.res.opt_def_id().is_none() { None } else { Some(register_res(cx, path.res)) };
+    let attrs = did.map(|did| cx.tcx.get_attrs(did).clean(cx));
+
+    ImportSource { did, path, attrs }
 }
 
 crate fn enter_impl_trait<F, R>(cx: &mut DocContext<'_>, f: F) -> R

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -16,7 +16,7 @@ use rustc_span::{symbol::sym, Symbol};
 use super::cache::{build_index, ExternalLocation};
 use super::print_item::{full_path, item_path, print_item};
 use super::write_shared::write_shared;
-use super::{print_sidebar, settings, AllTypes, NameDoc, StylePath, BASIC_KEYWORDS, CURRENT_DEPTH};
+use super::{print_sidebar, settings, AllTypes, NameDoc, StylePath, BASIC_KEYWORDS};
 
 use crate::clean::{self, AttributesExt};
 use crate::config::RenderOptions;
@@ -168,12 +168,6 @@ impl<'tcx> Context<'tcx> {
     }
 
     fn render_item(&self, it: &clean::Item, pushname: bool) -> String {
-        // A little unfortunate that this is done like this, but it sure
-        // does make formatting *a lot* nicer.
-        CURRENT_DEPTH.with(|slot| {
-            slot.set(self.current.len());
-        });
-
         let mut title = if it.is_primitive() || it.is_keyword() {
             // No need to include the namespace for primitive types and keywords
             String::new()
@@ -481,8 +475,6 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             shared: Rc::new(scx),
             cache: Rc::new(cache),
         };
-
-        CURRENT_DEPTH.with(|s| s.set(0));
 
         // Write shared runs within a flock; disable thread dispatching of IO temporarily.
         Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -35,7 +35,6 @@ mod write_shared;
 crate use context::*;
 crate use write_shared::FILES_UNVERSIONED;
 
-use std::cell::Cell;
 use std::collections::VecDeque;
 use std::default::Default;
 use std::fmt;
@@ -208,8 +207,6 @@ crate struct StylePath {
     /// What the `disabled` attribute should be set to in the HTML tag
     crate disabled: bool,
 }
-
-thread_local!(crate static CURRENT_DEPTH: Cell<usize> = Cell::new(0));
 
 fn write_srclink(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer) {
     if let Some(l) = cx.src_href(item) {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -989,7 +989,6 @@ fn render_assoc_item(
 
 const ALLOWED_ATTRIBUTES: &[Symbol] = &[
     sym::export_name,
-    sym::lang,
     sym::link_section,
     sym::must_use,
     sym::no_mangle,

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -282,9 +282,14 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
             }
 
             clean::ImportItem(ref import) => {
-                let (stab, stab_tags) = if let Some(def_id) = import.source.did {
-                    // Just need an item with the correct def_id
-                    let import_item = clean::Item { def_id, ..myitem.clone() };
+                let (stab, stab_tags) = if let (Some(def_id), Some(attrs)) =
+                    (import.source.did, import.source.attrs.clone())
+                {
+                    let attrs = Box::new(attrs);
+
+                    // Just need an item with the correct def_id and attrs
+                    let import_item = clean::Item { def_id, attrs, ..myitem.clone() };
+
                     let stab = import_item.stability_class(cx.tcx());
                     let stab_tags = Some(extra_info_tags(&import_item, item, cx.tcx()));
                     (stab, stab_tags)

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -296,7 +296,7 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
 
                 write!(
                     w,
-                    "<tr class=\"{stab}{add}module-item\">\
+                    "<tr class=\"{stab}{add}import-item\">\
                          <td><code>{vis}{imp}</code></td>\
                          <td class=\"docblock-short\">{stab_tags}</td>\
                      </tr>",

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -967,6 +967,10 @@ a.test-arrow:hover{
 	color: inherit;
 }
 
+.code-attribute {
+	font-weight: 300;
+}
+
 .collapse-toggle {
 	font-weight: 300;
 	position: absolute;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -868,7 +868,8 @@ body.blur > :not(#help) {
 		0 -1px 0 black;
 }
 
-.module-item .stab {
+.module-item .stab,
+.import-item .stab {
 	border-radius: 3px;
 	display: inline-block;
 	font-size: 80%;
@@ -879,7 +880,8 @@ body.blur > :not(#help) {
 	vertical-align: text-bottom;
 }
 
-.module-item.unstable {
+.module-item.unstable,
+.import-item.unstable {
 	opacity: 0.65;
 }
 

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -329,7 +329,8 @@ a.test-arrow:hover {
 	color: #c5c5c5;
 }
 
-.toggle-label {
+.toggle-label,
+.code-attribute {
 	color: #999;
 }
 

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -252,7 +252,8 @@ details.rustdoc-toggle > summary::before {
 	color: #929292;
 }
 
-.module-item .stab {
+.module-item .stab,
+.import-item .stab {
 	color: #000;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -217,7 +217,8 @@ details.rustdoc-toggle > summary::before {
 	box-shadow: 0 0 8px 4px #078dd8;
 }
 
-.module-item .stab {
+.module-item .stab,
+.import-item .stab {
 	color: #ddd;
 }
 

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -274,7 +274,8 @@ a.test-arrow:hover{
 	background-color: #4e8bca;
 }
 
-.toggle-label {
+.toggle-label,
+.code-attribute {
 	color: #999;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -267,7 +267,8 @@ a.test-arrow:hover{
 	background-color: #4e8bca;
 }
 
-.toggle-label {
+.toggle-label,
+.code-attribute {
 	color: #999;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -215,7 +215,8 @@ details.rustdoc-toggle > summary::before {
 	box-shadow: 0 0 8px #078dd8;
 }
 
-.module-item .stab {
+.module-item .stab,
+.import-item .stab {
 	color: #000;
 }
 

--- a/src/test/rustdoc/issue-83832.rs
+++ b/src/test/rustdoc/issue-83832.rs
@@ -1,21 +1,36 @@
 #![crate_name = "foo"]
+#![feature(doc_cfg)]
 
-pub mod io {
+pub mod tag {
     #[deprecated(since = "0.1.8", note = "Use bar() instead")]
-    pub trait Reader {}
-    pub trait Writer {}
+    pub trait Deprecated {}
+
+    #[doc(cfg(feature = "sync"))]
+    pub trait Portability {}
+
+    pub trait Unstable {}
 }
 
 // @has foo/mod1/index.html
 pub mod mod1 {
-    // @has - '//code' 'pub use io::Reader;'
+    // @has - '//code' 'pub use tag::Deprecated;'
     // @has - '//span' 'Deprecated'
-    pub use io::Reader;
+    // @!has - '//span' 'sync'
+    pub use tag::Deprecated;
 }
 
 // @has foo/mod2/index.html
 pub mod mod2 {
-    // @has - '//code' 'pub use io::Writer;'
+    // @has - '//code' 'pub use tag::Portability;'
     // @!has - '//span' 'Deprecated'
-    pub use io::Writer;
+    // @has - '//span' 'sync'
+    pub use tag::Portability;
+}
+
+// @has foo/mod3/index.html
+pub mod mod3 {
+    // @has - '//code' 'pub use tag::Unstable;'
+    // @!has - '//span' 'Deprecated'
+    // @!has - '//span' 'sync'
+    pub use tag::Unstable;
 }

--- a/src/test/rustdoc/issue-83832.rs
+++ b/src/test/rustdoc/issue-83832.rs
@@ -1,0 +1,21 @@
+#![crate_name = "foo"]
+
+pub mod io {
+    #[deprecated(since = "0.1.8", note = "Use bar() instead")]
+    pub trait Reader {}
+    pub trait Writer {}
+}
+
+// @has foo/mod1/index.html
+pub mod mod1 {
+    // @has - '//code' 'pub use io::Reader;'
+    // @has - '//span' 'Deprecated'
+    pub use io::Reader;
+}
+
+// @has foo/mod2/index.html
+pub mod mod2 {
+    // @has - '//code' 'pub use io::Writer;'
+    // @!has - '//span' 'Deprecated'
+    pub use io::Writer;
+}

--- a/src/test/rustdoc/reexport-stability-tags-deprecated-and-portability.rs
+++ b/src/test/rustdoc/reexport-stability-tags-deprecated-and-portability.rs
@@ -8,7 +8,11 @@ pub mod tag {
     #[doc(cfg(feature = "sync"))]
     pub trait Portability {}
 
-    pub trait Unstable {}
+    #[deprecated(since = "0.1.8", note = "Use bar() instead")]
+    #[doc(cfg(feature = "sync"))]
+    pub trait Both {}
+
+    pub trait None {}
 }
 
 // @has foo/mod1/index.html
@@ -29,8 +33,16 @@ pub mod mod2 {
 
 // @has foo/mod3/index.html
 pub mod mod3 {
-    // @has - '//code' 'pub use tag::Unstable;'
+    // @has - '//code' 'pub use tag::Both;'
+    // @has - '//span' 'Deprecated'
+    // @has - '//span' 'sync'
+    pub use tag::Both;
+}
+
+// @has foo/mod4/index.html
+pub mod mod4 {
+    // @has - '//code' 'pub use tag::None;'
     // @!has - '//span' 'Deprecated'
     // @!has - '//span' 'sync'
-    pub use tag::Unstable;
+    pub use tag::None;
 }

--- a/src/test/rustdoc/reexport-stability-tags-unstable-and-portability.rs
+++ b/src/test/rustdoc/reexport-stability-tags-unstable-and-portability.rs
@@ -1,0 +1,61 @@
+#![crate_name = "foo"]
+#![feature(doc_cfg)]
+#![feature(staged_api)]
+#![stable(feature = "rust1", since = "1.0.0")]
+
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod tag {
+    #[unstable(feature = "humans", issue = "none")]
+    pub trait Unstable {}
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[doc(cfg(feature = "sync"))]
+    pub trait Portability {}
+
+    #[unstable(feature = "humans", issue = "none")]
+    #[doc(cfg(feature = "sync"))]
+    pub trait Both {}
+
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub trait None {}
+}
+
+// @has foo/mod1/index.html
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod mod1 {
+    // @has - '//code' 'pub use tag::Unstable;'
+    // @has - '//span' 'Experimental'
+    // @!has - '//span' 'sync'
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use tag::Unstable;
+}
+
+// @has foo/mod2/index.html
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod mod2 {
+    // @has - '//code' 'pub use tag::Portability;'
+    // @!has - '//span' 'Experimental'
+    // @has - '//span' 'sync'
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use tag::Portability;
+}
+
+// @has foo/mod3/index.html
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod mod3 {
+    // @has - '//code' 'pub use tag::Both;'
+    // @has - '//span' 'Experimental'
+    // @has - '//span' 'sync'
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use tag::Both;
+}
+
+// @has foo/mod4/index.html
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod mod4 {
+    // @has - '//code' 'pub use tag::None;'
+    // @!has - '//span' 'Experimental'
+    // @!has - '//span' 'sync'
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use tag::None;
+}

--- a/src/tools/clippy/tests/ui/wildcard_enum_match_arm.fixed
+++ b/src/tools/clippy/tests/ui/wildcard_enum_match_arm.fixed
@@ -77,7 +77,7 @@ fn main() {
     let error_kind = ErrorKind::NotFound;
     match error_kind {
         ErrorKind::NotFound => {},
-        ErrorKind::PermissionDenied | ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::NotConnected | ErrorKind::AddrInUse | ErrorKind::AddrNotAvailable | ErrorKind::BrokenPipe | ErrorKind::AlreadyExists | ErrorKind::WouldBlock | ErrorKind::InvalidInput | ErrorKind::InvalidData | ErrorKind::TimedOut | ErrorKind::WriteZero | ErrorKind::Interrupted | ErrorKind::Other | ErrorKind::UnexpectedEof | _ => {},
+        ErrorKind::PermissionDenied | ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::NotConnected | ErrorKind::AddrInUse | ErrorKind::AddrNotAvailable | ErrorKind::BrokenPipe | ErrorKind::AlreadyExists | ErrorKind::WouldBlock | ErrorKind::InvalidInput | ErrorKind::InvalidData | ErrorKind::TimedOut | ErrorKind::WriteZero | ErrorKind::Interrupted | ErrorKind::Other | ErrorKind::UnexpectedEof | ErrorKind::Unsupported | _ => {},
     }
     match error_kind {
         ErrorKind::NotFound => {},
@@ -98,6 +98,7 @@ fn main() {
         ErrorKind::Interrupted => {},
         ErrorKind::Other => {},
         ErrorKind::UnexpectedEof => {},
+        ErrorKind::Unsupported => {},
         _ => {},
     }
 }

--- a/src/tools/clippy/tests/ui/wildcard_enum_match_arm.rs
+++ b/src/tools/clippy/tests/ui/wildcard_enum_match_arm.rs
@@ -98,6 +98,7 @@ fn main() {
         ErrorKind::Interrupted => {},
         ErrorKind::Other => {},
         ErrorKind::UnexpectedEof => {},
+        ErrorKind::Unsupported => {},
         _ => {},
     }
 }

--- a/src/tools/clippy/tests/ui/wildcard_enum_match_arm.stderr
+++ b/src/tools/clippy/tests/ui/wildcard_enum_match_arm.stderr
@@ -32,7 +32,7 @@ error: wildcard matches known variants and will also match future added variants
   --> $DIR/wildcard_enum_match_arm.rs:80:9
    |
 LL |         _ => {},
-   |         ^ help: try this: `ErrorKind::PermissionDenied | ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::NotConnected | ErrorKind::AddrInUse | ErrorKind::AddrNotAvailable | ErrorKind::BrokenPipe | ErrorKind::AlreadyExists | ErrorKind::WouldBlock | ErrorKind::InvalidInput | ErrorKind::InvalidData | ErrorKind::TimedOut | ErrorKind::WriteZero | ErrorKind::Interrupted | ErrorKind::Other | ErrorKind::UnexpectedEof | _`
+   |         ^ help: try this: `ErrorKind::PermissionDenied | ErrorKind::ConnectionRefused | ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted | ErrorKind::NotConnected | ErrorKind::AddrInUse | ErrorKind::AddrNotAvailable | ErrorKind::BrokenPipe | ErrorKind::AlreadyExists | ErrorKind::WouldBlock | ErrorKind::InvalidInput | ErrorKind::InvalidData | ErrorKind::TimedOut | ErrorKind::WriteZero | ErrorKind::Interrupted | ErrorKind::Other | ErrorKind::UnexpectedEof | ErrorKind::Unsupported | _`
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #78880 (Add `Unsupported` to `std::io::ErrorKind`)
 - #83900 (Add stability tags to ImportItem.)
 - #84283 (rustdoc: Reduce visual weight of attributes.)
 - #84288 (rustdoc: get rid of CURRENT_DEPTH)
 - #84294 (Slightly change wording in doc comment and fix typo in vec/mod.rs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=78880,83900,84283,84288,84294)
<!-- homu-ignore:end -->