### PR TITLE
rustdoc: Remove double toggle to show undocumented items

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2682,6 +2682,13 @@ function hideThemeButtonState() {
                 inner_toggle.onclick = toggleClicked;
                 e.insertBefore(inner_toggle, e.firstChild);
                 impl_call(e.previousSibling, inner_toggle);
+
+                // If *all* the items are hidden by default, remove the unnecessary indirection
+                // by toggling the items to be visible and removing the toggle.
+                if (e.childElementCount - 1 === hiddenElems.length) {
+                    inner_toggle.click();
+                    e.removeChild(inner_toggle);
+                }
             }
         });
 


### PR DESCRIPTION
This removes an indirection, having to expand a trait impl first, just to have *another* toggle inside.

TBH, the toggles code in rustdoc is super hard to understand.

Before:

![grafik](https://user-images.githubusercontent.com/580492/115158654-83fb8b00-a08f-11eb-881c-351053265068.png)

After:

![grafik](https://user-images.githubusercontent.com/580492/115158661-8eb62000-a08f-11eb-97e0-f91e5689036c.png)
