### PR TITLE
rustdoc: Convert sub-variant toggle to HTML

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -934,6 +934,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
 
             use crate::clean::Variant;
             if let clean::VariantItem(Variant::Struct(ref s)) = *variant.kind {
+                toggle_open(w, "fields");
                 let variant_id = cx.derive_id(format!(
                     "{}.{}.fields",
                     ItemType::Variant,
@@ -967,6 +968,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                     }
                 }
                 w.write_str("</div></div>");
+                toggle_close(w);
             }
             render_stability_since(w, variant, it, cx.tcx());
         }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -428,6 +428,15 @@ function hideThemeButtonState() {
         handleHashes(ev);
     }
 
+    function openParentDetails(elem) {
+        while (elem) {
+            if (elem.tagName === "DETAILS") {
+                elem.open = true;
+            }
+            elem = elem.parentNode;
+        }
+    }
+
     function expandSection(id) {
         var elem = document.getElementById(id);
         if (elem && isHidden(elem)) {
@@ -442,6 +451,8 @@ function hideThemeButtonState() {
                     // The element is not visible, we need to make it appear!
                     collapseDocs(collapses[0], "show");
                 }
+                // In case this is a sub-variant, toggle the <details> open.
+                openParentDetails(h3.parentNode);
             }
         }
     }
@@ -2418,7 +2429,7 @@ function hideThemeButtonState() {
             if (hasClass(relatedDoc, "item-info")) {
                 relatedDoc = relatedDoc.nextElementSibling;
             }
-            if (hasClass(relatedDoc, "docblock") || hasClass(relatedDoc, "sub-variant")) {
+            if (hasClass(relatedDoc, "docblock")) {
                 if (mode === "toggle") {
                     if (hasClass(relatedDoc, "hidden-by-usual-hider")) {
                         action = "show";
@@ -2727,8 +2738,6 @@ function hideThemeButtonState() {
                 if (hasClass(e, "type-decl")) {
                     // We do something special for these
                     return;
-                } else if (hasClass(e, "sub-variant")) {
-                    otherMessage = "&nbsp;Show&nbsp;fields";
                 } else if (hasClass(e, "non-exhaustive")) {
                     otherMessage = "&nbsp;This&nbsp;";
                     if (hasClass(e, "non-exhaustive-struct")) {
@@ -2760,7 +2769,6 @@ function hideThemeButtonState() {
         }
 
         onEachLazy(document.getElementsByClassName("docblock"), buildToggleWrapper);
-        onEachLazy(document.getElementsByClassName("sub-variant"), buildToggleWrapper);
 
         autoCollapse(getSettingValue("collapse") === "true");
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -451,7 +451,7 @@ function hideThemeButtonState() {
                     // The element is not visible, we need to make it appear!
                     collapseDocs(collapses[0], "show");
                 }
-                // In case this is a sub-variant, toggle the <details> open.
+                // Open all ancestor <details> to make this element visible.
                 openParentDetails(h3.parentNode);
             }
         }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1031,10 +1031,11 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 }
 
 .sub-variant, .sub-variant > h3 {
-	margin-top: 1px !important;
+	margin-top: 0px !important;
+	padding-top: 1px;
 }
 
-#main > .sub-variant > h3 {
+#main > details > .sub-variant > h3 {
 	font-size: 15px;
 	margin-left: 25px;
 	margin-bottom: 5px;

--- a/src/test/rustdoc-gui/lib.rs
+++ b/src/test/rustdoc-gui/lib.rs
@@ -29,7 +29,9 @@ pub struct Foo;
 
 impl Foo {
     #[must_use]
-    pub fn must_use(&self) -> bool { true }
+    pub fn must_use(&self) -> bool {
+        true
+    }
 }
 
 /// Just a normal enum.
@@ -85,3 +87,7 @@ pub trait AnotherOne {
 /// let x = 12;
 /// ```
 pub fn check_list_code_block() {}
+
+pub enum AnEnum {
+    WithVariants { and: usize, sub: usize, variants: usize },
+}

--- a/src/test/rustdoc/item-hide-threshold.rs
+++ b/src/test/rustdoc/item-hide-threshold.rs
@@ -62,7 +62,8 @@ pub struct PrivStruct {
 }
 
 // @has 'item_hide_threshold/enum.Enum.html'
-// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 0
+// @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 1
+// @has - '//details[@class="rustdoc-toggle type-contents-toggle"]' 'Show fields'
 pub enum Enum {
     A, B, C,
     D {


### PR DESCRIPTION
Instead of creating a JS toggle, this injects details/summary for
sub-variants of enums. This also fixes the CSS so that the toggle button
does not jump when expanding/collapsing.

Takes inspiration from #83337 and should be considered part of #83332. Not quite sure if the `.sub-variant` selectors could be further simplified? AFAICS it is only used in that place, and that does not seem to allow any recursion.