### PR TITLE
Remove unused footer section

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -110,7 +110,6 @@ crate fn render<T: Print, S: Print>(
     </nav>\
     <section id=\"main\" class=\"content\">{content}</section>\
     <section id=\"search\" class=\"content hidden\"></section>\
-    <section class=\"footer\"></section>\
     {after_content}\
     <div id=\"rustdoc-vars\" data-root-path=\"{root_path}\" data-current-crate=\"{krate}\" \
        data-search-index-js=\"{root_path}search-index{suffix}.js\" \


### PR DESCRIPTION
I realized yesterday while working on docs.rs that rustdoc was generating a "footer"section that it doesn't use. No need to keep it then.

r? @jyn514 