### PR TITLE
Move proc_macro_line_column under its own feature flag

### DIFF
--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_span)]
+#![feature(proc_macro_line_column)]
 #![feature(try_blocks)]
 
 #[macro_use]

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -342,13 +342,13 @@ impl Span {
     }
 
     /// Gets the starting line/column in the source file for this span.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[unstable(feature = "proc_macro_line_column", issue = "54725")]
     pub fn start(&self) -> LineColumn {
         self.0.start()
     }
 
     /// Gets the ending line/column in the source file for this span.
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[unstable(feature = "proc_macro_line_column", issue = "54725")]
     pub fn end(&self) -> LineColumn {
         self.0.end()
     }
@@ -408,31 +408,31 @@ impl fmt::Debug for Span {
 }
 
 /// A line-column pair representing the start or end of a `Span`.
-#[unstable(feature = "proc_macro_span", issue = "54725")]
+#[unstable(feature = "proc_macro_line_column", issue = "54725")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct LineColumn {
     /// The 1-indexed line in the source file on which the span starts or ends (inclusive).
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[unstable(feature = "proc_macro_line_column", issue = "54725")]
     pub line: usize,
     /// The 0-indexed column (in UTF-8 characters) in the source file on which
     /// the span starts or ends (inclusive).
-    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    #[unstable(feature = "proc_macro_line_column", issue = "54725")]
     pub column: usize,
 }
 
-#[unstable(feature = "proc_macro_span", issue = "54725")]
+#[unstable(feature = "proc_macro_line_column", issue = "54725")]
 impl !Send for LineColumn {}
-#[unstable(feature = "proc_macro_span", issue = "54725")]
+#[unstable(feature = "proc_macro_line_column", issue = "54725")]
 impl !Sync for LineColumn {}
 
-#[unstable(feature = "proc_macro_span", issue = "54725")]
+#[unstable(feature = "proc_macro_line_column", issue = "54725")]
 impl Ord for LineColumn {
     fn cmp(&self, other: &Self) -> Ordering {
         self.line.cmp(&other.line).then(self.column.cmp(&other.column))
     }
 }
 
-#[unstable(feature = "proc_macro_span", issue = "54725")]
+#[unstable(feature = "proc_macro_line_column", issue = "54725")]
 impl PartialOrd for LineColumn {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))

--- a/library/proc_macro/tests/test.rs
+++ b/library/proc_macro/tests/test.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_span)]
+#![feature(proc_macro_line_column)]
 
 use proc_macro::{LineColumn, Punct};
 

--- a/src/test/ui/macros/auxiliary/proc_macro_sequence.rs
+++ b/src/test/ui/macros/auxiliary/proc_macro_sequence.rs
@@ -2,7 +2,7 @@
 // no-prefer-dynamic
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_span, proc_macro_quote)]
+#![feature(proc_macro_span, proc_macro_line_column, proc_macro_quote)]
 
 extern crate proc_macro;
 

--- a/src/test/ui/proc-macro/auxiliary/macro-only-syntax.rs
+++ b/src/test/ui/proc-macro/auxiliary/macro-only-syntax.rs
@@ -10,7 +10,7 @@
 // lossy string reparse hack (https://github.com/rust-lang/rust/issues/43081).
 
 #![crate_type = "proc-macro"]
-#![feature(proc_macro_span)]
+#![feature(proc_macro_span, proc_macro_line_column)]
 
 extern crate proc_macro;
 use proc_macro::{token_stream, Delimiter, TokenStream, TokenTree};


### PR DESCRIPTION
This moves proc macro APIs related to LineColumn under their own feature flag so that they can be more easily stabilized in the future. As part of what's mentioned in https://github.com/rust-lang/rust/issues/54725#issuecomment-813648911