### PR TITLE
rustdoc: Show nag box on IE11

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -68,7 +68,7 @@ crate fn render<T: Print, S: Print>(
     </style>\
 </head>\
 <body class=\"rustdoc {css_class}\">\
-    <!--[if lte IE 8]>\
+    <!--[if lte IE 11]>\
     <div class=\"warning\">\
         This old browser is unsupported and will most likely display funky \
         things.\

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1281,7 +1281,7 @@ function hideThemeButtonState() {
         if (currentType) {
             currentType = currentType.getElementsByClassName("rust")[0];
             if (currentType) {
-                currentType.classList.forEach(function(item) {
+                onEachLazy(currentType.classList, function(item) {
                     if (item !== "main") {
                         className = item;
                         return true;


### PR DESCRIPTION
Rustdoc doesn't work on IE11. It's been broken for months, it isn't supported by the [tiered browser support list], it's even more severely broken on other Rust websites, and IE11 doesn't support the `<details>` tag that we want to use.

In the interest of honesty, let's give an actual error message for anyone on IE11.

[tiered browser support list]: https://github.com/rust-lang/rfcs/blob/master/text/1985-tiered-browser-support.md