### PR TITLE
Suggest `.as_ref()` on borrow error involving `Option`/`Result`

### DIFF
--- a/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/conflict_errors.rs
@@ -197,7 +197,11 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 );
                             }
                         }
-                        FnSelfUseKind::Normal { self_arg, implicit_into_iter } => {
+                        FnSelfUseKind::Normal {
+                            self_arg,
+                            implicit_into_iter,
+                            is_option_or_result,
+                        } => {
                             if implicit_into_iter {
                                 err.span_label(
                                     fn_call_span,
@@ -213,6 +217,14 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                         "{} {}moved due to this method call{}",
                                         place_name, partially_str, loop_message
                                     ),
+                                );
+                            }
+                            if is_option_or_result {
+                                err.span_suggestion_verbose(
+                                    fn_call_span.shrink_to_lo(),
+                                    "consider calling `.as_ref()` to borrow the type's contents",
+                                    "as_ref().".to_string(),
+                                    Applicability::MachineApplicable,
                                 );
                             }
                             // Avoid pointing to the same function in multiple different

--- a/src/test/ui/suggestions/as-ref-2.fixed
+++ b/src/test/ui/suggestions/as-ref-2.fixed
@@ -1,0 +1,13 @@
+// run-rustfix
+
+struct Struct;
+
+fn bar(_: &Struct) -> Struct {
+    Struct
+}
+
+fn main() {
+    let foo = Some(Struct);
+    let _x: Option<Struct> = foo.as_ref().map(|s| bar(&s));
+    let _y = foo; //~ERROR use of moved value: `foo`
+}

--- a/src/test/ui/suggestions/as-ref-2.rs
+++ b/src/test/ui/suggestions/as-ref-2.rs
@@ -1,0 +1,13 @@
+// run-rustfix
+
+struct Struct;
+
+fn bar(_: &Struct) -> Struct {
+    Struct
+}
+
+fn main() {
+    let foo = Some(Struct);
+    let _x: Option<Struct> = foo.map(|s| bar(&s));
+    let _y = foo; //~ERROR use of moved value: `foo`
+}

--- a/src/test/ui/suggestions/as-ref-2.stderr
+++ b/src/test/ui/suggestions/as-ref-2.stderr
@@ -1,0 +1,23 @@
+error[E0382]: use of moved value: `foo`
+  --> $DIR/as-ref-2.rs:12:14
+   |
+LL |     let foo = Some(Struct);
+   |         --- move occurs because `foo` has type `Option<Struct>`, which does not implement the `Copy` trait
+LL |     let _x: Option<Struct> = foo.map(|s| bar(&s));
+   |                                  ---------------- `foo` moved due to this method call
+LL |     let _y = foo;
+   |              ^^^ value used here after move
+   |
+note: this function takes ownership of the receiver `self`, which moves `foo`
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U> {
+   |                                      ^^^^
+help: consider calling `.as_ref()` to borrow the type's contents
+   |
+LL |     let _x: Option<Struct> = foo.as_ref().map(|s| bar(&s));
+   |                                  ^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/suggestions/as-ref.rs
+++ b/src/test/ui/suggestions/as-ref.rs
@@ -1,25 +1,20 @@
 struct Foo;
+
 fn takes_ref(_: &Foo) {}
 
 fn main() {
-  let ref opt = Some(Foo);
-  opt.map(|arg| takes_ref(arg));
-  //~^ ERROR mismatched types [E0308]
-  opt.and_then(|arg| Some(takes_ref(arg)));
-  //~^ ERROR mismatched types [E0308]
-  let ref opt: Result<_, ()> = Ok(Foo);
-  opt.map(|arg| takes_ref(arg));
-  //~^ ERROR mismatched types [E0308]
-  opt.and_then(|arg| Ok(takes_ref(arg)));
-  //~^ ERROR mismatched types [E0308]
-  let x: &Option<usize> = &Some(3);
-  let y: Option<&usize> = x;
-  //~^ ERROR mismatched types [E0308]
-  let x: &Result<usize, usize> = &Ok(3);
-  let y: Result<&usize, &usize> = x;
-  //~^ ERROR mismatched types [E0308]
-  // note: do not suggest because of `E: usize`
-  let x: &Result<usize, usize> = &Ok(3);
-  let y: Result<&usize, usize> = x;
-  //~^ ERROR mismatched types [E0308]
+    let ref opt = Some(Foo);
+    opt.map(|arg| takes_ref(arg)); //~ ERROR mismatched types [E0308]
+    opt.and_then(|arg| Some(takes_ref(arg))); //~ ERROR mismatched types [E0308]
+    let ref opt: Result<_, ()> = Ok(Foo);
+    opt.map(|arg| takes_ref(arg)); //~ ERROR mismatched types [E0308]
+    opt.and_then(|arg| Ok(takes_ref(arg))); //~ ERROR mismatched types [E0308]
+    let x: &Option<usize> = &Some(3);
+    let y: Option<&usize> = x; //~ ERROR mismatched types [E0308]
+    let x: &Result<usize, usize> = &Ok(3);
+    let y: Result<&usize, &usize> = x;
+    //~^ ERROR mismatched types [E0308]
+    // note: do not suggest because of `E: usize`
+    let x: &Result<usize, usize> = &Ok(3);
+    let y: Result<&usize, usize> = x; //~ ERROR mismatched types [E0308]
 }

--- a/src/test/ui/suggestions/as-ref.stderr
+++ b/src/test/ui/suggestions/as-ref.stderr
@@ -1,70 +1,70 @@
 error[E0308]: mismatched types
-  --> $DIR/as-ref.rs:6:27
+  --> $DIR/as-ref.rs:7:29
    |
-LL |   opt.map(|arg| takes_ref(arg));
-   |       ---                 ^^^ expected `&Foo`, found struct `Foo`
-   |       |
-   |       help: consider using `as_ref` instead: `as_ref().map`
+LL |     opt.map(|arg| takes_ref(arg));
+   |         ---                 ^^^ expected `&Foo`, found struct `Foo`
+   |         |
+   |         help: consider using `as_ref` instead: `as_ref().map`
 
 error[E0308]: mismatched types
-  --> $DIR/as-ref.rs:8:37
+  --> $DIR/as-ref.rs:8:39
    |
-LL |   opt.and_then(|arg| Some(takes_ref(arg)));
-   |       --------                      ^^^ expected `&Foo`, found struct `Foo`
-   |       |
-   |       help: consider using `as_ref` instead: `as_ref().and_then`
+LL |     opt.and_then(|arg| Some(takes_ref(arg)));
+   |         --------                      ^^^ expected `&Foo`, found struct `Foo`
+   |         |
+   |         help: consider using `as_ref` instead: `as_ref().and_then`
 
 error[E0308]: mismatched types
-  --> $DIR/as-ref.rs:11:27
+  --> $DIR/as-ref.rs:10:29
    |
-LL |   opt.map(|arg| takes_ref(arg));
-   |       ---                 ^^^ expected `&Foo`, found struct `Foo`
-   |       |
-   |       help: consider using `as_ref` instead: `as_ref().map`
+LL |     opt.map(|arg| takes_ref(arg));
+   |         ---                 ^^^ expected `&Foo`, found struct `Foo`
+   |         |
+   |         help: consider using `as_ref` instead: `as_ref().map`
 
 error[E0308]: mismatched types
-  --> $DIR/as-ref.rs:13:35
+  --> $DIR/as-ref.rs:11:37
    |
-LL |   opt.and_then(|arg| Ok(takes_ref(arg)));
-   |       --------                    ^^^ expected `&Foo`, found struct `Foo`
-   |       |
-   |       help: consider using `as_ref` instead: `as_ref().and_then`
+LL |     opt.and_then(|arg| Ok(takes_ref(arg)));
+   |         --------                    ^^^ expected `&Foo`, found struct `Foo`
+   |         |
+   |         help: consider using `as_ref` instead: `as_ref().and_then`
 
 error[E0308]: mismatched types
-  --> $DIR/as-ref.rs:16:27
+  --> $DIR/as-ref.rs:13:29
    |
-LL |   let y: Option<&usize> = x;
-   |          --------------   ^
-   |          |                |
-   |          |                expected enum `Option`, found `&Option<usize>`
-   |          |                help: you can convert from `&Option<T>` to `Option<&T>` using `.as_ref()`: `x.as_ref()`
-   |          expected due to this
+LL |     let y: Option<&usize> = x;
+   |            --------------   ^
+   |            |                |
+   |            |                expected enum `Option`, found `&Option<usize>`
+   |            |                help: you can convert from `&Option<T>` to `Option<&T>` using `.as_ref()`: `x.as_ref()`
+   |            expected due to this
    |
    = note:   expected enum `Option<&usize>`
            found reference `&Option<usize>`
 
 error[E0308]: mismatched types
-  --> $DIR/as-ref.rs:19:35
+  --> $DIR/as-ref.rs:15:37
    |
-LL |   let y: Result<&usize, &usize> = x;
-   |          ----------------------   ^ expected enum `Result`, found reference
-   |          |
-   |          expected due to this
+LL |     let y: Result<&usize, &usize> = x;
+   |            ----------------------   ^ expected enum `Result`, found reference
+   |            |
+   |            expected due to this
    |
    = note:   expected enum `Result<&usize, &usize>`
            found reference `&Result<usize, usize>`
 help: you can convert from `&Result<T, E>` to `Result<&T, &E>` using `.as_ref()`
    |
-LL |   let y: Result<&usize, &usize> = x.as_ref();
-   |                                   ^^^^^^^^^^
+LL |     let y: Result<&usize, &usize> = x.as_ref();
+   |                                     ^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/as-ref.rs:23:34
+  --> $DIR/as-ref.rs:19:36
    |
-LL |   let y: Result<&usize, usize> = x;
-   |          ---------------------   ^ expected enum `Result`, found reference
-   |          |
-   |          expected due to this
+LL |     let y: Result<&usize, usize> = x;
+   |            ---------------------   ^ expected enum `Result`, found reference
+   |            |
+   |            expected due to this
    |
    = note:   expected enum `Result<&usize, usize>`
            found reference `&Result<usize, usize>`


### PR DESCRIPTION
When encountering a E0382 borrow error involving an `Option` or `Result`
provide a suggestion to use `.as_ref()` on the prior move location to
avoid the move.

Fix #84165.