### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -594,34 +594,6 @@ impl<T> Option<T> {
         }
     }
 
-    /// Inserts `value` into the option then returns a mutable reference to it.
-    ///
-    /// If the option already contains a value, the old value is dropped.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// let mut opt = None;
-    /// let val = opt.insert(1);
-    /// assert_eq!(*val, 1);
-    /// assert_eq!(opt.unwrap(), 1);
-    /// let val = opt.insert(2);
-    /// assert_eq!(*val, 2);
-    /// *val = 3;
-    /// assert_eq!(opt.unwrap(), 3);
-    /// ```
-    #[inline]
-    #[stable(feature = "option_insert", since = "1.53.0")]
-    pub fn insert(&mut self, value: T) -> &mut T {
-        *self = Some(value);
-
-        match self {
-            Some(v) => v,
-            // SAFETY: the code above just filled the option
-            None => unsafe { hint::unreachable_unchecked() },
-        }
-    }
-
     /////////////////////////////////////////////////////////////////////////
     // Iterator constructors
     /////////////////////////////////////////////////////////////////////////
@@ -849,11 +821,45 @@ impl<T> Option<T> {
     }
 
     /////////////////////////////////////////////////////////////////////////
-    // Entry-like operations to insert if None and return a reference
+    // Entry-like operations to insert a value and return a reference
     /////////////////////////////////////////////////////////////////////////
+
+    /// Inserts `value` into the option then returns a mutable reference to it.
+    ///
+    /// If the option already contains a value, the old value is dropped.
+    ///
+    /// See also [`Option::get_or_insert`], which doesn't update the value if
+    /// the option already contains [`Some`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let mut opt = None;
+    /// let val = opt.insert(1);
+    /// assert_eq!(*val, 1);
+    /// assert_eq!(opt.unwrap(), 1);
+    /// let val = opt.insert(2);
+    /// assert_eq!(*val, 2);
+    /// *val = 3;
+    /// assert_eq!(opt.unwrap(), 3);
+    /// ```
+    #[inline]
+    #[stable(feature = "option_insert", since = "1.53.0")]
+    pub fn insert(&mut self, value: T) -> &mut T {
+        *self = Some(value);
+
+        match self {
+            Some(v) => v,
+            // SAFETY: the code above just filled the option
+            None => unsafe { hint::unreachable_unchecked() },
+        }
+    }
 
     /// Inserts `value` into the option if it is [`None`], then
     /// returns a mutable reference to the contained value.
+    ///
+    /// See also [`Option::insert`], which updates the value even if
+    /// the option already contains [`Some`].
     ///
     /// # Examples
     ///

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -461,15 +461,6 @@ impl Step for Std {
         // create correct links between crates because rustdoc depends on the
         // existence of the output directories to know if it should be a local
         // or remote link.
-        //
-        // There's also a mild hack here where we build the first crate in this
-        // list, core, twice. This is currently necessary to make sure that
-        // cargo's cached rustc/rustdoc versions are up to date which means
-        // cargo won't delete the out_dir we create for the stampfile.
-        // Essentially any crate could go into the first slot here as it's
-        // output directory will be deleted by us (as cargo will purge the stamp
-        // file during the first slot's run), and core is relatively fast to
-        // build so works OK to fill this 'dummy' slot.
         let krates = ["core", "alloc", "std", "proc_macro", "test"];
         for krate in &krates {
             run_cargo_rustdoc_for(krate);

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -68,7 +68,7 @@ crate fn render<T: Print, S: Print>(
     </style>\
 </head>\
 <body class=\"rustdoc {css_class}\">\
-    <!--[if lte IE 8]>\
+    <!--[if lte IE 11]>\
     <div class=\"warning\">\
         This old browser is unsupported and will most likely display funky \
         things.\

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1281,7 +1281,7 @@ function hideThemeButtonState() {
         if (currentType) {
             currentType = currentType.getElementsByClassName("rust")[0];
             if (currentType) {
-                currentType.classList.forEach(function(item) {
+                onEachLazy(currentType.classList, function(item) {
                     if (item !== "main") {
                         className = item;
                         return true;


### PR DESCRIPTION
Successful merges:

 - #84337 (Clarify the difference between insert and get_or_insert)
 - #84340 (rustdoc: Show nag box on IE11)
 - #84345 (Remove comment about doc hack.)
 - #84347 (rustdoc: Simplify some document functions)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=84337,84340,84345,84347)
<!-- homu-ignore:end -->