### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0404.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0404.md
@@ -8,14 +8,15 @@ struct Foo;
 struct Bar;
 
 impl Foo for Bar {} // error: `Foo` is not a trait
+fn baz<T: Foo>(t: T) {} // error: `Foo` is not a trait
 ```
 
 Another erroneous code example:
 
 ```compile_fail,E0404
-struct Foo;
+type Foo = Iterator<Item=String>;
 
-fn bar<T: Foo>(t: T) {} // error: `Foo` is not a trait
+fn bar<T: Foo>(t: T) {} // error: `Foo` is a type alias
 ```
 
 Please verify that the trait's name was not misspelled or that the right
@@ -30,14 +31,27 @@ struct Bar;
 impl Foo for Bar { // ok!
     // functions implementation
 }
+
+fn baz<T: Foo>(t: T) {} // ok!
 ```
 
-or:
+Alternatively, you could introduce a new trait with your desired restrictions
+as a super trait:
 
 ```
-trait Foo {
-    // some functions
-}
+# trait Foo {}
+# struct Bar;
+# impl Foo for Bar {}
+trait Qux: Foo {} // Anything that implements Qux also needs to implement Foo
+fn baz<T: Qux>(t: T) {} // also ok!
+```
+
+Finally, if you are on nightly and want to use a trait alias
+instead of a type alias, you should use `#![feature(trait_alias)]`:
+
+```
+#![feature(trait_alias)]
+trait Foo = Iterator<Item=String>;
 
 fn bar<T: Foo>(t: T) {} // ok!
 ```

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -589,10 +589,11 @@ impl DeadVisitor<'tcx> {
                     Applicability::MachineApplicable,
                 )
                 .note(&format!(
-                    "the leading underscore helps signal to the reader that the {} may still serve\n\
-                    a purpose even if it isn't used in a way that we can detect (e.g. the {}\nis \
-                    only used through FFI or used only for its effect when dropped)",
-                    descr, descr,
+                    "The leading underscore signals to the reader that while the {} may not be {}\n\
+                    by any Rust code, it still serves some other purpose that isn't detected by rustc.\n\
+                    (e.g. some values are used for their effect when dropped or used in FFI code\n\
+                    exclusively through raw pointers)",
+                    descr, participle,
                 ));
                 // Force the note we added to the front, before any other subdiagnostics
                 diag.children.rotate_right(1);

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -928,7 +928,14 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                     let msg = "you might have meant to use `#![feature(trait_alias)]` instead of a \
                                `type` alias";
                     if let Some(span) = self.def_span(def_id) {
-                        err.span_help(span, msg);
+                        if let Ok(snip) = self.r.session.source_map().span_to_snippet(span) {
+                            // The span contains a type alias so we should be able to
+                            // replace `type` with `trait`.
+                            let snip = snip.replacen("type", "trait", 1);
+                            err.span_suggestion(span, msg, snip, Applicability::MaybeIncorrect);
+                        } else {
+                            err.span_help(span, msg);
+                        }
                     } else {
                         err.help(msg);
                     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -75,19 +75,21 @@ impl_stable_hash_via_hash!(OptLevel);
 
 /// This is what the `LtoCli` values get mapped to after resolving defaults and
 /// and taking other command line options into account.
+///
+/// Note that linker plugin-based LTO is a different mechanism entirely.
 #[derive(Clone, PartialEq)]
 pub enum Lto {
-    /// Don't do any LTO whatsoever
+    /// Don't do any LTO whatsoever.
     No,
 
-    /// Do a full crate graph LTO with ThinLTO
+    /// Do a full-crate-graph (inter-crate) LTO with ThinLTO.
     Thin,
 
-    /// Do a local graph LTO with ThinLTO (only relevant for multiple codegen
-    /// units).
+    /// Do a local ThinLTO (intra-crate, over the CodeGen Units of the local crate only). This is
+    /// only relevant if multiple CGUs are used.
     ThinLocal,
 
-    /// Do a full crate graph LTO with "fat" LTO
+    /// Do a full-crate-graph (inter-crate) LTO with "fat" LTO.
     Fat,
 }
 

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -4,10 +4,8 @@ error: associated constant is never used: `BAR`
 LL |     const BAR: u32 = 1;
    |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
    |
-   = note: The leading underscore signals to the reader that while the associated constant may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated constant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -2,8 +2,11 @@ error: associated constant is never used: `BAR`
   --> $DIR/associated-const-dead-code.rs:6:5
    |
 LL |     const BAR: u32 = 1;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
    |
+   = note: the leading underscore helps signal to the reader that the associated constant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated constant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -4,9 +4,10 @@ error: associated constant is never used: `BAR`
 LL |     const BAR: u32 = 1;
    |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
    |
-   = note: the leading underscore helps signal to the reader that the associated constant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated constant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated constant may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -2,10 +2,11 @@ error: associated constant is never used: `BAR`
   --> $DIR/associated-const-dead-code.rs:6:5
    |
 LL |     const BAR: u32 = 1;
-   |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
+   |     ^^^^^^---^^^^^^^^^^
+   |           |
+   |           help: if this is intentional, prefix it with an underscore: `_BAR`
    |
-   = note: the leading underscore signals that this associated constant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated constant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/codemap_tests/two_files.stderr
+++ b/src/test/ui/codemap_tests/two_files.stderr
@@ -5,10 +5,9 @@ LL | impl Bar for Baz { }
    |      ^^^ type aliases cannot be used as traits
    |
 help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
-  --> $DIR/two_files_data.rs:5:1
    |
-LL | type Bar = dyn Foo;
-   | ^^^^^^^^^^^^^^^^^^^
+LL | trait Bar = dyn Foo;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -2,10 +2,11 @@ warning: variant is never constructed: `Void`
   --> $DIR/derive-uninhabited-enum-38885.rs:13:5
    |
 LL |     Void(Void),
-   |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
+   |     ----^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Void`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -2,8 +2,11 @@ warning: variant is never constructed: `Void`
   --> $DIR/derive-uninhabited-enum-38885.rs:13:5
    |
 LL |     Void(Void),
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -4,9 +4,10 @@ warning: variant is never constructed: `Void`
 LL |     Void(Void),
    |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -4,10 +4,8 @@ warning: variant is never constructed: `Void`
 LL |     Void(Void),
    |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -2,8 +2,11 @@ warning: type alias is never used: `Z`
   --> $DIR/issue-37515.rs:5:1
    |
 LL | type Z = dyn for<'x> Send;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
    |
+   = note: the leading underscore helps signal to the reader that the type alias may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -4,9 +4,10 @@ warning: type alias is never used: `Z`
 LL | type Z = dyn for<'x> Send;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
    |
-   = note: the leading underscore helps signal to the reader that the type alias may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the type alias may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -2,10 +2,11 @@ warning: type alias is never used: `Z`
   --> $DIR/issue-37515.rs:5:1
    |
 LL | type Z = dyn for<'x> Send;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
+   | ^^^^^-^^^^^^^^^^^^^^^^^^^^
+   |      |
+   |      help: if this is intentional, prefix it with an underscore: `_Z`
    |
-   = note: the leading underscore signals that this type alias serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this type alias serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -4,10 +4,8 @@ warning: type alias is never used: `Z`
 LL | type Z = dyn for<'x> Send;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
    |
-   = note: The leading underscore signals to the reader that while the type alias may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this type alias serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -4,8 +4,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -4,10 +4,8 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -2,8 +2,11 @@ error: function is never used: `foo`
   --> $DIR/basic.rs:4:4
    |
 LL | fn foo() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -4,9 +4,10 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -4,9 +4,10 @@ warning: variant is never constructed: `B`
 LL |     B,
    |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -19,9 +20,10 @@ warning: variant is never constructed: `C`
 LL |     C,
    |     ^ help: if this is intentional, prefix it with an underscore: `_C`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -4,8 +4,7 @@ warning: variant is never constructed: `B`
 LL |     B,
    |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -18,8 +17,7 @@ warning: variant is never constructed: `C`
 LL |     C,
    |     ^ help: if this is intentional, prefix it with an underscore: `_C`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -4,10 +4,8 @@ warning: variant is never constructed: `B`
 LL |     B,
    |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -20,10 +18,8 @@ warning: variant is never constructed: `C`
 LL |     C,
    |     ^ help: if this is intentional, prefix it with an underscore: `_C`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -2,8 +2,11 @@ warning: variant is never constructed: `B`
   --> $DIR/const-and-self.rs:33:5
    |
 LL |     B,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -14,7 +17,11 @@ warning: variant is never constructed: `C`
   --> $DIR/const-and-self.rs:34:5
    |
 LL |     C,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_C`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.rs
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.rs
@@ -1,0 +1,42 @@
+//! The field `guard` is never used directly, but it is still useful for its side effect when
+//! dropped. Since rustc doesn't consider a `Drop` impl as a use, we want to make sure we at least
+//! produce a helpful diagnostic that points the user to what they can do if they indeed intended to
+//! have a field that is only used for its `Drop` side effect.
+//!
+//! Issue: https://github.com/rust-lang/rust/issues/81658
+
+#![deny(dead_code)]
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Holds a locked value until it is dropped
+pub struct Locked<'a, T> {
+    // Field is kept for its affect when dropped, but otherwise unused
+    guard: MutexGuard<'a, T>, //~ ERROR field is never read
+}
+
+impl<'a, T> Locked<'a, T> {
+    pub fn new(value: &'a Mutex<T>) -> Self {
+        Self {
+            guard: value.lock().unwrap(),
+        }
+    }
+}
+
+fn main() {
+    let items = Mutex::new(vec![1, 2, 3]);
+
+    // Hold a lock on items while doing something else
+    let result = {
+        // The lock will be released at the end of this scope
+        let _lock = Locked::new(&items);
+
+        do_something_else()
+    };
+
+    println!("{}", result);
+}
+
+fn do_something_else() -> i32 {
+    1 + 1
+}

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -2,11 +2,11 @@ error: field is never read: `guard`
   --> $DIR/drop-only-field-issue-81658.rs:15:5
    |
 LL |     guard: MutexGuard<'a, T>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
+   |     -----^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_guard`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -2,8 +2,11 @@ error: field is never read: `guard`
   --> $DIR/drop-only-field-issue-81658.rs:15:5
    |
 LL |     guard: MutexGuard<'a, T>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -1,0 +1,14 @@
+error: field is never read: `guard`
+  --> $DIR/drop-only-field-issue-81658.rs:15:5
+   |
+LL |     guard: MutexGuard<'a, T>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/drop-only-field-issue-81658.rs:8:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -4,9 +4,10 @@ error: field is never read: `guard`
 LL |     guard: MutexGuard<'a, T>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -4,10 +4,9 @@ error: field is never read: `guard`
 LL |     guard: MutexGuard<'a, T>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -2,8 +2,11 @@ error: enum is never used: `E`
   --> $DIR/empty-unused-enum.rs:3:6
    |
 LL | enum E {}
-   |      ^
+   |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -4,8 +4,7 @@ error: enum is never used: `E`
 LL | enum E {}
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -4,9 +4,10 @@ error: enum is never used: `E`
 LL | enum E {}
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -4,10 +4,8 @@ error: enum is never used: `E`
 LL | enum E {}
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.rs
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.rs
@@ -1,0 +1,50 @@
+//! The field `items` is being "used" by FFI (implicitly through pointers). However, since rustc
+//! doesn't know how to detect that, we produce a message that says the field is unused. This can
+//! cause some confusion and we want to make sure our diagnostics help as much as they can.
+//!
+//! Issue: https://github.com/rust-lang/rust/issues/81658
+
+#![deny(dead_code)]
+
+/// A struct for holding on to data while it is being used in our FFI code
+pub struct FFIData<T> {
+    /// These values cannot be dropped while the pointers to each item
+    /// are still in use
+    items: Option<Vec<T>>, //~ ERROR field is never read
+}
+
+impl<T> FFIData<T> {
+    pub fn new() -> Self {
+        Self {items: None}
+    }
+
+    /// Load items into this type and return pointers to each item that can
+    /// be passed to FFI
+    pub fn load(&mut self, items: Vec<T>) -> Vec<*const T> {
+        let ptrs = items.iter().map(|item| item as *const _).collect();
+
+        self.items = Some(items);
+
+        ptrs
+    }
+}
+
+extern {
+    /// The FFI code that uses items
+    fn process_item(item: *const i32);
+}
+
+fn main() {
+    // Data cannot be dropped until the end of this scope or else the items
+    // will be dropped before they are processed
+    let mut data = FFIData::new();
+
+    let ptrs = data.load(vec![1, 2, 3, 4, 5]);
+
+    for ptr in ptrs {
+        // Safety: This pointer is valid as long as the arena is in scope
+        unsafe { process_item(ptr); }
+    }
+
+    // Items will be safely freed at the end of this scope
+}

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -4,9 +4,10 @@ error: field is never read: `items`
 LL |     items: Option<Vec<T>>,
    |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -2,8 +2,11 @@ error: field is never read: `items`
   --> $DIR/field-used-in-ffi-issue-81658.rs:13:5
    |
 LL |     items: Option<Vec<T>>,
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -4,10 +4,9 @@ error: field is never read: `items`
 LL |     items: Option<Vec<T>>,
    |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -1,0 +1,14 @@
+error: field is never read: `items`
+  --> $DIR/field-used-in-ffi-issue-81658.rs:13:5
+   |
+LL |     items: Option<Vec<T>>,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -2,11 +2,11 @@ error: field is never read: `items`
   --> $DIR/field-used-in-ffi-issue-81658.rs:13:5
    |
 LL |     items: Option<Vec<T>>,
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
+   |     -----^^^^^^^^^^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_items`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -4,9 +4,10 @@ error: type alias is never used: `Unused`
 LL | type Unused = ();
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore helps signal to the reader that the type alias may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the type alias may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -4,10 +4,8 @@ error: type alias is never used: `Unused`
 LL | type Unused = ();
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: The leading underscore signals to the reader that while the type alias may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this type alias serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -2,8 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/impl-trait.rs:12:1
    |
 LL | type Unused = ();
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
+   = note: the leading underscore helps signal to the reader that the type alias may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -2,10 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/impl-trait.rs:12:1
    |
 LL | type Unused = ();
-   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
+   | ^^^^^------^^^^^^
+   |      |
+   |      help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore signals that this type alias serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this type alias serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `Bar`
   --> $DIR/lint-dead-code-1.rs:12:16
    |
 LL |     pub struct Bar;
-   |                ^^^
+   |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -14,55 +17,91 @@ error: static is never used: `priv_static`
   --> $DIR/lint-dead-code-1.rs:20:1
    |
 LL | static priv_static: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
+   |
+   = note: the leading underscore helps signal to the reader that the static may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the static
+           is only used through FFI or used only for its effect when dropped)
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
    |
 LL | const priv_const: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
+   |
+   = note: the leading underscore helps signal to the reader that the constant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the constant
+           is only used through FFI or used only for its effect when dropped)
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
    |
 LL | struct PrivStruct;
-   |        ^^^^^^^^^^
+   |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
+   |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
    |
 LL | enum priv_enum { foo2, bar2 }
-   |      ^^^^^^^^^
+   |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
    |
 LL |     bar3
-   |     ^^^^
+   |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
    |
 LL | fn priv_fn() {
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
    |
 LL | fn foo() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
    |
 LL | fn bar() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
    |
 LL | fn baz() -> impl Copy {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `Bar`
 LL |     pub struct Bar;
    |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -16,19 +15,21 @@ error: static is never used: `priv_static`
   --> $DIR/lint-dead-code-1.rs:20:1
    |
 LL | static priv_static: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
+   | ^^^^^^^-----------^^^^^^^^^^^^
+   |        |
+   |        help: if this is intentional, prefix it with an underscore: `_priv_static`
    |
-   = note: the leading underscore signals that this static serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this static serves some other purpose even if it isn't used in a way that we can detect.
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
    |
 LL | const priv_const: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
+   | ^^^^^^----------^^^^^^^^^^^^
+   |       |
+   |       help: if this is intentional, prefix it with an underscore: `_priv_const`
    |
-   = note: the leading underscore signals that this constant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this constant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
@@ -36,8 +37,7 @@ error: struct is never constructed: `PrivStruct`
 LL | struct PrivStruct;
    |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
@@ -45,8 +45,7 @@ error: enum is never used: `priv_enum`
 LL | enum priv_enum { foo2, bar2 }
    |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
@@ -54,8 +53,7 @@ error: variant is never constructed: `bar3`
 LL |     bar3
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
@@ -63,8 +61,7 @@ error: function is never used: `priv_fn`
 LL | fn priv_fn() {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
@@ -72,8 +69,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
@@ -81,8 +77,7 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
@@ -90,8 +85,7 @@ error: function is never used: `baz`
 LL | fn baz() -> impl Copy {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `Bar`
 LL |     pub struct Bar;
    |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -19,9 +20,10 @@ error: static is never used: `priv_static`
 LL | static priv_static: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
    |
-   = note: the leading underscore helps signal to the reader that the static may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the static
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the static may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
@@ -29,9 +31,10 @@ error: constant is never used: `priv_const`
 LL | const priv_const: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
    |
-   = note: the leading underscore helps signal to the reader that the constant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the constant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the constant may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
@@ -39,9 +42,10 @@ error: struct is never constructed: `PrivStruct`
 LL | struct PrivStruct;
    |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
@@ -49,9 +53,10 @@ error: enum is never used: `priv_enum`
 LL | enum priv_enum { foo2, bar2 }
    |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
@@ -59,9 +64,10 @@ error: variant is never constructed: `bar3`
 LL |     bar3
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
@@ -69,9 +75,10 @@ error: function is never used: `priv_fn`
 LL | fn priv_fn() {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
@@ -79,9 +86,10 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
@@ -89,9 +97,10 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
@@ -99,9 +108,10 @@ error: function is never used: `baz`
 LL | fn baz() -> impl Copy {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `Bar`
 LL |     pub struct Bar;
    |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -20,10 +18,8 @@ error: static is never used: `priv_static`
 LL | static priv_static: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
    |
-   = note: The leading underscore signals to the reader that while the static may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this static serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
@@ -31,10 +27,8 @@ error: constant is never used: `priv_const`
 LL | const priv_const: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
    |
-   = note: The leading underscore signals to the reader that while the constant may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this constant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
@@ -42,10 +36,8 @@ error: struct is never constructed: `PrivStruct`
 LL | struct PrivStruct;
    |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
@@ -53,10 +45,8 @@ error: enum is never used: `priv_enum`
 LL | enum priv_enum { foo2, bar2 }
    |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
@@ -64,10 +54,8 @@ error: variant is never constructed: `bar3`
 LL |     bar3
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
@@ -75,10 +63,8 @@ error: function is never used: `priv_fn`
 LL | fn priv_fn() {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
@@ -86,10 +72,8 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
@@ -97,10 +81,8 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
@@ -108,10 +90,8 @@ error: function is never used: `baz`
 LL | fn baz() -> impl Copy {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -4,8 +4,7 @@ error: function is never used: `dead_fn`
 LL | fn dead_fn() {}
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -18,8 +17,7 @@ error: function is never used: `dead_fn2`
 LL | fn dead_fn2() {}
    |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
@@ -27,8 +25,7 @@ error: function is never used: `main`
 LL | fn main() {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -2,8 +2,11 @@ error: function is never used: `dead_fn`
   --> $DIR/lint-dead-code-2.rs:22:4
    |
 LL | fn dead_fn() {}
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -14,13 +17,21 @@ error: function is never used: `dead_fn2`
   --> $DIR/lint-dead-code-2.rs:25:4
    |
 LL | fn dead_fn2() {}
-   |    ^^^^^^^^
+   |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
    |
 LL | fn main() {
-   |    ^^^^
+   |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -4,10 +4,8 @@ error: function is never used: `dead_fn`
 LL | fn dead_fn() {}
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -20,10 +18,8 @@ error: function is never used: `dead_fn2`
 LL | fn dead_fn2() {}
    |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
@@ -31,10 +27,8 @@ error: function is never used: `main`
 LL | fn main() {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -4,9 +4,10 @@ error: function is never used: `dead_fn`
 LL | fn dead_fn() {}
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -19,9 +20,10 @@ error: function is never used: `dead_fn2`
 LL | fn dead_fn2() {}
    |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
@@ -29,9 +31,10 @@ error: function is never used: `main`
 LL | fn main() {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `Foo`
   --> $DIR/lint-dead-code-3.rs:14:8
    |
 LL | struct Foo;
-   |        ^^^
+   |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -14,25 +17,41 @@ error: associated function is never used: `foo`
   --> $DIR/lint-dead-code-3.rs:16:8
    |
 LL |     fn foo(&self) {
-   |        ^^^
+   |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
    |
 LL | fn bar() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
    |
 LL | enum c_void {}
-   |      ^^^^^^
+   |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
    |
 LL |     fn free(p: *const c_void);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `Foo`
 LL | struct Foo;
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -18,8 +17,7 @@ error: associated function is never used: `foo`
 LL |     fn foo(&self) {
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
@@ -27,8 +25,7 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
@@ -36,17 +33,17 @@ error: enum is never used: `c_void`
 LL | enum c_void {}
    |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
    |
 LL |     fn free(p: *const c_void);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
+   |     ^^^----^^^^^^^^^^^^^^^^^^^
+   |        |
+   |        help: if this is intentional, prefix it with an underscore: `_free`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `Foo`
 LL | struct Foo;
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -20,10 +18,8 @@ error: associated function is never used: `foo`
 LL |     fn foo(&self) {
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
@@ -31,10 +27,8 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
@@ -42,10 +36,8 @@ error: enum is never used: `c_void`
 LL | enum c_void {}
    |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
@@ -53,10 +45,8 @@ error: function is never used: `free`
 LL |     fn free(p: *const c_void);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `Foo`
 LL | struct Foo;
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -19,9 +20,10 @@ error: associated function is never used: `foo`
 LL |     fn foo(&self) {
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
@@ -29,9 +31,10 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
@@ -39,9 +42,10 @@ error: enum is never used: `c_void`
 LL | enum c_void {}
    |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
@@ -49,9 +53,10 @@ error: function is never used: `free`
 LL |     fn free(p: *const c_void);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -4,9 +4,10 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -19,9 +20,10 @@ error: variant is never constructed: `X`
 LL |     X,
    |     ^ help: if this is intentional, prefix it with an underscore: `_X`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
@@ -33,9 +35,10 @@ LL | |         c: i32,
 LL | |     },
    | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -43,9 +46,10 @@ error: enum is never used: `ABC`
 LL | enum ABC {
    |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
@@ -53,9 +57,10 @@ error: variant is never constructed: `I`
 LL |     I,
    |     ^ help: if this is intentional, prefix it with an underscore: `_I`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
@@ -63,9 +68,10 @@ error: field is never read: `b`
 LL |         b: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
@@ -73,9 +79,10 @@ error: field is never read: `c`
 LL |         c: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
@@ -83,9 +90,10 @@ error: variant is never constructed: `K`
 LL |     K
    |     ^ help: if this is intentional, prefix it with an underscore: `_K`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
@@ -93,9 +101,10 @@ error: field is never read: `x`
 LL |     x: usize,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
@@ -103,9 +112,10 @@ error: field is never read: `c`
 LL |     c: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -2,11 +2,11 @@ error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:7:5
    |
 LL |     b: bool,
-   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |     -^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -19,21 +19,22 @@ error: variant is never constructed: `X`
 LL |     X,
    |     ^ help: if this is intentional, prefix it with an underscore: `_X`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
    |
-LL | /     Y {
+LL |       Y {
+   |       ^ help: if this is intentional, prefix it with an underscore: `_Y`
+   |  _____|
+   | |
 LL | |         a: String,
 LL | |         b: i32,
 LL | |         c: i32,
 LL | |     },
-   | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
+   | |_____^
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -41,8 +42,7 @@ error: enum is never used: `ABC`
 LL | enum ABC {
    |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
@@ -50,28 +50,27 @@ error: variant is never constructed: `I`
 LL |     I,
    |     ^ help: if this is intentional, prefix it with an underscore: `_I`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
    |
 LL |         b: i32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
    |
 LL |         c: i32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
@@ -79,28 +78,27 @@ error: variant is never constructed: `K`
 LL |     K
    |     ^ help: if this is intentional, prefix it with an underscore: `_K`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
    |
 LL |     x: usize,
-   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
+   |     -^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_x`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
    |
 LL |     c: bool,
-   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |     -^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -2,8 +2,11 @@ error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:7:5
    |
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -14,7 +17,11 @@ error: variant is never constructed: `X`
   --> $DIR/lint-dead-code-4.rs:15:5
    |
 LL |     X,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_X`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
@@ -24,49 +31,81 @@ LL | |         a: String,
 LL | |         b: i32,
 LL | |         c: i32,
 LL | |     },
-   | |_____^
+   | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
    |
 LL | enum ABC {
-   |      ^^^
+   |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
    |
 LL |     I,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_I`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
    |
 LL |         b: i32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
    |
 LL |         c: i32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
    |
 LL |     K
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_K`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
    |
 LL |     x: usize,
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
    |
 LL |     c: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -4,10 +4,9 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -20,10 +19,8 @@ error: variant is never constructed: `X`
 LL |     X,
    |     ^ help: if this is intentional, prefix it with an underscore: `_X`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
@@ -35,10 +32,8 @@ LL | |         c: i32,
 LL | |     },
    | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -46,10 +41,8 @@ error: enum is never used: `ABC`
 LL | enum ABC {
    |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
@@ -57,10 +50,8 @@ error: variant is never constructed: `I`
 LL |     I,
    |     ^ help: if this is intentional, prefix it with an underscore: `_I`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
@@ -68,10 +59,9 @@ error: field is never read: `b`
 LL |         b: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
@@ -79,10 +69,9 @@ error: field is never read: `c`
 LL |         c: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
@@ -90,10 +79,8 @@ error: variant is never constructed: `K`
 LL |     K
    |     ^ help: if this is intentional, prefix it with an underscore: `_K`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
@@ -101,10 +88,9 @@ error: field is never read: `x`
 LL |     x: usize,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
@@ -112,10 +98,9 @@ error: field is never read: `c`
 LL |     c: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -4,9 +4,10 @@ error: variant is never constructed: `Variant2`
 LL |     Variant2
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -19,9 +20,10 @@ error: variant is never constructed: `Variant5`
 LL |     Variant5 { _x: isize },
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
@@ -29,9 +31,10 @@ error: variant is never constructed: `Variant6`
 LL |     Variant6(isize),
    |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
@@ -39,9 +42,10 @@ error: enum is never used: `Enum3`
 LL | enum Enum3 {
    |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -2,8 +2,11 @@ error: variant is never constructed: `Variant2`
   --> $DIR/lint-dead-code-5.rs:6:5
    |
 LL |     Variant2
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -14,19 +17,31 @@ error: variant is never constructed: `Variant5`
   --> $DIR/lint-dead-code-5.rs:13:5
    |
 LL |     Variant5 { _x: isize },
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
    |
 LL |     Variant6(isize),
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
    |
 LL | enum Enum3 {
-   |      ^^^^^
+   |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -4,8 +4,7 @@ error: variant is never constructed: `Variant2`
 LL |     Variant2
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -16,19 +15,21 @@ error: variant is never constructed: `Variant5`
   --> $DIR/lint-dead-code-5.rs:13:5
    |
 LL |     Variant5 { _x: isize },
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
+   |     --------^^^^^^^^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Variant5`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
    |
 LL |     Variant6(isize),
-   |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
+   |     --------^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Variant6`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
@@ -36,8 +37,7 @@ error: enum is never used: `Enum3`
 LL | enum Enum3 {
    |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -4,10 +4,8 @@ error: variant is never constructed: `Variant2`
 LL |     Variant2
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -20,10 +18,8 @@ error: variant is never constructed: `Variant5`
 LL |     Variant5 { _x: isize },
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
@@ -31,10 +27,8 @@ error: variant is never constructed: `Variant6`
 LL |     Variant6(isize),
    |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
@@ -42,10 +36,8 @@ error: enum is never used: `Enum3`
 LL | enum Enum3 {
    |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `UnusedStruct`
   --> $DIR/lint-dead-code-6.rs:3:8
    |
 LL | struct UnusedStruct;
-   |        ^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -14,19 +17,31 @@ error: associated function is never used: `unused_impl_fn_1`
   --> $DIR/lint-dead-code-6.rs:5:8
    |
 LL |     fn unused_impl_fn_1() {
-   |        ^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
    |
 LL |     fn unused_impl_fn_2(var: i32) {
-   |        ^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
    |
 LL |     fn unused_impl_fn_3(
-   |        ^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `UnusedStruct`
 LL | struct UnusedStruct;
    |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -19,9 +20,10 @@ error: associated function is never used: `unused_impl_fn_1`
 LL |     fn unused_impl_fn_1() {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
@@ -29,9 +31,10 @@ error: associated function is never used: `unused_impl_fn_2`
 LL |     fn unused_impl_fn_2(var: i32) {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
@@ -39,9 +42,10 @@ error: associated function is never used: `unused_impl_fn_3`
 LL |     fn unused_impl_fn_3(
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `UnusedStruct`
 LL | struct UnusedStruct;
    |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -18,8 +17,7 @@ error: associated function is never used: `unused_impl_fn_1`
 LL |     fn unused_impl_fn_1() {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
@@ -27,8 +25,7 @@ error: associated function is never used: `unused_impl_fn_2`
 LL |     fn unused_impl_fn_2(var: i32) {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
@@ -36,8 +33,7 @@ error: associated function is never used: `unused_impl_fn_3`
 LL |     fn unused_impl_fn_3(
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `UnusedStruct`
 LL | struct UnusedStruct;
    |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -20,10 +18,8 @@ error: associated function is never used: `unused_impl_fn_1`
 LL |     fn unused_impl_fn_1() {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
@@ -31,10 +27,8 @@ error: associated function is never used: `unused_impl_fn_2`
 LL |     fn unused_impl_fn_2(var: i32) {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
@@ -42,10 +36,8 @@ error: associated function is never used: `unused_impl_fn_3`
 LL |     fn unused_impl_fn_3(
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -4,8 +4,7 @@ error: function is never used: `unused`
 LL | fn unused() {
    |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -18,8 +17,7 @@ error: function is never used: `unused2`
 LL | fn unused2(var: i32) {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
@@ -27,8 +25,7 @@ error: function is never used: `unused3`
 LL | fn unused3(
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -4,9 +4,10 @@ error: function is never used: `unused`
 LL | fn unused() {
    |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -19,9 +20,10 @@ error: function is never used: `unused2`
 LL | fn unused2(var: i32) {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
@@ -29,9 +31,10 @@ error: function is never used: `unused3`
 LL | fn unused3(
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -4,10 +4,8 @@ error: function is never used: `unused`
 LL | fn unused() {
    |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -20,10 +18,8 @@ error: function is never used: `unused2`
 LL | fn unused2(var: i32) {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
@@ -31,10 +27,8 @@ error: function is never used: `unused3`
 LL | fn unused3(
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -2,8 +2,11 @@ error: function is never used: `unused`
   --> $DIR/newline-span.rs:3:4
    |
 LL | fn unused() {
-   |    ^^^^^^
+   |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -14,13 +17,21 @@ error: function is never used: `unused2`
   --> $DIR/newline-span.rs:7:4
    |
 LL | fn unused2(var: i32) {
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
    |
 LL | fn unused3(
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -2,8 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/type-alias.rs:4:1
    |
 LL | type Unused = u8;
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
+   = note: the leading underscore helps signal to the reader that the type alias may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -4,9 +4,10 @@ error: type alias is never used: `Unused`
 LL | type Unused = u8;
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore helps signal to the reader that the type alias may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the type alias may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -4,10 +4,8 @@ error: type alias is never used: `Unused`
 LL | type Unused = u8;
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: The leading underscore signals to the reader that while the type alias may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this type alias serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -2,10 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/type-alias.rs:4:1
    |
 LL | type Unused = u8;
-   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
+   | ^^^^^------^^^^^^
+   |      |
+   |      help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore signals that this type alias serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this type alias serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `F`
 LL | struct F;
    |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -20,9 +21,10 @@ error: struct is never constructed: `B`
 LL | struct B;
    |        ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
@@ -30,9 +32,10 @@ error: enum is never used: `E`
 LL | enum E {
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `F`
   --> $DIR/unused-enum.rs:3:8
    |
 LL | struct F;
-   |        ^
+   |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -15,13 +18,21 @@ error: struct is never constructed: `B`
   --> $DIR/unused-enum.rs:4:8
    |
 LL | struct B;
-   |        ^
+   |        ^ help: if this is intentional, prefix it with an underscore: `_B`
+   |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
    |
 LL | enum E {
-   |      ^
+   |      ^ help: if this is intentional, prefix it with an underscore: `_E`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `F`
 LL | struct F;
    |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -21,10 +19,8 @@ error: struct is never constructed: `B`
 LL | struct B;
    |        ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
@@ -32,10 +28,8 @@ error: enum is never used: `E`
 LL | enum E {
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `F`
 LL | struct F;
    |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -19,8 +18,7 @@ error: struct is never constructed: `B`
 LL | struct B;
    |        ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
@@ -28,8 +26,7 @@ error: enum is never used: `E`
 LL | enum E {
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -4,9 +4,10 @@ error: variant is never constructed: `Bar`
 LL |     Bar(B),
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -2,8 +2,11 @@ error: variant is never constructed: `Bar`
   --> $DIR/unused-struct-variant.rs:8:5
    |
 LL |     Bar(B),
-   |     ^^^^^^
+   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -4,10 +4,8 @@ error: variant is never constructed: `Bar`
 LL |     Bar(B),
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -2,10 +2,11 @@ error: variant is never constructed: `Bar`
   --> $DIR/unused-struct-variant.rs:8:5
    |
 LL |     Bar(B),
-   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
+   |     ---^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -2,8 +2,11 @@ error: variant is never constructed: `Variant1`
   --> $DIR/unused-variant.rs:5:5
    |
 LL |     Variant1,
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -4,10 +4,8 @@ error: variant is never constructed: `Variant1`
 LL |     Variant1,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -4,8 +4,7 @@ error: variant is never constructed: `Variant1`
 LL |     Variant1,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -4,9 +4,10 @@ error: variant is never constructed: `Variant1`
 LL |     Variant1,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -4,9 +4,10 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -4,8 +4,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -4,10 +4,8 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -2,8 +2,11 @@ error: function is never used: `foo`
   --> $DIR/with-core-crate.rs:7:4
    |
 LL | fn foo() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -2,8 +2,11 @@ error: field is never read: `f`
   --> $DIR/write-only-field.rs:4:5
    |
 LL |     f: i32,
-   |     ^^^^^^
+   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -14,31 +17,51 @@ error: field is never read: `sub`
   --> $DIR/write-only-field.rs:5:5
    |
 LL |     sub: Sub,
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
    |
 LL |     f: i32,
-   |     ^^^^^^
+   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
    |
 LL |         y: bool,
-   |         ^^^^^^^
+   |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
    |
 LL |         u: u32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
    |
 LL |         v: u32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -4,9 +4,10 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -19,9 +20,10 @@ error: field is never read: `sub`
 LL |     sub: Sub,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
@@ -29,9 +31,10 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
@@ -39,9 +42,10 @@ error: field is never read: `y`
 LL |         y: bool,
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
@@ -49,9 +53,10 @@ error: field is never read: `u`
 LL |         u: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
@@ -59,9 +64,10 @@ error: field is never read: `v`
 LL |         v: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -4,10 +4,9 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -20,10 +19,9 @@ error: field is never read: `sub`
 LL |     sub: Sub,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
@@ -31,10 +29,9 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
@@ -42,10 +39,9 @@ error: field is never read: `y`
 LL |         y: bool,
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
@@ -53,10 +49,9 @@ error: field is never read: `u`
 LL |         u: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
@@ -64,10 +59,9 @@ error: field is never read: `v`
 LL |         v: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -2,11 +2,11 @@ error: field is never read: `f`
   --> $DIR/write-only-field.rs:4:5
    |
 LL |     f: i32,
-   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
+   |     -^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -17,51 +17,51 @@ error: field is never read: `sub`
   --> $DIR/write-only-field.rs:5:5
    |
 LL |     sub: Sub,
-   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
+   |     ---^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_sub`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
    |
 LL |     f: i32,
-   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
+   |     -^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
    |
 LL |         y: bool,
-   |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
+   |         -^^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_y`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
    |
 LL |         u: u32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_u`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
    |
 LL |         v: u32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_v`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -4,9 +4,10 @@ error: constant is never used: `foo`
 LL | const foo: isize = 3;
    | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the constant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the constant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the constant may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -2,8 +2,11 @@ error: constant is never used: `foo`
   --> $DIR/issue-17718-const-naming.rs:4:1
    |
 LL | const foo: isize = 3;
-   | ^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
+   = note: the leading underscore helps signal to the reader that the constant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the constant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -4,10 +4,8 @@ error: constant is never used: `foo`
 LL | const foo: isize = 3;
    | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the constant may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this constant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -2,10 +2,11 @@ error: constant is never used: `foo`
   --> $DIR/issue-17718-const-naming.rs:4:1
    |
 LL | const foo: isize = 3;
-   | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   | ^^^^^^---^^^^^^^^^^^^
+   |       |
+   |       help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this constant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this constant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/resolve/issue-3907.stderr
+++ b/src/test/ui/resolve/issue-3907.stderr
@@ -5,10 +5,9 @@ LL | impl Foo for S {
    |      ^^^ type aliases cannot be used as traits
    |
 help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
-  --> $DIR/issue-3907.rs:5:1
    |
-LL | type Foo = dyn issue_3907::Foo;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | trait Foo = dyn issue_3907::Foo;
+   |
 help: consider importing this trait instead
    |
 LL | use issue_3907::Foo;

--- a/src/test/ui/resolve/issue-5035.stderr
+++ b/src/test/ui/resolve/issue-5035.stderr
@@ -11,16 +11,16 @@ LL | trait I {}
    | ------- similarly named trait `I` defined here
 LL | type K = dyn I;
 LL | impl K for isize {}
-   |      ^
-   |      |
-   |      type aliases cannot be used as traits
-   |      help: a trait with a similar name exists: `I`
+   |      ^ type aliases cannot be used as traits
    |
 help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
-  --> $DIR/issue-5035.rs:2:1
    |
-LL | type K = dyn I;
-   | ^^^^^^^^^^^^^^^
+LL | trait K = dyn I;
+   |
+help: a trait with a similar name exists
+   |
+LL | impl I for isize {}
+   |      ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/resolve/unboxed-closure-sugar-nonexistent-trait.stderr
+++ b/src/test/ui/resolve/unboxed-closure-sugar-nonexistent-trait.stderr
@@ -11,10 +11,9 @@ LL | fn g<F:Typedef(isize) -> isize>(x: F) {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^ type aliases cannot be used as traits
    |
 help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
-  --> $DIR/unboxed-closure-sugar-nonexistent-trait.rs:4:1
    |
-LL | type Typedef = isize;
-   | ^^^^^^^^^^^^^^^^^^^^^
+LL | trait Typedef = isize;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -2,13 +2,14 @@ warning: struct is never constructed: `S`
   --> $DIR/macro-span-replacement.rs:7:14
    |
 LL |         $b $a;
-   |              ^ help: if this is intentional, prefix it with an underscore: `_S`
+   |            --^
+   |            |
+   |            help: if this is intentional, prefix it with an underscore: `_S`
 ...
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -7,10 +7,8 @@ LL |         $b $a;
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -2,11 +2,14 @@ warning: struct is never constructed: `S`
   --> $DIR/macro-span-replacement.rs:7:14
    |
 LL |         $b $a;
-   |              ^
+   |              ^ help: if this is intentional, prefix it with an underscore: `_S`
 ...
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -7,9 +7,10 @@ LL |         $b $a;
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -4,10 +4,8 @@ warning: enum is never used: `Enum`
 LL | enum Enum {
    |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -21,10 +19,8 @@ warning: struct is never constructed: `Struct`
 LL | struct Struct {
    |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
@@ -32,10 +28,8 @@ warning: function is never used: `func`
 LL | fn func() -> usize {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
@@ -43,10 +37,8 @@ warning: function is never used: `func_complete_span`
 LL | func_complete_span()
    | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -4,9 +4,10 @@ warning: enum is never used: `Enum`
 LL | enum Enum {
    |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -20,9 +21,10 @@ warning: struct is never constructed: `Struct`
 LL | struct Struct {
    |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
@@ -30,9 +32,10 @@ warning: function is never used: `func`
 LL | fn func() -> usize {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
@@ -40,9 +43,10 @@ warning: function is never used: `func_complete_span`
 LL | func_complete_span()
    | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -2,8 +2,11 @@ warning: enum is never used: `Enum`
   --> $DIR/unused-warning-point-at-identifier.rs:5:6
    |
 LL | enum Enum {
-   |      ^^^^
+   |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -15,19 +18,31 @@ warning: struct is never constructed: `Struct`
   --> $DIR/unused-warning-point-at-identifier.rs:12:8
    |
 LL | struct Struct {
-   |        ^^^^^^
+   |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
+   |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
    |
 LL | fn func() -> usize {
-   |    ^^^^
+   |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
    |
 LL | func_complete_span()
-   | ^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -4,8 +4,7 @@ warning: enum is never used: `Enum`
 LL | enum Enum {
    |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -19,8 +18,7 @@ warning: struct is never constructed: `Struct`
 LL | struct Struct {
    |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
@@ -28,8 +26,7 @@ warning: function is never used: `func`
 LL | fn func() -> usize {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
@@ -37,8 +34,7 @@ warning: function is never used: `func_complete_span`
 LL | func_complete_span()
    | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -2,8 +2,11 @@ error: function is never used: `dead`
   --> $DIR/test-warns-dead-code.rs:5:4
    |
 LL | fn dead() {}
-   |    ^^^^
+   |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -4,8 +4,7 @@ error: function is never used: `dead`
 LL | fn dead() {}
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -4,9 +4,10 @@ error: function is never used: `dead`
 LL | fn dead() {}
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -4,10 +4,8 @@ error: function is never used: `dead`
 LL | fn dead() {}
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/traits/alias/suggest-trait-alias-instead-of-type.fixed
+++ b/src/test/ui/traits/alias/suggest-trait-alias-instead-of-type.fixed
@@ -1,0 +1,13 @@
+// Regression test of #43913.
+
+// run-rustfix
+
+#![feature(trait_alias)]
+#![allow(bare_trait_objects, dead_code)]
+
+trait Strings = Iterator<Item=String>;
+
+struct Struct<S: Strings>(S);
+//~^ ERROR: expected trait, found type alias `Strings`
+
+fn main() {}

--- a/src/test/ui/traits/alias/suggest-trait-alias-instead-of-type.rs
+++ b/src/test/ui/traits/alias/suggest-trait-alias-instead-of-type.rs
@@ -1,0 +1,13 @@
+// Regression test of #43913.
+
+// run-rustfix
+
+#![feature(trait_alias)]
+#![allow(bare_trait_objects, dead_code)]
+
+type Strings = Iterator<Item=String>;
+
+struct Struct<S: Strings>(S);
+//~^ ERROR: expected trait, found type alias `Strings`
+
+fn main() {}

--- a/src/test/ui/traits/alias/suggest-trait-alias-instead-of-type.stderr
+++ b/src/test/ui/traits/alias/suggest-trait-alias-instead-of-type.stderr
@@ -1,0 +1,14 @@
+error[E0404]: expected trait, found type alias `Strings`
+  --> $DIR/suggest-trait-alias-instead-of-type.rs:10:18
+   |
+LL | struct Struct<S: Strings>(S);
+   |                  ^^^^^^^ type aliases cannot be used as traits
+   |
+help: you might have meant to use `#![feature(trait_alias)]` instead of a `type` alias
+   |
+LL | trait Strings = Iterator<Item=String>;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0404`.

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -2,11 +2,11 @@ error: field is never read: `c`
   --> $DIR/union-fields-1.rs:6:5
    |
 LL |     c: u8,
-   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |     -^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -17,31 +17,31 @@ error: field is never read: `a`
   --> $DIR/union-fields-1.rs:9:5
    |
 LL |     a: u8,
-   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |     -^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
    |
 LL | union NoDropLike { a: u8 }
-   |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |                    -^^^^
+   |                    |
+   |                    help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
    |
 LL |     c: u8,
-   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |     -^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -4,9 +4,10 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -19,9 +20,10 @@ error: field is never read: `a`
 LL |     a: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
@@ -29,9 +31,10 @@ error: field is never read: `a`
 LL | union NoDropLike { a: u8 }
    |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
@@ -39,9 +42,10 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -4,10 +4,9 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -20,10 +19,9 @@ error: field is never read: `a`
 LL |     a: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
@@ -31,10 +29,9 @@ error: field is never read: `a`
 LL | union NoDropLike { a: u8 }
    |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
@@ -42,10 +39,9 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -2,8 +2,11 @@ error: field is never read: `c`
   --> $DIR/union-fields-1.rs:6:5
    |
 LL |     c: u8,
-   |     ^^^^^
+   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -14,19 +17,31 @@ error: field is never read: `a`
   --> $DIR/union-fields-1.rs:9:5
    |
 LL |     a: u8,
-   |     ^^^^^
+   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
    |
 LL | union NoDropLike { a: u8 }
-   |                    ^^^^^
+   |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
    |
 LL |     c: u8,
-   |     ^^^^^
+   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -2,11 +2,11 @@ error: field is never read: `b`
   --> $DIR/union-lint-dead-code.rs:5:5
    |
 LL |     b: bool,
-   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |     -^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -2,8 +2,11 @@ error: field is never read: `b`
   --> $DIR/union-lint-dead-code.rs:5:5
    |
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -4,10 +4,9 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -4,9 +4,10 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |


### PR DESCRIPTION
Successful merges:

 - #83004 (Improve diagnostic for when field is never read)
 - #83729 (Add a suggestion when using a type alias instead of trait alias)
 - #84359 (:arrow_up: rust-analyzer)
 - #84365 (Improve the docstrings of the `Lto` struct.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83004,83729,84359,84365)
<!-- homu-ignore:end -->