### PR TITLE
Encode spans relative to the enclosing item

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -367,7 +367,7 @@ impl MetaItem {
             let is_first = i == 0;
             if !is_first {
                 let mod_sep_span =
-                    Span::new(last_pos, segment.ident.span.lo(), segment.ident.span.ctxt());
+                    Span::new(last_pos, segment.ident.span.lo(), segment.ident.span.ctxt(), None);
                 idents.push(TokenTree::token(token::ModSep, mod_sep_span).into());
             }
             idents.push(TokenTree::Token(Token::from_ast_ident(segment.ident)).into());

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -423,6 +423,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let if_expr = self.expr(span, if_kind, ThinVec::new());
         let block = self.block_expr(self.arena.alloc(if_expr));
         let span = self.lower_span(span.with_hi(cond.span.hi()));
+        let opt_label = self.lower_label(opt_label);
         hir::ExprKind::Loop(block, opt_label, hir::LoopSource::While, span)
     }
 

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -422,7 +422,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let if_kind = hir::ExprKind::If(new_cond, self.arena.alloc(then), Some(else_expr));
         let if_expr = self.expr(span, if_kind, ThinVec::new());
         let block = self.block_expr(self.arena.alloc(if_expr));
-        hir::ExprKind::Loop(block, opt_label, hir::LoopSource::While, span.with_hi(cond.span.hi()))
+        let span = self.lower_span(span.with_hi(cond.span.hi()));
+        hir::ExprKind::Loop(block, opt_label, hir::LoopSource::While, span)
     }
 
     /// Desugar `try { <stmts>; <expr> }` into `{ <stmts>; ::std::ops::Try::from_output(<expr>) }`,

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -165,6 +165,8 @@ struct LoweringContext<'a, 'hir: 'a> {
 pub trait ResolverAstLowering {
     fn def_key(&mut self, id: DefId) -> DefKey;
 
+    fn def_span(&self, id: LocalDefId) -> Span;
+
     fn item_generics_num_lifetimes(&self, def: DefId) -> usize;
 
     fn legacy_const_generic_args(&mut self, expr: &Expr) -> Option<Vec<usize>>;
@@ -213,6 +215,11 @@ impl<'a> rustc_span::HashStableContext for LoweringHasher<'a> {
     #[inline]
     fn hash_spans(&self) -> bool {
         true
+    }
+
+    #[inline]
+    fn def_span(&self, id: LocalDefId) -> Span {
+        self.resolver.def_span(id)
     }
 
     #[inline]

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -718,9 +718,14 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     }
 
     /// Intercept all spans entering HIR.
-    /// For now we are not doing anything with the intercepted spans.
+    /// Mark a span as relative to the current owning item.
     fn lower_span(&self, span: Span) -> Span {
-        span
+        if self.sess.opts.debugging_opts.incremental_relative_spans {
+            span.with_parent(Some(self.current_hir_id_owner.0))
+        } else {
+            // Do not make spans relative when not using incremental compilation.
+            span
+        }
     }
 
     fn lower_ident(&self, ident: Ident) -> Ident {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -788,7 +788,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             node_id,
             DefPathData::LifetimeNs(str_name),
             ExpnId::root(),
-            span,
+            span.with_parent(None),
         );
 
         hir::GenericParam {
@@ -1520,7 +1520,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         def_node_id,
                         DefPathData::LifetimeNs(name.ident().name),
                         ExpnId::root(),
-                        span,
+                        span.with_parent(None),
                     );
 
                     let (name, kind) = match name {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -15,7 +15,7 @@ use rustc_lint_defs::builtin::PROC_MACRO_BACK_COMPAT;
 use rustc_lint_defs::BuiltinLintDiagnostics;
 use rustc_parse::{self, nt_to_tokenstream, parser, MACRO_ARGUMENTS};
 use rustc_session::{parse::ParseSess, Limit, Session};
-use rustc_span::def_id::{CrateNum, DefId};
+use rustc_span::def_id::{CrateNum, DefId, LocalDefId};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind, LocalExpnId};
 use rustc_span::source_map::SourceMap;
@@ -843,6 +843,7 @@ pub type DeriveResolutions = Vec<(ast::Path, Annotatable, Option<Lrc<SyntaxExten
 
 pub trait ResolverExpand {
     fn next_node_id(&mut self) -> NodeId;
+    fn invocation_parent(&self, id: LocalExpnId) -> LocalDefId;
 
     fn resolve_dollar_crates(&mut self);
     fn visit_ast_fragment_with_placeholders(

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -745,7 +745,7 @@ impl server::Span for Rustc<'_> {
         self.sess.source_map().lookup_char_pos(span.lo()).file
     }
     fn parent(&mut self, span: Self::Span) -> Option<Self::Span> {
-        span.parent()
+        span.parent_callsite()
     }
     fn source(&mut self, span: Self::Span) -> Self::Span {
         span.source_callsite()

--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -345,6 +345,8 @@ impl Definitions {
         assert_eq!(root.local_def_index, CRATE_DEF_INDEX);
 
         let mut def_id_to_span = IndexVec::new();
+        // A relative span's parent must be an absolute span.
+        debug_assert_eq!(crate_span.data_untracked().parent, None);
         let _root = def_id_to_span.push(crate_span);
         debug_assert_eq!(_root, root);
 
@@ -394,6 +396,8 @@ impl Definitions {
             self.expansions_that_defined.insert(def_id, expn_id);
         }
 
+        // A relative span's parent must be an absolute span.
+        debug_assert_eq!(span.data_untracked().parent, None);
         let _id = self.def_id_to_span.push(span);
         debug_assert_eq!(_id, def_id);
 

--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -14,6 +14,7 @@ use rustc_data_structures::unhash::UnhashMap;
 use rustc_index::vec::IndexVec;
 use rustc_span::hygiene::ExpnId;
 use rustc_span::symbol::{kw, sym, Symbol};
+use rustc_span::Span;
 
 use std::fmt::{self, Write};
 use std::hash::Hash;
@@ -107,6 +108,8 @@ pub struct Definitions {
 
     /// Item with a given `LocalDefId` was defined during macro expansion with ID `ExpnId`.
     expansions_that_defined: FxHashMap<LocalDefId, ExpnId>,
+
+    def_id_to_span: IndexVec<LocalDefId, Span>,
 }
 
 /// A unique identifier that we can use to lookup a definition
@@ -324,7 +327,7 @@ impl Definitions {
     }
 
     /// Adds a root definition (no parent) and a few other reserved definitions.
-    pub fn new(stable_crate_id: StableCrateId) -> Definitions {
+    pub fn new(stable_crate_id: StableCrateId, crate_span: Span) -> Definitions {
         let key = DefKey {
             parent: None,
             disambiguated_data: DisambiguatedDefPathData {
@@ -341,11 +344,16 @@ impl Definitions {
         let root = LocalDefId { local_def_index: table.allocate(key, def_path_hash) };
         assert_eq!(root.local_def_index, CRATE_DEF_INDEX);
 
+        let mut def_id_to_span = IndexVec::new();
+        let _root = def_id_to_span.push(crate_span);
+        debug_assert_eq!(_root, root);
+
         Definitions {
             table,
             def_id_to_hir_id: Default::default(),
             hir_id_to_def_id: Default::default(),
             expansions_that_defined: Default::default(),
+            def_id_to_span,
         }
     }
 
@@ -361,6 +369,7 @@ impl Definitions {
         data: DefPathData,
         expn_id: ExpnId,
         mut next_disambiguator: impl FnMut(LocalDefId, DefPathData) -> u32,
+        span: Span,
     ) -> LocalDefId {
         debug!("create_def(parent={:?}, data={:?}, expn_id={:?})", parent, data, expn_id);
 
@@ -384,6 +393,9 @@ impl Definitions {
         if expn_id != ExpnId::root() {
             self.expansions_that_defined.insert(def_id, expn_id);
         }
+
+        let _id = self.def_id_to_span.push(span);
+        debug_assert_eq!(_id, def_id);
 
         def_id
     }
@@ -410,6 +422,12 @@ impl Definitions {
 
     pub fn expansion_that_defined(&self, id: LocalDefId) -> ExpnId {
         self.expansions_that_defined.get(&id).copied().unwrap_or_else(ExpnId::root)
+    }
+
+    /// Retrieves the span of the given `DefId` if `DefId` is in the local crate.
+    #[inline]
+    pub fn def_span(&self, def_id: LocalDefId) -> Span {
+        self.def_id_to_span[def_id]
     }
 
     pub fn iter_local_def_id(&self) -> impl Iterator<Item = LocalDefId> + '_ {

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -25,6 +25,14 @@ fn span_debug(span: rustc_span::Span, f: &mut fmt::Formatter<'_>) -> fmt::Result
     })
 }
 
+fn track_span_parent(def_id: rustc_span::def_id::LocalDefId) {
+    tls::with_opt(|tcx| {
+        if let Some(tcx) = tcx {
+            let _ = tcx.source_span(def_id);
+        }
+    })
+}
+
 /// This is a callback from `rustc_ast` as it cannot access the implicit state
 /// in `rustc_middle` otherwise. It is used to when diagnostic messages are
 /// emitted and stores them in the current query, if there is one.
@@ -56,6 +64,7 @@ fn def_id_debug(def_id: rustc_hir::def_id::DefId, f: &mut fmt::Formatter<'_>) ->
 /// TyCtxt in.
 pub fn setup_callbacks() {
     rustc_span::SPAN_DEBUG.swap(&(span_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
+    rustc_span::SPAN_TRACK.swap(&(track_span_parent as fn(_)));
     rustc_hir::def_id::DEF_ID_DEBUG.swap(&(def_id_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
     TRACK_DIAGNOSTICS.swap(&(track_diagnostic as fn(&_)));
 }

--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -28,7 +28,9 @@ fn span_debug(span: rustc_span::Span, f: &mut fmt::Formatter<'_>) -> fmt::Result
 fn track_span_parent(def_id: rustc_span::def_id::LocalDefId) {
     tls::with_opt(|tcx| {
         if let Some(tcx) = tcx {
-            let _ = tcx.source_span(def_id);
+            let _span = tcx.source_span(def_id);
+            // Sanity check: relative span's parent must be an absolute span.
+            debug_assert_eq!(_span.data_untracked().parent, None);
         }
     })
 }

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -536,7 +536,8 @@ impl<'a, 'tcx> Decodable<DecodeContext<'a, 'tcx>> for Span {
         let hi =
             (hi + source_file.translated_source_file.start_pos) - source_file.original_start_pos;
 
-        Ok(Span::new(lo, hi, ctxt))
+        // Do not try to decode parent for foreign spans.
+        Ok(Span::new(lo, hi, ctxt, None))
     }
 }
 

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -153,6 +153,7 @@ pub fn provide(providers: &mut Providers) {
         index.parenting.get(&id).copied().unwrap_or(CRATE_HIR_ID)
     };
     providers.hir_attrs = |tcx, id| AttributeMap { map: &tcx.untracked_crate.attrs, prefix: id };
+    providers.source_span = |tcx, def_id| tcx.resolutions(()).definitions.def_span(def_id);
     providers.def_span = |tcx, def_id| tcx.hir().span_if_local(def_id).unwrap_or(DUMMY_SP);
     providers.fn_arg_names = |tcx, id| {
         let hir = tcx.hir();

--- a/compiler/rustc_middle/src/ich/hcx.rs
+++ b/compiler/rustc_middle/src/ich/hcx.rs
@@ -12,7 +12,7 @@ use rustc_hir::definitions::{DefPathHash, Definitions};
 use rustc_session::Session;
 use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::Symbol;
-use rustc_span::{BytePos, CachingSourceMapView, SourceFile, SpanData};
+use rustc_span::{BytePos, CachingSourceMapView, SourceFile, Span, SpanData};
 
 use smallvec::SmallVec;
 use std::cmp::Ord;
@@ -227,6 +227,11 @@ impl<'a> rustc_span::HashStableContext for StableHashingContext<'a> {
     #[inline]
     fn def_path_hash(&self, def_id: DefId) -> DefPathHash {
         self.def_path_hash(def_id)
+    }
+
+    #[inline]
+    fn def_span(&self, def_id: LocalDefId) -> Span {
+        self.definitions.def_span(def_id)
     }
 
     fn span_data_to_lines_and_cols(

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -20,6 +20,14 @@ rustc_queries! {
         desc { "get the resolver outputs" }
     }
 
+    /// Return the span for a definition.
+    /// Contrary to `def_span` below, this query returns the full absolute span of the definition.
+    /// This span is meant for dep-tracking rather than diagnostics. It should not be used outside
+    /// of rustc_middle::hir::source_map.
+    query source_span(key: LocalDefId) -> Span {
+        desc { "get the source span" }
+    }
+
     /// Represents crate as a whole (as distinct from the top-level crate module).
     /// If you call `hir_crate` (e.g., indirectly by calling `tcx.hir().krate()`),
     /// we will have to assume that any change means that you need to be recompiled.

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -964,7 +964,7 @@ fn foo(&self) -> Self::T { String::new() }
         {
             let (span, sugg) = if has_params {
                 let pos = span.hi() - BytePos(1);
-                let span = Span::new(pos, pos, span.ctxt());
+                let span = Span::new(pos, pos, span.ctxt(), span.parent());
                 (span, format!(", {} = {}", assoc.ident, ty))
             } else {
                 let item_args = self.format_generic_args(assoc_substs);

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -196,7 +196,11 @@ impl CoverageSpan {
     /// body_span), returns the macro name symbol.
     pub fn visible_macro(&self, body_span: Span) -> Option<Symbol> {
         if let Some(current_macro) = self.current_macro() {
-            if self.expn_span.parent().unwrap_or_else(|| bug!("macro must have a parent")).ctxt()
+            if self
+                .expn_span
+                .parent_callsite()
+                .unwrap_or_else(|| bug!("macro must have a parent"))
+                .ctxt()
                 == body_span.ctxt()
             {
                 return Some(current_macro);

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -131,7 +131,7 @@ fn maybe_source_file_to_parser(
     let mut parser = stream_to_parser(sess, stream, None);
     parser.unclosed_delims = unclosed_delims;
     if parser.token == token::Eof {
-        parser.token.span = Span::new(end_pos, end_pos, parser.token.span.ctxt());
+        parser.token.span = Span::new(end_pos, end_pos, parser.token.span.ctxt(), None);
     }
 
     Ok(parser)

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -23,7 +23,7 @@ use rustc_span::hygiene::{
 };
 use rustc_span::source_map::{SourceMap, StableSourceFileId};
 use rustc_span::CachingSourceMapView;
-use rustc_span::{BytePos, ExpnData, ExpnHash, SourceFile, Span, DUMMY_SP};
+use rustc_span::{BytePos, ExpnData, ExpnHash, Pos, SourceFile, Span};
 use std::collections::hash_map::Entry;
 use std::mem;
 
@@ -33,6 +33,7 @@ const TAG_FILE_FOOTER: u128 = 0xC0FFEE_C0FFEE_C0FFEE_C0FFEE_C0FFEE;
 const TAG_FULL_SPAN: u8 = 0;
 // A partial span with no location information, encoded only with a `SyntaxContext`
 const TAG_PARTIAL_SPAN: u8 = 1;
+const TAG_RELATIVE_SPAN: u8 = 2;
 
 const TAG_SYNTAX_CONTEXT: u8 = 0;
 const TAG_EXPN_DATA: u8 = 1;
@@ -829,11 +830,25 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for ExpnId {
 
 impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for Span {
     fn decode(decoder: &mut CacheDecoder<'a, 'tcx>) -> Result<Self, String> {
+        let ctxt = SyntaxContext::decode(decoder)?;
+        let parent = Option::<LocalDefId>::decode(decoder)?;
         let tag: u8 = Decodable::decode(decoder)?;
 
         if tag == TAG_PARTIAL_SPAN {
-            let ctxt = SyntaxContext::decode(decoder)?;
-            return Ok(DUMMY_SP.with_ctxt(ctxt));
+            return Ok(Span::new(BytePos(0), BytePos(0), ctxt, parent));
+        } else if tag == TAG_RELATIVE_SPAN {
+            let dlo = u32::decode(decoder)?;
+            let dto = u32::decode(decoder)?;
+
+            let enclosing = decoder.tcx.definitions_untracked().def_span(parent.unwrap()).data();
+            let span = Span::new(
+                enclosing.lo + BytePos::from_u32(dlo),
+                enclosing.lo + BytePos::from_u32(dto),
+                ctxt,
+                parent,
+            );
+
+            return Ok(span);
         } else {
             debug_assert_eq!(tag, TAG_FULL_SPAN);
         }
@@ -842,13 +857,12 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for Span {
         let line_lo = usize::decode(decoder)?;
         let col_lo = BytePos::decode(decoder)?;
         let len = BytePos::decode(decoder)?;
-        let ctxt = SyntaxContext::decode(decoder)?;
 
         let file_lo = decoder.file_index_to_file(file_lo_index);
         let lo = file_lo.lines[line_lo - 1] + col_lo;
         let hi = lo + len;
 
-        Ok(Span::new(lo, hi, ctxt, None))
+        Ok(Span::new(lo, hi, ctxt, parent))
     }
 }
 
@@ -1009,9 +1023,21 @@ where
 {
     fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
         let span_data = self.data();
-        if self.is_dummy() {
-            TAG_PARTIAL_SPAN.encode(s)?;
-            return span_data.ctxt.encode(s);
+        span_data.ctxt.encode(s)?;
+        span_data.parent.encode(s)?;
+
+        if span_data.is_dummy() {
+            return TAG_PARTIAL_SPAN.encode(s);
+        }
+
+        if let Some(parent) = span_data.parent {
+            let enclosing = s.tcx.definitions_untracked().def_span(parent).data();
+            if enclosing.contains(span_data) {
+                TAG_RELATIVE_SPAN.encode(s)?;
+                (span_data.lo - enclosing.lo).to_u32().encode(s)?;
+                (span_data.hi - enclosing.lo).to_u32().encode(s)?;
+                return Ok(());
+            }
         }
 
         let pos = s.source_map.byte_pos_to_line_and_col(span_data.lo);
@@ -1021,8 +1047,7 @@ where
         };
 
         if partial_span {
-            TAG_PARTIAL_SPAN.encode(s)?;
-            return span_data.ctxt.encode(s);
+            return TAG_PARTIAL_SPAN.encode(s);
         }
 
         let (file_lo, line_lo, col_lo) = pos.unwrap();
@@ -1035,8 +1060,7 @@ where
         source_file_index.encode(s)?;
         line_lo.encode(s)?;
         col_lo.encode(s)?;
-        len.encode(s)?;
-        span_data.ctxt.encode(s)
+        len.encode(s)
     }
 }
 

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -840,7 +840,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for Span {
             let dlo = u32::decode(decoder)?;
             let dto = u32::decode(decoder)?;
 
-            let enclosing = decoder.tcx.definitions_untracked().def_span(parent.unwrap()).data();
+            let enclosing = decoder.tcx.definitions_untracked().def_span(parent.unwrap()).decode();
             let span = Span::new(
                 enclosing.lo + BytePos::from_u32(dlo),
                 enclosing.lo + BytePos::from_u32(dto),
@@ -1022,7 +1022,7 @@ where
     E: 'a + OpaqueEncoder,
 {
     fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
-        let span_data = self.data();
+        let span_data = self.decode();
         span_data.ctxt.encode(s)?;
         span_data.parent.encode(s)?;
 
@@ -1031,7 +1031,7 @@ where
         }
 
         if let Some(parent) = span_data.parent {
-            let enclosing = s.tcx.definitions_untracked().def_span(parent).data();
+            let enclosing = s.tcx.definitions_untracked().def_span(parent).decode();
             if enclosing.contains(span_data) {
                 TAG_RELATIVE_SPAN.encode(s)?;
                 (span_data.lo - enclosing.lo).to_u32().encode(s)?;

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -848,7 +848,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for Span {
         let lo = file_lo.lines[line_lo - 1] + col_lo;
         let hi = lo + len;
 
-        Ok(Span::new(lo, hi, ctxt))
+        Ok(Span::new(lo, hi, ctxt, None))
     }
 }
 

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -840,7 +840,8 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for Span {
             let dlo = u32::decode(decoder)?;
             let dto = u32::decode(decoder)?;
 
-            let enclosing = decoder.tcx.definitions_untracked().def_span(parent.unwrap()).decode();
+            let enclosing =
+                decoder.tcx.definitions_untracked().def_span(parent.unwrap()).data_untracked();
             let span = Span::new(
                 enclosing.lo + BytePos::from_u32(dlo),
                 enclosing.lo + BytePos::from_u32(dto),
@@ -1022,7 +1023,7 @@ where
     E: 'a + OpaqueEncoder,
 {
     fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
-        let span_data = self.decode();
+        let span_data = self.data_untracked();
         span_data.ctxt.encode(s)?;
         span_data.parent.encode(s)?;
 
@@ -1031,7 +1032,7 @@ where
         }
 
         if let Some(parent) = span_data.parent {
-            let enclosing = s.tcx.definitions_untracked().def_span(parent).decode();
+            let enclosing = s.tcx.definitions_untracked().def_span(parent).data_untracked();
             if enclosing.contains(span_data) {
                 TAG_RELATIVE_SPAN.encode(s)?;
                 (span_data.lo - enclosing.lo).to_u32().encode(s)?;

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -32,7 +32,13 @@ impl<'a, 'b> DefCollector<'a, 'b> {
     fn create_def(&mut self, node_id: NodeId, data: DefPathData, span: Span) -> LocalDefId {
         let parent_def = self.parent_def;
         debug!("create_def(node_id={:?}, data={:?}, parent_def={:?})", node_id, data, parent_def);
-        self.resolver.create_def(parent_def, node_id, data, self.expansion.to_expn_id(), span)
+        self.resolver.create_def(
+            parent_def,
+            node_id,
+            data,
+            self.expansion.to_expn_id(),
+            span.with_parent(None),
+        )
     }
 
     fn with_parent<F: FnOnce(&mut Self)>(&mut self, parent_def: LocalDefId, f: F) {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -768,6 +768,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                                             args[1].span.lo(),
                                             args.last().unwrap().span.hi(),
                                             call_span.ctxt(),
+                                            None,
                                         ))
                                     } else {
                                         None

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1114,6 +1114,11 @@ impl ResolverAstLowering for Resolver<'_> {
         }
     }
 
+    #[inline]
+    fn def_span(&self, id: LocalDefId) -> Span {
+        self.definitions.def_span(id)
+    }
+
     fn item_generics_num_lifetimes(&self, def_id: DefId) -> usize {
         if let Some(def_id) = def_id.as_local() {
             self.item_generics_num_lifetimes[&def_id]
@@ -1219,6 +1224,11 @@ impl<'a, 'b> rustc_span::HashStableContext for ExpandHasher<'a, 'b> {
     #[inline]
     fn hash_spans(&self) -> bool {
         true
+    }
+
+    #[inline]
+    fn def_span(&self, id: LocalDefId) -> Span {
+        self.resolver.def_span(id)
     }
 
     #[inline]

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -180,6 +180,10 @@ impl<'a> ResolverExpand for Resolver<'a> {
         self.next_node_id()
     }
 
+    fn invocation_parent(&self, id: LocalExpnId) -> LocalDefId {
+        self.invocation_parents[&id].0
+    }
+
     fn resolve_dollar_crates(&mut self) {
         hygiene::update_dollar_crate_names(|ctxt| {
             let ident = Ident::new(kw::DollarCrate, DUMMY_SP.with_ctxt(ctxt));

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1106,6 +1106,8 @@ options! {
     incremental_info: bool = (false, parse_bool, [UNTRACKED],
         "print high-level information about incremental reuse (or the lack thereof) \
         (default: no)"),
+    incremental_relative_spans: bool = (false, parse_bool, [TRACKED],
+        "hash spans relative to their parent item for incr. comp. (default: no)"),
     incremental_verify_ich: bool = (false, parse_bool, [UNTRACKED],
         "verify incr. comp. hashes of green query instances (default: no)"),
     inline_mir: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -41,7 +41,7 @@ use hygiene::Transparency;
 pub use hygiene::{DesugaringKind, ExpnKind, ForLoopLoc, MacroKind};
 pub use hygiene::{ExpnData, ExpnHash, ExpnId, LocalExpnId, SyntaxContext};
 pub mod def_id;
-use def_id::{CrateNum, DefId, DefPathHash, LOCAL_CRATE};
+use def_id::{CrateNum, DefId, DefPathHash, LocalDefId, LOCAL_CRATE};
 pub mod lev_distance;
 mod span_encoding;
 pub use span_encoding::{Span, DUMMY_SP};
@@ -434,24 +434,38 @@ pub struct SpanData {
     /// Information about where the macro came from, if this piece of
     /// code was created by a macro expansion.
     pub ctxt: SyntaxContext,
+    pub parent: Option<LocalDefId>,
 }
 
 impl SpanData {
     #[inline]
     pub fn span(&self) -> Span {
-        Span::new(self.lo, self.hi, self.ctxt)
+        Span::new(self.lo, self.hi, self.ctxt, self.parent)
     }
     #[inline]
     pub fn with_lo(&self, lo: BytePos) -> Span {
-        Span::new(lo, self.hi, self.ctxt)
+        Span::new(lo, self.hi, self.ctxt, self.parent)
     }
     #[inline]
     pub fn with_hi(&self, hi: BytePos) -> Span {
-        Span::new(self.lo, hi, self.ctxt)
+        Span::new(self.lo, hi, self.ctxt, self.parent)
     }
     #[inline]
     pub fn with_ctxt(&self, ctxt: SyntaxContext) -> Span {
-        Span::new(self.lo, self.hi, ctxt)
+        Span::new(self.lo, self.hi, ctxt, self.parent)
+    }
+    #[inline]
+    pub fn with_parent(&self, parent: Option<LocalDefId>) -> Span {
+        Span::new(self.lo, self.hi, self.ctxt, parent)
+    }
+    /// Returns `true` if this is a dummy span with any hygienic context.
+    #[inline]
+    pub fn is_dummy(self) -> bool {
+        self.lo.0 == 0 && self.hi.0 == 0
+    }
+    /// Returns `true` if `self` fully encloses `other`.
+    pub fn contains(self, other: Self) -> bool {
+        self.lo <= other.lo && other.hi <= self.hi
     }
 }
 
@@ -513,12 +527,19 @@ impl Span {
     pub fn with_ctxt(self, ctxt: SyntaxContext) -> Span {
         self.data().with_ctxt(ctxt)
     }
+    #[inline]
+    pub fn parent(self) -> Option<LocalDefId> {
+        self.data().parent
+    }
+    #[inline]
+    pub fn with_parent(self, ctxt: Option<LocalDefId>) -> Span {
+        self.data().with_parent(ctxt)
+    }
 
     /// Returns `true` if this is a dummy span with any hygienic context.
     #[inline]
     pub fn is_dummy(self) -> bool {
-        let span = self.data();
-        span.lo.0 == 0 && span.hi.0 == 0
+        self.data().is_dummy()
     }
 
     /// Returns `true` if this span comes from a macro or desugaring.
@@ -534,7 +555,7 @@ impl Span {
 
     #[inline]
     pub fn with_root_ctxt(lo: BytePos, hi: BytePos) -> Span {
-        Span::new(lo, hi, SyntaxContext::root())
+        Span::new(lo, hi, SyntaxContext::root(), None)
     }
 
     /// Returns a new span representing an empty span at the beginning of this span.
@@ -566,7 +587,7 @@ impl Span {
     pub fn contains(self, other: Span) -> bool {
         let span = self.data();
         let other = other.data();
-        span.lo <= other.lo && other.hi <= span.hi
+        span.contains(other)
     }
 
     /// Returns `true` if `self` touches `other`.
@@ -602,7 +623,7 @@ impl Span {
 
     /// The `Span` for the tokens in the previous macro expansion from which `self` was generated,
     /// if any.
-    pub fn parent(self) -> Option<Span> {
+    pub fn parent_callsite(self) -> Option<Span> {
         let expn_data = self.ctxt().outer_expn_data();
         if !expn_data.is_root() { Some(expn_data.call_site) } else { None }
     }
@@ -610,7 +631,7 @@ impl Span {
     /// Walk down the expansion ancestors to find a span that's contained within `outer`.
     pub fn find_ancestor_inside(mut self, outer: Span) -> Option<Span> {
         while !outer.contains(self) {
-            self = self.parent()?;
+            self = self.parent_callsite()?;
         }
         Some(self)
     }
@@ -731,6 +752,7 @@ impl Span {
             cmp::min(span_data.lo, end_data.lo),
             cmp::max(span_data.hi, end_data.hi),
             if span_data.ctxt == SyntaxContext::root() { end_data.ctxt } else { span_data.ctxt },
+            if span_data.parent == end_data.parent { span_data.parent } else { None },
         )
     }
 
@@ -748,6 +770,7 @@ impl Span {
             span.hi,
             end.lo,
             if end.ctxt == SyntaxContext::root() { end.ctxt } else { span.ctxt },
+            if span.parent == end.parent { span.parent } else { None },
         )
     }
 
@@ -765,6 +788,7 @@ impl Span {
             span.lo,
             end.lo,
             if end.ctxt == SyntaxContext::root() { end.ctxt } else { span.ctxt },
+            if span.parent == end.parent { span.parent } else { None },
         )
     }
 
@@ -774,6 +798,7 @@ impl Span {
             span.lo + BytePos::from_usize(inner.start),
             span.lo + BytePos::from_usize(inner.end),
             span.ctxt,
+            span.parent,
         )
     }
 
@@ -812,7 +837,7 @@ impl Span {
     pub fn remove_mark(&mut self) -> ExpnId {
         let mut span = self.data();
         let mark = span.ctxt.remove_mark();
-        *self = Span::new(span.lo, span.hi, span.ctxt);
+        *self = Span::new(span.lo, span.hi, span.ctxt, span.parent);
         mark
     }
 
@@ -820,7 +845,7 @@ impl Span {
     pub fn adjust(&mut self, expn_id: ExpnId) -> Option<ExpnId> {
         let mut span = self.data();
         let mark = span.ctxt.adjust(expn_id);
-        *self = Span::new(span.lo, span.hi, span.ctxt);
+        *self = Span::new(span.lo, span.hi, span.ctxt, span.parent);
         mark
     }
 
@@ -828,7 +853,7 @@ impl Span {
     pub fn normalize_to_macros_2_0_and_adjust(&mut self, expn_id: ExpnId) -> Option<ExpnId> {
         let mut span = self.data();
         let mark = span.ctxt.normalize_to_macros_2_0_and_adjust(expn_id);
-        *self = Span::new(span.lo, span.hi, span.ctxt);
+        *self = Span::new(span.lo, span.hi, span.ctxt, span.parent);
         mark
     }
 
@@ -836,7 +861,7 @@ impl Span {
     pub fn glob_adjust(&mut self, expn_id: ExpnId, glob_span: Span) -> Option<Option<ExpnId>> {
         let mut span = self.data();
         let mark = span.ctxt.glob_adjust(expn_id, glob_span);
-        *self = Span::new(span.lo, span.hi, span.ctxt);
+        *self = Span::new(span.lo, span.hi, span.ctxt, span.parent);
         mark
     }
 
@@ -848,7 +873,7 @@ impl Span {
     ) -> Option<Option<ExpnId>> {
         let mut span = self.data();
         let mark = span.ctxt.reverse_glob_adjust(expn_id, glob_span);
-        *self = Span::new(span.lo, span.hi, span.ctxt);
+        *self = Span::new(span.lo, span.hi, span.ctxt, span.parent);
         mark
     }
 
@@ -900,7 +925,7 @@ impl<D: Decoder> Decodable<D> for Span {
             let lo = d.read_struct_field("lo", Decodable::decode)?;
             let hi = d.read_struct_field("hi", Decodable::decode)?;
 
-            Ok(Span::new(lo, hi, SyntaxContext::root()))
+            Ok(Span::new(lo, hi, SyntaxContext::root(), None))
         })
     }
 }
@@ -961,7 +986,7 @@ impl fmt::Debug for Span {
 
 impl fmt::Debug for SpanData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        (*SPAN_DEBUG)(Span::new(self.lo, self.hi, self.ctxt), f)
+        (*SPAN_DEBUG)(Span::new(self.lo, self.hi, self.ctxt, self.parent), f)
     }
 }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1947,6 +1947,7 @@ pub struct FileLines {
 
 pub static SPAN_DEBUG: AtomicRef<fn(Span, &mut fmt::Formatter<'_>) -> fmt::Result> =
     AtomicRef::new(&(default_span_debug as fn(_, &mut fmt::Formatter<'_>) -> _));
+pub static SPAN_TRACK: AtomicRef<fn(LocalDefId)> = AtomicRef::new(&((|_| {}) as fn(_)));
 
 // _____________________________________________________________________________
 // SpanLinesError, SpanSnippetError, DistinctSources, MalformedSourceMapPositions
@@ -2031,7 +2032,7 @@ where
             return;
         }
 
-        let span = self.data();
+        let span = self.decode();
         span.ctxt.hash_stable(ctx, hasher);
         span.parent.hash_stable(ctx, hasher);
 
@@ -2041,7 +2042,7 @@ where
         }
 
         if let Some(parent) = span.parent {
-            let def_span = ctx.def_span(parent).data();
+            let def_span = ctx.def_span(parent).decode();
             if def_span.contains(span) {
                 // This span is enclosed in a definition: only hash the relative position.
                 Hash::hash(&TAG_RELATIVE_SPAN, hasher);

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -521,11 +521,11 @@ impl Span {
     }
     #[inline]
     pub fn ctxt(self) -> SyntaxContext {
-        self.data().ctxt
+        self.data_untracked().ctxt
     }
     #[inline]
     pub fn with_ctxt(self, ctxt: SyntaxContext) -> Span {
-        self.data().with_ctxt(ctxt)
+        self.data_untracked().with_ctxt(ctxt)
     }
     #[inline]
     pub fn parent(self) -> Option<LocalDefId> {
@@ -539,7 +539,7 @@ impl Span {
     /// Returns `true` if this is a dummy span with any hygienic context.
     #[inline]
     pub fn is_dummy(self) -> bool {
-        self.data().is_dummy()
+        self.data_untracked().is_dummy()
     }
 
     /// Returns `true` if this span comes from a macro or desugaring.
@@ -561,20 +561,20 @@ impl Span {
     /// Returns a new span representing an empty span at the beginning of this span.
     #[inline]
     pub fn shrink_to_lo(self) -> Span {
-        let span = self.data();
+        let span = self.data_untracked();
         span.with_hi(span.lo)
     }
     /// Returns a new span representing an empty span at the end of this span.
     #[inline]
     pub fn shrink_to_hi(self) -> Span {
-        let span = self.data();
+        let span = self.data_untracked();
         span.with_lo(span.hi)
     }
 
     #[inline]
     /// Returns `true` if `hi == lo`.
     pub fn is_empty(&self) -> bool {
-        let span = self.data();
+        let span = self.data_untracked();
         span.hi == span.lo
     }
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2032,7 +2032,7 @@ where
             return;
         }
 
-        let span = self.decode();
+        let span = self.data_untracked();
         span.ctxt.hash_stable(ctx, hasher);
         span.parent.hash_stable(ctx, hasher);
 
@@ -2042,7 +2042,7 @@ where
         }
 
         if let Some(parent) = span.parent {
-            let def_span = ctx.def_span(parent).decode();
+            let def_span = ctx.def_span(parent).data_untracked();
             if def_span.contains(span) {
                 // This span is enclosed in a definition: only hash the relative position.
                 Hash::hash(&TAG_RELATIVE_SPAN, hasher);

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -2001,6 +2001,7 @@ impl InnerSpan {
 pub trait HashStableContext {
     fn def_path_hash(&self, def_id: DefId) -> DefPathHash;
     fn hash_spans(&self) -> bool;
+    fn def_span(&self, def_id: LocalDefId) -> Span;
     fn span_data_to_lines_and_cols(
         &mut self,
         span: &SpanData,
@@ -2024,22 +2025,35 @@ where
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         const TAG_VALID_SPAN: u8 = 0;
         const TAG_INVALID_SPAN: u8 = 1;
+        const TAG_RELATIVE_SPAN: u8 = 2;
 
         if !ctx.hash_spans() {
             return;
         }
 
-        self.ctxt().hash_stable(ctx, hasher);
+        let span = self.data();
+        span.ctxt.hash_stable(ctx, hasher);
+        span.parent.hash_stable(ctx, hasher);
 
-        if self.is_dummy() {
+        if span.is_dummy() {
             Hash::hash(&TAG_INVALID_SPAN, hasher);
             return;
+        }
+
+        if let Some(parent) = span.parent {
+            let def_span = ctx.def_span(parent).data();
+            if def_span.contains(span) {
+                // This span is enclosed in a definition: only hash the relative position.
+                Hash::hash(&TAG_RELATIVE_SPAN, hasher);
+                (span.lo - def_span.lo).to_u32().hash_stable(ctx, hasher);
+                (span.hi - def_span.lo).to_u32().hash_stable(ctx, hasher);
+                return;
+            }
         }
 
         // If this is not an empty or invalid span, we want to hash the last
         // position that belongs to it, as opposed to hashing the first
         // position past it.
-        let span = self.data();
         let (file, line_lo, col_lo, line_hi, col_hi) = match ctx.span_data_to_lines_and_cols(&span)
         {
             Some(pos) => pos,

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -794,7 +794,7 @@ impl SourceMap {
             start_of_next_point.checked_add(width - 1).unwrap_or(start_of_next_point);
 
         let end_of_next_point = BytePos(cmp::max(sp.lo().0 + 1, end_of_next_point));
-        Span::new(BytePos(start_of_next_point), end_of_next_point, sp.ctxt())
+        Span::new(BytePos(start_of_next_point), end_of_next_point, sp.ctxt(), None)
     }
 
     /// Finds the width of the character, either before or after the end of provided span,

--- a/compiler/rustc_span/src/span_encoding.rs
+++ b/compiler/rustc_span/src/span_encoding.rs
@@ -101,7 +101,7 @@ impl Span {
 
     #[inline]
     pub fn data(self) -> SpanData {
-        let data = self.decode();
+        let data = self.data_untracked();
         if let Some(parent) = data.parent {
             (*SPAN_TRACK)(parent);
         }
@@ -111,7 +111,7 @@ impl Span {
     /// Internal function to translate between an encoded span and the expanded representation.
     /// This function must not be used outside the incremental engine.
     #[inline]
-    pub fn decode(self) -> SpanData {
+    pub fn data_untracked(self) -> SpanData {
         if self.len_or_tag != LEN_TAG {
             // Inline format.
             debug_assert!(self.len_or_tag as u32 <= MAX_LEN);

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -589,7 +589,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // E.g. for `&format!("")`, where we want the span to the
                     // `format!()` invocation instead of its expansion.
                     if let Some(call_span) =
-                        iter::successors(Some(expr.span), |s| s.parent()).find(|&s| sp.contains(s))
+                        iter::successors(Some(expr.span), |s| s.parent_callsite())
+                            .find(|&s| sp.contains(s))
                     {
                         if sm.span_to_snippet(call_span).is_ok() {
                             return Some((

--- a/src/test/incremental/change_symbol_export_status.rs
+++ b/src/test/incremental/change_symbol_export_status.rs
@@ -1,9 +1,15 @@
-// revisions: rpass1 rpass2
+// revisions: rpass1 rpass2 rpass3 rpass4
 // compile-flags: -Zquery-dep-graph
+// [rpass1]compile-flags: -Zincremental-ignore-spans
+// [rpass2]compile-flags: -Zincremental-ignore-spans
+// [rpass3]compile-flags: -Zincremental-relative-spans
+// [rpass4]compile-flags: -Zincremental-relative-spans
 
 #![feature(rustc_attrs)]
-#![rustc_partition_codegened(module = "change_symbol_export_status-mod1", cfg = "rpass2")]
+#![rustc_partition_reused(module = "change_symbol_export_status-mod1", cfg = "rpass2")]
 #![rustc_partition_reused(module = "change_symbol_export_status-mod2", cfg = "rpass2")]
+#![rustc_partition_reused(module = "change_symbol_export_status-mod1", cfg = "rpass4")]
+#![rustc_partition_reused(module = "change_symbol_export_status-mod2", cfg = "rpass4")]
 
 // This test case makes sure that a change in symbol visibility is detected by
 // our dependency tracking. We do this by changing a module's visibility to
@@ -13,13 +19,13 @@
 // even from an executable. Plain Rust functions are only exported from Rust
 // libraries, which our test infrastructure does not support.
 
-#[cfg(rpass1)]
+#[cfg(any(rpass1,rpass3))]
 pub mod mod1 {
     #[no_mangle]
     pub fn foo() {}
 }
 
-#[cfg(rpass2)]
+#[cfg(any(rpass2,rpass4))]
 mod mod1 {
     #[no_mangle]
     pub fn foo() {}

--- a/src/test/incremental/hashes/call_expressions.rs
+++ b/src/test/incremental/hashes/call_expressions.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 
 #![allow(warnings)]
@@ -19,14 +25,16 @@ fn callee2(_x: u32, _y: i64) {}
 
 
 // Change Callee (Function)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_callee_function() {
     callee1(1, 2)
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_callee_function() {
     callee2(1, 2)
 }
@@ -34,14 +42,16 @@ pub fn change_callee_function() {
 
 
 // Change Argument (Function)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_argument_function() {
     callee1(1, 2)
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_argument_function() {
     callee1(1, 3)
 }
@@ -50,13 +60,15 @@ pub fn change_argument_function() {
 
 // Change Callee Indirectly (Function)
 mod change_callee_indirectly_function {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::callee1 as callee;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::callee2 as callee;
 
     #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn change_callee_indirectly_function() {
         callee(1, 2)
     }
@@ -70,15 +82,17 @@ impl Struct {
 }
 
 // Change Callee (Method)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_callee_method() {
     let s = Struct;
     s.method1('x', true);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_callee_method() {
     let s = Struct;
     s.method2('x', true);
@@ -87,15 +101,17 @@ pub fn change_callee_method() {
 
 
 // Change Argument (Method)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_argument_method() {
     let s = Struct;
     s.method1('x', true);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_argument_method() {
     let s = Struct;
     s.method1('y', true);
@@ -104,15 +120,17 @@ pub fn change_argument_method() {
 
 
 // Change Callee (Method, UFCS)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_ufcs_callee_method() {
     let s = Struct;
     Struct::method1(&s, 'x', true);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_ufcs_callee_method() {
     let s = Struct;
     Struct::method2(&s, 'x', true);
@@ -121,32 +139,36 @@ pub fn change_ufcs_callee_method() {
 
 
 // Change Argument (Method, UFCS)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_argument_method_ufcs() {
     let s = Struct;
     Struct::method1(&s, 'x', true);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_argument_method_ufcs() {
     let s = Struct;
-    Struct::method1(&s, 'x', false);
+    Struct::method1(&s, 'x',false);
 }
 
 
 
 // Change To UFCS
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_to_ufcs() {
     let s = Struct;
-    s.method1('x', true);
+    s.method1('x', true); // ------
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 // One might think this would be expanded in the hir_owner_nodes/Mir, but it actually
 // results in slightly different hir_owner/Mir.
 pub fn change_to_ufcs() {
@@ -162,15 +184,15 @@ impl Struct2 {
 
 // Change UFCS Callee Indirectly
 pub mod change_ufcs_callee_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::Struct as Struct;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::Struct2 as Struct;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
     #[rustc_clean(cfg="cfail3")]
-
-
+    #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn change_ufcs_callee_indirectly() {
         let s = Struct;
         Struct::method1(&s, 'q', false)

--- a/src/test/incremental/hashes/closure_expressions.rs
+++ b/src/test/incremental/hashes/closure_expressions.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans -Zmir-opt-level=0
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph -Zmir-opt-level=0
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -15,14 +21,16 @@
 
 
 // Change closure body
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_closure_body() {
     let _ = || 1u32;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_closure_body() {
     let _ = || 3u32;
 }
@@ -30,15 +38,17 @@ pub fn change_closure_body() {
 
 
 // Add parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_parameter() {
     let x = 0u32;
-    let _ = || x + 1;
+    let _ = |      | x + 1;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_parameter() {
     let x = 0u32;
     let _ = |x: u32| x + 1;
@@ -47,14 +57,16 @@ pub fn add_parameter() {
 
 
 // Change parameter pattern
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_parameter_pattern() {
-    let _ = |x: (u32,)| x;
+    let _ = | x  : (u32,)| x;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, typeck, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, typeck, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_parameter_pattern() {
     let _ = |(x,): (u32,)| x;
 }
@@ -62,14 +74,16 @@ pub fn change_parameter_pattern() {
 
 
 // Add `move` to closure
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_move() {
-    let _ = || 1;
+    let _ =      || 1;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_move() {
     let _ = move || 1;
 }
@@ -77,15 +91,17 @@ pub fn add_move() {
 
 
 // Add type ascription to parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_type_ascription_to_parameter() {
-    let closure = |x| x + 1u32;
+    let closure = |x     | x + 1u32;
     let _: u32 = closure(1);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner_nodes, typeck")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner_nodes, typeck")]
+#[rustc_clean(cfg = "cfail6")]
 pub fn add_type_ascription_to_parameter() {
     let closure = |x: u32| x + 1u32;
     let _: u32 = closure(1);
@@ -94,15 +110,17 @@ pub fn add_type_ascription_to_parameter() {
 
 
 // Change parameter type
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_parameter_type() {
     let closure = |x: u32| (x as u64) + 1;
     let _ = closure(1);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_parameter_type() {
     let closure = |x: u16| (x as u64) + 1;
     let _ = closure(1);

--- a/src/test/incremental/hashes/consts.rs
+++ b/src/test/incremental/hashes/consts.rs
@@ -7,7 +7,7 @@
 
 // build-pass (FIXME(62277): could be check-pass?)
 // revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// compile-flags: -Z query-dep-graph
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/hashes/enum_constructors.rs
+++ b/src/test/incremental/hashes/enum_constructors.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans -Zmir-opt-level=0
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph -Zmir-opt-level=0
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -24,7 +30,7 @@ pub enum Enum {
 }
 
 // Change field value (struct-like) -----------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_field_value_struct_like() -> Enum {
     Enum::Struct {
         x: 0,
@@ -33,9 +39,11 @@ pub fn change_field_value_struct_like() -> Enum {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_field_value_struct_like() -> Enum {
     Enum::Struct {
         x: 0,
@@ -47,7 +55,7 @@ pub fn change_field_value_struct_like() -> Enum {
 
 
 // Change field order (struct-like) -----------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_field_order_struct_like() -> Enum {
     Enum::Struct {
         x: 3,
@@ -56,9 +64,11 @@ pub fn change_field_order_struct_like() -> Enum {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 // FIXME(michaelwoerister):Interesting. I would have thought that that changes the MIR. And it
 // would if it were not all constants
 pub fn change_field_order_struct_like() -> Enum {
@@ -86,18 +96,20 @@ pub enum Enum2 {
 }
 
 // Change constructor path (struct-like) ------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_path_struct_like() {
-    let _ = Enum::Struct {
+    let _ = Enum ::Struct {
         x: 0,
         y: 1,
         z: 2,
     };
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_struct_like() {
     let _ = Enum2::Struct {
         x: 0,
@@ -109,18 +121,20 @@ pub fn change_constructor_path_struct_like() {
 
 
 // Change variant (regular struct) ------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_variant_struct_like() {
-    let _ = Enum2::Struct {
+    let _ = Enum2::Struct  {
         x: 0,
         y: 1,
         z: 2,
     };
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_variant_struct_like() {
     let _ = Enum2::Struct2 {
         x: 0,
@@ -132,9 +146,9 @@ pub fn change_constructor_variant_struct_like() {
 
 // Change constructor path indirectly (struct-like) -------------------------
 pub mod change_constructor_path_indirectly_struct_like {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::Enum as TheEnum;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::Enum2 as TheEnum;
 
     #[rustc_clean(
@@ -143,6 +157,12 @@ pub mod change_constructor_path_indirectly_struct_like {
                 typeck"
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="fn_sig,hir_owner,hir_owner_nodes,optimized_mir,\
+                typeck"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn function() -> TheEnum {
         TheEnum::Struct {
             x: 0,
@@ -156,13 +176,15 @@ pub mod change_constructor_path_indirectly_struct_like {
 // Change constructor variant indirectly (struct-like) ---------------------------
 pub mod change_constructor_variant_indirectly_struct_like {
     use super::Enum2;
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::Enum2::Struct as Variant;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::Enum2::Struct2 as Variant;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn function() -> Enum2 {
         Variant {
             x: 0,
@@ -174,14 +196,16 @@ pub mod change_constructor_variant_indirectly_struct_like {
 
 
 // Change field value (tuple-like) -------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_field_value_tuple_like() -> Enum {
     Enum::Tuple(0, 1, 2)
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_field_value_tuple_like() -> Enum {
     Enum::Tuple(0, 1, 3)
 }
@@ -189,17 +213,22 @@ pub fn change_field_value_tuple_like() -> Enum {
 
 
 // Change constructor path (tuple-like) --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_path_tuple_like() {
-    let _ = Enum::Tuple(0, 1, 2);
+    let _ = Enum ::Tuple(0, 1, 2);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg="cfail2",
     except="hir_owner_nodes,optimized_mir,typeck"
 )]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(
+    cfg="cfail5",
+    except="hir_owner_nodes,optimized_mir,typeck"
+)]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_tuple_like() {
     let _ = Enum2::Tuple(0, 1, 2);
 }
@@ -207,17 +236,22 @@ pub fn change_constructor_path_tuple_like() {
 
 
 // Change constructor variant (tuple-like) --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_variant_tuple_like() {
-    let _ = Enum2::Tuple(0, 1, 2);
+    let _ = Enum2::Tuple (0, 1, 2);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg="cfail2",
     except="hir_owner_nodes,optimized_mir,typeck"
 )]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(
+    cfg="cfail5",
+    except="hir_owner_nodes,optimized_mir,typeck"
+)]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_variant_tuple_like() {
     let _ = Enum2::Tuple2(0, 1, 2);
 }
@@ -225,9 +259,9 @@ pub fn change_constructor_variant_tuple_like() {
 
 // Change constructor path indirectly (tuple-like) ---------------------------
 pub mod change_constructor_path_indirectly_tuple_like {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::Enum as TheEnum;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::Enum2 as TheEnum;
 
     #[rustc_clean(
@@ -236,6 +270,12 @@ pub mod change_constructor_path_indirectly_tuple_like {
                 typeck"
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="fn_sig,hir_owner,hir_owner_nodes,optimized_mir,\
+                typeck"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn function() -> TheEnum {
         TheEnum::Tuple(0, 1, 2)
     }
@@ -246,13 +286,15 @@ pub mod change_constructor_path_indirectly_tuple_like {
 // Change constructor variant indirectly (tuple-like) ---------------------------
 pub mod change_constructor_variant_indirectly_tuple_like {
     use super::Enum2;
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::Enum2::Tuple as Variant;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::Enum2::Tuple2 as Variant;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn function() -> Enum2 {
         Variant(0, 1, 2)
     }
@@ -272,14 +314,16 @@ pub enum Clike2 {
 }
 
 // Change constructor path (C-like) --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_path_c_like() {
-    let _x = Clike::B;
+    let _x = Clike ::B;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_c_like() {
     let _x = Clike2::B;
 }
@@ -287,14 +331,16 @@ pub fn change_constructor_path_c_like() {
 
 
 // Change constructor variant (C-like) --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_variant_c_like() {
     let _x = Clike::A;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_variant_c_like() {
     let _x = Clike::C;
 }
@@ -302,9 +348,9 @@ pub fn change_constructor_variant_c_like() {
 
 // Change constructor path indirectly (C-like) ---------------------------
 pub mod change_constructor_path_indirectly_c_like {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::Clike as TheEnum;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::Clike2 as TheEnum;
 
     #[rustc_clean(
@@ -313,6 +359,12 @@ pub mod change_constructor_path_indirectly_c_like {
                 typeck"
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="fn_sig,hir_owner,hir_owner_nodes,optimized_mir,\
+                typeck"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn function() -> TheEnum {
         TheEnum::B
     }
@@ -323,13 +375,15 @@ pub mod change_constructor_path_indirectly_c_like {
 // Change constructor variant indirectly (C-like) ---------------------------
 pub mod change_constructor_variant_indirectly_c_like {
     use super::Clike;
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::Clike::A as Variant;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::Clike::B as Variant;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn function() -> Clike {
         Variant
     }

--- a/src/test/incremental/hashes/enum_defs.rs
+++ b/src/test/incremental/hashes/enum_defs.rs
@@ -11,8 +11,14 @@
 // the same between rev2 and rev3.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -22,12 +28,14 @@
 
 
 // Change enum visibility -----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumVisibility { A }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub enum EnumVisibility {
     A
 }
@@ -35,15 +43,17 @@ pub enum EnumVisibility {
 
 
 // Change name of a c-style variant -------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeNameCStyleVariant {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeNameCStyleVariant {
     Variant1,
     Variant2Changed,
@@ -52,15 +62,17 @@ enum EnumChangeNameCStyleVariant {
 
 
 // Change name of a tuple-style variant ---------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeNameTupleStyleVariant {
     Variant1,
     Variant2(u32, f32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeNameTupleStyleVariant {
     Variant1,
     Variant2Changed(u32, f32),
@@ -69,15 +81,17 @@ enum EnumChangeNameTupleStyleVariant {
 
 
 // Change name of a struct-style variant --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeNameStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: f32 },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeNameStructStyleVariant {
     Variant1,
     Variant2Changed { a: u32, b: f32 },
@@ -86,31 +100,33 @@ enum EnumChangeNameStructStyleVariant {
 
 
 // Change the value of a c-style variant --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeValueCStyleVariant0 {
     Variant1,
     Variant2 = 11,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeValueCStyleVariant0 {
     Variant1,
-
-    Variant2 =
-        22,
+    Variant2 = 22,
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeValueCStyleVariant1 {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeValueCStyleVariant1 {
     Variant1,
     Variant2 = 11,
@@ -119,14 +135,16 @@ enum EnumChangeValueCStyleVariant1 {
 
 
 // Add a c-style variant ------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddCStyleVariant {
     Variant1,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddCStyleVariant {
     Variant1,
     Variant2,
@@ -135,15 +153,17 @@ enum EnumAddCStyleVariant {
 
 
 // Remove a c-style variant ---------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumRemoveCStyleVariant {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumRemoveCStyleVariant {
     Variant1,
 }
@@ -151,14 +171,16 @@ enum EnumRemoveCStyleVariant {
 
 
 // Add a tuple-style variant --------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddTupleStyleVariant {
     Variant1,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddTupleStyleVariant {
     Variant1,
     Variant2(u32, f32),
@@ -167,15 +189,17 @@ enum EnumAddTupleStyleVariant {
 
 
 // Remove a tuple-style variant -----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumRemoveTupleStyleVariant {
     Variant1,
     Variant2(u32, f32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumRemoveTupleStyleVariant {
     Variant1,
 }
@@ -183,14 +207,16 @@ enum EnumRemoveTupleStyleVariant {
 
 
 // Add a struct-style variant -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddStructStyleVariant {
     Variant1,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: f32 },
@@ -199,15 +225,17 @@ enum EnumAddStructStyleVariant {
 
 
 // Remove a struct-style variant ----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumRemoveStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: f32 },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumRemoveStructStyleVariant {
     Variant1,
 }
@@ -215,14 +243,16 @@ enum EnumRemoveStructStyleVariant {
 
 
 // Change the type of a field in a tuple-style variant ------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeFieldTypeTupleStyleVariant {
     Variant1(u32, u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeFieldTypeTupleStyleVariant {
     Variant1(u32,
         u64),
@@ -231,15 +261,17 @@ enum EnumChangeFieldTypeTupleStyleVariant {
 
 
 // Change the type of a field in a struct-style variant -----------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeFieldTypeStructStyleVariant {
     Variant1,
     Variant2 { a: u32, b: u32 },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeFieldTypeStructStyleVariant {
     Variant1,
     Variant2 {
@@ -251,14 +283,16 @@ enum EnumChangeFieldTypeStructStyleVariant {
 
 
 // Change the name of a field in a struct-style variant -----------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeFieldNameStructStyleVariant {
     Variant1 { a: u32, b: u32 },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeFieldNameStructStyleVariant {
     Variant1 { a: u32, c: u32 },
 }
@@ -266,14 +300,16 @@ enum EnumChangeFieldNameStructStyleVariant {
 
 
 // Change order of fields in a tuple-style variant ----------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeOrderTupleStyleVariant {
     Variant1(u32, u64),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeOrderTupleStyleVariant {
     Variant1(
         u64,
@@ -283,14 +319,16 @@ enum EnumChangeOrderTupleStyleVariant {
 
 
 // Change order of fields in a struct-style variant ---------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeFieldOrderStructStyleVariant {
     Variant1 { a: u32, b: f32 },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeFieldOrderStructStyleVariant {
     Variant1 { b: f32, a: u32 },
 }
@@ -298,14 +336,16 @@ enum EnumChangeFieldOrderStructStyleVariant {
 
 
 // Add a field to a tuple-style variant ---------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddFieldTupleStyleVariant {
     Variant1(u32, u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddFieldTupleStyleVariant {
     Variant1(u32, u32, u32),
 }
@@ -313,14 +353,16 @@ enum EnumAddFieldTupleStyleVariant {
 
 
 // Add a field to a struct-style variant --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddFieldStructStyleVariant {
     Variant1 { a: u32, b: u32 },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddFieldStructStyleVariant {
     Variant1 { a: u32, b: u32, c: u32 },
 }
@@ -328,15 +370,17 @@ enum EnumAddFieldStructStyleVariant {
 
 
 // Add #[must_use] to the enum ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddMustUse {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 #[must_use]
 enum EnumAddMustUse {
     Variant1,
@@ -346,15 +390,17 @@ enum EnumAddMustUse {
 
 
 // Add #[repr(C)] to the enum -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddReprC {
     Variant1,
     Variant2,
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="type_of")]
+#[rustc_clean(cfg="cfail6")]
 #[repr(C)]
 enum EnumAddReprC {
     Variant1,
@@ -364,14 +410,16 @@ enum EnumAddReprC {
 
 
 // Change the name of a type parameter ----------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeNameOfTypeParameter<S> {
     Variant1(S),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeNameOfTypeParameter<T> {
     Variant1(T),
 }
@@ -379,15 +427,17 @@ enum EnumChangeNameOfTypeParameter<T> {
 
 
 // Add a type parameter ------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddTypeParameter<S> {
     Variant1(S),
     Variant2(S),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddTypeParameter<S, T> {
     Variant1(S),
     Variant2(T),
@@ -396,14 +446,16 @@ enum EnumAddTypeParameter<S, T> {
 
 
 // Change the name of a lifetime parameter ------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumChangeNameOfLifetimeParameter<'a> {
     Variant1(&'a u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumChangeNameOfLifetimeParameter<'b> {
     Variant1(&'b u32),
 }
@@ -411,15 +463,17 @@ enum EnumChangeNameOfLifetimeParameter<'b> {
 
 
 // Add a lifetime parameter ---------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddLifetimeParameter<'a> {
     Variant1(&'a u32),
     Variant2(&'a u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddLifetimeParameter<'a, 'b> {
     Variant1(&'a u32),
     Variant2(&'b u32),
@@ -428,30 +482,34 @@ enum EnumAddLifetimeParameter<'a, 'b> {
 
 
 // Add a lifetime bound to a lifetime parameter -------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddLifetimeParameterBound<'a, 'b> {
     Variant1(&'a u32),
     Variant2(&'b u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,predicates_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddLifetimeParameterBound<'a, 'b: 'a> {
     Variant1(&'a u32),
     Variant2(&'b u32),
 }
 
 // Add a lifetime bound to a type parameter -----------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddLifetimeBoundToParameter<'a, T> {
     Variant1(T),
     Variant2(&'a u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddLifetimeBoundToParameter<'a, T: 'a> {
     Variant1(T),
     Variant2(&'a u32),
@@ -460,14 +518,16 @@ enum EnumAddLifetimeBoundToParameter<'a, T: 'a> {
 
 
 // Add a trait bound to a type parameter --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddTraitBound<S> {
     Variant1(S),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddTraitBound<T: Sync> {
     Variant1(T),
 }
@@ -475,15 +535,17 @@ enum EnumAddTraitBound<T: Sync> {
 
 
 // Add a lifetime bound to a lifetime parameter in where clause ---------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddLifetimeParameterBoundWhere<'a, 'b> {
     Variant1(&'a u32),
     Variant2(&'b u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,predicates_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,predicates_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddLifetimeParameterBoundWhere<'a, 'b> where 'b: 'a {
     Variant1(&'a u32),
     Variant2(&'b u32),
@@ -492,15 +554,17 @@ enum EnumAddLifetimeParameterBoundWhere<'a, 'b> where 'b: 'a {
 
 
 // Add a lifetime bound to a type parameter in where clause -------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddLifetimeBoundToParameterWhere<'a, T> {
     Variant1(T),
     Variant2(&'a u32),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddLifetimeBoundToParameterWhere<'a, T> where T: 'a {
     Variant1(T),
     Variant2(&'a u32),
@@ -509,14 +573,16 @@ enum EnumAddLifetimeBoundToParameterWhere<'a, T> where T: 'a {
 
 
 // Add a trait bound to a type parameter in where clause ----------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumAddTraitBoundWhere<S> {
     Variant1(S),
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumAddTraitBoundWhere<T> where T: Sync {
     Variant1(T),
 }
@@ -524,15 +590,17 @@ enum EnumAddTraitBoundWhere<T> where T: Sync {
 
 
 // In an enum with two variants, swap usage of type parameters ----------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumSwapUsageTypeParameters<A, B> {
     Variant1 { a: A },
     Variant2 { a: B },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumSwapUsageTypeParameters<A, B> {
     Variant1 {
         a: B
@@ -545,15 +613,17 @@ enum EnumSwapUsageTypeParameters<A, B> {
 
 
 // In an enum with two variants, swap usage of lifetime parameters ------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 enum EnumSwapUsageLifetimeParameters<'a, 'b> {
     Variant1 { a: &'a u32 },
     Variant2 { b: &'b u32 },
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 enum EnumSwapUsageLifetimeParameters<'a, 'b> {
     Variant1 {
         a: &'b u32
@@ -572,13 +642,15 @@ struct ReferencedType2;
 
 // Change field type in tuple-style variant indirectly by modifying a use statement
 mod change_field_type_indirectly_tuple_style {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedType2 as FieldType;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+    #[rustc_clean(cfg="cfail6")]
     enum TupleStyle {
         Variant1(
             FieldType
@@ -590,13 +662,15 @@ mod change_field_type_indirectly_tuple_style {
 
 // Change field type in record-style variant indirectly by modifying a use statement
 mod change_field_type_indirectly_struct_style {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedType2 as FieldType;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+    #[rustc_clean(cfg="cfail6")]
     enum StructStyle {
         Variant1 {
             a: FieldType
@@ -613,13 +687,15 @@ trait ReferencedTrait2 {}
 
 // Change trait bound of type parameter indirectly by modifying a use statement
 mod change_trait_bound_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,predicates_of")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="cfail6")]
     enum Enum<T: Trait> {
         Variant1(T)
     }
@@ -629,13 +705,15 @@ mod change_trait_bound_indirectly {
 
 // Change trait bound of type parameter in where clause indirectly by modifying a use statement
 mod change_trait_bound_indirectly_where {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,predicates_of")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="cfail6")]
     enum Enum<T> where T: Trait {
         Variant1(T)
     }

--- a/src/test/incremental/hashes/exported_vs_not.rs
+++ b/src/test/incremental/hashes/exported_vs_not.rs
@@ -1,6 +1,12 @@
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -10,14 +16,16 @@
 //         the hash of the hir_owner_nodes node should change, but not the hash of
 //         either the hir_owner or the Metadata node.
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn body_not_exported_to_metadata() -> u32 {
     1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn body_not_exported_to_metadata() -> u32 {
     2
 }
@@ -28,15 +36,17 @@ pub fn body_not_exported_to_metadata() -> u32 {
 //         marked as #[inline]. Only the hash of the hir_owner depnode should be
 //         unaffected by a change to the body.
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[inline]
 pub fn body_exported_to_metadata_because_of_inline() -> u32 {
     1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[inline]
 pub fn body_exported_to_metadata_because_of_inline() -> u32 {
     2
@@ -48,15 +58,17 @@ pub fn body_exported_to_metadata_because_of_inline() -> u32 {
 //         generic. Only the hash of the hir_owner depnode should be
 //         unaffected by a change to the body.
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[inline]
 pub fn body_exported_to_metadata_because_of_generic() -> u32 {
     1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[inline]
 pub fn body_exported_to_metadata_because_of_generic() -> u32 {
     2

--- a/src/test/incremental/hashes/extern_mods.rs
+++ b/src/test/incremental/hashes/extern_mods.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -15,146 +21,168 @@
 #![crate_type = "rlib"]
 
 // Change function name --------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
     pub fn change_function_name1(c: i64) -> i32;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn change_function_name2(c: i64) -> i32;
 }
 
 // Change parameter name -------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
     pub fn change_parameter_name(c: i64) -> i32;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn change_parameter_name(d: i64) -> i32;
 }
 
 // Change parameter type -------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
     pub fn change_parameter_type(c: i64) -> i32;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn change_parameter_type(c: i32) -> i32;
 }
 
 // Change return type ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
     pub fn change_return_type(c: i32) -> i32;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
-    pub fn change_return_type(c: i32) -> i8;
+    pub fn change_return_type(c: i32) -> i8 ;
 }
 
 // Add parameter ---------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
-    pub fn add_parameter(c: i32) -> i32;
+    pub fn add_parameter(c: i32        ) -> i32;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn add_parameter(c: i32, d: i32) -> i32;
 }
 
 // Add return type -------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
-    pub fn add_return_type(c: i32);
+    pub fn add_return_type(c: i32)       ;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn add_return_type(c: i32) -> i32;
 }
 
 // Make function variadic ------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
-    pub fn make_function_variadic(c: i32);
+    pub fn make_function_variadic(c: i32     );
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn make_function_variadic(c: i32, ...);
 }
 
 // Change calling convention ---------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
     pub fn change_calling_convention(c: i32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner")]
+#[rustc_clean(cfg = "cfail6")]
 extern "rust-call" {
     pub fn change_calling_convention(c: i32);
 }
 
 // Make function public --------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
     fn make_function_public(c: i32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn make_function_public(c: i32);
 }
 
 // Add function ----------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 extern "C" {
     pub fn add_function1(c: i32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner")]
+#[rustc_clean(cfg = "cfail6")]
 extern "C" {
     pub fn add_function1(c: i32);
     pub fn add_function2();
 }
 
 // Change link-name ------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[link(name = "foo")]
 extern "C" {
     pub fn change_link_name(c: i32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 #[link(name = "bar")]
 extern "C" {
     pub fn change_link_name(c: i32);
@@ -165,13 +193,15 @@ type c_i64 = i64;
 
 // Indirectly change parameter type --------------------------------------------
 mod indirectly_change_parameter_type {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::c_i32 as c_int;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::c_i64 as c_int;
 
     #[rustc_clean(cfg = "cfail2")]
     #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(cfg = "cfail5")]
+    #[rustc_clean(cfg = "cfail6")]
     extern "C" {
         pub fn indirectly_change_parameter_type(c: c_int);
     }
@@ -179,13 +209,15 @@ mod indirectly_change_parameter_type {
 
 // Indirectly change return type --------------------------------------------
 mod indirectly_change_return_type {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::c_i32 as c_int;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::c_i64 as c_int;
 
     #[rustc_clean(cfg = "cfail2")]
     #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(cfg = "cfail5")]
+    #[rustc_clean(cfg = "cfail6")]
     extern "C" {
         pub fn indirectly_change_return_type() -> c_int;
     }

--- a/src/test/incremental/hashes/for_loops.rs
+++ b/src/test/incremental/hashes/for_loops.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -15,7 +21,7 @@
 
 
 // Change loop body ------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -24,9 +30,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -38,7 +46,7 @@ pub fn change_loop_body() {
 
 
 // Change iteration variable name ----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_iteration_variable_name() {
     let mut _x = 0;
     for _i in 0..1 {
@@ -47,9 +55,11 @@ pub fn change_iteration_variable_name() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_iteration_variable_name() {
     let mut _x = 0;
     for _a in 0..1 {
@@ -61,18 +71,20 @@ pub fn change_iteration_variable_name() {
 
 
 // Change iteration variable pattern -------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_iteration_variable_pattern() {
     let mut _x = 0;
-    for _i in &[0, 1, 2] {
+    for  _i in &[0, 1, 2] {
         _x = 1;
         break;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck, promoted_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_iteration_variable_pattern() {
     let mut _x = 0;
     for &_i in &[0, 1, 2] {
@@ -84,7 +96,7 @@ pub fn change_iteration_variable_pattern() {
 
 
 // Change iterable -------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_iterable() {
     let mut _x = 0;
     for _ in &[0, 1, 2] {
@@ -93,9 +105,11 @@ pub fn change_iterable() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, promoted_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, promoted_mir, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_iterable() {
     let mut _x = 0;
     for _ in &[0, 1, 3] {
@@ -107,17 +121,20 @@ pub fn change_iterable() {
 
 
 // Add break -------------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_break() {
     let mut _x = 0;
     for _ in 0..1 {
         _x = 1;
+        // ---
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -129,18 +146,20 @@ pub fn add_break() {
 
 
 // Add loop label --------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
-    for _ in 0..1 {
+            for _ in 0..1 {
         _x = 1;
         break;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -152,18 +171,20 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break -----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: for _ in 0..1 {
         _x = 1;
-        break;
+        break       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -175,7 +196,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -186,9 +207,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -202,18 +225,20 @@ pub fn change_break_label() {
 
 
 // Add loop label to continue --------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: for _ in 0..1 {
         _x = 1;
-        continue;
+        continue       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: for _ in 0..1 {
@@ -225,7 +250,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -236,9 +261,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: for _ in 0..1 {
@@ -252,7 +279,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break ----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     for _ in 0..1 {
@@ -261,13 +288,15 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     for _ in 0..1 {
         _x = 1;
-        break;
+        break   ;
     }
 }

--- a/src/test/incremental/hashes/function_interfaces.rs
+++ b/src/test/incremental/hashes/function_interfaces.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(linkage)]
@@ -16,248 +22,310 @@
 
 // Add Parameter ---------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_parameter() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub fn add_parameter(p: i32) {}
 
 // Add Return Type -------------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn add_return_type() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn add_return_type()       {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg = "cfail6")]
 pub fn add_return_type() -> () {}
 
 // Change Parameter Type -------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn type_of_parameter(p: i32) {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub fn type_of_parameter(p: i64) {}
 
 // Change Parameter Type Reference ---------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn type_of_parameter_ref(p: &i32) {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub fn type_of_parameter_ref(p: &mut i32) {}
 
 // Change Parameter Order ------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn order_of_parameters(p1: i32, p2: i64) {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub fn order_of_parameters(p2: i64, p1: i32) {}
 
 // Unsafe ----------------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn make_unsafe() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub unsafe fn make_unsafe() {}
 
 // Extern ----------------------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn make_extern() {}
+#[cfg(any(cfail1,cfail4))]
+pub            fn make_extern() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, typeck, fn_sig")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, typeck, fn_sig")]
+#[rustc_clean(cfg = "cfail6")]
 pub extern "C" fn make_extern() {}
 
 // Type Parameter --------------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn type_parameter() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn type_parameter   () {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, generics_of, type_of, predicates_of"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, generics_of, type_of, predicates_of"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub fn type_parameter<T>() {}
 
 // Lifetime Parameter ----------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn lifetime_parameter() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn lifetime_parameter    () {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, generics_of,fn_sig")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, generics_of,fn_sig")]
+#[rustc_clean(cfg = "cfail6")]
 pub fn lifetime_parameter<'a>() {}
 
 // Trait Bound -----------------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn trait_bound<T>() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn trait_bound<T    >() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, predicates_of")]
 #[rustc_clean(cfg = "cfail3")]
 pub fn trait_bound<T: Eq>() {}
 
 // Builtin Bound ---------------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn builtin_bound<T>() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn builtin_bound<T      >() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, predicates_of")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, predicates_of")]
+#[rustc_clean(cfg = "cfail6")]
 pub fn builtin_bound<T: Send>() {}
 
 // Lifetime Bound --------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn lifetime_bound<'a, T>() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig,optimized_mir"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub fn lifetime_bound<'a, T: 'a>() {}
 
 // Second Trait Bound ----------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn second_trait_bound<T: Eq>() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn second_trait_bound<T: Eq        >() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, predicates_of")]
 #[rustc_clean(cfg = "cfail3")]
 pub fn second_trait_bound<T: Eq + Clone>() {}
 
 // Second Builtin Bound --------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn second_builtin_bound<T: Send>() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn second_builtin_bound<T: Send        >() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, predicates_of")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, predicates_of")]
+#[rustc_clean(cfg = "cfail6")]
 pub fn second_builtin_bound<T: Send + Sized>() {}
 
 // Second Lifetime Bound -------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn second_lifetime_bound<'a, 'b, T: 'a>() {}
+#[cfg(any(cfail1,cfail4))]
+pub fn second_lifetime_bound<'a, 'b, T: 'a     >() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(
     cfg = "cfail2",
     except = "hir_owner, hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig"
 )]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(
+    cfg = "cfail5",
+    except = "hir_owner, hir_owner_nodes, generics_of, type_of, predicates_of,fn_sig"
+)]
+#[rustc_clean(cfg = "cfail6")]
 pub fn second_lifetime_bound<'a, 'b, T: 'a + 'b>() {}
 
 // Inline ----------------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn inline() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 #[inline]
 pub fn inline() {}
 
 // Inline Never ----------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[inline(always)]
 pub fn inline_never() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 #[inline(never)]
 pub fn inline_never() {}
 
 // No Mangle -------------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn no_mangle() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 #[no_mangle]
 pub fn no_mangle() {}
 
 // Linkage ---------------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn linkage() {}
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
 #[linkage = "weak_odr"]
 pub fn linkage() {}
 
 // Return Impl Trait -----------------------------------------------------------
 
-#[cfg(cfail1)]
-pub fn return_impl_trait() -> i32 {
+#[cfg(any(cfail1,cfail4))]
+pub fn return_impl_trait() -> i32        {
     0
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, typeck, fn_sig")]
 #[rustc_clean(cfg = "cfail3")]
+#[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, typeck, fn_sig, optimized_mir")]
+#[rustc_clean(cfg = "cfail6")]
 pub fn return_impl_trait() -> impl Clone {
     0
 }
 
 // Change Return Impl Trait ----------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_return_impl_trait() -> impl Clone {
     0u32
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg = "cfail2")]
 #[rustc_clean(cfg = "cfail3")]
-pub fn change_return_impl_trait() -> impl Copy {
+#[rustc_clean(cfg = "cfail5")]
+#[rustc_clean(cfg = "cfail6")]
+pub fn change_return_impl_trait() -> impl  Copy {
     0u32
 }
 
@@ -267,9 +335,9 @@ pub struct ReferencedType1;
 pub struct ReferencedType2;
 
 pub mod change_return_type_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedType1 as ReturnType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedType2 as ReturnType;
 
     #[rustc_clean(
@@ -277,6 +345,11 @@ pub mod change_return_type_indirectly {
         except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
     )]
     #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(
+        cfg = "cfail5",
+        except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    )]
+    #[rustc_clean(cfg = "cfail6")]
     pub fn indirect_return_type() -> ReturnType {
         ReturnType {}
     }
@@ -285,9 +358,9 @@ pub mod change_return_type_indirectly {
 // Change Parameter Type Indirectly --------------------------------------------
 
 pub mod change_parameter_type_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedType1 as ParameterType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedType2 as ParameterType;
 
     #[rustc_clean(
@@ -295,6 +368,11 @@ pub mod change_parameter_type_indirectly {
         except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
     )]
     #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(
+        cfg = "cfail5",
+        except = "hir_owner, hir_owner_nodes, optimized_mir, typeck, fn_sig"
+    )]
+    #[rustc_clean(cfg = "cfail6")]
     pub fn indirect_parameter_type(p: ParameterType) {}
 }
 
@@ -304,26 +382,30 @@ pub trait ReferencedTrait1 {}
 pub trait ReferencedTrait2 {}
 
 pub mod change_trait_bound_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, predicates_of")]
     #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, predicates_of")]
+    #[rustc_clean(cfg = "cfail6")]
     pub fn indirect_trait_bound<T: Trait>(p: T) {}
 }
 
 // Change Trait Bound Indirectly In Where Clause -------------------------------
 
 pub mod change_trait_bound_indirectly_in_where_clause {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_clean(cfg = "cfail2", except = "hir_owner, hir_owner_nodes, predicates_of")]
     #[rustc_clean(cfg = "cfail3")]
+    #[rustc_clean(cfg = "cfail5", except = "hir_owner, hir_owner_nodes, predicates_of")]
+    #[rustc_clean(cfg = "cfail6")]
     pub fn indirect_trait_bound_where<T>(p: T)
     where
         T: Trait,

--- a/src/test/incremental/hashes/if_expressions.rs
+++ b/src/test/incremental/hashes/if_expressions.rs
@@ -214,7 +214,7 @@ pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
     let mut ret = 1;

--- a/src/test/incremental/hashes/if_expressions.rs
+++ b/src/test/incremental/hashes/if_expressions.rs
@@ -6,27 +6,34 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
-
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
 
 // Change condition (if)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_condition(x: bool) -> u32 {
-    if x {
+    if  x {
         return 1
     }
 
     return 0
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_condition(x: bool) -> u32 {
     if !x {
         return 1
@@ -36,7 +43,7 @@ pub fn change_condition(x: bool) -> u32 {
 }
 
 // Change then branch (if)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_then_branch(x: bool) -> u32 {
     if x {
         return 1
@@ -45,9 +52,11 @@ pub fn change_then_branch(x: bool) -> u32 {
     return 0
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_then_branch(x: bool) -> u32 {
     if x {
         return 2
@@ -59,7 +68,7 @@ pub fn change_then_branch(x: bool) -> u32 {
 
 
 // Change else branch (if)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_else_branch(x: bool) -> u32 {
     if x {
         1
@@ -68,9 +77,11 @@ pub fn change_else_branch(x: bool) -> u32 {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_else_branch(x: bool) -> u32 {
     if x {
         1
@@ -82,20 +93,23 @@ pub fn change_else_branch(x: bool) -> u32 {
 
 
 // Add else branch (if)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_else_branch(x: bool) -> u32 {
     let mut ret = 1;
 
     if x {
         ret = 2;
+    /*----*/
     }
 
     ret
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_else_branch(x: bool) -> u32 {
     let mut ret = 1;
 
@@ -110,7 +124,7 @@ pub fn add_else_branch(x: bool) -> u32 {
 
 
 // Change condition (if let)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_condition_if_let(x: Option<u32>) -> u32 {
     if let Some(_x) = x {
         return 1
@@ -119,11 +133,13 @@ pub fn change_condition_if_let(x: Option<u32>) -> u32 {
     0
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_condition_if_let(x: Option<u32>) -> u32 {
-    if let Some(_) = x {
+    if let Some(_ ) = x {
         return 1
     }
 
@@ -133,18 +149,20 @@ pub fn change_condition_if_let(x: Option<u32>) -> u32 {
 
 
 // Change then branch (if let)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
-        return x
+        return x //-
     }
 
     0
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
         return x + 1
@@ -156,7 +174,7 @@ pub fn change_then_branch_if_let(x: Option<u32>) -> u32 {
 
 
 // Change else branch (if let)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
         x
@@ -165,9 +183,11 @@ pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
     if let Some(x) = x {
         x
@@ -179,20 +199,23 @@ pub fn change_else_branch_if_let(x: Option<u32>) -> u32 {
 
 
 // Add else branch (if let)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
     let mut ret = 1;
 
     if let Some(x) = x {
         ret = x;
+    /*----*/
     }
 
     ret
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_else_branch_if_let(x: Option<u32>) -> u32 {
     let mut ret = 1;
 

--- a/src/test/incremental/hashes/indexing_expressions.rs
+++ b/src/test/incremental/hashes/indexing_expressions.rs
@@ -6,22 +6,30 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
 
 // Change simple index
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 fn change_simple_index(slice: &[u32]) -> u32 {
     slice[3]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 fn change_simple_index(slice: &[u32]) -> u32 {
     slice[4]
 }
@@ -29,14 +37,16 @@ fn change_simple_index(slice: &[u32]) -> u32 {
 
 
 // Change lower bound
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 fn change_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[3..5]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 fn change_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[2..5]
 }
@@ -44,14 +54,16 @@ fn change_lower_bound(slice: &[u32]) -> &[u32] {
 
 
 // Change upper bound
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 fn change_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..5]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 fn change_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..7]
 }
@@ -59,14 +71,16 @@ fn change_upper_bound(slice: &[u32]) -> &[u32] {
 
 
 // Add lower bound
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 fn add_lower_bound(slice: &[u32]) -> &[u32] {
-    &slice[..4]
+    &slice[ ..4]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 fn add_lower_bound(slice: &[u32]) -> &[u32] {
     &slice[3..4]
 }
@@ -74,14 +88,16 @@ fn add_lower_bound(slice: &[u32]) -> &[u32] {
 
 
 // Add upper bound
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 fn add_upper_bound(slice: &[u32]) -> &[u32] {
-    &slice[3..]
+    &slice[3.. ]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 fn add_upper_bound(slice: &[u32]) -> &[u32] {
     &slice[3..7]
 }
@@ -89,29 +105,33 @@ fn add_upper_bound(slice: &[u32]) -> &[u32] {
 
 
 // Change mutability
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 fn change_mutability(slice: &mut [u32]) -> u32 {
     (&mut slice[3..5])[0]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 fn change_mutability(slice: &mut [u32]) -> u32 {
-    (&slice[3..5])[0]
+    (&    slice[3..5])[0]
 }
 
 
 
 // Exclusive to inclusive range
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
-    &slice[3..7]
+    &slice[3.. 7]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 fn exclusive_to_inclusive_range(slice: &[u32]) -> &[u32] {
     &slice[3..=7]
 }

--- a/src/test/incremental/hashes/inherent_impls.rs
+++ b/src/test/incremental/hashes/inherent_impls.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 
 #![allow(warnings)]
@@ -17,36 +23,46 @@
 pub struct Foo;
 
 // Change Method Name -----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
     pub fn method_name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,associated_item_def_ids")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,associated_item_def_ids")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn method_name2() { }
 }
 
 // Change Method Body -----------------------------------------------------------
 //
 // This should affect the method itself, but not the impl.
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn method_body() { }
+    //--------------------------------------------------------------------------------------
+    //--------------------------
+    //--------------------------------------------------------------------------------------
+    //--------------------------
+    pub fn method_body() {
+        // -----------------------
+    }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(
-        cfg="cfail2",
-        except="hir_owner_nodes,optimized_mir,promoted_mir,typeck"
-    )]
+    #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,promoted_mir,typeck")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,promoted_mir,typeck")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn method_body() {
         println!("Hello, world!");
     }
@@ -56,21 +72,40 @@ impl Foo {
 // Change Method Body (inlined) ------------------------------------------------
 //
 // This should affect the method itself, but not the impl.
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
+    //------------
+    //---------------
+    //------------------------------------------------------------
+    //
+    //--------------------------
+    //------------
+    //---------------
+    //------------------------------------------------------------
+    //
+    //--------------------------
     #[inline]
-    pub fn method_body_inlined() { }
+    pub fn method_body_inlined() {
+        // -----------------------
+    }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(
         cfg="cfail2",
         except="hir_owner_nodes,optimized_mir,promoted_mir,typeck"
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="hir_owner_nodes,optimized_mir,promoted_mir,typeck"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     #[inline]
     pub fn method_body_inlined() {
         println!("Hello, world!");
@@ -79,146 +114,205 @@ impl Foo {
 
 
 // Change Method Privacy -------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
     pub fn method_privacy() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="associated_item,hir_owner,hir_owner_nodes")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="associated_item,hir_owner,hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_privacy() { }
 }
 
 // Change Method Selfness -----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
+    //------------
+    //---------------
+    //---------------------------------------------------------------------------------------------
+    //
+    //--------------------------
+    //------------
+    //---------------
+    //---------------------------------------------------------------------------------------------
+    //
+    //--------------------------
     pub fn method_selfness() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(
         cfg="cfail2",
         except="hir_owner,hir_owner_nodes,fn_sig,generics_of,typeck,associated_item,optimized_mir",
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="hir_owner,hir_owner_nodes,fn_sig,generics_of,typeck,associated_item,optimized_mir",
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn method_selfness(&self) { }
 }
 
 // Change Method Selfmutness ---------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn method_selfmutness(&self) { }
+    //------------------------------------------------------------------------------------------
+    //--------------------------
+    //------------------------------------------------------------------------------------------
+    //--------------------------
+    pub fn method_selfmutness(&    self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(
-        cfg="cfail2",
-        except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir"
-    )]
+    #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn method_selfmutness(&mut self) { }
 }
 
 
 
 // Add Method To Impl ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
     pub fn add_method_to_impl1(&self) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,associated_item_def_ids")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,associated_item_def_ids")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_method_to_impl1(&self) { }
 
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_method_to_impl2(&self) { }
 }
 
 
 
 // Add Method Parameter --------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn add_method_parameter(&self) { }
+    //------------------------------------------------------------------------------------------
+    //--------------------------
+    //------------------------------------------------------------------------------------------
+    //--------------------------
+    pub fn add_method_parameter(&self        ) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(
-        cfg="cfail2",
-        except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir"
-    )]
+    #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_method_parameter(&self, _: i32) { }
 }
 
 
 
 // Change Method Parameter Name ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
+    //------------------------------------------------------------------
+    //--------------------------
+    //------------------------------------------------------------------
+    //--------------------------
     pub fn change_method_parameter_name(&self, a: i64) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn change_method_parameter_name(&self, b: i64) { }
 }
 
 
 
 // Change Method Return Type ---------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
+    //------------------------------------------------------------------------------------------
+    //--------------------------
+    //------------------------------------------------------------------------------------------
+    //--------------------------
     pub fn change_method_return_type(&self) -> u16 { 0 }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(
-        cfg="cfail2",
-        except="hir_owner,hir_owner_nodes,fn_sig,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig,optimized_mir,typeck")]
     #[rustc_clean(cfg="cfail3")]
-    pub fn change_method_return_type(&self) -> u8 { 0 }
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,fn_sig,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail6")]
+    pub fn change_method_return_type(&self) -> u32 { 0 }
 }
 
 
 
 // Make Method #[inline] -------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
+    //--------------------------
+    //--------------------------
+    //--------------------------
+    //--------------------------
+    //-------
     pub fn make_method_inline(&self) -> u8 { 0 }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     #[inline]
     pub fn make_method_inline(&self) -> u8 { 0 }
 }
@@ -226,85 +320,129 @@ impl Foo {
 
 
 //  Change order of parameters -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
+    //------------------------------------------------------------------
+    //--------------------------
+    //------------------------------------------------------------------
+    //--------------------------
     pub fn change_method_parameter_order(&self, a: i64, b: i64) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn change_method_parameter_order(&self, b: i64, a: i64) { }
 }
 
 
 
 // Make method unsafe ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn make_method_unsafe(&self) { }
+    //------------------------------------------------------------------------------------------
+    //--------------------------
+    //------------------------------------------------------------------------------------------
+    //--------------------------
+    pub        fn make_method_unsafe(&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
-    #[rustc_clean(
-        cfg="cfail2",
-        except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir"
-    )]
+    #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir")]
+    #[rustc_clean(cfg="cfail6")]
     pub unsafe fn make_method_unsafe(&self) { }
 }
 
 
 
 // Make method extern ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn make_method_extern(&self) { }
+    //----------------------------------------------------------------------------
+    //--------------------------
+    //----------------------------------------------------------------------------
+    //--------------------------
+    pub            fn make_method_extern(&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig,typeck")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail6")]
     pub extern "C" fn make_method_extern(&self) { }
 }
 
 
 
 // Change method calling convention --------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub extern "C" fn change_method_calling_convention(&self) { }
+    //----------------------------------------------------------------------------
+    //--------------------------
+    //----------------------------------------------------------------------------
+    //--------------------------
+    pub extern "C"      fn change_method_calling_convention(&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig,typeck")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,fn_sig,typeck")]
+    #[rustc_clean(cfg="cfail6")]
     pub extern "system" fn change_method_calling_convention(&self) { }
 }
 
 
 
 // Add Lifetime Parameter to Method --------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn add_lifetime_parameter_to_method(&self) { }
+    // -----------------------------------------------------
+    // ---------------------------------------------------------
+    // ----------------------------------------------------------
+    // -------------------------------------------------------
+    // -------------------------------------------------------
+    // --------------------------------------------------------
+    // ----------------------------------------------------------
+    // -----------------------------------------------------------
+    // ----------------------------------------------------------
+    // --------------------------------------------------------------------
+    // -------------------------
+    // --------------------------------------------------------------------------------
+    // -------------------------
+    pub fn add_lifetime_parameter_to_method    (&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck` are coming up clean here.
     // The addition or removal of lifetime parameters that don't
@@ -317,20 +455,43 @@ impl Foo {
     // `typeck` appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,fn_sig")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,fn_sig,generics_of")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_lifetime_parameter_to_method<'a>(&self) { }
 }
 
 
 
 // Add Type Parameter To Method ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn add_type_parameter_to_method(&self) { }
+    // -----------------------------------------------------
+    // ---------------------------------------------------------------
+    // -------------------------------------------------------------
+    // -----------------------------------------------------
+    // -------------------------------------------------------------
+    // ---------------------------------------------------
+    // ------------------------------------------------------------
+    // ------------------------------------------------------
+    // -------------------------------------------------
+    // -----------
+    // --------------
+    // ----------------------------------------------------------------------
+    //
+    // -------------------------
+    // -----------
+    // --------------
+    // ----------------------------------------------------------------------
+    //
+    // -------------------------
+    pub fn add_type_parameter_to_method   (&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck` are coming up clean here.
     // The addition or removal of type parameters that don't appear in
@@ -346,40 +507,83 @@ impl Foo {
         except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of",
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of",
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_type_parameter_to_method<T>(&self) { }
 }
 
 
 
 // Add Lifetime Bound to Lifetime Parameter of Method --------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn add_lifetime_bound_to_lifetime_param_of_method<'a, 'b>(&self) { }
+    //------------
+    //---------------
+    //-----------------------------------------------------------------------------
+    //
+    //--------------------------
+    //------------
+    //---------------
+    //-----------------------------------------------------------------------------
+    //
+    //--------------------------
+    pub fn add_lifetime_bound_to_lifetime_param_of_method<'a, 'b    >(&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(
         cfg="cfail2",
         except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_lifetime_bound_to_lifetime_param_of_method<'a, 'b: 'a>(&self) { }
 }
 
 
 
 // Add Lifetime Bound to Type Parameter of Method ------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn add_lifetime_bound_to_type_param_of_method<'a, T>(&self) { }
+    // -----------------------------------------------------
+    // ----------------------------------------------------------
+    // -------------------------------------------------------------
+    // -------------------------------------------------
+    // -------------------------------------------------------------
+    // ---------------------------------------------------
+    // ------------------------------------------------------------
+    // ------------------------------------------------------
+    // -------------------------------------------------
+    // -----------
+    // --------------
+    // ----------------------------------------------------------------------------
+    //
+    // -------------------------
+    // -----------
+    // --------------
+    // ----------------------------------------------------------------------------
+    //
+    // -------------------------
+    pub fn add_lifetime_bound_to_type_param_of_method<'a, T    >(&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck` are coming up clean here.
     // The addition or removal of bounds that don't appear in the
@@ -390,23 +594,45 @@ impl Foo {
     // generics before the body, then the `HirId` for things in the
     // body will be affected. So if you start to see `typeck`
     // appear dirty, that might be the cause. -nmatsakis
-    #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of,\
-                                        type_of,fn_sig")]
+    #[rustc_clean(
+        cfg="cfail2",
+        except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
+    )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="hir_owner,hir_owner_nodes,generics_of,predicates_of,type_of,fn_sig"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_lifetime_bound_to_type_param_of_method<'a, T: 'a>(&self) { }
 }
 
 
 
 // Add Trait Bound to Type Parameter of Method ------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
-    pub fn add_trait_bound_to_type_param_of_method<T>(&self) { }
+    // -----------------------------------------------------
+    // ----------------------------------------------------------
+    // -------------------------------------------------------------
+    // -------------------------------------------------
+    // -------------------------------------------------------------
+    // ---------------------------------------------------
+    // ------------------------------------------------------------
+    // ------------------------------------------------------
+    // -------------------------------------------------
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    pub fn add_trait_bound_to_type_param_of_method<T       >(&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     // Warning: Note that `typeck` are coming up clean here.
     // The addition or removal of bounds that don't appear in the
@@ -419,23 +645,34 @@ impl Foo {
     // appear dirty, that might be the cause. -nmatsakis
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,predicates_of")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,predicates_of")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_trait_bound_to_type_param_of_method<T: Clone>(&self) { }
 }
 
 
 
 // Add #[no_mangle] to Method --------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Foo {
+    //--------------------------
+    //--------------------------
+    //--------------------------
+    //--------------------------
+    //----------
     pub fn add_no_mangle_to_method(&self) { }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl Foo {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     #[no_mangle]
     pub fn add_no_mangle_to_method(&self) { }
 }
@@ -445,71 +682,90 @@ impl Foo {
 struct Bar<T>(T);
 
 // Add Type Parameter To Impl --------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Bar<u32> {
     pub fn add_type_parameter_to_impl(&self) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of")]
+#[rustc_clean(cfg="cfail6")]
 impl<T> Bar<T> {
     #[rustc_clean(
         cfg="cfail2",
         except="generics_of,fn_sig,typeck,type_of,optimized_mir"
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="generics_of,fn_sig,typeck,type_of,optimized_mir"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_type_parameter_to_impl(&self) { }
 }
 
 
 
 // Change Self Type of Impl ----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl Bar<u32> {
     pub fn change_impl_self_type(&self) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner")]
+#[rustc_clean(cfg="cfail6")]
 impl Bar<u64> {
     #[rustc_clean(cfg="cfail2", except="fn_sig,optimized_mir,typeck")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="fn_sig,optimized_mir,typeck")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn change_impl_self_type(&self) { }
 }
 
 
 
 // Add Lifetime Bound to Impl --------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl<T> Bar<T> {
     pub fn add_lifetime_bound_to_impl_parameter(&self) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl<T: 'static> Bar<T> {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_lifetime_bound_to_impl_parameter(&self) { }
 }
 
 
 
 // Add Trait Bound to Impl Parameter -------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl<T> Bar<T> {
     pub fn add_trait_bound_to_impl_parameter(&self) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 impl<T: Clone> Bar<T> {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     pub fn add_trait_bound_to_impl_parameter(&self) { }
 }
 
@@ -518,12 +774,12 @@ impl<T: Clone> Bar<T> {
 pub fn instantiation_root() {
     Foo::method_privacy();
 
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     {
         Bar(0u32).change_impl_self_type();
     }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     {
         Bar(0u64).change_impl_self_type();
     }

--- a/src/test/incremental/hashes/inline_asm.rs
+++ b/src/test/incremental/hashes/inline_asm.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -17,7 +23,7 @@
 
 
 // Change template
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_template(a: i32) -> i32 {
     let c: i32;
@@ -32,9 +38,11 @@ pub fn change_template(a: i32) -> i32 {
     c
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_template(a: i32) -> i32 {
     let c: i32;
@@ -52,7 +60,7 @@ pub fn change_template(a: i32) -> i32 {
 
 
 // Change output
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_output(a: i32) -> i32 {
     let mut _out1: i32 = 0;
@@ -68,9 +76,11 @@ pub fn change_output(a: i32) -> i32 {
     _out1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_output(a: i32) -> i32 {
     let mut _out1: i32 = 0;
@@ -89,7 +99,7 @@ pub fn change_output(a: i32) -> i32 {
 
 
 // Change input
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -104,9 +114,11 @@ pub fn change_input(_a: i32, _b: i32) -> i32 {
     _out
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -124,7 +136,7 @@ pub fn change_input(_a: i32, _b: i32) -> i32 {
 
 
 // Change input constraint
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -139,9 +151,11 @@ pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     _out
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
     let _out;
@@ -159,7 +173,7 @@ pub fn change_input_constraint(_a: i32, _b: i32) -> i32 {
 
 
 // Change clobber
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_clobber(_a: i32) -> i32 {
     let _out;
@@ -167,16 +181,18 @@ pub fn change_clobber(_a: i32) -> i32 {
         llvm_asm!("add 1, $0"
                   : "=r"(_out)
                   : "0"(_a)
-                  :
+                  :/*--*/
                   :
                   );
     }
     _out
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_clobber(_a: i32) -> i32 {
     let _out;
@@ -194,7 +210,7 @@ pub fn change_clobber(_a: i32) -> i32 {
 
 
 // Change options
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_options(_a: i32) -> i32 {
     let _out;
@@ -203,15 +219,17 @@ pub fn change_options(_a: i32) -> i32 {
                   : "=r"(_out)
                   : "0"(_a)
                   :
-                  :
+                  :/*-------*/
                   );
     }
     _out
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub fn change_options(_a: i32) -> i32 {
     let _out;

--- a/src/test/incremental/hashes/let_expressions.rs
+++ b/src/test/incremental/hashes/let_expressions.rs
@@ -6,24 +6,30 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
-
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
 
 // Change Name -----------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_name() {
     let _x = 2u64;
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_name() {
     let _y = 2u64;
 }
@@ -31,15 +37,16 @@ pub fn change_name() {
 
 
 // Add Type --------------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_type() {
-    let _x = 2u32;
+    let _x      = 2u32;
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_type() {
     let _x: u32 = 2u32;
 }
@@ -47,31 +54,33 @@ pub fn add_type() {
 
 
 // Change Type -----------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_type() {
     let _x: u64 = 2;
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_type() {
-    let _x: u8 = 2;
+    let _x: u8  = 2;
 }
 
 
 
 // Change Mutability of Reference Type -----------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_mutability_of_reference_type() {
-    let _x: &u64;
+    let _x: &    u64;
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_reference_type() {
     let _x: &mut u64;
 }
@@ -79,31 +88,33 @@ pub fn change_mutability_of_reference_type() {
 
 
 // Change Mutability of Slot ---------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_mutability_of_slot() {
     let mut _x: u64 = 0;
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_slot() {
-    let _x: u64 = 0;
+    let     _x: u64 = 0;
 }
 
 
 
 // Change Simple Binding to Pattern --------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_simple_binding_to_pattern() {
-    let _x = (0u8, 'x');
+    let  _x      = (0u8, 'x');
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_simple_binding_to_pattern() {
     let (_a, _b) = (0u8, 'x');
 }
@@ -111,15 +122,16 @@ pub fn change_simple_binding_to_pattern() {
 
 
 // Change Name in Pattern ------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_name_in_pattern() {
     let (_a, _b) = (1u8, 'y');
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_name_in_pattern() {
     let (_a, _c) = (1u8, 'y');
 }
@@ -127,15 +139,16 @@ pub fn change_name_in_pattern() {
 
 
 // Add `ref` in Pattern --------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_ref_in_pattern() {
-    let (_a, _b) = (1u8, 'y');
+    let (    _a, _b) = (1u8, 'y');
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_ref_in_pattern() {
     let (ref _a, _b) = (1u8, 'y');
 }
@@ -143,15 +156,16 @@ pub fn add_ref_in_pattern() {
 
 
 // Add `&` in Pattern ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_amp_in_pattern() {
-    let (_a, _b) = (&1u8, 'y');
+    let ( _a, _b) = (&1u8, 'y');
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_amp_in_pattern() {
     let (&_a, _b) = (&1u8, 'y');
 }
@@ -159,15 +173,16 @@ pub fn add_amp_in_pattern() {
 
 
 // Change Mutability of Binding in Pattern -------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_mutability_of_binding_in_pattern() {
-    let (_a, _b) = (99u8, 'q');
+    let (    _a, _b) = (99u8, 'q');
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_binding_in_pattern() {
     let (mut _a, _b) = (99u8, 'q');
 }
@@ -175,15 +190,16 @@ pub fn change_mutability_of_binding_in_pattern() {
 
 
 // Add Initializer -------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_initializer() {
-    let _x: i16;
+    let _x: i16       ;
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,typeck,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_initializer() {
     let _x: i16 = 3i16;
 }
@@ -191,15 +207,16 @@ pub fn add_initializer() {
 
 
 // Change Initializer ----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_initializer() {
     let _x = 4u16;
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_initializer() {
     let _x = 5u16;
 }

--- a/src/test/incremental/hashes/loop_expressions.rs
+++ b/src/test/incremental/hashes/loop_expressions.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -15,7 +21,7 @@
 
 
 // Change loop body
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     loop {
@@ -24,9 +30,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     loop {
@@ -38,17 +46,20 @@ pub fn change_loop_body() {
 
 
 // Add break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_break() {
     let mut _x = 0;
     loop {
         _x = 1;
+        //----
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;
     loop {
@@ -60,18 +71,20 @@ pub fn add_break() {
 
 
 // Add loop label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
-    loop {
+    /*---*/ loop {
         _x = 1;
         break;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: loop {
@@ -83,18 +96,20 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: loop {
         _x = 1;
-        break;
+        break       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: loop {
@@ -106,7 +121,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: loop {
@@ -117,9 +132,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: loop {
@@ -133,18 +150,20 @@ pub fn change_break_label() {
 
 
 // Add loop label to continue
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: loop {
         _x = 1;
-        continue;
+        continue       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: loop {
@@ -156,7 +175,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: loop {
@@ -167,9 +186,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, typeck, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: loop {
@@ -183,7 +204,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     loop {
@@ -192,13 +213,15 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes, typeck, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, typeck, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     loop {
         _x = 1;
-        break;
+        break   ;
     }
 }

--- a/src/test/incremental/hashes/match_expressions.rs
+++ b/src/test/incremental/hashes/match_expressions.rs
@@ -6,28 +6,35 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
-
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
 
 // Add Arm ---------------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_arm(x: u32) -> u32 {
     match x {
         0 => 0,
         1 => 1,
+        /*---*/
         _ => 100,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_arm(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -40,7 +47,7 @@ pub fn add_arm(x: u32) -> u32 {
 
 
 // Change Order Of Arms --------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_order_of_arms(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -49,10 +56,11 @@ pub fn change_order_of_arms(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_order_of_arms(x: u32) -> u32 {
     match x {
         1 => 1,
@@ -64,19 +72,20 @@ pub fn change_order_of_arms(x: u32) -> u32 {
 
 
 // Add Guard Clause ------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
-        1 => 1,
+        1      => 1,
         _ => 100,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
@@ -88,19 +97,20 @@ pub fn add_guard_clause(x: u32, y: bool) -> u32 {
 
 
 // Change Guard Clause ------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
-        1 if y => 1,
+        1 if  y => 1,
         _ => 100,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_guard_clause(x: u32, y: bool) -> u32 {
     match x {
         0 => 0,
@@ -112,19 +122,20 @@ pub fn change_guard_clause(x: u32, y: bool) -> u32 {
 
 
 // Add @-Binding ---------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
         1 => 1,
-        _ => x,
+            _ => x,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -136,7 +147,7 @@ pub fn add_at_binding(x: u32) -> u32 {
 
 
 // Change Name of @-Binding ----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_name_of_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -145,10 +156,11 @@ pub fn change_name_of_at_binding(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_name_of_at_binding(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -160,18 +172,19 @@ pub fn change_name_of_at_binding(x: u32) -> u32 {
 
 
 // Change Simple Binding To Pattern --------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_simple_name_to_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (0, 0) => 0,
-        a => 1,
+         a     => 1,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_simple_name_to_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (0, 0) => 0,
@@ -182,7 +195,7 @@ pub fn change_simple_name_to_pattern(x: u32) -> u32 {
 
 
 // Change Name In Pattern ------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_name_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (a, 0) => 0,
@@ -191,10 +204,11 @@ pub fn change_name_in_pattern(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_name_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (b, 0) => 0,
@@ -206,18 +220,19 @@ pub fn change_name_in_pattern(x: u32) -> u32 {
 
 
 // Change Mutability Of Binding In Pattern -------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
-        (a, 0) => 0,
+        (    a, 0) => 0,
         _ => 1,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (mut a, 0) => 0,
@@ -228,18 +243,19 @@ pub fn change_mutability_of_binding_in_pattern(x: u32) -> u32 {
 
 
 // Add `ref` To Binding In Pattern -------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
-        (a, 0) => 0,
+        (    a, 0) => 0,
         _ => 1,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
     match (x, x & 1) {
         (ref a, 0) => 0,
@@ -250,18 +266,19 @@ pub fn add_ref_to_binding_in_pattern(x: u32) -> u32 {
 
 
 // Add `&` To Binding In Pattern -------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
     match (&x, x & 1) {
-        (a, 0) => 0,
+        ( a, 0) => 0,
         _ => 1,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
     match (&x, x & 1) {
         (&a, 0) => 0,
@@ -272,7 +289,7 @@ pub fn add_amp_to_binding_in_pattern(x: u32) -> u32 {
 
 
 // Change RHS Of Arm -----------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_rhs_of_arm(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -281,10 +298,11 @@ pub fn change_rhs_of_arm(x: u32) -> u32 {
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_rhs_of_arm(x: u32) -> u32 {
     match x {
         0 => 0,
@@ -296,19 +314,20 @@ pub fn change_rhs_of_arm(x: u32) -> u32 {
 
 
 // Add Alternative To Arm ------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_alternative_to_arm(x: u32) -> u32 {
     match x {
-        0 => 0,
+        0     => 0,
         1 => 1,
         _ => 2,
     }
 }
 
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2",
-    except="hir_owner_nodes,optimized_mir,typeck")]
+#[cfg(not(any(cfail1,cfail4)))]
+#[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_alternative_to_arm(x: u32) -> u32 {
     match x {
         0 | 7 => 0,

--- a/src/test/incremental/hashes/statics.rs
+++ b/src/test/incremental/hashes/statics.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -17,86 +23,102 @@
 
 
 // Change static visibility
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 static STATIC_VISIBILITY: u8 = 0;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub static STATIC_VISIBILITY: u8 = 0;
 
 
 // Change static mutability
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 static STATIC_MUTABILITY: u8 = 0;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 static mut STATIC_MUTABILITY: u8 = 0;
 
 
 // Add linkage attribute
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 static STATIC_LINKAGE: u8 = 0;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 #[linkage="weak_odr"]
 static STATIC_LINKAGE: u8 = 0;
 
 
 // Add no_mangle attribute
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 static STATIC_NO_MANGLE: u8 = 0;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 #[no_mangle]
 static STATIC_NO_MANGLE: u8 = 0;
 
 
 // Add thread_local attribute
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 static STATIC_THREAD_LOCAL: u8 = 0;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 #[thread_local]
 static STATIC_THREAD_LOCAL: u8 = 0;
 
 
 // Change type from i16 to u64
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 static STATIC_CHANGE_TYPE_1: i16 = 0;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 static STATIC_CHANGE_TYPE_1: u64 = 0;
 
 
 // Change type from Option<i8> to Option<u16>
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 static STATIC_CHANGE_TYPE_2: Option<i8> = None;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+#[rustc_clean(cfg="cfail6")]
 static STATIC_CHANGE_TYPE_2: Option<u16> = None;
 
 
 // Change value between simple literals
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 static STATIC_CHANGE_VALUE_1: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     { 1 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     { 2 }
 };
 
@@ -104,31 +126,37 @@ static STATIC_CHANGE_VALUE_1: i16 = {
 // Change value between expressions
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 static STATIC_CHANGE_VALUE_2: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     { 1 + 1 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     { 1 + 2 }
 };
 
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 static STATIC_CHANGE_VALUE_3: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     { 2 + 3 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     { 2 * 3 }
 };
 
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 static STATIC_CHANGE_VALUE_4: i16 = {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     { 1 + 2 * 3 }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     { 1 + 2 * 4 }
 };
 
@@ -138,17 +166,21 @@ struct ReferencedType1;
 struct ReferencedType2;
 
 mod static_change_type_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedType1 as Type;
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedType2 as Type;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="cfail6")]
     static STATIC_CHANGE_TYPE_INDIRECTLY_1: Type = Type;
 
     #[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,type_of")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,type_of")]
+    #[rustc_clean(cfg="cfail6")]
     static STATIC_CHANGE_TYPE_INDIRECTLY_2: Option<Type> = None;
 }

--- a/src/test/incremental/hashes/struct_constructors.rs
+++ b/src/test/incremental/hashes/struct_constructors.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -21,7 +27,7 @@ pub struct RegularStruct {
 }
 
 // Change field value (regular struct)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_field_value_regular_struct() -> RegularStruct {
     RegularStruct {
         x: 0,
@@ -30,9 +36,11 @@ pub fn change_field_value_regular_struct() -> RegularStruct {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_field_value_regular_struct() -> RegularStruct {
     RegularStruct {
         x: 0,
@@ -44,7 +52,7 @@ pub fn change_field_value_regular_struct() -> RegularStruct {
 
 
 // Change field order (regular struct)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_field_order_regular_struct() -> RegularStruct {
     RegularStruct {
         x: 3,
@@ -53,9 +61,11 @@ pub fn change_field_order_regular_struct() -> RegularStruct {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_field_order_regular_struct() -> RegularStruct {
     RegularStruct {
         y: 4,
@@ -67,7 +77,7 @@ pub fn change_field_order_regular_struct() -> RegularStruct {
 
 
 // Add field (regular struct)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_field_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -77,13 +87,16 @@ pub fn add_field_regular_struct() -> RegularStruct {
 
     RegularStruct {
         x: 7,
+        // --
         .. struct1
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_field_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -101,7 +114,7 @@ pub fn add_field_regular_struct() -> RegularStruct {
 
 
 // Change field label (regular struct)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_field_label_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -116,9 +129,11 @@ pub fn change_field_label_regular_struct() -> RegularStruct {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_field_label_regular_struct() -> RegularStruct {
     let struct1 = RegularStruct {
         x: 3,
@@ -142,18 +157,20 @@ pub struct RegularStruct2 {
 }
 
 // Change constructor path (regular struct)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_path_regular_struct() {
-    let _ = RegularStruct {
+    let _ = RegularStruct  {
         x: 0,
         y: 1,
         z: 2,
     };
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_regular_struct() {
     let _ = RegularStruct2 {
         x: 0,
@@ -166,9 +183,9 @@ pub fn change_constructor_path_regular_struct() {
 
 // Change constructor path indirectly (regular struct)
 pub mod change_constructor_path_indirectly_regular_struct {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::RegularStruct as Struct;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::RegularStruct2 as Struct;
 
     #[rustc_clean(
@@ -176,6 +193,11 @@ pub mod change_constructor_path_indirectly_regular_struct {
         except="fn_sig,hir_owner,hir_owner_nodes,optimized_mir,typeck"
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        cfg="cfail5",
+        except="fn_sig,hir_owner,hir_owner_nodes,optimized_mir,typeck"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     pub fn function() -> Struct {
         Struct {
             x: 0,
@@ -190,14 +212,16 @@ pub mod change_constructor_path_indirectly_regular_struct {
 pub struct TupleStruct(i32, i64, i16);
 
 // Change field value (tuple struct)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_field_value_tuple_struct() -> TupleStruct {
     TupleStruct(0, 1, 2)
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_field_value_tuple_struct() -> TupleStruct {
     TupleStruct(0, 1, 3)
 }
@@ -207,14 +231,16 @@ pub fn change_field_value_tuple_struct() -> TupleStruct {
 pub struct TupleStruct2(u16, u16, u16);
 
 // Change constructor path (tuple struct)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_constructor_path_tuple_struct() {
-    let _ = TupleStruct(0, 1, 2);
+    let _ = TupleStruct (0, 1, 2);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_constructor_path_tuple_struct() {
     let _ = TupleStruct2(0, 1, 2);
 }
@@ -223,11 +249,16 @@ pub fn change_constructor_path_tuple_struct() {
 
 // Change constructor path indirectly (tuple struct)
 pub mod change_constructor_path_indirectly_tuple_struct {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::TupleStruct as Struct;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::TupleStruct2 as Struct;
 
+    #[rustc_clean(
+        cfg="cfail5",
+        except="fn_sig,hir_owner,hir_owner_nodes,optimized_mir,typeck"
+    )]
+    #[rustc_clean(cfg="cfail6")]
     #[rustc_clean(
         cfg="cfail2",
         except="fn_sig,hir_owner,hir_owner_nodes,optimized_mir,typeck"

--- a/src/test/incremental/hashes/struct_defs.rs
+++ b/src/test/incremental/hashes/struct_defs.rs
@@ -11,42 +11,53 @@
 // the same between rev2 and rev3.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
-
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
 #![crate_type="rlib"]
 
 // Layout ----------------------------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub struct LayoutPacked;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="type_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="type_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 #[repr(packed)]
 pub struct LayoutPacked;
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct LayoutC;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="type_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="type_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 #[repr(C)]
 struct LayoutC;
 
 
 // Tuple Struct Change Field Type ----------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct TupleStructFieldType(i32);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 // Note that changing the type of a field does not change the type of the struct or enum, but
 // adding/removing fields or changing a fields name or visibility does.
 struct TupleStructFieldType(
@@ -56,12 +67,14 @@ struct TupleStructFieldType(
 
 // Tuple Struct Add Field ------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct TupleStructAddField(i32);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct TupleStructAddField(
     i32,
     u32
@@ -70,23 +83,27 @@ struct TupleStructAddField(
 
 // Tuple Struct Field Visibility -----------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct TupleStructFieldVisibility(char);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct TupleStructFieldVisibility(pub char);
 
 
 // Record Struct Field Type ----------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct RecordStructFieldType { x: f32 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 // Note that changing the type of a field does not change the type of the struct or enum, but
 // adding/removing fields or changing a fields name or visibility does.
 struct RecordStructFieldType {
@@ -96,23 +113,27 @@ struct RecordStructFieldType {
 
 // Record Struct Field Name ----------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct RecordStructFieldName { x: f32 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct RecordStructFieldName { y: f32 }
 
 
 // Record Struct Add Field -----------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct RecordStructAddField { x: f32 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct RecordStructAddField {
     x: f32,
     y: () }
@@ -120,12 +141,14 @@ struct RecordStructAddField {
 
 // Record Struct Field Visibility ----------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct RecordStructFieldVisibility { x: f32 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,type_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct RecordStructFieldVisibility {
     pub x: f32
 }
@@ -133,34 +156,40 @@ struct RecordStructFieldVisibility {
 
 // Add Lifetime Parameter ------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct AddLifetimeParameter<'a>(&'a f32, &'a f64);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,type_of,generics_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,type_of,generics_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct AddLifetimeParameter<'a, 'b>(&'a f32, &'b f64);
 
 
 // Add Lifetime Parameter Bound ------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct AddLifetimeParameterBound<'a, 'b>(&'a f32, &'b f64);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct AddLifetimeParameterBound<'a, 'b: 'a>(
     &'a f32,
     &'b f64
 );
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct AddLifetimeParameterBoundWhereClause<'a, 'b>(&'a f32, &'b f64);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct AddLifetimeParameterBoundWhereClause<'a, 'b>(
     &'a f32,
     &'b f64)
@@ -169,12 +198,14 @@ struct AddLifetimeParameterBoundWhereClause<'a, 'b>(
 
 // Add Type Parameter ----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct AddTypeParameter<T1>(T1, T1);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,type_of,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,type_of,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct AddTypeParameter<T1, T2>(
      // The field contains the parent's Generics, so it's dirty even though its
      // type hasn't changed.
@@ -185,23 +216,27 @@ struct AddTypeParameter<T1, T2>(
 
 // Add Type Parameter Bound ----------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct AddTypeParameterBound<T>(T);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct AddTypeParameterBound<T: Send>(
     T
 );
 
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct AddTypeParameterBoundWhereClause<T>(T);
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 struct AddTypeParameterBoundWhereClause<T>(
     T
 ) where T: Sync;
@@ -214,17 +249,21 @@ struct AddTypeParameterBoundWhereClause<T>(
 // Note: there is no #[cfg(...)], so this is ALWAYS compiled
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub struct EmptyStruct;
 
 
 // Visibility ------------------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 struct Visibility;
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub struct Visibility;
 
 struct ReferencedType1;
@@ -232,13 +271,15 @@ struct ReferencedType2;
 
 // Tuple Struct Change Field Type Indirectly -----------------------------------
 mod tuple_struct_change_field_type_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedType2 as FieldType;
 
     #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     struct TupleStruct(
         FieldType
     );
@@ -247,13 +288,15 @@ mod tuple_struct_change_field_type_indirectly {
 
 // Record Struct Change Field Type Indirectly -----------------------------------
 mod record_struct_change_field_type_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedType1 as FieldType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedType2 as FieldType;
 
     #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     struct RecordStruct {
         _x: FieldType
     }
@@ -267,24 +310,28 @@ trait ReferencedTrait2 {}
 
 // Change Trait Bound Indirectly -----------------------------------------------
 mod change_trait_bound_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     struct Struct<T: Trait>(T);
 }
 
 // Change Trait Bound Indirectly In Where Clause -------------------------------
 mod change_trait_bound_indirectly_in_where_clause {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait1 as Trait;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait2 as Trait;
 
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     struct Struct<T>(T) where T : Trait;
 }

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -11,8 +11,14 @@
 // the same between rev2 and rev3.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -21,35 +27,41 @@
 
 
 // Change trait visibility
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitVisibility { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub trait TraitVisibility { }
 
 
 
 // Change trait unsafety
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitUnsafety { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 unsafe trait TraitUnsafety { }
 
 
 
 // Add method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddMethod {
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub trait TraitAddMethod {
     fn method();
 }
@@ -57,14 +69,16 @@ pub trait TraitAddMethod {
 
 
 // Change name of method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeMethodName {
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeMethodName {
     fn methodChanged();
 }
@@ -72,157 +86,227 @@ trait TraitChangeMethodName {
 
 
 // Add return type to method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddReturnType {
-    fn method();
+    //-----------------------------------------------------
+    //--------------------------
+    //-----------------------------------------------------
+    //--------------------------
+    fn method()       ;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddReturnType {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method() -> u32;
 }
 
 
 
 // Change return type of method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeReturnType {
+    // --------------------------------------------------------------------
+    // -------------------------
+    // --------------------------------------------------------------------
+    // -------------------------
     fn method() -> u32;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeReturnType {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method() -> u64;
 }
 
 
 
 // Add parameter to method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddParameterToMethod {
-    fn method();
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
+    fn method(      );
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddParameterToMethod {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(a: u32);
 }
 
 
 
 // Change name of method parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeMethodParameterName {
+    //------------------------------------------------------
+    //----------------------------------------------
+    //--------------------------
+    //----------------------------------------------
+    //--------------------------
     fn method(a: u32);
+
+    //------------------------------------------------------------------
+    //--------------------------
+    //------------------------------------------------------------------
+    //--------------------------
     fn with_default(x: i32) {}
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeMethodParameterName {
     // FIXME(#38501) This should preferably always be clean.
     #[rustc_clean(except="hir_owner", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(b: u32);
 
     #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn with_default(y: i32) {}
 }
 
 
 
 // Change type of method parameter (i32 => i64)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeMethodParameterType {
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
     fn method(a: i32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeMethodParameterType {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(a: i64);
 }
 
 
 
 // Change type of method parameter (&i32 => &mut i32)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeMethodParameterTypeRef {
-    fn method(a: &i32);
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
+    fn method(a: &    i32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeMethodParameterTypeRef {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(a: &mut i32);
 }
 
 
 
 // Change order of method parameters
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeMethodParametersOrder {
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
     fn method(a: i32, b: i64);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeMethodParametersOrder {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(b: i64, a: i32);
 }
 
 
 
 // Add default implementation to method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddMethodAutoImplementation {
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddMethodAutoImplementation {
     #[rustc_clean(except="hir_owner,associated_item", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,associated_item", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method() { }
 }
 
 
 
 // Change order of methods
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeOrderOfMethods {
     fn method0();
     fn method1();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeOrderOfMethods {
     fn method1();
     fn method0();
@@ -231,134 +315,198 @@ trait TraitChangeOrderOfMethods {
 
 
 // Change mode of self parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeModeSelfRefToMut {
-    fn method(&self);
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
+    fn method(&    self);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeModeSelfRefToMut {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(&mut self);
 }
 
 
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeModeSelfOwnToMut: Sized {
-    fn method(self) {}
+    // ----------------------------------------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------------------------------------
+    // -------------------------
+    fn method(    self) {}
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeModeSelfOwnToMut: Sized {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(mut self) {}
 }
 
 
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeModeSelfOwnToRef {
-    fn method(self);
+    // ----------------------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------------------
+    // -------------------------
+    fn method( self);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeModeSelfOwnToRef {
     #[rustc_clean(except="hir_owner,fn_sig,generics_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig,generics_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method(&self);
 }
 
 
 
 // Add unsafe modifier to method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddUnsafeModifier {
-    fn method();
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
+    fn method()       ;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddUnsafeModifier {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     unsafe fn method();
 }
 
 
 
 // Add extern modifier to method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddExternModifier {
-    fn method();
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
+    fn method()           ;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddExternModifier {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     extern "C" fn method();
 }
 
 
 
 // Change extern "C" to extern "stdcall"
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeExternCToRustIntrinsic {
-    extern "C" fn method();
+    // ----------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------
+    // -------------------------
+    extern "C"       fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeExternCToRustIntrinsic {
     #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     extern "stdcall" fn method();
 }
 
 
 
 // Add type parameter to method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTypeParameterToMethod {
-    fn method();
+    // -------------------------------------------------------------------------------
+    // -------------------------
+    // -------------------------------------------------------------------------------
+    // -------------------------
+    fn method   ();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTypeParameterToMethod {
     #[rustc_clean(except="hir_owner,generics_of,predicates_of,type_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,generics_of,predicates_of,type_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method<T>();
 }
 
 
 
 // Add lifetime parameter to method
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeParameterToMethod {
-    fn method();
+    // ----------------------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------------------
+    // -------------------------
+    fn method    ();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeParameterToMethod {
     #[rustc_clean(except="hir_owner,fn_sig,generics_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,fn_sig,generics_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method<'a>();
 }
 
@@ -369,137 +517,220 @@ trait ReferencedTrait0 { }
 trait ReferencedTrait1 { }
 
 // Add trait bound to method type parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTraitBoundToMethodTypeParameter {
-    fn method<T>();
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    fn method<T                  >();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTraitBoundToMethodTypeParameter {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method<T: ReferencedTrait0>();
 }
 
 
 
 // Add builtin bound to method type parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddBuiltinBoundToMethodTypeParameter {
-    fn method<T>();
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    fn method<T       >();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundToMethodTypeParameter {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method<T: Sized>();
 }
 
 
 
 // Add lifetime bound to method lifetime parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeBoundToMethodLifetimeParameter {
-    fn method<'a, 'b>(a: &'a u32, b: &'b u32);
+    // -----------
+    // -----------------------------------------------------------------------------
+    // --------------
+    //
+    // -------------------------
+    // -----------
+    // -----------------------------------------------------------------------------
+    // --------------
+    //
+    // -------------------------
+    fn method<'a, 'b    >(a: &'a u32, b: &'b u32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToMethodLifetimeParameter {
     #[rustc_clean(
         except="hir_owner,hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        except="hir_owner,hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
+        cfg="cfail5",
+    )]
+    #[rustc_clean(cfg="cfail6")]
     fn method<'a, 'b: 'a>(a: &'a u32, b: &'b u32);
 }
 
 
 
 // Add second trait bound to method type parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondTraitBoundToMethodTypeParameter {
-    fn method<T: ReferencedTrait0>();
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    fn method<T: ReferencedTrait0                   >();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondTraitBoundToMethodTypeParameter {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method<T: ReferencedTrait0 + ReferencedTrait1>();
 }
 
 
 
 // Add second builtin bound to method type parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
-    fn method<T: Sized>();
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    // ---------------------------------------------------------------------------
+    // -------------------------
+    fn method<T: Sized       >();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondBuiltinBoundToMethodTypeParameter {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method<T: Sized + Sync>();
 }
 
 
 
 // Add second lifetime bound to method lifetime parameter
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondLifetimeBoundToMethodLifetimeParameter {
-    fn method<'a, 'b, 'c: 'a>(a: &'a u32, b: &'b u32, c: &'c u32);
+    // -----------
+    // -----------------------------------------------------------------------------
+    // --------------
+    //
+    // -------------------------
+    // -----------
+    // -----------------------------------------------------------------------------
+    // --------------
+    //
+    // -------------------------
+    fn method<'a, 'b, 'c: 'a     >(a: &'a u32, b: &'b u32, c: &'c u32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeBoundToMethodLifetimeParameter {
     #[rustc_clean(
         except="hir_owner,hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        except="hir_owner,hir_owner_nodes,generics_of,predicates_of,fn_sig,type_of",
+        cfg="cfail5",
+    )]
+    #[rustc_clean(cfg="cfail6")]
     fn method<'a, 'b, 'c: 'a + 'b>(a: &'a u32, b: &'b u32, c: &'c u32);
 }
 
 
 
 // Add associated type
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddAssociatedType {
+    //--------------------------
+    //--------------------------
+    // -------------
 
-    #[rustc_clean(except="hir_owner", cfg="cfail2")]
-    #[rustc_clean(cfg="cfail3")]
+    //--------------------------
+    //--------------------------
+    //--------------------------
+    //--------------------------
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddAssociatedType {
+    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail6")]
     type Associated;
 
+    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method();
 }
 
 
 
 // Add trait bound to associated type
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTraitBoundToAssociatedType {
-    type Associated;
+    // ---------------------------------------------
+    // -------------------------
+    // ---------------------------------------------
+    // -------------------------
+    type Associated                  ;
 
     fn method();
 }
@@ -507,12 +738,16 @@ trait TraitAddTraitBoundToAssociatedType {
 
 // Apparently the type bound contributes to the predicates of the trait, but
 // does not change the associated item itself.
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTraitBoundToAssociatedType {
     #[rustc_clean(except="hir_owner", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     type Associated: ReferencedTrait0;
 
     fn method();
@@ -521,19 +756,27 @@ trait TraitAddTraitBoundToAssociatedType {
 
 
 // Add lifetime bound to associated type
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeBoundToAssociatedType<'a> {
-    type Associated;
+    // ---------------------------------------------
+    // -------------------------
+    // ---------------------------------------------
+    // -------------------------
+    type Associated    ;
 
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToAssociatedType<'a> {
     #[rustc_clean(except="hir_owner", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     type Associated: 'a;
 
     fn method();
@@ -542,19 +785,23 @@ trait TraitAddLifetimeBoundToAssociatedType<'a> {
 
 
 // Add default to associated type
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddDefaultToAssociatedType {
     type Associated;
 
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddDefaultToAssociatedType {
     #[rustc_clean(except="hir_owner,associated_item", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,associated_item", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     type Associated = ReferenceType0;
 
     fn method();
@@ -563,14 +810,16 @@ trait TraitAddDefaultToAssociatedType {
 
 
 // Add associated constant
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddAssociatedConstant {
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddAssociatedConstant {
     const Value: u32;
 
@@ -580,269 +829,331 @@ trait TraitAddAssociatedConstant {
 
 
 // Add initializer to associated constant
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddInitializerToAssociatedConstant {
     const Value: u32;
 
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddInitializerToAssociatedConstant {
     #[rustc_clean(except="hir_owner,associated_item", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,associated_item", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     const Value: u32 = 1;
 
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method();
 }
 
 
 
 // Change type of associated constant
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitChangeTypeOfAssociatedConstant {
+    // -----------------------------------------------------
+    // -------------------------
+    // -----------------------------------------------------
+    // -------------------------
     const Value: u32;
 
+    // -------------------------
+    // -------------------------
+    // -------------------------
+    // -------------------------
     fn method();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitChangeTypeOfAssociatedConstant {
     #[rustc_clean(except="hir_owner,type_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,type_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     const Value: f64;
 
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method();
 }
 
 
 
 // Add super trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSuperTrait { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSuperTrait : ReferencedTrait0 { }
 
 
 
 // Add builtin bound (Send or Copy)
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddBuiltiBound { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltiBound : Send { }
 
 
 
 // Add 'static lifetime bound to trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddStaticLifetimeBound { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddStaticLifetimeBound : 'static { }
 
 
 
 // Add super trait as second bound
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTraitAsSecondBound : ReferencedTrait0 { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTraitAsSecondBound : ReferencedTrait0 + ReferencedTrait1 { }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTraitAsSecondBoundFromBuiltin : Send { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTraitAsSecondBoundFromBuiltin : Send + ReferencedTrait0 { }
 
 
 
 // Add builtin bound as second bound
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddBuiltinBoundAsSecondBound : ReferencedTrait0 { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundAsSecondBound : ReferencedTrait0 + Send { }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin : Send { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundAsSecondBoundFromBuiltin: Send + Copy { }
 
 
 
 // Add 'static bounds as second bound
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddStaticBoundAsSecondBound : ReferencedTrait0 { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddStaticBoundAsSecondBound : ReferencedTrait0 + 'static { }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddStaticBoundAsSecondBoundFromBuiltin : Send { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddStaticBoundAsSecondBoundFromBuiltin : Send + 'static { }
 
 
 
 // Add type parameter to trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTypeParameterToTrait { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTypeParameterToTrait<T> { }
 
 
 
 // Add lifetime parameter to trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeParameterToTrait { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeParameterToTrait<'a> { }
 
 
 
 // Add trait bound to type parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTraitBoundToTypeParameterOfTrait<T> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0> { }
 
 
 
 // Add lifetime bound to type parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T: 'a> { }
 
 
 
 // Add lifetime bound to lifetime parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTrait<'a, 'b> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTrait<'a: 'b, 'b> { }
 
 
 
 // Add builtin bound to type parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddBuiltinBoundToTypeParameterOfTrait<T> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundToTypeParameterOfTrait<T: Send> { }
 
 
 
 // Add second type parameter to trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondTypeParameterToTrait<T> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondTypeParameterToTrait<T, S> { }
 
 
 
 // Add second lifetime parameter to trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondLifetimeParameterToTrait<'a> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeParameterToTrait<'a, 'b> { }
 
 
 
 // Add second trait bound to type parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0 + ReferencedTrait1> { }
 
 
 
 // Add second lifetime bound to type parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a + 'b> { }
 
 
 
 // Add second lifetime bound to lifetime parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTrait<'a: 'b, 'b, 'c> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTrait<'a: 'b + 'c, 'b, 'c> { }
 
 
 
 // Add second builtin bound to type parameter of trait
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTrait<T: Send> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTrait<T: Send + Sync> { }
 
 
@@ -853,105 +1164,125 @@ struct ReferenceType1 {}
 
 
 // Add trait bound to type parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferencedTrait0 { }
 
 
 
 // Add lifetime bound to type parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> where T: 'a { }
 
 
 
 // Add lifetime bound to lifetime parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b> where 'a: 'b { }
 
 
 
 // Add builtin bound to type parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddBuiltinBoundToTypeParameterOfTraitWhere<T> { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send { }
 
 
 
 // Add second trait bound to type parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferencedTrait0 { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T>
     where T: ReferencedTrait0 + ReferencedTrait1 { }
 
 
 
 // Add second lifetime bound to type parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a + 'b { }
 
 
 
 // Add second lifetime bound to lifetime parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b, 'c> where 'a: 'b { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeBoundToLifetimeParameterOfTraitWhere<'a, 'b, 'c> where 'a: 'b + 'c { }
 
 
 
 // Add second builtin bound to type parameter of trait in where clause
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send { }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondBuiltinBoundToTypeParameterOfTraitWhere<T> where T: Send + Sync { }
 
 
 // Change return type of method indirectly by modifying a use statement
 mod change_return_type_of_method_indirectly_use {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferenceType0 as ReturnType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferenceType1 as ReturnType;
 
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     trait TraitChangeReturnType {
         #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig", cfg="cfail2")]
         #[rustc_clean(cfg="cfail3")]
+        #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig", cfg="cfail5")]
+        #[rustc_clean(cfg="cfail6")]
         fn method() -> ReturnType;
     }
 }
@@ -960,9 +1291,9 @@ mod change_return_type_of_method_indirectly_use {
 
 // Change type of method parameter indirectly by modifying a use statement
 mod change_method_parameter_type_indirectly_by_use {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferenceType0 as ArgType;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferenceType1 as ArgType;
 
     #[rustc_clean(cfg="cfail2")]
@@ -978,9 +1309,9 @@ mod change_method_parameter_type_indirectly_by_use {
 
 // Change trait bound of method type parameter indirectly by modifying a use statement
 mod change_method_parameter_type_bound_indirectly_by_use {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait1 as Bound;
 
     #[rustc_clean(cfg="cfail2")]
@@ -997,16 +1328,20 @@ mod change_method_parameter_type_bound_indirectly_by_use {
 // Change trait bound of method type parameter in where clause indirectly
 // by modifying a use statement
 mod change_method_parameter_type_bound_indirectly_by_use_where {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait1 as Bound;
 
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     trait TraitChangeBoundOfMethodTypeParameterWhere {
         #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
         #[rustc_clean(cfg="cfail3")]
+        #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+        #[rustc_clean(cfg="cfail6")]
         fn method<T>(a: T) where T: Bound;
     }
 }
@@ -1015,9 +1350,9 @@ mod change_method_parameter_type_bound_indirectly_by_use_where {
 
 // Change trait bound of trait type parameter indirectly by modifying a use statement
 mod change_method_type_parameter_bound_indirectly {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait1 as Bound;
 
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
@@ -1032,13 +1367,15 @@ mod change_method_type_parameter_bound_indirectly {
 // Change trait bound of trait type parameter in where clause indirectly
 // by modifying a use statement
 mod change_method_type_parameter_bound_indirectly_where {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1,cfail4))]
     use super::ReferencedTrait0 as Bound;
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1,cfail4)))]
     use super::ReferencedTrait1 as Bound;
 
     #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     trait TraitChangeTraitBoundWhere<T> where T: Bound {
         fn method(a: T);
     }

--- a/src/test/incremental/hashes/trait_impls.rs
+++ b/src/test/incremental/hashes/trait_impls.rs
@@ -6,9 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
-
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -19,29 +24,35 @@ struct Foo;
 
 // Change Method Name -----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait ChangeMethodNameTrait {
     fn method_name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeMethodNameTrait for Foo {
     fn method_name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub trait ChangeMethodNameTrait {
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name2();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeMethodNameTrait for Foo {
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name2() { }
 }
 
@@ -53,17 +64,27 @@ pub trait ChangeMethodBodyTrait {
     fn method_name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeMethodBodyTrait for Foo {
-    fn method_name() { }
+    // ----------------------------------------------------------
+    // -------------------------
+    // ----------------------------------------------------------
+    // -------------------------
+    fn method_name() {
+        //
+    }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeMethodBodyTrait for Foo {
     #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner_nodes,typeck", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name() {
         ()
     }
@@ -77,18 +98,28 @@ pub trait ChangeMethodBodyTraitInlined {
     fn method_name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeMethodBodyTraitInlined for Foo {
+    // ------------------------------------------------------------------------
+    // -------------------------
+    // ------------------------------------------------------------------------
+    // -------------------------
     #[inline]
-    fn method_name() { }
+    fn method_name() {
+        // -----
+    }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeMethodBodyTraitInlined for Foo {
     #[rustc_clean(except="hir_owner_nodes,typeck,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner_nodes,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     #[inline]
     fn method_name() {
         panic!()
@@ -97,30 +128,37 @@ impl ChangeMethodBodyTraitInlined for Foo {
 
 // Change Method Selfness ------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait ChangeMethodSelfnessTrait {
     fn method_name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeMethodSelfnessTrait for Foo {
     fn method_name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait ChangeMethodSelfnessTrait {
     fn method_name(&self);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeMethodSelfnessTrait for Foo {
     #[rustc_clean(
         except="hir_owner,hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        except="hir_owner,hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
+        cfg="cfail5",
+    )]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name(&self) {
         ()
     }
@@ -128,130 +166,151 @@ impl ChangeMethodSelfnessTrait for Foo {
 
 // Change Method Selfness -----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait RemoveMethodSelfnessTrait {
     fn method_name(&self);
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl RemoveMethodSelfnessTrait for Foo {
     fn method_name(&self) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait RemoveMethodSelfnessTrait {
     fn method_name();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl RemoveMethodSelfnessTrait for Foo {
     #[rustc_clean(
         except="hir_owner,hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(
+        except="hir_owner,hir_owner_nodes,associated_item,generics_of,fn_sig,typeck,optimized_mir",
+        cfg="cfail5",
+    )]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name() {}
 }
 
 // Change Method Selfmutness -----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait ChangeMethodSelfmutnessTrait {
     fn method_name(&self);
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeMethodSelfmutnessTrait for Foo {
-    fn method_name(&self) { }
+    // -----------------------------------------------------------------------------------------
+    // -------------------------
+    // -----------------------------------------------------------------------------------------
+    // -------------------------
+    fn method_name(&    self) {}
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait ChangeMethodSelfmutnessTrait {
     fn method_name(&mut self);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeMethodSelfmutnessTrait for Foo {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name(&mut self) {}
 }
 
 // Change item kind -----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait ChangeItemKindTrait {
     fn name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeItemKindTrait for Foo {
     fn name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait ChangeItemKindTrait {
     type name;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeItemKindTrait for Foo {
     type name = ();
 }
 
 // Remove item -----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait RemoveItemTrait {
     type TypeName;
     fn method_name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl RemoveItemTrait for Foo {
     type TypeName = ();
     fn method_name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait RemoveItemTrait {
     type TypeName;
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl RemoveItemTrait for Foo {
     type TypeName = ();
 }
 
 // Add item -----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait AddItemTrait {
     type TypeName;
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl AddItemTrait for Foo {
     type TypeName = ();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait AddItemTrait {
     type TypeName;
     fn method_name();
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,associated_item_def_ids", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl AddItemTrait for Foo {
     type TypeName = ();
     fn method_name() { }
@@ -259,28 +318,34 @@ impl AddItemTrait for Foo {
 
 // Change has-value -----------------------------------------------------------
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait ChangeHasValueTrait {
     fn method_name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeHasValueTrait for Foo {
     fn method_name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub trait ChangeHasValueTrait {
     #[rustc_clean(except="hir_owner,associated_item", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,associated_item", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeHasValueTrait for Foo {
     fn method_name() { }
 }
@@ -291,69 +356,91 @@ pub trait AddDefaultTrait {
     fn method_name();
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl AddDefaultTrait for Foo {
-    fn method_name() { }
+    // -------------------------------------------------------------------------------------------
+    // -------------------------
+            fn method_name() { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl AddDefaultTrait for Foo {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,associated_item", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,associated_item,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     default fn method_name() { }
 }
 
 // Add arguments
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait AddArgumentTrait {
     fn method_name(&self);
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl AddArgumentTrait for Foo {
-    fn method_name(&self) { }
+    // -----------------------------------------------------------------------------------------
+    // -------------------------
+    // -----------------------------------------------------------------------------------------
+    // -------------------------
+    fn method_name(&self         ) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait AddArgumentTrait {
     fn method_name(&self, x: u32);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl AddArgumentTrait for Foo {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name(&self, _x: u32) { }
 }
 
 // Change argument type
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub trait ChangeArgumentTypeTrait {
     fn method_name(&self, x: u32);
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeArgumentTypeTrait for Foo {
-    fn method_name(&self, _x: u32) { }
+    // -----------------------------------------------------------------------------------------
+    // -------------------------
+    // -----------------------------------------------------------------------------------------
+    // -------------------------
+    fn method_name(&self, _x: u32 ) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 pub trait ChangeArgumentTypeTrait {
     fn method_name(&self, x: char);
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeArgumentTypeTrait for Foo {
     #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="hir_owner,hir_owner_nodes,fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn method_name(&self, _x: char) { }
 }
 
@@ -366,21 +453,28 @@ trait AddTypeParameterToImpl<T> {
     fn id(t: T) -> T;
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl AddTypeParameterToImpl<u32> for Bar<u32> {
     fn id(t: u32) -> u32 { t }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,generics_of,impl_trait_ref", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-impl<T> AddTypeParameterToImpl<T> for Bar<T> {
+#[rustc_clean(except="hir_owner,generics_of,impl_trait_ref", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
+impl<TTT> AddTypeParameterToImpl<TTT> for Bar<TTT> {
     #[rustc_clean(
         except="hir_owner,hir_owner_nodes,generics_of,fn_sig,type_of,typeck,optimized_mir",
         cfg="cfail2",
     )]
     #[rustc_clean(cfg="cfail3")]
-    fn id(t: T) -> T { t }
+    #[rustc_clean(
+        except="hir_owner,hir_owner_nodes,generics_of,fn_sig,type_of,typeck,optimized_mir",
+        cfg="cfail5",
+    )]
+    #[rustc_clean(cfg="cfail6")]
+    fn id(t: TTT) -> TTT { t }
 }
 
 
@@ -390,17 +484,21 @@ trait ChangeSelfTypeOfImpl {
     fn id(self) -> Self;
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl ChangeSelfTypeOfImpl for u32 {
     fn id(self) -> Self { self }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,impl_trait_ref", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,impl_trait_ref", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl ChangeSelfTypeOfImpl for u64 {
     #[rustc_clean(except="fn_sig,typeck,optimized_mir", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(except="fn_sig,typeck,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn id(self) -> Self { self }
 }
 
@@ -411,17 +509,21 @@ trait AddLifetimeBoundToImplParameter {
     fn id(self) -> Self;
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl<T> AddLifetimeBoundToImplParameter for T {
     fn id(self) -> Self { self }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl<T: 'static> AddLifetimeBoundToImplParameter for T {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn id(self) -> Self { self }
 }
 
@@ -432,17 +534,21 @@ trait AddTraitBoundToImplParameter {
     fn id(self) -> Self;
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl<T> AddTraitBoundToImplParameter for T {
     fn id(self) -> Self { self }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl<T: Clone> AddTraitBoundToImplParameter for T {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     fn id(self) -> Self { self }
 }
 
@@ -453,17 +559,26 @@ trait AddNoMangleToMethod {
     fn add_no_mangle_to_method(&self) { }
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl AddNoMangleToMethod for Foo {
+    // -------------------------
+    // -------------------------
+    // -------------------------
+    // -------------------------
+    // ---------
     fn add_no_mangle_to_method(&self) { }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl AddNoMangleToMethod for Foo {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     #[no_mangle]
     fn add_no_mangle_to_method(&self) { }
 }
@@ -474,17 +589,26 @@ trait MakeMethodInline {
     fn make_method_inline(&self) -> u8 { 0 }
 }
 
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 impl MakeMethodInline for Foo {
+    // -------------------------
+    // -------------------------
+    // -------------------------
+    // -------------------------
+    // ------
     fn make_method_inline(&self) -> u8 { 0 }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 impl MakeMethodInline for Foo {
     #[rustc_clean(cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
+    #[rustc_clean(cfg="cfail5")]
+    #[rustc_clean(cfg="cfail6")]
     #[inline]
     fn make_method_inline(&self) -> u8 { 0 }
 }

--- a/src/test/incremental/hashes/type_defs.rs
+++ b/src/test/incremental/hashes/type_defs.rs
@@ -12,7 +12,7 @@
 
 // build-pass (FIXME(62277): could be check-pass?)
 // revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// compile-flags: -Z query-dep-graph
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]

--- a/src/test/incremental/hashes/unary_and_binary_exprs.rs
+++ b/src/test/incremental/hashes/unary_and_binary_exprs.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -15,44 +21,50 @@
 
 
 // Change constant operand of negation -----------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn const_negation() -> i32 {
     -10
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn const_negation() -> i32 {
-    -1
+     -1
 }
 
 
 
 // Change constant operand of bitwise not --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn const_bitwise_not() -> i32 {
     !100
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn const_bitwise_not() -> i32 {
-    !99
+     !99
 }
 
 
 
 // Change variable operand of negation -----------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn var_negation(x: i32, y: i32) -> i32 {
     -x
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn var_negation(x: i32, y: i32) -> i32 {
     -y
 }
@@ -60,14 +72,16 @@ pub fn var_negation(x: i32, y: i32) -> i32 {
 
 
 // Change variable operand of bitwise not --------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn var_bitwise_not(x: i32, y: i32) -> i32 {
     !x
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn var_bitwise_not(x: i32, y: i32) -> i32 {
     !y
 }
@@ -75,14 +89,16 @@ pub fn var_bitwise_not(x: i32, y: i32) -> i32 {
 
 
 // Change variable operand of deref --------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn var_deref(x: &i32, y: &i32) -> i32 {
     *x
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn var_deref(x: &i32, y: &i32) -> i32 {
     *y
 }
@@ -90,14 +106,16 @@ pub fn var_deref(x: &i32, y: &i32) -> i32 {
 
 
 // Change first constant operand of addition -----------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn first_const_add() -> i32 {
     1 + 3
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn first_const_add() -> i32 {
     2 + 3
 }
@@ -105,14 +123,16 @@ pub fn first_const_add() -> i32 {
 
 
 // Change second constant operand of addition -----------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn second_const_add() -> i32 {
     1 + 2
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn second_const_add() -> i32 {
     1 + 3
 }
@@ -120,14 +140,16 @@ pub fn second_const_add() -> i32 {
 
 
 // Change first variable operand of addition -----------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn first_var_add(a: i32, b: i32) -> i32 {
     a + 2
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn first_var_add(a: i32, b: i32) -> i32 {
     b + 2
 }
@@ -135,14 +157,16 @@ pub fn first_var_add(a: i32, b: i32) -> i32 {
 
 
 // Change second variable operand of addition ----------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn second_var_add(a: i32, b: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn second_var_add(a: i32, b: i32) -> i32 {
     1 + b
 }
@@ -150,14 +174,16 @@ pub fn second_var_add(a: i32, b: i32) -> i32 {
 
 
 // Change operator from + to - -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn plus_to_minus(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn plus_to_minus(a: i32) -> i32 {
     1 - a
 }
@@ -165,14 +191,16 @@ pub fn plus_to_minus(a: i32) -> i32 {
 
 
 // Change operator from + to * -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn plus_to_mult(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn plus_to_mult(a: i32) -> i32 {
     1 * a
 }
@@ -180,14 +208,16 @@ pub fn plus_to_mult(a: i32) -> i32 {
 
 
 // Change operator from + to / -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn plus_to_div(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn plus_to_div(a: i32) -> i32 {
     1 / a
 }
@@ -195,14 +225,16 @@ pub fn plus_to_div(a: i32) -> i32 {
 
 
 // Change operator from + to % -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn plus_to_mod(a: i32) -> i32 {
     1 + a
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn plus_to_mod(a: i32) -> i32 {
     1 % a
 }
@@ -210,14 +242,16 @@ pub fn plus_to_mod(a: i32) -> i32 {
 
 
 // Change operator from && to || -----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn and_to_or(a: bool, b: bool) -> bool {
     a && b
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn and_to_or(a: bool, b: bool) -> bool {
     a || b
 }
@@ -225,14 +259,16 @@ pub fn and_to_or(a: bool, b: bool) -> bool {
 
 
 // Change operator from & to | -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn bitwise_and_to_bitwise_or(a: i32) -> i32 {
     1 & a
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn bitwise_and_to_bitwise_or(a: i32) -> i32 {
     1 | a
 }
@@ -240,14 +276,16 @@ pub fn bitwise_and_to_bitwise_or(a: i32) -> i32 {
 
 
 // Change operator from & to ^ -------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn bitwise_and_to_bitwise_xor(a: i32) -> i32 {
     1 & a
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn bitwise_and_to_bitwise_xor(a: i32) -> i32 {
     1 ^ a
 }
@@ -255,14 +293,16 @@ pub fn bitwise_and_to_bitwise_xor(a: i32) -> i32 {
 
 
 // Change operator from & to << ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn bitwise_and_to_lshift(a: i32) -> i32 {
-    a & 1
+    a  & 1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn bitwise_and_to_lshift(a: i32) -> i32 {
     a << 1
 }
@@ -270,14 +310,16 @@ pub fn bitwise_and_to_lshift(a: i32) -> i32 {
 
 
 // Change operator from & to >> ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn bitwise_and_to_rshift(a: i32) -> i32 {
-    a & 1
+    a  & 1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn bitwise_and_to_rshift(a: i32) -> i32 {
     a >> 1
 }
@@ -285,14 +327,16 @@ pub fn bitwise_and_to_rshift(a: i32) -> i32 {
 
 
 // Change operator from == to != -----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn eq_to_uneq(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn eq_to_uneq(a: i32) -> bool {
     a != 1
 }
@@ -300,44 +344,50 @@ pub fn eq_to_uneq(a: i32) -> bool {
 
 
 // Change operator from == to < ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn eq_to_lt(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn eq_to_lt(a: i32) -> bool {
-    a < 1
+    a  < 1
 }
 
 
 
 // Change operator from == to > ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn eq_to_gt(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn eq_to_gt(a: i32) -> bool {
-    a > 1
+    a  > 1
 }
 
 
 
 // Change operator from == to <= -----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn eq_to_le(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn eq_to_le(a: i32) -> bool {
     a <= 1
 }
@@ -345,14 +395,16 @@ pub fn eq_to_le(a: i32) -> bool {
 
 
 // Change operator from == to >= -----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn eq_to_ge(a: i32) -> bool {
     a == 1
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn eq_to_ge(a: i32) -> bool {
     a >= 1
 }
@@ -360,16 +412,18 @@ pub fn eq_to_ge(a: i32) -> bool {
 
 
 // Change type in cast expression ----------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn type_cast(a: u8) -> u64 {
     let b = a as i32;
     let c = b as u64;
     c
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir,typeck", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir,typeck", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn type_cast(a: u8) -> u64 {
     let b = a as u32;
     let c = b as u64;
@@ -379,14 +433,16 @@ pub fn type_cast(a: u8) -> u64 {
 
 
 // Change value in cast expression ---------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn value_cast(a: u32) -> i32 {
     1 as i32
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn value_cast(a: u32) -> i32 {
     2 as i32
 }
@@ -394,7 +450,7 @@ pub fn value_cast(a: u32) -> i32 {
 
 
 // Change place in assignment --------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn place() -> i32 {
     let mut x = 10;
     let mut y = 11;
@@ -402,9 +458,11 @@ pub fn place() -> i32 {
     x
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn place() -> i32 {
     let mut x = 10;
     let mut y = 11;
@@ -415,16 +473,18 @@ pub fn place() -> i32 {
 
 
 // Change r-value in assignment ------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn rvalue() -> i32 {
     let mut x = 10;
     x = 9;
     x
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn rvalue() -> i32 {
     let mut x = 10;
     x = 8;
@@ -434,14 +494,16 @@ pub fn rvalue() -> i32 {
 
 
 // Change index into slice -----------------------------------------------------
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn index_to_slice(s: &[u8], i: usize, j: usize) -> u8 {
     s[i]
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(except="hir_owner_nodes,optimized_mir", cfg="cfail5")]
+#[rustc_clean(cfg="cfail6")]
 pub fn index_to_slice(s: &[u8], i: usize, j: usize) -> u8 {
     s[j]
 }

--- a/src/test/incremental/hashes/while_let_loops.rs
+++ b/src/test/incremental/hashes/while_let_loops.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -15,7 +21,7 @@
 
 
 // Change loop body
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -24,9 +30,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -38,7 +46,7 @@ pub fn change_loop_body() {
 
 
 // Change loop body
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_loop_condition() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -47,9 +55,11 @@ pub fn change_loop_condition() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_loop_condition() {
     let mut _x = 0;
     while let Some(1u32) = None {
@@ -61,17 +71,20 @@ pub fn change_loop_condition() {
 
 
 // Add break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_break() {
     let mut _x = 0;
     while let Some(0u32) = None {
         _x = 1;
+        // ---
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -83,18 +96,20 @@ pub fn add_break() {
 
 
 // Add loop label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
-    while let Some(0u32) = None {
+            while let Some(0u32) = None {
         _x = 1;
         break;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -106,18 +121,20 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
         _x = 1;
-        break;
+        break       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -129,7 +146,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -140,9 +157,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -154,18 +173,20 @@ pub fn change_break_label() {
 }
 
 // Add loop label to continue
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
         _x = 1;
-        continue;
+        continue       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while let Some(0u32) = None {
@@ -177,7 +198,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -188,9 +209,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while let Some(0u32) = None {
@@ -204,7 +227,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while let Some(0u32) = None {
@@ -213,13 +236,15 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while let Some(0u32) = None {
         _x = 1;
-        break;
+        break   ;
     }
 }

--- a/src/test/incremental/hashes/while_loops.rs
+++ b/src/test/incremental/hashes/while_loops.rs
@@ -214,7 +214,7 @@ pub fn change_continue_label() {
 #[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck,optimized_mir")]
 #[rustc_clean(cfg="cfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;

--- a/src/test/incremental/hashes/while_loops.rs
+++ b/src/test/incremental/hashes/while_loops.rs
@@ -6,8 +6,14 @@
 // rev3 and make sure that the hash has not changed.
 
 // build-pass (FIXME(62277): could be check-pass?)
-// revisions: cfail1 cfail2 cfail3
-// compile-flags: -Z query-dep-graph -Zincremental-ignore-spans
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// compile-flags: -Z query-dep-graph
+// [cfail1]compile-flags: -Zincremental-ignore-spans
+// [cfail2]compile-flags: -Zincremental-ignore-spans
+// [cfail3]compile-flags: -Zincremental-ignore-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 
 #![allow(warnings)]
 #![feature(rustc_attrs)]
@@ -15,7 +21,7 @@
 
 
 // Change loop body
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_loop_body() {
     let mut _x = 0;
     while true {
@@ -24,9 +30,11 @@ pub fn change_loop_body() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_loop_body() {
     let mut _x = 0;
     while true {
@@ -38,18 +46,20 @@ pub fn change_loop_body() {
 
 
 // Change loop body
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_loop_condition() {
     let mut _x = 0;
-    while true {
+    while true  {
         _x = 1;
         break;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_loop_condition() {
     let mut _x = 0;
     while false {
@@ -61,17 +71,20 @@ pub fn change_loop_condition() {
 
 
 // Add break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_break() {
     let mut _x = 0;
     while true {
         _x = 1;
+        // ---
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir, typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir, typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_break() {
     let mut _x = 0;
     while true {
@@ -83,18 +96,20 @@ pub fn add_break() {
 
 
 // Add loop label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label() {
     let mut _x = 0;
-    while true {
+            while true {
         _x = 1;
         break;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label() {
     let mut _x = 0;
     'label: while true {
@@ -106,18 +121,20 @@ pub fn add_loop_label() {
 
 
 // Add loop label to break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while true {
         _x = 1;
-        break;
+        break       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_break() {
     let mut _x = 0;
     'label: while true {
@@ -129,7 +146,7 @@ pub fn add_loop_label_to_break() {
 
 
 // Change break label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while true {
@@ -140,9 +157,11 @@ pub fn change_break_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,optimized_mir,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_break_label() {
     let mut _x = 0;
     'outer: while true {
@@ -156,18 +175,20 @@ pub fn change_break_label() {
 
 
 // Add loop label to continue
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while true {
         _x = 1;
-        continue;
+        continue       ;
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes")]
+#[rustc_clean(cfg="cfail6")]
 pub fn add_loop_label_to_continue() {
     let mut _x = 0;
     'label: while true {
@@ -179,7 +200,7 @@ pub fn add_loop_label_to_continue() {
 
 
 // Change continue label
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while true {
@@ -190,9 +211,11 @@ pub fn change_continue_label() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes,typeck")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_label() {
     let mut _x = 0;
     'outer: while true {
@@ -206,7 +229,7 @@ pub fn change_continue_label() {
 
 
 // Change continue to break
-#[cfg(cfail1)]
+#[cfg(any(cfail1,cfail4))]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while true {
@@ -215,13 +238,15 @@ pub fn change_continue_to_break() {
     }
 }
 
-#[cfg(not(cfail1))]
+#[cfg(not(any(cfail1,cfail4)))]
 #[rustc_clean(cfg="cfail2", except="hir_owner_nodes, optimized_mir")]
 #[rustc_clean(cfg="cfail3")]
+#[rustc_clean(cfg="cfail5", except="hir_owner_nodes, optimized_mir")]
+#[rustc_clean(cfg="cfail6")]
 pub fn change_continue_to_break() {
     let mut _x = 0;
     while true {
         _x = 1;
-        break;
+        break   ;
     }
 }

--- a/src/test/incremental/spans_significant_w_debuginfo.rs
+++ b/src/test/incremental/spans_significant_w_debuginfo.rs
@@ -1,16 +1,21 @@
 // This test makes sure that just changing a definition's location in the
 // source file also changes its incr. comp. hash, if debuginfo is enabled.
 
-// revisions:rpass1 rpass2
+// revisions:rpass1 rpass2 rpass3 rpass4
 
 // ignore-asmjs wasm2js does not support source maps yet
 // compile-flags: -g -Z query-dep-graph
+// [rpass3]compile-flags: -Zincremental-relative-spans
+// [rpass4]compile-flags: -Zincremental-relative-spans
 
 #![feature(rustc_attrs)]
+#![rustc_partition_codegened(module = "spans_significant_w_debuginfo", cfg = "rpass2")]
+#![rustc_partition_codegened(module = "spans_significant_w_debuginfo", cfg = "rpass4")]
 
-#[cfg(rpass1)]
+#[cfg(any(rpass1, rpass3))]
 pub fn main() {}
 
-#[cfg(rpass2)]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,optimized_mir", cfg="rpass2")]
+#[cfg(any(rpass2, rpass4))]
+#[rustc_clean(except = "hir_owner,hir_owner_nodes,optimized_mir", cfg = "rpass2")]
+#[rustc_clean(cfg = "rpass4")]
 pub fn main() {}

--- a/src/test/incremental/spans_significant_w_panic.rs
+++ b/src/test/incremental/spans_significant_w_panic.rs
@@ -1,19 +1,29 @@
 // This test makes sure that just changing a definition's location in the
 // source file also changes its incr. comp. hash, if debuginfo is enabled.
 
-// revisions:rpass1 rpass2
+// revisions:rpass1 rpass2 rpass3 rpass4
+// [rpass3]compile-flags: -Zincremental-relative-spans
+// [rpass4]compile-flags: -Zincremental-relative-spans
 
 // compile-flags: -C overflow-checks=on -Z query-dep-graph
 
 #![feature(rustc_attrs)]
+#![feature(bench_black_box)]
+#![rustc_partition_codegened(module = "spans_significant_w_panic", cfg = "rpass2")]
+#![rustc_partition_codegened(module = "spans_significant_w_panic", cfg = "rpass4")]
 
-#[cfg(rpass1)]
+#[cfg(any(rpass1, rpass3))]
 pub fn main() {
-    let _ = 0u8 + 1;
+    if std::hint::black_box(false) {
+        panic!()
+    }
 }
 
-#[cfg(rpass2)]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,optimized_mir", cfg="rpass2")]
+#[cfg(any(rpass2, rpass4))]
+#[rustc_clean(except = "hir_owner,hir_owner_nodes,optimized_mir", cfg = "rpass2")]
+#[rustc_clean(cfg = "rpass4")]
 pub fn main() {
-    let _ = 0u8 + 1;
+    if std::hint::black_box(false) {
+        panic!()
+    }
 }

--- a/src/test/incremental/string_constant.rs
+++ b/src/test/incremental/string_constant.rs
@@ -1,5 +1,7 @@
-// revisions: cfail1 cfail2
+// revisions: cfail1 cfail2 cfail3 cfail4
 // compile-flags: -Z query-dep-graph
+// [cfail3]compile-flags: -Zincremental-relative-spans
+// [cfail4]compile-flags: -Zincremental-relative-spans
 // build-pass (FIXME(62277): could be check-pass?)
 
 #![allow(warnings)]
@@ -10,15 +12,15 @@
 // Therefore, the compiler deduces (correctly) that typeck is not
 // needed even for callers of `x`.
 
-
 pub mod x {
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1, cfail3))]
     pub fn x() {
         println!("{}", "1");
     }
 
-    #[cfg(cfail2)]
-    #[rustc_clean(except="hir_owner,hir_owner_nodes,optimized_mir,promoted_mir", cfg="cfail2")]
+    #[cfg(any(cfail2, cfail4))]
+    #[rustc_clean(except = "hir_owner,hir_owner_nodes,optimized_mir,promoted_mir", cfg = "cfail2")]
+    #[rustc_clean(except = "hir_owner_nodes,promoted_mir", cfg = "cfail4")]
     pub fn x() {
         println!("{}", "2");
     }
@@ -27,7 +29,8 @@ pub mod x {
 pub mod y {
     use x;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg = "cfail2")]
+    #[rustc_clean(cfg = "cfail4")]
     pub fn y() {
         x::x();
     }
@@ -36,7 +39,8 @@ pub mod y {
 pub mod z {
     use y;
 
-    #[rustc_clean(cfg="cfail2")]
+    #[rustc_clean(cfg = "cfail2")]
+    #[rustc_clean(cfg = "cfail4")]
     pub fn z() {
         y::y();
     }

--- a/src/test/incremental/thinlto/cgu_keeps_identical_fn.rs
+++ b/src/test/incremental/thinlto/cgu_keeps_identical_fn.rs
@@ -3,36 +3,61 @@
 // ends up with any spans in its LLVM bitecode, so LLVM is able to skip
 // re-building any modules which import 'inlined_fn'
 
-// revisions: cfail1 cfail2 cfail3
+// revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
+// [cfail4]compile-flags: -Zincremental-relative-spans
+// [cfail5]compile-flags: -Zincremental-relative-spans
+// [cfail6]compile-flags: -Zincremental-relative-spans
 // compile-flags: -Z query-dep-graph -O
 // build-pass (FIXME(62277): could be check-pass?)
 
 #![feature(rustc_attrs)]
-#![crate_type="rlib"]
-
-#![rustc_expected_cgu_reuse(module="cgu_keeps_identical_fn-foo",
-                            cfg="cfail2",
-                            kind="no")]
-#![rustc_expected_cgu_reuse(module="cgu_keeps_identical_fn-foo",
-                            cfg="cfail3",
-                            kind="post-lto")]
-
-#![rustc_expected_cgu_reuse(module="cgu_keeps_identical_fn-bar",
-                            cfg="cfail2",
-                            kind="post-lto")]
-#![rustc_expected_cgu_reuse(module="cgu_keeps_identical_fn-bar",
-                            cfg="cfail3",
-                            kind="post-lto")]
+#![crate_type = "rlib"]
+#![rustc_expected_cgu_reuse(module = "cgu_keeps_identical_fn-foo", cfg = "cfail2", kind = "no")]
+#![rustc_expected_cgu_reuse(
+    module = "cgu_keeps_identical_fn-foo",
+    cfg = "cfail3",
+    kind = "post-lto"
+)]
+#![rustc_expected_cgu_reuse(
+    module = "cgu_keeps_identical_fn-foo",
+    cfg = "cfail5",
+    kind = "post-lto"
+)]
+#![rustc_expected_cgu_reuse(
+    module = "cgu_keeps_identical_fn-foo",
+    cfg = "cfail6",
+    kind = "post-lto"
+)]
+#![rustc_expected_cgu_reuse(
+    module = "cgu_keeps_identical_fn-bar",
+    cfg = "cfail2",
+    kind = "post-lto"
+)]
+#![rustc_expected_cgu_reuse(
+    module = "cgu_keeps_identical_fn-bar",
+    cfg = "cfail3",
+    kind = "post-lto"
+)]
+#![rustc_expected_cgu_reuse(
+    module = "cgu_keeps_identical_fn-bar",
+    cfg = "cfail5",
+    kind = "post-lto"
+)]
+#![rustc_expected_cgu_reuse(
+    module = "cgu_keeps_identical_fn-bar",
+    cfg = "cfail6",
+    kind = "post-lto"
+)]
 
 mod foo {
 
     // Trivial functions like this one are imported very reliably by ThinLTO.
-    #[cfg(cfail1)]
+    #[cfg(any(cfail1, cfail4))]
     pub fn inlined_fn() -> u32 {
         1234
     }
 
-    #[cfg(not(cfail1))]
+    #[cfg(not(any(cfail1, cfail4)))]
     pub fn inlined_fn() -> u32 {
         1234
     }

--- a/src/tools/clippy/clippy_lints/src/attrs.rs
+++ b/src/tools/clippy/clippy_lints/src/attrs.rs
@@ -527,8 +527,8 @@ fn check_empty_line_after_outer_attr(cx: &EarlyContext<'_>, item: &rustc_ast::It
                 return;
             }
 
-            let begin_of_attr_to_item = Span::new(attr.span.lo(), item.span.lo(), item.span.ctxt());
-            let end_of_attr_to_item = Span::new(attr.span.hi(), item.span.lo(), item.span.ctxt());
+            let begin_of_attr_to_item = Span::new(attr.span.lo(), item.span.lo(), item.span.ctxt(), item.span.parent());
+            let end_of_attr_to_item = Span::new(attr.span.hi(), item.span.lo(), item.span.ctxt(), item.span.parent());
 
             if let Some(snippet) = snippet_opt(cx, end_of_attr_to_item) {
                 let lines = snippet.split('\n').collect::<Vec<_>>();

--- a/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
+++ b/src/tools/clippy/clippy_lints/src/cognitive_complexity.rs
@@ -95,7 +95,7 @@ impl CognitiveComplexity {
                     });
 
                     if let Some((low, high)) = pos {
-                        Span::new(low, high, header_span.ctxt())
+                        Span::new(low, high, header_span.ctxt(), header_span.parent())
                     } else {
                         return;
                     }

--- a/src/tools/clippy/clippy_lints/src/copies.rs
+++ b/src/tools/clippy/clippy_lints/src/copies.rs
@@ -472,7 +472,7 @@ fn emit_branches_sharing_code_lint(
 
         let mut span = moved_start.to(span_end);
         // Improve formatting if the inner block has indention (i.e. normal Rust formatting)
-        let test_span = Span::new(span.lo() - BytePos(4), span.lo(), span.ctxt());
+        let test_span = Span::new(span.lo() - BytePos(4), span.lo(), span.ctxt(), span.parent());
         if snippet_opt(cx, test_span)
             .map(|snip| snip == "    ")
             .unwrap_or_default()

--- a/src/tools/clippy/clippy_lints/src/doc.rs
+++ b/src/tools/clippy/clippy_lints/src/doc.rs
@@ -665,6 +665,7 @@ fn check_text(cx: &LateContext<'_>, valid_idents: &FxHashSet<String>, text: &str
             span.lo() + BytePos::from_usize(offset),
             span.lo() + BytePos::from_usize(offset + word.len()),
             span.ctxt(),
+            span.parent(),
         );
 
         check_word(cx, word, span);

--- a/src/tools/clippy/clippy_lints/src/implicit_hasher.rs
+++ b/src/tools/clippy/clippy_lints/src/implicit_hasher.rs
@@ -130,7 +130,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitHasher {
                         let pos = snippet_opt(cx, item.span.until(target.span()))
                             .and_then(|snip| Some(item.span.lo() + BytePos(snip.find("impl")? as u32 + 4)));
                         if let Some(pos) = pos {
-                            Span::new(pos, pos, item.span.data().ctxt)
+                            Span::new(pos, pos, item.span.ctxt(), item.span.parent())
                         } else {
                             return;
                         }
@@ -173,7 +173,7 @@ impl<'tcx> LateLintPass<'tcx> for ImplicitHasher {
                                     Some(item.span.lo() + BytePos((i + (&snip[i..]).find('(')?) as u32))
                                 })
                                 .expect("failed to create span for type parameters");
-                            Span::new(pos, pos, item.span.data().ctxt)
+                            Span::new(pos, pos, item.span.ctxt(), item.span.parent())
                         });
 
                         let mut ctr_vis = ImplicitHasherConstructorVisitor::new(cx, target);

--- a/src/tools/clippy/clippy_lints/src/large_const_arrays.rs
+++ b/src/tools/clippy/clippy_lints/src/large_const_arrays.rs
@@ -63,6 +63,7 @@ impl<'tcx> LateLintPass<'tcx> for LargeConstArrays {
                     hi_pos - BytePos::from_usize("const".len()),
                     hi_pos,
                     item.span.ctxt(),
+                    item.span.parent(),
                 );
                 span_lint_and_then(
                     cx,

--- a/src/tools/clippy/clippy_lints/src/methods/manual_split_once.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/manual_split_once.rs
@@ -182,7 +182,7 @@ fn parse_iter_usage(
                 },
                 _,
             ) => {
-                let parent_span = e.span.parent().unwrap();
+                let parent_span = e.span.parent_callsite().unwrap();
                 if parent_span.ctxt() == ctxt {
                     (Some(UnwrapKind::QuestionMark), parent_span)
                 } else {

--- a/src/tools/clippy/clippy_lints/src/module_style.rs
+++ b/src/tools/clippy/clippy_lints/src/module_style.rs
@@ -120,7 +120,7 @@ impl EarlyLintPass for ModStyle {
                     correct.push("mod.rs");
                     cx.struct_span_lint(
                         SELF_NAMED_MODULE_FILES,
-                        Span::new(file.start_pos, file.start_pos, SyntaxContext::root()),
+                        Span::new(file.start_pos, file.start_pos, SyntaxContext::root(), None),
                         |build| {
                             let mut lint =
                                 build.build(&format!("`mod.rs` files are required, found `{}`", path.display()));
@@ -167,7 +167,7 @@ fn check_self_named_mod_exists(cx: &EarlyContext<'_>, path: &Path, file: &Source
 
         cx.struct_span_lint(
             MOD_MODULE_FILES,
-            Span::new(file.start_pos, file.start_pos, SyntaxContext::root()),
+            Span::new(file.start_pos, file.start_pos, SyntaxContext::root(), None),
             |build| {
                 let mut lint = build.build(&format!("`mod.rs` files are not allowed, found `{}`", path.display()));
                 lint.help(&format!("move `{}` to `{}`", path.display(), mod_file.display(),));

--- a/src/tools/clippy/clippy_lints/src/regex.rs
+++ b/src/tools/clippy/clippy_lints/src/regex.rs
@@ -91,7 +91,7 @@ fn str_span(base: Span, c: regex_syntax::ast::Span, offset: u16) -> Span {
     let end = base.lo() + BytePos(u32::try_from(c.end.offset).expect("offset too large") + offset);
     let start = base.lo() + BytePos(u32::try_from(c.start.offset).expect("offset too large") + offset);
     assert!(start <= end);
-    Span::new(start, end, base.ctxt())
+    Span::new(start, end, base.ctxt(), base.parent())
 }
 
 fn const_str<'tcx>(cx: &LateContext<'tcx>, e: &'tcx Expr<'_>) -> Option<String> {

--- a/src/tools/clippy/clippy_lints/src/tabs_in_doc_comments.rs
+++ b/src/tools/clippy/clippy_lints/src/tabs_in_doc_comments.rs
@@ -69,6 +69,7 @@ impl TabsInDocComments {
                     attr.span.lo() + BytePos(3 + lo),
                     attr.span.lo() + BytePos(3 + hi),
                     attr.span.ctxt(),
+                    attr.span.parent(),
                 );
                 span_lint_and_sugg(
                     cx,

--- a/src/tools/rustfmt/src/macros.rs
+++ b/src/tools/rustfmt/src/macros.rs
@@ -1270,7 +1270,12 @@ impl MacroParser {
                 let data = delimited_span.entire().data();
                 (
                     data.hi,
-                    Span::new(data.lo + BytePos(1), data.hi - BytePos(1), data.ctxt),
+                    Span::new(
+                        data.lo + BytePos(1),
+                        data.hi - BytePos(1),
+                        data.ctxt,
+                        data.parent,
+                    ),
                     delimited_span.entire(),
                 )
             }

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -356,11 +356,11 @@ macro_rules! source {
 }
 
 pub(crate) fn mk_sp(lo: BytePos, hi: BytePos) -> Span {
-    Span::new(lo, hi, SyntaxContext::root())
+    Span::new(lo, hi, SyntaxContext::root(), None)
 }
 
 pub(crate) fn mk_sp_lo_plus_one(lo: BytePos) -> Span {
-    Span::new(lo, lo + BytePos(1), SyntaxContext::root())
+    Span::new(lo, lo + BytePos(1), SyntaxContext::root(), None)
 }
 
 // Returns `true` if the given span does not intersect with file lines.


### PR DESCRIPTION
The aim of this PR is to avoid recomputing queries when code is moved without modification.

MCP at https://github.com/rust-lang/compiler-team/issues/443

This is achieved by :
1. storing the HIR owner LocalDefId information inside the span;
2. encoding and decoding spans relative to the enclosing item in the incremental on-disk cache;
3. marking a dependency to the `source_span(LocalDefId)` query when we translate a span from the short (`Span`) representation to its explicit (`SpanData`) representation.

Since all client code uses `Span`, step 3 ensures that all manipulations
of span byte positions actually create the dependency edge between
the caller and the `source_span(LocalDefId)`.
This query return the actual absolute span of the parent item.
As a consequence, any source code motion that changes the absolute byte position of a node will either:
- modify the distance to the parent's beginning, so change the relative span's hash;
- dirty `source_span`, and trigger the incremental recomputation of all code that
  depends on the span's absolute byte position.

With this scheme, I believe the dependency tracking to be accurate.

For the moment, the spans are marked during lowering.
I'd rather do this during def-collection,
but the AST MutVisitor is not practical enough just yet.
The only difference is that we attach macro-expanded spans
to their expansion point instead of the macro itself.