### PR TITLE
[beta] Beta rollups

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1310,7 +1310,11 @@ mod return_keyword {}
 /// [Reference]: ../reference/items/associated-items.html#methods
 mod self_keyword {}
 
-#[doc(keyword = "Self")]
+// FIXME: Once rustdoc can handle URL conflicts on case insensitive file systems, we can remove the
+// three next lines and put back: `#[doc(keyword = "Self")]`.
+#[doc(alias = "Self")]
+#[allow(rustc::existing_doc_keyword)]
+#[doc(keyword = "SelfTy")]
 //
 /// The implementing type within a [`trait`] or [`impl`] block, or the current type within a type
 /// definition.

--- a/src/ci/docker/host-x86_64/dist-riscv64-linux/riscv64-unknown-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-riscv64-linux/riscv64-unknown-linux-gnu.config
@@ -644,7 +644,7 @@ CT_EXPAT_PATCH_GLOBAL=y
 CT_EXPAT_PATCH_ORDER="global"
 CT_EXPAT_V_2_2=y
 # CT_EXPAT_NO_VERSIONS is not set
-CT_EXPAT_VERSION="2.2.6"
+CT_EXPAT_VERSION="2.3.0"
 CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"


### PR DESCRIPTION
- Upgrade expat dependency in riscv64 to newer version. #84394
- Fix Self keyword doc URL conflict on case insensitive file systems (until definitely fixed on rustdoc) #83678
- Cargo:
    - Backport "Don't give a hard error when the end-user specifies RUSTC_BOOTSTRAP=crate_name" (rust-lang/cargo#9385)
    - [beta] Revert rust-lang/cargo#9133, moving to git HEAD dependencies by default (rust-lang/cargo#9383)