### PR TITLE
Enforce that `closure: 'a` requires that `closure_ret_ty: 'a` holds

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsicck.rs
@@ -108,7 +108,7 @@ pub struct InlineAsmCtxt<'a, 'tcx> {
     get_operand_ty: Box<dyn Fn(&'tcx hir::Expr<'tcx>) -> Ty<'tcx> + 'a>,
 }
 
-impl<'a, 'tcx> InlineAsmCtxt<'a, 'tcx> {
+impl<'a, 'tcx: 'a> InlineAsmCtxt<'a, 'tcx> {
     pub fn new_global_asm(tcx: TyCtxt<'tcx>) -> Self {
         InlineAsmCtxt {
             tcx,

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -335,7 +335,7 @@ pub struct InferCtxt<'tcx> {
     universe: Cell<ty::UniverseIndex>,
 
     normalize_fn_sig_for_diagnostic:
-        Option<Lrc<dyn Fn(&InferCtxt<'tcx>, ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx>>>,
+        Option<Lrc<dyn Fn(&InferCtxt<'tcx>, ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx> + 'tcx>>,
 }
 
 /// See the `error_reporting` module for more details.
@@ -552,7 +552,7 @@ pub struct InferCtxtBuilder<'tcx> {
     defining_use_anchor: DefiningAnchor,
     considering_regions: bool,
     normalize_fn_sig_for_diagnostic:
-        Option<Lrc<dyn Fn(&InferCtxt<'tcx>, ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx>>>,
+        Option<Lrc<dyn Fn(&InferCtxt<'tcx>, ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx> + 'tcx>>,
 }
 
 pub trait TyCtxtInferExt<'tcx> {
@@ -589,7 +589,7 @@ impl<'tcx> InferCtxtBuilder<'tcx> {
 
     pub fn with_normalize_fn_sig_for_diagnostic(
         mut self,
-        fun: Lrc<dyn Fn(&InferCtxt<'tcx>, ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx>>,
+        fun: Lrc<dyn Fn(&InferCtxt<'tcx>, ty::PolyFnSig<'tcx>) -> ty::PolyFnSig<'tcx> + 'tcx>,
     ) -> Self {
         self.normalize_fn_sig_for_diagnostic = Some(fun);
         self

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -76,7 +76,7 @@ where
         R: Try<Output = Acc>,
     {
         #[inline]
-        fn enumerate<'a, T, Acc, R>(
+        fn enumerate<'a, T, Acc, R: 'a>(
             count: &'a mut usize,
             mut fold: impl FnMut(Acc, (usize, T)) -> R + 'a,
         ) -> impl FnMut(Acc, T) -> R + 'a {

--- a/library/core/src/iter/adapters/filter.rs
+++ b/library/core/src/iter/adapters/filter.rs
@@ -37,7 +37,7 @@ fn filter_fold<T, Acc>(
     move |acc, item| if predicate(&item) { fold(acc, item) } else { acc }
 }
 
-fn filter_try_fold<'a, T, Acc, R: Try<Output = Acc>>(
+fn filter_try_fold<'a, T, Acc, R: Try<Output = Acc> + 'a>(
     predicate: &'a mut impl FnMut(&T) -> bool,
     mut fold: impl FnMut(Acc, T) -> R + 'a,
 ) -> impl FnMut(Acc, T) -> R + 'a {

--- a/library/core/src/iter/adapters/filter_map.rs
+++ b/library/core/src/iter/adapters/filter_map.rs
@@ -39,7 +39,7 @@ fn filter_map_fold<T, B, Acc>(
     }
 }
 
-fn filter_map_try_fold<'a, T, B, Acc, R: Try<Output = Acc>>(
+fn filter_map_try_fold<'a, T, B, Acc, R: Try<Output = Acc> + 'a>(
     f: &'a mut impl FnMut(T) -> Option<B>,
     mut fold: impl FnMut(Acc, B) -> R + 'a,
 ) -> impl FnMut(Acc, T) -> R + 'a {
@@ -94,9 +94,9 @@ where
     #[inline]
     fn next_back(&mut self) -> Option<B> {
         #[inline]
-        fn find<T, B>(
-            f: &mut impl FnMut(T) -> Option<B>,
-        ) -> impl FnMut((), T) -> ControlFlow<B> + '_ {
+        fn find<'a, T, B: 'a>(
+            f: &'a mut impl FnMut(T) -> Option<B>,
+        ) -> impl FnMut((), T) -> ControlFlow<B> + 'a {
             move |(), x| match f(x) {
                 Some(x) => ControlFlow::Break(x),
                 None => ControlFlow::CONTINUE,

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -334,9 +334,9 @@ where
         Fold: FnMut(Acc, U) -> Acc,
     {
         #[inline]
-        fn flatten<T: IntoIterator, Acc>(
-            fold: &mut impl FnMut(Acc, T::IntoIter) -> Acc,
-        ) -> impl FnMut(Acc, T) -> Acc + '_ {
+        fn flatten<'a, T: IntoIterator, Acc: 'a>(
+            fold: &'a mut impl FnMut(Acc, T::IntoIter) -> Acc,
+        ) -> impl FnMut(Acc, T) -> Acc + 'a {
             move |acc, iter| fold(acc, iter.into_iter())
         }
 
@@ -365,7 +365,7 @@ where
         R: Try<Output = Acc>,
     {
         #[inline]
-        fn flatten<'a, T: IntoIterator, Acc, R: Try<Output = Acc>>(
+        fn flatten<'a, T: IntoIterator, Acc, R: Try<Output = Acc> + 'a>(
             frontiter: &'a mut Option<T::IntoIter>,
             fold: &'a mut impl FnMut(Acc, &mut T::IntoIter) -> R,
         ) -> impl FnMut(Acc, T) -> R + 'a {
@@ -403,9 +403,9 @@ where
         Fold: FnMut(Acc, U) -> Acc,
     {
         #[inline]
-        fn flatten<T: IntoIterator, Acc>(
-            fold: &mut impl FnMut(Acc, T::IntoIter) -> Acc,
-        ) -> impl FnMut(Acc, T) -> Acc + '_ {
+        fn flatten<'a, T: IntoIterator, Acc: 'a>(
+            fold: &'a mut impl FnMut(Acc, T::IntoIter) -> Acc,
+        ) -> impl FnMut(Acc, T) -> Acc + 'a {
             move |acc, iter| fold(acc, iter.into_iter())
         }
 
@@ -434,7 +434,7 @@ where
         R: Try<Output = Acc>,
     {
         #[inline]
-        fn flatten<'a, T: IntoIterator, Acc, R: Try>(
+        fn flatten<'a, T: IntoIterator, Acc, R: Try + 'a>(
             backiter: &'a mut Option<T::IntoIter>,
             fold: &'a mut impl FnMut(Acc, &mut T::IntoIter) -> R,
         ) -> impl FnMut(Acc, T) -> R + 'a {

--- a/library/core/src/iter/adapters/inspect.rs
+++ b/library/core/src/iter/adapters/inspect.rs
@@ -54,7 +54,7 @@ fn inspect_fold<T, Acc>(
     }
 }
 
-fn inspect_try_fold<'a, T, Acc, R>(
+fn inspect_try_fold<'a, T, Acc, R: 'a>(
     f: &'a mut impl FnMut(&T),
     mut fold: impl FnMut(Acc, T) -> R + 'a,
 ) -> impl FnMut(Acc, T) -> R + 'a {

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -84,7 +84,7 @@ fn map_fold<T, B, Acc>(
     move |acc, elt| g(acc, f(elt))
 }
 
-fn map_try_fold<'a, T, B, Acc, R>(
+fn map_try_fold<'a, T, B, Acc, R: 'a>(
     f: &'a mut impl FnMut(T) -> B,
     mut g: impl FnMut(Acc, B) -> R + 'a,
 ) -> impl FnMut(Acc, T) -> R + 'a {

--- a/library/core/src/iter/adapters/scan.rs
+++ b/library/core/src/iter/adapters/scan.rs
@@ -58,7 +58,7 @@ where
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
-        fn scan<'a, T, St, B, Acc, R: Try<Output = Acc>>(
+        fn scan<'a, T, St, B, Acc: 'a, R: Try<Output = Acc> + 'a>(
             state: &'a mut St,
             f: &'a mut impl FnMut(&mut St, T) -> Option<B>,
             mut fold: impl FnMut(Acc, B) -> R + 'a,

--- a/library/core/src/iter/adapters/take.rs
+++ b/library/core/src/iter/adapters/take.rs
@@ -79,7 +79,7 @@ where
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
-        fn check<'a, T, Acc, R: Try<Output = Acc>>(
+        fn check<'a, T, Acc: 'a, R: Try<Output = Acc> + 'a>(
             n: &'a mut usize,
             mut fold: impl FnMut(Acc, T) -> R + 'a,
         ) -> impl FnMut(Acc, T) -> ControlFlow<R, Acc> + 'a {

--- a/library/core/src/iter/adapters/take_while.rs
+++ b/library/core/src/iter/adapters/take_while.rs
@@ -70,7 +70,7 @@ where
         Fold: FnMut(Acc, Self::Item) -> R,
         R: Try<Output = Acc>,
     {
-        fn check<'a, T, Acc, R: Try<Output = Acc>>(
+        fn check<'a, T, Acc: 'a, R: Try<Output = Acc> + 'a>(
             flag: &'a mut bool,
             p: &'a mut impl FnMut(&T) -> bool,
             mut fold: impl FnMut(Acc, T) -> R + 'a,

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3848,7 +3848,7 @@ where
     F: FnMut(A::Item, B::Item) -> ControlFlow<T>,
 {
     #[inline]
-    fn compare<'a, B, X, T>(
+    fn compare<'a, B, X, T: 'a>(
         b: &'a mut B,
         mut f: impl FnMut(X, B::Item) -> ControlFlow<T> + 'a,
     ) -> impl FnMut(X) -> ControlFlow<ControlFlow<T, Ordering>> + 'a

--- a/src/test/ui/closures/issue-84366-closure-outlives-ret.rs
+++ b/src/test/ui/closures/issue-84366-closure-outlives-ret.rs
@@ -1,0 +1,37 @@
+// Regression test for issue #84366
+// Ensures that proving `closure: 'a` requires that
+// we prove `closure_ret_type: 'a`
+
+use std::fmt;
+trait Trait {
+    type Associated;
+}
+
+impl<R, F: Fn() -> R> Trait for F {
+    type Associated = R;
+}
+
+fn static_transfers_to_associated<T: Trait + 'static>(
+    _: &T,
+    x: T::Associated,
+) -> Box<dyn fmt::Display /* + 'static */>
+where
+    T::Associated: fmt::Display,
+{
+    Box::new(x) // T::Associated: 'static follows from T: 'static
+}
+
+fn make_static_displayable<'a>(s: &'a str) -> Box<dyn fmt::Display> {
+    let f = || -> &'a str { "" };
+    // problem is: the closure type of `f` is 'static
+    static_transfers_to_associated(&f, s) //~ ERROR borrowed data escapes
+}
+
+fn main() {
+    let d;
+    {
+        let x = "Hello World".to_string();
+        d = make_static_displayable(&x);
+    }
+    println!("{}", d);
+}

--- a/src/test/ui/closures/issue-84366-closure-outlives-ret.stderr
+++ b/src/test/ui/closures/issue-84366-closure-outlives-ret.stderr
@@ -1,0 +1,17 @@
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/issue-84366-closure-outlives-ret.rs:27:5
+   |
+LL | fn make_static_displayable<'a>(s: &'a str) -> Box<dyn fmt::Display> {
+   |                            --  - `s` is a reference that is only valid in the function body
+   |                            |
+   |                            lifetime `'a` defined here
+...
+LL |     static_transfers_to_associated(&f, s)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `s` escapes the function body here
+   |     argument requires that `'a` must outlive `'static`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/generator/issue-84366-generator-outlives-return.rs
+++ b/src/test/ui/generator/issue-84366-generator-outlives-return.rs
@@ -1,0 +1,40 @@
+// A version of issue #84366, but involving generator return types instead of closures
+
+#![feature(generators)]
+#![feature(generator_trait)]
+
+use std::fmt;
+use std::ops::Generator;
+
+trait Trait {
+    type Associated;
+}
+
+impl<R, F: Generator<Return = R>> Trait for F {
+    type Associated = R;
+}
+
+fn static_transfers_to_associated<T: Trait + 'static>(
+    _: &T,
+    x: T::Associated,
+) -> Box<dyn fmt::Display /* + 'static */>
+where
+    T::Associated: fmt::Display,
+{
+    Box::new(x) // T::Associated: 'static follows from T: 'static
+}
+
+fn make_static_displayable<'a>(s: &'a str) -> Box<dyn fmt::Display> {
+    let f = || { yield ""; "" };
+    // problem is: the closure type of `f` is 'static
+    static_transfers_to_associated(&f, s) //~ ERROR borrowed data escapes
+}
+
+fn main() {
+    let d;
+    {
+        let x = "Hello World".to_string();
+        d = make_static_displayable(&x);
+    }
+    println!("{}", d);
+}

--- a/src/test/ui/generator/issue-84366-generator-outlives-return.stderr
+++ b/src/test/ui/generator/issue-84366-generator-outlives-return.stderr
@@ -1,0 +1,17 @@
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/issue-84366-generator-outlives-return.rs:30:5
+   |
+LL | fn make_static_displayable<'a>(s: &'a str) -> Box<dyn fmt::Display> {
+   |                            --  - `s` is a reference that is only valid in the function body
+   |                            |
+   |                            lifetime `'a` defined here
+...
+LL |     static_transfers_to_associated(&f, s)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `s` escapes the function body here
+   |     argument requires that `'a` must outlive `'static`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/generator/issue-84366-generator-outlives-yield.rs
+++ b/src/test/ui/generator/issue-84366-generator-outlives-yield.rs
@@ -1,0 +1,40 @@
+// A version of issue #84366, but involving generators instead of closures
+
+#![feature(generators)]
+#![feature(generator_trait)]
+
+use std::fmt;
+use std::ops::Generator;
+
+trait Trait {
+    type Associated;
+}
+
+impl<R, F: Generator<Yield = R>> Trait for F {
+    type Associated = R;
+}
+
+fn static_transfers_to_associated<T: Trait + 'static>(
+    _: &T,
+    x: T::Associated,
+) -> Box<dyn fmt::Display /* + 'static */>
+where
+    T::Associated: fmt::Display,
+{
+    Box::new(x) // T::Associated: 'static follows from T: 'static
+}
+
+fn make_static_displayable<'a>(s: &'a str) -> Box<dyn fmt::Display> {
+    let f = || { yield ""; "" };
+    // problem is: the closure type of `f` is 'static
+    static_transfers_to_associated(&f, s) //~ ERROR borrowed data escapes
+}
+
+fn main() {
+    let d;
+    {
+        let x = "Hello World".to_string();
+        d = make_static_displayable(&x);
+    }
+    println!("{}", d);
+}

--- a/src/test/ui/generator/issue-84366-generator-outlives-yield.stderr
+++ b/src/test/ui/generator/issue-84366-generator-outlives-yield.stderr
@@ -1,0 +1,17 @@
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/issue-84366-generator-outlives-yield.rs:30:5
+   |
+LL | fn make_static_displayable<'a>(s: &'a str) -> Box<dyn fmt::Display> {
+   |                            --  - `s` is a reference that is only valid in the function body
+   |                            |
+   |                            lifetime `'a` defined here
+...
+LL |     static_transfers_to_associated(&f, s)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `s` escapes the function body here
+   |     argument requires that `'a` must outlive `'static`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0521`.


### PR DESCRIPTION
Fixes #84366

RFC 1214 allows us to infer that `<T as Trait<P0, ... PN>>::Out: 'a`
holds, so long as `T: 'a, P0: 'a, ..., PN: 'a` all hold.

In order for this to be sound, we must ensure that whenever we need to
prove `T: 'a` for some concrete type `T`, we also ensure that
any type which could appear in the output type for an impl also outlives
`'a`

However, we failed to enforce this for closures. Specifically, we
allowed `closure: 'a` to hold without requiring that `closure_ret_ty:
'a` also holds. Since `closure_ret_ty` appears in the output of the
`FnOnce` impl for closures, it was possible to extend a lifetime by
causing rustc to assume that the closure return type outlived a lifetime
based on the fact that the closure itself outlived a lifetime.

This commit includes the closure return type as one of the 'components'
used when computing outlives requirements. To minimize the extent of
this breaking change, we do *not* include the arguments of the closure
as 'components'. Doing so is still sound, but introduces an
inconsistency with function pointers (which do treat their arguments as
'components')

Several uses of closures in libcore needed to be adjusted, all of them
involving returning a closure via an `impl Fn` opaque type. In all
cases, we needed to add extra lifetime bounds to generic parameters that
ended up in the return type `R` of `impl Fn() -> R`.