### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -75,19 +75,21 @@ impl_stable_hash_via_hash!(OptLevel);
 
 /// This is what the `LtoCli` values get mapped to after resolving defaults and
 /// and taking other command line options into account.
+///
+/// Note that linker plugin-based LTO is a different mechanism entirely.
 #[derive(Clone, PartialEq)]
 pub enum Lto {
-    /// Don't do any LTO whatsoever
+    /// Don't do any LTO whatsoever.
     No,
 
-    /// Do a full crate graph LTO with ThinLTO
+    /// Do a full-crate-graph (inter-crate) LTO with ThinLTO.
     Thin,
 
-    /// Do a local graph LTO with ThinLTO (only relevant for multiple codegen
-    /// units).
+    /// Do a local ThinLTO (intra-crate, over the CodeGen Units of the local crate only). This is
+    /// only relevant if multiple CGUs are used.
     ThinLocal,
 
-    /// Do a full crate graph LTO with "fat" LTO
+    /// Do a full-crate-graph (inter-crate) LTO with "fat" LTO.
     Fat,
 }
 

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -23,7 +23,7 @@ macro_rules! impl_nonzero_fmt {
 }
 
 macro_rules! nonzero_integers {
-    ( $( #[$stability: meta] $Ty: ident($Int: ty); )+ ) => {
+    ( $( #[$stability: meta] #[$const_new_unchecked_stability: meta] $Ty: ident($Int: ty); )+ ) => {
         $(
             /// An integer that is known not to equal zero.
             ///
@@ -48,7 +48,7 @@ macro_rules! nonzero_integers {
                 ///
                 /// The value must not be zero.
                 #[$stability]
-                #[rustc_const_stable(feature = "nonzero", since = "1.34.0")]
+                #[$const_new_unchecked_stability]
                 #[inline]
                 pub const unsafe fn new_unchecked(n: $Int) -> Self {
                     // SAFETY: this is guaranteed to be safe by the caller.
@@ -146,18 +146,18 @@ macro_rules! nonzero_integers {
 }
 
 nonzero_integers! {
-    #[stable(feature = "nonzero", since = "1.28.0")] NonZeroU8(u8);
-    #[stable(feature = "nonzero", since = "1.28.0")] NonZeroU16(u16);
-    #[stable(feature = "nonzero", since = "1.28.0")] NonZeroU32(u32);
-    #[stable(feature = "nonzero", since = "1.28.0")] NonZeroU64(u64);
-    #[stable(feature = "nonzero", since = "1.28.0")] NonZeroU128(u128);
-    #[stable(feature = "nonzero", since = "1.28.0")] NonZeroUsize(usize);
-    #[stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI8(i8);
-    #[stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI16(i16);
-    #[stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI32(i32);
-    #[stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI64(i64);
-    #[stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI128(i128);
-    #[stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroIsize(isize);
+    #[stable(feature = "nonzero", since = "1.28.0")] #[rustc_const_stable(feature = "nonzero", since = "1.28.0")] NonZeroU8(u8);
+    #[stable(feature = "nonzero", since = "1.28.0")] #[rustc_const_stable(feature = "nonzero", since = "1.28.0")] NonZeroU16(u16);
+    #[stable(feature = "nonzero", since = "1.28.0")] #[rustc_const_stable(feature = "nonzero", since = "1.28.0")] NonZeroU32(u32);
+    #[stable(feature = "nonzero", since = "1.28.0")] #[rustc_const_stable(feature = "nonzero", since = "1.28.0")] NonZeroU64(u64);
+    #[stable(feature = "nonzero", since = "1.28.0")] #[rustc_const_stable(feature = "nonzero", since = "1.28.0")] NonZeroU128(u128);
+    #[stable(feature = "nonzero", since = "1.28.0")] #[rustc_const_stable(feature = "nonzero", since = "1.28.0")] NonZeroUsize(usize);
+    #[stable(feature = "signed_nonzero", since = "1.34.0")] #[rustc_const_stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI8(i8);
+    #[stable(feature = "signed_nonzero", since = "1.34.0")] #[rustc_const_stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI16(i16);
+    #[stable(feature = "signed_nonzero", since = "1.34.0")] #[rustc_const_stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI32(i32);
+    #[stable(feature = "signed_nonzero", since = "1.34.0")] #[rustc_const_stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI64(i64);
+    #[stable(feature = "signed_nonzero", since = "1.34.0")] #[rustc_const_stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroI128(i128);
+    #[stable(feature = "signed_nonzero", since = "1.34.0")] #[rustc_const_stable(feature = "signed_nonzero", since = "1.34.0")] NonZeroIsize(isize);
 }
 
 macro_rules! from_str_radix_nzint_impl {

--- a/library/core/src/ops/index.rs
+++ b/library/core/src/ops/index.rs
@@ -64,7 +64,7 @@ pub trait Index<Idx: ?Sized> {
     ///
     /// # Panics
     ///
-    /// Panics if the index is out of bounds.
+    /// May panic if the index is out of bounds.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[track_caller]
     fn index(&self, index: Idx) -> &Self::Output;
@@ -168,7 +168,7 @@ pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
     ///
     /// # Panics
     ///
-    /// Panics if the index is out of bounds.
+    /// May panic if the index is out of bounds.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[track_caller]
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output;

--- a/library/core/src/ops/index.rs
+++ b/library/core/src/ops/index.rs
@@ -61,6 +61,10 @@ pub trait Index<Idx: ?Sized> {
     type Output: ?Sized;
 
     /// Performs the indexing (`container[index]`) operation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[track_caller]
     fn index(&self, index: Idx) -> &Self::Output;
@@ -161,6 +165,10 @@ see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#ind
 #[doc(alias = "[]")]
 pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
     /// Performs the mutable indexing (`container[index]`) operation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[track_caller]
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output;

--- a/src/doc/unstable-book/src/language-features/lang-items.md
+++ b/src/doc/unstable-book/src/language-features/lang-items.md
@@ -191,7 +191,7 @@ mechanisms of the compiler. This is often mapped to GCC's personality function
 which do not trigger a panic can be assured that this function is never
 called. The language item's name is `eh_personality`.
 
-[unwind]: https://github.com/rust-lang/rust/blob/master/src/libpanic_unwind/gcc.rs
+[unwind]: https://github.com/rust-lang/rust/blob/master/library/panic_unwind/src/gcc.rs
 
 The second function, `rust_begin_panic`, is also used by the failure mechanisms of the
 compiler. When a panic happens, this controls the message that's displayed on

--- a/src/test/ui/associated-type-bounds/issue-79949.rs
+++ b/src/test/ui/associated-type-bounds/issue-79949.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+#![allow(incomplete_features)]
+#![feature(associated_type_bounds)]
+#![feature(generic_associated_types)]
+
+trait MP {
+    type T<'a>;
+}
+struct S(String);
+impl MP for S {
+    type T<'a> = &'a str;
+}
+
+trait SR: MP {
+    fn sr<IM>(&self) -> i32
+    where
+        for<'a> IM: T<T: U<<Self as MP>::T<'a>>>;
+}
+
+trait T {
+    type T;
+}
+trait U<X> {}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-70303.rs
+++ b/src/test/ui/generic-associated-types/issue-70303.rs
@@ -1,0 +1,60 @@
+// check-pass
+
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+
+trait Document {
+    type Cursor<'a>: DocCursor<'a>;
+
+    fn cursor(&self) -> Self::Cursor<'_>;
+}
+
+struct DocumentImpl {}
+
+impl Document for DocumentImpl {
+    type Cursor<'a> = DocCursorImpl<'a>;
+
+    fn cursor(&self) -> Self::Cursor<'_> {
+        DocCursorImpl {
+            document: &self,
+        }
+    }
+}
+
+
+trait DocCursor<'a> {}
+
+struct DocCursorImpl<'a> {
+    document: &'a DocumentImpl,
+}
+
+impl<'a> DocCursor<'a> for DocCursorImpl<'a> {}
+
+struct Lexer<'d, Cursor>
+where
+    Cursor: DocCursor<'d>,
+{
+    cursor: Cursor,
+    _phantom: std::marker::PhantomData<&'d ()>,
+}
+
+
+impl<'d, Cursor> Lexer<'d, Cursor>
+where
+    Cursor: DocCursor<'d>,
+{
+    pub fn from<Doc>(document: &'d Doc) -> Lexer<'d, Cursor>
+    where
+        Doc: Document<Cursor<'d> = Cursor>,
+    {
+        Lexer {
+            cursor: document.cursor(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+pub fn main() {
+    let doc = DocumentImpl {};
+    let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
+}

--- a/src/test/ui/generic-associated-types/issue-70304.rs
+++ b/src/test/ui/generic-associated-types/issue-70304.rs
@@ -1,0 +1,63 @@
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+
+trait Document {
+    type Cursor<'a>: DocCursor<'a>;
+
+    fn cursor(&self) -> Self::Cursor<'_>;
+}
+
+struct DocumentImpl {}
+
+impl Document for DocumentImpl {
+    type Cursor<'a> = DocCursorImpl<'a>;
+
+    fn cursor(&self) -> Self::Cursor<'_> {
+        DocCursorImpl {
+            document: &self,
+        }
+    }
+}
+
+
+trait DocCursor<'a> {}
+
+struct DocCursorImpl<'a> {
+    document: &'a DocumentImpl,
+}
+
+impl<'a> DocCursor<'a> for DocCursorImpl<'a> {}
+
+struct Lexer<'d, Cursor>
+where
+    Cursor: DocCursor<'d>,
+{
+    cursor: Cursor,
+    _phantom: std::marker::PhantomData<&'d ()>,
+}
+
+
+impl<'d, Cursor> Lexer<'d, Cursor>
+where
+    Cursor: DocCursor<'d>,
+{
+    pub fn from<Doc>(document: &'d Doc) -> Lexer<'d, Cursor>
+    where
+        Doc: Document<Cursor<'d> = Cursor>,
+    {
+        Lexer {
+            cursor: document.cursor(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
+                                       //~^ ERROR: missing lifetime specifier
+    DocumentImpl {}
+}
+
+pub fn main() {
+    let doc = create_doc();
+    let lexer: Lexer<'_, DocCursorImpl<'_>> = Lexer::from(&doc);
+}

--- a/src/test/ui/generic-associated-types/issue-70304.stderr
+++ b/src/test/ui/generic-associated-types/issue-70304.stderr
@@ -1,0 +1,15 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-70304.rs:55:41
+   |
+LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
+   |                                         ^^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime
+   |
+LL | fn create_doc() -> impl Document<Cursor<'static> = DocCursorImpl<'_>> {
+   |                                         ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/generic-associated-types/issue-71176.rs
+++ b/src/test/ui/generic-associated-types/issue-71176.rs
@@ -1,0 +1,21 @@
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+
+trait Provider {
+    type A<'a>;
+      //~^ ERROR: missing generics for associated type
+}
+
+impl Provider for () {
+    type A<'a> = ();
+}
+
+struct Holder<B> {
+  inner: Box<dyn Provider<A = B>>,
+}
+
+fn main() {
+    Holder {
+        inner: Box::new(()),
+    };
+}

--- a/src/test/ui/generic-associated-types/issue-71176.stderr
+++ b/src/test/ui/generic-associated-types/issue-71176.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for associated type `Provider::A`
+  --> $DIR/issue-71176.rs:5:10
+   |
+LL |     type A<'a>;
+   |          ^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-71176.rs:5:10
+   |
+LL |     type A<'a>;
+   |          ^ --
+help: use angle brackets to add missing lifetime argument
+   |
+LL |     type A<'a><'a>;
+   |           ^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-78671.rs
+++ b/src/test/ui/generic-associated-types/issue-78671.rs
@@ -1,0 +1,14 @@
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+
+trait CollectionFamily {
+    type Member<T>;
+         //~^ ERROR: missing generics for associated type
+}
+fn floatify() {
+    Box::new(Family) as &dyn CollectionFamily<Member=usize>
+}
+
+struct Family;
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-78671.stderr
+++ b/src/test/ui/generic-associated-types/issue-78671.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for associated type `CollectionFamily::Member`
+  --> $DIR/issue-78671.rs:5:10
+   |
+LL |     type Member<T>;
+   |          ^^^^^^ expected 1 type argument
+   |
+note: associated type defined here, with 1 type parameter: `T`
+  --> $DIR/issue-78671.rs:5:10
+   |
+LL |     type Member<T>;
+   |          ^^^^^^ -
+help: use angle brackets to add missing type argument
+   |
+LL |     type Member<T><T>;
+   |                ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-79636-1.rs
+++ b/src/test/ui/generic-associated-types/issue-79636-1.rs
@@ -1,0 +1,24 @@
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+
+trait Monad {
+    type Unwrapped;
+    type Wrapped<B>;
+         //~^ ERROR: missing generics for associated type `Monad::Wrapped`
+
+    fn bind<B, F>(self, f: F) -> Self::Wrapped<B> {
+        todo!()
+    }
+}
+
+fn join<MOuter, MInner, A>(outer: MOuter) -> MOuter::Wrapped<A>
+where
+    MOuter: Monad<Unwrapped = MInner>,
+    MInner: Monad<Unwrapped = A, Wrapped = MOuter::Wrapped<A>>,
+{
+    outer.bind(|inner| inner)
+}
+
+fn main() {
+    assert_eq!(join(Some(Some(true))), Some(true));
+}

--- a/src/test/ui/generic-associated-types/issue-79636-1.stderr
+++ b/src/test/ui/generic-associated-types/issue-79636-1.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for associated type `Monad::Wrapped`
+  --> $DIR/issue-79636-1.rs:6:10
+   |
+LL |     type Wrapped<B>;
+   |          ^^^^^^^ expected 1 type argument
+   |
+note: associated type defined here, with 1 type parameter: `B`
+  --> $DIR/issue-79636-1.rs:6:10
+   |
+LL |     type Wrapped<B>;
+   |          ^^^^^^^ -
+help: use angle brackets to add missing type argument
+   |
+LL |     type Wrapped<B><B>;
+   |                 ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-79636-2.rs
+++ b/src/test/ui/generic-associated-types/issue-79636-2.rs
@@ -1,0 +1,18 @@
+#![allow(incomplete_features)]
+#![feature(generic_associated_types)]
+
+trait SomeTrait {
+    type Wrapped<A>: SomeTrait;
+         //~^ ERROR: missing generics for associated type `SomeTrait::Wrapped`
+
+    fn f() -> ();
+}
+
+fn program<W>() -> ()
+where
+    W: SomeTrait<Wrapped = W>,
+{
+    return W::f();
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-79636-2.stderr
+++ b/src/test/ui/generic-associated-types/issue-79636-2.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for associated type `SomeTrait::Wrapped`
+  --> $DIR/issue-79636-2.rs:5:10
+   |
+LL |     type Wrapped<A>: SomeTrait;
+   |          ^^^^^^^ expected 1 type argument
+   |
+note: associated type defined here, with 1 type parameter: `A`
+  --> $DIR/issue-79636-2.rs:5:10
+   |
+LL |     type Wrapped<A>: SomeTrait;
+   |          ^^^^^^^ -
+help: use angle brackets to add missing type argument
+   |
+LL |     type Wrapped<A><A>: SomeTrait;
+   |                 ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - #84251 (fix 'const-stable since' for NonZeroU*::new_unchecked)
 - #84301 (Document that `index` and `index_mut` can panic)
 - #84359 (:arrow_up: rust-analyzer)
 - #84365 (Improve the docstrings of the `Lto` struct.)
 - #84378 (Fix broken doc link)
 - #84379 (Add GAT related tests)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=84251,84301,84359,84365,84378,84379)
<!-- homu-ignore:end -->