### PR TITLE
Support `x.py doc std --open`

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -479,12 +479,16 @@ impl Step for Std {
         // Look for library/std, library/core etc in the `x.py doc` arguments and
         // open the corresponding rendered docs.
         for path in builder.paths.iter().map(components_simplified) {
-            if path.get(0) == Some(&"library") {
-                let requested_crate = &path[1];
-                if krates.contains(&requested_crate) {
-                    let index = out.join(requested_crate).join("index.html");
-                    open(builder, &index);
-                }
+            let requested_crate = if path.get(0) == Some(&"library") {
+                &path[1]
+            } else if !path.is_empty() {
+                &path[0]
+            } else {
+                continue;
+            };
+            if krates.contains(&requested_crate) {
+                let index = out.join(requested_crate).join("index.html");
+                open(builder, &index);
             }
         }
     }


### PR DESCRIPTION
I usually run this command:

```
./x.py doc std --stage 1 --jobs 8
```

Then I gave a try to `--open` and realized it wasn't working. I finally realized it was simply because it was only handling paths starting with `library`. This PR allows to handle both kinds of paths.

cc @jyn514 
r? @Mark-Simulacrum 