### PR TITLE
Upgrade `expat` dependency in riscv64 to newer version.

### DIFF
--- a/src/ci/docker/host-x86_64/dist-riscv64-linux/riscv64-unknown-linux-gnu.config
+++ b/src/ci/docker/host-x86_64/dist-riscv64-linux/riscv64-unknown-linux-gnu.config
@@ -644,7 +644,7 @@ CT_EXPAT_PATCH_GLOBAL=y
 CT_EXPAT_PATCH_ORDER="global"
 CT_EXPAT_V_2_2=y
 # CT_EXPAT_NO_VERSIONS is not set
-CT_EXPAT_VERSION="2.2.6"
+CT_EXPAT_VERSION="2.3.0"
 CT_EXPAT_MIRRORS="http://downloads.sourceforge.net/project/expat/expat/${CT_EXPAT_VERSION}"
 CT_EXPAT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_EXPAT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"


### PR DESCRIPTION
The old version was renamed to `expat-2.2.6-RENAMED-VULNERABLE-PLEASE-USE-2.3.0-INSTEAD`. :)

r? @Mark-Simulacrum