### PR TITLE
[HACK] rustc_codegen_ssa: remove micro-opt around `cleanup_ret` trampoline.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,11 @@ jobs:
           - name: mingw-check
             os: ubuntu-latest-xl
             env: {}
-          - name: x86_64-gnu-llvm-10
-            os: ubuntu-latest-xl
-            env: {}
+          - name: x86_64-msvc-2
+            env:
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-profiler"
+              SCRIPT: make ci-subset-2
+            os: windows-latest-xl
           - name: x86_64-gnu-tools
             env:
               CI_ONLY_WHEN_SUBMODULES_CHANGED: 1

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -88,14 +88,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
         bx: &mut Bx,
         target: mir::BasicBlock,
     ) {
-        let (lltarget, is_cleanupret) = self.lltarget(fx, target);
-        if is_cleanupret {
-            // micro-optimization: generate a `ret` rather than a jump
-            // to a trampoline.
-            bx.cleanup_ret(self.funclet(fx).unwrap(), Some(lltarget));
-        } else {
-            bx.br(lltarget);
-        }
+        bx.br(self.llblock(fx, target));
     }
 
     /// Call `fn_ptr` of `fn_abi` with the arguments `llargs`, the optional

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -280,8 +280,11 @@ jobs:
           - name: mingw-check
             <<: *job-linux-xl
 
-          - name: x86_64-gnu-llvm-10
-            <<: *job-linux-xl
+          - name: x86_64-msvc-2
+            env:
+              RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+              SCRIPT: make ci-subset-2
+            <<: *job-windows-xl
 
           - name: x86_64-gnu-tools
             env:


### PR DESCRIPTION
I'm hoping this only has a minimal impact, and that we can clean up this codepath.

My motivation for messing with this at all, is pre-generating all such auxiliary blocks, without having to know ahead of time whether they will get used via (the suboptimally named) `llblock` (which can be e.g. one of the targets of a conditional branch or `switch`) or `funclet_br` (used for direct branches).

(By pre-generating all such blocks, the lifecycles of basic block builders - and so the borrowing relationship between `Bx` and `CodegenCx` - could be much simpler. I already started on a refactor, and landing pad / funclet `cleanup_ret` trampolines are the main offenders, because they're on-demand)

Sadly, I don't have a good way to test a MSVC target, and much less so compare compiletimes (especially as AFAIK we don't have anything like perf.rust-lang.org for Windows - cc @Mark-Simulacrum)

I've switched out the PR CI builder to `x86_64-msvc-2` for this test PR but I don't know how much good it will do - I'm hoping it will give me comparable build times to `auto` bors CI, at least.