### PR TITLE
Remove `delete` alias from `mem::drop`.

### DIFF
--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -886,7 +886,6 @@ pub const fn replace<T>(dest: &mut T, src: T) -> T {
 /// ```
 ///
 /// [`RefCell`]: crate::cell::RefCell
-#[doc(alias = "delete")]
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn drop<T>(_x: T) {}


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/81988#issuecomment-824168459 and https://github.com/rust-lang/rust/pull/81988#issuecomment-824213843