### PR TITLE
bump jobserver dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,9 +1744,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
 ]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -13,7 +13,7 @@ cc = "1.0.1"
 itertools = "0.9"
 tracing = "0.1"
 libc = "0.2.50"
-jobserver = "0.1.11"
+jobserver = "0.1.22"
 tempfile = "3.1"
 pathdiff = "0.2.0"
 


### PR DESCRIPTION
the newest jobserver version should slightly reduce context switches
in highly parallel build environments on linux kernels >= 5.6