### PR TITLE
Fix generic arg mismatch errors being ignored with explicit late bound lifetimes

### DIFF
--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -264,9 +264,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                 // another. This is an error. However, if we already know that
                                 // the arguments don't match up with the parameters, we won't issue
                                 // an additional error, as the user already knows what's wrong.
-                                if arg_count.correct.is_ok()
-                                    && arg_count.explicit_late_bound == ExplicitLateBound::No
-                                {
+                                if arg_count.correct.is_ok() {
                                     // We're going to iterate over the parameters to sort them out, and
                                     // show that order to the user as a possible order for the parameters
                                     let mut param_types_present = defs
@@ -446,7 +444,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
 
                 if silent {
-                    return false;
+                    return true;
                 }
 
                 if provided > expected_max {

--- a/src/test/ui/const-generics/issues/issue-83466.rs
+++ b/src/test/ui/const-generics/issues/issue-83466.rs
@@ -1,0 +1,17 @@
+// regression test for #83466- tests that generic arg mismatch errors between
+// consts and types are not supressed when there are explicit late bound lifetimes
+
+struct S;
+impl S {
+    fn func<'a, U>(self) -> U {
+        todo!()
+    }
+}
+fn dont_crash<'a, U>() {
+    S.func::<'a, 10_u32>()
+    //~^ WARNING cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+    //~^^ WARNING this was previously accepted by
+    //~^^^ ERROR constant provided when a type was expected [E0747]
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-83466.stderr
+++ b/src/test/ui/const-generics/issues/issue-83466.stderr
@@ -1,0 +1,22 @@
+warning: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/issue-83466.rs:11:14
+   |
+LL |     fn func<'a, U>(self) -> U {
+   |             -- the late bound lifetime parameter is introduced here
+...
+LL |     S.func::<'a, 10_u32>()
+   |              ^^
+   |
+   = note: `#[warn(late_bound_lifetime_arguments)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+
+error[E0747]: constant provided when a type was expected
+  --> $DIR/issue-83466.rs:11:18
+   |
+LL |     S.func::<'a, 10_u32>()
+   |                  ^^^^^^
+
+error: aborting due to previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0747`.


### PR DESCRIPTION
Fixes #83466

r? @varkor 