### PR TITLE
Remove `sys::args::Args::inner_debug` and use `Debug` instead

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -799,7 +799,7 @@ impl DoubleEndedIterator for Args {
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for Args {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Args").field("inner", &self.inner.inner.inner_debug()).finish()
+        f.debug_struct("Args").field("inner", &self.inner.inner).finish()
     }
 }
 
@@ -840,7 +840,7 @@ impl DoubleEndedIterator for ArgsOs {
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for ArgsOs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ArgsOs").field("inner", &self.inner.inner_debug()).finish()
+        f.debug_struct("ArgsOs").field("inner", &self.inner).finish()
     }
 }
 

--- a/library/std/src/sys/hermit/args.rs
+++ b/library/std/src/sys/hermit/args.rs
@@ -1,4 +1,5 @@
 use crate::ffi::OsString;
+use crate::fmt;
 use crate::marker::PhantomData;
 use crate::vec;
 
@@ -22,9 +23,9 @@ pub struct Args {
     _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
 
-impl Args {
-    pub fn inner_debug(&self) -> &[OsString] {
-        self.iter.as_slice()
+impl fmt::Debug for Args {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.iter.as_slice().fmt(f)
     }
 }
 

--- a/library/std/src/sys/sgx/args.rs
+++ b/library/std/src/sys/sgx/args.rs
@@ -1,5 +1,6 @@
 use super::abi::usercalls::{alloc, raw::ByteBuffer};
 use crate::ffi::OsString;
+use crate::fmt;
 use crate::slice;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sys::os_str::Buf;
@@ -31,9 +32,9 @@ pub fn args() -> Args {
 
 pub struct Args(slice::Iter<'static, OsString>);
 
-impl Args {
-    pub fn inner_debug(&self) -> &[OsString] {
-        self.0.as_slice()
+impl fmt::Debug for Args {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.as_slice().fmt(f)
     }
 }
 

--- a/library/std/src/sys/unix/args.rs
+++ b/library/std/src/sys/unix/args.rs
@@ -6,6 +6,7 @@
 #![allow(dead_code)] // runtime init functions not used during testing
 
 use crate::ffi::OsString;
+use crate::fmt;
 use crate::marker::PhantomData;
 use crate::vec;
 
@@ -29,9 +30,9 @@ pub struct Args {
     _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
 
-impl Args {
-    pub fn inner_debug(&self) -> &[OsString] {
-        self.iter.as_slice()
+impl fmt::Debug for Args {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.iter.as_slice().fmt(f)
     }
 }
 

--- a/library/std/src/sys/unsupported/args.rs
+++ b/library/std/src/sys/unsupported/args.rs
@@ -9,9 +9,9 @@ pub fn args() -> Args {
     Args {}
 }
 
-impl Args {
-    pub fn inner_debug(&self) -> &[OsString] {
-        &[]
+impl fmt::Debug for Args {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().finish()
     }
 }
 

--- a/library/std/src/sys/wasi/args.rs
+++ b/library/std/src/sys/wasi/args.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use crate::ffi::{CStr, OsStr, OsString};
+use crate::fmt;
 use crate::marker::PhantomData;
 use crate::os::wasi::ffi::OsStrExt;
 use crate::vec;
@@ -38,9 +39,9 @@ fn maybe_args() -> Option<Vec<OsString>> {
     }
 }
 
-impl Args {
-    pub fn inner_debug(&self) -> &[OsString] {
-        self.iter.as_slice()
+impl fmt::Debug for Args {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.iter.as_slice().fmt(f)
     }
 }
 

--- a/library/std/src/sys/wasm/args.rs
+++ b/library/std/src/sys/wasm/args.rs
@@ -1,4 +1,5 @@
 use crate::ffi::OsString;
+use crate::fmt;
 use crate::marker::PhantomData;
 use crate::vec;
 
@@ -17,9 +18,9 @@ pub struct Args {
     _dont_send_or_sync_me: PhantomData<*mut ()>,
 }
 
-impl Args {
-    pub fn inner_debug(&self) -> &[OsString] {
-        self.iter.as_slice()
+impl fmt::Debug for Args {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.iter.as_slice().fmt(f)
     }
 }
 

--- a/library/std/src/sys/windows/args.rs
+++ b/library/std/src/sys/windows/args.rs
@@ -164,19 +164,9 @@ pub struct Args {
     parsed_args_list: vec::IntoIter<OsString>,
 }
 
-pub struct ArgsInnerDebug<'a> {
-    args: &'a Args,
-}
-
-impl<'a> fmt::Debug for ArgsInnerDebug<'a> {
+impl fmt::Debug for Args {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.args.parsed_args_list.as_slice().fmt(f)
-    }
-}
-
-impl Args {
-    pub fn inner_debug(&self) -> ArgsInnerDebug<'_> {
-        ArgsInnerDebug { args: self }
+        self.parsed_args_list.as_slice().fmt(f)
     }
 }
 


### PR DESCRIPTION
This removes the method `sys::args::Args::inner_debug` on all platforms and implements `Debug` for `Args` instead.

I believe this creates a more natural API for the different platforms under `sys`: export a type `Args: Debug + Iterator + ...` vs. `Args: Iterator + ...` and with a method `inner_debug`.