### PR TITLE
Add `UnnamedField` type and refactor `FieldDef` to allow unnamed fields

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2471,19 +2471,39 @@ impl VisibilityKind {
     }
 }
 
+/// Named field type
+#[derive(Clone, Encodable, Decodable, Debug)]
+pub struct NamedField {
+    // FIXME: Maybe remove option and use UnnamedField::Type instead of NamedField?
+    pub ident: Option<Ident>,
+    pub ty: P<Ty>,
+}
+
+/// Unnamed field type
+#[derive(Clone, Encodable, Decodable, Debug)]
+pub enum UnnamedField {
+    Struct(Vec<FieldDef>),
+    Union(Vec<FieldDef>),
+    Type(P<Ty>),
+}
+
+#[derive(Clone, Encodable, Decodable, Debug)]
+pub enum FieldVariant {
+    Named(NamedField),
+    Unnamed(UnnamedField),
+}
+
 /// Field definition in a struct, variant or union.
 ///
 /// E.g., `bar: usize` as in `struct Foo { bar: usize }`.
 #[derive(Clone, Encodable, Decodable, Debug)]
 pub struct FieldDef {
     pub attrs: Vec<Attribute>,
-    pub id: NodeId,
     pub span: Span,
     pub vis: Visibility,
-    pub ident: Option<Ident>,
-
-    pub ty: P<Ty>,
+    pub id: NodeId,
     pub is_placeholder: bool,
+    pub variant: FieldVariant,
 }
 
 /// Fields and constructor ids of enum variants and structs.

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -909,13 +909,19 @@ pub fn noop_flat_map_field_def<T: MutVisitor>(
     mut fd: FieldDef,
     visitor: &mut T,
 ) -> SmallVec<[FieldDef; 1]> {
-    let FieldDef { span, ident, vis, id, ty, attrs, is_placeholder: _ } = &mut fd;
+    let FieldDef { span, vis, id, attrs, is_placeholder: _, variant } = &mut fd;
     visitor.visit_span(span);
-    visit_opt(ident, |ident| visitor.visit_ident(ident));
     visitor.visit_vis(vis);
     visitor.visit_id(id);
-    visitor.visit_ty(ty);
     visit_attrs(attrs, visitor);
+    match variant {
+        FieldVariant::Named(NamedField { ident, ty }) => {
+            visit_opt(ident, |ident| visitor.visit_ident(ident));
+            visitor.visit_ty(ty);
+        }
+        // FIXME: Handle Unnamed variant
+        _ => {}
+    }
     smallvec![fd]
 }
 

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -673,10 +673,16 @@ pub fn walk_struct_def<'a, V: Visitor<'a>>(visitor: &mut V, struct_definition: &
 
 pub fn walk_field_def<'a, V: Visitor<'a>>(visitor: &mut V, field: &'a FieldDef) {
     visitor.visit_vis(&field.vis);
-    if let Some(ident) = field.ident {
-        visitor.visit_ident(ident);
+    match &field.variant {
+        FieldVariant::Named(NamedField { ident, ty }) => {
+            if let Some(ident) = ident {
+                visitor.visit_ident(*ident);
+            }
+            visitor.visit_ty(&ty);
+        }
+        // FIXME: Handle Unnamed variant
+        _ => {}
     }
-    visitor.visit_ty(&field.ty);
     walk_list!(visitor, visit_attribute, &field.attrs);
 }
 

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -300,6 +300,21 @@ impl<'a> PostExpansionVisitor<'a> {
 }
 
 impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
+    fn visit_field_def(&mut self, s: &'a ast::FieldDef) {
+        match s.variant {
+            ast::FieldVariant::Unnamed(_) => {
+                gate_feature_post!(
+                    &self,
+                    unnamed_fields,
+                    s.span,
+                    "unnamed fields are not yet fully implemented"
+                )
+            }
+            _ => {}
+        }
+        visit::walk_field_def(self, s);
+    }
+
     fn visit_attribute(&mut self, attr: &ast::Attribute) {
         let attr_info =
             attr.ident().and_then(|ident| BUILTIN_ATTRIBUTE_MAP.get(&ident.name)).map(|a| **a);
@@ -692,6 +707,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
         gate_all!(destructuring_assignment, "destructuring assignments are unstable");
     }
     gate_all!(pub_macro_rules, "`pub` on `macro_rules` items is unstable");
+    gate_all!(unnamed_fields, "unnamed fields are not yet fully implemented");
 
     // All uses of `gate_all!` below this point were added in #65742,
     // and subsequently disabled (with the non-early gating readded).

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1408,7 +1408,13 @@ impl<'a> State<'a> {
                         s.maybe_print_comment(field.span.lo());
                         s.print_outer_attributes(&field.attrs);
                         s.print_visibility(&field.vis);
-                        s.print_type(&field.ty)
+                        match &field.variant {
+                            ast::FieldVariant::Named(ast::NamedField { ident: _, ty }) => {
+                                s.print_type(ty)
+                            }
+                            // FIXME: Handle Unnamed variant
+                            _ => {}
+                        }
                     });
                     self.pclose();
                 }
@@ -1430,10 +1436,15 @@ impl<'a> State<'a> {
                     self.maybe_print_comment(field.span.lo());
                     self.print_outer_attributes(&field.attrs);
                     self.print_visibility(&field.vis);
-                    self.print_ident(field.ident.unwrap());
-                    self.word_nbsp(":");
-                    self.print_type(&field.ty);
-                    self.s.word(",");
+                    match &field.variant {
+                        ast::FieldVariant::Named(ast::NamedField { ident, ty }) => {
+                            self.print_ident(ident.unwrap());
+                            self.word_nbsp(":");
+                            self.print_type(ty);
+                            self.s.word(",");
+                        }
+                        _ => {}
+                    }
                 }
 
                 self.bclose(span)

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -127,7 +127,13 @@ fn cs_clone_shallow(
     fn process_variant(cx: &mut ExtCtxt<'_>, stmts: &mut Vec<ast::Stmt>, variant: &VariantData) {
         for field in variant.fields() {
             // let _: AssertParamIsClone<FieldTy>;
-            assert_ty_bounds(cx, stmts, field.ty.clone(), field.span, "AssertParamIsClone");
+            match &field.variant {
+                ast::FieldVariant::Named(ast::NamedField { ident: _, ty }) => {
+                    assert_ty_bounds(cx, stmts, ty.clone(), field.span, "AssertParamIsClone")
+                }
+                // FIXME: Handle Unnamed variant
+                _ => {}
+            }
         }
     }
 

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -78,7 +78,13 @@ fn cs_total_eq_assert(
     ) {
         for field in variant.fields() {
             // let _: AssertParamIsEq<FieldTy>;
-            assert_ty_bounds(cx, stmts, field.ty.clone(), field.span, "AssertParamIsEq");
+            match &field.variant {
+                ast::FieldVariant::Named(ast::NamedField { ident: _, ty }) => {
+                    assert_ty_bounds(cx, stmts, ty.clone(), field.span, "AssertParamIsEq")
+                }
+                // FIXME: Handle Unnamed variant
+                _ => {}
+            }
         }
     }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -328,11 +328,15 @@ impl InvocationKind {
         // and it holds because only inert attributes are supported in this position.
         match self {
             InvocationKind::Attr { item: Annotatable::FieldDef(field), .. }
-            | InvocationKind::Derive { item: Annotatable::FieldDef(field), .. }
-                if field.ident.is_none() =>
+            | InvocationKind::Derive { item: Annotatable::FieldDef(field), .. } => match field
+                .variant
             {
-                Some(field.vis.clone())
-            }
+                ast::FieldVariant::Named(ast::NamedField { ident, ty: _ }) if ident.is_none() => {
+                    Some(field.vis.clone())
+                }
+                // FIXME: Handle Unnamed variant
+                _ => None,
+            },
             _ => None,
         }
     }

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -155,12 +155,12 @@ pub fn placeholder(
         }]),
         AstFragmentKind::StructFields => AstFragment::StructFields(smallvec![ast::FieldDef {
             attrs: Default::default(),
-            id,
-            ident: None,
             span,
-            ty: ty(),
             vis,
+            id,
             is_placeholder: true,
+            // FIXME: Maybe change to UnnamedField?
+            variant: ast::FieldVariant::Named(ast::NamedField { ident: None, ty: ty() })
         }]),
         AstFragmentKind::Variants => AstFragment::Variants(smallvec![ast::Variant {
             attrs: Default::default(),

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -642,6 +642,9 @@ declare_features! (
     /// Allows `extern "wasm" fn`
     (active, wasm_abi, "1.53.0", Some(83788), None),
 
+    /// Allows unnamed fields of struct and union type
+    (active, unnamed_fields, "1.53.0", Some(49804), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------
@@ -669,6 +672,7 @@ pub const INCOMPLETE_FEATURES: &[Symbol] = &[
     sym::const_generics_defaults,
     sym::inherent_associated_types,
     sym::type_alias_impl_trait,
+    sym::unnamed_fields,
 ];
 
 /// Some features are not allowed to be used together at the same time, if

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -342,7 +342,13 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
         let field_names = vdata
             .fields()
             .iter()
-            .map(|field| respan(field.span, field.ident.map_or(kw::Empty, |ident| ident.name)))
+            .filter_map(|field| match &field.variant {
+                ast::FieldVariant::Named(ast::NamedField { ident, ty: _ }) => {
+                    Some(respan(field.span, ident.map_or(kw::Empty, |ident| ident.name)))
+                }
+                // FIXME: Handle Unnamed variant
+                _ => None,
+            })
             .collect();
         self.insert_field_names(def_id, field_names);
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1254,6 +1254,7 @@ symbols! {
         unix,
         unlikely,
         unmarked_api,
+        unnamed_fields,
         unpin,
         unreachable,
         unreachable_code,

--- a/src/test/ui/feature-gates/feature-gate-unnamed_fields.rs
+++ b/src/test/ui/feature-gates/feature-gate-unnamed_fields.rs
@@ -1,0 +1,16 @@
+struct Foo {
+    _: struct { //~ ERROR unnamed fields are not yet fully implemented
+        foo: u8
+    }
+}
+
+union Bar {
+    _: union { //~ ERROR unnamed fields are not yet fully implemented
+        bar: u8
+    }
+}
+
+struct S;
+struct Baz {
+    _: S //~ ERROR unnamed fields are not yet fully implemented
+}

--- a/src/tools/clippy/clippy_lints/src/excessive_bools.rs
+++ b/src/tools/clippy/clippy_lints/src/excessive_bools.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::{in_macro, match_path_ast};
-use rustc_ast::ast::{AssocItemKind, Extern, FnKind, FnSig, ImplKind, Item, ItemKind, TraitKind, Ty, TyKind};
+use rustc_ast::ast::{AssocItemKind, Extern, FnKind, FnSig, ImplKind, Item, ItemKind, TraitKind, Ty, TyKind, FieldVariant, NamedField};
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::{sym, Span};
@@ -145,7 +145,11 @@ impl EarlyLintPass for ExcessiveBools {
                 let struct_bools = variant_data
                     .fields()
                     .iter()
-                    .filter(|field| is_bool_ty(&field.ty))
+                    .filter(|field| match &field.variant {
+                        FieldVariant::Named(NamedField{ty, ident:_}) if is_bool_ty(ty) => true,
+                        // FIXME: Handle Unnamed variant
+                        _ => false
+                    })
                     .count()
                     .try_into()
                     .unwrap();

--- a/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
+++ b/src/tools/clippy/clippy_lints/src/manual_non_exhaustive.rs
@@ -3,7 +3,7 @@ use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::meets_msrv;
 use clippy_utils::source::snippet_opt;
 use if_chain::if_chain;
-use rustc_ast::ast::{FieldDef, Item, ItemKind, Variant, VariantData, VisibilityKind};
+use rustc_ast::ast::{FieldDef, Item, ItemKind, Variant, VariantData, VisibilityKind, FieldVariant, NamedField};
 use rustc_errors::Applicability;
 use rustc_lint::{EarlyContext, EarlyLintPass};
 use rustc_semver::RustcVersion;
@@ -141,7 +141,12 @@ fn check_manual_non_exhaustive_struct(cx: &EarlyContext<'_>, item: &Item, data: 
     }
 
     fn is_non_exhaustive_marker(field: &FieldDef) -> bool {
-        is_private(field) && field.ty.kind.is_unit() && field.ident.map_or(true, |n| n.as_str().starts_with('_'))
+        match &field.variant {
+            FieldVariant::Named(NamedField{ty, ident}) =>
+            is_private(field) && ty.kind.is_unit() && ident.map_or(true, |n| n.as_str().starts_with('_')),
+            // FIXME: Handle Unnamed variant
+            _ => false
+        }
     }
 
     fn find_header_span(cx: &EarlyContext<'_>, item: &Item, data: &VariantData) -> Span {

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -362,11 +362,23 @@ pub fn eq_variant_data(l: &VariantData, r: &VariantData) -> bool {
 }
 
 pub fn eq_struct_field(l: &FieldDef, r: &FieldDef) -> bool {
-    l.is_placeholder == r.is_placeholder
-        && over(&l.attrs, &r.attrs, |l, r| eq_attr(l, r))
-        && eq_vis(&l.vis, &r.vis)
-        && both(&l.ident, &r.ident, |l, r| eq_id(*l, *r))
-        && eq_ty(&l.ty, &r.ty)
+    if l.is_placeholder != r.is_placeholder
+    || !over(&l.attrs, &r.attrs, |l, r| eq_attr(l, r))
+    || !eq_vis(&l.vis, &r.vis)
+    {
+        false
+    } else {
+        match (&l.variant, &r.variant) {
+            (FieldVariant::Named(NamedField{ident: l_ident, ty: l_ty}),
+            FieldVariant::Named(NamedField{ident: r_ident, ty: r_ty})) =>
+            both(l_ident, r_ident, |l, r| eq_id(*l, *r))
+            && eq_ty(l_ty, r_ty),
+            // FIXME: Compare two unnamed fields and check for equality
+            (FieldVariant::Unnamed(_),
+            FieldVariant::Named(_)) => false,
+            _ => false
+        }
+    }
 }
 
 pub fn eq_fn_sig(l: &FnSig, r: &FnSig) -> bool {

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -371,11 +371,18 @@ pub fn eq_struct_field(l: &FieldDef, r: &FieldDef) -> bool {
         match (&l.variant, &r.variant) {
             (FieldVariant::Named(NamedField{ident: l_ident, ty: l_ty}),
             FieldVariant::Named(NamedField{ident: r_ident, ty: r_ty})) =>
-            both(l_ident, r_ident, |l, r| eq_id(*l, *r))
-            && eq_ty(l_ty, r_ty),
-            // FIXME: Compare two unnamed fields and check for equality
-            (FieldVariant::Unnamed(_),
-            FieldVariant::Named(_)) => false,
+            both(l_ident, r_ident, |l, r| eq_id(*l, *r)) && eq_ty(l_ty, r_ty),
+
+            (FieldVariant::Unnamed(UnnamedField::Struct(l_v)),
+            FieldVariant::Unnamed(UnnamedField::Struct(r_v)))
+            | (FieldVariant::Unnamed(UnnamedField::Union(l_v)),
+            FieldVariant::Unnamed(UnnamedField::Union(r_v))) =>
+            l_v.iter().zip(r_v.iter()).all(|(l_f, r_f)| eq_struct_field(l_f, r_f)),
+
+            (FieldVariant::Unnamed(UnnamedField::Type(l_ty)),
+            FieldVariant::Unnamed(UnnamedField::Type(r_ty))) =>
+            eq_ty(l_ty, r_ty),
+
             _ => false
         }
     }


### PR DESCRIPTION
Additionally added the `unnamed_fields` feature gate. 

Covers the Parsing section of the [RFC 2102](https://github.com/rust-lang/rust/issues/49804). Hopefully this can allow a full implementation of the feature. 