### PR TITLE
rustdoc: Hide `#text` in doc-tests

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -147,12 +147,19 @@ fn map_line(s: &str) -> Line<'_> {
     let trimmed = s.trim();
     if trimmed.starts_with("##") {
         Line::Shown(Cow::Owned(s.replacen("##", "#", 1)))
-    } else if let Some(stripped) = trimmed.strip_prefix("# ") {
-        // # text
-        Line::Hidden(&stripped)
-    } else if trimmed == "#" {
-        // We cannot handle '#text' because it could be #[attr].
-        Line::Hidden("")
+    } else if trimmed.starts_with('#') {
+        let mut without_hash = trimmed[1..].trim_start();
+        if without_hash.starts_with('!') {
+            // #! text
+            without_hash = without_hash[1..].trim_start_matches(' ');
+        }
+        if without_hash.starts_with('[') {
+            // #[attr] or #![attr]
+            Line::Shown(Cow::Borrowed(s))
+        } else {
+            // #text
+            Line::Hidden(without_hash)
+        }
     } else {
         Line::Shown(Cow::Borrowed(s))
     }

--- a/src/test/rustdoc-ui/test-hidden.rs
+++ b/src/test/rustdoc-ui/test-hidden.rs
@@ -1,0 +1,25 @@
+// check-pass
+// compile-flags:--test
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+
+/// ```
+// If `const_err` becomes a hard error in the future, please replace this with another
+// deny-by-default lint instead of removing it altogether
+/// # ! [allow(const_err)]
+/// const C: usize = 1/0;
+///
+/// # use std::path::PathBuf;
+/// #use std::path::Path;
+/// let x = Path::new("y.rs");
+/// let x = PathBuf::from("y.rs");
+///
+/// #[cfg(FALSE)]
+/// assert!(false);
+///
+/// # [cfg(FALSE)]
+/// assert!(false);
+/// ```
+fn main() {
+    panic!();
+}

--- a/src/test/rustdoc-ui/test-hidden.stdout
+++ b/src/test/rustdoc-ui/test-hidden.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/test-hidden.rs - main (line 6) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Since `#![attr]` and `#[attr]` are the only valid syntax that start with `#`, we can just special case those two tokens.

Fixes https://github.com/rust-lang/rust/issues/83284.