### PR TITLE
Give a better error when `std` or `core` are missing

### DIFF
--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -511,8 +511,11 @@ impl<'a> CrateLoader<'a> {
         if dep.is_none() {
             self.used_extern_options.insert(name);
         }
-        self.maybe_resolve_crate(name, dep_kind, dep)
-            .unwrap_or_else(|err| err.report(self.sess, span))
+        self.maybe_resolve_crate(name, dep_kind, dep).unwrap_or_else(|err| {
+            let missing_core =
+                self.maybe_resolve_crate(sym::core, CrateDepKind::Explicit, None).is_err();
+            err.report(&self.sess, span, missing_core)
+        })
     }
 
     fn maybe_resolve_crate<'b>(

--- a/src/test/ui/crate-loading/missing-std.rs
+++ b/src/test/ui/crate-loading/missing-std.rs
@@ -1,0 +1,11 @@
+// compile-flags: --target x86_64-unknown-uefi
+// rustc-env:CARGO=/usr/bin/cargo
+// rustc-env:RUSTUP_HOME=/home/bors/.rustup
+#![no_core]
+extern crate core;
+//~^ ERROR can't find crate for `core`
+//~| NOTE can't find crate
+//~| NOTE target may not be installed
+//~| HELP consider building the standard library from source with `cargo build -Zbuild-std`
+//~| HELP consider downloading the target with `rustup target add x86_64-unknown-uefi`
+fn main() {}

--- a/src/test/ui/crate-loading/missing-std.stderr
+++ b/src/test/ui/crate-loading/missing-std.stderr
@@ -1,0 +1,13 @@
+error[E0463]: can't find crate for `core`
+  --> $DIR/missing-std.rs:5:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^ can't find crate
+   |
+   = note: the `x86_64-unknown-uefi` target may not be installed
+   = help: consider downloading the target with `rustup target add x86_64-unknown-uefi`
+   = help: consider building the standard library from source with `cargo build -Zbuild-std`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0463`.


### PR DESCRIPTION
- Suggest using `rustup target add` if `RUSTUP_HOME` is set. I don't know if there's any precedent for doing this, but it seems harmless enough and it will be a big help.
- On nightly, suggest using `cargo build -Z build-std` if `CARGO` is set
- Add a note about `#![no_std]` if `std` is missing but not core
- Add a note that std may be unsupported if `std` is missing but not core

Fixes https://github.com/rust-lang/rust/issues/84418.

r? @petrochenkov