### PR TITLE
rustdoc: Remove unnecessary `is_crate` field from doctree::Module and clean::Module

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -487,7 +487,7 @@ fn build_module(
         }
     }
 
-    clean::Module { items, is_crate: false }
+    clean::Module { items }
 }
 
 crate fn print_inlined_const(tcx: TyCtxt<'_>, did: DefId) -> String {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -112,12 +112,8 @@ impl Clean<Item> for doctree::Module<'_> {
             }
         };
 
-        let what_rustc_thinks = Item::from_hir_id_and_parts(
-            self.id,
-            Some(self.name),
-            ModuleItem(Module { is_crate: self.is_crate, items }),
-            cx,
-        );
+        let what_rustc_thinks =
+            Item::from_hir_id_and_parts(self.id, Some(self.name), ModuleItem(Module { items }), cx);
         Item { span: span.clean(cx), ..what_rustc_thinks }
     }
 }

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -391,12 +391,9 @@ impl Item {
     }
 
     crate fn is_crate(&self) -> bool {
-        matches!(
-            *self.kind,
-            StrippedItem(box ModuleItem(Module { is_crate: true, .. }))
-                | ModuleItem(Module { is_crate: true, .. })
-        )
+        self.is_mod() && self.def_id.index == CRATE_DEF_INDEX
     }
+
     crate fn is_mod(&self) -> bool {
         self.type_() == ItemType::Module
     }
@@ -608,7 +605,6 @@ impl ItemKind {
 #[derive(Clone, Debug)]
 crate struct Module {
     crate items: Vec<Item>,
-    crate is_crate: bool,
 }
 
 crate struct ListAttributesIter<'a> {
@@ -1983,7 +1979,7 @@ crate enum Variant {
 
 /// Small wrapper around [`rustc_span::Span]` that adds helper methods
 /// and enforces calling [`rustc_span::Span::source_callsite()`].
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 crate struct Span(rustc_span::Span);
 
 impl Span {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -14,7 +14,6 @@ crate struct Module<'hir> {
     crate items: Vec<(&'hir hir::Item<'hir>, Option<Symbol>)>,
     crate foreigns: Vec<(&'hir hir::ForeignItem<'hir>, Option<Symbol>)>,
     crate macros: Vec<(&'hir hir::MacroDef<'hir>, Option<Symbol>)>,
-    crate is_crate: bool,
 }
 
 impl Module<'hir> {
@@ -28,7 +27,6 @@ impl Module<'hir> {
             items: Vec::new(),
             foreigns: Vec::new(),
             macros: Vec::new(),
-            is_crate: false,
         }
     }
 }

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -80,10 +80,7 @@ crate trait DocFolder: Sized {
     }
 
     fn fold_mod(&mut self, m: Module) -> Module {
-        Module {
-            is_crate: m.is_crate,
-            items: m.items.into_iter().filter_map(|i| self.fold_item(i)).collect(),
-        }
+        Module { items: m.items.into_iter().filter_map(|i| self.fold_item(i)).collect() }
     }
 
     fn fold_crate(&mut self, mut c: Crate) -> Crate {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -28,8 +28,8 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer)
     // Write the breadcrumb trail header for the top
     buf.write_str("<h1 class=\"fqn\"><span class=\"in-band\">");
     let name = match *item.kind {
-        clean::ModuleItem(ref m) => {
-            if m.is_crate {
+        clean::ModuleItem(_) => {
+            if item.is_crate() {
                 "Crate "
             } else {
                 "Module "

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -78,7 +78,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             &krate.item,
             self.cx.tcx.crate_name,
         );
-        top_level_module.is_crate = true;
         // Attach the crate's exported macros to the top-level module.
         // In the case of macros 2.0 (`pub macro`), and for built-in `derive`s or attributes as
         // well (_e.g._, `Copy`), these are wrongly bundled in there too, so we need to fix that by


### PR DESCRIPTION
It can be calculated on-demand even without a TyCtxt.

This also changed `json::conversions::from_item_kind` to take a whole item, which avoids
having to add more and more parameters.

Helps with https://github.com/rust-lang/rust/issues/76382.

r? @camelid