### PR TITLE
change message infered type for closure

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -1082,7 +1082,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.span_note(
                         sp,
                         &format!(
-                            "return type inferred to be `{}` here",
+                            "type inferred to be `{}` here",
                             self.resolve_vars_if_possible(expected)
                         ),
                     );

--- a/src/test/ui/closures/closure-return-type-mismatch.stderr
+++ b/src/test/ui/closures/closure-return-type-mismatch.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |         a
    |         ^ expected `&str`, found `bool`
    |
-note: return type inferred to be `&str` here
+note: type inferred to be `&str` here
   --> $DIR/closure-return-type-mismatch.rs:4:20
    |
 LL |             return "test";

--- a/src/test/ui/closures/issue-84128.stderr
+++ b/src/test/ui/closures/issue-84128.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL |         Foo(())
    |             ^^ expected integer, found `()`
    |
-note: return type inferred to be `{integer}` here
+note: type inferred to be `{integer}` here
   --> $DIR/issue-84128.rs:10:20
    |
 LL |             return Foo(0);

--- a/src/test/ui/generator/type-mismatch-signature-deduction.stderr
+++ b/src/test/ui/generator/type-mismatch-signature-deduction.stderr
@@ -6,7 +6,7 @@ LL |         5
    |
    = note: expected type `Result<{integer}, _>`
               found type `{integer}`
-note: return type inferred to be `Result<{integer}, _>` here
+note: type inferred to be `Result<{integer}, _>` here
   --> $DIR/type-mismatch-signature-deduction.rs:8:20
    |
 LL |             return Ok(6);


### PR DESCRIPTION
fixes confusing message for inferred type for closure introduced in #84244.

--------

I would prefer to have display something like `return type inferred to be `Foo<{integer}>` here` for code like
```rust
struct Foo<T>(T);

fn main() {
    || {
        if false {
            return Foo(0);
        }
        Foo(())
    };
}
```
But I was not able to to so. I would greatly  appreciate If someone could help me or commit this change