### PR TITLE
Add new tool to check HTML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-checker"
+version = "0.1.0"
+dependencies = [
+ "walkdir",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
   "src/tools/unicode-table-generator",
   "src/tools/expand-yaml-anchors",
   "src/tools/jsondocck",
+  "src/tools/html-checker",
 ]
 
 exclude = [

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -432,6 +432,7 @@ impl<'a> Builder<'a> {
                 test::RustdocTheme,
                 test::RustdocUi,
                 test::RustdocJson,
+                test::HtmlCheck,
                 // Run bootstrap close to the end as it's unlikely to fail
                 test::Bootstrap,
                 // Run run-make last, since these won't pass without make on Windows

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -501,8 +501,8 @@ impl Step for Std {
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Rustc {
-    stage: u32,
-    target: TargetSelection,
+    pub stage: u32,
+    pub target: TargetSelection,
 }
 
 impl Step for Rustc {

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -375,6 +375,7 @@ bootstrap_tool!(
     ExpandYamlAnchors, "src/tools/expand-yaml-anchors", "expand-yaml-anchors";
     LintDocs, "src/tools/lint-docs", "lint-docs";
     JsonDocCk, "src/tools/jsondocck", "jsondocck";
+    HtmlChecker, "src/tools/html-checker", "html-checker";
 );
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Ord, PartialOrd)]

--- a/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-aux/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libgl1-mesa-dev \
   llvm-dev \
   libfreetype6-dev \
-  libexpat1-dev
+  libexpat1-dev \
+  tidy
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   cmake \
   libssl-dev \
   sudo \
-  xz-utils
+  xz-utils \
+  tidy
 
 # Install dependencies for chromium browser
 RUN apt-get install -y \

--- a/src/tools/html-checker/Cargo.toml
+++ b/src/tools/html-checker/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "html-checker"
+version = "0.1.0"
+authors = ["Guillaume Gomez <guillaume1.gomez@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "html-checker"
+path = "main.rs"
+
+[dependencies]
+walkdir = "2"

--- a/src/tools/html-checker/main.rs
+++ b/src/tools/html-checker/main.rs
@@ -1,0 +1,96 @@
+use std::env;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn check_html_file(file: &Path) -> usize {
+    let to_mute = &[
+        // "disabled" on <link> or "autocomplete" on <select> emit this warning
+        "PROPRIETARY_ATTRIBUTE",
+        // It complains when multiple in the same page link to the same anchor for some reason...
+        "ANCHOR_NOT_UNIQUE",
+        // If a <span> contains only HTML elements and no text, it complains about it.
+        "TRIM_EMPTY_ELEMENT",
+        // FIXME: the three next warnings are about <pre> elements which are not supposed to
+        //        contain HTML. The solution here would be to replace them with a <div> with
+        //        ""
+        "MISSING_ENDTAG_BEFORE",
+        "INSERTING_TAG",
+        "DISCARDING_UNEXPECTED",
+        // FIXME: mdbook repeats the name attribute on <input>. When the fix is merged upstream,
+        //        this warning can be used again.
+        "REPEATED_ATTRIBUTE",
+        // FIXME: mdbook uses "align" attribute on <td>, which is not allowed.
+        "MISMATCHED_ATTRIBUTE_WARN",
+        // FIXME: mdbook doesn't add "alt" attribute on images.
+        "MISSING_ATTRIBUTE",
+        // FIXME: mdbook doesn't escape `&` (in "&String" for example).
+        "UNKNOWN_ENTITY",
+        // Compiler docs have some inlined <style> in the markdown.
+        "MOVED_STYLE_TO_HEAD",
+    ];
+    let to_mute_s = to_mute.join(",");
+    let mut command = Command::new("tidy");
+    command
+        .arg("-errors")
+        .arg("-quiet")
+        .arg("--mute-id") // this option is useful in case we want to mute more warnings
+        .arg("yes")
+        .arg("--mute")
+        .arg(&to_mute_s)
+        .arg(file);
+
+    let Output { status, stderr, .. } = command.output().expect("failed to run tidy command");
+    if status.success() {
+        0
+    } else {
+        let stderr = String::from_utf8(stderr).expect("String::from_utf8 failed...");
+        if stderr.is_empty() && status.code() != Some(2) {
+            0
+        } else {
+            eprintln!(
+                "=> Errors for `{}` (error code: {}) <=",
+                file.display(),
+                status.code().unwrap_or(-1)
+            );
+            eprintln!("{}", stderr);
+            stderr.lines().count()
+        }
+    }
+}
+
+// Returns the number of files read and the number of errors.
+fn find_all_html_files(dir: &Path) -> (usize, usize) {
+    let mut files_read = 0;
+    let mut errors = 0;
+
+    for entry in walkdir::WalkDir::new(dir) {
+        let entry = entry.expect("failed to read file");
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let entry = entry.path();
+        if entry.extension().and_then(|s| s.to_str()) == Some("html") {
+            errors += check_html_file(&entry);
+            files_read += 1;
+        }
+    }
+    (files_read, errors)
+}
+
+fn main() -> Result<(), String> {
+    let args = env::args().collect::<Vec<_>>();
+    if args.len() != 2 {
+        return Err(format!("Usage: {} <doc folder>", args[0]));
+    }
+
+    println!("Running HTML checker...");
+
+    let (files_read, errors) = find_all_html_files(&Path::new(&args[1]));
+    println!("Done! Read {} files...", files_read);
+    if errors > 0 {
+        Err(format!("HTML check failed: {} errors", errors))
+    } else {
+        println!("No error found!");
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a new tool to validate the HTML generated by rustdoc. To be noted, for now it has a lot of errors so opening it as a draft until I fix all reported issues.

Helps with https://github.com/rust-lang/rust/issues/84356.

r? @jyn514 