### PR TITLE
Handle pretty printing of `else if let` clauses without ICEing

### DIFF
--- a/src/test/ui/match/issue-82392.rs
+++ b/src/test/ui/match/issue-82392.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/82329
+// compile-flags: -Zunpretty=hir,typed
+// check-pass
+
+pub fn main() {
+    if true {
+    } else if let Some(a) = Some(3) {
+    }
+}

--- a/src/test/ui/match/issue-82392.stdout
+++ b/src/test/ui/match/issue-82392.stdout
@@ -1,0 +1,20 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// https://github.com/rust-lang/rust/issues/82329
+// compile-flags: -Zunpretty=hir,typed
+// check-pass
+
+pub fn main() ({
+                   (if (true as bool)
+                       ({ } as
+                           ()) else {match ((Some as
+                                                fn(i32) -> Option<i32> {Option::<i32>::Some})((3
+                                                                                                  as
+                                                                                                  i32))
+                                               as Option<i32>) {
+                                         Some(a) => { }
+                                         _ => { }
+                                     }} as ())
+                    } as ())

--- a/src/test/ui/match/issue-84434.rs
+++ b/src/test/ui/match/issue-84434.rs
@@ -1,0 +1,18 @@
+// https://github.com/rust-lang/rust/issues/84434
+// check-pass
+
+use std::path::Path;
+struct A {
+    pub func: fn(check: bool, a: &Path, b: Option<&Path>),
+}
+const MY_A: A = A {
+    func: |check, a, b| {
+        if check {
+            let _ = ();
+        } else if let Some(parent) = b.and_then(|p| p.parent()) {
+            let _ = ();
+        }
+    },
+};
+
+fn main() {}


### PR DESCRIPTION
When pretty printing the HIR of `if ... {} else if let ... {}` clauses, this displays it the `else if let` part as `match` it gets desugared to, the same way normal `if let` statements are currently displayed, instead of ICEing.

```rust
pub fn main() {
    if true {
        // 1
    } else if let a = 1 {
        // 2
    } else {
        // 3
    }
}
```

now gets desugared (via `rustc -Zunpretty=hir,typed src/x.rs`) to:

```rust
#[prelude_import]
use ::std::prelude::rust_2015::*;
#[macro_use]
extern crate std;
pub fn main() ({
                   (if (true as bool)
                       ({
                            // 1
                        } as
                           ()) else {match (1 as i32) {
                                         a => {
                                             // 2
                                         }
                                         _ => {
                                             // 3
                                         }
                                     }} as ())
                    } as ())
```

For comparison, this code gets HIR prettyprinted the same way before and after this change:

```rust
pub fn main() {
    if let a = 1 {
        // 2
    } else {
        // 3
    }
}
```
turns into
```rust
#[prelude_import]
use ::std::prelude::rust_2015::*;
#[macro_use]
extern crate std;
pub fn main() ({
                   (match (1 as i32) {
                        a => {
                            // 2
                        }
                        _ => {
                            // 3
                        }
                    } as ())
               } as ())
```

This closes #82329. It closes #84434 as well, due to having the same root cause.