### PR TITLE
Mark item_children as eval_always.

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1315,6 +1315,7 @@ rustc_queries! {
         desc { "fetching what a crate is named" }
     }
     query item_children(def_id: DefId) -> &'tcx [Export<hir::HirId>] {
+        eval_always
         desc { |tcx| "collecting child items of `{}`", tcx.def_path_str(def_id) }
     }
     query extern_mod_stmt_cnum(def_id: LocalDefId) -> Option<CrateNum> {


### PR DESCRIPTION
This information is only provided for extern crates, and decoded from their metadata.
Caching it on-disk for the local crate is useless.