### PR TITLE
`test tidy` should ignore alternative `build` dir patterns

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -7,6 +7,8 @@ merge_derives = false
 # tidy only checks files which are not ignored, each entry follows gitignore style
 ignore = [
     "/build/",
+    "/*-build/",
+    "/build-*/",
     "/vendor/",
 
     # tests for now are not formatted, as they are sometimes pretty-printing constrained


### PR DESCRIPTION
I need to have multiple `build` directories, such as `build`,
`build-fuchsia`, and `build-test`. But when I'm uploading a change, I
run `./x.py test tidy`, and if I have a `build-something` directory with
Rust sources, I git a bunch of formatting errors.

`rustfmt.toml` only ignores the directory named `build`.

This change extends the patterns to also ignore `build-*` and `*-build`.

As a rustc contributor, I not only build the rust compiler to develop
new features, but I also build alternative "distributions" (using
secondary `*-config.toml` files with different configurations),
including:

* To occasionally rebuild a version of the compiler that `rust-analyzer`
can use to `check` source (which fixes issues in the VS Code UI, so
changing and rebuilding the compiler does not break VS Code editing Rust
code).
* To build custom distributions for Fuchsia
* To build test distributions when working on changes to `bootstrap`
(e.g., when I recently added `rust-demangler` to distributions)