### PR TITLE
Ignore commented out lines when finding features

### DIFF
--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -425,7 +425,7 @@ fn map_lib_features(
                 }
 
                 lazy_static::lazy_static! {
-                    static ref COMMENT_LINE: Regex = Regex::new(r"\s*//").unwrap();
+                    static ref COMMENT_LINE: Regex = Regex::new(r"^\s*//").unwrap();
                 }
                 // exclude commented out lines
                 if COMMENT_LINE.is_match(line) {

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -423,6 +423,15 @@ fn map_lib_features(
                         continue;
                     }};
                 }
+
+                lazy_static::lazy_static! {
+                    static ref COMMENT_LINE: Regex = Regex::new(r"\s*//").unwrap();
+                }
+                // exclude commented out lines
+                if COMMENT_LINE.is_match(line) {
+                    continue;
+                }
+
                 if let Some((ref name, ref mut f)) = becoming_feature {
                     if f.tracking_issue.is_none() {
                         f.tracking_issue = find_attr_val(line, "issue").and_then(handle_issue_none);


### PR DESCRIPTION
This fixes #76246, where commented out lines were being detected as features by `tidy`, by ignoring those lines when looking for features. It's still not perfect, since it can be fooled by things like:
```rust
/*
#[unstable(feature = "foo", issue = "1234")]
*/
```
But luckily that never happens in `rustc`, so `foo` now ceases to appear in the unstable book.