### PR TITLE
Build sanitizers for x86_64-unknown-linux-musl

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -38,6 +38,7 @@ ENV HOSTS=x86_64-unknown-linux-musl
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-x86_64=/usr/local/x86_64-linux-musl \
       --enable-extended \
+      --enable-sanitizers \
       --enable-profiler \
       --enable-lld \
       --set target.x86_64-unknown-linux-musl.crt-static=false \


### PR DESCRIPTION
The support of sanitizers on target `x86_64-unknown-linux-musl` is landed in https://github.com/rust-lang/rust/pull/84126  