### PR TITLE
Inline most raw socket, fd and handle conversions

### DIFF
--- a/library/std/src/sys/sgx/ext/io.rs
+++ b/library/std/src/sys/sgx/ext/io.rs
@@ -63,12 +63,14 @@ pub trait TryIntoRawFd: Sized {
 }
 
 impl AsRawFd for net::TcpStream {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.as_inner().as_inner().as_inner().as_inner()
     }
 }
 
 impl AsRawFd for net::TcpListener {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.as_inner().as_inner().as_inner().as_inner()
     }
@@ -87,6 +89,7 @@ pub struct TcpStreamMetadata {
 impl FromRawFd for net::TcpStream {
     type Metadata = TcpStreamMetadata;
 
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd, metadata: Self::Metadata) -> net::TcpStream {
         let fd = sys::fd::FileDesc::from_inner(fd);
         let socket = sys::net::Socket::from_inner((fd, metadata.local_addr));
@@ -105,6 +108,7 @@ pub struct TcpListenerMetadata {
 impl FromRawFd for net::TcpListener {
     type Metadata = TcpListenerMetadata;
 
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd, metadata: Self::Metadata) -> net::TcpListener {
         let fd = sys::fd::FileDesc::from_inner(fd);
         let socket = sys::net::Socket::from_inner((fd, metadata.local_addr));
@@ -113,6 +117,7 @@ impl FromRawFd for net::TcpListener {
 }
 
 impl TryIntoRawFd for net::TcpStream {
+    #[inline]
     fn try_into_raw_fd(self) -> Result<RawFd, Self> {
         let (socket, peer_addr) = self.into_inner().into_inner();
         match socket.try_into_inner() {
@@ -126,6 +131,7 @@ impl TryIntoRawFd for net::TcpStream {
 }
 
 impl TryIntoRawFd for net::TcpListener {
+    #[inline]
     fn try_into_raw_fd(self) -> Result<RawFd, Self> {
         match self.into_inner().into_inner().try_into_inner() {
             Ok(fd) => Ok(fd.into_inner()),

--- a/library/std/src/sys/unix/ext/io.rs
+++ b/library/std/src/sys/unix/ext/io.rs
@@ -104,18 +104,21 @@ pub trait IntoRawFd {
 
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl AsRawFd for RawFd {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl IntoRawFd for RawFd {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl FromRawFd for RawFd {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
         fd
     }
@@ -123,18 +126,21 @@ impl FromRawFd for RawFd {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for fs::File {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
 }
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawFd for fs::File {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> fs::File {
         fs::File::from_inner(sys::fs::File::from_inner(fd))
     }
 }
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for fs::File {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
@@ -142,6 +148,7 @@ impl IntoRawFd for fs::File {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO
     }
@@ -149,6 +156,7 @@ impl AsRawFd for io::Stdin {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO
     }
@@ -156,6 +164,7 @@ impl AsRawFd for io::Stdout {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO
     }
@@ -163,6 +172,7 @@ impl AsRawFd for io::Stderr {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdinLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO
     }
@@ -170,6 +180,7 @@ impl<'a> AsRawFd for io::StdinLock<'a> {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdoutLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO
     }
@@ -177,6 +188,7 @@ impl<'a> AsRawFd for io::StdoutLock<'a> {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StderrLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO
     }

--- a/library/std/src/sys/unix/ext/net/datagram.rs
+++ b/library/std/src/sys/unix/ext/net/datagram.rs
@@ -879,6 +879,7 @@ impl UnixDatagram {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl AsRawFd for UnixDatagram {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.0.as_inner()
     }
@@ -886,6 +887,7 @@ impl AsRawFd for UnixDatagram {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl FromRawFd for UnixDatagram {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> UnixDatagram {
         UnixDatagram(Socket::from_inner(fd))
     }
@@ -893,6 +895,7 @@ impl FromRawFd for UnixDatagram {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl IntoRawFd for UnixDatagram {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.0.into_inner()
     }

--- a/library/std/src/sys/unix/ext/net/listener.rs
+++ b/library/std/src/sys/unix/ext/net/listener.rs
@@ -240,6 +240,7 @@ impl UnixListener {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl AsRawFd for UnixListener {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.0.as_inner()
     }
@@ -247,6 +248,7 @@ impl AsRawFd for UnixListener {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl FromRawFd for UnixListener {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> UnixListener {
         UnixListener(Socket::from_inner(fd))
     }
@@ -254,6 +256,7 @@ impl FromRawFd for UnixListener {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl IntoRawFd for UnixListener {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.0.into_inner()
     }

--- a/library/std/src/sys/unix/ext/net/raw_fd.rs
+++ b/library/std/src/sys/unix/ext/net/raw_fd.rs
@@ -6,6 +6,7 @@ macro_rules! impl_as_raw_fd {
     ($($t:ident)*) => {$(
         #[stable(feature = "rust1", since = "1.0.0")]
         impl AsRawFd for net::$t {
+            #[inline]
             fn as_raw_fd(&self) -> RawFd {
                 *self.as_inner().socket().as_inner()
             }
@@ -18,6 +19,7 @@ macro_rules! impl_from_raw_fd {
     ($($t:ident)*) => {$(
         #[stable(feature = "from_raw_os", since = "1.1.0")]
         impl FromRawFd for net::$t {
+            #[inline]
             unsafe fn from_raw_fd(fd: RawFd) -> net::$t {
                 let socket = sys::net::Socket::from_inner(fd);
                 net::$t::from_inner(sys_common::net::$t::from_inner(socket))
@@ -31,6 +33,7 @@ macro_rules! impl_into_raw_fd {
     ($($t:ident)*) => {$(
         #[stable(feature = "into_raw_os", since = "1.4.0")]
         impl IntoRawFd for net::$t {
+            #[inline]
             fn into_raw_fd(self) -> RawFd {
                 self.into_inner().into_socket().into_inner()
             }

--- a/library/std/src/sys/unix/ext/net/stream.rs
+++ b/library/std/src/sys/unix/ext/net/stream.rs
@@ -654,6 +654,7 @@ impl<'a> io::Write for &'a UnixStream {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl AsRawFd for UnixStream {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.0.as_inner()
     }
@@ -661,6 +662,7 @@ impl AsRawFd for UnixStream {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl FromRawFd for UnixStream {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> UnixStream {
         UnixStream(Socket::from_inner(fd))
     }
@@ -668,6 +670,7 @@ impl FromRawFd for UnixStream {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl IntoRawFd for UnixStream {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.0.into_inner()
     }

--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -274,6 +274,7 @@ impl ExitStatusExt for process::ExitStatus {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl FromRawFd for process::Stdio {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> process::Stdio {
         let fd = sys::fd::FileDesc::new(fd);
         let io = sys::process::Stdio::Fd(fd);
@@ -283,6 +284,7 @@ impl FromRawFd for process::Stdio {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
@@ -290,6 +292,7 @@ impl AsRawFd for process::ChildStdin {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
@@ -297,6 +300,7 @@ impl AsRawFd for process::ChildStdout {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
@@ -304,6 +308,7 @@ impl AsRawFd for process::ChildStderr {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for process::ChildStdin {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
@@ -311,6 +316,7 @@ impl IntoRawFd for process::ChildStdin {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for process::ChildStdout {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
@@ -318,6 +324,7 @@ impl IntoRawFd for process::ChildStdout {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for process::ChildStderr {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }

--- a/library/std/src/sys/wasi/ext/io.rs
+++ b/library/std/src/sys/wasi/ext/io.rs
@@ -54,126 +54,147 @@ pub trait IntoRawFd {
 
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl AsRawFd for RawFd {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl IntoRawFd for RawFd {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl FromRawFd for RawFd {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
         fd
     }
 }
 
 impl AsRawFd for net::TcpStream {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for net::TcpStream {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> net::TcpStream {
         net::TcpStream::from_inner(sys::net::TcpStream::from_inner(fd))
     }
 }
 
 impl IntoRawFd for net::TcpStream {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for net::TcpListener {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for net::TcpListener {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> net::TcpListener {
         net::TcpListener::from_inner(sys::net::TcpListener::from_inner(fd))
     }
 }
 
 impl IntoRawFd for net::TcpListener {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for net::UdpSocket {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for net::UdpSocket {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> net::UdpSocket {
         net::UdpSocket::from_inner(sys::net::UdpSocket::from_inner(fd))
     }
 }
 
 impl IntoRawFd for net::UdpSocket {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for fs::File {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for fs::File {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> fs::File {
         fs::File::from_inner(sys::fs::File::from_inner(fd))
     }
 }
 
 impl IntoRawFd for fs::File {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for io::Stdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO as RawFd
     }
 }
 
 impl AsRawFd for io::Stdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO as RawFd
     }
 }
 
 impl AsRawFd for io::Stderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StdinLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StdoutLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StderrLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO as RawFd
     }

--- a/library/std/src/sys/windows/ext/io.rs
+++ b/library/std/src/sys/windows/ext/io.rs
@@ -59,6 +59,7 @@ pub trait IntoRawHandle {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawHandle for fs::File {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as RawHandle
     }
@@ -108,6 +109,7 @@ impl<'a> AsRawHandle for io::StderrLock<'a> {
 
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawHandle for fs::File {
+    #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> fs::File {
         let handle = handle as c::HANDLE;
         fs::File::from_inner(sys::fs::File::from_inner(handle))
@@ -116,6 +118,7 @@ impl FromRawHandle for fs::File {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawHandle for fs::File {
+    #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
     }
@@ -161,18 +164,21 @@ pub trait IntoRawSocket {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawSocket for net::TcpStream {
+    #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         *self.as_inner().socket().as_inner()
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawSocket for net::TcpListener {
+    #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         *self.as_inner().socket().as_inner()
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawSocket for net::UdpSocket {
+    #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         *self.as_inner().socket().as_inner()
     }
@@ -180,6 +186,7 @@ impl AsRawSocket for net::UdpSocket {
 
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::TcpStream {
+    #[inline]
     unsafe fn from_raw_socket(sock: RawSocket) -> net::TcpStream {
         let sock = sys::net::Socket::from_inner(sock);
         net::TcpStream::from_inner(sys_common::net::TcpStream::from_inner(sock))
@@ -187,6 +194,7 @@ impl FromRawSocket for net::TcpStream {
 }
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::TcpListener {
+    #[inline]
     unsafe fn from_raw_socket(sock: RawSocket) -> net::TcpListener {
         let sock = sys::net::Socket::from_inner(sock);
         net::TcpListener::from_inner(sys_common::net::TcpListener::from_inner(sock))
@@ -194,6 +202,7 @@ impl FromRawSocket for net::TcpListener {
 }
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::UdpSocket {
+    #[inline]
     unsafe fn from_raw_socket(sock: RawSocket) -> net::UdpSocket {
         let sock = sys::net::Socket::from_inner(sock);
         net::UdpSocket::from_inner(sys_common::net::UdpSocket::from_inner(sock))
@@ -202,6 +211,7 @@ impl FromRawSocket for net::UdpSocket {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::TcpStream {
+    #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }
@@ -209,6 +219,7 @@ impl IntoRawSocket for net::TcpStream {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::TcpListener {
+    #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }
@@ -216,6 +227,7 @@ impl IntoRawSocket for net::TcpListener {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::UdpSocket {
+    #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -19,6 +19,7 @@ impl FromRawHandle for process::Stdio {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::Child {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -33,6 +34,7 @@ impl IntoRawHandle for process::Child {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStdin {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -40,6 +42,7 @@ impl AsRawHandle for process::ChildStdin {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStdout {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -47,6 +50,7 @@ impl AsRawHandle for process::ChildStdout {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStderr {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }

--- a/library/std/src/sys/windows/ext/thread.rs
+++ b/library/std/src/sys/windows/ext/thread.rs
@@ -8,6 +8,7 @@ use crate::thread;
 
 #[stable(feature = "thread_extensions", since = "1.9.0")]
 impl<T> AsRawHandle for thread::JoinHandle<T> {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -15,6 +16,7 @@ impl<T> AsRawHandle for thread::JoinHandle<T> {
 
 #[stable(feature = "thread_extensions", since = "1.9.0")]
 impl<T> IntoRawHandle for thread::JoinHandle<T> {
+    #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
     }


### PR DESCRIPTION
Now that file descriptor types on Unix have niches, it is advantageous for user libraries which provide file descriptor wrappers (e.g. `Socket` from socket2) to store a `File` internally instead of a `RawFd`, so that the niche can be taken advantage of. However, doing so will currently result in worse performance as `IntoRawFd`, `FromRawFd` and `AsRawFd` are not inlined. This change adds `#[inline]` to those methods on std types that wrap file descriptors, handles or sockets.