### PR TITLE
Fix 'const-stable since' of reverse_bits

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -254,7 +254,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(0, 0", stringify!($SelfT), ".reverse_bits());")]
         /// ```
         #[stable(feature = "reverse_bits", since = "1.37.0")]
-        #[rustc_const_stable(feature = "const_int_methods", since = "1.32.0")]
+        #[rustc_const_stable(feature = "const_int_methods", since = "1.37.0")]
         #[inline(always)]
         #[must_use]
         pub const fn reverse_bits(self) -> Self {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -257,7 +257,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0, 0", stringify!($SelfT), ".reverse_bits());")]
         /// ```
         #[stable(feature = "reverse_bits", since = "1.37.0")]
-        #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
+        #[rustc_const_stable(feature = "const_math", since = "1.37.0")]
         #[inline(always)]
         #[must_use]
         pub const fn reverse_bits(self) -> Self {


### PR DESCRIPTION
This fixes the const_stable `since` of `reverse_bits` for the signed and unsigned integer types. The previous value was incorrect, as it pointed to an older version where `reverse_bits` hadn't been stabilized yet.

`reverse_bits` was const-stable from the start, as can be seen from:

https://doc.rust-lang.org/1.37.0/std/primitive.u32.html#method.reverse_bits
https://doc.rust-lang.org/1.37.0/std/primitive.i32.html#method.reverse_bits