### PR TITLE
Always reject `const fn` in `trait` during parsing.

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -586,12 +586,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
     fn visit_assoc_item(&mut self, i: &'a ast::AssocItem, ctxt: AssocCtxt) {
         let is_fn = match i.kind {
-            ast::AssocItemKind::Fn(box ast::FnKind(_, ref sig, _, _)) => {
-                if let (ast::Const::Yes(_), AssocCtxt::Trait) = (sig.header.constness, ctxt) {
-                    gate_feature_post!(&self, const_fn, i.span, "const fn is unstable");
-                }
-                true
-            }
+            ast::AssocItemKind::Fn(_) => true,
             ast::AssocItemKind::TyAlias(box ast::TyAliasKind(_, ref generics, _, ref ty)) => {
                 if let (Some(_), AssocCtxt::Trait) = (ty, ctxt) {
                     gate_feature_post!(

--- a/compiler/rustc_error_codes/src/error_codes/E0379.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0379.md
@@ -3,8 +3,6 @@ A trait method was declared const.
 Erroneous code example:
 
 ```compile_fail,E0379
-#![feature(const_fn)]
-
 trait Foo {
     const fn bar() -> u32; // error!
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0764.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0764.md
@@ -3,7 +3,6 @@ A mutable reference was used in a constant.
 Erroneous code example:
 
 ```compile_fail,E0764
-#![feature(const_fn)]
 #![feature(const_mut_refs)]
 
 fn main() {
@@ -27,7 +26,6 @@ Remember: you cannot use a function call inside a constant or static. However,
 you can totally use it in constant functions:
 
 ```
-#![feature(const_fn)]
 #![feature(const_mut_refs)]
 
 const fn foo(x: usize) -> usize {

--- a/src/test/ui/consts/const-fn-not-in-trait.rs
+++ b/src/test/ui/consts/const-fn-not-in-trait.rs
@@ -1,5 +1,5 @@
 // Test that const fn is illegal in a trait declaration, whether or
-// not a default is provided.
+// not a default is provided, and even with the feature gate.
 
 #![feature(const_fn)]
 

--- a/src/test/ui/feature-gates/feature-gate-const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.rs
@@ -3,10 +3,8 @@
 const fn foo() -> usize { 0 } // ok
 
 trait Foo {
-    const fn foo() -> u32; //~ ERROR const fn is unstable
-                           //~| ERROR functions in traits cannot be declared const
-    const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
-                                //~| ERROR functions in traits cannot be declared const
+    const fn foo() -> u32; //~ ERROR functions in traits cannot be declared const
+    const fn bar() -> u32 { 0 } //~ ERROR functions in traits cannot be declared const
 }
 
 impl Foo for u32 {

--- a/src/test/ui/feature-gates/feature-gate-const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.stderr
@@ -5,36 +5,17 @@ LL |     const fn foo() -> u32;
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-const_fn.rs:8:5
+  --> $DIR/feature-gate-const_fn.rs:7:5
    |
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-const_fn.rs:13:5
+  --> $DIR/feature-gate-const_fn.rs:11:5
    |
 LL |     const fn foo() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-const_fn.rs:6:5
-   |
-LL |     const fn foo() -> u32;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+error: aborting due to 3 previous errors
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-const_fn.rs:8:5
-   |
-LL |     const fn bar() -> u32 { 0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0379, E0658.
-For more information about an error, try `rustc --explain E0379`.
+For more information about this error, try `rustc --explain E0379`.

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
@@ -3,10 +3,8 @@
 const fn foo() -> usize { 0 } // stabilized
 
 trait Foo {
-    const fn foo() -> u32; //~ ERROR const fn is unstable
-                           //~| ERROR functions in traits cannot be declared const
-    const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
-                                //~| ERROR functions in traits cannot be declared const
+    const fn foo() -> u32; //~ ERROR functions in traits cannot be declared const
+    const fn bar() -> u32 { 0 } //~ ERROR functions in traits cannot be declared const
 }
 
 impl Foo for u32 {

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -5,36 +5,17 @@ LL |     const fn foo() -> u32;
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-min_const_fn.rs:8:5
+  --> $DIR/feature-gate-min_const_fn.rs:7:5
    |
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-min_const_fn.rs:13:5
+  --> $DIR/feature-gate-min_const_fn.rs:11:5
    |
 LL |     const fn foo() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-min_const_fn.rs:6:5
-   |
-LL |     const fn foo() -> u32;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+error: aborting due to 3 previous errors
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-min_const_fn.rs:8:5
-   |
-LL |     const fn bar() -> u32 { 0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0379, E0658.
-For more information about an error, try `rustc --explain E0379`.
+For more information about this error, try `rustc --explain E0379`.


### PR DESCRIPTION
'const fn' in trait are rejected in the AST:
https://github.com/rust-lang/rust/blob/b78c0d8a4d5af91a4a55d029293e3ecb879ec142/compiler/rustc_ast_passes/src/ast_validation.rs#L1411
So this feature gate check is a NOP and we can just remove it.

The src/test/ui/feature-gates/feature-gate-min_const_fn.rs and src/test/ui/feature-gates/feature-gate-const_fn.rs tests ensure that we still reject `const fn` in `trait`

Cc https://github.com/rust-lang/rust/issues/84510
r? @oli-obk 