### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -754,7 +754,7 @@ fn validate_generic_param_order(
             GenericParamKind::Type { default: _ } => (ParamKindOrd::Type, ident),
             GenericParamKind::Const { ref ty, kw_span: _, default: _ } => {
                 let ty = pprust::ty_to_string(ty);
-                let unordered = sess.features_untracked().const_generics;
+                let unordered = sess.features_untracked().unordered_const_ty_params();
                 (ParamKindOrd::Const { unordered }, Some(format!("const {}: {}", param.ident, ty)))
             }
         };

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -586,12 +586,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
     fn visit_assoc_item(&mut self, i: &'a ast::AssocItem, ctxt: AssocCtxt) {
         let is_fn = match i.kind {
-            ast::AssocItemKind::Fn(box ast::FnKind(_, ref sig, _, _)) => {
-                if let (ast::Const::Yes(_), AssocCtxt::Trait) = (sig.header.constness, ctxt) {
-                    gate_feature_post!(&self, const_fn, i.span, "const fn is unstable");
-                }
-                true
-            }
+            ast::AssocItemKind::Fn(_) => true,
             ast::AssocItemKind::TyAlias(box ast::TyAliasKind(_, ref generics, _, ref ty)) => {
                 if let (Some(_), AssocCtxt::Trait) = (ty, ctxt) {
                     gate_feature_post!(

--- a/compiler/rustc_error_codes/src/error_codes/E0379.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0379.md
@@ -3,8 +3,6 @@ A trait method was declared const.
 Erroneous code example:
 
 ```compile_fail,E0379
-#![feature(const_fn)]
-
 trait Foo {
     const fn bar() -> u32; // error!
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0764.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0764.md
@@ -3,7 +3,6 @@ A mutable reference was used in a constant.
 Erroneous code example:
 
 ```compile_fail,E0764
-#![feature(const_fn)]
 #![feature(const_mut_refs)]
 
 fn main() {
@@ -27,7 +26,6 @@ Remember: you cannot use a function call inside a constant or static. However,
 you can totally use it in constant functions:
 
 ```
-#![feature(const_fn)]
 #![feature(const_mut_refs)]
 
 const fn foo(x: usize) -> usize {

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -7,21 +7,17 @@ pub struct StyledBuffer {
     lines: Vec<Vec<StyledChar>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct StyledChar {
     chr: char,
     style: Style,
 }
 
 impl StyledChar {
-    fn new(chr: char, style: Style) -> Self {
-        StyledChar { chr, style }
-    }
-}
+    const SPACE: Self = StyledChar::new(' ', Style::NoStyle);
 
-impl Default for StyledChar {
-    fn default() -> Self {
-        StyledChar::new(' ', Style::NoStyle)
+    const fn new(chr: char, style: Style) -> Self {
+        StyledChar { chr, style }
     }
 }
 
@@ -66,31 +62,25 @@ impl StyledBuffer {
     }
 
     fn ensure_lines(&mut self, line: usize) {
-        while line >= self.lines.len() {
-            self.lines.push(vec![]);
+        if line >= self.lines.len() {
+            self.lines.resize(line + 1, Vec::new());
         }
     }
 
     /// Sets `chr` with `style` for given `line`, `col`.
-    /// If line not exist in `StyledBuffer`, adds lines up to given
-    /// and fills last line with spaces and `Style::NoStyle` style
+    /// If `line` does not exist in our buffer, adds empty lines up to the given
+    /// and fills the last line with unstyled whitespace.
     pub fn putc(&mut self, line: usize, col: usize, chr: char, style: Style) {
         self.ensure_lines(line);
-        if col < self.lines[line].len() {
-            self.lines[line][col] = StyledChar::new(chr, style);
-        } else {
-            let mut i = self.lines[line].len();
-            while i < col {
-                self.lines[line].push(StyledChar::default());
-                i += 1;
-            }
-            self.lines[line].push(StyledChar::new(chr, style));
+        if col >= self.lines[line].len() {
+            self.lines[line].resize(col + 1, StyledChar::SPACE);
         }
+        self.lines[line][col] = StyledChar::new(chr, style);
     }
 
     /// Sets `string` with `style` for given `line`, starting from `col`.
-    /// If line not exist in `StyledBuffer`, adds lines up to given
-    /// and fills last line with spaces and `Style::NoStyle` style
+    /// If `line` does not exist in our buffer, adds empty lines up to the given
+    /// and fills the last line with unstyled whitespace.
     pub fn puts(&mut self, line: usize, col: usize, string: &str, style: Style) {
         let mut n = col;
         for c in string.chars() {
@@ -108,7 +98,7 @@ impl StyledBuffer {
         if !self.lines[line].is_empty() {
             // Push the old content over to make room for new content
             for _ in 0..string_len {
-                self.lines[line].insert(0, StyledChar::default());
+                self.lines[line].insert(0, StyledChar::SPACE);
             }
         }
 

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -148,11 +148,11 @@ impl StyledBuffer {
 
     /// Set `style` for `line`, `col` if:
     /// 1. That line and column exist in `StyledBuffer`
-    /// 2. Existing style is `Style::NoStyle` or `Style::Quotation` or `overwrite` is `true`
+    /// 2. `overwrite` is `true` or existing style is `Style::NoStyle` or `Style::Quotation`
     pub fn set_style(&mut self, line: usize, col: usize, style: Style, overwrite: bool) {
         if let Some(ref mut line) = self.text.get_mut(line) {
             if let Some(StyledChar { style: s, .. }) = line.get_mut(col) {
-                if *s == Style::NoStyle || *s == Style::Quotation || overwrite {
+                if overwrite || *s == Style::NoStyle || *s == Style::Quotation {
                     *s = style;
                 }
             }

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -105,9 +105,11 @@ impl StyledBuffer {
         self.ensure_lines(line);
         let string_len = string.chars().count();
 
-        // Push the old content over to make room for new content
-        for _ in 0..string_len {
-            self.text[line].insert(0, StyledChar::default());
+        if !self.text[line].is_empty() {
+            // Push the old content over to make room for new content
+            for _ in 0..string_len {
+                self.text[line].insert(0, StyledChar::default());
+            }
         }
 
         self.puts(line, 0, string, style);

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -30,6 +30,7 @@ impl StyledBuffer {
         StyledBuffer { text: vec![] }
     }
 
+    /// Returns content of `StyledBuffer` splitted by lines and line styles
     pub fn render(&self) -> Vec<Vec<StyledString>> {
         // Tabs are assumed to have been replaced by spaces in calling code.
         debug_assert!(self.text.iter().all(|r| !r.iter().any(|sc| sc.chr == '\t')));
@@ -70,6 +71,9 @@ impl StyledBuffer {
         }
     }
 
+    /// Sets `chr` with `style` for given `line`, `col`.
+    /// If line not exist in `StyledBuffer`, adds lines up to given
+    /// and fills last line with spaces and `Style::NoStyle` style
     pub fn putc(&mut self, line: usize, col: usize, chr: char, style: Style) {
         self.ensure_lines(line);
         if col < self.text[line].len() {
@@ -84,6 +88,9 @@ impl StyledBuffer {
         }
     }
 
+    /// Sets `string` with `style` for given `line`, starting from `col`.
+    /// If line not exist in `StyledBuffer`, adds lines up to given
+    /// and fills last line with spaces and `Style::NoStyle` style
     pub fn puts(&mut self, line: usize, col: usize, string: &str, style: Style) {
         let mut n = col;
         for c in string.chars() {
@@ -92,6 +99,8 @@ impl StyledBuffer {
         }
     }
 
+    /// For given `line` inserts `string` with `style` before old content of that line,
+    /// adding lines if needed
     pub fn prepend(&mut self, line: usize, string: &str, style: Style) {
         self.ensure_lines(line);
         let string_len = string.chars().count();
@@ -104,6 +113,8 @@ impl StyledBuffer {
         self.puts(line, 0, string, style);
     }
 
+    /// For given `line` inserts `string` with `style` after old content of that line,
+    /// adding lines if needed
     pub fn append(&mut self, line: usize, string: &str, style: Style) {
         if line >= self.text.len() {
             self.puts(line, 0, string, style);
@@ -117,6 +128,9 @@ impl StyledBuffer {
         self.text.len()
     }
 
+    /// Set `style` for `line`, `col_start..col_end` range if:
+    /// 1. That line and column range exist in `StyledBuffer`
+    /// 2. `overwrite` is `true` or existing style is `Style::NoStyle` or `Style::Quotation`
     pub fn set_style_range(
         &mut self,
         line: usize,
@@ -130,6 +144,9 @@ impl StyledBuffer {
         }
     }
 
+    /// Set `style` for `line`, `col` if:
+    /// 1. That line and column exist in `StyledBuffer`
+    /// 2. Existing style is `Style::NoStyle` or `Style::Quotation` or `overwrite` is `true`
     pub fn set_style(&mut self, line: usize, col: usize, style: Style, overwrite: bool) {
         if let Some(ref mut line) = self.text.get_mut(line) {
             if let Some(StyledChar { style: s, .. }) = line.get_mut(col) {

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -19,6 +19,12 @@ impl StyledChar {
     }
 }
 
+impl Default for StyledChar {
+    fn default() -> Self {
+        StyledChar::new(' ', Style::NoStyle)
+    }
+}
+
 impl StyledBuffer {
     pub fn new() -> StyledBuffer {
         StyledBuffer { text: vec![] }
@@ -71,7 +77,7 @@ impl StyledBuffer {
         } else {
             let mut i = self.text[line].len();
             while i < col {
-                self.text[line].push(StyledChar::new(' ', Style::NoStyle));
+                self.text[line].push(StyledChar::default());
                 i += 1;
             }
             self.text[line].push(StyledChar::new(chr, style));
@@ -92,7 +98,7 @@ impl StyledBuffer {
 
         // Push the old content over to make room for new content
         for _ in 0..string_len {
-            self.text[line].insert(0, StyledChar::new(' ', Style::NoStyle));
+            self.text[line].insert(0, StyledChar::default());
         }
 
         self.puts(line, 0, string, style);

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -63,6 +63,10 @@ macro_rules! declare_features {
                     _ => panic!("`{}` was not listed in `declare_features`", feature),
                 }
             }
+
+            pub fn unordered_const_ty_params(&self) -> bool {
+                self.const_generics || self.const_generics_defaults
+            }
         }
     };
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -296,7 +296,9 @@ impl GenericArg<'_> {
         match self {
             GenericArg::Lifetime(_) => ast::ParamKindOrd::Lifetime,
             GenericArg::Type(_) => ast::ParamKindOrd::Type,
-            GenericArg::Const(_) => ast::ParamKindOrd::Const { unordered: feats.const_generics },
+            GenericArg::Const(_) => {
+                ast::ParamKindOrd::Const { unordered: feats.unordered_const_ty_params() }
+            }
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -36,7 +36,7 @@ impl GenericParamDefKind {
             GenericParamDefKind::Lifetime => ast::ParamKindOrd::Lifetime,
             GenericParamDefKind::Type { .. } => ast::ParamKindOrd::Type,
             GenericParamDefKind::Const { .. } => {
-                ast::ParamKindOrd::Const { unordered: tcx.features().const_generics }
+                ast::ParamKindOrd::Const { unordered: tcx.features().unordered_const_ty_params() }
             }
         }
     }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -472,17 +472,6 @@ impl<'a> Resolver<'a> {
                 );
                 err
             }
-            ResolutionError::ParamInAnonConstInTyDefault(name) => {
-                let mut err = self.session.struct_span_err(
-                    span,
-                    "constant values inside of type parameter defaults must not depend on generic parameters",
-                );
-                err.span_label(
-                    span,
-                    format!("the anonymous constant must not depend on the parameter `{}`", name),
-                );
-                err
-            }
             ResolutionError::ParamInNonTrivialAnonConst { name, is_type } => {
                 let mut err = self.session.struct_span_err(
                     span,

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -286,7 +286,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                                         ParamKindOrd::Const {
                                                             unordered: tcx
                                                                 .features()
-                                                                .const_generics,
+                                                                .unordered_const_ty_params(),
                                                         }
                                                     }
                                                 },
@@ -309,7 +309,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                                             GenericArg::Lifetime(_) => ParamKindOrd::Lifetime,
                                             GenericArg::Type(_) => ParamKindOrd::Type,
                                             GenericArg::Const(_) => ParamKindOrd::Const {
-                                                unordered: tcx.features().const_generics,
+                                                unordered: tcx
+                                                    .features()
+                                                    .unordered_const_ty_params(),
                                             },
                                         }),
                                         Some(&format!(

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -513,7 +513,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                     GenericParamDefKind::Const { has_default } => {
                         let ty = tcx.at(self.span).type_of(param.def_id);
                         if !infer_args && has_default {
-                            tcx.const_param_default(param.def_id).into()
+                            tcx.const_param_default(param.def_id)
+                                .subst_spanned(tcx, substs.unwrap(), Some(self.span))
+                                .into()
                         } else {
                             if infer_args {
                                 self.astconv.ct_infer(ty, Some(param), self.span).into()

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1494,7 +1494,9 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         if let (Some((expr, _)), Some((fn_decl, _, _))) =
             (expression, fcx.get_node_fn_decl(parent_item))
         {
-            fcx.suggest_missing_return_expr(&mut err, expr, fn_decl, expected, found, parent_id);
+            fcx.suggest_missing_break_or_return_expr(
+                &mut err, expr, fn_decl, expected, found, id, parent_id,
+            );
         }
 
         if let (Some(sp), Some(fn_output)) = (fcx.ret_coercion_span.get(), fn_output) {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1446,7 +1446,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     GenericParamDefKind::Const { has_default, .. } => {
                         if !infer_args && has_default {
-                            tcx.const_param_default(param.def_id).into()
+                            tcx.const_param_default(param.def_id)
+                                .subst_spanned(tcx, substs.unwrap(), Some(self.span))
+                                .into()
                         } else {
                             self.fcx.var_for_def(self.span, param)
                         }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -8,7 +8,7 @@ use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind};
 use rustc_hir::lang_items::LangItem;
-use rustc_hir::{ExprKind, ItemKind, Node};
+use rustc_hir::{ExprKind, ItemKind, Node, StmtKind};
 use rustc_infer::infer;
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::{self, Binder, Ty};
@@ -55,7 +55,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             pointing_at_return_type =
                 self.suggest_missing_return_type(err, &fn_decl, expected, found, can_suggest);
             let fn_id = self.tcx.hir().get_return_block(blk_id).unwrap();
-            self.suggest_missing_return_expr(err, expr, &fn_decl, expected, found, fn_id);
+            self.suggest_missing_break_or_return_expr(
+                err, expr, &fn_decl, expected, found, blk_id, fn_id,
+            );
         }
         pointing_at_return_type
     }
@@ -472,7 +474,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    pub(in super::super) fn suggest_missing_return_expr(
+    pub(in super::super) fn suggest_missing_break_or_return_expr(
         &self,
         err: &mut DiagnosticBuilder<'_>,
         expr: &'tcx hir::Expr<'tcx>,
@@ -480,14 +482,30 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
         id: hir::HirId,
+        fn_id: hir::HirId,
     ) {
         if !expected.is_unit() {
             return;
         }
         let found = self.resolve_vars_with_obligations(found);
+
+        if self.in_loop(id) {
+            if self.in_local_statement(id) {
+                err.multipart_suggestion(
+                    "you might have meant to break the loop with this value",
+                    vec![
+                        (expr.span.shrink_to_lo(), "break ".to_string()),
+                        (expr.span.shrink_to_hi(), ";".to_string()),
+                    ],
+                    Applicability::MaybeIncorrect,
+                );
+                return;
+            }
+        }
+
         if let hir::FnRetTy::Return(ty) = fn_decl.output {
             let ty = <dyn AstConv<'_>>::ast_ty_to_ty(self, ty);
-            let bound_vars = self.tcx.late_bound_vars(id);
+            let bound_vars = self.tcx.late_bound_vars(fn_id);
             let ty = self.tcx.erase_late_bound_regions(Binder::bind_with_vars(ty, bound_vars));
             let ty = self.normalize_associated_types_in(expr.span, ty);
             if self.can_coerce(found, ty) {
@@ -513,5 +531,57 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // `{ 42 } &&x` (#61475) or `{ 42 } && if x { 1 } else { 0 }`
             self.tcx.sess.parse_sess.expr_parentheses_needed(err, *sp, None);
         }
+    }
+
+    fn in_loop(&self, id: hir::HirId) -> bool {
+        if self.is_loop(id) {
+            return true;
+        }
+
+        for (parent_id, _) in self.tcx.hir().parent_iter(id) {
+            if self.is_loop(parent_id) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn is_loop(&self, id: hir::HirId) -> bool {
+        let node = self.tcx.hir().get(id);
+
+        if let Node::Expr(expr) = node {
+            if let ExprKind::Loop(..) = expr.kind {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn in_local_statement(&self, id: hir::HirId) -> bool {
+        if self.is_local_statement(id) {
+            return true;
+        }
+
+        for (parent_id, _) in self.tcx.hir().parent_iter(id) {
+            if self.is_local_statement(parent_id) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn is_local_statement(&self, id: hir::HirId) -> bool {
+        let node = self.tcx.hir().get(id);
+
+        if let Node::Stmt(stmt) = node {
+            if let StmtKind::Local(..) = stmt.kind {
+                return true;
+            }
+        }
+
+        false
     }
 }

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1047,7 +1047,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
         }
-        if !alt_rcvr_sugg && self.suggest_valid_traits(err, valid_out_of_scope_traits) {
+        if self.suggest_valid_traits(err, valid_out_of_scope_traits) {
             return;
         }
 

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -988,6 +988,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut alt_rcvr_sugg = false;
         if let SelfSource::MethodCall(rcvr) = source {
             debug!(?span, ?item_name, ?rcvr_ty, ?rcvr);
+            let skippable = [
+                self.tcx.lang_items().clone_trait(),
+                self.tcx.lang_items().deref_trait(),
+                self.tcx.lang_items().deref_mut_trait(),
+                self.tcx.lang_items().drop_trait(),
+            ];
             // Try alternative arbitrary self types that could fulfill this call.
             // FIXME: probe for all types that *could* be arbitrary self-types, not
             // just this list.
@@ -996,6 +1002,27 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (self.tcx.mk_mut_ref(&ty::ReErased, rcvr_ty), "&mut "),
                 (self.tcx.mk_imm_ref(&ty::ReErased, rcvr_ty), "&"),
             ] {
+                if let Ok(pick) = self.lookup_probe(
+                    span,
+                    item_name,
+                    rcvr_ty,
+                    rcvr,
+                    crate::check::method::probe::ProbeScope::AllTraits,
+                ) {
+                    // If the method is defined for the receiver we have, it likely wasn't `use`d.
+                    // We point at the method, but we just skip the rest of the check for arbitrary
+                    // self types and rely on the suggestion to `use` the trait from
+                    // `suggest_valid_traits`.
+                    let did = Some(pick.item.container.id());
+                    let skip = skippable.contains(&did);
+                    if pick.autoderefs == 0 && !skip {
+                        err.span_label(
+                            pick.item.ident.span,
+                            &format!("the method is available for `{}` here", rcvr_ty),
+                        );
+                    }
+                    break;
+                }
                 for (rcvr_ty, pre) in &[
                     (self.tcx.mk_lang_item(rcvr_ty, LangItem::OwnedBox), "Box::new"),
                     (self.tcx.mk_lang_item(rcvr_ty, LangItem::Pin), "Pin::new"),
@@ -1015,13 +1042,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             // We don't want to suggest a container type when the missing
                             // method is `.clone()` or `.deref()` otherwise we'd suggest
                             // `Arc::new(foo).clone()`, which is far from what the user wants.
-                            let skip = [
-                                self.tcx.lang_items().clone_trait(),
-                                self.tcx.lang_items().deref_trait(),
-                                self.tcx.lang_items().deref_mut_trait(),
-                                self.tcx.lang_items().drop_trait(),
-                            ]
-                            .contains(&did);
+                            let skip = skippable.contains(&did);
                             // Make sure the method is defined for the *actual* receiver: we don't
                             // want to treat `Box<Self>` as a receiver if it only works because of
                             // an autoderef to `&self`

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -1316,13 +1316,13 @@ fn has_late_bound_regions<'tcx>(tcx: TyCtxt<'tcx>, node: Node<'tcx>) -> Option<S
     }
 }
 
-struct AnonConstInParamListDetector {
-    in_param_list: bool,
-    found_anon_const_in_list: bool,
+struct AnonConstInParamTyDetector {
+    in_param_ty: bool,
+    found_anon_const_in_param_ty: bool,
     ct: HirId,
 }
 
-impl<'v> Visitor<'v> for AnonConstInParamListDetector {
+impl<'v> Visitor<'v> for AnonConstInParamTyDetector {
     type Map = intravisit::ErasedMap<'v>;
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
@@ -1330,15 +1330,17 @@ impl<'v> Visitor<'v> for AnonConstInParamListDetector {
     }
 
     fn visit_generic_param(&mut self, p: &'v hir::GenericParam<'v>) {
-        let prev = self.in_param_list;
-        self.in_param_list = true;
-        intravisit::walk_generic_param(self, p);
-        self.in_param_list = prev;
+        if let GenericParamKind::Const { ref ty, default: _ } = p.kind {
+            let prev = self.in_param_ty;
+            self.in_param_ty = true;
+            self.visit_ty(ty);
+            self.in_param_ty = prev;
+        }
     }
 
     fn visit_anon_const(&mut self, c: &'v hir::AnonConst) {
-        if self.in_param_list && self.ct == c.hir_id {
-            self.found_anon_const_in_list = true;
+        if self.in_param_ty && self.ct == c.hir_id {
+            self.found_anon_const_in_param_ty = true;
         } else {
             intravisit::walk_anon_const(self, c)
         }
@@ -1366,27 +1368,24 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
             let parent_id = tcx.hir().get_parent_item(hir_id);
             let parent_def_id = tcx.hir().local_def_id(parent_id);
 
-            let mut in_param_list = false;
+            let mut in_param_ty = false;
             for (_parent, node) in tcx.hir().parent_iter(hir_id) {
                 if let Some(generics) = node.generics() {
-                    let mut visitor = AnonConstInParamListDetector {
-                        in_param_list: false,
-                        found_anon_const_in_list: false,
+                    let mut visitor = AnonConstInParamTyDetector {
+                        in_param_ty: false,
+                        found_anon_const_in_param_ty: false,
                         ct: hir_id,
                     };
 
                     visitor.visit_generics(generics);
-                    in_param_list = visitor.found_anon_const_in_list;
+                    in_param_ty = visitor.found_anon_const_in_param_ty;
                     break;
                 }
             }
 
-            if in_param_list {
+            if in_param_ty {
                 // We do not allow generic parameters in anon consts if we are inside
-                // of a param list.
-                //
-                // This affects both default type bindings, e.g. `struct<T, U = [u8; std::mem::size_of::<T>()]>(T, U)`,
-                // and the types of const parameters, e.g. `struct V<const N: usize, const M: [u8; N]>();`.
+                // of a const parameter type, e.g. `struct Foo<const N: usize, const M: [u8; N]>` is not allowed.
                 None
             } else if tcx.lazy_normalization() {
                 // HACK(eddyb) this provides the correct generics when

--- a/src/test/ui/const-generics/defaults/auxiliary/const_defaulty.rs
+++ b/src/test/ui/const-generics/defaults/auxiliary/const_defaulty.rs
@@ -1,4 +1,4 @@
-#![feature(const_generics)]
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
@@ -1,16 +1,18 @@
-error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/complex-generic-default-expr.rs:9:62
+error: constant expression depends on a generic parameter
+  --> $DIR/complex-generic-default-expr.rs:6:34
+   |
+LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
+   |                                  ^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/complex-generic-default-expr.rs:10:21
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
-   |            -                                                 ^ doesn't have a size known at compile-time
-   |            |
-   |            this type parameter needs to be `std::marker::Sized`
-   | 
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |                     ^^^^^^^^^
    |
-LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
+   = note: this may fail depending on what value the parameter takes
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.full.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/complex-generic-default-expr.rs:6:62
+  --> $DIR/complex-generic-default-expr.rs:9:62
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |            -                                                 ^ doesn't have a size known at compile-time

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -1,0 +1,20 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-generic-default-expr.rs:6:47
+   |
+LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
+   |                                               ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/complex-generic-default-expr.rs:9:62
+   |
+LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
+   |                                                              ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:10:47
+  --> $DIR/complex-generic-default-expr.rs:6:47
    |
 LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |                                               ^ cannot perform const operation using `N`
@@ -8,7 +8,7 @@ LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:13:62
+  --> $DIR/complex-generic-default-expr.rs:10:62
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |                                                              ^ cannot perform const operation using `T`

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:6:47
+  --> $DIR/complex-generic-default-expr.rs:10:47
    |
 LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    |                                               ^ cannot perform const operation using `N`
@@ -8,7 +8,7 @@ LL | struct Foo<const N: usize, const M: usize = { N + 1 }>;
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/complex-generic-default-expr.rs:9:62
+  --> $DIR/complex-generic-default-expr.rs:13:62
    |
 LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
    |                                                              ^ cannot perform const operation using `T`

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,4 +1,8 @@
-// revisions: full min
+// revisions: min
+// FIXME(const_generics): add the `full` revision,
+// currently causes an ICE as we don't supply substs to
+// anon consts in the parameter listing, as that would
+// cause that anon const to reference itself.
 #![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
@@ -8,6 +12,6 @@ struct Foo<const N: usize, const M: usize = { N + 1 }>;
 
 struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
 //[min]~^ ERROR generic parameters may not be used in const operations
-//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time 
+//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,9 +1,13 @@
-#![feature(const_generics, const_generics_defaults)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct Foo<const N: usize, const M: usize = { N + 1 }>;
+//[min]~^ ERROR generic parameters may not be used in const operations
 
 struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
-//~^ ERROR the size for values of type `T` cannot be known at compilation time 
+//[min]~^ ERROR generic parameters may not be used in const operations
+//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time 
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,0 +1,9 @@
+#![feature(const_generics, const_generics_defaults)]
+#![allow(incomplete_features)]
+
+struct Foo<const N: usize, const M: usize = { N + 1 }>;
+
+struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
+//~^ ERROR the size for values of type `T` cannot be known at compilation time 
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.rs
@@ -1,17 +1,14 @@
-// revisions: min
-// FIXME(const_generics): add the `full` revision,
-// currently causes an ICE as we don't supply substs to
-// anon consts in the parameter listing, as that would
-// cause that anon const to reference itself.
+// revisions: full min
 #![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct Foo<const N: usize, const M: usize = { N + 1 }>;
-//[min]~^ ERROR generic parameters may not be used in const operations
+//[full]~^ ERROR constant expression depends on a generic parameter
+//[min]~^^ ERROR generic parameters may not be used in const operations
 
 struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
-//[min]~^ ERROR generic parameters may not be used in const operations
-//[full]~^^ ERROR the size for values of type `T` cannot be known at compilation time
+//[full]~^ ERROR constant expression depends on a generic parameter
+//[min]~^^ ERROR generic parameters may not be used in const operations
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/complex-generic-default-expr.stderr
+++ b/src/test/ui/const-generics/defaults/complex-generic-default-expr.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/complex-generic-default-expr.rs:6:62
+   |
+LL | struct Bar<T, const TYPE_SIZE: usize = { std::mem::size_of::<T>() }>(T);
+   |            -                                                 ^ doesn't have a size known at compile-time
+   |            |
+   |            this type parameter needs to be `std::marker::Sized`
+   | 
+  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/defaults/const-default.rs
+++ b/src/test/ui/const-generics/defaults/const-default.rs
@@ -1,6 +1,6 @@
 // run-pass
-
-#![feature(const_generics)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
+++ b/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
@@ -8,7 +8,16 @@ fn foo<const N: usize>() -> Foo<N> {
     Foo(x, x)
 }
 
+// To check that we actually apply the correct substs for const param defaults.
+fn concrete_foo() -> Foo<13> {
+    Foo(Default::default(), Default::default())
+}
+
+
 fn main() {
     let val = foo::<13>();
+    assert_eq!(val.0, val.1);
+
+    let val = concrete_foo();
     assert_eq!(val.0, val.1);
 }

--- a/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
+++ b/src/test/ui/const-generics/defaults/const-param-as-default-value.rs
@@ -1,0 +1,14 @@
+// run-pass
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
+struct Foo<const N: usize, const M: usize = N>([u8; N], [u8; M]);
+
+fn foo<const N: usize>() -> Foo<N> {
+    let x = [0; N];
+    Foo(x, x)
+}
+
+fn main() {
+    let val = foo::<13>();
+    assert_eq!(val.0, val.1);
+}

--- a/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
+++ b/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
@@ -1,0 +1,18 @@
+// run-pass
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
+// FIXME(const_generics_defaults): while we can allow this,
+// we probably won't easily allow this with more complex const operations.
+//
+// So we have to make a conscious decision here when stabilizing a relaxed parameter ordering.
+struct Foo<const N: usize, T = [u8; N]>(T);
+
+impl<const N: usize> Foo<N> {
+    fn new() -> Self {
+        Foo([0; N])
+    }
+}
+
+fn main() {
+    assert_eq!(Foo::new().0, [0; 10]);
+}

--- a/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
+++ b/src/test/ui/const-generics/defaults/const-param-in-ty-defaults.rs
@@ -1,10 +1,6 @@
 // run-pass
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
-// FIXME(const_generics_defaults): while we can allow this,
-// we probably won't easily allow this with more complex const operations.
-//
-// So we have to make a conscious decision here when stabilizing a relaxed parameter ordering.
 struct Foo<const N: usize, T = [u8; N]>(T);
 
 impl<const N: usize> Foo<N> {

--- a/src/test/ui/const-generics/defaults/default-on-impl.full.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.full.stderr
@@ -1,5 +1,5 @@
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/default-on-impl.rs:6:12
+  --> $DIR/default-on-impl.rs:8:12
    |
 LL | impl<const N: usize = 1> Foo<N> {}
    |            ^

--- a/src/test/ui/const-generics/defaults/default-on-impl.min.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.min.stderr
@@ -1,0 +1,8 @@
+error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/default-on-impl.rs:8:12
+   |
+LL | impl<const N: usize = 1> Foo<N> {}
+   |            ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/defaults/default-on-impl.rs
+++ b/src/test/ui/const-generics/defaults/default-on-impl.rs
@@ -1,4 +1,6 @@
-#![feature(const_generics, const_generics_defaults)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct Foo<const N: usize>;

--- a/src/test/ui/const-generics/defaults/default-on-impl.rs
+++ b/src/test/ui/const-generics/defaults/default-on-impl.rs
@@ -1,0 +1,9 @@
+#![feature(const_generics, const_generics_defaults)]
+#![allow(incomplete_features)]
+
+struct Foo<const N: usize>;
+
+impl<const N: usize = 1> Foo<N> {}
+//~^ ERROR defaults for const parameters are only allowed
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/default-on-impl.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.stderr
@@ -1,0 +1,8 @@
+error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/default-on-impl.rs:6:12
+   |
+LL | impl<const N: usize = 1> Foo<N> {}
+   |            ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/defaults/default-param-wf-concrete.rs
+++ b/src/test/ui/const-generics/defaults/default-param-wf-concrete.rs
@@ -1,0 +1,5 @@
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
+struct Foo<const N: u8 = { 255 + 1 }>;
+//~^ ERROR evaluation of constant value failed
+fn main() {}

--- a/src/test/ui/const-generics/defaults/default-param-wf-concrete.stderr
+++ b/src/test/ui/const-generics/defaults/default-param-wf-concrete.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/default-param-wf-concrete.rs:3:28
+   |
+LL | struct Foo<const N: u8 = { 255 + 1 }>;
+   |                            ^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/const-generics/defaults/external.rs
+++ b/src/test/ui/const-generics/defaults/external.rs
@@ -1,5 +1,7 @@
 // aux-build:const_defaulty.rs
 // check-pass
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/intermixed-lifetime.full.stderr
+++ b/src/test/ui/const-generics/defaults/intermixed-lifetime.full.stderr
@@ -1,5 +1,5 @@
 error: lifetime parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:6:28
+  --> $DIR/intermixed-lifetime.rs:7:28
    |
 LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
    |           -----------------^^---------- help: reorder the parameters: lifetimes, then consts and types: `<'a, const N: usize, T = u32>`

--- a/src/test/ui/const-generics/defaults/intermixed-lifetime.min.stderr
+++ b/src/test/ui/const-generics/defaults/intermixed-lifetime.min.stderr
@@ -1,26 +1,14 @@
 error: lifetime parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:6:28
+  --> $DIR/intermixed-lifetime.rs:7:28
    |
 LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
-   |           -----------------^^---------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
+   |           -----------------^^---------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const N: usize, T = u32>`
 
-error: type parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:6:32
-   |
-LL | struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
-   |           ---------------------^------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
-
-error: lifetime parameters must be declared prior to const parameters
+error: lifetime parameters must be declared prior to type parameters
   --> $DIR/intermixed-lifetime.rs:10:37
    |
 LL | struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-   |           --------------------------^^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
+   |           --------------------------^^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const N: usize, T = u32>`
 
-error: type parameters must be declared prior to const parameters
-  --> $DIR/intermixed-lifetime.rs:10:28
-   |
-LL | struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-   |           -----------------^----------- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/defaults/intermixed-lifetime.rs
+++ b/src/test/ui/const-generics/defaults/intermixed-lifetime.rs
@@ -1,15 +1,13 @@
-// revisions: full min
 // Checks that lifetimes cannot be interspersed between consts and types.
+// revisions: full min
 #![cfg_attr(full, feature(const_generics))]
-#![cfg_attr(full, allow(incomplete_features))]
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
 
 struct Foo<const N: usize, 'a, T = u32>(&'a (), T);
 //~^ Error lifetime parameters must be declared prior to const parameters
-//[min]~^^ Error type parameters must be declared prior to const parameters
 
 struct Bar<const N: usize, T = u32, 'a>(&'a (), T);
-//[full]~^ Error lifetime parameters must be declared prior to type parameters
-//[min]~^^ Error type parameters must be declared prior to const parameters
-//[min]~| Error lifetime parameters must be declared prior to const parameters
+//~^ Error lifetime parameters must be declared prior to type parameters
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/mismatch.full.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.full.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:11:28
+  --> $DIR/mismatch.rs:12:28
    |
 LL |     let e: Example::<13> = ();
    |            -------------   ^^ expected struct `Example`, found `()`
@@ -7,7 +7,7 @@ LL |     let e: Example::<13> = ();
    |            expected due to this
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:13:34
+  --> $DIR/mismatch.rs:14:34
    |
 LL |     let e: Example2::<u32, 13> = ();
    |            -------------------   ^^ expected struct `Example2`, found `()`
@@ -18,7 +18,7 @@ LL |     let e: Example2::<u32, 13> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:15:34
+  --> $DIR/mismatch.rs:16:34
    |
 LL |     let e: Example3::<13, u32> = ();
    |            -------------------   ^^ expected struct `Example3`, found `()`
@@ -29,7 +29,7 @@ LL |     let e: Example3::<13, u32> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:17:28
+  --> $DIR/mismatch.rs:18:28
    |
 LL |     let e: Example3::<7> = ();
    |            -------------   ^^ expected struct `Example3`, found `()`
@@ -40,7 +40,7 @@ LL |     let e: Example3::<7> = ();
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/mismatch.rs:21:28
+  --> $DIR/mismatch.rs:22:28
    |
 LL |     let e: Example4::<7> = ();
    |            -------------   ^^ expected struct `Example4`, found `()`

--- a/src/test/ui/const-generics/defaults/mismatch.min.stderr
+++ b/src/test/ui/const-generics/defaults/mismatch.min.stderr
@@ -1,0 +1,52 @@
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:12:28
+   |
+LL |     let e: Example::<13> = ();
+   |            -------------   ^^ expected struct `Example`, found `()`
+   |            |
+   |            expected due to this
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:14:34
+   |
+LL |     let e: Example2::<u32, 13> = ();
+   |            -------------------   ^^ expected struct `Example2`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Example2`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:16:34
+   |
+LL |     let e: Example3::<13, u32> = ();
+   |            -------------------   ^^ expected struct `Example3`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Example3`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:18:28
+   |
+LL |     let e: Example3::<7> = ();
+   |            -------------   ^^ expected struct `Example3`, found `()`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `Example3<7_usize>`
+           found unit type `()`
+
+error[E0308]: mismatched types
+  --> $DIR/mismatch.rs:22:28
+   |
+LL |     let e: Example4::<7> = ();
+   |            -------------   ^^ expected struct `Example4`, found `()`
+   |            |
+   |            expected due to this
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/const-generics/defaults/mismatch.rs
+++ b/src/test/ui/const-generics/defaults/mismatch.rs
@@ -1,4 +1,5 @@
-#![feature(const_generics)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
 #![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
@@ -11,4 +11,3 @@ trait Foo<const KIND: bool = true> {}
 fn foo<const SIZE: usize = 5>() {}
 
 struct Range<const FROM: usize = 0, const LEN: usize = 0, const TO: usize = FROM>;
-

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.rs
@@ -10,4 +10,5 @@ trait Foo<const KIND: bool = true> {}
 
 fn foo<const SIZE: usize = 5>() {}
 
-struct Range<const FROM: usize = 0, const LEN: usize = 0, const TO: usize = {FROM + LEN}>;
+struct Range<const FROM: usize = 0, const LEN: usize = 0, const TO: usize = FROM>;
+

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -17,4 +17,5 @@ trait Foo<const KIND : bool = true> { }
 fn foo<const SIZE : usize = 5>() { }
 
 struct Range<const FROM : usize = 0, const LEN : usize = 0, const TO : usize =
-             { FROM + LEN }>;
+             FROM>;
+

--- a/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
+++ b/src/test/ui/const-generics/defaults/pretty-printing-ast.stdout
@@ -18,4 +18,3 @@ fn foo<const SIZE : usize = 5>() { }
 
 struct Range<const FROM : usize = 0, const LEN : usize = 0, const TO : usize =
              FROM>;
-

--- a/src/test/ui/const-generics/defaults/repr-c-issue-82792.rs
+++ b/src/test/ui/const-generics/defaults/repr-c-issue-82792.rs
@@ -6,7 +6,7 @@
 #![allow(incomplete_features)]
 
 #[repr(C)]
-pub struct Loaf<T: Sized, const N: usize = 1usize> {
+pub struct Loaf<T: Sized, const N: usize = 1> {
     head: [T; N],
     slice: [T],
 }

--- a/src/test/ui/const-generics/defaults/simple-defaults.min.stderr
+++ b/src/test/ui/const-generics/defaults/simple-defaults.min.stderr
@@ -1,8 +1,0 @@
-error: type parameters must be declared prior to const parameters
-  --> $DIR/simple-defaults.rs:8:40
-   |
-LL | struct FixedOutput<'a, const N: usize, T=u32> {
-   |                   ---------------------^----- help: reorder the parameters: lifetimes, then types, then consts: `<'a, T = u32, const N: usize>`
-
-error: aborting due to previous error
-

--- a/src/test/ui/const-generics/defaults/simple-defaults.rs
+++ b/src/test/ui/const-generics/defaults/simple-defaults.rs
@@ -1,12 +1,12 @@
-// [full] run-pass
-// revisions: min full
-// Checks some basic test cases for defaults.
+// run-pass
+// Checks that type param defaults are allowed after const params.
+// revisions: full min
 #![cfg_attr(full, feature(const_generics))]
-#![cfg_attr(full, allow(incomplete_features))]
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
 #![allow(dead_code)]
 
 struct FixedOutput<'a, const N: usize, T=u32> {
-    //[min]~^ ERROR type parameters must be declared prior to const parameters
     out: &'a [T; N],
 }
 

--- a/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
+++ b/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
@@ -1,5 +1,7 @@
 // check-pass
-#![feature(const_generics, const_generics_defaults)]
+// revisions: full min
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
 #![allow(incomplete_features)]
 
 struct N;

--- a/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
+++ b/src/test/ui/const-generics/defaults/type-default-const-param-name.rs
@@ -1,0 +1,17 @@
+// check-pass
+#![feature(const_generics, const_generics_defaults)]
+#![allow(incomplete_features)]
+
+struct N;
+
+struct Foo<const N: usize = 1, T = N>(T);
+
+impl Foo {
+    fn new() -> Self {
+        Foo(N)
+    }
+}
+
+fn main() {
+    let Foo::<1, N>(N) = Foo::new();
+}

--- a/src/test/ui/const-generics/defaults/wrong-order.full.stderr
+++ b/src/test/ui/const-generics/defaults/wrong-order.full.stderr
@@ -1,19 +1,8 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/wrong-order.rs:4:10
+  --> $DIR/wrong-order.rs:6:10
    |
 LL | struct A<T = u32, const N: usize> {
    |          ^
-   |
-   = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
-warning: the feature `const_generics` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/wrong-order.rs:2:27
-   |
-LL | #![cfg_attr(full, feature(const_generics))]
-   |                           ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
-
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/wrong-order.min.stderr
+++ b/src/test/ui/const-generics/defaults/wrong-order.min.stderr
@@ -1,10 +1,8 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/wrong-order.rs:4:10
+  --> $DIR/wrong-order.rs:6:10
    |
 LL | struct A<T = u32, const N: usize> {
    |          ^
-   |
-   = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/defaults/wrong-order.rs
+++ b/src/test/ui/const-generics/defaults/wrong-order.rs
@@ -1,5 +1,7 @@
 // revisions: full min
-#![cfg_attr(full, feature(const_generics))] //[full]~WARN the feature `const_generics` is incomplete
+#![cfg_attr(full, feature(const_generics))]
+#![feature(const_generics_defaults)]
+#![allow(incomplete_features)]
 
 struct A<T = u32, const N: usize> {
     //~^ ERROR generic parameters with a default must be trailing

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
@@ -6,17 +6,26 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    |
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
-error: constant values inside of type parameter defaults must not depend on generic parameters
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
-   |
-LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-   |                                            ^ the anonymous constant must not depend on the parameter `T`
-
-error: constant values inside of type parameter defaults must not depend on generic parameters
+error[E0128]: generic parameters with a default cannot use forward declared identifiers
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
-   |                     ^ the anonymous constant must not depend on the parameter `N`
+   |                     ^ defaulted generic parameters cannot be forward declared
+
+error[E0277]: the size for values of type `T` cannot be known at compilation time
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
+   |
+LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
+   |            -                               ^ doesn't have a size known at compile-time
+   |            |
+   |            this type parameter needs to be `std::marker::Sized`
+   | 
+  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
 
 error: aborting due to 3 previous errors
 
+Some errors have detailed explanations: E0128, E0277.
+For more information about an error, try `rustc --explain E0128`.

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -7,25 +7,11 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared
 
-error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
-   |
-LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-   |            -                               ^ doesn't have a size known at compile-time
-   |            |
-   |            this type parameter needs to be `std::marker::Sized`
-   | 
-  ::: $SRC_DIR/core/src/mem/mod.rs:LL:COL
-   |
-LL | pub const fn size_of<T>() -> usize {
-   |                      - required by this bound in `std::mem::size_of`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0128, E0277.
-For more information about an error, try `rustc --explain E0128`.
+For more information about this error, try `rustc --explain E0128`.

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.full.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -7,7 +7,7 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -16,7 +16,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -1,5 +1,5 @@
 error: generic parameters with a default must be trailing
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:12
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:12
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |            ^
@@ -7,7 +7,7 @@ LL | struct Bar<T = [u8; N], const N: usize>(T);
    = note: using type defaults and const parameters in the same parameter list is currently not permitted
 
 error: generic parameters may not be used in const operations
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:6:44
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:5:44
    |
 LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    |                                            ^ cannot perform const operation using `T`
@@ -16,7 +16,7 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
 error[E0128]: generic parameters with a default cannot use forward declared identifiers
-  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:10:21
+  --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:8:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
    |                     ^ defaulted generic parameters cannot be forward declared

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.min.stderr
@@ -15,11 +15,12 @@ LL | struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
    = note: type parameters may not be used in const expressions
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
-error: constant values inside of type parameter defaults must not depend on generic parameters
+error[E0128]: generic parameters with a default cannot use forward declared identifiers
   --> $DIR/params-in-ct-in-ty-param-lazy-norm.rs:11:21
    |
 LL | struct Bar<T = [u8; N], const N: usize>(T);
-   |                     ^ the anonymous constant must not depend on the parameter `N`
+   |                     ^ defaulted generic parameters cannot be forward declared
 
 error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0128`.

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -7,7 +7,6 @@ struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
 //[full]~^ ERROR the size for values of type `T` cannot be known at compilation time
 //[min]~^^ ERROR generic parameters may not be used in const operations
 
-// FIXME(const_generics_defaults): We still don't know how to deal with type defaults.
 struct Bar<T = [u8; N], const N: usize>(T);
 //~^ ERROR generic parameters with a default cannot use forward declared identifiers
 //~| ERROR generic parameters with a default

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -1,11 +1,9 @@
 // revisions: full min
-
 #![cfg_attr(full, feature(const_generics))]
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-//[full]~^ ERROR the size for values of type `T` cannot be known at compilation time
-//[min]~^^ ERROR generic parameters may not be used in const operations
+//[min]~^ ERROR generic parameters may not be used in const operations
 
 struct Bar<T = [u8; N], const N: usize>(T);
 //~^ ERROR generic parameters with a default cannot use forward declared identifiers

--- a/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
+++ b/src/test/ui/const-generics/params-in-ct-in-ty-param-lazy-norm.rs
@@ -4,12 +4,12 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Foo<T, U = [u8; std::mem::size_of::<T>()]>(T, U);
-//[full]~^ ERROR constant values inside of type parameter defaults
+//[full]~^ ERROR the size for values of type `T` cannot be known at compilation time
 //[min]~^^ ERROR generic parameters may not be used in const operations
 
 // FIXME(const_generics_defaults): We still don't know how to deal with type defaults.
 struct Bar<T = [u8; N], const N: usize>(T);
-//~^ ERROR constant values inside of type parameter defaults
+//~^ ERROR generic parameters with a default cannot use forward declared identifiers
 //~| ERROR generic parameters with a default
 
 fn main() {}

--- a/src/test/ui/consts/const-fn-not-in-trait.rs
+++ b/src/test/ui/consts/const-fn-not-in-trait.rs
@@ -1,5 +1,5 @@
 // Test that const fn is illegal in a trait declaration, whether or
-// not a default is provided.
+// not a default is provided, and even with the feature gate.
 
 #![feature(const_fn)]
 

--- a/src/test/ui/feature-gates/feature-gate-const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.rs
@@ -3,10 +3,8 @@
 const fn foo() -> usize { 0 } // ok
 
 trait Foo {
-    const fn foo() -> u32; //~ ERROR const fn is unstable
-                           //~| ERROR functions in traits cannot be declared const
-    const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
-                                //~| ERROR functions in traits cannot be declared const
+    const fn foo() -> u32; //~ ERROR functions in traits cannot be declared const
+    const fn bar() -> u32 { 0 } //~ ERROR functions in traits cannot be declared const
 }
 
 impl Foo for u32 {

--- a/src/test/ui/feature-gates/feature-gate-const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.stderr
@@ -5,36 +5,17 @@ LL |     const fn foo() -> u32;
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-const_fn.rs:8:5
+  --> $DIR/feature-gate-const_fn.rs:7:5
    |
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-const_fn.rs:13:5
+  --> $DIR/feature-gate-const_fn.rs:11:5
    |
 LL |     const fn foo() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-const_fn.rs:6:5
-   |
-LL |     const fn foo() -> u32;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+error: aborting due to 3 previous errors
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-const_fn.rs:8:5
-   |
-LL |     const fn bar() -> u32 { 0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0379, E0658.
-For more information about an error, try `rustc --explain E0379`.
+For more information about this error, try `rustc --explain E0379`.

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
@@ -3,10 +3,8 @@
 const fn foo() -> usize { 0 } // stabilized
 
 trait Foo {
-    const fn foo() -> u32; //~ ERROR const fn is unstable
-                           //~| ERROR functions in traits cannot be declared const
-    const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
-                                //~| ERROR functions in traits cannot be declared const
+    const fn foo() -> u32; //~ ERROR functions in traits cannot be declared const
+    const fn bar() -> u32 { 0 } //~ ERROR functions in traits cannot be declared const
 }
 
 impl Foo for u32 {

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -5,36 +5,17 @@ LL |     const fn foo() -> u32;
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-min_const_fn.rs:8:5
+  --> $DIR/feature-gate-min_const_fn.rs:7:5
    |
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-min_const_fn.rs:13:5
+  --> $DIR/feature-gate-min_const_fn.rs:11:5
    |
 LL |     const fn foo() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-min_const_fn.rs:6:5
-   |
-LL |     const fn foo() -> u32;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+error: aborting due to 3 previous errors
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-min_const_fn.rs:8:5
-   |
-LL |     const fn bar() -> u32 { 0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0379, E0658.
-For more information about an error, try `rustc --explain E0379`.
+For more information about this error, try `rustc --explain E0379`.

--- a/src/test/ui/generics/generic-non-trailing-defaults.rs
+++ b/src/test/ui/generics/generic-non-trailing-defaults.rs
@@ -5,5 +5,6 @@ struct Vec<A = Heap, T>(A, T);
 
 struct Foo<A, B = Vec<C>, C>(A, B, C);
 //~^ ERROR generic parameters with a default must be trailing
+//~| ERROR generic parameters with a default cannot use
 
 fn main() {}

--- a/src/test/ui/generics/generic-non-trailing-defaults.stderr
+++ b/src/test/ui/generics/generic-non-trailing-defaults.stderr
@@ -10,5 +10,12 @@ error: generic parameters with a default must be trailing
 LL | struct Foo<A, B = Vec<C>, C>(A, B, C);
    |               ^
 
-error: aborting due to 2 previous errors
+error[E0128]: generic parameters with a default cannot use forward declared identifiers
+  --> $DIR/generic-non-trailing-defaults.rs:6:23
+   |
+LL | struct Foo<A, B = Vec<C>, C>(A, B, C);
+   |                       ^ defaulted generic parameters cannot be forward declared
 
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0128`.

--- a/src/test/ui/hygiene/trait_items.stderr
+++ b/src/test/ui/hygiene/trait_items.stderr
@@ -1,6 +1,9 @@
 error[E0599]: no method named `f` found for unit type `()` in the current scope
   --> $DIR/trait_items.rs:17:24
    |
+LL |         fn f(&self) {}
+   |            - the method is available for `()` here
+...
 LL |     fn f() { ::baz::m!(); }
    |              ------------ in this macro invocation
 ...

--- a/src/test/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/src/test/ui/impl-trait/no-method-suggested-traits.stderr
@@ -37,6 +37,9 @@ LL | use no_method_suggested_traits::Reexported;
 error[E0599]: no method named `method` found for type `char` in the current scope
   --> $DIR/no-method-suggested-traits.rs:30:9
    |
+LL |         fn method(&self) {}
+   |            ------ the method is available for `char` here
+...
 LL |     'a'.method();
    |         ^^^^^^ method not found in `char`
    |
@@ -63,6 +66,11 @@ error[E0599]: no method named `method` found for type `i32` in the current scope
    |
 LL |     1i32.method();
    |          ^^^^^^ method not found in `i32`
+   | 
+  ::: $DIR/auxiliary/no_method_suggested_traits.rs:8:12
+   |
+LL |         fn method(&self) {}
+   |            ------ the method is available for `i32` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/issues/issue-43189.stderr
+++ b/src/test/ui/issues/issue-43189.stderr
@@ -3,6 +3,11 @@ error[E0599]: no method named `a` found for unit type `()` in the current scope
    |
 LL |     ().a();
    |        ^ method not found in `()`
+   | 
+  ::: $DIR/auxiliary/xcrate-issue-43189-a.rs:5:8
+   |
+LL |     fn a(&self) {}
+   |        - the method is available for `()` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/issues/issue-56175.stderr
+++ b/src/test/ui/issues/issue-56175.stderr
@@ -3,6 +3,11 @@ error[E0599]: no method named `trait_method` found for struct `FooStruct` in the
    |
 LL |     reexported_trait::FooStruct.trait_method();
    |                                 ^^^^^^^^^^^^ method not found in `FooStruct`
+   | 
+  ::: $DIR/auxiliary/reexported-trait.rs:3:12
+   |
+LL |         fn trait_method(&self) {
+   |            ------------ the method is available for `FooStruct` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
@@ -15,6 +20,11 @@ error[E0599]: no method named `trait_method_b` found for struct `FooStruct` in t
    |
 LL |     reexported_trait::FooStruct.trait_method_b();
    |                                 ^^^^^^^^^^^^^^ method not found in `FooStruct`
+   | 
+  ::: $DIR/auxiliary/reexported-trait.rs:7:12
+   |
+LL |         fn trait_method_b(&self) {
+   |            -------------- the method is available for `FooStruct` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/loops/loop-no-implicit-break.rs
+++ b/src/test/ui/loops/loop-no-implicit-break.rs
@@ -24,4 +24,8 @@ fn foo() -> i8 {
     loop {
         return 1;
     }
+
+    loop {
+        1 //~ ERROR mismatched types
+    }
 }

--- a/src/test/ui/loops/loop-no-implicit-break.rs
+++ b/src/test/ui/loops/loop-no-implicit-break.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let x: i8 = loop {
+        10 //~ ERROR mismatched types
+    };
+}

--- a/src/test/ui/loops/loop-no-implicit-break.rs
+++ b/src/test/ui/loops/loop-no-implicit-break.rs
@@ -1,5 +1,27 @@
 fn main() {
-    let x: i8 = loop {
-        10 //~ ERROR mismatched types
+    let a: i8 = loop {
+        1 //~ ERROR mismatched types
     };
+
+    let b: i8 = loop {
+        break 1;
+    };
+}
+
+fn foo() -> i8 {
+    let a: i8 = loop {
+        1 //~ ERROR mismatched types
+    };
+
+    let b: i8 = loop {
+        break 1;
+    };
+
+    loop {
+        1 //~ ERROR mismatched types
+    }
+
+    loop {
+        return 1;
+    }
 }

--- a/src/test/ui/loops/loop-no-implicit-break.stderr
+++ b/src/test/ui/loops/loop-no-implicit-break.stderr
@@ -31,6 +31,17 @@ help: you might have meant to return this value
 LL |         return 1;
    |         ^^^^^^  ^
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:29:9
+   |
+LL |         1
+   |         ^ expected `()`, found integer
+   |
+help: you might have meant to return this value
+   |
+LL |         return 1;
+   |         ^^^^^^  ^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/loops/loop-no-implicit-break.stderr
+++ b/src/test/ui/loops/loop-no-implicit-break.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:3:9
+   |
+LL |         10
+   |         ^^ expected `()`, found integer
+   |
+help: you might have meant to break the loop with this value
+   |
+LL |         break 10;
+   |         ^^^^^   ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/loops/loop-no-implicit-break.stderr
+++ b/src/test/ui/loops/loop-no-implicit-break.stderr
@@ -1,14 +1,36 @@
 error[E0308]: mismatched types
   --> $DIR/loop-no-implicit-break.rs:3:9
    |
-LL |         10
-   |         ^^ expected `()`, found integer
+LL |         1
+   |         ^ expected `()`, found integer
    |
 help: you might have meant to break the loop with this value
    |
-LL |         break 10;
-   |         ^^^^^   ^
+LL |         break 1;
+   |         ^^^^^  ^
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:13:9
+   |
+LL |         1
+   |         ^ expected `()`, found integer
+   |
+help: you might have meant to break the loop with this value
+   |
+LL |         break 1;
+   |         ^^^^^  ^
+
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:21:9
+   |
+LL |         1
+   |         ^ expected `()`, found integer
+   |
+help: you might have meant to return this value
+   |
+LL |         return 1;
+   |         ^^^^^^  ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/match/issue-82392.rs
+++ b/src/test/ui/match/issue-82392.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/82329
+// compile-flags: -Zunpretty=hir,typed
+// check-pass
+
+pub fn main() {
+    if true {
+    } else if let Some(a) = Some(3) {
+    }
+}

--- a/src/test/ui/match/issue-82392.stdout
+++ b/src/test/ui/match/issue-82392.stdout
@@ -1,0 +1,20 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// https://github.com/rust-lang/rust/issues/82329
+// compile-flags: -Zunpretty=hir,typed
+// check-pass
+
+pub fn main() ({
+                   (if (true as bool)
+                       ({ } as
+                           ()) else {match ((Some as
+                                                fn(i32) -> Option<i32> {Option::<i32>::Some})((3
+                                                                                                  as
+                                                                                                  i32))
+                                               as Option<i32>) {
+                                         Some(a) => { }
+                                         _ => { }
+                                     }} as ())
+                    } as ())

--- a/src/test/ui/match/issue-84434.rs
+++ b/src/test/ui/match/issue-84434.rs
@@ -1,0 +1,18 @@
+// https://github.com/rust-lang/rust/issues/84434
+// check-pass
+
+use std::path::Path;
+struct A {
+    pub func: fn(check: bool, a: &Path, b: Option<&Path>),
+}
+const MY_A: A = A {
+    func: |check, a, b| {
+        if check {
+            let _ = ();
+        } else if let Some(parent) = b.and_then(|p| p.parent()) {
+            let _ = ();
+        }
+    },
+};
+
+fn main() {}

--- a/src/test/ui/rust-2018/trait-import-suggestions.stderr
+++ b/src/test/ui/rust-2018/trait-import-suggestions.stderr
@@ -1,6 +1,9 @@
 error[E0599]: no method named `foobar` found for type `u32` in the current scope
   --> $DIR/trait-import-suggestions.rs:22:11
    |
+LL |             fn foobar(&self) { }
+   |                ------ the method is available for `u32` here
+...
 LL |         x.foobar();
    |           ^^^^^^ method not found in `u32`
    |
@@ -11,6 +14,9 @@ LL |         x.foobar();
 error[E0599]: no method named `bar` found for type `u32` in the current scope
   --> $DIR/trait-import-suggestions.rs:28:7
    |
+LL |         fn bar(&self) { }
+   |            --- the method is available for `u32` here
+...
 LL |     x.bar();
    |       ^^^ method not found in `u32`
    |

--- a/src/test/ui/shadowed/shadowed-trait-methods.stderr
+++ b/src/test/ui/shadowed/shadowed-trait-methods.stderr
@@ -1,6 +1,9 @@
 error[E0599]: no method named `f` found for unit type `()` in the current scope
   --> $DIR/shadowed-trait-methods.rs:13:8
    |
+LL |     pub trait T { fn f(&self) {} }
+   |                      - the method is available for `()` here
+...
 LL |     ().f()
    |        ^ method not found in `()`
    |

--- a/src/test/ui/suggestions/import-trait-for-method-call.rs
+++ b/src/test/ui/suggestions/import-trait-for-method-call.rs
@@ -1,0 +1,9 @@
+use std::hash::BuildHasher;
+
+fn next_u64() -> u64 {
+    let bh = std::collections::hash_map::RandomState::new();
+    let h = bh.build_hasher();
+    h.finish() //~ ERROR no method named `finish` found for struct `DefaultHasher`
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -7,20 +7,9 @@ LL |     h.finish()
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn finish(&self) -> u64;
-   |        ------
-   |        |
-   |        the method is available for `Box<DefaultHasher>` here
-   |        the method is available for `Box<&mut DefaultHasher>` here
+   |        ------ the method is available for `DefaultHasher` here
    |
    = help: items from traits can only be used if the trait is in scope
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |     Box::new(h).finish()
-   |     ^^^^^^^^^ ^
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |     Box::new(&mut h).finish()
-   |     ^^^^^^^^^^^^^  ^
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
 LL | use std::hash::Hasher;

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -1,0 +1,26 @@
+error[E0599]: no method named `finish` found for struct `DefaultHasher` in the current scope
+  --> $DIR/import-trait-for-method-call.rs:6:7
+   |
+LL |     h.finish()
+   |       ^^^^^^ method not found in `DefaultHasher`
+   | 
+  ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
+   |
+LL |     fn finish(&self) -> u64;
+   |        ------
+   |        |
+   |        the method is available for `Box<DefaultHasher>` here
+   |        the method is available for `Box<&mut DefaultHasher>` here
+   |
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |     Box::new(h).finish()
+   |     ^^^^^^^^^ ^
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |     Box::new(&mut h).finish()
+   |     ^^^^^^^^^^^^^  ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -12,6 +12,7 @@ LL |     fn finish(&self) -> u64;
    |        the method is available for `Box<DefaultHasher>` here
    |        the method is available for `Box<&mut DefaultHasher>` here
    |
+   = help: items from traits can only be used if the trait is in scope
 help: consider wrapping the receiver expression with the appropriate type
    |
 LL |     Box::new(h).finish()
@@ -20,6 +21,10 @@ help: consider wrapping the receiver expression with the appropriate type
    |
 LL |     Box::new(&mut h).finish()
    |     ^^^^^^^^^^^^^  ^
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use std::hash::Hasher;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -20,6 +20,9 @@ error[E0599]: no method named `b` found for struct `S` in the current scope
 LL | struct S;
    | --------- method `b` not found for this
 ...
+LL |         fn b(&self) { }
+   |            - the method is available for `S` here
+...
 LL |     S.b();
    |       ^ method not found in `S`
    |


### PR DESCRIPTION
Successful merges:

 - #84235 (refactor StyledBuffer)
 - #84299 (various const parameter defaults improvements)
 - #84481 (update Miri)
 - #84486 (Handle pretty printing of `else if let` clauses without ICEing)
 - #84499 (Tweak trait not `use`d suggestion)
 - #84516 (Add suggestion to "use break" when attempting to implicit-break a loop)
 - #84544 (Always reject `const fn` in `trait` during parsing.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=84235,84299,84481,84486,84499,84516,84544)
<!-- homu-ignore:end -->