### PR TITLE
Open impl blocks by default

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1305,7 +1305,7 @@ fn render_impl(
         if let Some(use_absolute) = use_absolute {
             write!(
                 w,
-                "<details class=\"rustdoc-toggle implementors-toggle\">\
+                "<details class=\"rustdoc-toggle implementors-toggle\" open>\
                      <summary>\
                          <h3 id=\"{}\" class=\"impl\"{}>\
                              <code class=\"in-band\">",
@@ -1334,7 +1334,7 @@ fn render_impl(
         } else {
             write!(
                 w,
-                "<details class=\"rustdoc-toggle implementors-toggle\">\
+                "<details class=\"rustdoc-toggle implementors-toggle\" open>\
                      <summary>\
                          <h3 id=\"{}\" class=\"impl\"{}>\
                              <code class=\"in-band\">{}</code>",

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1429,8 +1429,6 @@ function hideThemeButtonState() {
                 } else if (nextTagName !== "DETAILS") {
                     e.nextElementSibling.style.display = "block";
                 }
-            } else if (e.tagName === "DETAILS") {
-                e.open = true;
             }
         });
     }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1422,11 +1422,13 @@ function hideThemeButtonState() {
             // errors in mobile browsers).
             if (e.tagName === "H2" || e.tagName === "H3") {
                 var nextTagName = e.nextElementSibling.tagName;
-                if (nextTagName == "H2" || nextTagName == "H3") {
+                if (nextTagName === "H2" || nextTagName === "H3") {
                     e.nextElementSibling.style.display = "flex";
-                } else {
+                } else if (nextTagName !== "DETAILS") {
                     e.nextElementSibling.style.display = "block";
                 }
+            } else if (e.tagName === "DETAILS") {
+                e.open = true;
             }
         });
     }

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -480,6 +480,8 @@ function hideThemeButtonState() {
                 }
                 // Open all ancestor <details> to make this element visible.
                 openParentDetails(h3.parentNode);
+            } else {
+                openParentDetails(elem.parentNode);
             }
         }
     }

--- a/src/test/rustdoc-gui/hash-item-expansion.goml
+++ b/src/test/rustdoc-gui/hash-item-expansion.goml
@@ -1,0 +1,18 @@
+// This test ensures that the element corresponding to the hash is displayed.
+goto: file://|DOC_PATH|/struct.Foo.html#method.borrow
+// In the blanket implementations list, "Borrow" is the second one, hence the ":nth(2)".
+assert: ("#blanket-implementations-list > details:nth-child(2)", "open", "")
+// Please note the "\" below is needed because otherwise ".borrow" would be interpreted as
+// a class selector.
+assert: ("#method\.borrow", {"display": "flex"})
+// We first check that the impl block is open by default.
+assert: ("#implementations + details", "open", "")
+// We collapse it.
+click: "#implementations + details > summary"
+// We check that it was collapsed as expected.
+assert-false: ("#implementations + details", "open", "")
+// To ensure that we will click on the currently hidden method.
+assert: (".sidebar-links > a", "must_use")
+click: ".sidebar-links > a"
+// We check that the impl block was opened as expected so that we can see the method.
+assert: ("#implementations + details", "open", "")

--- a/src/test/rustdoc-gui/impl-default-expansion.goml
+++ b/src/test/rustdoc-gui/impl-default-expansion.goml
@@ -1,0 +1,3 @@
+// This test ensures that the impl blocks are open by default.
+goto: file://|DOC_PATH|/struct.Foo.html
+assert: ("#main > details.implementors-toggle", "open", "")

--- a/src/test/rustdoc-gui/nojs-attr-pos.goml
+++ b/src/test/rustdoc-gui/nojs-attr-pos.goml
@@ -1,5 +1,0 @@
-// Check that the attributes are well positioned when javascript is disabled (since
-// there is no toggle to display)
-javascript: false
-goto: file://|DOC_PATH|/struct.Foo.html
-assert: (".attributes", {"margin-left": "0px"})


### PR DESCRIPTION
Fixes #84558.
Part of #84422.

As you can see on https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/ty/context/struct.TyCtxt.html, impl blocks are currently not open by default whereas they should.

I also realized that a test was outdated so I removed it and opened #84550 because it seems like the rustdoc-gui test suite isn't run on CI...

cc @jyn514 
r? @jsha