### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -586,12 +586,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
     fn visit_assoc_item(&mut self, i: &'a ast::AssocItem, ctxt: AssocCtxt) {
         let is_fn = match i.kind {
-            ast::AssocItemKind::Fn(box ast::FnKind(_, ref sig, _, _)) => {
-                if let (ast::Const::Yes(_), AssocCtxt::Trait) = (sig.header.constness, ctxt) {
-                    gate_feature_post!(&self, const_fn, i.span, "const fn is unstable");
-                }
-                true
-            }
+            ast::AssocItemKind::Fn(_) => true,
             ast::AssocItemKind::TyAlias(box ast::TyAliasKind(_, ref generics, _, ref ty)) => {
                 if let (Some(_), AssocCtxt::Trait) = (ty, ctxt) {
                     gate_feature_post!(

--- a/compiler/rustc_error_codes/src/error_codes/E0379.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0379.md
@@ -3,8 +3,6 @@ A trait method was declared const.
 Erroneous code example:
 
 ```compile_fail,E0379
-#![feature(const_fn)]
-
 trait Foo {
     const fn bar() -> u32; // error!
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0764.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0764.md
@@ -3,7 +3,6 @@ A mutable reference was used in a constant.
 Erroneous code example:
 
 ```compile_fail,E0764
-#![feature(const_fn)]
 #![feature(const_mut_refs)]
 
 fn main() {
@@ -27,7 +26,6 @@ Remember: you cannot use a function call inside a constant or static. However,
 you can totally use it in constant functions:
 
 ```
-#![feature(const_fn)]
 #![feature(const_mut_refs)]
 
 const fn foo(x: usize) -> usize {

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -7,21 +7,17 @@ pub struct StyledBuffer {
     lines: Vec<Vec<StyledChar>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct StyledChar {
     chr: char,
     style: Style,
 }
 
 impl StyledChar {
-    fn new(chr: char, style: Style) -> Self {
-        StyledChar { chr, style }
-    }
-}
+    const SPACE: Self = StyledChar::new(' ', Style::NoStyle);
 
-impl Default for StyledChar {
-    fn default() -> Self {
-        StyledChar::new(' ', Style::NoStyle)
+    const fn new(chr: char, style: Style) -> Self {
+        StyledChar { chr, style }
     }
 }
 
@@ -66,31 +62,25 @@ impl StyledBuffer {
     }
 
     fn ensure_lines(&mut self, line: usize) {
-        while line >= self.lines.len() {
-            self.lines.push(vec![]);
+        if line >= self.lines.len() {
+            self.lines.resize(line + 1, Vec::new());
         }
     }
 
     /// Sets `chr` with `style` for given `line`, `col`.
-    /// If line not exist in `StyledBuffer`, adds lines up to given
-    /// and fills last line with spaces and `Style::NoStyle` style
+    /// If `line` does not exist in our buffer, adds empty lines up to the given
+    /// and fills the last line with unstyled whitespace.
     pub fn putc(&mut self, line: usize, col: usize, chr: char, style: Style) {
         self.ensure_lines(line);
-        if col < self.lines[line].len() {
-            self.lines[line][col] = StyledChar::new(chr, style);
-        } else {
-            let mut i = self.lines[line].len();
-            while i < col {
-                self.lines[line].push(StyledChar::default());
-                i += 1;
-            }
-            self.lines[line].push(StyledChar::new(chr, style));
+        if col >= self.lines[line].len() {
+            self.lines[line].resize(col + 1, StyledChar::SPACE);
         }
+        self.lines[line][col] = StyledChar::new(chr, style);
     }
 
     /// Sets `string` with `style` for given `line`, starting from `col`.
-    /// If line not exist in `StyledBuffer`, adds lines up to given
-    /// and fills last line with spaces and `Style::NoStyle` style
+    /// If `line` does not exist in our buffer, adds empty lines up to the given
+    /// and fills the last line with unstyled whitespace.
     pub fn puts(&mut self, line: usize, col: usize, string: &str, style: Style) {
         let mut n = col;
         for c in string.chars() {
@@ -108,7 +98,7 @@ impl StyledBuffer {
         if !self.lines[line].is_empty() {
             // Push the old content over to make room for new content
             for _ in 0..string_len {
-                self.lines[line].insert(0, StyledChar::default());
+                self.lines[line].insert(0, StyledChar::SPACE);
             }
         }
 

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -148,11 +148,11 @@ impl StyledBuffer {
 
     /// Set `style` for `line`, `col` if:
     /// 1. That line and column exist in `StyledBuffer`
-    /// 2. Existing style is `Style::NoStyle` or `Style::Quotation` or `overwrite` is `true`
+    /// 2. `overwrite` is `true` or existing style is `Style::NoStyle` or `Style::Quotation`
     pub fn set_style(&mut self, line: usize, col: usize, style: Style, overwrite: bool) {
         if let Some(ref mut line) = self.text.get_mut(line) {
             if let Some(StyledChar { style: s, .. }) = line.get_mut(col) {
-                if *s == Style::NoStyle || *s == Style::Quotation || overwrite {
+                if overwrite || *s == Style::NoStyle || *s == Style::Quotation {
                     *s = style;
                 }
             }

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -105,9 +105,11 @@ impl StyledBuffer {
         self.ensure_lines(line);
         let string_len = string.chars().count();
 
-        // Push the old content over to make room for new content
-        for _ in 0..string_len {
-            self.text[line].insert(0, StyledChar::default());
+        if !self.text[line].is_empty() {
+            // Push the old content over to make room for new content
+            for _ in 0..string_len {
+                self.text[line].insert(0, StyledChar::default());
+            }
         }
 
         self.puts(line, 0, string, style);

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -30,6 +30,7 @@ impl StyledBuffer {
         StyledBuffer { text: vec![] }
     }
 
+    /// Returns content of `StyledBuffer` splitted by lines and line styles
     pub fn render(&self) -> Vec<Vec<StyledString>> {
         // Tabs are assumed to have been replaced by spaces in calling code.
         debug_assert!(self.text.iter().all(|r| !r.iter().any(|sc| sc.chr == '\t')));
@@ -70,6 +71,9 @@ impl StyledBuffer {
         }
     }
 
+    /// Sets `chr` with `style` for given `line`, `col`.
+    /// If line not exist in `StyledBuffer`, adds lines up to given
+    /// and fills last line with spaces and `Style::NoStyle` style
     pub fn putc(&mut self, line: usize, col: usize, chr: char, style: Style) {
         self.ensure_lines(line);
         if col < self.text[line].len() {
@@ -84,6 +88,9 @@ impl StyledBuffer {
         }
     }
 
+    /// Sets `string` with `style` for given `line`, starting from `col`.
+    /// If line not exist in `StyledBuffer`, adds lines up to given
+    /// and fills last line with spaces and `Style::NoStyle` style
     pub fn puts(&mut self, line: usize, col: usize, string: &str, style: Style) {
         let mut n = col;
         for c in string.chars() {
@@ -92,6 +99,8 @@ impl StyledBuffer {
         }
     }
 
+    /// For given `line` inserts `string` with `style` before old content of that line,
+    /// adding lines if needed
     pub fn prepend(&mut self, line: usize, string: &str, style: Style) {
         self.ensure_lines(line);
         let string_len = string.chars().count();
@@ -104,6 +113,8 @@ impl StyledBuffer {
         self.puts(line, 0, string, style);
     }
 
+    /// For given `line` inserts `string` with `style` after old content of that line,
+    /// adding lines if needed
     pub fn append(&mut self, line: usize, string: &str, style: Style) {
         if line >= self.text.len() {
             self.puts(line, 0, string, style);
@@ -117,6 +128,9 @@ impl StyledBuffer {
         self.text.len()
     }
 
+    /// Set `style` for `line`, `col_start..col_end` range if:
+    /// 1. That line and column range exist in `StyledBuffer`
+    /// 2. `overwrite` is `true` or existing style is `Style::NoStyle` or `Style::Quotation`
     pub fn set_style_range(
         &mut self,
         line: usize,
@@ -130,6 +144,9 @@ impl StyledBuffer {
         }
     }
 
+    /// Set `style` for `line`, `col` if:
+    /// 1. That line and column exist in `StyledBuffer`
+    /// 2. Existing style is `Style::NoStyle` or `Style::Quotation` or `overwrite` is `true`
     pub fn set_style(&mut self, line: usize, col: usize, style: Style, overwrite: bool) {
         if let Some(ref mut line) = self.text.get_mut(line) {
             if let Some(StyledChar { style: s, .. }) = line.get_mut(col) {

--- a/compiler/rustc_errors/src/styled_buffer.rs
+++ b/compiler/rustc_errors/src/styled_buffer.rs
@@ -19,6 +19,12 @@ impl StyledChar {
     }
 }
 
+impl Default for StyledChar {
+    fn default() -> Self {
+        StyledChar::new(' ', Style::NoStyle)
+    }
+}
+
 impl StyledBuffer {
     pub fn new() -> StyledBuffer {
         StyledBuffer { text: vec![] }
@@ -71,7 +77,7 @@ impl StyledBuffer {
         } else {
             let mut i = self.text[line].len();
             while i < col {
-                self.text[line].push(StyledChar::new(' ', Style::NoStyle));
+                self.text[line].push(StyledChar::default());
                 i += 1;
             }
             self.text[line].push(StyledChar::new(chr, style));
@@ -92,7 +98,7 @@ impl StyledBuffer {
 
         // Push the old content over to make room for new content
         for _ in 0..string_len {
-            self.text[line].insert(0, StyledChar::new(' ', Style::NoStyle));
+            self.text[line].insert(0, StyledChar::default());
         }
 
         self.puts(line, 0, string, style);

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -1476,7 +1476,7 @@ impl<'tcx> Liveness<'_, 'tcx> {
         for p in body.params {
             self.check_unused_vars_in_pat(&p.pat, Some(entry_ln), |spans, hir_id, ln, var| {
                 if !self.live_on_entry(ln, var) {
-                    self.report_unsed_assign(hir_id, spans, var, |name| {
+                    self.report_unused_assign(hir_id, spans, var, |name| {
                         format!("value passed to `{}` is never read", name)
                     });
                 }
@@ -1615,13 +1615,13 @@ impl<'tcx> Liveness<'_, 'tcx> {
 
     fn warn_about_dead_assign(&self, spans: Vec<Span>, hir_id: HirId, ln: LiveNode, var: Variable) {
         if !self.live_on_exit(ln, var) {
-            self.report_unsed_assign(hir_id, spans, var, |name| {
+            self.report_unused_assign(hir_id, spans, var, |name| {
                 format!("value assigned to `{}` is never read", name)
             });
         }
     }
 
-    fn report_unsed_assign(
+    fn report_unused_assign(
         &self,
         hir_id: HirId,
         spans: Vec<Span>,

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1494,7 +1494,9 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
         if let (Some((expr, _)), Some((fn_decl, _, _))) =
             (expression, fcx.get_node_fn_decl(parent_item))
         {
-            fcx.suggest_missing_return_expr(&mut err, expr, fn_decl, expected, found, parent_id);
+            fcx.suggest_missing_break_or_return_expr(
+                &mut err, expr, fn_decl, expected, found, id, parent_id,
+            );
         }
 
         if let (Some(sp), Some(fn_output)) = (fcx.ret_coercion_span.get(), fn_output) {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -8,7 +8,7 @@ use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind};
 use rustc_hir::lang_items::LangItem;
-use rustc_hir::{ExprKind, ItemKind, Node};
+use rustc_hir::{ExprKind, ItemKind, Node, StmtKind};
 use rustc_infer::infer;
 use rustc_middle::lint::in_external_macro;
 use rustc_middle::ty::{self, Binder, Ty};
@@ -55,7 +55,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             pointing_at_return_type =
                 self.suggest_missing_return_type(err, &fn_decl, expected, found, can_suggest);
             let fn_id = self.tcx.hir().get_return_block(blk_id).unwrap();
-            self.suggest_missing_return_expr(err, expr, &fn_decl, expected, found, fn_id);
+            self.suggest_missing_break_or_return_expr(
+                err, expr, &fn_decl, expected, found, blk_id, fn_id,
+            );
         }
         pointing_at_return_type
     }
@@ -472,7 +474,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    pub(in super::super) fn suggest_missing_return_expr(
+    pub(in super::super) fn suggest_missing_break_or_return_expr(
         &self,
         err: &mut DiagnosticBuilder<'_>,
         expr: &'tcx hir::Expr<'tcx>,
@@ -480,14 +482,30 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
         id: hir::HirId,
+        fn_id: hir::HirId,
     ) {
         if !expected.is_unit() {
             return;
         }
         let found = self.resolve_vars_with_obligations(found);
+
+        if self.in_loop(id) {
+            if self.in_local_statement(id) {
+                err.multipart_suggestion(
+                    "you might have meant to break the loop with this value",
+                    vec![
+                        (expr.span.shrink_to_lo(), "break ".to_string()),
+                        (expr.span.shrink_to_hi(), ";".to_string()),
+                    ],
+                    Applicability::MaybeIncorrect,
+                );
+                return;
+            }
+        }
+
         if let hir::FnRetTy::Return(ty) = fn_decl.output {
             let ty = <dyn AstConv<'_>>::ast_ty_to_ty(self, ty);
-            let bound_vars = self.tcx.late_bound_vars(id);
+            let bound_vars = self.tcx.late_bound_vars(fn_id);
             let ty = self.tcx.erase_late_bound_regions(Binder::bind_with_vars(ty, bound_vars));
             let ty = self.normalize_associated_types_in(expr.span, ty);
             if self.can_coerce(found, ty) {
@@ -513,5 +531,57 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // `{ 42 } &&x` (#61475) or `{ 42 } && if x { 1 } else { 0 }`
             self.tcx.sess.parse_sess.expr_parentheses_needed(err, *sp, None);
         }
+    }
+
+    fn in_loop(&self, id: hir::HirId) -> bool {
+        if self.is_loop(id) {
+            return true;
+        }
+
+        for (parent_id, _) in self.tcx.hir().parent_iter(id) {
+            if self.is_loop(parent_id) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn is_loop(&self, id: hir::HirId) -> bool {
+        let node = self.tcx.hir().get(id);
+
+        if let Node::Expr(expr) = node {
+            if let ExprKind::Loop(..) = expr.kind {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn in_local_statement(&self, id: hir::HirId) -> bool {
+        if self.is_local_statement(id) {
+            return true;
+        }
+
+        for (parent_id, _) in self.tcx.hir().parent_iter(id) {
+            if self.is_local_statement(parent_id) {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn is_local_statement(&self, id: hir::HirId) -> bool {
+        let node = self.tcx.hir().get(id);
+
+        if let Node::Stmt(stmt) = node {
+            if let StmtKind::Local(..) = stmt.kind {
+                return true;
+            }
+        }
+
+        false
     }
 }

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1047,7 +1047,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
         }
-        if !alt_rcvr_sugg && self.suggest_valid_traits(err, valid_out_of_scope_traits) {
+        if self.suggest_valid_traits(err, valid_out_of_scope_traits) {
             return;
         }
 

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -988,6 +988,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut alt_rcvr_sugg = false;
         if let SelfSource::MethodCall(rcvr) = source {
             debug!(?span, ?item_name, ?rcvr_ty, ?rcvr);
+            let skippable = [
+                self.tcx.lang_items().clone_trait(),
+                self.tcx.lang_items().deref_trait(),
+                self.tcx.lang_items().deref_mut_trait(),
+                self.tcx.lang_items().drop_trait(),
+            ];
             // Try alternative arbitrary self types that could fulfill this call.
             // FIXME: probe for all types that *could* be arbitrary self-types, not
             // just this list.
@@ -996,6 +1002,27 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 (self.tcx.mk_mut_ref(&ty::ReErased, rcvr_ty), "&mut "),
                 (self.tcx.mk_imm_ref(&ty::ReErased, rcvr_ty), "&"),
             ] {
+                if let Ok(pick) = self.lookup_probe(
+                    span,
+                    item_name,
+                    rcvr_ty,
+                    rcvr,
+                    crate::check::method::probe::ProbeScope::AllTraits,
+                ) {
+                    // If the method is defined for the receiver we have, it likely wasn't `use`d.
+                    // We point at the method, but we just skip the rest of the check for arbitrary
+                    // self types and rely on the suggestion to `use` the trait from
+                    // `suggest_valid_traits`.
+                    let did = Some(pick.item.container.id());
+                    let skip = skippable.contains(&did);
+                    if pick.autoderefs == 0 && !skip {
+                        err.span_label(
+                            pick.item.ident.span,
+                            &format!("the method is available for `{}` here", rcvr_ty),
+                        );
+                    }
+                    break;
+                }
                 for (rcvr_ty, pre) in &[
                     (self.tcx.mk_lang_item(rcvr_ty, LangItem::OwnedBox), "Box::new"),
                     (self.tcx.mk_lang_item(rcvr_ty, LangItem::Pin), "Pin::new"),
@@ -1015,13 +1042,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             // We don't want to suggest a container type when the missing
                             // method is `.clone()` or `.deref()` otherwise we'd suggest
                             // `Arc::new(foo).clone()`, which is far from what the user wants.
-                            let skip = [
-                                self.tcx.lang_items().clone_trait(),
-                                self.tcx.lang_items().deref_trait(),
-                                self.tcx.lang_items().deref_mut_trait(),
-                                self.tcx.lang_items().drop_trait(),
-                            ]
-                            .contains(&did);
+                            let skip = skippable.contains(&did);
                             // Make sure the method is defined for the *actual* receiver: we don't
                             // want to treat `Box<Self>` as a receiver if it only works because of
                             // an autoderef to `&self`

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -254,7 +254,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(0, 0", stringify!($SelfT), ".reverse_bits());")]
         /// ```
         #[stable(feature = "reverse_bits", since = "1.37.0")]
-        #[rustc_const_stable(feature = "const_int_methods", since = "1.32.0")]
+        #[rustc_const_stable(feature = "const_int_methods", since = "1.37.0")]
         #[inline(always)]
         #[must_use]
         pub const fn reverse_bits(self) -> Self {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -257,7 +257,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0, 0", stringify!($SelfT), ".reverse_bits());")]
         /// ```
         #[stable(feature = "reverse_bits", since = "1.37.0")]
-        #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
+        #[rustc_const_stable(feature = "const_math", since = "1.37.0")]
         #[inline(always)]
         #[must_use]
         pub const fn reverse_bits(self) -> Self {

--- a/library/std/src/sys/sgx/ext/io.rs
+++ b/library/std/src/sys/sgx/ext/io.rs
@@ -63,12 +63,14 @@ pub trait TryIntoRawFd: Sized {
 }
 
 impl AsRawFd for net::TcpStream {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.as_inner().as_inner().as_inner().as_inner()
     }
 }
 
 impl AsRawFd for net::TcpListener {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.as_inner().as_inner().as_inner().as_inner()
     }
@@ -87,6 +89,7 @@ pub struct TcpStreamMetadata {
 impl FromRawFd for net::TcpStream {
     type Metadata = TcpStreamMetadata;
 
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd, metadata: Self::Metadata) -> net::TcpStream {
         let fd = sys::fd::FileDesc::from_inner(fd);
         let socket = sys::net::Socket::from_inner((fd, metadata.local_addr));
@@ -105,6 +108,7 @@ pub struct TcpListenerMetadata {
 impl FromRawFd for net::TcpListener {
     type Metadata = TcpListenerMetadata;
 
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd, metadata: Self::Metadata) -> net::TcpListener {
         let fd = sys::fd::FileDesc::from_inner(fd);
         let socket = sys::net::Socket::from_inner((fd, metadata.local_addr));
@@ -113,6 +117,7 @@ impl FromRawFd for net::TcpListener {
 }
 
 impl TryIntoRawFd for net::TcpStream {
+    #[inline]
     fn try_into_raw_fd(self) -> Result<RawFd, Self> {
         let (socket, peer_addr) = self.into_inner().into_inner();
         match socket.try_into_inner() {
@@ -126,6 +131,7 @@ impl TryIntoRawFd for net::TcpStream {
 }
 
 impl TryIntoRawFd for net::TcpListener {
+    #[inline]
     fn try_into_raw_fd(self) -> Result<RawFd, Self> {
         match self.into_inner().into_inner().try_into_inner() {
             Ok(fd) => Ok(fd.into_inner()),

--- a/library/std/src/sys/unix/ext/io.rs
+++ b/library/std/src/sys/unix/ext/io.rs
@@ -104,18 +104,21 @@ pub trait IntoRawFd {
 
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl AsRawFd for RawFd {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl IntoRawFd for RawFd {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl FromRawFd for RawFd {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
         fd
     }
@@ -123,18 +126,21 @@ impl FromRawFd for RawFd {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawFd for fs::File {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
 }
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawFd for fs::File {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> fs::File {
         fs::File::from_inner(sys::fs::File::from_inner(fd))
     }
 }
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for fs::File {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
@@ -142,6 +148,7 @@ impl IntoRawFd for fs::File {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO
     }
@@ -149,6 +156,7 @@ impl AsRawFd for io::Stdin {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO
     }
@@ -156,6 +164,7 @@ impl AsRawFd for io::Stdout {
 
 #[stable(feature = "asraw_stdio", since = "1.21.0")]
 impl AsRawFd for io::Stderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO
     }
@@ -163,6 +172,7 @@ impl AsRawFd for io::Stderr {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdinLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO
     }
@@ -170,6 +180,7 @@ impl<'a> AsRawFd for io::StdinLock<'a> {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StdoutLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO
     }
@@ -177,6 +188,7 @@ impl<'a> AsRawFd for io::StdoutLock<'a> {
 
 #[stable(feature = "asraw_stdio_locks", since = "1.35.0")]
 impl<'a> AsRawFd for io::StderrLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO
     }

--- a/library/std/src/sys/unix/ext/net/datagram.rs
+++ b/library/std/src/sys/unix/ext/net/datagram.rs
@@ -879,6 +879,7 @@ impl UnixDatagram {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl AsRawFd for UnixDatagram {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.0.as_inner()
     }
@@ -886,6 +887,7 @@ impl AsRawFd for UnixDatagram {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl FromRawFd for UnixDatagram {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> UnixDatagram {
         UnixDatagram(Socket::from_inner(fd))
     }
@@ -893,6 +895,7 @@ impl FromRawFd for UnixDatagram {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl IntoRawFd for UnixDatagram {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.0.into_inner()
     }

--- a/library/std/src/sys/unix/ext/net/listener.rs
+++ b/library/std/src/sys/unix/ext/net/listener.rs
@@ -240,6 +240,7 @@ impl UnixListener {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl AsRawFd for UnixListener {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.0.as_inner()
     }
@@ -247,6 +248,7 @@ impl AsRawFd for UnixListener {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl FromRawFd for UnixListener {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> UnixListener {
         UnixListener(Socket::from_inner(fd))
     }
@@ -254,6 +256,7 @@ impl FromRawFd for UnixListener {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl IntoRawFd for UnixListener {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.0.into_inner()
     }

--- a/library/std/src/sys/unix/ext/net/raw_fd.rs
+++ b/library/std/src/sys/unix/ext/net/raw_fd.rs
@@ -6,6 +6,7 @@ macro_rules! impl_as_raw_fd {
     ($($t:ident)*) => {$(
         #[stable(feature = "rust1", since = "1.0.0")]
         impl AsRawFd for net::$t {
+            #[inline]
             fn as_raw_fd(&self) -> RawFd {
                 *self.as_inner().socket().as_inner()
             }
@@ -18,6 +19,7 @@ macro_rules! impl_from_raw_fd {
     ($($t:ident)*) => {$(
         #[stable(feature = "from_raw_os", since = "1.1.0")]
         impl FromRawFd for net::$t {
+            #[inline]
             unsafe fn from_raw_fd(fd: RawFd) -> net::$t {
                 let socket = sys::net::Socket::from_inner(fd);
                 net::$t::from_inner(sys_common::net::$t::from_inner(socket))
@@ -31,6 +33,7 @@ macro_rules! impl_into_raw_fd {
     ($($t:ident)*) => {$(
         #[stable(feature = "into_raw_os", since = "1.4.0")]
         impl IntoRawFd for net::$t {
+            #[inline]
             fn into_raw_fd(self) -> RawFd {
                 self.into_inner().into_socket().into_inner()
             }

--- a/library/std/src/sys/unix/ext/net/stream.rs
+++ b/library/std/src/sys/unix/ext/net/stream.rs
@@ -654,6 +654,7 @@ impl<'a> io::Write for &'a UnixStream {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl AsRawFd for UnixStream {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self.0.as_inner()
     }
@@ -661,6 +662,7 @@ impl AsRawFd for UnixStream {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl FromRawFd for UnixStream {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> UnixStream {
         UnixStream(Socket::from_inner(fd))
     }
@@ -668,6 +670,7 @@ impl FromRawFd for UnixStream {
 
 #[stable(feature = "unix_socket", since = "1.10.0")]
 impl IntoRawFd for UnixStream {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.0.into_inner()
     }

--- a/library/std/src/sys/unix/ext/process.rs
+++ b/library/std/src/sys/unix/ext/process.rs
@@ -274,6 +274,7 @@ impl ExitStatusExt for process::ExitStatus {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl FromRawFd for process::Stdio {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> process::Stdio {
         let fd = sys::fd::FileDesc::new(fd);
         let io = sys::process::Stdio::Fd(fd);
@@ -283,6 +284,7 @@ impl FromRawFd for process::Stdio {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
@@ -290,6 +292,7 @@ impl AsRawFd for process::ChildStdin {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
@@ -297,6 +300,7 @@ impl AsRawFd for process::ChildStdout {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawFd for process::ChildStderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().raw()
     }
@@ -304,6 +308,7 @@ impl AsRawFd for process::ChildStderr {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for process::ChildStdin {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
@@ -311,6 +316,7 @@ impl IntoRawFd for process::ChildStdin {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for process::ChildStdout {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
@@ -318,6 +324,7 @@ impl IntoRawFd for process::ChildStdout {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawFd for process::ChildStderr {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }

--- a/library/std/src/sys/wasi/ext/io.rs
+++ b/library/std/src/sys/wasi/ext/io.rs
@@ -54,126 +54,147 @@ pub trait IntoRawFd {
 
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl AsRawFd for RawFd {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         *self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl IntoRawFd for RawFd {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self
     }
 }
 #[stable(feature = "raw_fd_reflexive_traits", since = "1.48.0")]
 impl FromRawFd for RawFd {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> RawFd {
         fd
     }
 }
 
 impl AsRawFd for net::TcpStream {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for net::TcpStream {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> net::TcpStream {
         net::TcpStream::from_inner(sys::net::TcpStream::from_inner(fd))
     }
 }
 
 impl IntoRawFd for net::TcpStream {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for net::TcpListener {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for net::TcpListener {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> net::TcpListener {
         net::TcpListener::from_inner(sys::net::TcpListener::from_inner(fd))
     }
 }
 
 impl IntoRawFd for net::TcpListener {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for net::UdpSocket {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for net::UdpSocket {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> net::UdpSocket {
         net::UdpSocket::from_inner(sys::net::UdpSocket::from_inner(fd))
     }
 }
 
 impl IntoRawFd for net::UdpSocket {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for fs::File {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         self.as_inner().fd().as_raw()
     }
 }
 
 impl FromRawFd for fs::File {
+    #[inline]
     unsafe fn from_raw_fd(fd: RawFd) -> fs::File {
         fs::File::from_inner(sys::fs::File::from_inner(fd))
     }
 }
 
 impl IntoRawFd for fs::File {
+    #[inline]
     fn into_raw_fd(self) -> RawFd {
         self.into_inner().into_fd().into_raw()
     }
 }
 
 impl AsRawFd for io::Stdin {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO as RawFd
     }
 }
 
 impl AsRawFd for io::Stdout {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO as RawFd
     }
 }
 
 impl AsRawFd for io::Stderr {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StdinLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDIN_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StdoutLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDOUT_FILENO as RawFd
     }
 }
 
 impl<'a> AsRawFd for io::StderrLock<'a> {
+    #[inline]
     fn as_raw_fd(&self) -> RawFd {
         libc::STDERR_FILENO as RawFd
     }

--- a/library/std/src/sys/windows/ext/io.rs
+++ b/library/std/src/sys/windows/ext/io.rs
@@ -59,6 +59,7 @@ pub trait IntoRawHandle {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawHandle for fs::File {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as RawHandle
     }
@@ -108,6 +109,7 @@ impl<'a> AsRawHandle for io::StderrLock<'a> {
 
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawHandle for fs::File {
+    #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> fs::File {
         let handle = handle as c::HANDLE;
         fs::File::from_inner(sys::fs::File::from_inner(handle))
@@ -116,6 +118,7 @@ impl FromRawHandle for fs::File {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawHandle for fs::File {
+    #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
     }
@@ -161,18 +164,21 @@ pub trait IntoRawSocket {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawSocket for net::TcpStream {
+    #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         *self.as_inner().socket().as_inner()
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawSocket for net::TcpListener {
+    #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         *self.as_inner().socket().as_inner()
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl AsRawSocket for net::UdpSocket {
+    #[inline]
     fn as_raw_socket(&self) -> RawSocket {
         *self.as_inner().socket().as_inner()
     }
@@ -180,6 +186,7 @@ impl AsRawSocket for net::UdpSocket {
 
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::TcpStream {
+    #[inline]
     unsafe fn from_raw_socket(sock: RawSocket) -> net::TcpStream {
         let sock = sys::net::Socket::from_inner(sock);
         net::TcpStream::from_inner(sys_common::net::TcpStream::from_inner(sock))
@@ -187,6 +194,7 @@ impl FromRawSocket for net::TcpStream {
 }
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::TcpListener {
+    #[inline]
     unsafe fn from_raw_socket(sock: RawSocket) -> net::TcpListener {
         let sock = sys::net::Socket::from_inner(sock);
         net::TcpListener::from_inner(sys_common::net::TcpListener::from_inner(sock))
@@ -194,6 +202,7 @@ impl FromRawSocket for net::TcpListener {
 }
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 impl FromRawSocket for net::UdpSocket {
+    #[inline]
     unsafe fn from_raw_socket(sock: RawSocket) -> net::UdpSocket {
         let sock = sys::net::Socket::from_inner(sock);
         net::UdpSocket::from_inner(sys_common::net::UdpSocket::from_inner(sock))
@@ -202,6 +211,7 @@ impl FromRawSocket for net::UdpSocket {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::TcpStream {
+    #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }
@@ -209,6 +219,7 @@ impl IntoRawSocket for net::TcpStream {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::TcpListener {
+    #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }
@@ -216,6 +227,7 @@ impl IntoRawSocket for net::TcpListener {
 
 #[stable(feature = "into_raw_os", since = "1.4.0")]
 impl IntoRawSocket for net::UdpSocket {
+    #[inline]
     fn into_raw_socket(self) -> RawSocket {
         self.into_inner().into_socket().into_inner()
     }

--- a/library/std/src/sys/windows/ext/process.rs
+++ b/library/std/src/sys/windows/ext/process.rs
@@ -19,6 +19,7 @@ impl FromRawHandle for process::Stdio {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::Child {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -33,6 +34,7 @@ impl IntoRawHandle for process::Child {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStdin {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -40,6 +42,7 @@ impl AsRawHandle for process::ChildStdin {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStdout {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -47,6 +50,7 @@ impl AsRawHandle for process::ChildStdout {
 
 #[stable(feature = "process_extensions", since = "1.2.0")]
 impl AsRawHandle for process::ChildStderr {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }

--- a/library/std/src/sys/windows/ext/thread.rs
+++ b/library/std/src/sys/windows/ext/thread.rs
@@ -8,6 +8,7 @@ use crate::thread;
 
 #[stable(feature = "thread_extensions", since = "1.9.0")]
 impl<T> AsRawHandle for thread::JoinHandle<T> {
+    #[inline]
     fn as_raw_handle(&self) -> RawHandle {
         self.as_inner().handle().raw() as *mut _
     }
@@ -15,6 +16,7 @@ impl<T> AsRawHandle for thread::JoinHandle<T> {
 
 #[stable(feature = "thread_extensions", since = "1.9.0")]
 impl<T> IntoRawHandle for thread::JoinHandle<T> {
+    #[inline]
     fn into_raw_handle(self) -> RawHandle {
         self.into_inner().into_handle().into_raw() as *mut _
     }

--- a/src/test/ui/consts/const-fn-not-in-trait.rs
+++ b/src/test/ui/consts/const-fn-not-in-trait.rs
@@ -1,5 +1,5 @@
 // Test that const fn is illegal in a trait declaration, whether or
-// not a default is provided.
+// not a default is provided, and even with the feature gate.
 
 #![feature(const_fn)]
 

--- a/src/test/ui/feature-gates/feature-gate-const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.rs
@@ -3,10 +3,8 @@
 const fn foo() -> usize { 0 } // ok
 
 trait Foo {
-    const fn foo() -> u32; //~ ERROR const fn is unstable
-                           //~| ERROR functions in traits cannot be declared const
-    const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
-                                //~| ERROR functions in traits cannot be declared const
+    const fn foo() -> u32; //~ ERROR functions in traits cannot be declared const
+    const fn bar() -> u32 { 0 } //~ ERROR functions in traits cannot be declared const
 }
 
 impl Foo for u32 {

--- a/src/test/ui/feature-gates/feature-gate-const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.stderr
@@ -5,36 +5,17 @@ LL |     const fn foo() -> u32;
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-const_fn.rs:8:5
+  --> $DIR/feature-gate-const_fn.rs:7:5
    |
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-const_fn.rs:13:5
+  --> $DIR/feature-gate-const_fn.rs:11:5
    |
 LL |     const fn foo() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-const_fn.rs:6:5
-   |
-LL |     const fn foo() -> u32;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+error: aborting due to 3 previous errors
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-const_fn.rs:8:5
-   |
-LL |     const fn bar() -> u32 { 0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0379, E0658.
-For more information about an error, try `rustc --explain E0379`.
+For more information about this error, try `rustc --explain E0379`.

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.rs
@@ -3,10 +3,8 @@
 const fn foo() -> usize { 0 } // stabilized
 
 trait Foo {
-    const fn foo() -> u32; //~ ERROR const fn is unstable
-                           //~| ERROR functions in traits cannot be declared const
-    const fn bar() -> u32 { 0 } //~ ERROR const fn is unstable
-                                //~| ERROR functions in traits cannot be declared const
+    const fn foo() -> u32; //~ ERROR functions in traits cannot be declared const
+    const fn bar() -> u32 { 0 } //~ ERROR functions in traits cannot be declared const
 }
 
 impl Foo for u32 {

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -5,36 +5,17 @@ LL |     const fn foo() -> u32;
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-min_const_fn.rs:8:5
+  --> $DIR/feature-gate-min_const_fn.rs:7:5
    |
 LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
 error[E0379]: functions in traits cannot be declared const
-  --> $DIR/feature-gate-min_const_fn.rs:13:5
+  --> $DIR/feature-gate-min_const_fn.rs:11:5
    |
 LL |     const fn foo() -> u32 { 0 }
    |     ^^^^^ functions in traits cannot be const
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-min_const_fn.rs:6:5
-   |
-LL |     const fn foo() -> u32;
-   |     ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
+error: aborting due to 3 previous errors
 
-error[E0658]: const fn is unstable
-  --> $DIR/feature-gate-min_const_fn.rs:8:5
-   |
-LL |     const fn bar() -> u32 { 0 }
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn)]` to the crate attributes to enable
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0379, E0658.
-For more information about an error, try `rustc --explain E0379`.
+For more information about this error, try `rustc --explain E0379`.

--- a/src/test/ui/hygiene/trait_items.stderr
+++ b/src/test/ui/hygiene/trait_items.stderr
@@ -1,6 +1,9 @@
 error[E0599]: no method named `f` found for unit type `()` in the current scope
   --> $DIR/trait_items.rs:17:24
    |
+LL |         fn f(&self) {}
+   |            - the method is available for `()` here
+...
 LL |     fn f() { ::baz::m!(); }
    |              ------------ in this macro invocation
 ...

--- a/src/test/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/src/test/ui/impl-trait/no-method-suggested-traits.stderr
@@ -37,6 +37,9 @@ LL | use no_method_suggested_traits::Reexported;
 error[E0599]: no method named `method` found for type `char` in the current scope
   --> $DIR/no-method-suggested-traits.rs:30:9
    |
+LL |         fn method(&self) {}
+   |            ------ the method is available for `char` here
+...
 LL |     'a'.method();
    |         ^^^^^^ method not found in `char`
    |
@@ -63,6 +66,11 @@ error[E0599]: no method named `method` found for type `i32` in the current scope
    |
 LL |     1i32.method();
    |          ^^^^^^ method not found in `i32`
+   | 
+  ::: $DIR/auxiliary/no_method_suggested_traits.rs:8:12
+   |
+LL |         fn method(&self) {}
+   |            ------ the method is available for `i32` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/issues/issue-43189.stderr
+++ b/src/test/ui/issues/issue-43189.stderr
@@ -3,6 +3,11 @@ error[E0599]: no method named `a` found for unit type `()` in the current scope
    |
 LL |     ().a();
    |        ^ method not found in `()`
+   | 
+  ::: $DIR/auxiliary/xcrate-issue-43189-a.rs:5:8
+   |
+LL |     fn a(&self) {}
+   |        - the method is available for `()` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/issues/issue-56175.stderr
+++ b/src/test/ui/issues/issue-56175.stderr
@@ -3,6 +3,11 @@ error[E0599]: no method named `trait_method` found for struct `FooStruct` in the
    |
 LL |     reexported_trait::FooStruct.trait_method();
    |                                 ^^^^^^^^^^^^ method not found in `FooStruct`
+   | 
+  ::: $DIR/auxiliary/reexported-trait.rs:3:12
+   |
+LL |         fn trait_method(&self) {
+   |            ------------ the method is available for `FooStruct` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
@@ -15,6 +20,11 @@ error[E0599]: no method named `trait_method_b` found for struct `FooStruct` in t
    |
 LL |     reexported_trait::FooStruct.trait_method_b();
    |                                 ^^^^^^^^^^^^^^ method not found in `FooStruct`
+   | 
+  ::: $DIR/auxiliary/reexported-trait.rs:7:12
+   |
+LL |         fn trait_method_b(&self) {
+   |            -------------- the method is available for `FooStruct` here
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/loops/loop-no-implicit-break.rs
+++ b/src/test/ui/loops/loop-no-implicit-break.rs
@@ -24,4 +24,8 @@ fn foo() -> i8 {
     loop {
         return 1;
     }
+
+    loop {
+        1 //~ ERROR mismatched types
+    }
 }

--- a/src/test/ui/loops/loop-no-implicit-break.rs
+++ b/src/test/ui/loops/loop-no-implicit-break.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let x: i8 = loop {
+        10 //~ ERROR mismatched types
+    };
+}

--- a/src/test/ui/loops/loop-no-implicit-break.rs
+++ b/src/test/ui/loops/loop-no-implicit-break.rs
@@ -1,5 +1,27 @@
 fn main() {
-    let x: i8 = loop {
-        10 //~ ERROR mismatched types
+    let a: i8 = loop {
+        1 //~ ERROR mismatched types
     };
+
+    let b: i8 = loop {
+        break 1;
+    };
+}
+
+fn foo() -> i8 {
+    let a: i8 = loop {
+        1 //~ ERROR mismatched types
+    };
+
+    let b: i8 = loop {
+        break 1;
+    };
+
+    loop {
+        1 //~ ERROR mismatched types
+    }
+
+    loop {
+        return 1;
+    }
 }

--- a/src/test/ui/loops/loop-no-implicit-break.stderr
+++ b/src/test/ui/loops/loop-no-implicit-break.stderr
@@ -31,6 +31,17 @@ help: you might have meant to return this value
 LL |         return 1;
    |         ^^^^^^  ^
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:29:9
+   |
+LL |         1
+   |         ^ expected `()`, found integer
+   |
+help: you might have meant to return this value
+   |
+LL |         return 1;
+   |         ^^^^^^  ^
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/loops/loop-no-implicit-break.stderr
+++ b/src/test/ui/loops/loop-no-implicit-break.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:3:9
+   |
+LL |         10
+   |         ^^ expected `()`, found integer
+   |
+help: you might have meant to break the loop with this value
+   |
+LL |         break 10;
+   |         ^^^^^   ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/loops/loop-no-implicit-break.stderr
+++ b/src/test/ui/loops/loop-no-implicit-break.stderr
@@ -1,14 +1,36 @@
 error[E0308]: mismatched types
   --> $DIR/loop-no-implicit-break.rs:3:9
    |
-LL |         10
-   |         ^^ expected `()`, found integer
+LL |         1
+   |         ^ expected `()`, found integer
    |
 help: you might have meant to break the loop with this value
    |
-LL |         break 10;
-   |         ^^^^^   ^
+LL |         break 1;
+   |         ^^^^^  ^
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:13:9
+   |
+LL |         1
+   |         ^ expected `()`, found integer
+   |
+help: you might have meant to break the loop with this value
+   |
+LL |         break 1;
+   |         ^^^^^  ^
+
+error[E0308]: mismatched types
+  --> $DIR/loop-no-implicit-break.rs:21:9
+   |
+LL |         1
+   |         ^ expected `()`, found integer
+   |
+help: you might have meant to return this value
+   |
+LL |         return 1;
+   |         ^^^^^^  ^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/match/issue-82392.rs
+++ b/src/test/ui/match/issue-82392.rs
@@ -1,0 +1,9 @@
+// https://github.com/rust-lang/rust/issues/82329
+// compile-flags: -Zunpretty=hir,typed
+// check-pass
+
+pub fn main() {
+    if true {
+    } else if let Some(a) = Some(3) {
+    }
+}

--- a/src/test/ui/match/issue-82392.stdout
+++ b/src/test/ui/match/issue-82392.stdout
@@ -1,0 +1,20 @@
+#[prelude_import]
+use ::std::prelude::rust_2015::*;
+#[macro_use]
+extern crate std;
+// https://github.com/rust-lang/rust/issues/82329
+// compile-flags: -Zunpretty=hir,typed
+// check-pass
+
+pub fn main() ({
+                   (if (true as bool)
+                       ({ } as
+                           ()) else {match ((Some as
+                                                fn(i32) -> Option<i32> {Option::<i32>::Some})((3
+                                                                                                  as
+                                                                                                  i32))
+                                               as Option<i32>) {
+                                         Some(a) => { }
+                                         _ => { }
+                                     }} as ())
+                    } as ())

--- a/src/test/ui/match/issue-84434.rs
+++ b/src/test/ui/match/issue-84434.rs
@@ -1,0 +1,18 @@
+// https://github.com/rust-lang/rust/issues/84434
+// check-pass
+
+use std::path::Path;
+struct A {
+    pub func: fn(check: bool, a: &Path, b: Option<&Path>),
+}
+const MY_A: A = A {
+    func: |check, a, b| {
+        if check {
+            let _ = ();
+        } else if let Some(parent) = b.and_then(|p| p.parent()) {
+            let _ = ();
+        }
+    },
+};
+
+fn main() {}

--- a/src/test/ui/rust-2018/trait-import-suggestions.stderr
+++ b/src/test/ui/rust-2018/trait-import-suggestions.stderr
@@ -1,6 +1,9 @@
 error[E0599]: no method named `foobar` found for type `u32` in the current scope
   --> $DIR/trait-import-suggestions.rs:22:11
    |
+LL |             fn foobar(&self) { }
+   |                ------ the method is available for `u32` here
+...
 LL |         x.foobar();
    |           ^^^^^^ method not found in `u32`
    |
@@ -11,6 +14,9 @@ LL |         x.foobar();
 error[E0599]: no method named `bar` found for type `u32` in the current scope
   --> $DIR/trait-import-suggestions.rs:28:7
    |
+LL |         fn bar(&self) { }
+   |            --- the method is available for `u32` here
+...
 LL |     x.bar();
    |       ^^^ method not found in `u32`
    |

--- a/src/test/ui/shadowed/shadowed-trait-methods.stderr
+++ b/src/test/ui/shadowed/shadowed-trait-methods.stderr
@@ -1,6 +1,9 @@
 error[E0599]: no method named `f` found for unit type `()` in the current scope
   --> $DIR/shadowed-trait-methods.rs:13:8
    |
+LL |     pub trait T { fn f(&self) {} }
+   |                      - the method is available for `()` here
+...
 LL |     ().f()
    |        ^ method not found in `()`
    |

--- a/src/test/ui/suggestions/import-trait-for-method-call.rs
+++ b/src/test/ui/suggestions/import-trait-for-method-call.rs
@@ -1,0 +1,9 @@
+use std::hash::BuildHasher;
+
+fn next_u64() -> u64 {
+    let bh = std::collections::hash_map::RandomState::new();
+    let h = bh.build_hasher();
+    h.finish() //~ ERROR no method named `finish` found for struct `DefaultHasher`
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -7,20 +7,9 @@ LL |     h.finish()
   ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
    |
 LL |     fn finish(&self) -> u64;
-   |        ------
-   |        |
-   |        the method is available for `Box<DefaultHasher>` here
-   |        the method is available for `Box<&mut DefaultHasher>` here
+   |        ------ the method is available for `DefaultHasher` here
    |
    = help: items from traits can only be used if the trait is in scope
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |     Box::new(h).finish()
-   |     ^^^^^^^^^ ^
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |     Box::new(&mut h).finish()
-   |     ^^^^^^^^^^^^^  ^
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
 LL | use std::hash::Hasher;

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -1,0 +1,26 @@
+error[E0599]: no method named `finish` found for struct `DefaultHasher` in the current scope
+  --> $DIR/import-trait-for-method-call.rs:6:7
+   |
+LL |     h.finish()
+   |       ^^^^^^ method not found in `DefaultHasher`
+   | 
+  ::: $SRC_DIR/core/src/hash/mod.rs:LL:COL
+   |
+LL |     fn finish(&self) -> u64;
+   |        ------
+   |        |
+   |        the method is available for `Box<DefaultHasher>` here
+   |        the method is available for `Box<&mut DefaultHasher>` here
+   |
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |     Box::new(h).finish()
+   |     ^^^^^^^^^ ^
+help: consider wrapping the receiver expression with the appropriate type
+   |
+LL |     Box::new(&mut h).finish()
+   |     ^^^^^^^^^^^^^  ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -12,6 +12,7 @@ LL |     fn finish(&self) -> u64;
    |        the method is available for `Box<DefaultHasher>` here
    |        the method is available for `Box<&mut DefaultHasher>` here
    |
+   = help: items from traits can only be used if the trait is in scope
 help: consider wrapping the receiver expression with the appropriate type
    |
 LL |     Box::new(h).finish()
@@ -20,6 +21,10 @@ help: consider wrapping the receiver expression with the appropriate type
    |
 LL |     Box::new(&mut h).finish()
    |     ^^^^^^^^^^^^^  ^
+help: the following trait is implemented but not in scope; perhaps add a `use` for it:
+   |
+LL | use std::hash::Hasher;
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -20,6 +20,9 @@ error[E0599]: no method named `b` found for struct `S` in the current scope
 LL | struct S;
    | --------- method `b` not found for this
 ...
+LL |         fn b(&self) { }
+   |            - the method is available for `S` here
+...
 LL |     S.b();
    |       ^ method not found in `S`
    |


### PR DESCRIPTION
Successful merges:

 - #84235 (refactor StyledBuffer)
 - #84486 (Handle pretty printing of `else if let` clauses without ICEing)
 - #84499 (Tweak trait not `use`d suggestion)
 - #84516 (Add suggestion to "use break" when attempting to implicit-break a loop)
 - #84541 (Inline most raw socket, fd and handle conversions)
 - #84543 (Fix 'const-stable since' of reverse_bits)
 - #84544 (Always reject `const fn` in `trait` during parsing.)
 - #84546 (Fix typo  in report_unsed_assign)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=84235,84486,84499,84516,84541,84543,84544,84546)
<!-- homu-ignore:end -->