### PR TITLE
Set `backtrace-on-ice` by default for compiler and codegen profiles

### DIFF
--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -11,3 +11,5 @@ assertions = true
 debug-logging = true
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Print backtrace on internal compiler errors during bootstrap
+backtrace-on-ice = true

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -6,6 +6,8 @@
 debug-logging = true
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Print backtrace on internal compiler errors during bootstrap
+backtrace-on-ice = true
 
 [llvm]
 # Will download LLVM from CI if available on your platform.


### PR DESCRIPTION
If there's an ICE while bootstrapping, it's most likely because of a change to the compiler.