### PR TITLE
std: Fix st_lspare issue with FreeBSD 13 ABI

### DIFF
--- a/library/std/src/os/freebsd/fs.rs
+++ b/library/std/src/os/freebsd/fs.rs
@@ -143,11 +143,11 @@ impl MetadataExt for Metadata {
     fn st_flags(&self) -> u32 {
         self.as_inner().as_inner().st_flags as u32
     }
-    #[cfg(freebsd12)]
+    #[cfg(not(freebsd11))]
     fn st_lspare(&self) -> u32 {
-        panic!("st_lspare not supported with FreeBSD 12 ABI");
+        panic!("st_lspare not supported with FreeBSD 12+ ABI");
     }
-    #[cfg(not(freebsd12))]
+    #[cfg(freebsd11)]
     fn st_lspare(&self) -> u32 {
         self.as_inner().as_inner().st_lspare as u32
     }


### PR DESCRIPTION
The check for whether or not st_lspare exists was only checking against
freebsd12, not freebsd12 or any newer.

Since freebsd11 is the oldest supported, flip the sense of the check
and use the old implemention for freebsd11 instead of not(freebsd12).

This fixes building against freebsd13 ABI and future-proofs the check.