### PR TITLE
Deduplicate ParamCandidates with the same value except for bound vars

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1361,7 +1361,17 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ) => false,
 
             (ParamCandidate(other), ParamCandidate(victim)) => {
-                if other.value == victim.value && victim.constness == Constness::NotConst {
+                let value_same_except_bound_vars = other.value.skip_binder()
+                    == victim.value.skip_binder()
+                    && !other.value.skip_binder().has_escaping_bound_vars();
+                if value_same_except_bound_vars {
+                    // See issue #84398. In short, we can generate multiple ParamCandidates which are
+                    // the same except for unused bound vars. Just pick the current one (the should
+                    // both evaluate to the same answer). This is probably best characterized as a
+                    // "hack", since we might prefer to just do our best to *not* create essentially
+                    // duplicate candidates in the first place.
+                    true
+                } else if other.value == victim.value && victim.constness == Constness::NotConst {
                     // Drop otherwise equivalent non-const candidates in favor of const candidates.
                     true
                 } else {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1366,11 +1366,11 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     && !other.value.skip_binder().has_escaping_bound_vars();
                 if value_same_except_bound_vars {
                     // See issue #84398. In short, we can generate multiple ParamCandidates which are
-                    // the same except for unused bound vars. Just pick the current one (the should
-                    // both evaluate to the same answer). This is probably best characterized as a
-                    // "hack", since we might prefer to just do our best to *not* create essentially
-                    // duplicate candidates in the first place.
-                    true
+                    // the same except for unused bound vars. Just pick the one with the fewest bound vars
+                    // or the current one if tied (they should both evaluate to the same answer). This is
+                    // probably best characterized as a "hack", since we might prefer to just do our
+                    // best to *not* create essentially duplicate candidates in the first place.
+                    other.value.bound_vars().len() <= victim.value.bound_vars().len()
                 } else if other.value == victim.value && victim.constness == Constness::NotConst {
                     // Drop otherwise equivalent non-const candidates in favor of const candidates.
                     true

--- a/src/test/ui/lifetimes/issue-84398.rs
+++ b/src/test/ui/lifetimes/issue-84398.rs
@@ -1,0 +1,20 @@
+// check-pass
+
+pub trait Deserialize<'de>: Sized {}
+pub trait DeserializeOwned: for<'de> Deserialize<'de> {}
+
+pub trait Extensible {
+    type Config;
+}
+
+// The `C` here generates a `C: Sized` candidate
+pub trait Installer<C> {
+    fn init<B: Extensible<Config = C>>(&mut self) -> ()
+    where
+        // This clause generates a `for<'de> C: Sized` candidate
+        B::Config: DeserializeOwned,
+    {
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #84398

This is kind of a hack. I wonder if we can get other types of candidates that are the same except for bound vars. This won't be a problem with Chalk, since we don't really need to know that there are two different "candidates" if they both give the same final substitution.

r? @nikomatsakis 