### PR TITLE
Inline Iterator as IntoIterator.

### DIFF
--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -238,6 +238,7 @@ impl<I: Iterator> IntoIterator for I {
     type Item = I::Item;
     type IntoIter = I;
 
+    #[inline]
     fn into_iter(self) -> I {
         self
     }


### PR DESCRIPTION
For some reason, it appears on rustc's own perf stats.