### PR TITLE
make feature name plural: const_fn_trait_bound → const_fn_trait_bounds

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -650,7 +650,7 @@ declare_features! (
     (active, wasm_abi, "1.53.0", Some(83788), None),
 
     /// Allows trait bounds in `const fn`.
-    (active, const_fn_trait_bound, "1.53.0", Some(57563), None),
+    (active, const_fn_trait_bounds, "1.53.0", Some(57563), None),
 
     /// Allows unsizing coercions in `const fn`.
     (active, const_fn_unsize, "1.53.0", Some(64992), None),

--- a/compiler/rustc_mir/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/ops.rs
@@ -650,14 +650,14 @@ pub mod ty {
             if ccx.const_kind() != hir::ConstContext::ConstFn {
                 Status::Allowed
             } else {
-                Status::Unstable(sym::const_fn_trait_bound)
+                Status::Unstable(sym::const_fn_trait_bounds)
             }
         }
 
         fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> DiagnosticBuilder<'tcx> {
             feature_err(
                 &ccx.tcx.sess.parse_sess,
-                sym::const_fn_trait_bound,
+                sym::const_fn_trait_bounds,
                 span,
                 "trait bounds other than `Sized` on const fn parameters are unstable",
             )

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -382,7 +382,7 @@ symbols! {
         const_fn,
         const_fn_floating_point_arithmetic,
         const_fn_fn_ptr_basics,
-        const_fn_trait_bound,
+        const_fn_trait_bounds,
         const_fn_transmute,
         const_fn_union,
         const_fn_unsize,

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -90,7 +90,7 @@
 #![feature(coerce_unsized)]
 #![feature(const_btree_new)]
 #![cfg_attr(bootstrap, feature(const_fn))]
-#![cfg_attr(not(bootstrap), feature(const_fn_trait_bound))]
+#![cfg_attr(not(bootstrap), feature(const_fn_trait_bounds))]
 #![feature(cow_is_borrowed)]
 #![feature(const_cow_is_borrowed)]
 #![feature(destructuring_assignment)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -86,7 +86,7 @@
 #![feature(const_impl_trait)]
 #![feature(const_fn_floating_point_arithmetic)]
 #![feature(const_fn_fn_ptr_basics)]
-#![cfg_attr(not(bootstrap), feature(const_fn_trait_bound))]
+#![cfg_attr(not(bootstrap), feature(const_fn_trait_bounds))]
 #![feature(const_option)]
 #![feature(const_precise_live_drops)]
 #![feature(const_ptr_offset)]

--- a/src/test/ui/consts/const-eval/issue-49296.rs
+++ b/src/test/ui/consts/const-eval/issue-49296.rs
@@ -1,7 +1,7 @@
 // issue-49296: Unsafe shenigans in constants can result in missing errors
 
 #![feature(const_fn_union)]
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bounds)]
 
 const unsafe fn transmute<T: Copy, U: Copy>(t: T) -> U {
     #[repr(C)]

--- a/src/test/ui/consts/const-fn.rs
+++ b/src/test/ui/consts/const-fn.rs
@@ -4,7 +4,7 @@
 // A very basic test of const fn functionality.
 
 #![feature(const_indexing)]
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bounds)]
 
 const fn add(x: u32, y: u32) -> u32 {
     x + y

--- a/src/test/ui/consts/const_fn_trait_bounds.gated.stderr
+++ b/src/test/ui/consts/const_fn_trait_bounds.gated.stderr
@@ -1,5 +1,5 @@
 error: fatal error triggered by #[rustc_error]
-  --> $DIR/const_fn_trait_bound.rs:17:1
+  --> $DIR/const_fn_trait_bounds.rs:17:1
    |
 LL | fn main() {}
    | ^^^^^^^^^

--- a/src/test/ui/consts/const_fn_trait_bounds.rs
+++ b/src/test/ui/consts/const_fn_trait_bounds.rs
@@ -1,9 +1,9 @@
-// gate-test-const_fn_trait_bound
+// gate-test-const_fn_trait_bounds
 
 // revisions: stock gated
 
 #![feature(rustc_attrs)]
-#![cfg_attr(gated, feature(const_fn_trait_bound))]
+#![cfg_attr(gated, feature(const_fn_trait_bounds))]
 
 const fn test1<T: std::ops::Add>() {}
 //[stock]~^ trait bounds

--- a/src/test/ui/consts/const_fn_trait_bounds.stock.stderr
+++ b/src/test/ui/consts/const_fn_trait_bounds.stock.stderr
@@ -1,29 +1,29 @@
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/const_fn_trait_bound.rs:8:16
+  --> $DIR/const_fn_trait_bounds.rs:8:16
    |
 LL | const fn test1<T: std::ops::Add>() {}
    |                ^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/const_fn_trait_bound.rs:10:16
+  --> $DIR/const_fn_trait_bounds.rs:10:16
    |
 LL | const fn test2(_x: &dyn Send) {}
    |                ^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
-  --> $DIR/const_fn_trait_bound.rs:12:21
+  --> $DIR/const_fn_trait_bounds.rs:12:21
    |
 LL | const fn test3() -> &'static dyn Send { loop {} }
    |                     ^^^^^^^^^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -137,7 +137,7 @@ LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:86:18
@@ -146,7 +146,7 @@ LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0013]: constant functions cannot refer to statics
   --> $DIR/min_const_fn.rs:90:27
@@ -216,7 +216,7 @@ LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:115:6
@@ -225,7 +225,7 @@ LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:120:6
@@ -234,7 +234,7 @@ LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:126:34
@@ -243,7 +243,7 @@ LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:126:19
@@ -260,7 +260,7 @@ LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:129:18
@@ -277,7 +277,7 @@ LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    |                       ^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:134:32
@@ -286,7 +286,7 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: unsizing casts to types besides slices are not allowed in const fn
   --> $DIR/min_const_fn.rs:134:63

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -5,7 +5,7 @@ LL |     x.0.field;
    |     ^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
-   = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
+   = help: add `#![feature(const_fn_trait_bounds)]` to the crate attributes to enable
 
 error[E0658]: unsizing casts to types besides slices are not allowed in const fn
   --> $DIR/min_const_fn_dyn.rs:12:66

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.rs
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.rs
@@ -6,7 +6,7 @@
 #![stable(feature = "core", since = "1.6.0")]
 #![feature(rustc_const_unstable)]
 #![feature(staged_api)]
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bounds)]
 
 enum Opt<T> {
     Some(T),

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-chain.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-chain.rs
@@ -3,7 +3,7 @@
 // check-pass
 
 #![feature(const_trait_impl)]
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bounds)]
 #![allow(incomplete_features)]
 
 struct S;

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-dup-bound.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-dup-bound.rs
@@ -2,7 +2,7 @@
 
 #![feature(const_trait_impl)]
 #![feature(const_trait_bound_opt_out)]
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bounds)]
 #![allow(incomplete_features)]
 
 struct S;

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-pass.rs
@@ -3,7 +3,7 @@
 // check-pass
 
 #![feature(const_trait_impl)]
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bounds)]
 #![allow(incomplete_features)]
 
 struct S;

--- a/src/test/ui/rfc-2632-const-trait-impl/generic-bound.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/generic-bound.rs
@@ -2,7 +2,7 @@
 
 #![allow(incomplete_features)]
 #![feature(const_trait_impl)]
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bounds)]
 
 use std::marker::PhantomData;
 


### PR DESCRIPTION
Seems like we usually use plural for this -- and even though I picked the name I also keep expecting it to be plural.^^
No nightly has been released yet with the singular name (Cc https://github.com/rust-lang/rust/issues/84577), so if we are quick I think this will be rather painless.

Cc @oli-obk 