### PR TITLE
rustdoc - implement #[doc(codeblock_attr = ...)]

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -364,6 +364,7 @@ symbols! {
         cmp,
         cmpxchg16b_target_feature,
         cmse_nonsecure_entry,
+        codeblock_attr,
         coerce_unsized,
         cold,
         column,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1073,6 +1073,27 @@ impl Attributes {
         }
         aliases.into_iter().collect::<Vec<String>>().into()
     }
+
+    crate fn get_codeblock_attrs(&self) -> Box<[String]> {
+        let mut codeblocks = FxHashSet::default();
+
+        for attr in self.other_attrs.lists(sym::doc).filter(|a| a.has_name(sym::codeblock_attr)) {
+            if let Some(values) = attr.meta_item_list() {
+                for l in values {
+                    match l.literal().unwrap().kind {
+                        ast::LitKind::Str(s, _) => {
+                            codeblocks.insert(s.as_str().to_string());
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+            } else {
+                codeblocks.insert(attr.value_str().map(|s| s.to_string()).unwrap());
+            }
+        }
+
+        codeblocks.into_iter().collect::<Vec<String>>().into()
+    }
 }
 
 impl PartialEq for Attributes {

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1115,8 +1115,10 @@ impl<'a, 'hir, 'tcx> HirCollector<'a, 'hir, 'tcx> {
                 .map(|span| span.ctxt().outer_expn().expansion_cause().unwrap_or(span))
                 .unwrap_or(DUMMY_SP);
             self.collector.set_position(span);
+            let syntax_override = attrs.get_codeblock_attrs();
             markdown::find_testable_code(
                 &doc,
+                &syntax_override,
                 self.collector,
                 self.codes,
                 self.collector.enable_per_target_ignores,

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -132,7 +132,14 @@ crate fn test(mut options: Options) -> Result<(), String> {
     collector.set_position(DUMMY_SP);
     let codes = ErrorCodes::from(options.render_options.unstable_features.is_nightly_build());
 
-    find_testable_code(&input_str, &mut collector, codes, options.enable_per_target_ignores, None);
+    find_testable_code(
+        &input_str,
+        &[],
+        &mut collector,
+        codes,
+        options.enable_per_target_ignores,
+        None,
+    );
 
     options.test_args.insert(0, "rustdoctest".to_string());
     testing::test_main(

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -202,9 +202,11 @@ impl<'a, 'b> fold::DocFolder for CoverageCalculator<'a, 'b> {
             _ => {
                 let has_docs = !i.attrs.doc_strings.is_empty();
                 let mut tests = Tests { found_tests: 0 };
+                let syntax_override = i.attrs.get_codeblock_attrs();
 
                 find_testable_code(
                     &i.attrs.collapsed_doc_value().unwrap_or_default(),
+                    &syntax_override,
                     &mut tests,
                     ErrorCodes::No,
                     false,

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -112,7 +112,8 @@ impl<'a, 'tcx> DocFolder for SyntaxChecker<'a, 'tcx> {
         if let Some(dox) = &item.attrs.collapsed_doc_value() {
             let sp = item.attr_span(self.cx.tcx);
             let extra = crate::html::markdown::ExtraInfo::new_did(self.cx.tcx, item.def_id, sp);
-            for code_block in markdown::rust_code_blocks(&dox, &extra) {
+            let syntax_override = item.attrs.get_codeblock_attrs();
+            for code_block in markdown::rust_code_blocks(&dox, &syntax_override, &extra) {
                 self.check_rust_syntax(&item, &dox, code_block);
             }
         }

--- a/src/librustdoc/passes/doc_test_lints.rs
+++ b/src/librustdoc/passes/doc_test_lints.rs
@@ -91,8 +91,9 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
     };
 
     let mut tests = Tests { found_tests: 0 };
+    let syntax_override = item.attrs.get_codeblock_attrs();
 
-    find_testable_code(&dox, &mut tests, ErrorCodes::No, false, None);
+    find_testable_code(&dox, &syntax_override, &mut tests, ErrorCodes::No, false, None);
 
     if tests.found_tests == 0 && cx.tcx.sess.is_nightly_build() {
         if should_have_doc_example(cx, &item) {

--- a/src/test/rustdoc-ui/codeblock-badattr.rs
+++ b/src/test/rustdoc-ui/codeblock-badattr.rs
@@ -1,0 +1,22 @@
+#![crate_type = "lib"]
+
+#[doc = "test"]
+#[doc(codeblock_attr = "1,2,3")] //~ ERROR
+mod a {}
+
+#[doc = "test"]
+#[doc(codeblock_attr = "foo bar")] //~ ERROR
+mod b {}
+
+#[doc = "test"]
+#[doc(codeblock_attr(" ", ","))] //~ ERROR
+//~^ ERROR
+mod c {}
+
+#[doc = "test"]
+#[doc(codeblock_attr("rust"))] // OK!
+mod d {}
+
+#[doc = "test"]
+#[doc(codeblock_attr = "rust")] // OK!
+mod e {}

--- a/src/test/rustdoc-ui/codeblock-badattr.stderr
+++ b/src/test/rustdoc-ui/codeblock-badattr.stderr
@@ -1,0 +1,26 @@
+error: ',' character isn't allowed in `#[doc(codeblock_attr = "...")]`
+  --> $DIR/codeblock-badattr.rs:4:24
+   |
+LL | #[doc(codeblock_attr = "1,2,3")]
+   |                        ^^^^^^^
+
+error: ' ' character isn't allowed in `#[doc(codeblock_attr = "...")]`
+  --> $DIR/codeblock-badattr.rs:8:24
+   |
+LL | #[doc(codeblock_attr = "foo bar")]
+   |                        ^^^^^^^^^
+
+error: ' ' character isn't allowed in `#[doc(codeblock_attr("..."))]`
+  --> $DIR/codeblock-badattr.rs:12:22
+   |
+LL | #[doc(codeblock_attr(" ", ","))]
+   |                      ^^^
+
+error: ',' character isn't allowed in `#[doc(codeblock_attr("..."))]`
+  --> $DIR/codeblock-badattr.rs:12:27
+   |
+LL | #[doc(codeblock_attr(" ", ","))]
+   |                           ^^^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/rustdoc-ui/codeblock-override.rs
+++ b/src/test/rustdoc-ui/codeblock-override.rs
@@ -1,0 +1,84 @@
+// compile-flags:--test --test-args=--test-threads=1
+// build-pass
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+//! Crate documentation
+//!
+//! This is some perfectly normal code
+//! ```
+//! 10 print "hello...
+//! ```
+#![doc(codeblock_attr = "text")]
+
+#![crate_name = "foo"]
+#![crate_type = "lib"]
+
+#[doc = r#"
+Test code:
+```rust
+println!("I am evil")
+```
+"#]
+#[doc(codeblock_attr = "text")]
+fn test1() {}
+
+#[doc = r#"
+Test code:
+```
+println!("I am evil")
+```
+"#]
+#[doc(codeblock_attr = "text")]
+fn test2() {}
+
+#[doc = r#"
+Test code:
+```
+10 print "hello, I have a dangling quote
+```
+"#]
+#[doc(codeblock_attr = "text")]
+fn test3() {}
+
+#[doc = r#"
+Test code:
+
+    10 print "hello, I have a dangling quote
+
+"#]
+#[doc(codeblock_attr = "text")]
+fn test4() {}
+
+#[doc = r#"
+This is a test:
+```text
+panic!("Expected")
+```
+"#]
+#[doc(codeblock_attr = "should_panic")]
+#[doc(codeblock_attr = "rust")]
+fn panic_test0() {}
+
+/// This is a test:
+/// ```text
+/// panic!("Expected")
+/// ```
+#[doc(codeblock_attr = "should_panic")]
+#[doc(codeblock_attr = "rust")]
+fn panic_test1() {}
+
+/// This is a test:
+///
+///     panic!("Expected")
+///
+#[doc(codeblock_attr = "should_panic")]
+#[doc(codeblock_attr = "rust")]
+fn panic_test2() {}
+
+/// This is a test:
+///
+///     panic!("Expected")
+///
+#[doc(codeblock_attr ("rust", "should_panic"))]
+fn panic_test3() {}

--- a/src/test/rustdoc-ui/codeblock-override.stdout
+++ b/src/test/rustdoc-ui/codeblock-override.stdout
@@ -1,0 +1,9 @@
+
+running 4 tests
+test $DIR/codeblock-override.rs - panic_test0 (line 54) ... ok
+test $DIR/codeblock-override.rs - panic_test1 (line 64) ... ok
+test $DIR/codeblock-override.rs - panic_test2 (line 74) ... ok
+test $DIR/codeblock-override.rs - panic_test3 (line 82) ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/src/test/ui/rustdoc/codeblock-override.rs
+++ b/src/test/ui/rustdoc/codeblock-override.rs
@@ -1,0 +1,31 @@
+//! Crate documentation
+//!
+#![doc(codeblock_attr = "text")]
+
+// build-pass
+
+#![crate_type = "lib"]
+
+#[doc = r#"
+Test code:
+```rust
+println!("I am evil")
+```
+"#]
+#[doc(codeblock_attr = "text")]
+fn test1() {}
+
+/// This is a test:
+/// ```text
+/// panic!("Expected")
+/// ```
+#[doc(codeblock_attr = "should_panic")]
+#[doc(codeblock_attr = "rust")]
+fn panic_test() {}
+
+/// This is a test:
+///
+///     panic!("Expected")
+///
+#[doc(codeblock_attr ("rust", "should_panic"))]
+fn panic_test3() {}


### PR DESCRIPTION
This PR implements a `#[doc(codeblock_attr = )]` specification which allows all the codeblock attrs in a doc comment to be overridden. For example, if the doc comment has come from outside the Rust ecosystem (eg from bindgen, protoc, etc) then it may appear to have code blocks in its doc comments, but they are not intended to be in Rust. They will either fail to parse, causing spurious warnings, or worse, parse and do unintended things.

To address this, this PR allows all the code block attributes to be overridden for both ```` ``` ```` and indent-based code blocks (which don't currently have a way to specify attributes). For example:
```
#[doc = r#"
This is a random piece of code

    10 print "I don't have a closing quote
"#]
#[doc(codeblock_attr = "text")] // force indented code block to be treated as plain text
struct Foo;
```

I have some possible discussion points:
- Name of `codeblock_attr`
- Should there also be an "extend" counterpart. I don't have a need for it, in the use-cases I'm thinking of, but it's worth considering (not for this PR, but making sure this PR doesn't preclude a future extension).
- module/crate-level override/default? Doing it at a per-doc comment level seems simplest, so long as you can update your code generator to emit it. Doing it at a larger scope just means updating a prolog/template.

Personally I think this PR lands on the right answers for all of these, but I'm open to other thoughts.

https://internals.rust-lang.org/t/blanket-tags-for-doc-code-blocks/14567/ for irlo discussion.

Relevant issue: #59867

cc @joshtriplett @ehuss 