### PR TITLE
Reorder the parameter descriptions of map_or and map_or_else

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -489,8 +489,8 @@ impl<T> Option<T> {
         }
     }
 
-    /// Applies a function to the contained value (if any),
-    /// or returns the provided default (if not).
+    /// Returns the provided default result (if none),
+    /// or applies a function to the contained value (if any).
     ///
     /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`map_or_else`],
@@ -516,8 +516,8 @@ impl<T> Option<T> {
         }
     }
 
-    /// Applies a function to the contained value (if any),
-    /// or computes a default (if not).
+    /// Computes a default function result (if none), or
+    /// applies a different function to the contained value (if any).
     ///
     /// # Examples
     ///

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -506,8 +506,8 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Applies a function to the contained value (if [`Ok`]),
-    /// or returns the provided default (if [`Err`]).
+    /// Returns the provided default (if [`Err`]), or
+    /// applies a function to the contained value (if [`Ok`]),
     ///
     /// Arguments passed to `map_or` are eagerly evaluated; if you are passing
     /// the result of a function call, it is recommended to use [`map_or_else`],
@@ -533,9 +533,9 @@ impl<T, E> Result<T, E> {
         }
     }
 
-    /// Maps a `Result<T, E>` to `U` by applying a function to a
-    /// contained [`Ok`] value, or a fallback function to a
-    /// contained [`Err`] value.
+    /// Maps a `Result<T, E>` to `U` by applying a fallback function to a
+    /// contained [`Err`] value, or a default function to a
+    /// contained [`Ok`] value.
     ///
     /// This function can be used to unpack a successful result
     /// while handling an error.


### PR DESCRIPTION
They were described backwards, probably leading users to write arguments in the wrong order. Bug: #84608