### PR TITLE
Fix failed tests related to pointer printing when using GDB 10

### DIFF
--- a/src/test/debuginfo/extern-c-fn.rs
+++ b/src/test/debuginfo/extern-c-fn.rs
@@ -5,17 +5,16 @@
 // === GDB TESTS ===================================================================================
 // gdb-command:run
 
-// gdb-command:print s
-// gdbg-check:$1 = [...]"abcd"
-// gdbr-check:$1 = [...]"abcd\000"
+// gdb-command:printf "s = \"%s\"\n", s
+// gdb-check:s = "abcd"
 // gdb-command:print len
-// gdb-check:$2 = 20
+// gdb-check:$1 = 20
 // gdb-command:print local0
-// gdb-check:$3 = 19
+// gdb-check:$2 = 19
 // gdb-command:print local1
-// gdb-check:$4 = true
+// gdb-check:$3 = true
 // gdb-command:print local2
-// gdb-check:$5 = 20.5
+// gdb-check:$4 = 20.5
 
 // gdb-command:continue
 

--- a/src/test/debuginfo/pretty-huge-vec.rs
+++ b/src/test/debuginfo/pretty-huge-vec.rs
@@ -13,7 +13,7 @@
 // gdb-check:$1 = Vec(size=1000000000) = {[...]...}
 
 // gdb-command: print slice
-// gdb-check:$2 = &[u8] {data_ptr: [...]"\000", length: 1000000000}
+// gdb-check:$2 = &[u8] {data_ptr: [...], length: 1000000000}
 
 #![allow(unused_variables)]
 


### PR DESCRIPTION
As mentioned in #79009, there are four failed debuginfo test cases when using GDB 10. This PR fixes two of them, which fail because GDB 10 won't print pointers as string anymore. We can use `printf` as a workaround. It should work regardless of the version of GDB.

Refer this [comment] for more details.

[comment]: https://github.com/rust-lang/rust/issues/79009#issuecomment-826952708