### PR TITLE
Allow to get/set TOS field on sockets

### DIFF
--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -494,7 +494,7 @@ impl TcpStream {
     ///                        .expect("Couldn't connect to the server...");
     /// stream.set_tos(96).expect("set_tos call failed");
     /// ```
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    #[unstable(feature = "tos")]
     pub fn set_tos(&self, tos: u32) -> io::Result<()> {
         self.0.set_tos(tos)
     }
@@ -513,7 +513,7 @@ impl TcpStream {
     /// stream.set_tos(96).expect("set_tos call failed");
     /// assert_eq!(stream.tos().unwrap_or(0), 96);
     /// ```
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    #[unstable(feature = "tos")]
     pub fn tos(&self) -> io::Result<u32> {
         self.0.tos()
     }
@@ -890,7 +890,7 @@ impl TcpListener {
     /// listener.set_tos(96).expect("could not set TOS");
     /// assert_eq!(listener.tos().unwrap_or(0), 96);
     /// ```
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    #[unstable(feature = "tos")]
     pub fn tos(&self) -> io::Result<u32> {
         self.0.tos()
     }

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -480,6 +480,44 @@ impl TcpStream {
         self.0.ttl()
     }
 
+    /// Sets the value for the `IP_TOS` option on this socket.
+    ///
+    /// This value sets the type-of-service field that is used in every packet
+    /// sent from this socket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::TcpStream;
+    ///
+    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    ///                        .expect("Couldn't connect to the server...");
+    /// stream.set_tos(96).expect("set_tos call failed");
+    /// ```
+    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        self.0.set_tos(tos)
+    }
+
+    /// Gets the value of the `IP_TOS` option for this socket.
+    ///
+    /// For more information about this option, see [`TcpStream::set_tos`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::TcpStream;
+    ///
+    /// let stream = TcpStream::connect("127.0.0.1:8080")
+    ///                        .expect("Couldn't connect to the server...");
+    /// stream.set_tos(96).expect("set_tos call failed");
+    /// assert_eq!(stream.tos().unwrap_or(0), 96);
+    /// ```
+    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    pub fn tos(&self) -> io::Result<u32> {
+        self.0.tos()
+    }
+
     /// Gets the value of the `SO_ERROR` option on this socket.
     ///
     /// This will retrieve the stored error in the underlying socket, clearing
@@ -819,6 +857,42 @@ impl TcpListener {
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn ttl(&self) -> io::Result<u32> {
         self.0.ttl()
+    }
+
+    /// Sets the value for the `IP_TOS` option on this socket.
+    ///
+    /// This value sets the type-of-service field that is used in every packet
+    /// sent from this socket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::TcpListener;
+    ///
+    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// listener.set_tos(96).expect("could not set TOS");
+    /// ```
+    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        self.0.set_tos(tos)
+    }
+
+    /// Gets the value of the `IP_TOS` option for this socket.
+    ///
+    /// For more information about this option, see [`TcpListener::set_tos`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::TcpListener;
+    ///
+    /// let listener = TcpListener::bind("127.0.0.1:80").unwrap();
+    /// listener.set_tos(96).expect("could not set TOS");
+    /// assert_eq!(listener.tos().unwrap_or(0), 96);
+    /// ```
+    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    pub fn tos(&self) -> io::Result<u32> {
+        self.0.tos()
     }
 
     #[stable(feature = "net2_mutators", since = "1.9.0")]

--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -801,6 +801,23 @@ fn ttl() {
 
 #[test]
 #[cfg_attr(target_env = "sgx", ignore)]
+fn tos() {
+    let tos = 96;
+
+    let addr = next_test_ip4();
+    let listener = t!(TcpListener::bind(&addr));
+
+    t!(listener.set_tos(tos));
+    assert_eq!(tos, t!(listener.tos()));
+
+    let stream = t!(TcpStream::connect(&("localhost", addr.port())));
+
+    t!(stream.set_tos(tos));
+    assert_eq!(tos, t!(stream.tos()));
+}
+
+#[test]
+#[cfg_attr(target_env = "sgx", ignore)]
 fn set_nonblocking() {
     let addr = next_test_ip4();
     let listener = t!(TcpListener::bind(&addr));

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -550,6 +550,42 @@ impl UdpSocket {
         self.0.ttl()
     }
 
+    /// Sets the value for the `IP_TOS` option on this socket.
+    ///
+    /// This value sets the type-of-service field that is used in every packet
+    /// sent from this socket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// socket.set_tos(96).expect("set_tos call failed");
+    /// ```
+    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        self.0.set_tos(tos)
+    }
+
+    /// Gets the value of the `IP_TOS` option for this socket.
+    ///
+    /// For more information about this option, see [`UdpSocket::set_tos`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::net::UdpSocket;
+    ///
+    /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
+    /// socket.set_tos(96).expect("set_tos call failed");
+    /// assert_eq!(socket.tos().unwrap(), 96);
+    /// ```
+    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    pub fn tos(&self) -> io::Result<u32> {
+        self.0.tos()
+    }
+
     /// Executes an operation of the `IP_ADD_MEMBERSHIP` type.
     ///
     /// This function specifies a new multicast group for this socket to join.

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -581,7 +581,7 @@ impl UdpSocket {
     /// socket.set_tos(96).expect("set_tos call failed");
     /// assert_eq!(socket.tos().unwrap(), 96);
     /// ```
-    #[stable(feature = "net2_mutators", since = "1.9.0")]
+    #[unstable(feature = "tos")]
     pub fn tos(&self) -> io::Result<u32> {
         self.0.tos()
     }

--- a/library/std/src/net/udp/tests.rs
+++ b/library/std/src/net/udp/tests.rs
@@ -344,6 +344,18 @@ fn ttl() {
 }
 
 #[test]
+fn tos() {
+    let tos = 96;
+
+    let addr = next_test_ip4();
+
+    let stream = t!(UdpSocket::bind(&addr));
+
+    t!(stream.set_tos(tos));
+    assert_eq!(tos, t!(stream.tos()));
+}
+
+#[test]
 fn set_nonblocking() {
     each_ip(&mut |addr, _| {
         let socket = t!(UdpSocket::bind(&addr));

--- a/library/std/src/sys/hermit/net.rs
+++ b/library/std/src/sys/hermit/net.rs
@@ -198,6 +198,14 @@ impl TcpStream {
             .map_err(|_| io::Error::new_const(ErrorKind::Other, &"unable to get TTL"))
     }
 
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        unsupported()
+    }
+
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         unsupported()
     }
@@ -251,6 +259,14 @@ impl TcpListener {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
+        unsupported()
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
         unsupported()
     }
 
@@ -377,6 +393,14 @@ impl UdpSocket {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
+        unsupported()
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
         unsupported()
     }
 

--- a/library/std/src/sys/sgx/net.rs
+++ b/library/std/src/sys/sgx/net.rs
@@ -11,6 +11,7 @@ use crate::time::Duration;
 use super::abi::usercalls;
 
 const DEFAULT_FAKE_TTL: u32 = 64;
+const DEFAULT_FAKE_TOS: u32 = 64;
 
 #[derive(Debug, Clone)]
 pub struct Socket {
@@ -199,6 +200,14 @@ impl TcpStream {
         sgx_ineffective(DEFAULT_FAKE_TTL)
     }
 
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        sgx_ineffective(())
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        sgx_ineffective(DEFAULT_FAKE_TOS)
+    }
+
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         Ok(None)
     }
@@ -273,6 +282,14 @@ impl TcpListener {
 
     pub fn ttl(&self) -> io::Result<u32> {
         sgx_ineffective(DEFAULT_FAKE_TTL)
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        sgx_ineffective(())
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        sgx_ineffective(DEFAULT_FAKE_TOS)
     }
 
     pub fn set_only_v6(&self, _: bool) -> io::Result<()> {
@@ -410,6 +427,14 @@ impl UdpSocket {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
+        self.0
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        self.0
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
         self.0
     }
 

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -230,6 +230,14 @@ pub mod net {
             unimpl!();
         }
 
+        pub fn set_tos(&self, _: u32) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn tos(&self) -> io::Result<u32> {
+            unimpl!();
+        }
+
         pub fn take_error(&self) -> io::Result<Option<io::Error>> {
             unimpl!();
         }
@@ -285,6 +293,14 @@ pub mod net {
         }
 
         pub fn ttl(&self) -> io::Result<u32> {
+            unimpl!();
+        }
+
+        pub fn set_tos(&self, _: u32) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn tos(&self) -> io::Result<u32> {
             unimpl!();
         }
 
@@ -427,6 +443,14 @@ pub mod net {
         }
 
         pub fn ttl(&self) -> io::Result<u32> {
+            unimpl!();
+        }
+
+        pub fn set_tos(&self, _: u32) -> io::Result<()> {
+            unimpl!();
+        }
+
+        pub fn tos(&self) -> io::Result<u32> {
             unimpl!();
         }
 

--- a/library/std/src/sys/unsupported/net.rs
+++ b/library/std/src/sys/unsupported/net.rs
@@ -92,6 +92,14 @@ impl TcpStream {
         self.0
     }
 
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        self.0
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        self.0
+    }
+
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.0
     }
@@ -131,6 +139,14 @@ impl TcpListener {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
+        self.0
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        self.0
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
         self.0
     }
 
@@ -257,6 +273,14 @@ impl UdpSocket {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
+        self.0
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        self.0
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
         self.0
     }
 

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -98,6 +98,14 @@ impl TcpStream {
         unsupported()
     }
 
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        unsupported()
+    }
+
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         unsupported()
     }
@@ -153,6 +161,14 @@ impl TcpListener {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
+        unsupported()
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
         unsupported()
     }
 
@@ -295,6 +311,14 @@ impl UdpSocket {
     }
 
     pub fn ttl(&self) -> io::Result<u32> {
+        unsupported()
+    }
+
+    pub fn set_tos(&self, _: u32) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
         unsupported()
     }
 

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -236,6 +236,7 @@ pub const IPPROTO_IP: c_int = 0;
 pub const IPPROTO_TCP: c_int = 6;
 pub const IPPROTO_IPV6: c_int = 41;
 pub const TCP_NODELAY: c_int = 0x0001;
+pub const IP_TOS: c_int = 3;
 pub const IP_TTL: c_int = 4;
 pub const IPV6_V6ONLY: c_int = 27;
 pub const SO_ERROR: c_int = 0x1007;

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -320,6 +320,15 @@ impl TcpStream {
         Ok(raw as u32)
     }
 
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        setsockopt(&self.inner, c::IPPROTO_IP, c::IP_TOS, tos as c_int)
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TOS)?;
+        Ok(raw as u32)
+    }
+
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.inner.take_error()
     }
@@ -417,6 +426,15 @@ impl TcpListener {
 
     pub fn ttl(&self) -> io::Result<u32> {
         let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL)?;
+        Ok(raw as u32)
+    }
+
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        setsockopt(&self.inner, c::IPPROTO_IP, c::IP_TOS, tos as c_int)
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TOS)?;
         Ok(raw as u32)
     }
 
@@ -621,6 +639,15 @@ impl UdpSocket {
 
     pub fn ttl(&self) -> io::Result<u32> {
         let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TTL)?;
+        Ok(raw as u32)
+    }
+
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        setsockopt(&self.inner, c::IPPROTO_IP, c::IP_TOS, tos as c_int)
+    }
+
+    pub fn tos(&self) -> io::Result<u32> {
+        let raw: c_int = getsockopt(&self.inner, c::IPPROTO_IP, c::IP_TOS)?;
         Ok(raw as u32)
     }
 


### PR DESCRIPTION
Some network applications depend on proper marking of outgoing packets with ToS/DSCP fields. Routing protocols, management traffic, VoIP applications, etc., all depend on the ToS field.

ToS can be set at the socket level using the setsockopt call, using the IPPROTO_IP level and the IP_TOS option. TCPStream and UDPSocket already have `ttl` and `set_ttl` methods to get and set the TTL field. This PR adds a `tos` and `set_tos` methods.

This is an intermediate step to close this ticket: https://github.com/tokio-rs/tokio/issues/3545