### PR TITLE
rustdoc: change aliases attribute to data-aliases

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1546,7 +1546,7 @@ fn render_impl(
         let aliases = if aliases.is_empty() {
             String::new()
         } else {
-            format!(" aliases=\"{}\"", aliases.join(","))
+            format!(" data-aliases=\"{}\"", aliases.join(","))
         };
         if let Some(use_absolute) = use_absolute {
             write!(

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -834,7 +834,7 @@ function hideThemeButtonState() {
             // (like "Send" and "Sync").
             var inlined_types = new Set();
             onEachLazy(synthetic_implementors.getElementsByClassName("impl"), function(el) {
-                var aliases = el.getAttribute("aliases");
+                var aliases = el.getAttribute("data-aliases");
                 if (!aliases) {
                     return;
                 }

--- a/src/test/rustdoc/auto_aliases.rs
+++ b/src/test/rustdoc/auto_aliases.rs
@@ -1,6 +1,6 @@
 #![feature(auto_traits)]
 
-// @has auto_aliases/trait.Bar.html '//h3[@aliases="auto_aliases::Foo"]' 'impl Bar for Foo'
+// @has auto_aliases/trait.Bar.html '//h3[@data-aliases="auto_aliases::Foo"]' 'impl Bar for Foo'
 pub struct Foo;
 
 pub auto trait Bar {}


### PR DESCRIPTION
The "aliases" attribute is not listed [on MDN], so it sounds like it's rustdoc-specific. We don't want to conflict with any attributes that are added to the spec in the future.

[on MDN]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements