### PR TITLE
Implement `TryFrom<char>` for `u8`

### DIFF
--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -1,5 +1,6 @@
 //! Character conversions.
 
+use crate::char::TryFromCharError;
 use crate::convert::TryFrom;
 use crate::fmt;
 use crate::mem::transmute;
@@ -163,6 +164,20 @@ impl const From<char> for u128 {
         // The char is casted to the value of the code point, then zero-extended to 128 bit.
         // See [https://doc.rust-lang.org/reference/expressions/operator-expr.html#semantics]
         c as u128
+    }
+}
+
+/// Map `char` with code point in U+0000..=U+00FF to byte in 0x00..=0xFF with same value, failing
+/// if the code point is greater than U+00FF.
+///
+/// See [`impl From<u8> for char`](char#impl-From<u8>) for details on the encoding.
+#[stable(feature = "u8_from_char", since = "1.59.0")]
+impl TryFrom<char> for u8 {
+    type Error = TryFromCharError;
+
+    #[inline]
+    fn try_from(c: char) -> Result<u8, Self::Error> {
+        u8::try_from(u32::from(c)).map_err(|_| TryFromCharError(()))
     }
 }
 

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -544,3 +544,15 @@ impl fmt::Display for ToUppercase {
         fmt::Display::fmt(&self.0, f)
     }
 }
+
+/// The error type returned when a checked char conversion fails.
+#[stable(feature = "u8_from_char", since = "1.59.0")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TryFromCharError(pub(crate) ());
+
+#[stable(feature = "u8_from_char", since = "1.59.0")]
+impl fmt::Display for TryFromCharError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "unicode code point out of range".fmt(fmt)
+    }
+}

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -478,6 +478,9 @@ impl Error for char::DecodeUtf16Error {
     }
 }
 
+#[stable(feature = "u8_from_char", since = "1.59.0")]
+impl Error for char::TryFromCharError {}
+
 #[unstable(feature = "map_try_insert", issue = "82766")]
 impl<'a, K: Debug + Ord, V: Debug> Error
     for crate::collections::btree_map::OccupiedError<'a, K, V>


### PR DESCRIPTION
Previously suggested in https://github.com/rust-lang/rfcs/issues/2854.

It makes sense to have this since `char` implements `From<u8>`. Likewise `u32`, `u64`, and `u128` (since #79502) implement `From<char>`.