### PR TITLE
Inline trivial convert methods.

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -485,6 +485,7 @@ impl<T: ?Sized, U: ?Sized> AsRef<U> for &T
 where
     T: AsRef<U>,
 {
+    #[inline]
     fn as_ref(&self) -> &U {
         <T as AsRef<U>>::as_ref(*self)
     }
@@ -496,6 +497,7 @@ impl<T: ?Sized, U: ?Sized> AsRef<U> for &mut T
 where
     T: AsRef<U>,
 {
+    #[inline]
     fn as_ref(&self) -> &U {
         <T as AsRef<U>>::as_ref(*self)
     }
@@ -515,6 +517,7 @@ impl<T: ?Sized, U: ?Sized> AsMut<U> for &mut T
 where
     T: AsMut<U>,
 {
+    #[inline]
     fn as_mut(&mut self) -> &mut U {
         (*self).as_mut()
     }
@@ -534,6 +537,7 @@ impl<T, U> Into<U> for T
 where
     U: From<T>,
 {
+    #[inline]
     fn into(self) -> U {
         U::from(self)
     }
@@ -542,6 +546,7 @@ where
 // From (and thus Into) is reflexive
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> From<T> for T {
+    #[inline]
     fn from(t: T) -> T {
         t
     }
@@ -570,6 +575,7 @@ where
 {
     type Error = U::Error;
 
+    #[inline]
     fn try_into(self) -> Result<U, U::Error> {
         U::try_from(self)
     }
@@ -584,6 +590,7 @@ where
 {
     type Error = Infallible;
 
+    #[inline]
     fn try_from(value: U) -> Result<Self, Self::Error> {
         Ok(U::into(value))
     }
@@ -595,6 +602,7 @@ where
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> AsRef<[T]> for [T] {
+    #[inline]
     fn as_ref(&self) -> &[T] {
         self
     }
@@ -602,6 +610,7 @@ impl<T> AsRef<[T]> for [T] {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> AsMut<[T]> for [T] {
+    #[inline]
     fn as_mut(&mut self) -> &mut [T] {
         self
     }


### PR DESCRIPTION
These blancket impls are only used to forward to a more relevant impl.

For some reason, ThinLTO may fail to pick up those functions.