### PR TITLE
Update LLVM for more wasm simd updates

### DIFF
--- a/src/test/ui/asm/sym.rs
+++ b/src/test/ui/asm/sym.rs
@@ -1,6 +1,4 @@
 // min-llvm-version: 10.0.1
-// FIXME(#84025): codegen-units=1 leads to linkage errors
-// compile-flags: -C codegen-units=2
 // only-x86_64
 // only-linux
 // run-pass


### PR DESCRIPTION
This fixes the temporary regression introduced in #84339 where the wasm
target uses `fpto{s,u}i` intrinsics but the codegen for those intrinsics
with the `+nontrapping-fptoint` LLVM feature wasn't very good (aka it
didn't use the wasm instruction). The fixes brought in here fix that and
also implement the second-to-last simd instruction in LLVM.