### PR TITLE
Update list of allowed aarch64 features

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -152,6 +152,12 @@ pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
         ("x86", "avx512vpclmulqdq") => "vpclmulqdq",
         ("aarch64", "fp") => "fp-armv8",
         ("aarch64", "fp16") => "fullfp16",
+        ("aarch64", "fhm") => "fp16fml",
+        ("aarch64", "lse2") => "outline-atomics",
+        ("aarch64", "rcpc2") => "rcpc-immo",
+        ("aarch64", "dpb") => "ccpp",
+        ("aarch64", "dpb2") => "ccdp",
+        ("aarch64", "fcma") => "complxnum",
         (_, s) => s,
     }
 }

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -156,6 +156,7 @@ pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
         ("aarch64", "rcpc2") => "rcpc-immo",
         ("aarch64", "dpb") => "ccpp",
         ("aarch64", "dpb2") => "ccdp",
+        ("aarch64", "frintts") => "fptoint",
         ("aarch64", "fcma") => "complxnum",
         (_, s) => s,
     }

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -153,7 +153,6 @@ pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
         ("aarch64", "fp") => "fp-armv8",
         ("aarch64", "fp16") => "fullfp16",
         ("aarch64", "fhm") => "fp16fml",
-        ("aarch64", "lse2") => "outline-atomics",
         ("aarch64", "rcpc2") => "rcpc-immo",
         ("aarch64", "dpb") => "ccpp",
         ("aarch64", "dpb2") => "ccdp",

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -33,22 +33,95 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("thumb-mode", Some(sym::arm_target_feature)),
 ];
 
+// Commented features are not available in LLVM 9.0, or have since been renamed
 const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
-    ("fp", Some(sym::aarch64_target_feature)),
+    // FEAT_AdvSimd
     ("neon", Some(sym::aarch64_target_feature)),
-    ("sve", Some(sym::aarch64_target_feature)),
-    ("crc", Some(sym::aarch64_target_feature)),
-    ("crypto", Some(sym::aarch64_target_feature)),
-    ("ras", Some(sym::aarch64_target_feature)),
-    ("lse", Some(sym::aarch64_target_feature)),
-    ("rdm", Some(sym::aarch64_target_feature)),
+    // FEAT_FP
+    ("fp", Some(sym::aarch64_target_feature)),
+    // FEAT_FP16
     ("fp16", Some(sym::aarch64_target_feature)),
+    // FEAT_SVE
+    ("sve", Some(sym::aarch64_target_feature)),
+    // FEAT_CRC
+    ("crc", Some(sym::aarch64_target_feature)),
+    // Cryptographic extension
+    ("crypto", Some(sym::aarch64_target_feature)),
+    // FEAT_RAS
+    ("ras", Some(sym::aarch64_target_feature)),
+    // FEAT_LSE
+    ("lse", Some(sym::aarch64_target_feature)),
+    // FEAT_LSE2
+    // ("lse2", Some(sym::aarch64_target_feature)),
+    // FEAT_RDM
+    ("rdm", Some(sym::aarch64_target_feature)),
+    // FEAT_RCPC
     ("rcpc", Some(sym::aarch64_target_feature)),
+    // FEAT_RCPC2
+    ("rcpc2", Some(sym::aarch64_target_feature)),
+    // FEAT_DotProd
     ("dotprod", Some(sym::aarch64_target_feature)),
+    // FEAT_TME
     ("tme", Some(sym::aarch64_target_feature)),
+    // FEAT_FHM
+    ("fhm", Some(sym::aarch64_target_feature)),
+    // FEAT_DIT
+    ("dit", Some(sym::aarch64_target_feature)),
+    // FEAT_FLAGM
+    // ("flagm", Some(sym::aarch64_target_feature)),
+    // FEAT_SSBS
+    ("ssbs", Some(sym::aarch64_target_feature)),
+    // FEAT_SB
+    ("sb", Some(sym::aarch64_target_feature)),
+    // FEAT_PAUTH
+    // ("pauth", Some(sym::aarch64_target_feature)),
+    // FEAT_DPB
+    ("dpb", Some(sym::aarch64_target_feature)),
+    // FEAT_DPB2
+    ("dpb2", Some(sym::aarch64_target_feature)),
+    // FEAT_SVE2
+    ("sve2", Some(sym::aarch64_target_feature)),
+    // FEAT_SVE2_AES
+    ("sve2-aes", Some(sym::aarch64_target_feature)),
+    // FEAT_SVE2_SM4
+    ("sve2-sm4", Some(sym::aarch64_target_feature)),
+    // FEAT_SVE2_SHA3
+    ("sve2-sha3", Some(sym::aarch64_target_feature)),
+    // FEAT_SVE2_BitPerm
+    ("sve2-bitperm", Some(sym::aarch64_target_feature)),
+    // FEAT_FRINTTS
+    ("fptoint", Some(sym::aarch64_target_feature)),
+    // FEAT_I8MM
+    // ("i8mm", Some(sym::aarch64_target_feature)),
+    // FEAT_F32MM
+    // ("f32mm", Some(sym::aarch64_target_feature)),
+    // FEAT_F64MM
+    // ("f64mm", Some(sym::aarch64_target_feature)),
+    // FEAT_BF16
+    // ("bf16", Some(sym::aarch64_target_feature)),
+    // FEAT_RAND
+    ("rand", Some(sym::aarch64_target_feature)),
+    // FEAT_BTI
+    ("bti", Some(sym::aarch64_target_feature)),
+    // FEAT_MTE
+    ("mte", Some(sym::aarch64_target_feature)),
+    // FEAT_JSCVT
+    ("jsconv", Some(sym::aarch64_target_feature)),
+    // FEAT_FCMA
+    ("fcma", Some(sym::aarch64_target_feature)),
+    // FEAT_SHA1 & FEAT_SHA256
+    ("sha2", Some(sym::aarch64_target_feature)),
+    // FEAT_SHA512 & FEAT_SHA3
+    ("sha3", Some(sym::aarch64_target_feature)),
+    // FEAT_SM3 & FEAT_SM4
+    ("sm4", Some(sym::aarch64_target_feature)),
     ("v8.1a", Some(sym::aarch64_target_feature)),
     ("v8.2a", Some(sym::aarch64_target_feature)),
     ("v8.3a", Some(sym::aarch64_target_feature)),
+    ("v8.4a", Some(sym::aarch64_target_feature)),
+    ("v8.5a", Some(sym::aarch64_target_feature)),
+    // ("v8.6a", Some(sym::aarch64_target_feature)),
+    // ("v8.7a", Some(sym::aarch64_target_feature)),
 ];
 
 const X86_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -88,7 +88,7 @@ const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     // FEAT_SVE2_BitPerm
     ("sve2-bitperm", Some(sym::aarch64_target_feature)),
     // FEAT_FRINTTS
-    ("fptoint", Some(sym::aarch64_target_feature)),
+    ("frintts", Some(sym::aarch64_target_feature)),
     // FEAT_I8MM
     // ("i8mm", Some(sym::aarch64_target_feature)),
     // FEAT_F32MM

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -17,6 +17,8 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("neon", Some(sym::arm_target_feature)),
     ("crc", Some(sym::arm_target_feature)),
     ("crypto", Some(sym::arm_target_feature)),
+    ("aes", Some(sym::arm_target_feature)),
+    ("sha2", Some(sym::arm_target_feature)),
     ("v5te", Some(sym::arm_target_feature)),
     ("v6", Some(sym::arm_target_feature)),
     ("v6k", Some(sym::arm_target_feature)),
@@ -107,6 +109,8 @@ const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("jsconv", Some(sym::aarch64_target_feature)),
     // FEAT_FCMA
     ("fcma", Some(sym::aarch64_target_feature)),
+    // FEAT_AES
+    ("aes", Some(sym::aarch64_target_feature)),
     // FEAT_SHA1 & FEAT_SHA256
     ("sha2", Some(sym::aarch64_target_feature)),
     // FEAT_SHA512 & FEAT_SHA3

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -33,7 +33,7 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("thumb-mode", Some(sym::arm_target_feature)),
 ];
 
-// Commented features are not available in LLVM 9.0, or have since been renamed
+// Commented features are not available in LLVM 10.0, or have since been renamed
 const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     // FEAT_AdvSimd
     ("neon", Some(sym::aarch64_target_feature)),
@@ -51,8 +51,6 @@ const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("ras", Some(sym::aarch64_target_feature)),
     // FEAT_LSE
     ("lse", Some(sym::aarch64_target_feature)),
-    // FEAT_LSE2
-    // ("lse2", Some(sym::aarch64_target_feature)),
     // FEAT_RDM
     ("rdm", Some(sym::aarch64_target_feature)),
     // FEAT_RCPC

--- a/library/std/tests/run-time-detect.rs
+++ b/library/std/tests/run-time-detect.rs
@@ -27,7 +27,6 @@ fn aarch64_linux() {
     println!("asimd: {}", is_aarch64_feature_detected!("asimd"));
     println!("sve: {}", is_aarch64_feature_detected!("sve"));
     println!("crc: {}", is_aarch64_feature_detected!("crc"));
-    println!("crypto: {}", is_aarch64_feature_detected!("crypto"));
     println!("lse: {}", is_aarch64_feature_detected!("lse"));
     println!("rdm: {}", is_aarch64_feature_detected!("rdm"));
     println!("rcpc: {}", is_aarch64_feature_detected!("rcpc"));


### PR DESCRIPTION
I recently added these features to std_detect for aarch64 linux, pending [review](https://github.com/rust-lang/stdarch/pull/1146).

I have commented any features not supported by LLVM 9, the current minimum version for Rust. Some (PAuth at least) were renamed between 9 & 12 and I've left them disabled. TME, however, is not in LLVM 9 but I've left it enabled. 

See https://github.com/rust-lang/stdarch/issues/993