### PR TITLE
Remove unnecessary CSS rules for search results

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -385,13 +385,6 @@ nav.sub {
 	position: relative;
 }
 
-#results {
-	position: absolute;
-	right: 0;
-	left: 0;
-	overflow: auto;
-}
-
 #results > table {
 	width: 100%;
 	table-layout: fixed;


### PR DESCRIPTION
Discovered that this was useless when working on https://github.com/rust-lang/docs.rs/issues/1382.

r? @Nemo157 