### PR TITLE
Remove unneeded bottom margin on search results

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -395,7 +395,6 @@ nav.sub {
 #results > table {
 	width: 100%;
 	table-layout: fixed;
-	margin-bottom: 40px;
 }
 
 .content pre.line-numbers {


### PR DESCRIPTION
As you can see, there is still more than enough space at the bottom:

![Screenshot from 2021-04-29 11-26-57](https://user-images.githubusercontent.com/3050060/116530090-ea797800-a8dd-11eb-8eef-2288cf68e0d2.png)

r? @Nemo157 