### PR TITLE
rustc_codegen_ssa: eagerly create landing pad blocks.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/traits/type_.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/type_.rs
@@ -50,6 +50,11 @@ pub trait DerivedTypeMethods<'tcx>: BaseTypeMethods<'tcx> + MiscMethods<'tcx> {
         self.type_ptr_to_ext(self.type_i8(), address_space)
     }
 
+    // FIXME(eddyb) maybe the backend should get to control this?
+    fn type_landing_pad(&self) -> Self::Type {
+        self.type_struct(&[self.type_i8p(), self.type_i32()], false)
+    }
+
     fn type_int(&self) -> Self::Type {
         match &self.sess().target.c_int_width[..] {
             "16" => self.type_i16(),


### PR DESCRIPTION
Since we're supported "MSVC-style" EH codegen (via `cleanup_pad` and funclets), we've had the analysis needed to be able to also construct "GNU-style" `landing_pad` blocks ahead of time (like we do for `cleanup_pad`s).

The main reason not to do it eagerly is if they can get skipped often enough to reduce compile times.
(I'm hoping a perf run will be enough to reveal whether that is the case - at least this time it's not MSVC)

r? @nagisa 