### PR TITLE
Fix labels for regression issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -1,7 +1,7 @@
 ---
 name: Regression
 about: Report something that unexpectedly changed between Rust versions.
-labels: C-bug regression-untriaged
+labels: C-bug, regression-untriaged
 ---
 <!--
 Thank you for filing a regression report! 🐛 A regression is something that changed between versions of Rust but was not supposed to.


### PR DESCRIPTION
Each label needs to be separated by a comma (see the ICE issue template
for an example of correct usage).

As a result of this problem, the `regression-untriaged` label has not
been automatically added to issues opened with this template.

See c127530be76bd8aebc7b61f3b4a54f1be577f74c for another example of this.

r? @Mark-Simulacrum