### PR TITLE
impl FromStr for proc_macro::Literal

### DIFF
--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -107,6 +107,7 @@ macro_rules! with_api {
             Literal {
                 fn drop($self: $S::Literal);
                 fn clone($self: &$S::Literal) -> $S::Literal;
+                fn from_str(s: &str) -> Result<$S::Literal, ()>;
                 fn debug_kind($self: &$S::Literal) -> String;
                 fn symbol($self: &$S::Literal) -> String;
                 fn suffix($self: &$S::Literal) -> Option<String>;
@@ -312,6 +313,19 @@ impl<T: Unmark> Unmark for Option<T> {
     type Unmarked = Option<T::Unmarked>;
     fn unmark(self) -> Self::Unmarked {
         self.map(T::unmark)
+    }
+}
+
+impl<T: Mark, E: Mark> Mark for Result<T, E> {
+    type Unmarked = Result<T::Unmarked, E::Unmarked>;
+    fn mark(unmarked: Self::Unmarked) -> Self {
+        unmarked.map(T::mark).map_err(E::mark)
+    }
+}
+impl<T: Unmark, E: Unmark> Unmark for Result<T, E> {
+    type Unmarked = Result<T::Unmarked, E::Unmarked>;
+    fn unmark(self) -> Self::Unmarked {
+        self.map(T::unmark).map_err(E::unmark)
     }
 }
 

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -91,6 +91,12 @@ pub struct LexError {
     _inner: (),
 }
 
+impl LexError {
+    fn new() -> Self {
+        LexError { _inner: () }
+    }
+}
+
 #[stable(feature = "proc_macro_lexerror_impls", since = "1.44.0")]
 impl fmt::Display for LexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1168,6 +1174,28 @@ impl Literal {
         }
 
         self.0.subspan(cloned_bound(range.start_bound()), cloned_bound(range.end_bound())).map(Span)
+    }
+}
+
+/// Parse a single literal from its stringified representation.
+///
+/// In order to parse successfully, the input string must not contain anything
+/// but the literal token. Specifically, it must not contain whitespace or
+/// comments in addition to the literal.
+///
+/// The resulting literal token will have a `Span::call_site()` span.
+///
+/// NOTE: some errors may cause panics instead of returning `LexError`. We
+/// reserve the right to change these errors into `LexError`s later.
+#[stable(feature = "proc_macro_literal_parse", since = "1.54.0")]
+impl FromStr for Literal {
+    type Err = LexError;
+
+    fn from_str(src: &str) -> Result<Self, LexError> {
+        match bridge::client::Literal::from_str(src) {
+            Ok(literal) => Ok(Literal(literal)),
+            Err(()) => Err(LexError::new()),
+        }
     }
 }
 

--- a/src/test/ui/proc-macro/auxiliary/api/cmp.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/cmp.rs
@@ -1,8 +1,10 @@
-#![feature(proc_macro_span)]
-
 use proc_macro::{LineColumn, Punct};
 
-#[test]
+pub fn test() {
+    test_line_column_ord();
+    test_punct_eq();
+}
+
 fn test_line_column_ord() {
     let line0_column0 = LineColumn { line: 0, column: 0 };
     let line0_column1 = LineColumn { line: 0, column: 1 };
@@ -11,7 +13,6 @@ fn test_line_column_ord() {
     assert!(line0_column1 < line1_column0);
 }
 
-#[test]
 fn test_punct_eq() {
     // Good enough if it typechecks, since proc_macro::Punct can't exist in a test.
     fn _check(punct: Punct) {

--- a/src/test/ui/proc-macro/auxiliary/api/cmp.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/cmp.rs
@@ -1,4 +1,4 @@
-use proc_macro::{LineColumn, Punct};
+use proc_macro::{LineColumn, Punct, Spacing};
 
 pub fn test() {
     test_line_column_ord();
@@ -14,8 +14,8 @@ fn test_line_column_ord() {
 }
 
 fn test_punct_eq() {
-    // Good enough if it typechecks, since proc_macro::Punct can't exist in a test.
-    fn _check(punct: Punct) {
-        let _ = punct == ':';
-    }
+    let colon_alone = Punct::new(':', Spacing::Alone);
+    assert_eq!(colon_alone, ':');
+    let colon_joint = Punct::new(':', Spacing::Joint);
+    assert_eq!(colon_joint, ':');
 }

--- a/src/test/ui/proc-macro/auxiliary/api/mod.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/mod.rs
@@ -3,14 +3,18 @@
 
 #![crate_type = "proc-macro"]
 #![crate_name = "proc_macro_api_tests"]
+#![feature(proc_macro_span)]
 #![deny(dead_code)] // catch if a test function is never called
 
 extern crate proc_macro;
+
+mod cmp;
 
 use proc_macro::TokenStream;
 
 #[proc_macro]
 pub fn run(input: TokenStream) -> TokenStream {
     assert!(input.is_empty());
+    cmp::test();
     TokenStream::new()
 }

--- a/src/test/ui/proc-macro/auxiliary/api/mod.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/mod.rs
@@ -1,0 +1,16 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![crate_name = "proc_macro_api_tests"]
+#![deny(dead_code)] // catch if a test function is never called
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn run(input: TokenStream) -> TokenStream {
+    assert!(input.is_empty());
+    TokenStream::new()
+}

--- a/src/test/ui/proc-macro/auxiliary/api/mod.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/mod.rs
@@ -9,12 +9,16 @@
 extern crate proc_macro;
 
 mod cmp;
+mod parse;
 
 use proc_macro::TokenStream;
 
 #[proc_macro]
 pub fn run(input: TokenStream) -> TokenStream {
     assert!(input.is_empty());
+
     cmp::test();
+    parse::test();
+
     TokenStream::new()
 }

--- a/src/test/ui/proc-macro/auxiliary/api/parse.rs
+++ b/src/test/ui/proc-macro/auxiliary/api/parse.rs
@@ -1,0 +1,23 @@
+use proc_macro::Literal;
+
+pub fn test() {
+    test_parse_literal();
+}
+
+fn test_parse_literal() {
+    assert_eq!("1".parse::<Literal>().unwrap().to_string(), "1");
+    assert_eq!("1.0".parse::<Literal>().unwrap().to_string(), "1.0");
+    assert_eq!("'a'".parse::<Literal>().unwrap().to_string(), "'a'");
+    assert_eq!("\"\n\"".parse::<Literal>().unwrap().to_string(), "\"\n\"");
+    assert_eq!("b\"\"".parse::<Literal>().unwrap().to_string(), "b\"\"");
+    assert_eq!("r##\"\"##".parse::<Literal>().unwrap().to_string(), "r##\"\"##");
+    assert_eq!("10ulong".parse::<Literal>().unwrap().to_string(), "10ulong");
+
+    assert!("0 1".parse::<Literal>().is_err());
+    assert!("'a".parse::<Literal>().is_err());
+    assert!(" 0".parse::<Literal>().is_err());
+    assert!("0 ".parse::<Literal>().is_err());
+    assert!("/* comment */0".parse::<Literal>().is_err());
+    assert!("0/* comment */".parse::<Literal>().is_err());
+    assert!("0// comment".parse::<Literal>().is_err());
+}

--- a/src/test/ui/proc-macro/test.rs
+++ b/src/test/ui/proc-macro/test.rs
@@ -1,0 +1,12 @@
+// check-pass
+// aux-build:api/mod.rs
+
+//! This is for everything that *would* be a #[test] inside of libproc_macro,
+//! except for the fact that proc_macro objects are not capable of existing
+//! inside of an ordinary Rust test execution, only inside a macro.
+
+extern crate proc_macro_api_tests;
+
+proc_macro_api_tests::run!();
+
+fn main() {}


### PR DESCRIPTION
Note that unlike `impl FromStr for proc_macro::TokenStream`, this impl does not permit whitespace or comments. The input string must consist of nothing but your literal.

- `"1".parse::<Literal>()` ⟶ ok

- `"1.0".parse::<Literal>()` ⟶ ok

- `"'a'".parse::<Literal>()` ⟶ ok

- `"\"\n\"".parse::<Literal>()` ⟶ ok

- `"0 1".parse::<Literal>()` ⟶ LexError

- `" 0".parse::<Literal>()` ⟶ LexError

- `"0 ".parse::<Literal>()` ⟶ LexError

- `"/* comment */0".parse::<Literal>()` ⟶ LexError

- `"0/* comment */".parse::<Literal>()` ⟶ LexError

- `"0// comment".parse::<Literal>()` ⟶ LexError

---

## Use case

```rust
let hex_int: Literal = format!("0x{:x}", int).parse().unwrap();
```

The only way this is expressible in the current API is significantly worse.

```rust
let hex_int = match format!("0x{:x}", int)
    .parse::<TokenStream>()
    .unwrap()
    .into_iter()
    .next()
    .unwrap()
{
    TokenTree::Literal(literal) => literal,
    _ => unreachable!(),
};
```