### PR TITLE
Update compiler-builtins to 0.1.42 to get fix for outlined atomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.39"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3748f82c7d366a0b4950257d19db685d4958d2fa27c6d164a3f069fec42b748b"
+checksum = "0d0b4f96df35277d7546ca0b0b727ee4bf99e5590fd348553b70c5ee2bb95033"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
This should fix linking of other C code (and soon Rust-generated code)
on aarch64 musl.