### PR TITLE
Stabilize Bufwriter::into_raw_parts

### DIFF
--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -314,7 +314,6 @@ impl<W: Write> BufWriter<W> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(bufwriter_into_raw_parts)]
     /// use std::io::{BufWriter, Write};
     ///
     /// let mut buffer = [0u8; 10];
@@ -325,7 +324,7 @@ impl<W: Write> BufWriter<W> {
     /// assert_eq!(recovered_writer.len(), 0);
     /// assert_eq!(&buffered_data.unwrap(), b"ata");
     /// ```
-    #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+    #[stable(feature = "bufwriter_into_raw_parts", since = "1.53.0")]
     pub fn into_raw_parts(mut self) -> (W, Result<Vec<u8>, WriterPanicked>) {
         let buf = mem::take(&mut self.buf);
         let buf = if !self.panicked { Ok(buf) } else { Err(WriterPanicked { buf }) };
@@ -333,14 +332,13 @@ impl<W: Write> BufWriter<W> {
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[stable(feature = "bufwriter_into_raw_parts", since = "1.53.0")]
 /// Error returned for the buffered data from `BufWriter::into_raw_parts`, when the underlying
 /// writer has previously panicked.  Contains the (possibly partly written) buffered data.
 ///
 /// # Example
 ///
 /// ```
-/// #![feature(bufwriter_into_raw_parts)]
 /// use std::io::{self, BufWriter, Write};
 /// use std::panic::{catch_unwind, AssertUnwindSafe};
 ///
@@ -367,7 +365,7 @@ pub struct WriterPanicked {
 impl WriterPanicked {
     /// Returns the perhaps-unwritten data.  Some of this data may have been written by the
     /// panicking call(s) to the underlying writer, so simply writing it again is not a good idea.
-    #[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+    #[stable(feature = "bufwriter_into_raw_parts", since = "1.53.0")]
     pub fn into_inner(self) -> Vec<u8> {
         self.buf
     }
@@ -376,7 +374,7 @@ impl WriterPanicked {
         "BufWriter inner writer panicked, what data remains unwritten is not known";
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[stable(feature = "bufwriter_into_raw_parts", since = "1.53.0")]
 impl error::Error for WriterPanicked {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
@@ -384,14 +382,14 @@ impl error::Error for WriterPanicked {
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[stable(feature = "bufwriter_into_raw_parts", since = "1.53.0")]
 impl fmt::Display for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::DESCRIPTION)
     }
 }
 
-#[unstable(feature = "bufwriter_into_raw_parts", issue = "80690")]
+#[stable(feature = "bufwriter_into_raw_parts", since = "1.53.0")]
 impl fmt::Debug for WriterPanicked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WriterPanicked")

--- a/library/std/src/io/buffered/mod.rs
+++ b/library/std/src/io/buffered/mod.rs
@@ -133,7 +133,6 @@ impl<W> IntoInnerError<W> {
     ///
     /// # Example
     /// ```
-    /// #![feature(io_into_inner_error_parts)]
     /// use std::io::{BufWriter, ErrorKind, Write};
     ///
     /// let mut not_enough_space = [0u8; 10];
@@ -143,7 +142,7 @@ impl<W> IntoInnerError<W> {
     /// let err = into_inner_err.into_error();
     /// assert_eq!(err.kind(), ErrorKind::WriteZero);
     /// ```
-    #[unstable(feature = "io_into_inner_error_parts", issue = "79704")]
+    #[stable(feature = "io_into_inner_error_parts", since = "1.53.0")]
     pub fn into_error(self) -> Error {
         self.1
     }
@@ -156,7 +155,6 @@ impl<W> IntoInnerError<W> {
     ///
     /// # Example
     /// ```
-    /// #![feature(io_into_inner_error_parts)]
     /// use std::io::{BufWriter, ErrorKind, Write};
     ///
     /// let mut not_enough_space = [0u8; 10];
@@ -167,7 +165,7 @@ impl<W> IntoInnerError<W> {
     /// assert_eq!(err.kind(), ErrorKind::WriteZero);
     /// assert_eq!(recovered_writer.buffer(), b"t be actually written");
     /// ```
-    #[unstable(feature = "io_into_inner_error_parts", issue = "79704")]
+    #[stable(feature = "io_into_inner_error_parts", since = "1.53.0")]
     pub fn into_parts(self) -> (Error, W) {
         (self.1, self.0)
     }


### PR DESCRIPTION
## Update 2021-08-24

The FCP for this has already completed in #80690.  This was just blocked on #85901 (which changed the name), which is now merged.

## Update 2021-07-24

The methods on `IntoInnerError` were stabilised in #87175 (thanks, @inquisitivecrystal).

Stabilisation of `BufWriter::into[_raw]_parts` is blocked on #85901 which fixes some missing exports and changes the name.  That MR is awaiting review.

## Background and discussion

These two sets of methods both relate to disassembling a `BufWriter`.  It is most convenient to consider them together:

 * https://github.com/rust-lang/rust/issues/80690 `BufWriter::into_raw_parts` [(docs)](https://doc.rust-lang.org/std/io/struct.BufWriter.html#method.into_raw_parts)
 * https://github.com/rust-lang/rust/pull/79704 `IntoInnerError::into_parts` and `into_error` [(docs)](https://doc.rust-lang.org/std/io/struct.IntoInnerError.html#method.into_error)

Without at least one of these, if the underlying writer is failing, it is not possible to get all of the innards out in a useable form for error recovery, no matter how much you know about the underlying writer and what went wrong.

Strictly speaking, `BufWriter::into_raw_parts` is sufficient.  That avoids calling `BufWriter::into_inner` and therefore an `IntoInnerError` cannot arise.  It is possibly also simpler in some cases where the caller wants to take care about errors.  But `into_raw_parts` is clumsy in simpler situations (where what's wanted is a call that does the flush before disassembly and where errors will be considered to invalidate the underlying writer).

`BufWriter::into_raw_parts` was merged on 2021-01-19, and the `IntoInnerError` disassembly methods on 2020-12-05.

## Alternatives

 * Stabilise only `into_raw_parts`.  This would be sufficient, although it does leave `into_inner` as something of a decoy - if `into_inner` is used, but later a need to do error recovery arises, the maintenance programmers will have to replace `into_inner` with `into_raw_parts`, so as to avoid ending up with an intractable `IntoInnerError`, and reorganise the deconstruction code.  Some of the pain here could be mitigated through documentation, which could explain that that this is what is needed.  But it still seems rather perverse: it would be deliberately avoiding providing `into_*` deconstruction methods on a type which could easily have them.
 * Stabilise `into_raw_parts` and deprecate `into_inner`, `IntoInnerError`, and never stabilise the new disassembly methods on `IntoInnerError`.  This seems unfriendly as it makes this complicated in simple situations.
 * Stabilise neither of these facilities.  This means that when error recovery is needed, the programmer would need to copy `BufWriter`'s source into their project to add it.  This (the current situation on stable) is quite poor.

## Open questions

None.

## Resolved questions

 * Would a simpler return type from `into_raw_parts` be better?  No: https://github.com/rust-lang/rust/pull/79705#issuecomment-752730967