### PR TITLE
rustc_codegen_ssa: turn builders "unpositioned" after emitting a terminator.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -601,11 +601,7 @@ impl<'tcx> FnAbiLlvmExt<'tcx> for FnAbi<'tcx, Ty<'tcx>> {
     }
 }
 
-impl AbiBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
-    fn apply_attrs_callsite(&mut self, fn_abi: &FnAbi<'tcx, Ty<'tcx>>, callsite: Self::Value) {
-        fn_abi.apply_attrs_callsite(self, callsite)
-    }
-
+impl AbiBuilderMethods for Builder<'_, '_, '_> {
     fn get_param(&self, index: usize) -> Self::Value {
         llvm::get_param(self.llfn(), index as c_uint)
     }

--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -402,7 +402,7 @@ fn inline_asm_call(
                 alignstack,
                 llvm::AsmDialect::from_generic(dia),
             );
-            let call = bx.call(v, inputs, None);
+            let call = bx.call(v, inputs, None, None);
 
             // Store mark in a metadata node so we can map LLVM errors
             // back to source locations.  See #17552.

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -997,7 +997,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         &mut self,
         parent: Option<&'ll Value>,
         unwind: Option<&'ll BasicBlock>,
-        num_handlers: usize,
+        handlers: &[&'ll BasicBlock],
     ) -> &'ll Value {
         let name = cstr!("catchswitch");
         let ret = unsafe {
@@ -1005,17 +1005,17 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                 self.llbuilder,
                 parent,
                 unwind,
-                num_handlers as c_uint,
+                handlers.len() as c_uint,
                 name.as_ptr(),
             )
         };
-        ret.expect("LLVM does not have support for catchswitch")
-    }
-
-    fn add_handler(&mut self, catch_switch: &'ll Value, handler: &'ll BasicBlock) {
-        unsafe {
-            llvm::LLVMRustAddHandler(catch_switch, handler);
+        let catch_switch = ret.expect("LLVM does not have support for catchswitch");
+        for &handler in handlers {
+            unsafe {
+                llvm::LLVMRustAddHandler(catch_switch, handler);
+            }
         }
+        catch_switch
     }
 
     fn set_personality_fn(&mut self, personality: &'ll Value) {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -552,7 +552,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
         let next = body_bx.inbounds_gep(current, &[self.const_usize(1)]);
         body_bx.br(header_bx.llbb());
-        header_bx.add_incoming_to_phi(current, next, body_bx.llbb());
+        Self::add_incoming_to_phi(current, &[next], &[body_bx.llbb()]);
 
         next_bx
     }
@@ -1395,17 +1395,15 @@ impl Builder<'a, 'll, 'tcx> {
         vals: &[&'ll Value],
         bbs: &[&'ll BasicBlock],
     ) -> &'ll Value {
-        assert_eq!(vals.len(), bbs.len());
         let phi = unsafe { llvm::LLVMBuildPhi(self.llbuilder, ty, UNNAMED) };
-        unsafe {
-            llvm::LLVMAddIncoming(phi, vals.as_ptr(), bbs.as_ptr(), vals.len() as c_uint);
-            phi
-        }
+        Self::add_incoming_to_phi(phi, vals, bbs);
+        phi
     }
 
-    fn add_incoming_to_phi(&mut self, phi: &'ll Value, val: &'ll Value, bb: &'ll BasicBlock) {
+    fn add_incoming_to_phi(phi: &'ll Value, vals: &[&'ll Value], bbs: &[&'ll BasicBlock]) {
+        assert_eq!(vals.len(), bbs.len());
         unsafe {
-            llvm::LLVMAddIncoming(phi, &val, &bb, 1 as c_uint);
+            llvm::LLVMAddIncoming(phi, vals.as_ptr(), bbs.as_ptr(), vals.len() as c_uint);
         }
     }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -465,9 +465,8 @@ fn codegen_msvc_try(
 
         normal.ret(bx.const_i32(0));
 
-        let cs = catchswitch.catch_switch(None, None, 2);
-        catchswitch.add_handler(cs, catchpad_rust.llbb());
-        catchswitch.add_handler(cs, catchpad_foreign.llbb());
+        let cs =
+            catchswitch.catch_switch(None, None, &[catchpad_rust.llbb(), catchpad_foreign.llbb()]);
 
         // We can't use the TypeDescriptor defined in libpanic_unwind because it
         // might be in another DLL and the SEH encoding only supports specifying

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -90,10 +90,12 @@ fn emit_ptr_va_arg(
 }
 
 fn emit_aapcs_va_arg(
-    bx: &mut Builder<'a, 'll, 'tcx>,
+    mut bx: Builder<'a, 'll, 'tcx>,
     list: OperandRef<'tcx, &'ll Value>,
     target_ty: Ty<'tcx>,
-) -> &'ll Value {
+) -> (Builder<'a, 'll, 'tcx>, &'ll Value) {
+    let cx = bx.cx;
+
     // Implementation of the AAPCS64 calling convention for va_args see
     // https://github.com/ARM-software/abi-aa/blob/master/aapcs64/aapcs64.rst
     let va_list_addr = list.immediate();
@@ -101,7 +103,9 @@ fn emit_aapcs_va_arg(
 
     let mut maybe_reg = bx.build_sibling_block("va_arg.maybe_reg");
     let mut in_reg = bx.build_sibling_block("va_arg.in_reg");
+    let in_reg_llbb = in_reg.llbb();
     let mut on_stack = bx.build_sibling_block("va_arg.on_stack");
+    let on_stack_llbb = on_stack.llbb();
     let mut end = bx.build_sibling_block("va_arg.end");
     let zero = bx.const_i32(0);
     let offset_align = Align::from_bytes(4).unwrap();
@@ -127,10 +131,10 @@ fn emit_aapcs_va_arg(
     // the offset again.
 
     if gr_type && layout.align.abi.bytes() > 8 {
-        reg_off_v = maybe_reg.add(reg_off_v, bx.const_i32(15));
-        reg_off_v = maybe_reg.and(reg_off_v, bx.const_i32(-16));
+        reg_off_v = maybe_reg.add(reg_off_v, cx.const_i32(15));
+        reg_off_v = maybe_reg.and(reg_off_v, cx.const_i32(-16));
     }
-    let new_reg_off_v = maybe_reg.add(reg_off_v, bx.const_i32(slot_size as i32));
+    let new_reg_off_v = maybe_reg.add(reg_off_v, cx.const_i32(slot_size as i32));
 
     maybe_reg.store(new_reg_off_v, reg_off, offset_align);
 
@@ -140,16 +144,16 @@ fn emit_aapcs_va_arg(
     maybe_reg.cond_br(use_stack, &on_stack.llbb(), &in_reg.llbb());
 
     let top = in_reg.struct_gep(va_list_addr, reg_top_index);
-    let top = in_reg.load(top, bx.tcx().data_layout.pointer_align.abi);
+    let top = in_reg.load(top, cx.tcx().data_layout.pointer_align.abi);
 
     // reg_value = *(@top + reg_off_v);
     let mut reg_addr = in_reg.gep(top, &[reg_off_v]);
-    if bx.tcx().sess.target.endian == Endian::Big && layout.size.bytes() != slot_size {
+    if cx.tcx().sess.target.endian == Endian::Big && layout.size.bytes() != slot_size {
         // On big-endian systems the value is right-aligned in its slot.
-        let offset = bx.const_i32((slot_size - layout.size.bytes()) as i32);
+        let offset = cx.const_i32((slot_size - layout.size.bytes()) as i32);
         reg_addr = in_reg.gep(reg_addr, &[offset]);
     }
-    let reg_addr = in_reg.bitcast(reg_addr, bx.cx.type_ptr_to(layout.llvm_type(bx)));
+    let reg_addr = in_reg.bitcast(reg_addr, cx.type_ptr_to(layout.llvm_type(cx)));
     let reg_value = in_reg.load(reg_addr, layout.align.abi);
     in_reg.br(&end.llbb());
 
@@ -159,13 +163,12 @@ fn emit_aapcs_va_arg(
     on_stack.br(&end.llbb());
 
     let val = end.phi(
-        layout.immediate_llvm_type(bx),
+        layout.immediate_llvm_type(cx),
         &[reg_value, stack_value],
-        &[&in_reg.llbb(), &on_stack.llbb()],
+        &[&in_reg_llbb, &on_stack_llbb],
     );
 
-    *bx = end;
-    val
+    (end, val)
 }
 
 pub(super) fn emit_va_arg(
@@ -194,7 +197,11 @@ pub(super) fn emit_va_arg(
         "aarch64" if target.is_like_osx => {
             emit_ptr_va_arg(&mut bx, addr, target_ty, false, Align::from_bytes(8).unwrap(), true)
         }
-        "aarch64" => emit_aapcs_va_arg(&mut bx, addr, target_ty),
+        "aarch64" => {
+            let (new_bx, val) = emit_aapcs_va_arg(bx, addr, target_ty);
+            bx = new_bx;
+            val
+        }
         // Windows x86_64
         "x86_64" if target.is_like_windows => {
             let target_ty_size = bx.cx.size_of(target_ty).bytes();

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -447,7 +447,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             (rust_main, vec![arg_argc, arg_argv])
         };
 
-        let result = bx.call(start_fn, &args, None);
+        let result = bx.call(start_fn, &args, None, None);
         let cast = bx.intcast(result, cx.type_int(), true);
         bx.ret(cast);
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1245,9 +1245,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     }
 
     pub fn build_block(&self, bb: mir::BasicBlock) -> Bx {
-        let mut bx = Bx::with_cx(self.cx);
-        bx.position_at_end(self.blocks[bb]);
-        bx
+        Bx::position_at_end(Bx::unpositioned(self.cx), self.blocks[bb])
     }
 
     fn make_return_dest(

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -654,8 +654,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     })
                     .collect();
 
-                Self::codegen_intrinsic_call(
-                    &mut bx,
+                bx = Self::codegen_intrinsic_call(
+                    bx,
                     *instance.as_ref().unwrap(),
                     &fn_abi,
                     &args,

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -118,9 +118,14 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
             } else {
                 fx.unreachable_block()
             };
-            let invokeret =
-                bx.invoke(fn_ptr, &llargs, ret_bx, self.llblock(fx, cleanup), self.funclet(fx));
-            bx.apply_attrs_callsite(&fn_abi, invokeret);
+            let invokeret = bx.invoke(
+                fn_ptr,
+                &llargs,
+                ret_bx,
+                self.llblock(fx, cleanup),
+                self.funclet(fx),
+                Some(&fn_abi),
+            );
 
             if let Some((ret_dest, target)) = destination {
                 let mut ret_bx = fx.build_block(target);
@@ -128,8 +133,7 @@ impl<'a, 'tcx> TerminatorCodegenHelper<'tcx> {
                 fx.store_return(&mut ret_bx, ret_dest, &fn_abi.ret, invokeret);
             }
         } else {
-            let llret = bx.call(fn_ptr, &llargs, self.funclet(fx));
-            bx.apply_attrs_callsite(&fn_abi, llret);
+            let llret = bx.call(fn_ptr, &llargs, self.funclet(fx), Some(&fn_abi));
             if fx.mir[self.bb].is_cleanup {
                 // Cleanup is always the cold path. Don't inline
                 // drop glue. Also, when there is a deeply-nested

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -317,8 +317,7 @@ fn create_funclets<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                     let mut cp_bx = bx.build_sibling_block(&format!("cp_funclet{:?}", bb));
                     ret_llbb = cs_bx.llbb();
 
-                    let cs = cs_bx.catch_switch(None, None, 1);
-                    cs_bx.add_handler(cs, cp_bx.llbb());
+                    let cs = cs_bx.catch_switch(None, None, &[cp_bx.llbb()]);
 
                     // The "null" here is actually a RTTI type descriptor for the
                     // C++ personality function, but `catch (...)` has no type so

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -533,7 +533,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 };
                 let instance = ty::Instance::mono(bx.tcx(), def_id);
                 let r = bx.cx().get_fn_addr(instance);
-                let call = bx.call(r, &[llsize, llalign], None);
+                let call = bx.call(r, &[llsize, llalign], None, None);
                 let val = bx.pointercast(call, llty_ptr);
 
                 let operand = OperandRef { val: OperandValue::Immediate(val), layout: box_layout };

--- a/compiler/rustc_codegen_ssa/src/traits/abi.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/abi.rs
@@ -1,8 +1,7 @@
 use super::BackendTypes;
-use rustc_middle::ty::Ty;
-use rustc_target::abi::call::FnAbi;
 
-pub trait AbiBuilderMethods<'tcx>: BackendTypes {
-    fn apply_attrs_callsite(&mut self, fn_abi: &FnAbi<'tcx, Ty<'tcx>>, callsite: Self::Value);
+// FIXME(eddyb) move this into either `BuilderMethods` or some other abstraction
+// meant to handle whole-function aspects like params and stack slots (`alloca`s).
+pub trait AbiBuilderMethods: BackendTypes {
     fn get_param(&self, index: usize) -> Self::Value;
 }

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -16,6 +16,7 @@ use crate::MemFlags;
 use rustc_middle::ty::layout::{HasParamEnv, TyAndLayout};
 use rustc_middle::ty::Ty;
 use rustc_span::Span;
+use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::{Abi, Align, Scalar, Size};
 use rustc_target::spec::HasTargetSpec;
 
@@ -33,7 +34,7 @@ pub trait BuilderMethods<'a, 'tcx>:
     + CoverageInfoBuilderMethods<'tcx>
     + DebugInfoBuilderMethods
     + ArgAbiMethods<'tcx>
-    + AbiBuilderMethods<'tcx>
+    + AbiBuilderMethods
     + IntrinsicCallMethods<'tcx>
     + AsmBuilderMethods<'tcx>
     + StaticBuilderMethods
@@ -78,6 +79,7 @@ pub trait BuilderMethods<'a, 'tcx>:
         then: Self::BasicBlock,
         catch: Self::BasicBlock,
         funclet: Option<&Self::Funclet>,
+        fn_abi_for_attrs: Option<&FnAbi<'tcx, Ty<'tcx>>>,
     ) -> Self::Value;
     fn unreachable(&mut self);
 
@@ -295,6 +297,7 @@ pub trait BuilderMethods<'a, 'tcx>:
         llfn: Self::Value,
         args: &[Self::Value],
         funclet: Option<&Self::Funclet>,
+        fn_abi_for_attrs: Option<&FnAbi<'tcx, Ty<'tcx>>>,
     ) -> Self::Value;
     fn zext(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
 

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -253,9 +253,8 @@ pub trait BuilderMethods<'a, 'tcx>:
         &mut self,
         parent: Option<Self::Value>,
         unwind: Option<Self::BasicBlock>,
-        num_handlers: usize,
+        handlers: &[Self::BasicBlock],
     ) -> Self::Value;
-    fn add_handler(&mut self, catch_switch: Self::Value, handler: Self::BasicBlock);
     fn set_personality_fn(&mut self, personality: Self::Value);
 
     fn atomic_cmpxchg(

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -40,14 +40,22 @@ pub trait BuilderMethods<'a, 'tcx>:
     + HasParamEnv<'tcx>
     + HasTargetSpec
 {
+    /// IR builder (like `Self`) that doesn't have a set (insert) position, and
+    /// cannot be used until positioned (which converted it to `Self`).
+    // FIXME(eddyb) maybe move this associated type to a different trait, and/or
+    // provide an `UnpositionedBuilderMethods` trait for operations involving it.
+    type Unpositioned;
+
+    fn unpositioned(cx: &'a Self::CodegenCx) -> Self::Unpositioned;
+    fn position_at_end(bx: Self::Unpositioned, llbb: Self::BasicBlock) -> Self;
+    fn into_unpositioned(self) -> Self::Unpositioned;
+
     fn new_block<'b>(cx: &'a Self::CodegenCx, llfn: Self::Function, name: &'b str) -> Self;
-    fn with_cx(cx: &'a Self::CodegenCx) -> Self;
     fn build_sibling_block(&self, name: &str) -> Self;
     fn cx(&self) -> &Self::CodegenCx;
     fn llbb(&self) -> Self::BasicBlock;
     fn set_span(&mut self, span: Span);
 
-    fn position_at_end(&mut self, llbb: Self::BasicBlock);
     fn ret_void(&mut self);
     fn ret(&mut self, v: Self::Value);
     fn br(&mut self, dest: Self::BasicBlock);

--- a/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
@@ -9,13 +9,13 @@ pub trait IntrinsicCallMethods<'tcx>: BackendTypes {
     /// and in `library/core/src/intrinsics.rs`; if you need access to any LLVM intrinsics,
     /// add them to `compiler/rustc_codegen_llvm/src/context.rs`.
     fn codegen_intrinsic_call(
-        &mut self,
+        self,
         instance: ty::Instance<'tcx>,
         fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
         args: &[OperandRef<'tcx, Self::Value>],
         llresult: Self::Value,
         span: Span,
-    );
+    ) -> Self;
 
     fn abort(&mut self);
     fn assume(&mut self, val: Self::Value);


### PR DESCRIPTION
This PR introduces the concept of an "unpositioned builder" - that is, given `Bx: BuilderMethods`, there is also a `Bx::Unpositioned` type, which is like `Bx` but isn't known to be in a valid position.

As such, it doesn't have methods (like those from `BuilderMethods`) to add instructions -  the only valid use of an "unpositioned builder" (a `Bx::Unpositioned`) is to use `position_at_end` to turn it into a usable builder (a `Bx`).

(Bikeshed material: is the name too unwieldy? I was considering replacing "unpositioned" with "detached", which is both shorter *and* has a suitable verb, "detach", available)

The main use of this new split in builders is terminators: instead of simply mutating the builder like any other instruction-emitting method, adding a terminator will now take the builder by value (`self` instead of `&mut self`), and return it as an "unpositioned builder".

(Most of the commits in this PR are necessary refactors for the main change, and should be reviewed separately)

There's two reasons I think we should make terminators behave like that:
* correctness/safety: a block can only have at most one terminator, and no other instructions after it, but LLVM in particular may let us keep appending, since it just chains instructions for each block
  * with the new approach, you lose the ability to build more in that block because you lose your builder and get back the "unpositioned" one that has no functionality without first (re)positioning it
  * by keeping around the backend object (e.g. a LLVM `IRBuilder`) inside the "unpositioned builder", we can safely reuse it, so no resources are being wasted (reuse isn't done in this PR, but may be in the future)
  * additionally, being able to express (e.g. within `rustc_codegen_ssa::mir`) "builds within a block" as "taking `&mut Bx`" and "may introduce control-flow" as "taking `Bx` and returning `Bx::Unpositioned`", makes it possible to reason (albeit in a limited manner) about some codegen functionality without investigating the exact logic
* as hinted to in #84403, I hope this can allow backends to take advantage of more restricted builder usage
  * in particular, the ability to transition `Bx -> Bx::Unpositioned -> Bx` (i.e. finishing a block and moving to another), is a clean and safe way to keep reusing the same builder, potentially a single builder overall, for building multiple/all blocks in a function - in particular, something taking `Bx::Unpositioned` can build its own blocks *but not trample yours*
  * Rust-GPU's `rustc_codegen_spirv` would benefit from this (and is the reason I started down this path), as it right now has to use interior mutability, and has no way to statically enforce correct accesses, because it has unique ownership of the IR, unlike LLVM's pointer graph that you can go from anywhere to anywhere else on
  * but `rustc_codegen_llvm` could also benefit, if we go down this path and eventually have unique `&mut CodegenCx` - we could then remove interior mutability from `CodegenCx` fields and mutate them directly

r? @nagisa cc @bjorn3 