### PR TITLE
Fix `x.py test --stage 0 src/tools/miri`

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -466,6 +466,8 @@ impl Step for Miri {
             cargo.env("RUST_BACKTRACE", "1");
             // Let cargo-miri know where xargo ended up.
             cargo.env("XARGO_CHECK", builder.out.join("bin").join("xargo-check"));
+            // Allow cargo-miri to load libLLVM.so at runtime.
+            cargo.add_rustc_lib_path(builder, compiler);
 
             let mut cargo = Command::from(cargo);
             if !try_run(builder, &mut cargo) {


### PR DESCRIPTION
Previously, it would give an error that libLLVM.so couldn't be found.

Helps with https://github.com/rust-lang/rust/issues/78778. That seems to be tracking two separate issues; the original issue from the error-index is something different (cc https://github.com/rust-lang/rust/pull/84471).

r? @Mark-Simulacrum cc @RalfJung