### PR TITLE
Fix `x.py doc --stage 1 src/tools/error_index_generator`

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -392,7 +392,10 @@ impl ErrorIndex {
         let compiler = builder.compiler(builder.top_stage.saturating_sub(1), builder.config.build);
         let mut cmd = Command::new(builder.ensure(ErrorIndex { compiler }));
         add_dylib_path(
-            vec![PathBuf::from(&builder.sysroot_libdir(compiler, compiler.host))],
+            vec![
+                PathBuf::from(&builder.sysroot_libdir(compiler, compiler.host)),
+                PathBuf::from(builder.rustc_libdir(compiler)),
+            ],
             &mut cmd,
         );
         cmd


### PR DESCRIPTION
The error index is a complicated tool (because it depends on rustdoc)
and this fix is only one of many possible approaches.

Here is the sequence of fixes that culminated in this commit:

1. The error index gives an error that libLLVM-nightly.so isn't found.
2. libLLVM-nightly.so is present in stage1/lib, but not in stage0/lib.
3. `builder.sysroot()` returns `stage0-sysroot`, but
   `builder.rustc_libdir()` returns `stage0/lib`.
4. Therefore, special case the sysroot to be `stage0` for the error index and copy libLLVM-nightly.so into it.

Another, possibly better fix is to stop depending on rustdoc at all, and
call it as a binary or separate out a shared crate. But that's a larger
refactor.

Builds on https://github.com/rust-lang/rust/pull/84471. This is the same diff as https://github.com/rust-lang/rust/pull/84471#issuecomment-830504251. Helps with https://github.com/rust-lang/rust/issues/78778. Fixes https://github.com/rust-lang/rust/issues/80096.

r? @Mark-Simulacrum