### PR TITLE
[WIP] Don't require building a stage1 compiler before running cargotest

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -183,6 +183,7 @@ impl Step for Cargotest {
             builder,
             cmd.arg(&cargo)
                 .arg(&out_dir)
+                .args(builder.config.cmd.test_args())
                 .env("RUSTC", builder.rustc(compiler))
                 .env("RUSTDOC", builder.rustdoc(compiler)),
         );

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -595,7 +595,7 @@ impl Step for Cargo {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Cargo {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
+            compiler: run.builder.compiler(0, run.builder.config.build),
             target: run.target,
         });
     }
@@ -606,7 +606,7 @@ impl Step for Cargo {
                 compiler: self.compiler,
                 target: self.target,
                 tool: "cargo",
-                mode: Mode::ToolRustc,
+                mode: Mode::ToolBootstrap,
                 path: "src/tools/cargo",
                 is_optional_tool: false,
                 source_type: SourceType::Submodule,
@@ -621,7 +621,7 @@ impl Step for Cargo {
                 compiler: self.compiler,
                 target: self.target,
                 tool: name,
-                mode: Mode::ToolRustc,
+                mode: Mode::ToolBootstrap,
                 path,
                 is_optional_tool: true,
                 source_type: SourceType::Submodule,

--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -85,7 +85,9 @@ fn main() {
     let cargo = &Path::new(cargo);
 
     for test in TEST_REPOS.iter().rev() {
-        test_repo(cargo, out_dir, test);
+        if args[3..].is_empty() || args[3..].iter().any(|s| s.contains(test.name)) {
+            test_repo(cargo, out_dir, test);
+        }
     }
 }
 


### PR DESCRIPTION
- Always use a bootstrap compiler for cargo and cargo-credential helpers

  This seems wrong; I think cargo is intentionally built with stage 2
  because it's distributed with other parts of the release. However, I
  don't know how to avoid it - just changing CargoTest to build it with
  stage 0 unconditionally still builds rustc because it uses a `ToolRustc`
  mode.

- Don't call `builder.ensure(Rustc)`. It's unnecessary.
- Don't use the same compiler for building cargo as for testing.

Builds on https://github.com/rust-lang/rust/pull/84779 to avoid merge conflicts.