### PR TITLE
Reuse key hashes when operating with queries

### DIFF
--- a/compiler/rustc_query_system/src/query/mod.rs
+++ b/compiler/rustc_query_system/src/query/mod.rs
@@ -8,7 +8,7 @@ pub use self::job::{print_query_stack, QueryInfo, QueryJob, QueryJobId, QueryJob
 
 mod caches;
 pub use self::caches::{
-    ArenaCacheSelector, CacheSelector, DefaultCacheSelector, QueryCache, QueryStorage,
+    ArenaCacheSelector, CacheSelector, DefaultCacheSelector, QueryCache, QueryLookup, QueryStorage,
 };
 
 mod config;


### PR DESCRIPTION
This is a possible small run-time win, and should remove several hashes for each query operation, at least when we end up actually computing the query. It may be a mild compile-time hit, though likely less than 0.5%.