### PR TITLE
RustDoc: Fix bounds linking trait.Foo instead of traitalias.Foo

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -188,7 +188,7 @@ crate fn record_extern_fqn(cx: &mut DocContext<'_>, did: DefId, kind: ItemType) 
     if did.is_local() {
         cx.cache.exact_paths.insert(did, fqn);
     } else {
-        cx.cache.external_paths.insert(did, (fqn, ItemType::from(kind)));
+        cx.cache.external_paths.insert(did, (fqn, kind));
     }
 }
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -157,7 +157,12 @@ impl Clean<GenericBound> for hir::GenericBound<'_> {
 impl Clean<Type> for (ty::TraitRef<'_>, &[TypeBinding]) {
     fn clean(&self, cx: &mut DocContext<'_>) -> Type {
         let (trait_ref, bounds) = *self;
-        inline::record_extern_fqn(cx, trait_ref.def_id, ItemType::Trait);
+        let kind = match cx.tcx.def_kind(trait_ref.def_id) {
+            DefKind::Trait => ItemType::Trait,
+            DefKind::TraitAlias => ItemType::TraitAlias,
+            other => bug!("`TraitRef` had unexpected kind {:?}", other),
+        };
+        inline::record_extern_fqn(cx, trait_ref.def_id, kind);
         let path = external_path(
             cx,
             cx.tcx.item_name(trait_ref.def_id),

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -17,11 +17,11 @@ use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_infer::infer::region_constraints::{Constraint, RegionConstraintData};
-use rustc_middle::bug;
 use rustc_middle::middle::resolve_lifetime as rl;
 use rustc_middle::ty::fold::TypeFolder;
 use rustc_middle::ty::subst::{InternalSubsts, Subst};
 use rustc_middle::ty::{self, AdtKind, Lift, Ty, TyCtxt};
+use rustc_middle::{bug, span_bug};
 use rustc_mir::const_eval::{is_const_fn, is_unstable_const_fn};
 use rustc_span::hygiene::{AstPass, MacroKind};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
@@ -157,11 +157,14 @@ impl Clean<GenericBound> for hir::GenericBound<'_> {
 impl Clean<Type> for (ty::TraitRef<'_>, &[TypeBinding]) {
     fn clean(&self, cx: &mut DocContext<'_>) -> Type {
         let (trait_ref, bounds) = *self;
-        let kind = match cx.tcx.def_kind(trait_ref.def_id) {
-            DefKind::Trait => ItemType::Trait,
-            DefKind::TraitAlias => ItemType::TraitAlias,
-            other => bug!("`TraitRef` had unexpected kind {:?}", other),
-        };
+        let kind = cx.tcx.def_kind(trait_ref.def_id).into();
+        if !matches!(kind, ItemType::Trait | ItemType::TraitAlias) {
+            span_bug!(
+                cx.tcx.def_span(trait_ref.def_id),
+                "`TraitRef` had unexpected kind {:?}",
+                kind
+            );
+        }
         inline::record_extern_fqn(cx, trait_ref.def_id, kind);
         let path = external_path(
             cx,

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -340,6 +340,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
             | clean::EnumItem(..)
             | clean::TypedefItem(..)
             | clean::TraitItem(..)
+            | clean::TraitAliasItem(..)
             | clean::FunctionItem(..)
             | clean::ModuleItem(..)
             | clean::ForeignFunctionItem(..)
@@ -350,26 +351,43 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
             | clean::ForeignTypeItem
             | clean::MacroItem(..)
             | clean::ProcMacroItem(..)
-            | clean::VariantItem(..)
-                if !self.cache.stripped_mod =>
-            {
-                // Re-exported items mean that the same id can show up twice
-                // in the rustdoc ast that we're looking at. We know,
-                // however, that a re-exported item doesn't show up in the
-                // `public_items` map, so we can skip inserting into the
-                // paths map if there was already an entry present and we're
-                // not a public item.
-                if !self.cache.paths.contains_key(&item.def_id)
-                    || self.cache.access_levels.is_public(item.def_id)
-                {
-                    self.cache.paths.insert(item.def_id, (self.cache.stack.clone(), item.type_()));
+            | clean::VariantItem(..) => {
+                if !self.cache.stripped_mod {
+                    // Re-exported items mean that the same id can show up twice
+                    // in the rustdoc ast that we're looking at. We know,
+                    // however, that a re-exported item doesn't show up in the
+                    // `public_items` map, so we can skip inserting into the
+                    // paths map if there was already an entry present and we're
+                    // not a public item.
+                    if !self.cache.paths.contains_key(&item.def_id)
+                        || self.cache.access_levels.is_public(item.def_id)
+                    {
+                        self.cache
+                            .paths
+                            .insert(item.def_id, (self.cache.stack.clone(), item.type_()));
+                    }
                 }
             }
             clean::PrimitiveItem(..) => {
                 self.cache.paths.insert(item.def_id, (self.cache.stack.clone(), item.type_()));
             }
 
-            _ => {}
+            clean::ExternCrateItem { .. }
+            | clean::ImportItem(..)
+            | clean::OpaqueTyItem(..)
+            | clean::ImplItem(..)
+            | clean::TyMethodItem(..)
+            | clean::MethodItem(..)
+            | clean::StructFieldItem(..)
+            | clean::AssocConstItem(..)
+            | clean::AssocTypeItem(..)
+            | clean::StrippedItem(..)
+            | clean::KeywordItem(..) => {
+                // FIXME: Do these need handling?
+                // The person writing this comment doesn't know.
+                // So would rather leave them to an expert,
+                // as at least the list is better than `_ => {}`.
+            }
         }
 
         // Maintain the parent stack

--- a/src/test/rustdoc/auxiliary/trait-alias-mention.rs
+++ b/src/test/rustdoc/auxiliary/trait-alias-mention.rs
@@ -1,0 +1,3 @@
+#![feature(trait_alias)]
+
+pub trait SomeAlias = std::fmt::Debug + std::marker::Copy;

--- a/src/test/rustdoc/trait-alias-mention.rs
+++ b/src/test/rustdoc/trait-alias-mention.rs
@@ -1,0 +1,9 @@
+#![feature(trait_alias)]
+#![feature(ptr_metadata)]
+
+#![crate_name = "foo"]
+
+// @has foo/fn.this_never_panics.html '//a[@title="traitalias core::ptr::metadata::Thin"]' 'Thin'
+pub fn this_never_panics<T: std::ptr::Thin>() {
+    assert_eq!(std::mem::size_of::<&T>(), std::mem::size_of::<usize>())
+}

--- a/src/test/rustdoc/trait-alias-mention.rs
+++ b/src/test/rustdoc/trait-alias-mention.rs
@@ -1,9 +1,10 @@
-#![feature(trait_alias)]
-#![feature(ptr_metadata)]
+// aux-build:trait-alias-mention.rs
+// build-aux-docs
 
 #![crate_name = "foo"]
 
-// @has foo/fn.this_never_panics.html '//a[@title="traitalias core::ptr::metadata::Thin"]' 'Thin'
-pub fn this_never_panics<T: std::ptr::Thin>() {
-    assert_eq!(std::mem::size_of::<&T>(), std::mem::size_of::<usize>())
+extern crate trait_alias_mention;
+
+// @has foo/fn.mention_alias_in_bounds.html '//a[@href="../trait_alias_mention/traitalias.SomeAlias.html"]' 'SomeAlias'
+pub fn mention_alias_in_bounds<T: trait_alias_mention::SomeAlias>() {
 }

--- a/src/test/rustdoc/trait_alias.rs
+++ b/src/test/rustdoc/trait_alias.rs
@@ -19,3 +19,5 @@ pub trait CopyAlias = Copy;
 pub trait Alias2 = Copy + Debug;
 // @has foo/traitalias.Foo.html '//section[@id="main"]/pre' 'trait Foo<T> = Into<T> + Debug;'
 pub trait Foo<T> = Into<T> + Debug;
+// @has foo/fn.bar.html '//a[@href="traitalias.Alias2.html"]' 'Alias2'
+pub fn bar<T>() where T: Alias2 {}


### PR DESCRIPTION
Fixes #84782

The code was assuming `Trait` when adding bounds to the cache, so add a check on the DefId to see what its kind really is.

r? @jyn514 

Before:
![image](https://user-images.githubusercontent.com/18526288/116775611-6a751e80-aa53-11eb-84d0-ed6b7782be3c.png)

After:
![image](https://user-images.githubusercontent.com/18526288/116802227-d19cdc80-ab00-11eb-8133-7b34dd750da2.png)
