### PR TITLE
read_target_uint => read_target_ptr outside rustc_middle (nfc)

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -6,7 +6,7 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::ErrorReported;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 use rustc_middle::mir::interpret::{
-    read_target_uint, AllocId, Allocation, ConstValue, ErrorHandled, GlobalAlloc, Pointer, Scalar,
+    read_target_ptr, AllocId, Allocation, ConstValue, ErrorHandled, GlobalAlloc, Pointer, Scalar,
 };
 use rustc_middle::ty::ConstKind;
 
@@ -379,11 +379,11 @@ fn define_all_allocs(tcx: TyCtxt<'_>, module: &mut dyn Module, cx: &mut Constant
             let addend = {
                 let endianness = tcx.data_layout.endian;
                 let offset = offset.bytes() as usize;
-                let ptr_size = tcx.data_layout.pointer_size;
+                let ptr_size = tcx.data_layout.pointer_size.bytes() as usize;
                 let bytes = &alloc.inspect_with_uninit_and_ptr_outside_interpreter(
-                    offset..offset + ptr_size.bytes() as usize,
+                    offset..offset + ptr_size
                 );
-                read_target_uint(endianness, bytes).unwrap()
+                read_target_ptr(endianness, ptr_size, bytes)
             };
 
             let reloc_target_alloc = tcx.get_global_alloc(reloc).unwrap();

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
@@ -101,7 +101,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
                     let idx = match (fx.tcx.data_layout.endian, &idx_bytes[4*i.. 4*i + 4]) {
                         (Endian::Little, &[a, b, c, d]) => u32::from_le_bytes([a, b, c, d]),
                         (Endian::Big, &[a, b, c, d]) => u32::from_be_bytes([a, b, c, d]),
-                        (_, _) => panic!("cg_clif SIMD: can't get idx")
+                        (_, _) => unreachable!(),
                     };
                     u16::try_from(idx).expect("try_from u32")
                 }).collect::<Vec<u16>>()

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -555,12 +555,12 @@ impl<'tcx> TyCtxt<'tcx> {
 ////////////////////////////////////////////////////////////////////////////////
 
 #[inline]
-pub fn write_target_uint(
+fn write_target_uint(
     endianness: Endian,
     mut target: &mut [u8],
     data: u128,
 ) -> Result<(), io::Error> {
-    // This u128 holds an "any-size uint" (since smaller uints can fits in it)
+    // This u128 holds an "any-size uint" (since smaller uints can fit in it)
     // So we do not write all bytes of the u128, just the "payload".
     match endianness {
         Endian::Little => target.write(&data.to_le_bytes())?,


### PR DESCRIPTION
Uses a more narrow function for the actual purposes the callers have put it to, and locks down some previously public functions into private ones. A small refactoring with no functional changes, but hopefully makes future ones easier down the line.

I want to be sure the refactoring in cg_clif is correct, and if any further improvement can be made there, or if there's an obvious better place for read_target_ptr to live, so

r? @bjorn3