### PR TITLE
Avoid generating closures for each query

### DIFF
--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(once_cell)]
 #![feature(rustc_attrs)]
 #![feature(never_type)]
+#![feature(maybe_uninit_extra)]
 #![recursion_limit = "256"]
 
 #[macro_use]


### PR DESCRIPTION
This is a 3.6% compile-time win on the query crate triplet (system, middle, impl), while likely not adding too much runtime overhead. Calls here are already going through several layers of functions, so an additional indirect call isn't likely to add considerable overhead, I hope.

This PR is being opened to measure that runtime overhead, and see if the compile-time win here is worth it in comparison.