### PR TITLE
Do not print visibility in external traits

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -19,7 +19,7 @@ use crate::clean::{self, Attributes, AttributesExt, GetDefId, ToSource};
 use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
 
-use super::Clean;
+use super::{Clean, Visibility};
 
 type Attrs<'hir> = rustc_middle::ty::Attributes<'hir>;
 
@@ -193,8 +193,18 @@ crate fn record_extern_fqn(cx: &mut DocContext<'_>, did: DefId, kind: ItemType) 
 }
 
 crate fn build_external_trait(cx: &mut DocContext<'_>, did: DefId) -> clean::Trait {
-    let trait_items =
-        cx.tcx.associated_items(did).in_definition_order().map(|item| item.clean(cx)).collect();
+    let trait_items = cx
+        .tcx
+        .associated_items(did)
+        .in_definition_order()
+        .map(|item| {
+            // When building an external trait, the cleaned trait will have all items public,
+            // which causes methods to have a `pub` prefix, which is invalid since items in traits
+            // can not have a visibility prefix. Thus we override the visibility here manually.
+            // See https://github.com/rust-lang/rust/issues/81274
+            clean::Item { visibility: Visibility::Inherited, ..item.clean(cx) }
+        })
+        .collect();
 
     let predicates = cx.tcx.predicates_of(did);
     let generics = (cx.tcx.generics_of(did), predicates).clean(cx);

--- a/src/test/rustdoc/auxiliary/trait-visibility.rs
+++ b/src/test/rustdoc/auxiliary/trait-visibility.rs
@@ -1,0 +1,3 @@
+pub trait Bar {
+    fn foo();
+}

--- a/src/test/rustdoc/trait-visibility.rs
+++ b/src/test/rustdoc/trait-visibility.rs
@@ -1,0 +1,8 @@
+// aux-build:trait-visibility.rs
+
+#![crate_name = "foo"]
+
+extern crate trait_visibility;
+
+// @has foo/trait.Bar.html '//a[@href="#tymethod.foo"]/..' "fn foo()"
+pub use trait_visibility::Bar;


### PR DESCRIPTION
This PR fixes the bug that caused traits, which were re-exported, having visibility modifiers in front of methods, which is invalid.

It would be nice to add a test for this, but I don't even know if tests with multiple crates are possible.

Resolves #81274