### PR TITLE
Bump `cargo_metadata` to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,13 +263,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo"
 version = "0.54.0"
 dependencies = [
  "anyhow",
  "atty",
  "bytesize",
- "cargo-platform",
+ "cargo-platform 0.1.1",
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
@@ -371,6 +380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-test-macro"
 version = "0.1.0"
 
@@ -427,22 +445,14 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fec17b16f1ac67908af82e47d0a90a7afd0e1827b181cd77504323d3263d35"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
 dependencies = [
- "semver 0.10.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a5f7b42f606b7f23674f6f4d877628350682bc40687d3fae65679a58d55345"
-dependencies = [
+ "camino",
+ "cargo-platform 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.11.0",
+ "semver-parser 0.10.2",
  "serde",
  "serde_json",
 ]
@@ -562,7 +572,7 @@ dependencies = [
 name = "clippy"
 version = "0.1.53"
 dependencies = [
- "cargo_metadata 0.12.0",
+ "cargo_metadata 0.13.1",
  "clippy-mini-macro-test",
  "clippy_lints",
  "compiletest_rs",
@@ -599,7 +609,7 @@ dependencies = [
 name = "clippy_lints"
 version = "0.1.53"
 dependencies = [
- "cargo_metadata 0.12.0",
+ "cargo_metadata 0.13.1",
  "clippy_utils",
  "if_chain",
  "itertools 0.9.0",
@@ -5259,7 +5269,7 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
- "cargo_metadata 0.11.1",
+ "cargo_metadata 0.13.1",
  "crossbeam-utils 0.8.3",
  "lazy_static",
  "regex",

--- a/src/tools/clippy/Cargo.toml
+++ b/src/tools/clippy/Cargo.toml
@@ -30,7 +30,7 @@ rustc_tools_util = { version = "0.2.0", path = "rustc_tools_util" }
 tempfile = { version = "3.1.0", optional = true }
 
 [dev-dependencies]
-cargo_metadata = "0.12"
+cargo_metadata = "0.13"
 compiletest_rs = { version = "0.6.0", features = ["tmp"] }
 tester = "0.9"
 clippy-mini-macro-test = { version = "0.2", path = "mini-macro" }

--- a/src/tools/clippy/clippy_lints/Cargo.toml
+++ b/src/tools/clippy/clippy_lints/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["clippy", "lint", "plugin"]
 edition = "2018"
 
 [dependencies]
-cargo_metadata = "0.12"
+cargo_metadata = "0.13"
 clippy_utils = { path = "../clippy_utils" }
 if_chain = "1.0.0"
 itertools = "0.9"

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 autobins = false
 
 [dependencies]
-cargo_metadata = "0.11"
+cargo_metadata = "0.13"
 regex = "1"
 lazy_static = "1"
 walkdir = "2"


### PR DESCRIPTION
This brings the number of copies of `cargo_metadata` from 3 to 2.
Removing the final duplicate will require updates to `rls` and `rustfmt`