### PR TITLE
Change librustdoc write!(.. \n) to writeln!(..); fix comment grammar

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -46,7 +46,7 @@ crate fn render_with_highlighting(
 }
 
 fn write_header(out: &mut Buffer, class: Option<&str>) {
-    write!(out, "<div class=\"example-wrap\"><pre class=\"rust {}\">\n", class.unwrap_or_default());
+    writeln!(out, "<div class=\"example-wrap\"><pre class=\"rust {}\">", class.unwrap_or_default());
 }
 
 fn write_code(out: &mut Buffer, src: &str, edition: Edition) {
@@ -62,7 +62,7 @@ fn write_code(out: &mut Buffer, src: &str, edition: Edition) {
 }
 
 fn write_footer(out: &mut Buffer, playground_button: Option<&str>) {
-    write!(out, "</pre>{}</div>\n", playground_button.unwrap_or_default());
+    writeln!(out, "</pre>{}</div>", playground_button.unwrap_or_default());
 }
 
 /// How a span of text is classified. Mostly corresponds to token kinds.

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -964,7 +964,7 @@ fn attributes(it: &clean::Item) -> Vec<String> {
 // a whitespace prefix and newline.
 fn render_attributes_in_pre(w: &mut Buffer, it: &clean::Item, prefix: &str) {
     for a in attributes(it) {
-        write!(w, "{}{}\n", prefix, a);
+        writeln!(w, "{}{}", prefix, a);
     }
 }
 

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -177,7 +177,7 @@ fn print_src(buf: &mut Buffer, s: &str, edition: Edition) {
     }
     buf.write_str("<pre class=\"line-numbers\">");
     for i in 1..=lines {
-        write!(buf, "<span id=\"{0}\">{0:1$}</span>\n", i, cols);
+        writeln!(buf, "<span id=\"{0}\">{0:1$}</span>", i, cols);
     }
     buf.write_str("</pre>");
     highlight::render_with_highlighting(s, buf, None, None, None, edition);

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -17,7 +17,7 @@ crate struct CssPath {
 // This PartialEq implementation IS NOT COMMUTATIVE!!!
 //
 // The order is very important: the second object must have all first's rules.
-// However, the first doesn't require to have all second's rules.
+// However, the first is not required to have all of the second's rules.
 impl PartialEq for CssPath {
     fn eq(&self, other: &CssPath) -> bool {
         if self.name != other.name {


### PR DESCRIPTION
Howdy,

This PR does the following:
1. Updates the grammar of a comment in librustdoc.
2. Replaces a few write!(..\n) macros with writeln!(..\n) for clarity. (Please let me know if there is a reason why this might be wrong!) 

Best,
Mautamu