### PR TITLE
Follow PEP 8 when checking for empty sequences

### DIFF
--- a/src/etc/rust_types.py
+++ b/src/etc/rust_types.py
@@ -80,7 +80,7 @@ def is_tuple_fields(fields):
 
 
 def classify_struct(name, fields):
-    if len(fields) == 0:
+    if not fields:
         return RustType.EMPTY
 
     for ty, regex in STD_TYPE_TO_REGEX.items():
@@ -97,7 +97,7 @@ def classify_struct(name, fields):
 
 
 def classify_union(fields):
-    if len(fields) == 0:
+    if not fields:
         return RustType.EMPTY
 
     first_variant_name = fields[0].name


### PR DESCRIPTION
Currently, we are checking whether fields is empty like so: `len(fields) == 0`. This contradicts the PEP 8 recommendation on checking for empty sequences, which says:

* For sequences, (strings, lists, tuples), use the fact that empty sequences are false:

```python
# Correct:
if not seq:
if seq:

# Wrong:
if len(seq):
if not len(seq):
```

source: https://www.python.org/dev/peps/pep-0008/#programming-recommendations

Not sure how strict y'all are with regards to PEP 8, just wanted to bring it up in case you are PEP 8 fans.