### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -269,7 +269,7 @@ impl ModError<'_> {
                     diag,
                     span,
                     E0761,
-                    "file for module `{}` found at both {} and {}",
+                    "file for module `{}` found at both \"{}\" and \"{}\"",
                     ident,
                     default_path_short,
                     secondary_path_short,

--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -37,7 +37,7 @@ pub enum ModError<'a> {
     CircularInclusion(Vec<PathBuf>),
     ModInBlock(Option<Ident>),
     FileNotFound(Ident, PathBuf),
-    MultipleCandidates(Ident, String, String),
+    MultipleCandidates(Ident, PathBuf, PathBuf),
     ParserError(DiagnosticBuilder<'a>),
 }
 
@@ -220,9 +220,7 @@ pub fn default_submod_path<'a>(
             dir_ownership: DirOwnership::Owned { relative: None },
         }),
         (false, false) => Err(ModError::FileNotFound(ident, default_path)),
-        (true, true) => {
-            Err(ModError::MultipleCandidates(ident, default_path_str, secondary_path_str))
-        }
+        (true, true) => Err(ModError::MultipleCandidates(ident, default_path, secondary_path)),
     }
 }
 
@@ -264,15 +262,15 @@ impl ModError<'_> {
                 ));
                 err
             }
-            ModError::MultipleCandidates(ident, default_path_short, secondary_path_short) => {
+            ModError::MultipleCandidates(ident, default_path, secondary_path) => {
                 let mut err = struct_span_err!(
                     diag,
                     span,
                     E0761,
                     "file for module `{}` found at both \"{}\" and \"{}\"",
                     ident,
-                    default_path_short,
-                    secondary_path_short,
+                    default_path.display(),
+                    secondary_path.display(),
                 );
                 err.help("delete or rename one of them to remove the ambiguity");
                 err

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2288,7 +2288,7 @@ impl ToString for char {
     }
 }
 
-#[stable(feature = "u8_to_string_specialization", since = "1.999.0")]
+#[stable(feature = "u8_to_string_specialization", since = "1.54.0")]
 impl ToString for u8 {
     #[inline]
     fn to_string(&self) -> String {
@@ -2307,7 +2307,7 @@ impl ToString for u8 {
     }
 }
 
-#[stable(feature = "i8_to_string_specialization", since = "1.999.0")]
+#[stable(feature = "i8_to_string_specialization", since = "1.54.0")]
 impl ToString for i8 {
     #[inline]
     fn to_string(&self) -> String {

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -189,7 +189,7 @@ pub enum ErrorKind {
 
     /// An operation could not be completed, because it failed
     /// to allocate enough memory.
-    #[stable(feature = "out_of_memory_error", since = "1.53.0")]
+    #[stable(feature = "out_of_memory_error", since = "1.54.0")]
     OutOfMemory,
 }
 

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -159,7 +159,7 @@ impl UdpSocket {
     /// This will return an error when the IP version of the local socket
     /// does not match that returned from [`ToSocketAddrs`].
     ///
-    /// See issue #34202 for more details.
+    /// See [Issue #34202] for more details.
     ///
     /// # Examples
     ///
@@ -169,6 +169,8 @@ impl UdpSocket {
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// socket.send_to(&[0; 10], "127.0.0.1:4242").expect("couldn't send data");
     /// ```
+    ///
+    /// [Issue #34202]: https://github.com/rust-lang/rust/issues/34202
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], addr: A) -> io::Result<usize> {
         match addr.to_socket_addrs()?.next() {

--- a/src/doc/rustc/src/target-tier-policy.md
+++ b/src/doc/rustc/src/target-tier-policy.md
@@ -102,7 +102,7 @@ place minimal requirements on the introduction of targets.
 
 A proposed new tier 3 target must be reviewed and approved by a member of the
 compiler team based on these requirements. The reviewer may choose to gauge
-broader compiler team consensus via a Major Change Proposal (MCP).
+broader compiler team consensus via a [Major Change Proposal (MCP)][MCP].
 
 A proposed target or target-specific patch that substantially changes code
 shared with other targets (not just target-specific code) must be reviewed and
@@ -223,8 +223,8 @@ patches that fail to build on a target. Thus, we place requirements that ensure
 the target will not block forward progress of the Rust project.
 
 A proposed new tier 2 target must be reviewed and approved by the compiler team
-based on these requirements. Such review and approval may occur via a Major
-Change Proposal (MCP).
+based on these requirements. Such review and approval may occur via a [Major
+Change Proposal (MCP)][MCP].
 
 In addition, the infrastructure team must approve the integration of the target
 into Continuous Integration (CI), and the tier 2 CI-related requirements. This
@@ -391,7 +391,7 @@ development platform, not just a compilation target.
 
 A proposed new tier 2 target with host tools must be reviewed and approved by
 the compiler team based on these requirements. Such review and approval may
-occur via a Major Change Proposal (MCP).
+occur via a [Major Change Proposal (MCP)][MCP].
 
 In addition, the infrastructure team must approve the integration of the
 target's host tools into Continuous Integration (CI), and the CI-related
@@ -648,3 +648,5 @@ for demotion of a tier 1 target (with or without host tools) requires a full
 RFC process, with approval by the compiler and release teams. Any such proposal
 will be communicated widely to the Rust community, both when initially proposed
 and before being dropped from a stable release.
+
+[MCP]: https://forge.rust-lang.org/compiler/mcp.html

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -46,7 +46,7 @@ crate fn render_with_highlighting(
 }
 
 fn write_header(out: &mut Buffer, class: Option<&str>) {
-    write!(out, "<div class=\"example-wrap\"><pre class=\"rust {}\">\n", class.unwrap_or_default());
+    writeln!(out, "<div class=\"example-wrap\"><pre class=\"rust {}\">", class.unwrap_or_default());
 }
 
 fn write_code(out: &mut Buffer, src: &str, edition: Edition) {
@@ -62,7 +62,7 @@ fn write_code(out: &mut Buffer, src: &str, edition: Edition) {
 }
 
 fn write_footer(out: &mut Buffer, playground_button: Option<&str>) {
-    write!(out, "</pre>{}</div>\n", playground_button.unwrap_or_default());
+    writeln!(out, "</pre>{}</div>", playground_button.unwrap_or_default());
 }
 
 /// How a span of text is classified. Mostly corresponds to token kinds.

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -964,7 +964,7 @@ fn attributes(it: &clean::Item) -> Vec<String> {
 // a whitespace prefix and newline.
 fn render_attributes_in_pre(w: &mut Buffer, it: &clean::Item, prefix: &str) {
     for a in attributes(it) {
-        write!(w, "{}{}\n", prefix, a);
+        writeln!(w, "{}{}", prefix, a);
     }
 }
 

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -177,7 +177,7 @@ fn print_src(buf: &mut Buffer, s: &str, edition: Edition) {
     }
     buf.write_str("<pre class=\"line-numbers\">");
     for i in 1..=lines {
-        write!(buf, "<span id=\"{0}\">{0:1$}</span>\n", i, cols);
+        writeln!(buf, "<span id=\"{0}\">{0:1$}</span>", i, cols);
     }
     buf.write_str("</pre>");
     highlight::render_with_highlighting(s, buf, None, None, None, edition);

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -17,7 +17,7 @@ crate struct CssPath {
 // This PartialEq implementation IS NOT COMMUTATIVE!!!
 //
 // The order is very important: the second object must have all first's rules.
-// However, the first doesn't require to have all second's rules.
+// However, the first is not required to have all of the second's rules.
 impl PartialEq for CssPath {
     fn eq(&self, other: &CssPath) -> bool {
         if self.name != other.name {

--- a/src/test/ui/modules_and_files_visibility/mod_file_disambig.stderr
+++ b/src/test/ui/modules_and_files_visibility/mod_file_disambig.stderr
@@ -1,4 +1,4 @@
-error[E0761]: file for module `mod_file_disambig_aux` found at both "mod_file_disambig_aux.rs" and "mod_file_disambig_aux/mod.rs"
+error[E0761]: file for module `mod_file_disambig_aux` found at both "$DIR/mod_file_disambig_aux.rs" and "$DIR/mod_file_disambig_aux/mod.rs"
   --> $DIR/mod_file_disambig.rs:1:1
    |
 LL | mod mod_file_disambig_aux;

--- a/src/test/ui/modules_and_files_visibility/mod_file_disambig.stderr
+++ b/src/test/ui/modules_and_files_visibility/mod_file_disambig.stderr
@@ -1,4 +1,4 @@
-error[E0761]: file for module `mod_file_disambig_aux` found at both mod_file_disambig_aux.rs and mod_file_disambig_aux/mod.rs
+error[E0761]: file for module `mod_file_disambig_aux` found at both "mod_file_disambig_aux.rs" and "mod_file_disambig_aux/mod.rs"
   --> $DIR/mod_file_disambig.rs:1:1
    |
 LL | mod mod_file_disambig_aux;


### PR DESCRIPTION
Successful merges:

 - #84835 (Add link to Issue #34202 in udp docs)
 - #84852 (Change librustdoc write!(.. \n) to writeln!(..); fix comment grammar)
 - #84854 (use double quotes and full path for E0761)
 - #84856 (Correct stability of ErrorKind::OutOfMemory)
 - #84858 (Fix stability attributes of byte-to-string specialization)
 - #84860 (Link to MCP from target tier policy)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=84835,84852,84854,84856,84858,84860)
<!-- homu-ignore:end -->