### PR TITLE
std: Attempt again to inline thread-local-init across crates

### DIFF
--- a/src/test/codegen/auxiliary/thread_local_aux.rs
+++ b/src/test/codegen/auxiliary/thread_local_aux.rs
@@ -1,0 +1,6 @@
+#![crate_type = "lib"]
+#![feature(thread_local_const_init)]
+
+use std::cell::Cell;
+
+thread_local!(pub static A: Cell<u64> = const { Cell::new(0) });

--- a/src/test/codegen/thread-local.rs
+++ b/src/test/codegen/thread-local.rs
@@ -1,0 +1,50 @@
+// compile-flags: -O
+// aux-build:thread_local_aux.rs
+// ignore-windows FIXME(#84933)
+// ignore-wasm globals are used instead of thread locals
+// ignore-emscripten globals are used instead of thread locals
+// ignore-android does not use #[thread_local]
+
+#![crate_type = "lib"]
+#![feature(thread_local_const_init)]
+
+extern crate thread_local_aux as aux;
+
+use std::cell::Cell;
+
+thread_local!(static A: Cell<u32> = const { Cell::new(1) });
+
+// CHECK: [[TLS_AUX:@.+]] = external thread_local local_unnamed_addr global i64
+// CHECK: [[TLS:@.+]] = internal thread_local unnamed_addr global
+
+// CHECK-LABEL: @get
+#[no_mangle]
+fn get() -> u32 {
+    // CHECK: %0 = load i32, i32* bitcast ({{.*}} [[TLS]] to i32*)
+    // CHECK-NEXT: ret i32 %0
+    A.with(|a| a.get())
+}
+
+// CHECK-LABEL: @set
+#[no_mangle]
+fn set(v: u32) {
+    // CHECK: store i32 %0, i32* bitcast ({{.*}} [[TLS]] to i32*)
+    // CHECK-NEXT: ret void
+    A.with(|a| a.set(v))
+}
+
+// CHECK-LABEL: @get_aux
+#[no_mangle]
+fn get_aux() -> u64 {
+    // CHECK: %0 = load i64, i64* [[TLS_AUX]]
+    // CHECK-NEXT: ret i64 %0
+    aux::A.with(|a| a.get())
+}
+
+// CHECK-LABEL: @set_aux
+#[no_mangle]
+fn set_aux(v: u64) {
+    // CHECK: store i64 %0, i64* [[TLS_AUX]]
+    // CHECK-NEXT: ret void
+    aux::A.with(|a| a.set(v))
+}


### PR DESCRIPTION
Issue #25088 has been part of `thread_local!` for quite some time now.
Historical attempts have been made to add `#[inline]` to `__getit`
in #43931, #50252, and #59720, but these attempts ended up not landing
at the time due to segfaults on Windows.

In the interim though with `const`-initialized thread locals AFAIK this
is the only remaining bug which is why you might want to use
`#[thread_local]` over `thread_local!`. As a result I figured it was
time to resubmit this and see how it fares on CI and if I can help
debugging any issues that crop up.

Closes #25088