### PR TITLE
compiletest: "fix" FileCheck with --allow-unused-prefixes

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2293,7 +2293,7 @@ impl<'test> TestCx<'test> {
         // For now, though…
         if let Some(rev) = self.revision {
             let prefixes = format!("CHECK,{}", rev);
-            filecheck.args(&["--check-prefixes", &prefixes]);
+            filecheck.args(&["--allow-unused-prefixes", "--check-prefixes", &prefixes]);
         }
         self.compose_and_run(filecheck, "", None, None)
     }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2293,7 +2293,11 @@ impl<'test> TestCx<'test> {
         // For now, though…
         if let Some(rev) = self.revision {
             let prefixes = format!("CHECK,{}", rev);
-            filecheck.args(&["--allow-unused-prefixes", "--check-prefixes", &prefixes]);
+            if self.config.llvm_version.unwrap_or(0) >= 130000 {
+                filecheck.args(&["--allow-unused-prefixes", "--check-prefixes", &prefixes]);
+            } else {
+                filecheck.args(&["--check-prefixes", &prefixes]);
+            }
         }
         self.compose_and_run(filecheck, "", None, None)
     }


### PR DESCRIPTION
The default of --allow-unused-prefixes used to be false, but in LLVM
change 87dbdd2e3b (https://reviews.llvm.org/D95849) the default became
true. I'm not quite sure how we could do better here (specifically not
providing the CHECK prefix when it's not needed), but this seems to work
for now.

This reduces codegen test failures against LLVM HEAD from 31 cases to 5.