### PR TITLE
Update `is_trivially_sized` to know enums are always `Sized`

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2170,7 +2170,7 @@ impl<'tcx> TyS<'tcx> {
 
             ty::Tuple(tys) => tys.iter().all(|ty| ty.expect_ty().is_trivially_sized(tcx)),
 
-            ty::Adt(def, _substs) => def.sized_constraint(tcx).is_empty(),
+            ty::Adt(def, _substs) => def.is_enum() || def.sized_constraint(tcx).is_empty(),
 
             ty::Projection(_) | ty::Param(_) | ty::Opaque(..) => false,
 


### PR DESCRIPTION
Noticed this in passing looking at queries; made me curious whether it'd help.  Seems like looking at the flag could plausibly be easier than calling the `sized_constraint` query.