### PR TITLE
Add .clang-format and run clang-format -i *.cpp

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/.clang-format
+++ b/compiler/rustc_llvm/llvm-wrapper/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/ArchiveWrapper.cpp
@@ -13,10 +13,7 @@ struct RustArchiveMember {
   Archive::Child Child;
 
   RustArchiveMember()
-      : Filename(nullptr), Name(nullptr),
-        Child(nullptr, nullptr, nullptr)
-  {
-  }
+      : Filename(nullptr), Name(nullptr), Child(nullptr, nullptr, nullptr) {}
   ~RustArchiveMember() {}
 };
 
@@ -27,11 +24,8 @@ struct RustArchiveIterator {
   std::unique_ptr<Error> Err;
 
   RustArchiveIterator(Archive::child_iterator Cur, Archive::child_iterator End,
-      std::unique_ptr<Error> Err)
-    : First(true),
-      Cur(Cur),
-      End(End),
-      Err(std::move(Err)) {}
+                      std::unique_ptr<Error> Err)
+      : First(true), Cur(Cur), End(End), Err(std::move(Err)) {}
 };
 
 enum class LLVMRustArchiveKind {
@@ -143,8 +137,8 @@ extern "C" const char *
 LLVMRustArchiveChildName(LLVMRustArchiveChildConstRef Child, size_t *Size) {
   Expected<StringRef> NameOrErr = Child->getName();
   if (!NameOrErr) {
-    // rustc_codegen_llvm currently doesn't use this error string, but it might be
-    // useful in the future, and in the mean time this tells LLVM that the
+    // rustc_codegen_llvm currently doesn't use this error string, but it might
+    // be useful in the future, and in the mean time this tells LLVM that the
     // error was not ignored and that it shouldn't abort the process.
     LLVMRustSetLastError(toString(NameOrErr.takeError()).c_str());
     return nullptr;

--- a/compiler/rustc_llvm/llvm-wrapper/Linker.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/Linker.cpp
@@ -8,26 +8,18 @@ struct RustLinker {
   Linker L;
   LLVMContext &Ctx;
 
-  RustLinker(Module &M) :
-    L(M),
-    Ctx(M.getContext())
-  {}
+  RustLinker(Module &M) : L(M), Ctx(M.getContext()) {}
 };
 
-extern "C" RustLinker*
-LLVMRustLinkerNew(LLVMModuleRef DstRef) {
+extern "C" RustLinker *LLVMRustLinkerNew(LLVMModuleRef DstRef) {
   Module *Dst = unwrap(DstRef);
 
   return new RustLinker(*Dst);
 }
 
-extern "C" void
-LLVMRustLinkerFree(RustLinker *L) {
-  delete L;
-}
+extern "C" void LLVMRustLinkerFree(RustLinker *L) { delete L; }
 
-extern "C" bool
-LLVMRustLinkerAdd(RustLinker *L, char *BC, size_t Len) {
+extern "C" bool LLVMRustLinkerAdd(RustLinker *L, char *BC, size_t Len) {
   std::unique_ptr<MemoryBuffer> Buf =
       MemoryBuffer::getMemBufferCopy(StringRef(BC, Len));
 


### PR DESCRIPTION
It seems to me the original intent of the code style of the
LLVM wrapper was to follow the LLVM format. However, code style has
gotten a bit inconsistent inside the files. Thus, we add a
.clang-format file that indicates that the LLVM format is followed,
and run clang-format -i *.cpp on the files.

I file this PR as a request-for-comment. Please suggest some other code style if you prefer it. `clang-format` has a rich set of configuration options.

Also I wonder if CI should enforce this. It's easy to do, one just has to run `clang-format --dry-run --Werror *.cpp` in the `llvm-wrapper` directory. Should it maybe be added to tidy?