### PR TITLE
stabilize `int_error_matching`

### DIFF
--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -42,7 +42,6 @@
 #![feature(crate_visibility_modifier)]
 #![feature(associated_type_bounds)]
 #![feature(rustc_attrs)]
-#![feature(int_error_matching)]
 #![feature(half_open_range_patterns)]
 #![feature(exclusive_range_pattern)]
 #![feature(control_flow_enum)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -165,7 +165,6 @@
 #![feature(slice_ptr_get)]
 #![feature(no_niche)] // rust-lang/rust#68303
 #![feature(no_coverage)] // rust-lang/rust#84605
-#![feature(int_error_matching)]
 #![cfg_attr(bootstrap, feature(target_feature_11))]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(or_patterns_back_compat)]

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -74,26 +74,20 @@ pub struct ParseIntError {
 /// # Example
 ///
 /// ```
-/// #![feature(int_error_matching)]
-///
 /// # fn main() {
 /// if let Err(e) = i32::from_str_radix("a12", 10) {
 ///     println!("Failed conversion to i32: {:?}", e.kind());
 /// }
 /// # }
 /// ```
-#[unstable(
-    feature = "int_error_matching",
-    reason = "it can be useful to match errors when making error messages \
-              for integer parsing",
-    issue = "22639"
-)]
+#[stable(feature = "int_error_matching", since = "1.54.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IntErrorKind {
     /// Value being parsed is empty.
     ///
-    /// Among other causes, this variant will be constructed when parsing an empty string.
+    /// This variant will be constructed when parsing an empty string.
+    #[stable(feature = "int_error_matching", since = "1.54.0")]
     Empty,
     /// Contains an invalid digit in its context.
     ///
@@ -102,26 +96,25 @@ pub enum IntErrorKind {
     ///
     /// This variant is also constructed when a `+` or `-` is misplaced within a string
     /// either on its own or in the middle of a number.
+    #[stable(feature = "int_error_matching", since = "1.54.0")]
     InvalidDigit,
     /// Integer is too large to store in target integer type.
+    #[stable(feature = "int_error_matching", since = "1.54.0")]
     PosOverflow,
     /// Integer is too small to store in target integer type.
+    #[stable(feature = "int_error_matching", since = "1.54.0")]
     NegOverflow,
     /// Value was Zero
     ///
     /// This variant will be emitted when the parsing string has a value of zero, which
     /// would be illegal for non-zero types.
+    #[stable(feature = "int_error_matching", since = "1.54.0")]
     Zero,
 }
 
 impl ParseIntError {
     /// Outputs the detailed cause of parsing an integer failing.
-    #[unstable(
-        feature = "int_error_matching",
-        reason = "it can be useful to match errors when making error messages \
-              for integer parsing",
-        issue = "22639"
-    )]
+    #[stable(feature = "int_error_matching", since = "1.54.0")]
     pub fn kind(&self) -> &IntErrorKind {
         &self.kind
     }

--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -80,14 +80,14 @@ pub struct ParseIntError {
 /// }
 /// # }
 /// ```
-#[stable(feature = "int_error_matching", since = "1.54.0")]
+#[stable(feature = "int_error_matching", since = "1.55.0")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum IntErrorKind {
     /// Value being parsed is empty.
     ///
     /// This variant will be constructed when parsing an empty string.
-    #[stable(feature = "int_error_matching", since = "1.54.0")]
+    #[stable(feature = "int_error_matching", since = "1.55.0")]
     Empty,
     /// Contains an invalid digit in its context.
     ///
@@ -96,25 +96,25 @@ pub enum IntErrorKind {
     ///
     /// This variant is also constructed when a `+` or `-` is misplaced within a string
     /// either on its own or in the middle of a number.
-    #[stable(feature = "int_error_matching", since = "1.54.0")]
+    #[stable(feature = "int_error_matching", since = "1.55.0")]
     InvalidDigit,
     /// Integer is too large to store in target integer type.
-    #[stable(feature = "int_error_matching", since = "1.54.0")]
+    #[stable(feature = "int_error_matching", since = "1.55.0")]
     PosOverflow,
     /// Integer is too small to store in target integer type.
-    #[stable(feature = "int_error_matching", since = "1.54.0")]
+    #[stable(feature = "int_error_matching", since = "1.55.0")]
     NegOverflow,
     /// Value was Zero
     ///
     /// This variant will be emitted when the parsing string has a value of zero, which
     /// would be illegal for non-zero types.
-    #[stable(feature = "int_error_matching", since = "1.54.0")]
+    #[stable(feature = "int_error_matching", since = "1.55.0")]
     Zero,
 }
 
 impl ParseIntError {
     /// Outputs the detailed cause of parsing an integer failing.
-    #[stable(feature = "int_error_matching", since = "1.54.0")]
+    #[stable(feature = "int_error_matching", since = "1.55.0")]
     pub fn kind(&self) -> &IntErrorKind {
         &self.kind
     }

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -57,12 +57,7 @@ pub use nonzero::{NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, No
 #[stable(feature = "try_from", since = "1.34.0")]
 pub use error::TryFromIntError;
 
-#[unstable(
-    feature = "int_error_matching",
-    reason = "it can be useful to match errors when making error messages \
-              for integer parsing",
-    issue = "22639"
-)]
+#[stable(feature = "int_error_matching", since = "1.54.0")]
 pub use error::IntErrorKind;
 
 macro_rules! usize_isize_to_xe_bytes_doc {

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -57,7 +57,7 @@ pub use nonzero::{NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, No
 #[stable(feature = "try_from", since = "1.34.0")]
 pub use error::TryFromIntError;
 
-#[stable(feature = "int_error_matching", since = "1.54.0")]
+#[stable(feature = "int_error_matching", since = "1.55.0")]
 pub use error::IntErrorKind;
 
 macro_rules! usize_isize_to_xe_bytes_doc {

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -46,7 +46,6 @@
 #![feature(try_trait_v2)]
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]
-#![feature(int_error_matching)]
 #![feature(iter_advance_by)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_intersperse)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -275,7 +275,6 @@
 #![feature(global_asm)]
 #![feature(hashmap_internals)]
 #![feature(int_error_internals)]
-#![feature(int_error_matching)]
 #![feature(integer_atomics)]
 #![feature(into_future)]
 #![feature(intra_doc_pointers)]

--- a/library/std/src/num.rs
+++ b/library/std/src/num.rs
@@ -22,7 +22,7 @@ pub use core::num::{NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, 
 #[stable(feature = "nonzero", since = "1.28.0")]
 pub use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 
- #[stable(feature = "int_error_matching", since = "1.54.0")]
+#[stable(feature = "int_error_matching", since = "1.54.0")]
 pub use core::num::IntErrorKind;
 
 #[cfg(test)]

--- a/library/std/src/num.rs
+++ b/library/std/src/num.rs
@@ -22,12 +22,7 @@ pub use core::num::{NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, 
 #[stable(feature = "nonzero", since = "1.28.0")]
 pub use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 
-#[unstable(
-    feature = "int_error_matching",
-    reason = "it can be useful to match errors when making error messages \
-              for integer parsing",
-    issue = "22639"
-)]
+ #[stable(feature = "int_error_matching", since = "1.54.0")]
 pub use core::num::IntErrorKind;
 
 #[cfg(test)]

--- a/library/std/src/num.rs
+++ b/library/std/src/num.rs
@@ -22,7 +22,7 @@ pub use core::num::{NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, 
 #[stable(feature = "nonzero", since = "1.28.0")]
 pub use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 
-#[stable(feature = "int_error_matching", since = "1.54.0")]
+#[stable(feature = "int_error_matching", since = "1.55.0")]
 pub use core::num::IntErrorKind;
 
 #[cfg(test)]


### PR DESCRIPTION
closes #22639

> It has been over half a year since https://github.com/rust-lang/rust/pull/77640#pullrequestreview-511263516, and the indexing question is rejected in https://github.com/rust-lang/rust/pull/79728#pullrequestreview-633030341, so I guess we can submit another stabilization attempt? 😉

_Originally posted by @kennytm in https://github.com/rust-lang/rust/issues/22639#issuecomment-831738266_