### PR TITLE
marker_trait_attr: discard eval modulo regions in favor of eval to ok

### DIFF
--- a/src/test/ui/marker_trait_attr/prefer-evaluated-to-ok.rs
+++ b/src/test/ui/marker_trait_attr/prefer-evaluated-to-ok.rs
@@ -1,0 +1,10 @@
+// check-pass
+// Regression test for #84917.
+#![feature(marker_trait_attr)]
+
+#[marker]
+pub trait F {}
+impl<T> F for T where T: Copy {}
+impl<T> F for T where T: 'static {}
+
+fn main() {}


### PR DESCRIPTION
fixes #84917

cc https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits/topic/marker_trait_attr.20stabilization/near/237371224