### PR TITLE
slightly adopt and unify const generics terminology

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -386,7 +386,7 @@ pub enum GenericParamKind {
         ty: P<Ty>,
         /// Span of the `const` keyword.
         kw_span: Span,
-        /// Optional default value for the const generic param
+        /// Optional default value for the const param.
         default: Option<AnonConst>,
     },
 }

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -677,10 +677,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session) {
         extended_key_value_attributes,
         "arbitrary expressions in key-value attributes are unstable"
     );
-    gate_all!(
-        const_generics_defaults,
-        "default values for const generic parameters are experimental"
-    );
+    gate_all!(const_generics_defaults, "default values for const parameters are experimental");
     if sess.parse_sess.span_diagnostic.err_count() == 0 {
         // Errors for `destructuring_assignment` can get quite noisy, especially where `_` is
         // involved, so we only emit errors where there are no other parsing errors.

--- a/compiler/rustc_error_codes/src/error_codes/E0741.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0741.md
@@ -1,4 +1,4 @@
-A non-structural-match type was used as the type of a const generic parameter.
+A non-structural-match type was used as the type of a const parameter.
 
 Erroneous code example:
 
@@ -11,7 +11,7 @@ struct B<const X: A>; // error!
 ```
 
 Only structural-match types (that is, types that derive `PartialEq` and `Eq`)
-may be used as the types of const generic parameters.
+may be used as the types of const parameters.
 
 To fix the previous code example, we derive `PartialEq` and `Eq`:
 

--- a/compiler/rustc_error_codes/src/error_codes/E0771.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0771.md
@@ -1,5 +1,5 @@
-A non-`'static` lifetime was used in a const generic. This is currently not
-allowed.
+A non-`'static` lifetime was used in a const parameter type. This is
+currently not allowed.
 
 Erroneous code example:
 
@@ -9,8 +9,7 @@ Erroneous code example:
 fn function_with_str<'a, const STRING: &'a str>() {} // error!
 ```
 
-To fix this issue, the lifetime in the const generic need to be changed to
-`'static`:
+To fix this issue, considering changing the lifetime to `'static`:
 
 ```
 #![feature(const_generics)]

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -607,7 +607,7 @@ declare_features! (
     /// Allows arbitrary expressions in key-value attributes at parse time.
     (active, extended_key_value_attributes, "1.50.0", Some(78835), None),
 
-    /// Allows const generics to have default values (e.g. `struct Foo<const N: usize = 3>(...);`).
+    /// Allows const parameters to have default values (e.g. `struct Foo<const N: usize = 3>(...);`).
     (active, const_generics_defaults, "1.51.0", Some(44580), None),
 
     /// Allows references to types with interior mutability within constants

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -462,7 +462,7 @@ pub enum GenericParamKind<'hir> {
     },
     Const {
         ty: &'hir Ty<'hir>,
-        /// Optional default value for the const generic param
+        /// Optional default value for the const param.
         default: Option<AnonConst>,
     },
 }

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1389,7 +1389,7 @@ pub enum ConstContext {
     /// Other contexts include:
     /// - Array length expressions
     /// - Enum discriminants
-    /// - Const generics
+    /// - Const generic arguments
     ///
     /// For the most part, other contexts are treated just like a regular `const`, so they are
     /// lumped into the same category.

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -29,7 +29,7 @@ pub struct Const<'tcx> {
 static_assert_size!(Const<'_>, 48);
 
 impl<'tcx> Const<'tcx> {
-    /// Literals and const generic parameters are eagerly converted to a constant, everything else
+    /// Literals and const parameters are eagerly converted to a constant, everything else
     /// becomes `Unevaluated`.
     pub fn from_anon_const(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> &'tcx Self {
         Self::from_opt_const_arg_anon_const(tcx, ty::WithOptConstParam::unknown(def_id))
@@ -151,7 +151,7 @@ impl<'tcx> Const<'tcx> {
     #[inline]
     /// Attempts to evaluate the given constant to bits. Can fail to evaluate in the presence of
     /// generics (or erroneous code) or if the value can't be represented as bits (e.g. because it
-    /// contains const generic parameters or pointers).
+    /// contains const parameters or pointers).
     pub fn try_eval_bits(
         &self,
         tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_middle/src/ty/consts/kind.rs
+++ b/compiler/rustc_middle/src/ty/consts/kind.rs
@@ -25,7 +25,7 @@ pub struct Unevaluated<'tcx> {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable)]
 #[derive(Hash, HashStable)]
 pub enum ConstKind<'tcx> {
-    /// A const generic parameter.
+    /// A const parameter.
     Param(ty::ParamConst),
 
     /// Infer the value of the const.

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -334,7 +334,7 @@ fn mir_for_ctfe<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> &'tcx Body<'tcx> {
     }
 }
 
-/// Same as `mir_for_ctfe`, but used to get the MIR of a const generic parameter.
+/// Same as `mir_for_ctfe`, but used to get the MIR of a const parameter.
 /// The docs on `WithOptConstParam` explain this a bit more, but the TLDR is that
 /// we'd get cycle errors with `mir_for_ctfe`, because typeck would need to typeck
 /// the const parameter while type checking the main body, which in turn would try

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1871,17 +1871,13 @@ impl<'a> Parser<'a> {
     pub fn handle_unambiguous_unbraced_const_arg(&mut self) -> PResult<'a, P<Expr>> {
         let start = self.token.span;
         let expr = self.parse_expr_res(Restrictions::CONST_EXPR, None).map_err(|mut err| {
-            err.span_label(
-                start.shrink_to_lo(),
-                "while parsing a const generic argument starting here",
-            );
+            err.span_label(start.shrink_to_lo(), "while parsing a const argument starting here");
             err
         })?;
         if !self.expr_is_valid_const_arg(&expr) {
             self.struct_span_err(
                 expr.span,
-                "expressions must be enclosed in braces to be used as const generic \
-                    arguments",
+                "expressions must be enclosed in braces to be used as const arguments",
             )
             .multipart_suggestion(
                 "enclose the `const` expression in braces",
@@ -1939,14 +1935,12 @@ impl<'a> Parser<'a> {
             Ok(expr) => {
                 if token::Comma == self.token.kind || self.token.kind.should_end_const_arg() {
                     // Avoid the following output by checking that we consumed a full const arg:
-                    // help: expressions must be enclosed in braces to be used as const generic
-                    //       arguments
+                    // help: expressions must be enclosed in braces to be used as const arguments
                     //    |
                     // LL |     let sr: Vec<{ (u32, _, _) = vec![] };
                     //    |                 ^                      ^
                     err.multipart_suggestion(
-                        "expressions must be enclosed in braces to be used as const generic \
-                         arguments",
+                        "expressions must be enclosed in braces to be used as const arguments",
                         vec![
                             (start.shrink_to_lo(), "{ ".to_string()),
                             (expr.span.shrink_to_hi(), " }".to_string()),

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -56,7 +56,7 @@ impl<'a> Parser<'a> {
         self.expect(&token::Colon)?;
         let ty = self.parse_ty()?;
 
-        // Parse optional const generics default value, taking care of feature gating the spans
+        // Parse optional const parameter default value, taking care of feature gating the spans
         // with the unstable syntax mechanism.
         let default = if self.eat(&token::Eq) {
             // The gated span goes from the `=` to the end of the const argument that follows (and

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -967,7 +967,7 @@ impl CheckAttrVisitor<'tcx> {
                             "#[rustc_legacy_const_generics] functions must \
                              only have const generics",
                         )
-                        .span_label(param.span, "non-const generic parameter")
+                        .span_label(param.span, "not a const parameter")
                         .emit();
                     return false;
                 }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1781,13 +1781,13 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
 
     // FIXME(const_generics): This patches over a ICE caused by non-'static lifetimes in const
     // generics. We are disallowing this until we can decide on how we want to handle non-'static
-    // lifetimes in const generics. See issue #74052 for discussion.
+    // lifetimes in const parameter types. See issue #74052 for discussion.
     crate fn emit_non_static_lt_in_const_generic_error(&self, lifetime_ref: &hir::Lifetime) {
         let mut err = struct_span_err!(
             self.tcx.sess,
             lifetime_ref.span,
             E0771,
-            "use of non-static lifetime `{}` in const generic",
+            "use of non-static lifetime `{}` in a const parameter type",
             lifetime_ref
         );
         err.note(

--- a/compiler/rustc_save_analysis/src/sig.rs
+++ b/compiler/rustc_save_analysis/src/sig.rs
@@ -643,7 +643,7 @@ impl<'hir> Sig for hir::Generics<'hir> {
                         // FIXME descend properly into bounds.
                     }
                     hir::GenericParamKind::Const { .. } => {
-                        // Const generics cannot contain bounds.
+                        // Const parameters cannot contain bounds.
                     }
                 }
             }

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -82,7 +82,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         if param_type.is_suggestable() {
                             err.span_suggestion(
                                 tcx.def_span(src_def_id),
-                                "consider changing this type parameter to be a `const` generic",
+                                "consider using a const parameter instead",
                                 format!("const {}: {}", param_name, param_type),
                                 Applicability::MaybeIncorrect,
                             );

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -309,16 +309,13 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) {
                 if is_ptr {
                     tcx.sess.span_err(
                         hir_ty.span,
-                        &format!(
-                            "using {} as const generic parameters is forbidden",
-                            unsupported_type
-                        ),
+                        &format!("using {} as const parameters is forbidden", unsupported_type),
                     )
                 } else {
                     let mut err = tcx.sess.struct_span_err(
                         hir_ty.span,
                         &format!(
-                            "{} is forbidden as the type of a const generic parameter",
+                            "{} is forbidden as the type of a const parameter",
                             unsupported_type
                         ),
                     );

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -1373,8 +1373,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
             let parent_id = tcx.hir().get_parent_item(hir_id);
             Some(tcx.hir().local_def_id(parent_id).to_def_id())
         }
-        // FIXME(#43408) always enable this once `lazy_normalization` is
-        // stable enough and does not need a feature gate anymore.
+
         Node::AnonConst(_) => {
             let parent_id = tcx.hir().get_parent_item(hir_id);
             let parent_def_id = tcx.hir().local_def_id(parent_id);
@@ -1405,6 +1404,9 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                 //
                 // Note that we do not supply the parent generics when using
                 // `min_const_generics`.
+                //
+                // FIXME(#43408) always enable this once `lazy_normalization` is
+                // stable enough and does not need a feature gate anymore.
                 Some(parent_def_id.to_def_id())
             } else {
                 let parent_node = tcx.hir().get(tcx.hir().get_parent_node(hir_id));

--- a/src/test/ui/binding/const-param.rs
+++ b/src/test/ui/binding/const-param.rs
@@ -1,4 +1,4 @@
-// Identifier pattern referring to a const generic parameter is an error (issue #68853).
+// Identifier pattern referring to a const parameter is an error (issue #68853).
 // revisions: full min
 #![cfg_attr(full, feature(const_generics))]
 #![cfg_attr(full, allow(incomplete_features))]

--- a/src/test/ui/const-generics/array-size-in-generic-struct-param.min.stderr
+++ b/src/test/ui/const-generics/array-size-in-generic-struct-param.min.stderr
@@ -16,7 +16,7 @@ LL |     arr: [u8; CFG.arr_size],
    = help: const parameters may only be used as standalone arguments, i.e. `CFG`
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
-error: `Config` is forbidden as the type of a const generic parameter
+error: `Config` is forbidden as the type of a const parameter
   --> $DIR/array-size-in-generic-struct-param.rs:17:21
    |
 LL | struct B<const CFG: Config> {

--- a/src/test/ui/const-generics/closing-args-token.full.stderr
+++ b/src/test/ui/const-generics/closing-args-token.full.stderr
@@ -1,4 +1,4 @@
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/closing-args-token.rs:10:9
    |
 LL |     S::<5 + 2 >> 7>;

--- a/src/test/ui/const-generics/closing-args-token.min.stderr
+++ b/src/test/ui/const-generics/closing-args-token.min.stderr
@@ -1,4 +1,4 @@
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/closing-args-token.rs:10:9
    |
 LL |     S::<5 + 2 >> 7>;

--- a/src/test/ui/const-generics/closing-args-token.rs
+++ b/src/test/ui/const-generics/closing-args-token.rs
@@ -8,7 +8,7 @@ struct T<const X: bool>;
 
 fn bad_args_1() {
     S::<5 + 2 >> 7>;
-    //~^ ERROR expressions must be enclosed in braces to be used as const generic arguments
+    //~^ ERROR expressions must be enclosed in braces to be used as const arguments
     //~| ERROR comparison operators cannot be chained
 }
 

--- a/src/test/ui/const-generics/const-expression-parameter.full.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.full.stderr
@@ -1,4 +1,4 @@
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/const-expression-parameter.rs:15:20
    |
 LL |     i32_identity::<1 + 2>();

--- a/src/test/ui/const-generics/const-expression-parameter.min.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.min.stderr
@@ -1,4 +1,4 @@
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/const-expression-parameter.rs:15:20
    |
 LL |     i32_identity::<1 + 2>();

--- a/src/test/ui/const-generics/const-param-before-other-params.min.stderr
+++ b/src/test/ui/const-generics/const-param-before-other-params.min.stderr
@@ -10,7 +10,7 @@ error: type parameters must be declared prior to const parameters
 LL | fn foo<const X: (), T>(_: &T) {}
    |       --------------^- help: reorder the parameters: lifetimes, then types, then consts: `<T, const X: ()>`
 
-error: `()` is forbidden as the type of a const generic parameter
+error: `()` is forbidden as the type of a const parameter
   --> $DIR/const-param-before-other-params.rs:5:17
    |
 LL | fn bar<const X: (), 'a>(_: &'a ()) {
@@ -19,7 +19,7 @@ LL | fn bar<const X: (), 'a>(_: &'a ()) {
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `()` is forbidden as the type of a const generic parameter
+error: `()` is forbidden as the type of a const parameter
   --> $DIR/const-param-before-other-params.rs:10:17
    |
 LL | fn foo<const X: (), T>(_: &T) {}

--- a/src/test/ui/const-generics/const-param-before-other-params.rs
+++ b/src/test/ui/const-generics/const-param-before-other-params.rs
@@ -4,11 +4,11 @@
 
 fn bar<const X: (), 'a>(_: &'a ()) {
     //~^ ERROR lifetime parameters must be declared prior to const parameters
-    //[min]~^^ ERROR `()` is forbidden as the type of a const generic parameter
+    //[min]~^^ ERROR `()` is forbidden as the type of a const parameter
 }
 
 fn foo<const X: (), T>(_: &T) {}
 //[min]~^ ERROR type parameters must be declared prior to const parameters
-//[min]~^^ ERROR `()` is forbidden as the type of a const generic parameter
+//[min]~^^ ERROR `()` is forbidden as the type of a const parameter
 
 fn main() {}

--- a/src/test/ui/const-generics/const-param-elided-lifetime.min.stderr
+++ b/src/test/ui/const-generics/const-param-elided-lifetime.min.stderr
@@ -28,7 +28,7 @@ error[E0637]: `&` without an explicit lifetime name cannot be used here
 LL | fn bar<const N: &u8>() {}
    |                 ^ explicit lifetime name needed here
 
-error: `&'static u8` is forbidden as the type of a const generic parameter
+error: `&'static u8` is forbidden as the type of a const parameter
   --> $DIR/const-param-elided-lifetime.rs:10:19
    |
 LL | struct A<const N: &u8>;
@@ -37,7 +37,7 @@ LL | struct A<const N: &u8>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static u8` is forbidden as the type of a const generic parameter
+error: `&'static u8` is forbidden as the type of a const parameter
   --> $DIR/const-param-elided-lifetime.rs:15:15
    |
 LL | impl<const N: &u8> A<N> {
@@ -46,7 +46,7 @@ LL | impl<const N: &u8> A<N> {
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static u8` is forbidden as the type of a const generic parameter
+error: `&'static u8` is forbidden as the type of a const parameter
   --> $DIR/const-param-elided-lifetime.rs:23:15
    |
 LL | impl<const N: &u8> B for A<N> {}
@@ -55,7 +55,7 @@ LL | impl<const N: &u8> B for A<N> {}
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static u8` is forbidden as the type of a const generic parameter
+error: `&'static u8` is forbidden as the type of a const parameter
   --> $DIR/const-param-elided-lifetime.rs:27:17
    |
 LL | fn bar<const N: &u8>() {}
@@ -64,7 +64,7 @@ LL | fn bar<const N: &u8>() {}
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static u8` is forbidden as the type of a const generic parameter
+error: `&'static u8` is forbidden as the type of a const parameter
   --> $DIR/const-param-elided-lifetime.rs:18:21
    |
 LL |     fn foo<const M: &u8>(&self) {}

--- a/src/test/ui/const-generics/const-param-elided-lifetime.rs
+++ b/src/test/ui/const-generics/const-param-elided-lifetime.rs
@@ -1,6 +1,6 @@
-// Elided lifetimes within the type of a const generic parameters is disallowed. This matches the
+// Elided lifetimes within the type of a const parameters is disallowed. This matches the
 // behaviour of trait bounds where `fn foo<T: Ord<&u8>>() {}` is illegal. Though we could change
-// elided lifetimes within the type of a const generic parameters to be 'static, like elided
+// elided lifetimes within the type of a const parameters to be 'static, like elided
 // lifetimes within const/static items.
 // revisions: full min
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
@@ -10,7 +10,7 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                        ^ the type must not depend on the parameter `N`
 
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:11:47
    |
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
@@ -19,7 +19,7 @@ LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/const-param-type-depends-on-const-param.rs:15:35
    |
 LL | pub struct SelfDependent<const N: [u8; N]>;

--- a/src/test/ui/const-generics/diagnostics.stderr
+++ b/src/test/ui/const-generics/diagnostics.stderr
@@ -31,12 +31,9 @@ error[E0747]: type provided when a constant was expected
   --> $DIR/diagnostics.rs:12:19
    |
 LL | impl<N> Foo for B<N> {}
-   |                   ^
-   |
-help: consider changing this type parameter to be a `const` generic
-   |
-LL | impl<const N: u8> Foo for B<N> {}
-   |      ^^^^^^^^^^^
+   |      -            ^
+   |      |
+   |      help: consider using a const parameter instead: `const N: u8`
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/diagnostics.rs:16:32

--- a/src/test/ui/const-generics/different_byref.min.stderr
+++ b/src/test/ui/const-generics/different_byref.min.stderr
@@ -1,4 +1,4 @@
-error: `[usize; 1]` is forbidden as the type of a const generic parameter
+error: `[usize; 1]` is forbidden as the type of a const parameter
   --> $DIR/different_byref.rs:7:23
    |
 LL | struct Const<const V: [usize; 1]> {}

--- a/src/test/ui/const-generics/fn-const-param-call.full.stderr
+++ b/src/test/ui/const-generics/fn-const-param-call.full.stderr
@@ -1,10 +1,10 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/fn-const-param-call.rs:11:25
    |
 LL | struct Wrapper<const F: fn() -> u32>;
    |                         ^^^^^^^^^^^
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/fn-const-param-call.rs:13:15
    |
 LL | impl<const F: fn() -> u32> Wrapper<F> {

--- a/src/test/ui/const-generics/fn-const-param-call.min.stderr
+++ b/src/test/ui/const-generics/fn-const-param-call.min.stderr
@@ -1,10 +1,10 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/fn-const-param-call.rs:11:25
    |
 LL | struct Wrapper<const F: fn() -> u32>;
    |                         ^^^^^^^^^^^
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/fn-const-param-call.rs:13:15
    |
 LL | impl<const F: fn() -> u32> Wrapper<F> {

--- a/src/test/ui/const-generics/fn-const-param-call.rs
+++ b/src/test/ui/const-generics/fn-const-param-call.rs
@@ -8,10 +8,10 @@ fn function() -> u32 {
     17
 }
 
-struct Wrapper<const F: fn() -> u32>; //~ ERROR: using function pointers as const generic parameters
+struct Wrapper<const F: fn() -> u32>; //~ ERROR: using function pointers as const parameters
 
 impl<const F: fn() -> u32> Wrapper<F> {
-//~^ ERROR: using function pointers as const generic parameters
+//~^ ERROR: using function pointers as const parameters
     fn call() -> u32 {
         F()
     }

--- a/src/test/ui/const-generics/fn-const-param-infer.full.stderr
+++ b/src/test/ui/const-generics/fn-const-param-infer.full.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/fn-const-param-infer.rs:6:25
    |
 LL | struct Checked<const F: fn(usize) -> bool>;

--- a/src/test/ui/const-generics/fn-const-param-infer.min.stderr
+++ b/src/test/ui/const-generics/fn-const-param-infer.min.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/fn-const-param-infer.rs:6:25
    |
 LL | struct Checked<const F: fn(usize) -> bool>;

--- a/src/test/ui/const-generics/fn-const-param-infer.rs
+++ b/src/test/ui/const-generics/fn-const-param-infer.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Checked<const F: fn(usize) -> bool>;
-//~^ ERROR: using function pointers as const generic parameters
+//~^ ERROR: using function pointers as const parameters
 
 fn not_one(val: usize) -> bool { val != 1 }
 fn not_two(val: usize) -> bool { val != 2 }

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.min.stderr
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.min.stderr
@@ -1,4 +1,4 @@
-error: `A` is forbidden as the type of a const generic parameter
+error: `A` is forbidden as the type of a const parameter
   --> $DIR/forbid-non-structural_match-types.rs:9:19
    |
 LL | struct B<const X: A>; // ok
@@ -7,7 +7,7 @@ LL | struct B<const X: A>; // ok
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `C` is forbidden as the type of a const generic parameter
+error: `C` is forbidden as the type of a const parameter
   --> $DIR/forbid-non-structural_match-types.rs:14:19
    |
 LL | struct D<const X: C>;

--- a/src/test/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
+++ b/src/test/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
@@ -7,7 +7,7 @@ LL |     T: Trait<{std::intrinsics::type_name::<T>()}>
    = note: type parameters may not be used in const expressions
    = help: use `#![feature(const_generics)]` and `#![feature(const_evaluatable_checked)]` to allow generic const expressions
 
-error: `&'static str` is forbidden as the type of a const generic parameter
+error: `&'static str` is forbidden as the type of a const parameter
   --> $DIR/intrinsics-type_name-as-const-argument.rs:9:22
    |
 LL | trait Trait<const S: &'static str> {}

--- a/src/test/ui/const-generics/intrinsics-type_name-as-const-argument.rs
+++ b/src/test/ui/const-generics/intrinsics-type_name-as-const-argument.rs
@@ -7,7 +7,7 @@
 #![feature(const_type_name)]
 
 trait Trait<const S: &'static str> {}
-//[min]~^ ERROR `&'static str` is forbidden as the type of a const generic parameter
+//[min]~^ ERROR `&'static str` is forbidden as the type of a const parameter
 
 struct Bug<T>
 where

--- a/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.min.stderr
+++ b/src/test/ui/const-generics/issue-66596-impl-trait-for-str-const-arg.min.stderr
@@ -1,4 +1,4 @@
-error: `&'static str` is forbidden as the type of a const generic parameter
+error: `&'static str` is forbidden as the type of a const parameter
   --> $DIR/issue-66596-impl-trait-for-str-const-arg.rs:8:25
    |
 LL | trait Trait<const NAME: &'static str> {

--- a/src/test/ui/const-generics/issues/issue-56445-1.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-56445-1.full.stderr
@@ -7,7 +7,7 @@ LL | #![cfg_attr(full, feature(const_generics))]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
-error[E0771]: use of non-static lifetime `'a` in const generic
+error[E0771]: use of non-static lifetime `'a` in a const parameter type
   --> $DIR/issue-56445-1.rs:8:26
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);

--- a/src/test/ui/const-generics/issues/issue-56445-1.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-56445-1.min.stderr
@@ -1,4 +1,4 @@
-error[E0771]: use of non-static lifetime `'a` in const generic
+error[E0771]: use of non-static lifetime `'a` in a const parameter type
   --> $DIR/issue-56445-1.rs:8:26
    |
 LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);

--- a/src/test/ui/const-generics/issues/issue-56445-1.rs
+++ b/src/test/ui/const-generics/issues/issue-56445-1.rs
@@ -6,6 +6,6 @@
 use std::marker::PhantomData;
 
 struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
-//~^ ERROR: use of non-static lifetime `'a` in const generic
+//~^ ERROR: use of non-static lifetime `'a` in a const parameter type
 
 impl Bug<'_, ""> {}

--- a/src/test/ui/const-generics/issues/issue-62579-no-match.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-62579-no-match.min.stderr
@@ -1,4 +1,4 @@
-error: `NoMatch` is forbidden as the type of a const generic parameter
+error: `NoMatch` is forbidden as the type of a const parameter
   --> $DIR/issue-62579-no-match.rs:9:17
    |
 LL | fn foo<const T: NoMatch>() -> bool {

--- a/src/test/ui/const-generics/issues/issue-62579-no-match.rs
+++ b/src/test/ui/const-generics/issues/issue-62579-no-match.rs
@@ -7,7 +7,7 @@
 struct NoMatch;
 
 fn foo<const T: NoMatch>() -> bool {
-    //[min]~^ ERROR `NoMatch` is forbidden as the type of a const generic parameter
+    //[min]~^ ERROR `NoMatch` is forbidden as the type of a const parameter
     true
 }
 

--- a/src/test/ui/const-generics/issues/issue-62878.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-62878.min.stderr
@@ -4,7 +4,7 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                      ^ the type must not depend on the parameter `N`
 
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/issue-62878.rs:5:33
    |
 LL | fn foo<const N: usize, const A: [u8; N]>() {}

--- a/src/test/ui/const-generics/issues/issue-62878.rs
+++ b/src/test/ui/const-generics/issues/issue-62878.rs
@@ -4,7 +4,7 @@
 
 fn foo<const N: usize, const A: [u8; N]>() {}
 //~^ ERROR the type of const parameters must not
-//[min]~| ERROR `[u8; _]` is forbidden as the type of a const generic parameter
+//[min]~| ERROR `[u8; _]` is forbidden as the type of a const parameter
 
 fn main() {
     foo::<_, {[1]}>();

--- a/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.min.stderr
@@ -1,4 +1,4 @@
-error: `&'static (dyn A + 'static)` is forbidden as the type of a const generic parameter
+error: `&'static (dyn A + 'static)` is forbidden as the type of a const parameter
   --> $DIR/issue-63322-forbid-dyn.rs:9:18
    |
 LL | fn test<const T: &'static dyn A>() {

--- a/src/test/ui/const-generics/issues/issue-68615-adt.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-68615-adt.min.stderr
@@ -1,4 +1,4 @@
-error: `[usize; 0]` is forbidden as the type of a const generic parameter
+error: `[usize; 0]` is forbidden as the type of a const parameter
   --> $DIR/issue-68615-adt.rs:6:23
    |
 LL | struct Const<const V: [usize; 0]> {}

--- a/src/test/ui/const-generics/issues/issue-68615-adt.rs
+++ b/src/test/ui/const-generics/issues/issue-68615-adt.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Const<const V: [usize; 0]> {}
-//[min]~^ ERROR `[usize; 0]` is forbidden as the type of a const generic parameter
+//[min]~^ ERROR `[usize; 0]` is forbidden as the type of a const parameter
 type MyConst = Const<{ [] }>;
 
 fn main() {

--- a/src/test/ui/const-generics/issues/issue-68615-array.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-68615-array.min.stderr
@@ -1,4 +1,4 @@
-error: `[usize; 0]` is forbidden as the type of a const generic parameter
+error: `[usize; 0]` is forbidden as the type of a const parameter
   --> $DIR/issue-68615-array.rs:6:21
    |
 LL | struct Foo<const V: [usize; 0] > {}

--- a/src/test/ui/const-generics/issues/issue-68615-array.rs
+++ b/src/test/ui/const-generics/issues/issue-68615-array.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 struct Foo<const V: [usize; 0] > {}
-//[min]~^ ERROR `[usize; 0]` is forbidden as the type of a const generic parameter
+//[min]~^ ERROR `[usize; 0]` is forbidden as the type of a const parameter
 
 type MyFoo = Foo<{ [] }>;
 

--- a/src/test/ui/const-generics/issues/issue-71169.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-71169.min.stderr
@@ -4,7 +4,7 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
    |                                           ^^^ the type must not depend on the parameter `LEN`
 
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/issue-71169.rs:5:38
    |
 LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}

--- a/src/test/ui/const-generics/issues/issue-71169.rs
+++ b/src/test/ui/const-generics/issues/issue-71169.rs
@@ -4,7 +4,7 @@
 
 fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
 //~^ ERROR the type of const parameters must not
-//[min]~^^ ERROR `[u8; _]` is forbidden as the type of a const generic parameter
+//[min]~^^ ERROR `[u8; _]` is forbidden as the type of a const parameter
 fn main() {
     const DATA: [u8; 4] = *b"ABCD";
     foo::<4, DATA>();

--- a/src/test/ui/const-generics/issues/issue-71381.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-71381.full.stderr
@@ -10,13 +10,13 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71381.rs:14:61
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71381.rs:23:19
    |
 LL |         const FN: unsafe extern "C" fn(Args),

--- a/src/test/ui/const-generics/issues/issue-71381.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-71381.min.stderr
@@ -10,13 +10,13 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL |         const FN: unsafe extern "C" fn(Args),
    |                                        ^^^^ the type must not depend on the parameter `Args`
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71381.rs:14:61
    |
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71381.rs:23:19
    |
 LL |         const FN: unsafe extern "C" fn(Args),

--- a/src/test/ui/const-generics/issues/issue-71381.rs
+++ b/src/test/ui/const-generics/issues/issue-71381.rs
@@ -12,7 +12,7 @@ unsafe extern "C" fn pass(args: PassArg) {
 
 impl Test {
     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
-        //~^ ERROR: using function pointers as const generic parameters is forbidden
+        //~^ ERROR: using function pointers as const parameters is forbidden
         //~| ERROR: the type of const parameters must not depend on other generic parameters
         self.0 = Self::trampiline::<Args, IDX, FN> as _
     }
@@ -21,7 +21,7 @@ impl Test {
         Args: Sized,
         const IDX: usize,
         const FN: unsafe extern "C" fn(Args),
-        //~^ ERROR: using function pointers as const generic parameters is forbidden
+        //~^ ERROR: using function pointers as const parameters is forbidden
         //~| ERROR: the type of const parameters must not depend on other generic parameters
     >(
         args: Args,

--- a/src/test/ui/const-generics/issues/issue-71382.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-71382.full.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71382.rs:16:23
    |
 LL |     fn test<const FN: fn()>(&self) {

--- a/src/test/ui/const-generics/issues/issue-71382.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-71382.min.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71382.rs:16:23
    |
 LL |     fn test<const FN: fn()>(&self) {

--- a/src/test/ui/const-generics/issues/issue-71382.rs
+++ b/src/test/ui/const-generics/issues/issue-71382.rs
@@ -14,7 +14,7 @@ impl Test {
     }
 
     fn test<const FN: fn()>(&self) {
-        //~^ ERROR: using function pointers as const generic parameters is forbidden
+        //~^ ERROR: using function pointers as const parameters is forbidden
         FN();
     }
 }

--- a/src/test/ui/const-generics/issues/issue-71611.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-71611.full.stderr
@@ -4,7 +4,7 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71611.rs:5:21
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {

--- a/src/test/ui/const-generics/issues/issue-71611.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-71611.min.stderr
@@ -4,7 +4,7 @@ error[E0770]: the type of const parameters must not depend on other generic para
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                               ^ the type must not depend on the parameter `A`
 
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71611.rs:5:21
    |
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {

--- a/src/test/ui/const-generics/issues/issue-71611.rs
+++ b/src/test/ui/const-generics/issues/issue-71611.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 fn func<A, const F: fn(inner: A)>(outer: A) {
-    //~^ ERROR: using function pointers as const generic parameters is forbidden
+    //~^ ERROR: using function pointers as const parameters is forbidden
     //~| ERROR: the type of const parameters must not depend on other generic parameters
     F(outer);
 }

--- a/src/test/ui/const-generics/issues/issue-72352.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-72352.full.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-72352.rs:7:42
    |
 LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {

--- a/src/test/ui/const-generics/issues/issue-72352.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-72352.min.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-72352.rs:7:42
    |
 LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {

--- a/src/test/ui/const-generics/issues/issue-72352.rs
+++ b/src/test/ui/const-generics/issues/issue-72352.rs
@@ -5,7 +5,7 @@
 use std::ffi::{CStr, CString};
 
 unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const i8) -> usize {
-    //~^ ERROR: using function pointers as const generic parameters is forbidden
+    //~^ ERROR: using function pointers as const parameters is forbidden
     F(CStr::from_ptr(ptr))
 }
 

--- a/src/test/ui/const-generics/issues/issue-73491.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-73491.min.stderr
@@ -1,4 +1,4 @@
-error: `[u32; _]` is forbidden as the type of a const generic parameter
+error: `[u32; _]` is forbidden as the type of a const parameter
   --> $DIR/issue-73491.rs:8:19
    |
 LL | fn hoge<const IN: [u32; LEN]>() {}

--- a/src/test/ui/const-generics/issues/issue-73491.rs
+++ b/src/test/ui/const-generics/issues/issue-73491.rs
@@ -6,6 +6,6 @@
 const LEN: usize = 1024;
 
 fn hoge<const IN: [u32; LEN]>() {}
-//[min]~^ ERROR `[u32; _]` is forbidden as the type of a const generic parameter
+//[min]~^ ERROR `[u32; _]` is forbidden as the type of a const parameter
 
 fn main() {}

--- a/src/test/ui/const-generics/issues/issue-73508.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-73508.full.stderr
@@ -1,4 +1,4 @@
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/issue-73508.rs:5:33
    |
 LL | pub const fn func_name<const X: *const u32>() {}

--- a/src/test/ui/const-generics/issues/issue-73508.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-73508.min.stderr
@@ -1,4 +1,4 @@
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/issue-73508.rs:5:33
    |
 LL | pub const fn func_name<const X: *const u32>() {}

--- a/src/test/ui/const-generics/issues/issue-74101.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-74101.min.stderr
@@ -1,4 +1,4 @@
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/issue-74101.rs:6:18
    |
 LL | fn test<const N: [u8; 1 + 2]>() {}
@@ -7,7 +7,7 @@ LL | fn test<const N: [u8; 1 + 2]>() {}
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/issue-74101.rs:9:21
    |
 LL | struct Foo<const N: [u8; 1 + 2]>;

--- a/src/test/ui/const-generics/issues/issue-74101.rs
+++ b/src/test/ui/const-generics/issues/issue-74101.rs
@@ -4,9 +4,9 @@
 #![cfg_attr(full, allow(incomplete_features))]
 
 fn test<const N: [u8; 1 + 2]>() {}
-//[min]~^ ERROR `[u8; _]` is forbidden as the type of a const generic parameter
+//[min]~^ ERROR `[u8; _]` is forbidden as the type of a const parameter
 
 struct Foo<const N: [u8; 1 + 2]>;
-//[min]~^ ERROR `[u8; _]` is forbidden as the type of a const generic parameter
+//[min]~^ ERROR `[u8; _]` is forbidden as the type of a const parameter
 
 fn main() {}

--- a/src/test/ui/const-generics/issues/issue-74255.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-74255.min.stderr
@@ -1,4 +1,4 @@
-error: `IceEnum` is forbidden as the type of a const generic parameter
+error: `IceEnum` is forbidden as the type of a const parameter
   --> $DIR/issue-74255.rs:14:31
    |
 LL |     fn ice_struct_fn<const I: IceEnum>() {}

--- a/src/test/ui/const-generics/issues/issue-74255.rs
+++ b/src/test/ui/const-generics/issues/issue-74255.rs
@@ -12,7 +12,7 @@ struct IceStruct;
 
 impl IceStruct {
     fn ice_struct_fn<const I: IceEnum>() {}
-    //[min]~^ ERROR `IceEnum` is forbidden as the type of a const generic parameter
+    //[min]~^ ERROR `IceEnum` is forbidden as the type of a const parameter
 }
 
 fn main() {

--- a/src/test/ui/const-generics/issues/issue-74950.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-74950.min.stderr
@@ -1,4 +1,4 @@
-error: `Inner` is forbidden as the type of a const generic parameter
+error: `Inner` is forbidden as the type of a const parameter
   --> $DIR/issue-74950.rs:17:23
    |
 LL | struct Outer<const I: Inner>;
@@ -7,7 +7,7 @@ LL | struct Outer<const I: Inner>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `Inner` is forbidden as the type of a const generic parameter
+error: `Inner` is forbidden as the type of a const parameter
   --> $DIR/issue-74950.rs:17:23
    |
 LL | struct Outer<const I: Inner>;
@@ -16,7 +16,7 @@ LL | struct Outer<const I: Inner>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `Inner` is forbidden as the type of a const generic parameter
+error: `Inner` is forbidden as the type of a const parameter
   --> $DIR/issue-74950.rs:17:23
    |
 LL | struct Outer<const I: Inner>;
@@ -25,7 +25,7 @@ LL | struct Outer<const I: Inner>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `Inner` is forbidden as the type of a const generic parameter
+error: `Inner` is forbidden as the type of a const parameter
   --> $DIR/issue-74950.rs:17:23
    |
 LL | struct Outer<const I: Inner>;
@@ -34,7 +34,7 @@ LL | struct Outer<const I: Inner>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `Inner` is forbidden as the type of a const generic parameter
+error: `Inner` is forbidden as the type of a const parameter
   --> $DIR/issue-74950.rs:17:23
    |
 LL | struct Outer<const I: Inner>;

--- a/src/test/ui/const-generics/issues/issue-75047.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-75047.min.stderr
@@ -1,4 +1,4 @@
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/issue-75047.rs:14:21
    |
 LL | struct Foo<const N: [u8; Bar::<u32>::value()]>;

--- a/src/test/ui/const-generics/issues/issue-75047.rs
+++ b/src/test/ui/const-generics/issues/issue-75047.rs
@@ -12,6 +12,6 @@ impl<T> Bar<T> {
 }
 
 struct Foo<const N: [u8; Bar::<u32>::value()]>;
-//[min]~^ ERROR `[u8; _]` is forbidden as the type of a const generic parameter
+//[min]~^ ERROR `[u8; _]` is forbidden as the type of a const parameter
 
 fn main() {}

--- a/src/test/ui/const-generics/macro_rules-braces.full.stderr
+++ b/src/test/ui/const-generics/macro_rules-braces.full.stderr
@@ -1,4 +1,4 @@
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/macro_rules-braces.rs:48:17
    |
 LL |     let _: baz!(m::P);
@@ -9,7 +9,7 @@ help: enclose the `const` expression in braces
 LL |     let _: baz!({ m::P });
    |                 ^      ^
 
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/macro_rules-braces.rs:68:17
    |
 LL |     let _: baz!(10 + 7);

--- a/src/test/ui/const-generics/macro_rules-braces.min.stderr
+++ b/src/test/ui/const-generics/macro_rules-braces.min.stderr
@@ -1,4 +1,4 @@
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/macro_rules-braces.rs:48:17
    |
 LL |     let _: baz!(m::P);
@@ -9,7 +9,7 @@ help: enclose the `const` expression in braces
 LL |     let _: baz!({ m::P });
    |                 ^      ^
 
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/macro_rules-braces.rs:68:17
    |
 LL |     let _: baz!(10 + 7);

--- a/src/test/ui/const-generics/min_const_generics/complex-types.stderr
+++ b/src/test/ui/const-generics/min_const_generics/complex-types.stderr
@@ -1,4 +1,4 @@
-error: `[u8; 0]` is forbidden as the type of a const generic parameter
+error: `[u8; 0]` is forbidden as the type of a const parameter
   --> $DIR/complex-types.rs:3:21
    |
 LL | struct Foo<const N: [u8; 0]>;
@@ -7,7 +7,7 @@ LL | struct Foo<const N: [u8; 0]>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `()` is forbidden as the type of a const generic parameter
+error: `()` is forbidden as the type of a const parameter
   --> $DIR/complex-types.rs:6:21
    |
 LL | struct Bar<const N: ()>;
@@ -16,7 +16,7 @@ LL | struct Bar<const N: ()>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `No` is forbidden as the type of a const generic parameter
+error: `No` is forbidden as the type of a const parameter
   --> $DIR/complex-types.rs:11:21
    |
 LL | struct Fez<const N: No>;
@@ -25,7 +25,7 @@ LL | struct Fez<const N: No>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static u8` is forbidden as the type of a const generic parameter
+error: `&'static u8` is forbidden as the type of a const parameter
   --> $DIR/complex-types.rs:14:21
    |
 LL | struct Faz<const N: &'static u8>;
@@ -34,7 +34,7 @@ LL | struct Faz<const N: &'static u8>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `!` is forbidden as the type of a const generic parameter
+error: `!` is forbidden as the type of a const parameter
   --> $DIR/complex-types.rs:17:21
    |
 LL | struct Fiz<const N: !>;
@@ -43,7 +43,7 @@ LL | struct Fiz<const N: !>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `()` is forbidden as the type of a const generic parameter
+error: `()` is forbidden as the type of a const parameter
   --> $DIR/complex-types.rs:20:19
    |
 LL | enum Goo<const N: ()> { A, B }
@@ -52,7 +52,7 @@ LL | enum Goo<const N: ()> { A, B }
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `()` is forbidden as the type of a const generic parameter
+error: `()` is forbidden as the type of a const parameter
   --> $DIR/complex-types.rs:23:20
    |
 LL | union Boo<const N: ()> { a: () }

--- a/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
+++ b/src/test/ui/const-generics/min_const_generics/const-expression-suggest-missing-braces.stderr
@@ -4,12 +4,12 @@ error: expected one of `,` or `>`, found `3`
 LL |     foo::<BAR + 3>();
    |                 ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ BAR + 3 }>();
    |           ^         ^
 
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/const-expression-suggest-missing-braces.rs:19:11
    |
 LL |     foo::<3 + 3>();
@@ -26,7 +26,7 @@ error: expected one of `,` or `>`, found `-`
 LL |     foo::<BAR - 3>();
    |               ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ BAR - 3 }>();
    |           ^         ^
@@ -37,12 +37,12 @@ error: expected one of `,` or `>`, found `-`
 LL |     foo::<BAR - BAR>();
    |               ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ BAR - BAR }>();
    |           ^           ^
 
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/const-expression-suggest-missing-braces.rs:28:11
    |
 LL |     foo::<100 - BAR>();
@@ -59,7 +59,7 @@ error: expected one of `,` or `>`, found `(`
 LL |     foo::<bar<i32>()>();
    |                   ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ bar<i32>() }>();
    |           ^            ^
@@ -70,7 +70,7 @@ error: expected one of `,` or `>`, found `(`
 LL |     foo::<bar::<i32>()>();
    |                     ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ bar::<i32>() }>();
    |           ^              ^
@@ -81,7 +81,7 @@ error: expected one of `,` or `>`, found `(`
 LL |     foo::<bar::<i32>() + BAR>();
    |                     ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ bar::<i32>() + BAR }>();
    |           ^                    ^
@@ -92,7 +92,7 @@ error: expected one of `,` or `>`, found `(`
 LL |     foo::<bar::<i32>() - BAR>();
    |                     ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ bar::<i32>() - BAR }>();
    |           ^                    ^
@@ -103,7 +103,7 @@ error: expected one of `,` or `>`, found `-`
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ BAR - bar::<i32>() }>();
    |           ^                    ^
@@ -114,7 +114,7 @@ error: expected one of `,` or `>`, found `-`
 LL |     foo::<BAR - bar::<i32>()>();
    |               ^ expected one of `,` or `>`
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |     foo::<{ BAR - bar::<i32>() }>();
    |           ^                    ^

--- a/src/test/ui/const-generics/min_const_generics/default_trait_param.rs
+++ b/src/test/ui/const-generics/min_const_generics/default_trait_param.rs
@@ -1,4 +1,4 @@
 trait Foo<const KIND: bool = true> {}
-//~^ ERROR default values for const generic parameters are experimental
+//~^ ERROR default values for const parameters are experimental
 
 fn main() {}

--- a/src/test/ui/const-generics/min_const_generics/default_trait_param.stderr
+++ b/src/test/ui/const-generics/min_const_generics/default_trait_param.stderr
@@ -1,4 +1,4 @@
-error[E0658]: default values for const generic parameters are experimental
+error[E0658]: default values for const parameters are experimental
   --> $DIR/default_trait_param.rs:1:28
    |
 LL | trait Foo<const KIND: bool = true> {}

--- a/src/test/ui/const-generics/min_const_generics/static-reference-array-const-param.rs
+++ b/src/test/ui/const-generics/min_const_generics/static-reference-array-const-param.rs
@@ -1,5 +1,5 @@
 fn a<const X: &'static [u32]>() {}
-//~^ ERROR `&'static [u32]` is forbidden as the type of a const generic parameter
+//~^ ERROR `&'static [u32]` is forbidden as the type of a const parameter
 
 fn main() {
     a::<{&[]}>();

--- a/src/test/ui/const-generics/min_const_generics/static-reference-array-const-param.stderr
+++ b/src/test/ui/const-generics/min_const_generics/static-reference-array-const-param.stderr
@@ -1,4 +1,4 @@
-error: `&'static [u32]` is forbidden as the type of a const generic parameter
+error: `&'static [u32]` is forbidden as the type of a const parameter
   --> $DIR/static-reference-array-const-param.rs:1:15
    |
 LL | fn a<const X: &'static [u32]>() {}

--- a/src/test/ui/const-generics/min_const_generics/transmute-const-param-static-reference.rs
+++ b/src/test/ui/const-generics/min_const_generics/transmute-const-param-static-reference.rs
@@ -1,5 +1,5 @@
 struct Const<const P: &'static ()>;
-//~^ ERROR `&'static ()` is forbidden as the type of a const generic parameter
+//~^ ERROR `&'static ()` is forbidden as the type of a const parameter
 
 fn main() {
     const A: &'static () = unsafe {

--- a/src/test/ui/const-generics/min_const_generics/transmute-const-param-static-reference.stderr
+++ b/src/test/ui/const-generics/min_const_generics/transmute-const-param-static-reference.stderr
@@ -1,4 +1,4 @@
-error: `&'static ()` is forbidden as the type of a const generic parameter
+error: `&'static ()` is forbidden as the type of a const parameter
   --> $DIR/transmute-const-param-static-reference.rs:1:23
    |
 LL | struct Const<const P: &'static ()>;

--- a/src/test/ui/const-generics/nested-type.min.stderr
+++ b/src/test/ui/const-generics/nested-type.min.stderr
@@ -1,4 +1,4 @@
-error: `[u8; _]` is forbidden as the type of a const generic parameter
+error: `[u8; _]` is forbidden as the type of a const parameter
   --> $DIR/nested-type.rs:6:21
    |
 LL |   struct Foo<const N: [u8; {

--- a/src/test/ui/const-generics/raw-ptr-const-param-deref.full.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param-deref.full.stderr
@@ -1,10 +1,10 @@
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:9:23
    |
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
 
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:11:15
    |
 LL | impl<const P: *const u32> Const<P> {

--- a/src/test/ui/const-generics/raw-ptr-const-param-deref.min.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param-deref.min.stderr
@@ -1,10 +1,10 @@
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:9:23
    |
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
 
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:11:15
    |
 LL | impl<const P: *const u32> Const<P> {

--- a/src/test/ui/const-generics/raw-ptr-const-param-deref.rs
+++ b/src/test/ui/const-generics/raw-ptr-const-param-deref.rs
@@ -6,9 +6,9 @@
 
 const A: u32 = 3;
 
-struct Const<const P: *const u32>; //~ ERROR: using raw pointers as const generic parameters
+struct Const<const P: *const u32>; //~ ERROR: using raw pointers as const parameters
 
-impl<const P: *const u32> Const<P> { //~ ERROR: using raw pointers as const generic parameters
+impl<const P: *const u32> Const<P> { //~ ERROR: using raw pointers as const parameters
     fn get() -> u32 {
         unsafe {
             *P

--- a/src/test/ui/const-generics/raw-ptr-const-param.full.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param.full.stderr
@@ -1,4 +1,4 @@
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/raw-ptr-const-param.rs:6:23
    |
 LL | struct Const<const P: *const u32>;

--- a/src/test/ui/const-generics/raw-ptr-const-param.min.stderr
+++ b/src/test/ui/const-generics/raw-ptr-const-param.min.stderr
@@ -1,4 +1,4 @@
-error: using raw pointers as const generic parameters is forbidden
+error: using raw pointers as const parameters is forbidden
   --> $DIR/raw-ptr-const-param.rs:6:23
    |
 LL | struct Const<const P: *const u32>;

--- a/src/test/ui/const-generics/raw-ptr-const-param.rs
+++ b/src/test/ui/const-generics/raw-ptr-const-param.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(full, feature(const_generics))]
 #![cfg_attr(full, allow(incomplete_features))]
 
-struct Const<const P: *const u32>; //~ ERROR: using raw pointers as const generic parameters
+struct Const<const P: *const u32>; //~ ERROR: using raw pointers as const parameters
 
 fn main() {
     let _: Const<{ 15 as *const _ }> = Const::<{ 10 as *const _ }>;

--- a/src/test/ui/const-generics/slice-const-param-mismatch.min.stderr
+++ b/src/test/ui/const-generics/slice-const-param-mismatch.min.stderr
@@ -1,4 +1,4 @@
-error: `&'static str` is forbidden as the type of a const generic parameter
+error: `&'static str` is forbidden as the type of a const parameter
   --> $DIR/slice-const-param-mismatch.rs:7:29
    |
 LL | struct ConstString<const T: &'static str>;
@@ -7,7 +7,7 @@ LL | struct ConstString<const T: &'static str>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static [u8]` is forbidden as the type of a const generic parameter
+error: `&'static [u8]` is forbidden as the type of a const parameter
   --> $DIR/slice-const-param-mismatch.rs:9:28
    |
 LL | struct ConstBytes<const T: &'static [u8]>;

--- a/src/test/ui/const-generics/slice-const-param.min.stderr
+++ b/src/test/ui/const-generics/slice-const-param.min.stderr
@@ -1,4 +1,4 @@
-error: `&'static str` is forbidden as the type of a const generic parameter
+error: `&'static str` is forbidden as the type of a const parameter
   --> $DIR/slice-const-param.rs:7:40
    |
 LL | pub fn function_with_str<const STRING: &'static str>() -> &'static str {
@@ -7,7 +7,7 @@ LL | pub fn function_with_str<const STRING: &'static str>() -> &'static str {
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static [u8]` is forbidden as the type of a const generic parameter
+error: `&'static [u8]` is forbidden as the type of a const parameter
   --> $DIR/slice-const-param.rs:12:41
    |
 LL | pub fn function_with_bytes<const BYTES: &'static [u8]>() -> &'static [u8] {

--- a/src/test/ui/const-generics/std/const-generics-range.min.stderr
+++ b/src/test/ui/const-generics/std/const-generics-range.min.stderr
@@ -1,4 +1,4 @@
-error: `std::ops::Range<usize>` is forbidden as the type of a const generic parameter
+error: `std::ops::Range<usize>` is forbidden as the type of a const parameter
   --> $DIR/const-generics-range.rs:7:24
    |
 LL | struct _Range<const R: std::ops::Range<usize>>;
@@ -7,7 +7,7 @@ LL | struct _Range<const R: std::ops::Range<usize>>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `RangeFrom<usize>` is forbidden as the type of a const generic parameter
+error: `RangeFrom<usize>` is forbidden as the type of a const parameter
   --> $DIR/const-generics-range.rs:12:28
    |
 LL | struct _RangeFrom<const R: std::ops::RangeFrom<usize>>;
@@ -16,7 +16,7 @@ LL | struct _RangeFrom<const R: std::ops::RangeFrom<usize>>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `RangeFull` is forbidden as the type of a const generic parameter
+error: `RangeFull` is forbidden as the type of a const parameter
   --> $DIR/const-generics-range.rs:17:28
    |
 LL | struct _RangeFull<const R: std::ops::RangeFull>;
@@ -25,7 +25,7 @@ LL | struct _RangeFull<const R: std::ops::RangeFull>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `RangeInclusive<usize>` is forbidden as the type of a const generic parameter
+error: `RangeInclusive<usize>` is forbidden as the type of a const parameter
   --> $DIR/const-generics-range.rs:23:33
    |
 LL | struct _RangeInclusive<const R: std::ops::RangeInclusive<usize>>;
@@ -34,7 +34,7 @@ LL | struct _RangeInclusive<const R: std::ops::RangeInclusive<usize>>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `RangeTo<usize>` is forbidden as the type of a const generic parameter
+error: `RangeTo<usize>` is forbidden as the type of a const parameter
   --> $DIR/const-generics-range.rs:28:26
    |
 LL | struct _RangeTo<const R: std::ops::RangeTo<usize>>;
@@ -43,7 +43,7 @@ LL | struct _RangeTo<const R: std::ops::RangeTo<usize>>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `RangeToInclusive<usize>` is forbidden as the type of a const generic parameter
+error: `RangeToInclusive<usize>` is forbidden as the type of a const parameter
   --> $DIR/const-generics-range.rs:33:35
    |
 LL | struct _RangeToInclusive<const R: std::ops::RangeToInclusive<usize>>;

--- a/src/test/ui/const-generics/type-dependent/issue-71348.min.stderr
+++ b/src/test/ui/const-generics/type-dependent/issue-71348.min.stderr
@@ -1,4 +1,4 @@
-error: `&'static str` is forbidden as the type of a const generic parameter
+error: `&'static str` is forbidden as the type of a const parameter
   --> $DIR/issue-71348.rs:10:24
    |
 LL | trait Get<'a, const N: &'static str> {
@@ -7,7 +7,7 @@ LL | trait Get<'a, const N: &'static str> {
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(const_generics)]`
 
-error: `&'static str` is forbidden as the type of a const generic parameter
+error: `&'static str` is forbidden as the type of a const parameter
   --> $DIR/issue-71348.rs:18:25
    |
 LL |     fn ask<'a, const N: &'static str>(&'a self) -> &'a <Self as Get<N>>::Target

--- a/src/test/ui/const-generics/type-dependent/issue-71348.rs
+++ b/src/test/ui/const-generics/type-dependent/issue-71348.rs
@@ -8,7 +8,7 @@ struct Foo {
 }
 
 trait Get<'a, const N: &'static str> {
-    //[min]~^ ERROR `&'static str` is forbidden as the type of a const generic parameter
+    //[min]~^ ERROR `&'static str` is forbidden as the type of a const parameter
     type Target: 'a;
 
     fn get(&'a self) -> &'a Self::Target;
@@ -16,7 +16,7 @@ trait Get<'a, const N: &'static str> {
 
 impl Foo {
     fn ask<'a, const N: &'static str>(&'a self) -> &'a <Self as Get<N>>::Target
-    //[min]~^ ERROR `&'static str` is forbidden as the type of a const generic parameter
+    //[min]~^ ERROR `&'static str` is forbidden as the type of a const parameter
     where
         Self: Get<'a, N>,
     {

--- a/src/test/ui/const-generics/type-dependent/issue-71382.full.stderr
+++ b/src/test/ui/const-generics/type-dependent/issue-71382.full.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71382.rs:16:23
    |
 LL |     fn test<const FN: fn() -> u8>(&self) -> u8 {

--- a/src/test/ui/const-generics/type-dependent/issue-71382.min.stderr
+++ b/src/test/ui/const-generics/type-dependent/issue-71382.min.stderr
@@ -1,4 +1,4 @@
-error: using function pointers as const generic parameters is forbidden
+error: using function pointers as const parameters is forbidden
   --> $DIR/issue-71382.rs:16:23
    |
 LL |     fn test<const FN: fn() -> u8>(&self) -> u8 {

--- a/src/test/ui/const-generics/type-dependent/issue-71382.rs
+++ b/src/test/ui/const-generics/type-dependent/issue-71382.rs
@@ -14,7 +14,7 @@ impl Test {
     }
 
     fn test<const FN: fn() -> u8>(&self) -> u8 {
-        //~^ ERROR using function pointers as const generic parameters is forbidden
+        //~^ ERROR using function pointers as const parameters is forbidden
         FN()
     }
 }

--- a/src/test/ui/error-codes/E0771.stderr
+++ b/src/test/ui/error-codes/E0771.stderr
@@ -7,7 +7,7 @@ LL | #![feature(const_generics)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
 
-error[E0771]: use of non-static lifetime `'a` in const generic
+error[E0771]: use of non-static lifetime `'a` in a const parameter type
   --> $DIR/E0771.rs:4:41
    |
 LL | fn function_with_str<'a, const STRING: &'a str>() {}

--- a/src/test/ui/feature-gates/feature-gate-const_generics.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_generics.rs
@@ -1,4 +1,4 @@
-fn foo<const X: ()>() {} //~ ERROR `()` is forbidden as the type of a const generic parameter
+fn foo<const X: ()>() {} //~ ERROR `()` is forbidden as the type of a const parameter
 
 struct Foo<const X: usize>([(); X]);
 

--- a/src/test/ui/feature-gates/feature-gate-const_generics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics.stderr
@@ -1,4 +1,4 @@
-error: `()` is forbidden as the type of a const generic parameter
+error: `()` is forbidden as the type of a const parameter
   --> $DIR/feature-gate-const_generics.rs:1:17
    |
 LL | fn foo<const X: ()>() {}

--- a/src/test/ui/feature-gates/feature-gate-const_generics_defaults.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_generics_defaults.rs
@@ -1,9 +1,9 @@
 #[cfg(FALSE)]
 struct A<const N: usize = 3>;
-//~^ ERROR default values for const generic parameters are experimental
+//~^ ERROR default values for const parameters are experimental
 
 #[cfg(FALSE)]
 fn foo<const B: bool = false>() {}
-//~^ ERROR default values for const generic parameters are experimental
+//~^ ERROR default values for const parameters are experimental
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-const_generics_defaults.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics_defaults.stderr
@@ -1,4 +1,4 @@
-error[E0658]: default values for const generic parameters are experimental
+error[E0658]: default values for const parameters are experimental
   --> $DIR/feature-gate-const_generics_defaults.rs:2:25
    |
 LL | struct A<const N: usize = 3>;
@@ -7,7 +7,7 @@ LL | struct A<const N: usize = 3>;
    = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
    = help: add `#![feature(const_generics_defaults)]` to the crate attributes to enable
 
-error[E0658]: default values for const generic parameters are experimental
+error[E0658]: default values for const parameters are experimental
   --> $DIR/feature-gate-const_generics_defaults.rs:6:22
    |
 LL | fn foo<const B: bool = false>() {}

--- a/src/test/ui/generic-associated-types/parse/trait-path-expressions.stderr
+++ b/src/test/ui/generic-associated-types/parse/trait-path-expressions.stderr
@@ -4,7 +4,7 @@ error: expected expression, found `)`
 LL |   fn f1<'a>(arg : Box<dyn X< 1 = 32 >>) {}
    |                              -        ^ expected expression
    |                              |
-   |                              while parsing a const generic argument starting here
+   |                              while parsing a const argument starting here
 
 error: expected one of `,`, `:`, or `>`, found `=`
   --> $DIR/trait-path-expressions.rs:19:36

--- a/src/test/ui/generic-associated-types/parse/trait-path-missing-gen_arg.stderr
+++ b/src/test/ui/generic-associated-types/parse/trait-path-missing-gen_arg.stderr
@@ -4,7 +4,7 @@ error: expected one of `>`, a const expression, lifetime, or type, found `:`
 LL |   fn f1<'a>(arg : Box<dyn X< : 32 >>) {}
    |                              ^ expected one of `>`, a const expression, lifetime, or type
    |
-help: expressions must be enclosed in braces to be used as const generic arguments
+help: expressions must be enclosed in braces to be used as const arguments
    |
 LL |   fn f1<'a>(arg : Box<{ dyn X< : 32 } >>) {}
    |                       ^             ^

--- a/src/test/ui/invalid/invalid-rustc_legacy_const_generics-arguments.stderr
+++ b/src/test/ui/invalid/invalid-rustc_legacy_const_generics-arguments.stderr
@@ -64,7 +64,7 @@ error: #[rustc_legacy_const_generics] functions must only have const generics
 LL | #[rustc_legacy_const_generics(0)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL | fn foo8<X>() {}
-   |         - non-const generic parameter
+   |         - not a const parameter
 
 error: attribute should be applied to a function
   --> $DIR/invalid-rustc_legacy_const_generics-arguments.rs:25:5

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -209,7 +209,7 @@ fn outside_if_and_while_expr() {
     //~| ERROR mismatched types
 }
 
-// Let's make sure that `let` inside const generic arguments are considered.
+// Let's make sure that `let` inside const arguments are considered.
 fn inside_const_generic_arguments() {
     struct A<const B: bool>;
     impl<const B: bool> A<{B}> { const O: u32 = 5; }
@@ -230,7 +230,7 @@ fn inside_const_generic_arguments() {
     // Below however, we would not have a block and so an implementation might go
     // from visiting expressions to types without banning `let` expressions down the tree.
     // This tests ensures that we are not caught by surprise should the parser
-    // admit non-IDENT expressions in const generic arguments.
+    // admit non-IDENT expressions in const arguments.
 
     if A::<
         true && let 1 = 1

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1,4 +1,4 @@
-error: expressions must be enclosed in braces to be used as const generic arguments
+error: expressions must be enclosed in braces to be used as const arguments
   --> $DIR/disallowed-positions.rs:236:9
    |
 LL |         true && let 1 = 1


### PR DESCRIPTION
cc https://rust-lang.zulipchat.com/#narrow/stream/260443-project-const-generics/topic/terminology.3A.20const.20.28generic.29.20parameter

cc https://github.com/rust-lang/reference/pull/1014
