### PR TITLE
Format fat pointers as (addr, meta) for better insight.

### DIFF
--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -1,6 +1,6 @@
 #![unstable(feature = "ptr_metadata", issue = "81513")]
 
-use crate::fmt;
+use crate::fmt::{self, Debug};
 use crate::hash::{Hash, Hasher};
 
 /// Provides the pointer metadata type of any pointed-to type.
@@ -56,7 +56,7 @@ pub trait Pointee {
     // NOTE: Keep trait bounds in `static_assert_expected_bounds_for_metadata`
     // in `library/core/src/ptr/metadata.rs`
     // in sync with those here:
-    type Metadata: Copy + Send + Sync + Ord + Hash + Unpin;
+    type Metadata: Copy + Send + Sync + Ord + Hash + Unpin + Debug;
 }
 
 /// Pointers to types implementing this trait alias are “thin”.

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -500,7 +500,7 @@ fn ptr_metadata_bounds() {
     fn static_assert_expected_bounds_for_metadata<Meta>()
     where
         // Keep this in sync with the associated type in `library/core/src/ptr/metadata.rs`
-        Meta: Copy + Send + Sync + Ord + std::hash::Hash + Unpin,
+        Meta: Copy + Send + Sync + Ord + std::hash::Hash + Unpin + Debug,
     {
     }
 }


### PR DESCRIPTION
Now that we have `ptr::metadata()` I thought it would be nice to be able to see the meta part of fat ptrs in debug prints.
In past I'd run into a couple of situations where I needed to see the second part as well and this ~~is curretly kind of cumbersome / requires `unsafe` transmutes IIRC~~ Actually, with `metadata()` this is a lot easier now, but still, having this in `Debug` is IMO better...

cc  #81513 - I've added the `Debug` constrain to `Pointee::Metadata` (impls already implement it).

Not sure if there's a backcompat concern?
I really do hope people don't rely on debug prints of pointers, but one never knows...

Let me know what you think :slightly_smiling_face: 
