### PR TITLE
Remove FIXME about supporting beta for `download-rustc`

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -664,7 +664,7 @@ class RustBuild(object):
         if self.verbose:
             print("using downloaded stage1 artifacts from CI (commit {})".format(commit))
         self.rustc_commit = commit
-        # FIXME: support downloading artifacts from the beta channel
+        # NOTE: CI artifacts are stored under nightly even when this is run from the beta branch
         self.download_toolchain(False, "nightly")
 
     def rustc_stamp(self, stage0):


### PR DESCRIPTION
It already works as long as `dev: 1` isn't set. See https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Where.20are.20commit.20artifacts.20for.20beta.20stored.3F.