### PR TITLE
Add doc aliases for BinaryHeap pushpop and heapify implementations

### DIFF
--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -248,6 +248,8 @@ use super::SpecExtend;
 /// [peek\_mut]: BinaryHeap::peek_mut
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "BinaryHeap")]
+#[doc(alias = "priority queue")]
+#[doc(alias = "priority_queue")]
 pub struct BinaryHeap<T> {
     data: Vec<T>,
 }

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -405,6 +405,8 @@ impl<T: Ord> BinaryHeap<T> {
     /// If the item is modified then the worst case time complexity is *O*(log(*n*)),
     /// otherwise it's *O*(1).
     #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
+    #[doc(alias = "pushpop")]
+    #[doc(alias = "push_pop")]
     pub fn peek_mut(&mut self) -> Option<PeekMut<'_, T>> {
         if self.is_empty() { None } else { Some(PeekMut { heap: self, sift: false }) }
     }
@@ -1457,6 +1459,7 @@ impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
     /// Converts a `Vec<T>` into a `BinaryHeap<T>`.
     ///
     /// This conversion happens in-place, and has *O*(*n*) time complexity.
+    #[doc(alias = "heapify")]
     fn from(vec: Vec<T>) -> BinaryHeap<T> {
         let mut heap = BinaryHeap { data: vec };
         heap.rebuild();


### PR DESCRIPTION
BinaryHeap implements some common heap operations, like `heapify` and `pushpop` with non-standard names like `From<Vec<T>>` and `peek_mut` + `DerefMut`.

This PR follows up on rust-lang/rust#28147 and adds doc aliases to `From<Vec<T>>` as _heapify_ and `peek_mut` as _pushpop_ [0].

[0]: Based on its name in Python - https://docs.python.org/3/library/heapq.html#heapq.heappushpop

## Docs Screenshots

![image](https://user-images.githubusercontent.com/860434/117090830-4729c800-ad0e-11eb-925b-5dcdecac8a57.png)

![image](https://user-images.githubusercontent.com/860434/117090846-53158a00-ad0e-11eb-9be4-d6d3c3f341c5.png)
