### PR TITLE
Don't run sanity checks for `x.py setup`

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -444,8 +444,13 @@ impl Build {
 
         build.verbose("finding compilers");
         cc_detect::find(&mut build);
-        build.verbose("running sanity check");
-        sanity::check(&mut build);
+        // When running `setup`, the profile is about to change, so any requirements we have now may
+        // be different on the next invocation. Don't check for them until the next time x.py is
+        // run. This is ok because `setup` never runs any build commands, so it won't fail if commands are missing.
+        if !matches!(build.config.cmd, Subcommand::Setup { .. }) {
+            build.verbose("running sanity check");
+            sanity::check(&mut build);
+        }
 
         // If local-rust is the same major.minor as the current version, then force a
         // local-rebuild


### PR DESCRIPTION
These requirements change as soon as the command finishes running, and
`setup` doesn't build anything, so the check doesn't make sense.

Previously, `x.py setup` would give hard errors if `ninja` and `cmake`
were not installed, even if the new profile didn't require them.

Fixes https://github.com/rust-lang/rust/issues/84938.