### PR TITLE
rustdoc: Don't link to stable/beta docs for primitives

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -517,10 +517,9 @@ impl Item {
                                 Some(ExternalLocation::Remote(ref s)) => {
                                     format!("{}/std/", s.trim_end_matches('/'))
                                 }
-                                Some(ExternalLocation::Unknown) | None => format!(
-                                    "https://doc.rust-lang.org/{}/std/",
-                                    crate::doc_rust_lang_org_channel(),
-                                ),
+                                Some(ExternalLocation::Unknown) | None => {
+                                    "https://doc.rust-lang.org/nightly/std/".to_string()
+                                }
                             };
                             // This is a primitive so the url is done "by hand".
                             let tail = fragment.find('#').unwrap_or_else(|| fragment.len());


### PR DESCRIPTION
This has two issues:

1. The test suite is not set up for links that differ based on the
channel. This is not a giant deal; it's fixed by
https://github.com/jyn514/rust/commit/2a2126475d7cb6dbdddd684032f4f67638b1efd6.
2. It's inconsistent with non-primitive types, because libstd uses
`html_root_url = "rust-lang.org/nightly"`. Fixing this is non-trivial,
and the usefulness has also been called into question; see
https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Rustdoc.20unconditionally.20links.20to.20nightly.20libstd.20docs.

To avoid being inconsistent, this reverts linking to beta for now.

cc @pietroalbini, this should fix the test failure in https://github.com/rust-lang/rust/pull/84909#issuecomment-832028701 if you backport it.