### PR TITLE
Rollup of 13 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,151 @@
+Version 1.52.0 (2021-05-06)
+============================
+
+Language
+--------
+- [Added the `unsafe_op_in_unsafe_fn` lint, which checks whether the unsafe code
+  in an `unsafe fn` is wrapped in a `unsafe` block.][79208] This lint
+  is allowed by default, and may become a warning or hard error in a
+  future edition.
+- [You can now cast mutable references to arrays to a pointer of the same type as
+  the element.][81479]
+
+Compiler
+--------
+- [Upgraded the default LLVM to LLVM 12.][81451]
+
+Added tier 3\* support for the following targets.
+
+- [`s390x-unknown-linux-musl`][82166]
+- [`riscv32gc-unknown-linux-musl` & `riscv64gc-unknown-linux-musl`][82202]
+- [`powerpc-unknown-openbsd`][82733]
+
+\* Refer to Rust's [platform support page][platform-support-doc] for more
+information on Rust's tiered platform support.
+
+Libraries
+---------
+- [`OsString` now implements `Extend` and `FromIterator`.][82121]
+- [`cmp::Reverse` now has `#[repr(transparent)]` representation.][81879]
+- [`Arc<impl Error>` now implements `error::Error`.][80553]
+- [All integer division and remainder operations are now `const`.][80962]
+
+Stabilised APIs
+-------------
+- [`Arguments::as_str`]
+- [`char::MAX`]
+- [`char::REPLACEMENT_CHARACTER`]
+- [`char::UNICODE_VERSION`]
+- [`char::decode_utf16`]
+- [`char::from_digit`]
+- [`char::from_u32_unchecked`]
+- [`char::from_u32`]
+- [`slice::partition_point`]
+- [`str::rsplit_once`]
+- [`str::split_once`]
+
+The following previously stable APIs are now `const`.
+
+- [`char::len_utf8`]
+- [`char::len_utf16`]
+- [`char::to_ascii_uppercase`]
+- [`char::to_ascii_lowercase`]
+- [`char::eq_ignore_ascii_case`]
+- [`u8::to_ascii_uppercase`]
+- [`u8::to_ascii_lowercase`]
+- [`u8::eq_ignore_ascii_case`]
+
+Rustdoc
+-------
+- [Rustdoc lints are now treated as a tool lint, meaning that
+  lints are now prefixed with `rustdoc::` (e.g. `#[warn(rustdoc::non_autolinks)]`).][80527]
+  Using the old style is still allowed, and will become a warning in
+  a future release.
+- [Rustdoc now supports argument files.][82261]
+- [Rustdoc now generates smart punctuation for documentation.][79423]
+- [You can now use "task lists" in Rustdoc Markdown.][81766] E.g.
+  ```markdown
+  - [x] Complete
+  - [ ] Todo
+  ```
+
+Misc
+----
+- [You can now pass multiple filters to tests.][81356] E.g.
+  `cargo test -- foo bar` will run all tests that match `foo` and `bar`.
+- [Rustup now distributes PDB symbols for the `std` library on Windows,
+  allowing you to see `std` symbols when debugging.][82218]
+
+Internal Only
+-------------
+These changes provide no direct user facing benefits, but represent significant
+improvements to the internals and overall performance of rustc and
+related tools.
+
+- [Check the result cache before the DepGraph when ensuring queries][81855]
+- [Try fast_reject::simplify_type in coherence before doing full check][81744]
+- [Only store a LocalDefId in some HIR nodes][81611]
+- [Store HIR attributes in a side table][79519]
+
+Compatibility Notes
+-------------------
+- [Cargo build scripts are now forbidden from setting `RUSTC_BOOTSTRAP`.][cargo/9181]
+- [Removed support for the `x86_64-rumprun-netbsd` target.][82594]
+- [Deprecated the `x86_64-sun-solaris` target in favor of `x86_64-pc-solaris`.][82216]
+- [Rustdoc now only accepts `,`, ` `, and `\t` as delimiters for specifying
+  languages in code blocks.][78429]
+- [Rustc now catches more cases of `pub_use_of_private_extern_crate`][80763]
+- [Changes in how proc macros handle whitespace may lead to panics when used
+  with older `proc-macro-hack` versions. A `cargo update` should be sufficient to fix this in all cases.][84136]
+
+[84136]: https://github.com/rust-lang/rust/issues/84136
+[80763]: https://github.com/rust-lang/rust/pull/80763
+[82166]: https://github.com/rust-lang/rust/pull/82166
+[82121]: https://github.com/rust-lang/rust/pull/82121
+[81879]: https://github.com/rust-lang/rust/pull/81879
+[82261]: https://github.com/rust-lang/rust/pull/82261
+[82218]: https://github.com/rust-lang/rust/pull/82218
+[82216]: https://github.com/rust-lang/rust/pull/82216
+[82202]: https://github.com/rust-lang/rust/pull/82202
+[81855]: https://github.com/rust-lang/rust/pull/81855
+[81766]: https://github.com/rust-lang/rust/pull/81766
+[81744]: https://github.com/rust-lang/rust/pull/81744
+[81611]: https://github.com/rust-lang/rust/pull/81611
+[81479]: https://github.com/rust-lang/rust/pull/81479
+[81451]: https://github.com/rust-lang/rust/pull/81451
+[81356]: https://github.com/rust-lang/rust/pull/81356
+[80962]: https://github.com/rust-lang/rust/pull/80962
+[80553]: https://github.com/rust-lang/rust/pull/80553
+[80527]: https://github.com/rust-lang/rust/pull/80527
+[79519]: https://github.com/rust-lang/rust/pull/79519
+[79423]: https://github.com/rust-lang/rust/pull/79423
+[79208]: https://github.com/rust-lang/rust/pull/79208
+[78429]: https://github.com/rust-lang/rust/pull/78429
+[82733]: https://github.com/rust-lang/rust/pull/82733
+[82594]: https://github.com/rust-lang/rust/pull/82594
+[cargo/9181]: https://github.com/rust-lang/cargo/pull/9181
+[`char::MAX`]: https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.MAX
+[`char::REPLACEMENT_CHARACTER`]: https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.REPLACEMENT_CHARACTER
+[`char::UNICODE_VERSION`]: https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.UNICODE_VERSION
+[`char::decode_utf16`]: https://doc.rust-lang.org/std/primitive.char.html#method.decode_utf16
+[`char::from_u32`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_u32
+[`char::from_u32_unchecked`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_u32_unchecked
+[`char::from_digit`]: https://doc.rust-lang.org/std/primitive.char.html#method.from_digit
+[`Peekable::next_if`]: https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html#method.next_if
+[`Peekable::next_if_eq`]: https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html#method.next_if_eq
+[`Arguments::as_str`]: https://doc.rust-lang.org/stable/std/fmt/struct.Arguments.html#method.as_str
+[`str::split_once`]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.split_once
+[`str::rsplit_once`]: https://doc.rust-lang.org/stable/std/primitive.str.html#method.rsplit_once
+[`slice::partition_point`]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.partition_point
+[`char::len_utf8`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.len_utf8
+[`char::len_utf16`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.len_utf16
+[`char::to_ascii_uppercase`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.to_ascii_uppercase
+[`char::to_ascii_lowercase`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.to_ascii_lowercase
+[`char::eq_ignore_ascii_case`]: https://doc.rust-lang.org/stable/std/primitive.char.html#method.eq_ignore_ascii_case
+[`u8::to_ascii_uppercase`]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.to_ascii_uppercase
+[`u8::to_ascii_lowercase`]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.to_ascii_lowercase
+[`u8::eq_ignore_ascii_case`]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.eq_ignore_ascii_case
+
 Version 1.51.0 (2021-03-25)
 ============================
 

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -432,8 +432,6 @@ impl<'a> Linker for GccLinker<'a> {
         // insert it here.
         if self.sess.target.is_like_osx {
             self.linker_arg("-dead_strip");
-        } else if self.sess.target.is_like_solaris {
-            self.linker_arg("-zignore");
 
         // If we're building a dylib, we don't use --gc-sections because LLVM
         // has already done the best it can do, and we also don't want to
@@ -655,6 +653,10 @@ impl<'a> Linker for GccLinker<'a> {
     fn add_as_needed(&mut self) {
         if self.sess.target.linker_is_gnu {
             self.linker_arg("--as-needed");
+        } else if self.sess.target.is_like_solaris {
+            // -z ignore is the Solaris equivalent to the GNU ld --as-needed option
+            self.linker_arg("-z");
+            self.linker_arg("ignore");
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -171,7 +171,6 @@ impl fmt::Display for InvalidProgramInfo<'_> {
 #[derive(Debug, Copy, Clone, TyEncodable, TyDecodable, HashStable)]
 pub enum CheckInAllocMsg {
     MemoryAccessTest,
-    NullPointerTest,
     PointerArithmeticTest,
     InboundsTest,
 }
@@ -185,7 +184,6 @@ impl fmt::Display for CheckInAllocMsg {
             "{}",
             match *self {
                 CheckInAllocMsg::MemoryAccessTest => "memory access",
-                CheckInAllocMsg::NullPointerTest => "null pointer test",
                 CheckInAllocMsg::PointerArithmeticTest => "pointer arithmetic",
                 CheckInAllocMsg::InboundsTest => "inbounds test",
             }
@@ -308,9 +306,6 @@ impl fmt::Display for UndefinedBehaviorInfo<'_> {
                 ptr.alloc_id,
                 allocation_size.bytes()
             ),
-            DanglingIntPointer(_, CheckInAllocMsg::NullPointerTest) => {
-                write!(f, "null pointer is not allowed for this operation")
-            }
             DanglingIntPointer(i, msg) => {
                 write!(f, "{} failed: 0x{:x} is not a valid pointer", msg, i)
             }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -16,7 +16,7 @@ use rustc_middle::middle::privacy;
 use rustc_middle::ty::{self, DefIdTree, TyCtxt};
 use rustc_session::lint;
 
-use rustc_span::symbol::{sym, Symbol};
+use rustc_span::symbol::{sym, Ident, Symbol};
 
 // Any local node that may call something in its body block should be
 // explored. For example, if it's a live Node::Item that is a
@@ -580,7 +580,7 @@ impl DeadVisitor<'tcx> {
         &mut self,
         id: hir::HirId,
         span: rustc_span::Span,
-        name: Symbol,
+        name: Ident,
         participle: &str,
         extra_note: Option<ExtraNote>,
     ) {
@@ -589,7 +589,7 @@ impl DeadVisitor<'tcx> {
                 let def_id = self.tcx.hir().local_def_id(id);
                 let descr = self.tcx.def_kind(def_id).descr(def_id.to_def_id());
 
-                let prefixed = vec![(span, format!("_{}", name))];
+                let prefixed = vec![(name.span, format!("_{}", name))];
 
                 let mut diag =
                     lint.build(&format!("{} is never {}: `{}`", descr, participle, name));
@@ -602,11 +602,11 @@ impl DeadVisitor<'tcx> {
 
                 let mut note = format!(
                     "the leading underscore signals that this {} serves some other \
-                    purpose\neven if it isn't used in a way that we can detect.",
+                    purpose even if it isn't used in a way that we can detect.",
                     descr,
                 );
                 if matches!(extra_note, Some(ExtraNote::OtherPurposeExamples)) {
-                    note += " (e.g. for its effect\nwhen dropped or in foreign code)";
+                    note += " (e.g. for its effect when dropped or in foreign code)";
                 }
 
                 diag.note(&note);
@@ -661,7 +661,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
                 hir::ItemKind::Struct(..) => "constructed", // Issue #52325
                 _ => "used",
             };
-            self.warn_dead_code(item.hir_id(), span, item.ident.name, participle, None);
+            self.warn_dead_code(item.hir_id(), span, item.ident, participle, None);
         } else {
             // Only continue if we didn't warn
             intravisit::walk_item(self, item);
@@ -675,7 +675,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
         id: hir::HirId,
     ) {
         if self.should_warn_about_variant(&variant) {
-            self.warn_dead_code(variant.id, variant.span, variant.ident.name, "constructed", None);
+            self.warn_dead_code(variant.id, variant.span, variant.ident, "constructed", None);
         } else {
             intravisit::walk_variant(self, variant, g, id);
         }
@@ -683,7 +683,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
 
     fn visit_foreign_item(&mut self, fi: &'tcx hir::ForeignItem<'tcx>) {
         if self.should_warn_about_foreign_item(fi) {
-            self.warn_dead_code(fi.hir_id(), fi.span, fi.ident.name, "used", None);
+            self.warn_dead_code(fi.hir_id(), fi.span, fi.ident, "used", None);
         }
         intravisit::walk_foreign_item(self, fi);
     }
@@ -693,7 +693,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
             self.warn_dead_code(
                 field.hir_id,
                 field.span,
-                field.ident.name,
+                field.ident,
                 "read",
                 Some(ExtraNote::OtherPurposeExamples),
             );
@@ -708,7 +708,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
                     self.warn_dead_code(
                         impl_item.hir_id(),
                         impl_item.span,
-                        impl_item.ident.name,
+                        impl_item.ident,
                         "used",
                         None,
                     );
@@ -728,13 +728,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
                     } else {
                         impl_item.ident.span
                     };
-                    self.warn_dead_code(
-                        impl_item.hir_id(),
-                        span,
-                        impl_item.ident.name,
-                        "used",
-                        None,
-                    );
+                    self.warn_dead_code(impl_item.hir_id(), span, impl_item.ident, "used", None);
                 }
                 self.visit_nested_body(body_id)
             }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -508,6 +508,13 @@ fn find_live<'tcx>(
     symbol_visitor.live_symbols
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ExtraNote {
+    /// Use this to provide some examples in the diagnostic of potential other purposes for a value
+    /// or field that is dead code
+    OtherPurposeExamples,
+}
+
 struct DeadVisitor<'tcx> {
     tcx: TyCtxt<'tcx>,
     live_symbols: FxHashSet<hir::HirId>,
@@ -575,6 +582,7 @@ impl DeadVisitor<'tcx> {
         span: rustc_span::Span,
         name: Symbol,
         participle: &str,
+        extra_note: Option<ExtraNote>,
     ) {
         if !name.as_str().starts_with('_') {
             self.tcx.struct_span_lint_hir(lint::builtin::DEAD_CODE, id, span, |lint| {
@@ -585,19 +593,26 @@ impl DeadVisitor<'tcx> {
 
                 let mut diag =
                     lint.build(&format!("{} is never {}: `{}`", descr, participle, name));
+
                 diag.multipart_suggestion(
                     "if this is intentional, prefix it with an underscore",
                     prefixed,
                     Applicability::MachineApplicable,
-                )
-                .note(&format!(
-                    "The leading underscore signals to the reader that while the {} may not be {}\n\
-                    by any Rust code, it still serves some other purpose that isn't detected by rustc.\n\
-                    (e.g. some values are used for their effect when dropped or used in FFI code\n\
-                    exclusively through raw pointers)",
-                    descr, participle,
-                ));
+                );
+
+                let mut note = format!(
+                    "the leading underscore signals that this {} serves some other \
+                    purpose\neven if it isn't used in a way that we can detect.",
+                    descr,
+                );
+                if matches!(extra_note, Some(ExtraNote::OtherPurposeExamples)) {
+                    note += " (e.g. for its effect\nwhen dropped or in foreign code)";
+                }
+
+                diag.note(&note);
+
                 // Force the note we added to the front, before any other subdiagnostics
+                // added in lint.build(...)
                 diag.children.rotate_right(1);
 
                 diag.emit()
@@ -646,7 +661,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
                 hir::ItemKind::Struct(..) => "constructed", // Issue #52325
                 _ => "used",
             };
-            self.warn_dead_code(item.hir_id(), span, item.ident.name, participle);
+            self.warn_dead_code(item.hir_id(), span, item.ident.name, participle, None);
         } else {
             // Only continue if we didn't warn
             intravisit::walk_item(self, item);
@@ -660,7 +675,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
         id: hir::HirId,
     ) {
         if self.should_warn_about_variant(&variant) {
-            self.warn_dead_code(variant.id, variant.span, variant.ident.name, "constructed");
+            self.warn_dead_code(variant.id, variant.span, variant.ident.name, "constructed", None);
         } else {
             intravisit::walk_variant(self, variant, g, id);
         }
@@ -668,14 +683,20 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
 
     fn visit_foreign_item(&mut self, fi: &'tcx hir::ForeignItem<'tcx>) {
         if self.should_warn_about_foreign_item(fi) {
-            self.warn_dead_code(fi.hir_id(), fi.span, fi.ident.name, "used");
+            self.warn_dead_code(fi.hir_id(), fi.span, fi.ident.name, "used", None);
         }
         intravisit::walk_foreign_item(self, fi);
     }
 
     fn visit_field_def(&mut self, field: &'tcx hir::FieldDef<'tcx>) {
         if self.should_warn_about_field(&field) {
-            self.warn_dead_code(field.hir_id, field.span, field.ident.name, "read");
+            self.warn_dead_code(
+                field.hir_id,
+                field.span,
+                field.ident.name,
+                "read",
+                Some(ExtraNote::OtherPurposeExamples),
+            );
         }
         intravisit::walk_field_def(self, field);
     }
@@ -689,6 +710,7 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
                         impl_item.span,
                         impl_item.ident.name,
                         "used",
+                        None,
                     );
                 }
                 self.visit_nested_body(body_id)
@@ -706,7 +728,13 @@ impl Visitor<'tcx> for DeadVisitor<'tcx> {
                     } else {
                         impl_item.ident.span
                     };
-                    self.warn_dead_code(impl_item.hir_id(), span, impl_item.ident.name, "used");
+                    self.warn_dead_code(
+                        impl_item.hir_id(),
+                        span,
+                        impl_item.ident.name,
+                        "used",
+                        None,
+                    );
                 }
                 self.visit_nested_body(body_id)
             }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -3,6 +3,7 @@
 // from live codes are live, and everything else is dead.
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
@@ -579,7 +580,26 @@ impl DeadVisitor<'tcx> {
             self.tcx.struct_span_lint_hir(lint::builtin::DEAD_CODE, id, span, |lint| {
                 let def_id = self.tcx.hir().local_def_id(id);
                 let descr = self.tcx.def_kind(def_id).descr(def_id.to_def_id());
-                lint.build(&format!("{} is never {}: `{}`", descr, participle, name)).emit()
+
+                let prefixed = vec![(span, format!("_{}", name))];
+
+                let mut diag =
+                    lint.build(&format!("{} is never {}: `{}`", descr, participle, name));
+                diag.multipart_suggestion(
+                    "if this is intentional, prefix it with an underscore",
+                    prefixed,
+                    Applicability::MachineApplicable,
+                )
+                .note(&format!(
+                    "the leading underscore helps signal to the reader that the {} may still serve\n\
+                    a purpose even if it isn't used in a way that we can detect (e.g. the {}\nis \
+                    only used through FFI or used only for its effect when dropped)",
+                    descr, descr,
+                ));
+                // Force the note we added to the front, before any other subdiagnostics
+                diag.children.rotate_right(1);
+
+                diag.emit()
             });
         }
     }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -591,10 +591,11 @@ impl DeadVisitor<'tcx> {
                     Applicability::MachineApplicable,
                 )
                 .note(&format!(
-                    "the leading underscore helps signal to the reader that the {} may still serve\n\
-                    a purpose even if it isn't used in a way that we can detect (e.g. the {}\nis \
-                    only used through FFI or used only for its effect when dropped)",
-                    descr, descr,
+                    "The leading underscore signals to the reader that while the {} may not be {}\n\
+                    by any Rust code, it still serves some other purpose that isn't detected by rustc.\n\
+                    (e.g. some values are used for their effect when dropped or used in FFI code\n\
+                    exclusively through raw pointers)",
+                    descr, participle,
                 ));
                 // Force the note we added to the front, before any other subdiagnostics
                 diag.children.rotate_right(1);

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2332,17 +2332,17 @@ crate mod dep_tracking {
     }
 
     macro_rules! impl_dep_tracking_hash_via_hash {
-        ($t:ty) => {
+        ($($t:ty),+ $(,)?) => {$(
             impl DepTrackingHash for $t {
                 fn hash(&self, hasher: &mut DefaultHasher, _: ErrorOutputType) {
                     Hash::hash(self, hasher);
                 }
             }
-        };
+        )+};
     }
 
     macro_rules! impl_dep_tracking_hash_for_sortable_vec_of {
-        ($t:ty) => {
+        ($($t:ty),+ $(,)?) => {$(
             impl DepTrackingHash for Vec<$t> {
                 fn hash(&self, hasher: &mut DefaultHasher, error_format: ErrorOutputType) {
                     let mut elems: Vec<&$t> = self.iter().collect();
@@ -2354,61 +2354,65 @@ crate mod dep_tracking {
                     }
                 }
             }
-        };
+        )+};
     }
 
-    impl_dep_tracking_hash_via_hash!(bool);
-    impl_dep_tracking_hash_via_hash!(usize);
-    impl_dep_tracking_hash_via_hash!(u64);
-    impl_dep_tracking_hash_via_hash!(String);
-    impl_dep_tracking_hash_via_hash!(PathBuf);
-    impl_dep_tracking_hash_via_hash!(lint::Level);
-    impl_dep_tracking_hash_via_hash!(Option<bool>);
-    impl_dep_tracking_hash_via_hash!(Option<u32>);
-    impl_dep_tracking_hash_via_hash!(Option<usize>);
-    impl_dep_tracking_hash_via_hash!(Option<NonZeroUsize>);
-    impl_dep_tracking_hash_via_hash!(Option<String>);
-    impl_dep_tracking_hash_via_hash!(Option<(String, u64)>);
-    impl_dep_tracking_hash_via_hash!(Option<Vec<String>>);
-    impl_dep_tracking_hash_via_hash!(Option<MergeFunctions>);
-    impl_dep_tracking_hash_via_hash!(Option<RelocModel>);
-    impl_dep_tracking_hash_via_hash!(Option<CodeModel>);
-    impl_dep_tracking_hash_via_hash!(Option<TlsModel>);
-    impl_dep_tracking_hash_via_hash!(Option<WasiExecModel>);
-    impl_dep_tracking_hash_via_hash!(Option<PanicStrategy>);
-    impl_dep_tracking_hash_via_hash!(Option<RelroLevel>);
-    impl_dep_tracking_hash_via_hash!(Option<InstrumentCoverage>);
-    impl_dep_tracking_hash_via_hash!(Option<lint::Level>);
-    impl_dep_tracking_hash_via_hash!(Option<PathBuf>);
-    impl_dep_tracking_hash_via_hash!(CrateType);
-    impl_dep_tracking_hash_via_hash!(MergeFunctions);
-    impl_dep_tracking_hash_via_hash!(PanicStrategy);
-    impl_dep_tracking_hash_via_hash!(RelroLevel);
-    impl_dep_tracking_hash_via_hash!(Passes);
-    impl_dep_tracking_hash_via_hash!(OptLevel);
-    impl_dep_tracking_hash_via_hash!(LtoCli);
-    impl_dep_tracking_hash_via_hash!(DebugInfo);
-    impl_dep_tracking_hash_via_hash!(UnstableFeatures);
-    impl_dep_tracking_hash_via_hash!(OutputTypes);
-    impl_dep_tracking_hash_via_hash!(NativeLibKind);
-    impl_dep_tracking_hash_via_hash!(SanitizerSet);
-    impl_dep_tracking_hash_via_hash!(CFGuard);
-    impl_dep_tracking_hash_via_hash!(TargetTriple);
-    impl_dep_tracking_hash_via_hash!(Edition);
-    impl_dep_tracking_hash_via_hash!(LinkerPluginLto);
-    impl_dep_tracking_hash_via_hash!(Option<SplitDebuginfo>);
-    impl_dep_tracking_hash_via_hash!(SwitchWithOptPath);
-    impl_dep_tracking_hash_via_hash!(Option<SymbolManglingVersion>);
-    impl_dep_tracking_hash_via_hash!(Option<SourceFileHashAlgorithm>);
-    impl_dep_tracking_hash_via_hash!(TrimmedDefPaths);
+    impl_dep_tracking_hash_via_hash!(
+        bool,
+        usize,
+        u64,
+        String,
+        PathBuf,
+        lint::Level,
+        Option<bool>,
+        Option<u32>,
+        Option<usize>,
+        Option<NonZeroUsize>,
+        Option<String>,
+        Option<(String, u64)>,
+        Option<Vec<String>>,
+        Option<MergeFunctions>,
+        Option<RelocModel>,
+        Option<CodeModel>,
+        Option<TlsModel>,
+        Option<WasiExecModel>,
+        Option<PanicStrategy>,
+        Option<RelroLevel>,
+        Option<InstrumentCoverage>,
+        Option<lint::Level>,
+        Option<PathBuf>,
+        CrateType,
+        MergeFunctions,
+        PanicStrategy,
+        RelroLevel,
+        Passes,
+        OptLevel,
+        LtoCli,
+        DebugInfo,
+        UnstableFeatures,
+        OutputTypes,
+        NativeLibKind,
+        SanitizerSet,
+        CFGuard,
+        TargetTriple,
+        Edition,
+        LinkerPluginLto,
+        Option<SplitDebuginfo>,
+        SwitchWithOptPath,
+        Option<SymbolManglingVersion>,
+        Option<SourceFileHashAlgorithm>,
+        TrimmedDefPaths,
+    );
 
-    impl_dep_tracking_hash_for_sortable_vec_of!(String);
-    impl_dep_tracking_hash_for_sortable_vec_of!(PathBuf);
-    impl_dep_tracking_hash_for_sortable_vec_of!((PathBuf, PathBuf));
-    impl_dep_tracking_hash_for_sortable_vec_of!(CrateType);
-    impl_dep_tracking_hash_for_sortable_vec_of!((String, lint::Level));
-    impl_dep_tracking_hash_for_sortable_vec_of!((String, Option<String>, NativeLibKind));
-    impl_dep_tracking_hash_for_sortable_vec_of!((String, u64));
+    impl_dep_tracking_hash_for_sortable_vec_of!(
+        String,
+        PathBuf,
+        (PathBuf, PathBuf),
+        CrateType,
+        (String, lint::Level),
+        (String, Option<String>, NativeLibKind),
+        (String, u64)
+    );
 
     impl<T1, T2> DepTrackingHash for (T1, T2)
     where

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -191,7 +191,25 @@ pub(super) fn opt_const_param_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Option<
                     Res::Def(DefKind::Ctor(..), def_id) => {
                         tcx.generics_of(tcx.parent(def_id).unwrap())
                     }
-                    Res::Def(_, def_id) => tcx.generics_of(def_id),
+                    // Other `DefKind`s don't have generics and would ICE when calling
+                    // `generics_of`.
+                    Res::Def(
+                        DefKind::Struct
+                        | DefKind::Union
+                        | DefKind::Enum
+                        | DefKind::Variant
+                        | DefKind::Trait
+                        | DefKind::OpaqueTy
+                        | DefKind::TyAlias
+                        | DefKind::ForeignTy
+                        | DefKind::TraitAlias
+                        | DefKind::AssocTy
+                        | DefKind::Fn
+                        | DefKind::AssocFn
+                        | DefKind::AssocConst
+                        | DefKind::Impl,
+                        def_id,
+                    ) => tcx.generics_of(def_id),
                     Res::Err => {
                         tcx.sess.delay_span_bug(tcx.def_span(def_id), "anon const with Res::Err");
                         return None;

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -742,9 +742,6 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 ///
 /// ## On `packed` structs
 ///
-/// It is currently impossible to create raw pointers to unaligned fields
-/// of a packed struct.
-///
 /// Attempting to create a raw pointer to an `unaligned` struct field with
 /// an expression such as `&packed.unaligned as *const FieldType` creates an
 /// intermediate unaligned reference before converting that to a raw pointer.
@@ -753,9 +750,13 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 /// As a result, using `&packed.unaligned as *const FieldType` causes immediate
 /// *undefined behavior* in your program.
 ///
+/// Instead you must use the [`ptr::addr_of!`](addr_of) macro to
+/// create the pointer. You may use that returned pointer together with this
+/// function.
+///
 /// An example of what not to do and how this relates to `read_unaligned` is:
 ///
-/// ```no_run
+/// ```
 /// #[repr(packed, C)]
 /// struct Packed {
 ///     _padding: u8,
@@ -767,24 +768,15 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 ///     unaligned: 0x01020304,
 /// };
 ///
-/// #[allow(unaligned_references)]
-/// let v = unsafe {
-///     // Here we attempt to take the address of a 32-bit integer which is not aligned.
-///     let unaligned =
-///         // A temporary unaligned reference is created here which results in
-///         // undefined behavior regardless of whether the reference is used or not.
-///         &packed.unaligned
-///         // Casting to a raw pointer doesn't help; the mistake already happened.
-///         as *const u32;
+/// // Take the address of a 32-bit integer which is not aligned.
+/// // In contrast to `&packed.unaligned as *const _`, this has no undefined behavior.
+/// let unaligned = std::ptr::addr_of!(packed.unaligned);
 ///
-///     let v = std::ptr::read_unaligned(unaligned);
-///
-///     v
-/// };
+/// let v = unsafe { std::ptr::read_unaligned(unaligned) };
+/// assert_eq!(v, 0x01020304);
 /// ```
 ///
 /// Accessing unaligned fields directly with e.g. `packed.unaligned` is safe however.
-// FIXME: Update docs based on outcome of RFC #2582 and friends.
 ///
 /// # Examples
 ///
@@ -938,9 +930,6 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// ## On `packed` structs
 ///
-/// It is currently impossible to create raw pointers to unaligned fields
-/// of a packed struct.
-///
 /// Attempting to create a raw pointer to an `unaligned` struct field with
 /// an expression such as `&packed.unaligned as *const FieldType` creates an
 /// intermediate unaligned reference before converting that to a raw pointer.
@@ -949,36 +938,32 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
 /// As a result, using `&packed.unaligned as *const FieldType` causes immediate
 /// *undefined behavior* in your program.
 ///
-/// An example of what not to do and how this relates to `write_unaligned` is:
+/// Instead you must use the [`ptr::addr_of_mut!`](addr_of_mut)
+/// macro to create the pointer. You may use that returned pointer together with
+/// this function.
 ///
-/// ```no_run
+/// An example of how to do it and how this relates to `write_unaligned` is:
+///
+/// ```
 /// #[repr(packed, C)]
 /// struct Packed {
 ///     _padding: u8,
 ///     unaligned: u32,
 /// }
 ///
-/// let v = 0x01020304;
 /// let mut packed: Packed = unsafe { std::mem::zeroed() };
 ///
-/// #[allow(unaligned_references)]
-/// let v = unsafe {
-///     // Here we attempt to take the address of a 32-bit integer which is not aligned.
-///     let unaligned =
-///         // A temporary unaligned reference is created here which results in
-///         // undefined behavior regardless of whether the reference is used or not.
-///         &mut packed.unaligned
-///         // Casting to a raw pointer doesn't help; the mistake already happened.
-///         as *mut u32;
+/// // Take the address of a 32-bit integer which is not aligned.
+/// // In contrast to `&packed.unaligned as *mut _`, this has no undefined behavior.
+/// let unaligned = std::ptr::addr_of_mut!(packed.unaligned);
 ///
-///     std::ptr::write_unaligned(unaligned, v);
+/// unsafe { std::ptr::write_unaligned(unaligned, 42) };
 ///
-///     v
-/// };
+/// assert_eq!({packed.unaligned}, 42); // `{...}` forces copying the field instead of creating a reference.
 /// ```
 ///
-/// Accessing unaligned fields directly with e.g. `packed.unaligned` is safe however.
-// FIXME: Update docs based on outcome of RFC #2582 and friends.
+/// Accessing unaligned fields directly with e.g. `packed.unaligned` is safe however
+/// (as can be seen in the `assert_eq!` above).
 ///
 /// # Examples
 ///

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1948,8 +1948,9 @@ impl<T> [T] {
     /// assert!(!v.contains(&50));
     /// ```
     ///
-    /// If you do not have an `&T`, but just an `&U` such that `T: Borrow<U>`
-    /// (e.g. `String: Borrow<str>`), you can use `iter().any`:
+    /// If you do not have a `&T`, but some other value that you can compare
+    /// with one (for example, `String` implements `PartialEq<str>`), you can
+    /// use `iter().any`:
     ///
     /// ```
     /// let v = [String::from("hello"), String::from("world")]; // slice of `String`

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -518,13 +518,11 @@ impl Duration {
         if let Some(mut secs) = self.secs.checked_sub(rhs.secs) {
             let nanos = if self.nanos >= rhs.nanos {
                 self.nanos - rhs.nanos
+            } else if let Some(sub_secs) = secs.checked_sub(1) {
+                secs = sub_secs;
+                self.nanos + NANOS_PER_SEC - rhs.nanos
             } else {
-                if let Some(sub_secs) = secs.checked_sub(1) {
-                    secs = sub_secs;
-                    self.nanos + NANOS_PER_SEC - rhs.nanos
-                } else {
-                    return None;
-                }
+                return None;
             };
             debug_assert!(nanos < NANOS_PER_SEC);
             Some(Duration { secs, nanos })

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -61,6 +61,7 @@ pub fn current_dir() -> io::Result<PathBuf> {
 /// assert!(env::set_current_dir(&root).is_ok());
 /// println!("Successfully changed working directory to {}!", root.display());
 /// ```
+#[doc(alias = "chdir")]
 #[stable(feature = "env", since = "1.0.0")]
 pub fn set_current_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     os_imp::chdir(path.as_ref())

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -445,7 +445,27 @@ mod prim_unit {}
 /// Note that here the call to [`drop`] is for clarity - it indicates
 /// that we are done with the given value and it should be destroyed.
 ///
-/// ## 3. Get it from C.
+/// ## 3. Create it using `ptr::addr_of!`
+///
+/// Instead of coercing a reference to a raw pointer, you can use the macros
+/// [`ptr::addr_of!`] (for `*const T`) and [`ptr::addr_of_mut!`] (for `*mut T`).
+/// These macros allow you to create raw pointers to fields to which you cannot
+/// create a reference (without causing undefined behaviour), such as an
+/// unaligned field. This might be necessary if packed structs or uninitialized
+/// memory is involved.
+///
+/// ```
+/// #[derive(Debug, Default, Copy, Clone)]
+/// #[repr(C, packed)]
+/// struct S {
+///     aligned: u8,
+///     unaligned: u32,
+/// }
+/// let s = S::default();
+/// let p = std::ptr::addr_of!(s.unaligned); // not allowed with coercion
+/// ```
+///
+/// ## 4. Get it from C.
 ///
 /// ```
 /// # #![feature(rustc_private)]

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -113,7 +113,7 @@ The `std` column in the table below has the following meanings:
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
 
 target | std | notes
--------|-----|-------
+-------|:---:|-------
 `aarch64-apple-ios` | ✓ | ARM64 iOS
 `aarch64-fuchsia` | ✓ | ARM64 Fuchsia
 `aarch64-linux-android` | ✓ | ARM64 Android
@@ -194,7 +194,7 @@ The `host` column indicates whether the codebase includes support for building
 host tools.
 
 target | std | host | notes
--------|-----|------|-------
+-------|:---:|:----:|-------
 `aarch64-apple-ios-macabi` | ? |  | Apple Catalyst on ARM64
 `aarch64-apple-ios-sim` | ? |  | Apple iOS Simulator on ARM64
 `aarch64-apple-tvos` | * |  | ARM64 tvOS

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -4,10 +4,8 @@ error: associated constant is never used: `BAR`
 LL |     const BAR: u32 = 1;
    |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
    |
-   = note: The leading underscore signals to the reader that while the associated constant may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated constant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -2,8 +2,11 @@ error: associated constant is never used: `BAR`
   --> $DIR/associated-const-dead-code.rs:6:5
    |
 LL |     const BAR: u32 = 1;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
    |
+   = note: the leading underscore helps signal to the reader that the associated constant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated constant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -4,9 +4,10 @@ error: associated constant is never used: `BAR`
 LL |     const BAR: u32 = 1;
    |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
    |
-   = note: the leading underscore helps signal to the reader that the associated constant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated constant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated constant may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -2,10 +2,11 @@ error: associated constant is never used: `BAR`
   --> $DIR/associated-const-dead-code.rs:6:5
    |
 LL |     const BAR: u32 = 1;
-   |     ^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_BAR`
+   |     ^^^^^^---^^^^^^^^^^
+   |           |
+   |           help: if this is intentional, prefix it with an underscore: `_BAR`
    |
-   = note: the leading underscore signals that this associated constant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated constant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9
    |

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -2,10 +2,11 @@ warning: variant is never constructed: `Void`
   --> $DIR/derive-uninhabited-enum-38885.rs:13:5
    |
 LL |     Void(Void),
-   |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
+   |     ----^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Void`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -2,8 +2,11 @@ warning: variant is never constructed: `Void`
   --> $DIR/derive-uninhabited-enum-38885.rs:13:5
    |
 LL |     Void(Void),
-   |     ^^^^^^^^^^
+   |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -4,9 +4,10 @@ warning: variant is never constructed: `Void`
 LL |     Void(Void),
    |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -4,10 +4,8 @@ warning: variant is never constructed: `Void`
 LL |     Void(Void),
    |     ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Void`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
    = note: `-W dead-code` implied by `-W unused`
 
 warning: 1 warning emitted

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -2,8 +2,11 @@ warning: type alias is never used: `Z`
   --> $DIR/issue-37515.rs:5:1
    |
 LL | type Z = dyn for<'x> Send;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
    |
+   = note: the leading underscore helps signal to the reader that the type alias may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -4,9 +4,10 @@ warning: type alias is never used: `Z`
 LL | type Z = dyn for<'x> Send;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
    |
-   = note: the leading underscore helps signal to the reader that the type alias may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the type alias may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -2,10 +2,11 @@ warning: type alias is never used: `Z`
   --> $DIR/issue-37515.rs:5:1
    |
 LL | type Z = dyn for<'x> Send;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
+   | ^^^^^-^^^^^^^^^^^^^^^^^^^^
+   |      |
+   |      help: if this is intentional, prefix it with an underscore: `_Z`
    |
-   = note: the leading underscore signals that this type alias serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this type alias serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -4,10 +4,8 @@ warning: type alias is never used: `Z`
 LL | type Z = dyn for<'x> Send;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Z`
    |
-   = note: The leading underscore signals to the reader that while the type alias may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this type alias serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -4,8 +4,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -4,10 +4,8 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -2,8 +2,11 @@ error: function is never used: `foo`
   --> $DIR/basic.rs:4:4
    |
 LL | fn foo() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/basic.stderr
+++ b/src/test/ui/lint/dead-code/basic.stderr
@@ -4,9 +4,10 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/basic.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -4,9 +4,10 @@ warning: variant is never constructed: `B`
 LL |     B,
    |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -19,9 +20,10 @@ warning: variant is never constructed: `C`
 LL |     C,
    |     ^ help: if this is intentional, prefix it with an underscore: `_C`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -4,8 +4,7 @@ warning: variant is never constructed: `B`
 LL |     B,
    |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -18,8 +17,7 @@ warning: variant is never constructed: `C`
 LL |     C,
    |     ^ help: if this is intentional, prefix it with an underscore: `_C`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -4,10 +4,8 @@ warning: variant is never constructed: `B`
 LL |     B,
    |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -20,10 +18,8 @@ warning: variant is never constructed: `C`
 LL |     C,
    |     ^ help: if this is intentional, prefix it with an underscore: `_C`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/const-and-self.stderr
+++ b/src/test/ui/lint/dead-code/const-and-self.stderr
@@ -2,8 +2,11 @@ warning: variant is never constructed: `B`
   --> $DIR/const-and-self.rs:33:5
    |
 LL |     B,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/const-and-self.rs:3:9
    |
@@ -14,7 +17,11 @@ warning: variant is never constructed: `C`
   --> $DIR/const-and-self.rs:34:5
    |
 LL |     C,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_C`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.rs
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.rs
@@ -1,0 +1,42 @@
+//! The field `guard` is never used directly, but it is still useful for its side effect when
+//! dropped. Since rustc doesn't consider a `Drop` impl as a use, we want to make sure we at least
+//! produce a helpful diagnostic that points the user to what they can do if they indeed intended to
+//! have a field that is only used for its `Drop` side effect.
+//!
+//! Issue: https://github.com/rust-lang/rust/issues/81658
+
+#![deny(dead_code)]
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Holds a locked value until it is dropped
+pub struct Locked<'a, T> {
+    // Field is kept for its affect when dropped, but otherwise unused
+    guard: MutexGuard<'a, T>, //~ ERROR field is never read
+}
+
+impl<'a, T> Locked<'a, T> {
+    pub fn new(value: &'a Mutex<T>) -> Self {
+        Self {
+            guard: value.lock().unwrap(),
+        }
+    }
+}
+
+fn main() {
+    let items = Mutex::new(vec![1, 2, 3]);
+
+    // Hold a lock on items while doing something else
+    let result = {
+        // The lock will be released at the end of this scope
+        let _lock = Locked::new(&items);
+
+        do_something_else()
+    };
+
+    println!("{}", result);
+}
+
+fn do_something_else() -> i32 {
+    1 + 1
+}

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -2,11 +2,11 @@ error: field is never read: `guard`
   --> $DIR/drop-only-field-issue-81658.rs:15:5
    |
 LL |     guard: MutexGuard<'a, T>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
+   |     -----^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_guard`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -2,8 +2,11 @@ error: field is never read: `guard`
   --> $DIR/drop-only-field-issue-81658.rs:15:5
    |
 LL |     guard: MutexGuard<'a, T>,
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -1,0 +1,14 @@
+error: field is never read: `guard`
+  --> $DIR/drop-only-field-issue-81658.rs:15:5
+   |
+LL |     guard: MutexGuard<'a, T>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/drop-only-field-issue-81658.rs:8:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -4,9 +4,10 @@ error: field is never read: `guard`
 LL |     guard: MutexGuard<'a, T>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/drop-only-field-issue-81658.stderr
@@ -4,10 +4,9 @@ error: field is never read: `guard`
 LL |     guard: MutexGuard<'a, T>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_guard`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/drop-only-field-issue-81658.rs:8:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -2,8 +2,11 @@ error: enum is never used: `E`
   --> $DIR/empty-unused-enum.rs:3:6
    |
 LL | enum E {}
-   |      ^
+   |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -4,8 +4,7 @@ error: enum is never used: `E`
 LL | enum E {}
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -4,9 +4,10 @@ error: enum is never used: `E`
 LL | enum E {}
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/empty-unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/empty-unused-enum.stderr
@@ -4,10 +4,8 @@ error: enum is never used: `E`
 LL | enum E {}
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/empty-unused-enum.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.rs
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.rs
@@ -1,0 +1,50 @@
+//! The field `items` is being "used" by FFI (implicitly through pointers). However, since rustc
+//! doesn't know how to detect that, we produce a message that says the field is unused. This can
+//! cause some confusion and we want to make sure our diagnostics help as much as they can.
+//!
+//! Issue: https://github.com/rust-lang/rust/issues/81658
+
+#![deny(dead_code)]
+
+/// A struct for holding on to data while it is being used in our FFI code
+pub struct FFIData<T> {
+    /// These values cannot be dropped while the pointers to each item
+    /// are still in use
+    items: Option<Vec<T>>, //~ ERROR field is never read
+}
+
+impl<T> FFIData<T> {
+    pub fn new() -> Self {
+        Self {items: None}
+    }
+
+    /// Load items into this type and return pointers to each item that can
+    /// be passed to FFI
+    pub fn load(&mut self, items: Vec<T>) -> Vec<*const T> {
+        let ptrs = items.iter().map(|item| item as *const _).collect();
+
+        self.items = Some(items);
+
+        ptrs
+    }
+}
+
+extern {
+    /// The FFI code that uses items
+    fn process_item(item: *const i32);
+}
+
+fn main() {
+    // Data cannot be dropped until the end of this scope or else the items
+    // will be dropped before they are processed
+    let mut data = FFIData::new();
+
+    let ptrs = data.load(vec![1, 2, 3, 4, 5]);
+
+    for ptr in ptrs {
+        // Safety: This pointer is valid as long as the arena is in scope
+        unsafe { process_item(ptr); }
+    }
+
+    // Items will be safely freed at the end of this scope
+}

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -4,9 +4,10 @@ error: field is never read: `items`
 LL |     items: Option<Vec<T>>,
    |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -2,8 +2,11 @@ error: field is never read: `items`
   --> $DIR/field-used-in-ffi-issue-81658.rs:13:5
    |
 LL |     items: Option<Vec<T>>,
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -4,10 +4,9 @@ error: field is never read: `items`
 LL |     items: Option<Vec<T>>,
    |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -1,0 +1,14 @@
+error: field is never read: `items`
+  --> $DIR/field-used-in-ffi-issue-81658.rs:13:5
+   |
+LL |     items: Option<Vec<T>>,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
+   |
+LL | #![deny(dead_code)]
+   |         ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
+++ b/src/test/ui/lint/dead-code/field-used-in-ffi-issue-81658.stderr
@@ -2,11 +2,11 @@ error: field is never read: `items`
   --> $DIR/field-used-in-ffi-issue-81658.rs:13:5
    |
 LL |     items: Option<Vec<T>>,
-   |     ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_items`
+   |     -----^^^^^^^^^^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_items`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/field-used-in-ffi-issue-81658.rs:7:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -4,9 +4,10 @@ error: type alias is never used: `Unused`
 LL | type Unused = ();
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore helps signal to the reader that the type alias may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the type alias may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -4,10 +4,8 @@ error: type alias is never used: `Unused`
 LL | type Unused = ();
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: The leading underscore signals to the reader that while the type alias may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this type alias serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -2,8 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/impl-trait.rs:12:1
    |
 LL | type Unused = ();
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
+   = note: the leading underscore helps signal to the reader that the type alias may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -2,10 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/impl-trait.rs:12:1
    |
 LL | type Unused = ();
-   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
+   | ^^^^^------^^^^^^
+   |      |
+   |      help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore signals that this type alias serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this type alias serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `Bar`
   --> $DIR/lint-dead-code-1.rs:12:16
    |
 LL |     pub struct Bar;
-   |                ^^^
+   |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -14,55 +17,91 @@ error: static is never used: `priv_static`
   --> $DIR/lint-dead-code-1.rs:20:1
    |
 LL | static priv_static: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
+   |
+   = note: the leading underscore helps signal to the reader that the static may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the static
+           is only used through FFI or used only for its effect when dropped)
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
    |
 LL | const priv_const: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
+   |
+   = note: the leading underscore helps signal to the reader that the constant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the constant
+           is only used through FFI or used only for its effect when dropped)
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
    |
 LL | struct PrivStruct;
-   |        ^^^^^^^^^^
+   |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
+   |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
    |
 LL | enum priv_enum { foo2, bar2 }
-   |      ^^^^^^^^^
+   |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
    |
 LL |     bar3
-   |     ^^^^
+   |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
    |
 LL | fn priv_fn() {
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
    |
 LL | fn foo() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
    |
 LL | fn bar() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
    |
 LL | fn baz() -> impl Copy {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `Bar`
 LL |     pub struct Bar;
    |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -16,19 +15,21 @@ error: static is never used: `priv_static`
   --> $DIR/lint-dead-code-1.rs:20:1
    |
 LL | static priv_static: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
+   | ^^^^^^^-----------^^^^^^^^^^^^
+   |        |
+   |        help: if this is intentional, prefix it with an underscore: `_priv_static`
    |
-   = note: the leading underscore signals that this static serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this static serves some other purpose even if it isn't used in a way that we can detect.
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
    |
 LL | const priv_const: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
+   | ^^^^^^----------^^^^^^^^^^^^
+   |       |
+   |       help: if this is intentional, prefix it with an underscore: `_priv_const`
    |
-   = note: the leading underscore signals that this constant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this constant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
@@ -36,8 +37,7 @@ error: struct is never constructed: `PrivStruct`
 LL | struct PrivStruct;
    |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
@@ -45,8 +45,7 @@ error: enum is never used: `priv_enum`
 LL | enum priv_enum { foo2, bar2 }
    |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
@@ -54,8 +53,7 @@ error: variant is never constructed: `bar3`
 LL |     bar3
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
@@ -63,8 +61,7 @@ error: function is never used: `priv_fn`
 LL | fn priv_fn() {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
@@ -72,8 +69,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
@@ -81,8 +77,7 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
@@ -90,8 +85,7 @@ error: function is never used: `baz`
 LL | fn baz() -> impl Copy {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `Bar`
 LL |     pub struct Bar;
    |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -19,9 +20,10 @@ error: static is never used: `priv_static`
 LL | static priv_static: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
    |
-   = note: the leading underscore helps signal to the reader that the static may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the static
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the static may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
@@ -29,9 +31,10 @@ error: constant is never used: `priv_const`
 LL | const priv_const: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
    |
-   = note: the leading underscore helps signal to the reader that the constant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the constant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the constant may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
@@ -39,9 +42,10 @@ error: struct is never constructed: `PrivStruct`
 LL | struct PrivStruct;
    |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
@@ -49,9 +53,10 @@ error: enum is never used: `priv_enum`
 LL | enum priv_enum { foo2, bar2 }
    |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
@@ -59,9 +64,10 @@ error: variant is never constructed: `bar3`
 LL |     bar3
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
@@ -69,9 +75,10 @@ error: function is never used: `priv_fn`
 LL | fn priv_fn() {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
@@ -79,9 +86,10 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
@@ -89,9 +97,10 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
@@ -99,9 +108,10 @@ error: function is never used: `baz`
 LL | fn baz() -> impl Copy {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `Bar`
 LL |     pub struct Bar;
    |                ^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
@@ -20,10 +18,8 @@ error: static is never used: `priv_static`
 LL | static priv_static: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_static`
    |
-   = note: The leading underscore signals to the reader that while the static may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this static serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
@@ -31,10 +27,8 @@ error: constant is never used: `priv_const`
 LL | const priv_const: isize = 0;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_const`
    |
-   = note: The leading underscore signals to the reader that while the constant may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this constant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: struct is never constructed: `PrivStruct`
   --> $DIR/lint-dead-code-1.rs:35:8
@@ -42,10 +36,8 @@ error: struct is never constructed: `PrivStruct`
 LL | struct PrivStruct;
    |        ^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_PrivStruct`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `priv_enum`
   --> $DIR/lint-dead-code-1.rs:64:6
@@ -53,10 +45,8 @@ error: enum is never used: `priv_enum`
 LL | enum priv_enum { foo2, bar2 }
    |      ^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_enum`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `bar3`
   --> $DIR/lint-dead-code-1.rs:67:5
@@ -64,10 +54,8 @@ error: variant is never constructed: `bar3`
 LL |     bar3
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_bar3`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `priv_fn`
   --> $DIR/lint-dead-code-1.rs:88:4
@@ -75,10 +63,8 @@ error: function is never used: `priv_fn`
 LL | fn priv_fn() {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_priv_fn`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `foo`
   --> $DIR/lint-dead-code-1.rs:93:4
@@ -86,10 +72,8 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-1.rs:98:4
@@ -97,10 +81,8 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `baz`
   --> $DIR/lint-dead-code-1.rs:102:4
@@ -108,10 +90,8 @@ error: function is never used: `baz`
 LL | fn baz() -> impl Copy {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_baz`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -4,8 +4,7 @@ error: function is never used: `dead_fn`
 LL | fn dead_fn() {}
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -18,8 +17,7 @@ error: function is never used: `dead_fn2`
 LL | fn dead_fn2() {}
    |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
@@ -27,8 +25,7 @@ error: function is never used: `main`
 LL | fn main() {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -2,8 +2,11 @@ error: function is never used: `dead_fn`
   --> $DIR/lint-dead-code-2.rs:22:4
    |
 LL | fn dead_fn() {}
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -14,13 +17,21 @@ error: function is never used: `dead_fn2`
   --> $DIR/lint-dead-code-2.rs:25:4
    |
 LL | fn dead_fn2() {}
-   |    ^^^^^^^^
+   |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
    |
 LL | fn main() {
-   |    ^^^^
+   |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -4,10 +4,8 @@ error: function is never used: `dead_fn`
 LL | fn dead_fn() {}
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -20,10 +18,8 @@ error: function is never used: `dead_fn2`
 LL | fn dead_fn2() {}
    |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
@@ -31,10 +27,8 @@ error: function is never used: `main`
 LL | fn main() {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-2.stderr
@@ -4,9 +4,10 @@ error: function is never used: `dead_fn`
 LL | fn dead_fn() {}
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-2.rs:2:9
    |
@@ -19,9 +20,10 @@ error: function is never used: `dead_fn2`
 LL | fn dead_fn2() {}
    |    ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_dead_fn2`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `main`
   --> $DIR/lint-dead-code-2.rs:38:4
@@ -29,9 +31,10 @@ error: function is never used: `main`
 LL | fn main() {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_main`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `Foo`
   --> $DIR/lint-dead-code-3.rs:14:8
    |
 LL | struct Foo;
-   |        ^^^
+   |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -14,25 +17,41 @@ error: associated function is never used: `foo`
   --> $DIR/lint-dead-code-3.rs:16:8
    |
 LL |     fn foo(&self) {
-   |        ^^^
+   |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
    |
 LL | fn bar() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
    |
 LL | enum c_void {}
-   |      ^^^^^^
+   |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
    |
 LL |     fn free(p: *const c_void);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `Foo`
 LL | struct Foo;
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -18,8 +17,7 @@ error: associated function is never used: `foo`
 LL |     fn foo(&self) {
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
@@ -27,8 +25,7 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
@@ -36,17 +33,17 @@ error: enum is never used: `c_void`
 LL | enum c_void {}
    |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
    |
 LL |     fn free(p: *const c_void);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
+   |     ^^^----^^^^^^^^^^^^^^^^^^^
+   |        |
+   |        help: if this is intentional, prefix it with an underscore: `_free`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `Foo`
 LL | struct Foo;
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -20,10 +18,8 @@ error: associated function is never used: `foo`
 LL |     fn foo(&self) {
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
@@ -31,10 +27,8 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
@@ -42,10 +36,8 @@ error: enum is never used: `c_void`
 LL | enum c_void {}
    |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
@@ -53,10 +45,8 @@ error: function is never used: `free`
 LL |     fn free(p: *const c_void);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `Foo`
 LL | struct Foo;
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_Foo`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-3.rs:4:9
    |
@@ -19,9 +20,10 @@ error: associated function is never used: `foo`
 LL |     fn foo(&self) {
    |        ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `bar`
   --> $DIR/lint-dead-code-3.rs:21:4
@@ -29,9 +31,10 @@ error: function is never used: `bar`
 LL | fn bar() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_bar`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `c_void`
   --> $DIR/lint-dead-code-3.rs:60:6
@@ -39,9 +42,10 @@ error: enum is never used: `c_void`
 LL | enum c_void {}
    |      ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c_void`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `free`
   --> $DIR/lint-dead-code-3.rs:62:5
@@ -49,9 +53,10 @@ error: function is never used: `free`
 LL |     fn free(p: *const c_void);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_free`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -4,9 +4,10 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -19,9 +20,10 @@ error: variant is never constructed: `X`
 LL |     X,
    |     ^ help: if this is intentional, prefix it with an underscore: `_X`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
@@ -33,9 +35,10 @@ LL | |         c: i32,
 LL | |     },
    | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -43,9 +46,10 @@ error: enum is never used: `ABC`
 LL | enum ABC {
    |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
@@ -53,9 +57,10 @@ error: variant is never constructed: `I`
 LL |     I,
    |     ^ help: if this is intentional, prefix it with an underscore: `_I`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
@@ -63,9 +68,10 @@ error: field is never read: `b`
 LL |         b: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
@@ -73,9 +79,10 @@ error: field is never read: `c`
 LL |         c: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
@@ -83,9 +90,10 @@ error: variant is never constructed: `K`
 LL |     K
    |     ^ help: if this is intentional, prefix it with an underscore: `_K`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
@@ -93,9 +101,10 @@ error: field is never read: `x`
 LL |     x: usize,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
@@ -103,9 +112,10 @@ error: field is never read: `c`
 LL |     c: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -2,11 +2,11 @@ error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:7:5
    |
 LL |     b: bool,
-   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |     -^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -19,21 +19,22 @@ error: variant is never constructed: `X`
 LL |     X,
    |     ^ help: if this is intentional, prefix it with an underscore: `_X`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
    |
-LL | /     Y {
+LL |       Y {
+   |       ^ help: if this is intentional, prefix it with an underscore: `_Y`
+   |  _____|
+   | |
 LL | |         a: String,
 LL | |         b: i32,
 LL | |         c: i32,
 LL | |     },
-   | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
+   | |_____^
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -41,8 +42,7 @@ error: enum is never used: `ABC`
 LL | enum ABC {
    |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
@@ -50,28 +50,27 @@ error: variant is never constructed: `I`
 LL |     I,
    |     ^ help: if this is intentional, prefix it with an underscore: `_I`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
    |
 LL |         b: i32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
    |
 LL |         c: i32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
@@ -79,28 +78,27 @@ error: variant is never constructed: `K`
 LL |     K
    |     ^ help: if this is intentional, prefix it with an underscore: `_K`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
    |
 LL |     x: usize,
-   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
+   |     -^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_x`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
    |
 LL |     c: bool,
-   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |     -^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -2,8 +2,11 @@ error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:7:5
    |
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -14,7 +17,11 @@ error: variant is never constructed: `X`
   --> $DIR/lint-dead-code-4.rs:15:5
    |
 LL |     X,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_X`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
@@ -24,49 +31,81 @@ LL | |         a: String,
 LL | |         b: i32,
 LL | |         c: i32,
 LL | |     },
-   | |_____^
+   | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
    |
 LL | enum ABC {
-   |      ^^^
+   |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
    |
 LL |     I,
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_I`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
    |
 LL |         b: i32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
    |
 LL |         c: i32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
    |
 LL |     K
-   |     ^
+   |     ^ help: if this is intentional, prefix it with an underscore: `_K`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
    |
 LL |     x: usize,
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
    |
 LL |     c: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -4,10 +4,9 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
    |
@@ -20,10 +19,8 @@ error: variant is never constructed: `X`
 LL |     X,
    |     ^ help: if this is intentional, prefix it with an underscore: `_X`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Y`
   --> $DIR/lint-dead-code-4.rs:16:5
@@ -35,10 +32,8 @@ LL | |         c: i32,
 LL | |     },
    | |_____^ help: if this is intentional, prefix it with an underscore: `_Y`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `ABC`
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -46,10 +41,8 @@ error: enum is never used: `ABC`
 LL | enum ABC {
    |      ^^^ help: if this is intentional, prefix it with an underscore: `_ABC`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `I`
   --> $DIR/lint-dead-code-4.rs:36:5
@@ -57,10 +50,8 @@ error: variant is never constructed: `I`
 LL |     I,
    |     ^ help: if this is intentional, prefix it with an underscore: `_I`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: field is never read: `b`
   --> $DIR/lint-dead-code-4.rs:39:9
@@ -68,10 +59,9 @@ error: field is never read: `b`
 LL |         b: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:40:9
@@ -79,10 +69,9 @@ error: field is never read: `c`
 LL |         c: i32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: variant is never constructed: `K`
   --> $DIR/lint-dead-code-4.rs:42:5
@@ -90,10 +79,8 @@ error: variant is never constructed: `K`
 LL |     K
    |     ^ help: if this is intentional, prefix it with an underscore: `_K`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: field is never read: `x`
   --> $DIR/lint-dead-code-4.rs:61:5
@@ -101,10 +88,9 @@ error: field is never read: `x`
 LL |     x: usize,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_x`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/lint-dead-code-4.rs:63:5
@@ -112,10 +98,9 @@ error: field is never read: `c`
 LL |     c: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -4,9 +4,10 @@ error: variant is never constructed: `Variant2`
 LL |     Variant2
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -19,9 +20,10 @@ error: variant is never constructed: `Variant5`
 LL |     Variant5 { _x: isize },
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
@@ -29,9 +31,10 @@ error: variant is never constructed: `Variant6`
 LL |     Variant6(isize),
    |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
@@ -39,9 +42,10 @@ error: enum is never used: `Enum3`
 LL | enum Enum3 {
    |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -2,8 +2,11 @@ error: variant is never constructed: `Variant2`
   --> $DIR/lint-dead-code-5.rs:6:5
    |
 LL |     Variant2
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -14,19 +17,31 @@ error: variant is never constructed: `Variant5`
   --> $DIR/lint-dead-code-5.rs:13:5
    |
 LL |     Variant5 { _x: isize },
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
    |
 LL |     Variant6(isize),
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
+   |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
    |
 LL | enum Enum3 {
-   |      ^^^^^
+   |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -4,8 +4,7 @@ error: variant is never constructed: `Variant2`
 LL |     Variant2
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -16,19 +15,21 @@ error: variant is never constructed: `Variant5`
   --> $DIR/lint-dead-code-5.rs:13:5
    |
 LL |     Variant5 { _x: isize },
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
+   |     --------^^^^^^^^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Variant5`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
    |
 LL |     Variant6(isize),
-   |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
+   |     --------^^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Variant6`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
@@ -36,8 +37,7 @@ error: enum is never used: `Enum3`
 LL | enum Enum3 {
    |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -4,10 +4,8 @@ error: variant is never constructed: `Variant2`
 LL |     Variant2
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant2`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-5.rs:2:9
    |
@@ -20,10 +18,8 @@ error: variant is never constructed: `Variant5`
 LL |     Variant5 { _x: isize },
    |     ^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant5`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: variant is never constructed: `Variant6`
   --> $DIR/lint-dead-code-5.rs:14:5
@@ -31,10 +27,8 @@ error: variant is never constructed: `Variant6`
 LL |     Variant6(isize),
    |     ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant6`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `Enum3`
   --> $DIR/lint-dead-code-5.rs:35:6
@@ -42,10 +36,8 @@ error: enum is never used: `Enum3`
 LL | enum Enum3 {
    |      ^^^^^ help: if this is intentional, prefix it with an underscore: `_Enum3`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `UnusedStruct`
   --> $DIR/lint-dead-code-6.rs:3:8
    |
 LL | struct UnusedStruct;
-   |        ^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -14,19 +17,31 @@ error: associated function is never used: `unused_impl_fn_1`
   --> $DIR/lint-dead-code-6.rs:5:8
    |
 LL |     fn unused_impl_fn_1() {
-   |        ^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
    |
 LL |     fn unused_impl_fn_2(var: i32) {
-   |        ^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
    |
 LL |     fn unused_impl_fn_3(
-   |        ^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
+   |
+   = note: the leading underscore helps signal to the reader that the associated function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `UnusedStruct`
 LL | struct UnusedStruct;
    |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -19,9 +20,10 @@ error: associated function is never used: `unused_impl_fn_1`
 LL |     fn unused_impl_fn_1() {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
@@ -29,9 +31,10 @@ error: associated function is never used: `unused_impl_fn_2`
 LL |     fn unused_impl_fn_2(var: i32) {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
@@ -39,9 +42,10 @@ error: associated function is never used: `unused_impl_fn_3`
 LL |     fn unused_impl_fn_3(
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
    |
-   = note: the leading underscore helps signal to the reader that the associated function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the associated function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the associated function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `UnusedStruct`
 LL | struct UnusedStruct;
    |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -18,8 +17,7 @@ error: associated function is never used: `unused_impl_fn_1`
 LL |     fn unused_impl_fn_1() {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
@@ -27,8 +25,7 @@ error: associated function is never used: `unused_impl_fn_2`
 LL |     fn unused_impl_fn_2(var: i32) {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
@@ -36,8 +33,7 @@ error: associated function is never used: `unused_impl_fn_3`
 LL |     fn unused_impl_fn_3(
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
    |
-   = note: the leading underscore signals that this associated function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this associated function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-6.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `UnusedStruct`
 LL | struct UnusedStruct;
    |        ^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_UnusedStruct`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/lint-dead-code-6.rs:1:9
    |
@@ -20,10 +18,8 @@ error: associated function is never used: `unused_impl_fn_1`
 LL |     fn unused_impl_fn_1() {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_1`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_2`
   --> $DIR/lint-dead-code-6.rs:9:8
@@ -31,10 +27,8 @@ error: associated function is never used: `unused_impl_fn_2`
 LL |     fn unused_impl_fn_2(var: i32) {
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_2`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: associated function is never used: `unused_impl_fn_3`
   --> $DIR/lint-dead-code-6.rs:13:8
@@ -42,10 +36,8 @@ error: associated function is never used: `unused_impl_fn_3`
 LL |     fn unused_impl_fn_3(
    |        ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused_impl_fn_3`
    |
-   = note: The leading underscore signals to the reader that while the associated function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this associated function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -4,8 +4,7 @@ error: function is never used: `unused`
 LL | fn unused() {
    |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -18,8 +17,7 @@ error: function is never used: `unused2`
 LL | fn unused2(var: i32) {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
@@ -27,8 +25,7 @@ error: function is never used: `unused3`
 LL | fn unused3(
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -4,9 +4,10 @@ error: function is never used: `unused`
 LL | fn unused() {
    |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -19,9 +20,10 @@ error: function is never used: `unused2`
 LL | fn unused2(var: i32) {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
@@ -29,9 +31,10 @@ error: function is never used: `unused3`
 LL | fn unused3(
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -4,10 +4,8 @@ error: function is never used: `unused`
 LL | fn unused() {
    |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -20,10 +18,8 @@ error: function is never used: `unused2`
 LL | fn unused2(var: i32) {
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
@@ -31,10 +27,8 @@ error: function is never used: `unused3`
 LL | fn unused3(
    |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/newline-span.stderr
+++ b/src/test/ui/lint/dead-code/newline-span.stderr
@@ -2,8 +2,11 @@ error: function is never used: `unused`
   --> $DIR/newline-span.rs:3:4
    |
 LL | fn unused() {
-   |    ^^^^^^
+   |    ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/newline-span.rs:1:9
    |
@@ -14,13 +17,21 @@ error: function is never used: `unused2`
   --> $DIR/newline-span.rs:7:4
    |
 LL | fn unused2(var: i32) {
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused2`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: function is never used: `unused3`
   --> $DIR/newline-span.rs:11:4
    |
 LL | fn unused3(
-   |    ^^^^^^^
+   |    ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused3`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -2,8 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/type-alias.rs:4:1
    |
 LL | type Unused = u8;
-   | ^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
+   = note: the leading underscore helps signal to the reader that the type alias may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -4,9 +4,10 @@ error: type alias is never used: `Unused`
 LL | type Unused = u8;
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore helps signal to the reader that the type alias may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the type alias
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the type alias may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -4,10 +4,8 @@ error: type alias is never used: `Unused`
 LL | type Unused = u8;
    | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: The leading underscore signals to the reader that while the type alias may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this type alias serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -2,10 +2,11 @@ error: type alias is never used: `Unused`
   --> $DIR/type-alias.rs:4:1
    |
 LL | type Unused = u8;
-   | ^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Unused`
+   | ^^^^^------^^^^^^
+   |      |
+   |      help: if this is intentional, prefix it with an underscore: `_Unused`
    |
-   = note: the leading underscore signals that this type alias serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this type alias serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -4,9 +4,10 @@ error: struct is never constructed: `F`
 LL | struct F;
    |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -20,9 +21,10 @@ error: struct is never constructed: `B`
 LL | struct B;
    |        ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
@@ -30,9 +32,10 @@ error: enum is never used: `E`
 LL | enum E {
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -2,8 +2,11 @@ error: struct is never constructed: `F`
   --> $DIR/unused-enum.rs:3:8
    |
 LL | struct F;
-   |        ^
+   |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -15,13 +18,21 @@ error: struct is never constructed: `B`
   --> $DIR/unused-enum.rs:4:8
    |
 LL | struct B;
-   |        ^
+   |        ^ help: if this is intentional, prefix it with an underscore: `_B`
+   |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
    |
 LL | enum E {
-   |      ^
+   |      ^ help: if this is intentional, prefix it with an underscore: `_E`
+   |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -4,10 +4,8 @@ error: struct is never constructed: `F`
 LL | struct F;
    |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -21,10 +19,8 @@ error: struct is never constructed: `B`
 LL | struct B;
    |        ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
@@ -32,10 +28,8 @@ error: enum is never used: `E`
 LL | enum E {
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-enum.stderr
+++ b/src/test/ui/lint/dead-code/unused-enum.stderr
@@ -4,8 +4,7 @@ error: struct is never constructed: `F`
 LL | struct F;
    |        ^ help: if this is intentional, prefix it with an underscore: `_F`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-enum.rs:1:9
    |
@@ -19,8 +18,7 @@ error: struct is never constructed: `B`
 LL | struct B;
    |        ^ help: if this is intentional, prefix it with an underscore: `_B`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 
 error: enum is never used: `E`
   --> $DIR/unused-enum.rs:6:6
@@ -28,8 +26,7 @@ error: enum is never used: `E`
 LL | enum E {
    |      ^ help: if this is intentional, prefix it with an underscore: `_E`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -4,9 +4,10 @@ error: variant is never constructed: `Bar`
 LL |     Bar(B),
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -2,8 +2,11 @@ error: variant is never constructed: `Bar`
   --> $DIR/unused-struct-variant.rs:8:5
    |
 LL |     Bar(B),
-   |     ^^^^^^
+   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -4,10 +4,8 @@ error: variant is never constructed: `Bar`
 LL |     Bar(B),
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -2,10 +2,11 @@ error: variant is never constructed: `Bar`
   --> $DIR/unused-struct-variant.rs:8:5
    |
 LL |     Bar(B),
-   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Bar`
+   |     ---^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_Bar`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -2,8 +2,11 @@ error: variant is never constructed: `Variant1`
   --> $DIR/unused-variant.rs:5:5
    |
 LL |     Variant1,
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
+   = note: the leading underscore helps signal to the reader that the variant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the variant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -4,10 +4,8 @@ error: variant is never constructed: `Variant1`
 LL |     Variant1,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
-   = note: The leading underscore signals to the reader that while the variant may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this variant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -4,8 +4,7 @@ error: variant is never constructed: `Variant1`
 LL |     Variant1,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
-   = note: the leading underscore signals that this variant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this variant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -4,9 +4,10 @@ error: variant is never constructed: `Variant1`
 LL |     Variant1,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_Variant1`
    |
-   = note: the leading underscore helps signal to the reader that the variant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the variant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the variant may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-variant.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -4,9 +4,10 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -4,8 +4,7 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -4,10 +4,8 @@ error: function is never used: `foo`
 LL | fn foo() {
    |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/with-core-crate.stderr
+++ b/src/test/ui/lint/dead-code/with-core-crate.stderr
@@ -2,8 +2,11 @@ error: function is never used: `foo`
   --> $DIR/with-core-crate.rs:7:4
    |
 LL | fn foo() {
-   |    ^^^
+   |    ^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/with-core-crate.rs:1:9
    |

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -2,8 +2,11 @@ error: field is never read: `f`
   --> $DIR/write-only-field.rs:4:5
    |
 LL |     f: i32,
-   |     ^^^^^^
+   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -14,31 +17,51 @@ error: field is never read: `sub`
   --> $DIR/write-only-field.rs:5:5
    |
 LL |     sub: Sub,
-   |     ^^^^^^^^
+   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
    |
 LL |     f: i32,
-   |     ^^^^^^
+   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
    |
 LL |         y: bool,
-   |         ^^^^^^^
+   |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
    |
 LL |         u: u32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
    |
 LL |         v: u32,
-   |         ^^^^^^
+   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -4,9 +4,10 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -19,9 +20,10 @@ error: field is never read: `sub`
 LL |     sub: Sub,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
@@ -29,9 +31,10 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
@@ -39,9 +42,10 @@ error: field is never read: `y`
 LL |         y: bool,
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
@@ -49,9 +53,10 @@ error: field is never read: `u`
 LL |         u: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
@@ -59,9 +64,10 @@ error: field is never read: `v`
 LL |         v: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -4,10 +4,9 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -20,10 +19,9 @@ error: field is never read: `sub`
 LL |     sub: Sub,
    |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
@@ -31,10 +29,9 @@ error: field is never read: `f`
 LL |     f: i32,
    |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
@@ -42,10 +39,9 @@ error: field is never read: `y`
 LL |         y: bool,
    |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
@@ -53,10 +49,9 @@ error: field is never read: `u`
 LL |         u: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
@@ -64,10 +59,9 @@ error: field is never read: `v`
 LL |         v: u32,
    |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/dead-code/write-only-field.stderr
+++ b/src/test/ui/lint/dead-code/write-only-field.stderr
@@ -2,11 +2,11 @@ error: field is never read: `f`
   --> $DIR/write-only-field.rs:4:5
    |
 LL |     f: i32,
-   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
+   |     -^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/write-only-field.rs:1:9
    |
@@ -17,51 +17,51 @@ error: field is never read: `sub`
   --> $DIR/write-only-field.rs:5:5
    |
 LL |     sub: Sub,
-   |     ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_sub`
+   |     ---^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_sub`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `f`
   --> $DIR/write-only-field.rs:9:5
    |
 LL |     f: i32,
-   |     ^^^^^^ help: if this is intentional, prefix it with an underscore: `_f`
+   |     -^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_f`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `y`
   --> $DIR/write-only-field.rs:28:9
    |
 LL |         y: bool,
-   |         ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_y`
+   |         -^^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_y`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `u`
   --> $DIR/write-only-field.rs:58:9
    |
 LL |         u: u32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_u`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_u`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `v`
   --> $DIR/write-only-field.rs:59:9
    |
 LL |         v: u32,
-   |         ^^^^^^ help: if this is intentional, prefix it with an underscore: `_v`
+   |         -^^^^^
+   |         |
+   |         help: if this is intentional, prefix it with an underscore: `_v`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -4,9 +4,10 @@ error: constant is never used: `foo`
 LL | const foo: isize = 3;
    | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore helps signal to the reader that the constant may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the constant
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the constant may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -2,8 +2,11 @@ error: constant is never used: `foo`
   --> $DIR/issue-17718-const-naming.rs:4:1
    |
 LL | const foo: isize = 3;
-   | ^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
+   = note: the leading underscore helps signal to the reader that the constant may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the constant
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -4,10 +4,8 @@ error: constant is never used: `foo`
 LL | const foo: isize = 3;
    | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: The leading underscore signals to the reader that while the constant may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this constant serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -2,10 +2,11 @@ error: constant is never used: `foo`
   --> $DIR/issue-17718-const-naming.rs:4:1
    |
 LL | const foo: isize = 3;
-   | ^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_foo`
+   | ^^^^^^---^^^^^^^^^^^^
+   |       |
+   |       help: if this is intentional, prefix it with an underscore: `_foo`
    |
-   = note: the leading underscore signals that this constant serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this constant serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9
    |

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -2,13 +2,14 @@ warning: struct is never constructed: `S`
   --> $DIR/macro-span-replacement.rs:7:14
    |
 LL |         $b $a;
-   |              ^ help: if this is intentional, prefix it with an underscore: `_S`
+   |            --^
+   |            |
+   |            help: if this is intentional, prefix it with an underscore: `_S`
 ...
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -7,10 +7,8 @@ LL |         $b $a;
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -2,11 +2,14 @@ warning: struct is never constructed: `S`
   --> $DIR/macro-span-replacement.rs:7:14
    |
 LL |         $b $a;
-   |              ^
+   |              ^ help: if this is intentional, prefix it with an underscore: `_S`
 ...
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -7,9 +7,10 @@ LL |         $b $a;
 LL |     m!(S struct);
    |     ------------- in this macro invocation
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/macro-span-replacement.rs:3:9
    |

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -4,10 +4,8 @@ warning: enum is never used: `Enum`
 LL | enum Enum {
    |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
-   = note: The leading underscore signals to the reader that while the enum may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this enum serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -21,10 +19,8 @@ warning: struct is never constructed: `Struct`
 LL | struct Struct {
    |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
    |
-   = note: The leading underscore signals to the reader that while the struct may not be constructed
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this struct serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
@@ -32,10 +28,8 @@ warning: function is never used: `func`
 LL | fn func() -> usize {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
@@ -43,10 +37,8 @@ warning: function is never used: `func_complete_span`
 LL | func_complete_span()
    | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -4,9 +4,10 @@ warning: enum is never used: `Enum`
 LL | enum Enum {
    |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
-   = note: the leading underscore helps signal to the reader that the enum may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the enum
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the enum may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -20,9 +21,10 @@ warning: struct is never constructed: `Struct`
 LL | struct Struct {
    |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
    |
-   = note: the leading underscore helps signal to the reader that the struct may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the struct
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the struct may not be constructed
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
@@ -30,9 +32,10 @@ warning: function is never used: `func`
 LL | fn func() -> usize {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
@@ -40,9 +43,10 @@ warning: function is never used: `func_complete_span`
 LL | func_complete_span()
    | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -2,8 +2,11 @@ warning: enum is never used: `Enum`
   --> $DIR/unused-warning-point-at-identifier.rs:5:6
    |
 LL | enum Enum {
-   |      ^^^^
+   |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
+   = note: the leading underscore helps signal to the reader that the enum may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the enum
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -15,19 +18,31 @@ warning: struct is never constructed: `Struct`
   --> $DIR/unused-warning-point-at-identifier.rs:12:8
    |
 LL | struct Struct {
-   |        ^^^^^^
+   |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
+   |
+   = note: the leading underscore helps signal to the reader that the struct may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the struct
+           is only used through FFI or used only for its effect when dropped)
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
    |
 LL | fn func() -> usize {
-   |    ^^^^
+   |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
    |
 LL | func_complete_span()
-   | ^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
+   |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/span/unused-warning-point-at-identifier.stderr
+++ b/src/test/ui/span/unused-warning-point-at-identifier.stderr
@@ -4,8 +4,7 @@ warning: enum is never used: `Enum`
 LL | enum Enum {
    |      ^^^^ help: if this is intentional, prefix it with an underscore: `_Enum`
    |
-   = note: the leading underscore signals that this enum serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this enum serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/unused-warning-point-at-identifier.rs:3:9
    |
@@ -19,8 +18,7 @@ warning: struct is never constructed: `Struct`
 LL | struct Struct {
    |        ^^^^^^ help: if this is intentional, prefix it with an underscore: `_Struct`
    |
-   = note: the leading underscore signals that this struct serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this struct serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func`
   --> $DIR/unused-warning-point-at-identifier.rs:19:4
@@ -28,8 +26,7 @@ warning: function is never used: `func`
 LL | fn func() -> usize {
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_func`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: function is never used: `func_complete_span`
   --> $DIR/unused-warning-point-at-identifier.rs:24:1
@@ -37,8 +34,7 @@ warning: function is never used: `func_complete_span`
 LL | func_complete_span()
    | ^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_func_complete_span`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 
 warning: 4 warnings emitted
 

--- a/src/test/ui/suggestions/import-trait-for-method-call.rs
+++ b/src/test/ui/suggestions/import-trait-for-method-call.rs
@@ -6,4 +6,11 @@ fn next_u64() -> u64 {
     h.finish() //~ ERROR no method named `finish` found for struct `DefaultHasher`
 }
 
-fn main() {}
+trait Bar {}
+impl Bar for String {}
+
+fn main() {
+    let s = String::from("hey");
+    let x: &dyn Bar = &s;
+    x.as_ref(); //~ ERROR the method `as_ref` exists for reference `&dyn Bar`, but its trait bounds
+}

--- a/src/test/ui/suggestions/import-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/import-trait-for-method-call.stderr
@@ -15,6 +15,22 @@ help: the following trait is implemented but not in scope; perhaps add a `use` f
 LL | use std::hash::Hasher;
    |
 
-error: aborting due to previous error
+error[E0599]: the method `as_ref` exists for reference `&dyn Bar`, but its trait bounds were not satisfied
+  --> $DIR/import-trait-for-method-call.rs:15:7
+   |
+LL | trait Bar {}
+   | --------- doesn't satisfy `dyn Bar: AsRef<_>`
+...
+LL |     x.as_ref();
+   |       ^^^^^^ method cannot be called on `&dyn Bar` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `dyn Bar: AsRef<_>`
+           which is required by `&dyn Bar: AsRef<_>`
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `as_ref`, perhaps you need to implement it:
+           candidate #1: `AsRef`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -2,8 +2,11 @@ error: function is never used: `dead`
   --> $DIR/test-warns-dead-code.rs:5:4
    |
 LL | fn dead() {}
-   |    ^^^^
+   |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
+   = note: the leading underscore helps signal to the reader that the function may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the function
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -4,8 +4,7 @@ error: function is never used: `dead`
 LL | fn dead() {}
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
-   = note: the leading underscore signals that this function serves some other purpose
-           even if it isn't used in a way that we can detect.
+   = note: the leading underscore signals that this function serves some other purpose even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -4,9 +4,10 @@ error: function is never used: `dead`
 LL | fn dead() {}
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
-   = note: the leading underscore helps signal to the reader that the function may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the function
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the function may not be used
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/test-attrs/test-warns-dead-code.stderr
+++ b/src/test/ui/test-attrs/test-warns-dead-code.stderr
@@ -4,10 +4,8 @@ error: function is never used: `dead`
 LL | fn dead() {}
    |    ^^^^ help: if this is intentional, prefix it with an underscore: `_dead`
    |
-   = note: The leading underscore signals to the reader that while the function may not be used
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this function serves some other purpose
+           even if it isn't used in a way that we can detect.
 note: the lint level is defined here
   --> $DIR/test-warns-dead-code.rs:3:9
    |

--- a/src/test/ui/typeck/issue-84831.rs
+++ b/src/test/ui/typeck/issue-84831.rs
@@ -1,0 +1,9 @@
+fn f() {
+    std::<0>; //~ ERROR expected value
+}
+fn j() {
+    std::<_ as _>; //~ ERROR expected value
+    //~^ ERROR expected one of `,` or `>`, found keyword `as`
+}
+
+fn main () {}

--- a/src/test/ui/typeck/issue-84831.stderr
+++ b/src/test/ui/typeck/issue-84831.stderr
@@ -1,0 +1,26 @@
+error: expected one of `,` or `>`, found keyword `as`
+  --> $DIR/issue-84831.rs:5:13
+   |
+LL |     std::<_ as _>;
+   |             ^^ expected one of `,` or `>`
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     std::<{ _ as _ }>;
+   |           ^        ^
+
+error[E0423]: expected value, found crate `std`
+  --> $DIR/issue-84831.rs:2:5
+   |
+LL |     std::<0>;
+   |     ^^^^^^^^ not a value
+
+error[E0423]: expected value, found crate `std`
+  --> $DIR/issue-84831.rs:5:5
+   |
+LL |     std::<_ as _>;
+   |     ^^^^^^^^^^^^^ not a value
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0423`.

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -2,11 +2,11 @@ error: field is never read: `c`
   --> $DIR/union-fields-1.rs:6:5
    |
 LL |     c: u8,
-   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |     -^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -17,31 +17,31 @@ error: field is never read: `a`
   --> $DIR/union-fields-1.rs:9:5
    |
 LL |     a: u8,
-   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |     -^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
    |
 LL | union NoDropLike { a: u8 }
-   |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |                    -^^^^
+   |                    |
+   |                    help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
    |
 LL |     c: u8,
-   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |     -^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -4,9 +4,10 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -19,9 +20,10 @@ error: field is never read: `a`
 LL |     a: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
@@ -29,9 +31,10 @@ error: field is never read: `a`
 LL | union NoDropLike { a: u8 }
    |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
@@ -39,9 +42,10 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -4,10 +4,9 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -20,10 +19,9 @@ error: field is never read: `a`
 LL |     a: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
@@ -31,10 +29,9 @@ error: field is never read: `a`
 LL | union NoDropLike { a: u8 }
    |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
@@ -42,10 +39,9 @@ error: field is never read: `c`
 LL |     c: u8,
    |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-fields-1.stderr
+++ b/src/test/ui/union/union-fields-1.stderr
@@ -2,8 +2,11 @@ error: field is never read: `c`
   --> $DIR/union-fields-1.rs:6:5
    |
 LL |     c: u8,
-   |     ^^^^^
+   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:1:9
    |
@@ -14,19 +17,31 @@ error: field is never read: `a`
   --> $DIR/union-fields-1.rs:9:5
    |
 LL |     a: u8,
-   |     ^^^^^
+   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `a`
   --> $DIR/union-fields-1.rs:13:20
    |
 LL | union NoDropLike { a: u8 }
-   |                    ^^^^^
+   |                    ^^^^^ help: if this is intentional, prefix it with an underscore: `_a`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: field is never read: `c`
   --> $DIR/union-fields-1.rs:18:5
    |
 LL |     c: u8,
-   |     ^^^^^
+   |     ^^^^^ help: if this is intentional, prefix it with an underscore: `_c`
+   |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -2,11 +2,11 @@ error: field is never read: `b`
   --> $DIR/union-lint-dead-code.rs:5:5
    |
 LL |     b: bool,
-   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
+   |     -^^^^^^
+   |     |
+   |     help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore signals that this field serves some other purpose
-           even if it isn't used in a way that we can detect. (e.g. for its effect
-           when dropped or in foreign code)
+   = note: the leading underscore signals that this field serves some other purpose even if it isn't used in a way that we can detect. (e.g. for its effect when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -2,8 +2,11 @@ error: field is never read: `b`
   --> $DIR/union-lint-dead-code.rs:5:5
    |
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
+   = note: the leading underscore helps signal to the reader that the field may still serve
+           a purpose even if it isn't used in a way that we can detect (e.g. the field
+           is only used through FFI or used only for its effect when dropped)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -4,10 +4,9 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: The leading underscore signals to the reader that while the field may not be read
-           by any Rust code, it still serves some other purpose that isn't detected by rustc.
-           (e.g. some values are used for their effect when dropped or used in FFI code
-           exclusively through raw pointers)
+   = note: the leading underscore signals that this field serves some other purpose
+           even if it isn't used in a way that we can detect. (e.g. for its effect
+           when dropped or in foreign code)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |

--- a/src/test/ui/union/union-lint-dead-code.stderr
+++ b/src/test/ui/union/union-lint-dead-code.stderr
@@ -4,9 +4,10 @@ error: field is never read: `b`
 LL |     b: bool,
    |     ^^^^^^^ help: if this is intentional, prefix it with an underscore: `_b`
    |
-   = note: the leading underscore helps signal to the reader that the field may still serve
-           a purpose even if it isn't used in a way that we can detect (e.g. the field
-           is only used through FFI or used only for its effect when dropped)
+   = note: The leading underscore signals to the reader that while the field may not be read
+           by any Rust code, it still serves some other purpose that isn't detected by rustc.
+           (e.g. some values are used for their effect when dropped or used in FFI code
+           exclusively through raw pointers)
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:1:9
    |


### PR DESCRIPTION
Successful merges:

 - #83004 (Improve diagnostic for when field is never read)
 - #83553 (Update `ptr` docs with regards to `ptr::addr_of!`)
 - #84183 (Update RELEASES.md for 1.52.0)
 - #84468 (Fix#84467 linker_args with --target=sparcv9-sun-solaris)
 - #84709 (Add doc alias for `chdir` to `std::env::set_current_dir`)
 - #84803 (Reduce duplication in `impl_dep_tracking_hash` macros)
 - #84808 (Account for unsatisfied bounds in E0599)
 - #84843 (use else if in std library )
 - #84865 (rustbuild: Pass a `threads` flag that works to windows-gnu lld)
 - #84878 (Clarify documentation for `[T]::contains`)
 - #84882 (platform-support: Center the contents of the `std` and `host` columns)
 - #84903 (Remove `rustc_middle::mir::interpret::CheckInAllocMsg::NullPointerTest`)
 - #84913 (Do not ICE on invalid const param)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=83004,83553,84183,84468,84709,84803,84808,84843,84865,84878,84882,84903,84913)
<!-- homu-ignore:end -->