### PR TITLE
rustc: Rename `simd128` wasm feature to `wasm-simd128`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -141,7 +141,11 @@ pub fn time_trace_profiler_finish(file_name: &str) {
 // which might lead to failures if the oldest tested / supported LLVM version
 // doesn't yet support the relevant intrinsics
 pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
-    let arch = if sess.target.arch == "x86_64" { "x86" } else { &*sess.target.arch };
+    let arch = match &sess.target.arch[..] {
+        "x86_64" => "x86",
+        "wasm64" => "wasm32",
+        other => other,
+    };
     match (arch, s) {
         ("x86", "pclmulqdq") => "pclmul",
         ("x86", "rdrand") => "rdrnd",
@@ -152,6 +156,7 @@ pub fn to_llvm_feature<'a>(sess: &Session, s: &'a str) -> &'a str {
         ("x86", "avx512vpclmulqdq") => "vpclmulqdq",
         ("aarch64", "fp") => "fp-armv8",
         ("aarch64", "fp16") => "fullfp16",
+        ("wasm32", "wasm-simd128") => "simd128",
         (_, s) => s,
     }
 }

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -131,6 +131,7 @@ const RISCV_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
 
 const WASM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     ("simd128", Some(sym::wasm_target_feature)),
+    ("wasm-simd128", Some(sym::wasm_target_feature)),
     ("atomics", Some(sym::wasm_target_feature)),
     ("nontrapping-fptoint", Some(sym::wasm_target_feature)),
 ];

--- a/src/test/ui/target-feature/wasm-simd-128.rs
+++ b/src/test/ui/target-feature/wasm-simd-128.rs
@@ -1,0 +1,9 @@
+// only-wasm32
+// check-pass
+
+#![feature(wasm_target_feature)]
+
+#[target_feature(enable = "wasm-simd128")]
+unsafe fn foo() {}
+
+fn main() {}


### PR DESCRIPTION
This commit applies feedback from #74372 where the current name of the
wasm simd feature, `simd128`, felt a bit too bland and un-specific. This
commit renames the feature to `wasm-simd128`. This doesn't actually
delete the old `simd128` recognized name just yet because the stdarch
submodule needs to update first, so what this commit actually does is
introduce a new name (unstable like it was before), and then once
stdarch is updated we can delete the previously recognized `simd128` name.

Note that other wasm features (none currently stable) are left as-is to
choose an appropriate name if they're proposed for stabilization.