### PR TITLE
Sort rustdoc-gui tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -830,6 +830,7 @@ impl Step for RustdocGUI {
             command.arg("src/test/rustdoc-gui/lib.rs").arg("-o").arg(&out_dir);
             builder.run(&mut command);
 
+            let mut tests = Vec::new();
             for file in fs::read_dir("src/test/rustdoc-gui").unwrap() {
                 let file = file.unwrap();
                 let file_path = file.path();
@@ -838,13 +839,17 @@ impl Step for RustdocGUI {
                 if !file_name.to_str().unwrap().ends_with(".goml") {
                     continue;
                 }
+                tests.push(file_path);
+            }
+            tests.sort_unstable();
+            for test in tests {
                 let mut command = Command::new(&nodejs);
                 command
                     .arg("src/tools/rustdoc-gui/tester.js")
                     .arg("--doc-folder")
                     .arg(out_dir.join("test_docs"))
                     .arg("--test-file")
-                    .arg(file_path);
+                    .arg(test);
                 builder.run(&mut command);
             }
         } else {


### PR DESCRIPTION
The rustdoc-gui tests were randomly run. Not really a big issue but I prefer the tests to be sorted.