### PR TITLE
Error out if a PR is sent to the wrong channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: decide whether to skip this job
         run: src/ci/scripts/should-skip-this.sh
         if: success() && !env.SKIP_JOB
+      - name: ensure the channel matches the target branch
+        run: src/ci/scripts/verify-channel.sh
+        if: success() && !env.SKIP_JOB
       - name: configure GitHub Actions to kill the build when outdated
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
@@ -434,6 +437,9 @@ jobs:
       - name: decide whether to skip this job
         run: src/ci/scripts/should-skip-this.sh
         if: success() && !env.SKIP_JOB
+      - name: ensure the channel matches the target branch
+        run: src/ci/scripts/verify-channel.sh
+        if: success() && !env.SKIP_JOB
       - name: configure GitHub Actions to kill the build when outdated
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:
@@ -540,6 +546,9 @@ jobs:
         if: success() && !env.SKIP_JOB
       - name: decide whether to skip this job
         run: src/ci/scripts/should-skip-this.sh
+        if: success() && !env.SKIP_JOB
+      - name: ensure the channel matches the target branch
+        run: src/ci/scripts/verify-channel.sh
         if: success() && !env.SKIP_JOB
       - name: configure GitHub Actions to kill the build when outdated
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master

--- a/src/ci/channel
+++ b/src/ci/channel
@@ -1,0 +1,1 @@
+nightly

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -126,6 +126,10 @@ x--expand-yaml-anchors--remove:
         run: src/ci/scripts/should-skip-this.sh
         <<: *step
 
+      - name: ensure the channel matches the target branch
+        run: src/ci/scripts/verify-channel.sh
+        <<: *step
+
       - name: configure GitHub Actions to kill the build when outdated
         uses: rust-lang/simpleinfra/github-actions/cancel-outdated-builds@master
         with:

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -62,17 +62,10 @@ if [ "$DIST_SRC" = "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-dist-src"
 fi
 
-# If we're deploying artifacts then we set the release channel, otherwise if
-# we're not deploying then we want to be sure to enable all assertions because
-# we'll be running tests
-#
-# FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
-#        either automatically or manually.
-export RUST_RELEASE_CHANNEL=nightly
-
 # Always set the release channel for bootstrap; this is normally not important (i.e., only dist
 # builds would seem to matter) but in practice bootstrap wants to know whether we're targeting
 # master, beta, or stable with a build to determine whether to run some checks (notably toolstate).
+export RUST_RELEASE_CHANNEL="$(cat "${ci_dir}/channel")"
 RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
 
 if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then

--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# We want to make sure all PRs are targeting the right branch when they're
+# opened, otherwise we risk (for example) to land a beta-specific change to the
+# master branch. This script ensures the branch of the PR matches the channel.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
+
+declare -A CHANNEL_BRANCH
+CHANNEL_BRANCH["nightly"]="master"
+CHANNEL_BRANCH["beta"]="beta"
+CHANNEL_BRANCH["stable"]="stable"
+
+if isCiBranch auto || isCiBranch try; then
+    echo "channel verification is only executed on PR builds"
+    exit
+fi
+
+channel=$(cat "$(ciCheckoutPath)/src/ci/channel")
+branch="$(ciBaseBranch)"
+if [[ "${branch}" != "${CHANNEL_BRANCH[$channel]}" ]]; then
+    echo "error: PRs changing the \`${channel}\` channel should be sent to the \
+\`${CHANNEL_BRANCH[$channel]}\` branch!"
+
+    exit 1
+fi

--- a/src/ci/scripts/verify-channel.sh
+++ b/src/ci/scripts/verify-channel.sh
@@ -8,21 +8,31 @@ IFS=$'\n\t'
 
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
-declare -A CHANNEL_BRANCH
-CHANNEL_BRANCH["nightly"]="master"
-CHANNEL_BRANCH["beta"]="beta"
-CHANNEL_BRANCH["stable"]="stable"
-
 if isCiBranch auto || isCiBranch try; then
     echo "channel verification is only executed on PR builds"
     exit
 fi
 
 channel=$(cat "$(ciCheckoutPath)/src/ci/channel")
+case "${channel}" in
+    nightly)
+        channel_branch="master"
+        ;;
+    beta)
+        channel_branch="beta"
+        ;;
+    stable)
+        channel_branch="stable"
+        ;;
+    *)
+        echo "error: unknown channel defined in src/ci/channel: ${channel}"
+        exit 1
+esac
+
 branch="$(ciBaseBranch)"
-if [[ "${branch}" != "${CHANNEL_BRANCH[$channel]}" ]]; then
+if [[ "${branch}" != "${channel_branch}" ]]; then
     echo "error: PRs changing the \`${channel}\` channel should be sent to the \
-\`${CHANNEL_BRANCH[$channel]}\` branch!"
+\`${channel_branch}\` branch!"
 
     exit 1
 fi

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -73,6 +73,18 @@ function isCiBranch {
     fi
 }
 
+function ciBaseBranch {
+    if isAzurePipelines; then
+        echo "unsupported on Azure Pipelines"
+        exit 1
+    elif isGitHubActions; then
+        echo "${GITHUB_BASE_REF#refs/heads/}"
+    else
+        echo "ciBaseBranch only works inside CI!"
+        exit 1
+    fi
+}
+
 function ciCommit {
     if isAzurePipelines; then
         echo "${BUILD_SOURCEVERSION}"


### PR DESCRIPTION
It happened multiple times that a PR meant to go on beta ends up being opened (and occasionally merged) to master. This PR does two things:

* Moves the definition of the channel in `src/ci/channel` so it's easier for tools to read it. I was not sure whether to move it to `src/channel` (like `src/version`): ended up with `src/ci` as it's currently only used for CI, but I'm open to moving it to `src`. We'll need to update the release process after this.
* Adds a check on **non-bors** builds that errors out if the base branch is not the expected one for the currently defined channel. This will not cause problems for promotion PRs, as those PRs are meant to also update the channel name.

r? @Mark-Simulacrum 