### PR TITLE
Show nicer error when an 'unstable fingerprints' error occurs

### DIFF
--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -605,13 +605,19 @@ fn incremental_verify_ich<CTX, K, V: Debug>(
 
     let old_hash = tcx.dep_graph().prev_fingerprint_of(dep_node);
 
-    assert_eq!(
-        Some(new_hash),
-        old_hash,
-        "found unstable fingerprints for {:?}: {:?}",
-        dep_node,
-        result
-    );
+    if Some(new_hash) != old_hash {
+        let run_cmd = if let Some(crate_name) = &tcx.sess().opts.crate_name {
+            format!("`cargo clean -p {}` or `cargo clean`", crate_name)
+        } else {
+            "`cargo clean`".to_string()
+        };
+        tcx.sess().struct_err(&format!("internal compiler error: encountered incremental compilation error with {:?}", dep_node))
+            .help(&format!("This is a known issue with the compiler. Run {} to allow your project to compile", run_cmd))
+            .note(&format!("Please follow the instructions below to create a bug report with the provided information"))
+            .note(&format!("See <https://github.com/rust-lang/rust/issues/84970> for more information"))
+            .emit();
+        panic!("Found unstable fingerprints for {:?}: {:?}", dep_node, result);
+    }
 }
 
 fn force_query_with_job<C, CTX>(


### PR DESCRIPTION
An example of the error produced by this PR:

```
error: internal compiler error: encountered incremental compilation error with evaluate_obligation(9f2ad55260c30262-c36667639674ad83)
  |
  = help: This is a known issue with the compiler. Run `cargo clean -p syn` or `cargo clean` to allow your project to compile
  = note: Please follow the instructions below to create a bug report with the provided information

thread 'rustc' panicked at 'Found unstable fingerprints for evaluate_obligation(9f2ad55260c30262-c36667639674ad83): Ok(EvaluatedToOk)', /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:595:9
stack backtrace:
   0: rust_begin_unwind
             at /home/aaron/repos/rust/library/std/src/panicking.rs:493:5
   1: std::panicking::begin_panic_fmt
             at /home/aaron/repos/rust/library/std/src/panicking.rs:435:5
   2: rustc_query_system::query::plumbing::incremental_verify_ich
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:595:9
   3: rustc_query_system::query::plumbing::load_from_disk_and_cache_in_memory
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:557:9
   4: rustc_query_system::query::plumbing::try_execute_query::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:473:21
   5: core::option::Option<T>::map
             at /home/aaron/repos/rust/library/core/src/option.rs:487:29
   6: rustc_query_system::query::plumbing::try_execute_query::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:471:13
   7: stacker::maybe_grow
             at /home/aaron/.cargo/registry/src/github.com-1ecc6299db9ec823/stacker-0.1.12/src/lib.rs:55:9
   8: rustc_data_structures::stack::ensure_sufficient_stack
             at /home/aaron/repos/rust/compiler/rustc_data_structures/src/stack.rs:16:5
   9: <rustc_query_impl::plumbing::QueryCtxt as rustc_query_system::query::QueryContext>::start_query::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_impl/src/plumbing.rs:169:17
  10: rustc_middle::ty::context::tls::enter_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:50
  11: rustc_middle::ty::context::tls::set_tlv
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1720:9
  12: rustc_middle::ty::context::tls::enter_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:9
  13: <rustc_query_impl::plumbing::QueryCtxt as rustc_query_system::query::QueryContext>::start_query::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_impl/src/plumbing.rs:168:13
  14: rustc_middle::ty::context::tls::with_related_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1780:13
  15: rustc_middle::ty::context::tls::with_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:40
  16: rustc_middle::ty::context::tls::with_context_opt
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1753:22
  17: rustc_middle::ty::context::tls::with_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:9
  18: rustc_middle::ty::context::tls::with_related_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1777:9
  19: <rustc_query_impl::plumbing::QueryCtxt as rustc_query_system::query::QueryContext>::start_query
             at /home/aaron/repos/rust/compiler/rustc_query_impl/src/plumbing.rs:157:9
  20: rustc_query_system::query::plumbing::try_execute_query
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:469:22
  21: rustc_query_system::query::plumbing::get_query_impl
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:674:5
  22: rustc_query_system::query::plumbing::get_query
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:785:9
  23: <rustc_query_impl::Queries as rustc_middle::ty::query::QueryEngine>::evaluate_obligation
             at /home/aaron/repos/rust/compiler/rustc_query_impl/src/plumbing.rs:603:17
  24: rustc_middle::ty::query::TyCtxtAt::evaluate_obligation
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/query/mod.rs:204:17
  25: rustc_middle::ty::query::<impl rustc_middle::ty::context::TyCtxt>::evaluate_obligation
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/query/mod.rs:185:17
  26: <rustc_infer::infer::InferCtxt as rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt>::evaluate_obligation
             at /home/aaron/repos/rust/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs:72:9
  27: <rustc_infer::infer::InferCtxt as rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt>::evaluate_obligation_no_overflow
             at /home/aaron/repos/rust/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs:82:15
  28: <rustc_infer::infer::InferCtxt as rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt>::predicate_must_hold_modulo_regions
             at /home/aaron/repos/rust/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs:58:9
  29: rustc_trait_selection::traits::type_known_to_meet_bound_modulo_regions
             at /home/aaron/repos/rust/compiler/rustc_trait_selection/src/traits/mod.rs:146:18
  30: rustc_ty_utils::common_traits::is_item_raw::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_ty_utils/src/common_traits.rs:33:9
  31: rustc_infer::infer::InferCtxtBuilder::enter
             at /home/aaron/repos/rust/compiler/rustc_infer/src/infer/mod.rs:582:9
  32: rustc_ty_utils::common_traits::is_item_raw
             at /home/aaron/repos/rust/compiler/rustc_ty_utils/src/common_traits.rs:32:5
  33: rustc_query_system::query::config::QueryVtable<CTX,K,V>::compute
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/config.rs:44:9
  34: rustc_query_system::query::plumbing::load_from_disk_and_cache_in_memory::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:544:67
  35: rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/dep_graph/mod.rs:77:46
  36: rustc_middle::ty::context::tls::enter_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:50
  37: rustc_middle::ty::context::tls::set_tlv
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1720:9
  38: rustc_middle::ty::context::tls::enter_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:9
  39: rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/dep_graph/mod.rs:77:13
  40: rustc_middle::ty::context::tls::with_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:40
  41: rustc_middle::ty::context::tls::with_context_opt
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1753:22
  42: rustc_middle::ty::context::tls::with_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:9
  43: rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps
             at /home/aaron/repos/rust/compiler/rustc_middle/src/dep_graph/mod.rs:74:9
  44: rustc_query_system::dep_graph::graph::DepGraph<K>::with_ignore
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/dep_graph/graph.rs:167:9
  45: rustc_query_system::query::plumbing::load_from_disk_and_cache_in_memory
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:544:22
  46: rustc_query_system::query::plumbing::try_execute_query::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:473:21
  47: core::option::Option<T>::map
             at /home/aaron/repos/rust/library/core/src/option.rs:487:29
  48: rustc_query_system::query::plumbing::try_execute_query::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:471:13
  49: stacker::maybe_grow
             at /home/aaron/.cargo/registry/src/github.com-1ecc6299db9ec823/stacker-0.1.12/src/lib.rs:55:9
  50: rustc_data_structures::stack::ensure_sufficient_stack
             at /home/aaron/repos/rust/compiler/rustc_data_structures/src/stack.rs:16:5
  51: <rustc_query_impl::plumbing::QueryCtxt as rustc_query_system::query::QueryContext>::start_query::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_impl/src/plumbing.rs:169:17
  52: rustc_middle::ty::context::tls::enter_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:50
  53: rustc_middle::ty::context::tls::set_tlv
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1720:9
  54: rustc_middle::ty::context::tls::enter_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:9
  55: <rustc_query_impl::plumbing::QueryCtxt as rustc_query_system::query::QueryContext>::start_query::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_impl/src/plumbing.rs:168:13
  56: rustc_middle::ty::context::tls::with_related_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1780:13
  57: rustc_middle::ty::context::tls::with_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:40
  58: rustc_middle::ty::context::tls::with_context_opt
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1753:22
  59: rustc_middle::ty::context::tls::with_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:9
  60: rustc_middle::ty::context::tls::with_related_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1777:9
  61: <rustc_query_impl::plumbing::QueryCtxt as rustc_query_system::query::QueryContext>::start_query
             at /home/aaron/repos/rust/compiler/rustc_query_impl/src/plumbing.rs:157:9
  62: rustc_query_system::query::plumbing::try_execute_query
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:469:22
  63: rustc_query_system::query::plumbing::get_query_impl
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:674:5
  64: rustc_query_system::query::plumbing::get_query
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/query/plumbing.rs:785:9
  65: rustc_middle::ty::query::TyCtxtAt::is_unpin_raw
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/query/mod.rs:204:17
  66: rustc_middle::ty::util::<impl rustc_middle::ty::TyS>::is_unpin
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/util.rs:727:38
  67: rustc_middle::ty::layout::<impl rustc_target::abi::TyAndLayoutMethods<C> for &rustc_middle::ty::TyS>::pointee_info_at
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/layout.rs:2341:32
  68: rustc_target::abi::TyAndLayout<Ty>::pointee_info_at
             at /home/aaron/repos/rust/compiler/rustc_target/src/abi/mod.rs:1164:9
  69: <rustc_target::abi::call::FnAbi<&rustc_middle::ty::TyS> as rustc_middle::ty::layout::FnAbiExt<C>>::new_internal::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/layout.rs:2781:36
  70: <rustc_target::abi::call::FnAbi<&rustc_middle::ty::TyS> as rustc_middle::ty::layout::FnAbiExt<C>>::new_internal::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/layout.rs:2840:17
  71: rustc_target::abi::call::ArgAbi<Ty>::new
             at /home/aaron/repos/rust/compiler/rustc_target/src/abi/call/mod.rs:457:53
  72: <rustc_target::abi::call::FnAbi<&rustc_middle::ty::TyS> as rustc_middle::ty::layout::FnAbiExt<C>>::new_internal::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/layout.rs:2838:27
  73: <rustc_target::abi::call::FnAbi<&rustc_middle::ty::TyS> as rustc_middle::ty::layout::FnAbiExt<C>>::new_internal::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/layout.rs:2870:32
  74: core::iter::adapters::map::map_fold::{{closure}}
             at /home/aaron/repos/rust/library/core/src/iter/adapters/map.rs:82:28
  75: <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::fold::enumerate::{{closure}}
             at /home/aaron/repos/rust/library/core/src/iter/adapters/enumerate.rs:104:27
  76: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /home/aaron/repos/rust/library/core/src/ops/function.rs:269:13
  77: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /home/aaron/repos/rust/library/core/src/ops/function.rs:269:13
  78: core::iter::adapters::map::map_fold::{{closure}}
             at /home/aaron/repos/rust/library/core/src/iter/adapters/map.rs:82:21
  79: core::iter::traits::iterator::Iterator::fold
             at /home/aaron/repos/rust/library/core/src/iter/traits/iterator.rs:2146:21
  80: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /home/aaron/repos/rust/library/core/src/iter/adapters/map.rs:122:9
  81: <core::iter::adapters::cloned::Cloned<I> as core::iter::traits::iterator::Iterator>::fold
             at /home/aaron/repos/rust/library/core/src/iter/adapters/cloned.rs:58:9
  82: <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::fold
             at /home/aaron/repos/rust/library/core/src/iter/adapters/chain.rs:119:19
  83: <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::fold
             at /home/aaron/repos/rust/library/core/src/iter/adapters/chain.rs:119:19
  84: <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::fold
             at /home/aaron/repos/rust/library/core/src/iter/adapters/enumerate.rs:110:9
  85: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /home/aaron/repos/rust/library/core/src/iter/adapters/map.rs:122:9
  86: core::iter::traits::iterator::Iterator::for_each
             at /home/aaron/repos/rust/library/core/src/iter/traits/iterator.rs:776:9
  87: <alloc::vec::Vec<T,A> as alloc::vec::spec_extend::SpecExtend<T,I>>::spec_extend
             at /home/aaron/repos/rust/library/alloc/src/vec/spec_extend.rs:40:17
  88: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
             at /home/aaron/repos/rust/library/alloc/src/vec/spec_from_iter_nested.rs:56:9
  89: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter
             at /home/aaron/repos/rust/library/alloc/src/vec/spec_from_iter.rs:36:9
  90: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /home/aaron/repos/rust/library/alloc/src/vec/mod.rs:2448:9
  91: core::iter::traits::iterator::Iterator::collect
             at /home/aaron/repos/rust/library/core/src/iter/traits/iterator.rs:1788:9
  92: <rustc_target::abi::call::FnAbi<&rustc_middle::ty::TyS> as rustc_middle::ty::layout::FnAbiExt<C>>::new_internal
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/layout.rs:2864:19
  93: <rustc_target::abi::call::FnAbi<&rustc_middle::ty::TyS> as rustc_middle::ty::layout::FnAbiExt<C>>::of_instance
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/layout.rs:2670:9
  94: rustc_codegen_llvm::mono_item::<impl rustc_codegen_ssa::traits::declare::PreDefineMethods for rustc_codegen_llvm::context::CodegenCx>::predefine_fn
             at /home/aaron/repos/rust/compiler/rustc_codegen_llvm/src/mono_item.rs:57:22
  95: <rustc_middle::mir::mono::MonoItem as rustc_codegen_ssa::mono_item::MonoItemExt>::predefine
             at /home/aaron/repos/rust/compiler/rustc_codegen_ssa/src/mono_item.rs:76:17
  96: rustc_codegen_llvm::base::compile_codegen_unit::module_codegen
             at /home/aaron/repos/rust/compiler/rustc_codegen_llvm/src/base.rs:122:17
  97: rustc_query_system::dep_graph::graph::DepGraph<K>::with_task_impl::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/dep_graph/graph.rs:235:62
  98: rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/dep_graph/mod.rs:77:46
  99: rustc_middle::ty::context::tls::enter_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:50
 100: rustc_middle::ty::context::tls::set_tlv
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1720:9
 101: rustc_middle::ty::context::tls::enter_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:9
 102: rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/dep_graph/mod.rs:77:13
 103: rustc_middle::ty::context::tls::with_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:40
 104: rustc_middle::ty::context::tls::with_context_opt
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1753:22
 105: rustc_middle::ty::context::tls::with_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1764:9
 106: rustc_middle::dep_graph::<impl rustc_query_system::dep_graph::DepKind for rustc_middle::dep_graph::dep_node::DepKind>::with_deps
             at /home/aaron/repos/rust/compiler/rustc_middle/src/dep_graph/mod.rs:74:9
 107: rustc_query_system::dep_graph::graph::DepGraph<K>::with_task_impl
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/dep_graph/graph.rs:235:26
 108: rustc_query_system::dep_graph::graph::DepGraph<K>::with_task
             at /home/aaron/repos/rust/compiler/rustc_query_system/src/dep_graph/graph.rs:205:9
 109: rustc_codegen_llvm::base::compile_codegen_unit
             at /home/aaron/repos/rust/compiler/rustc_codegen_llvm/src/base.rs:103:9
 110: <rustc_codegen_llvm::LlvmCodegenBackend as rustc_codegen_ssa::traits::backend::ExtraBackendMethods>::compile_codegen_unit
             at /home/aaron/repos/rust/compiler/rustc_codegen_llvm/src/lib.rs:109:9
 111: rustc_codegen_ssa::base::codegen_crate
             at /home/aaron/repos/rust/compiler/rustc_codegen_ssa/src/base.rs:655:38
 112: <rustc_codegen_llvm::LlvmCodegenBackend as rustc_codegen_ssa::traits::backend::CodegenBackend>::codegen_crate
             at /home/aaron/repos/rust/compiler/rustc_codegen_llvm/src/lib.rs:270:18
 113: rustc_interface::passes::start_codegen::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/passes.rs:1021:9
 114: rustc_data_structures::profiling::VerboseTimingGuard::run
             at /home/aaron/repos/rust/compiler/rustc_data_structures/src/profiling.rs:573:9
 115: rustc_session::utils::<impl rustc_session::session::Session>::time
             at /home/aaron/repos/rust/compiler/rustc_session/src/utils.rs:16:9
 116: rustc_interface::passes::start_codegen
             at /home/aaron/repos/rust/compiler/rustc_interface/src/passes.rs:1020:19
 117: rustc_interface::queries::Queries::ongoing_codegen::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/queries.rs:296:20
 118: rustc_interface::passes::QueryContext::enter::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/passes.rs:755:42
 119: rustc_middle::ty::context::tls::enter_context::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:50
 120: rustc_middle::ty::context::tls::set_tlv
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1720:9
 121: rustc_middle::ty::context::tls::enter_context
             at /home/aaron/repos/rust/compiler/rustc_middle/src/ty/context.rs:1736:9
 122: rustc_interface::passes::QueryContext::enter
             at /home/aaron/repos/rust/compiler/rustc_interface/src/passes.rs:755:9
 123: rustc_interface::queries::Queries::ongoing_codegen::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/queries.rs:287:13
 124: rustc_interface::queries::Query<T>::compute
             at /home/aaron/repos/rust/compiler/rustc_interface/src/queries.rs:40:28
 125: rustc_interface::queries::Queries::ongoing_codegen
             at /home/aaron/repos/rust/compiler/rustc_interface/src/queries.rs:285:9
 126: rustc_driver::run_compiler::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_driver/src/lib.rs:442:13
 127: rustc_interface::queries::<impl rustc_interface::interface::Compiler>::enter
             at /home/aaron/repos/rust/compiler/rustc_interface/src/queries.rs:428:19
 128: rustc_driver::run_compiler::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_driver/src/lib.rs:337:22
 129: rustc_interface::interface::create_compiler_and_run::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/interface.rs:208:13
 130: rustc_span::with_source_map
             at /home/aaron/repos/rust/compiler/rustc_span/src/lib.rs:788:5
 131: rustc_interface::interface::create_compiler_and_run
             at /home/aaron/repos/rust/compiler/rustc_interface/src/interface.rs:202:5
 132: rustc_interface::interface::run_compiler::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/interface.rs:224:12
 133: rustc_interface::util::setup_callbacks_and_run_in_thread_pool_with_globals::{{closure}}::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/util.rs:155:13
 134: scoped_tls::ScopedKey<T>::set
             at /home/aaron/.cargo/registry/src/github.com-1ecc6299db9ec823/scoped-tls-1.0.0/src/lib.rs:137:9
 135: rustc_span::with_session_globals
             at /home/aaron/repos/rust/compiler/rustc_span/src/lib.rs:105:5
 136: rustc_interface::util::setup_callbacks_and_run_in_thread_pool_with_globals::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/util.rs:153:9
 137: rustc_interface::util::scoped_thread::{{closure}}
             at /home/aaron/repos/rust/compiler/rustc_interface/src/util.rs:128:24
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.54.0-dev running on x86_64-unknown-linux-gnu

note: compiler flags: -C opt-level=3 -C embed-bitcode=no -C incremental --crate-type lib

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
#0 [evaluate_obligation] evaluating trait selection obligation `quote::Tokens: std::marker::Unpin`
#1 [is_unpin_raw] computing whether `quote::Tokens` is `Unpin`
end of query stack
error: aborting due to previous error

error: could not compile `syn`

To learn more, run the command again with --verbose.
```

I've left in the panic and ICE following the pretty error, so that we still have all of the debug information available in a bug report.

This message can be reproduced by cloning the repository `https://github.com/Aaron1011/syn-crash`, and running the following shell script (with a `rustup override` set in the directory):

```
set -xe
cargo clean -p syn
cargo clean --release -p syn

git checkout minimize
cargo build --release -j 1

git checkout minimize-change
cargo build --release -j 1
```

r? @Mark-Simulacrum 

