### PR TITLE
Resolve `Self` in a submodule when the type is not in scope

### DIFF
--- a/src/test/rustdoc/issue-84827.rs
+++ b/src/test/rustdoc/issue-84827.rs
@@ -1,0 +1,15 @@
+#![deny(broken_intra_doc_links)]
+
+// @has issue_84827/struct.Foo.html
+// @has - '//a[@href="struct.Foo.html#structfield.foo"]' 'Self::foo'
+
+pub struct Foo {
+    pub foo: i32,
+}
+
+pub mod bar {
+    impl crate::Foo {
+        /// [`Self::foo`].
+        pub fn baz(&self) {}
+    }
+}


### PR DESCRIPTION
fix #84827 