### PR TITLE
Name the captured upvars for closures/generators in debuginfo

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1314,9 +1314,9 @@ struct TupleMemberDescriptionFactory<'tcx> {
 
 impl<'tcx> TupleMemberDescriptionFactory<'tcx> {
     fn create_member_descriptions(&self, cx: &CodegenCx<'ll, 'tcx>) -> Vec<MemberDescription<'ll>> {
-        let capture_names = match *self.ty.kind() {
+        let mut capture_names = match *self.ty.kind() {
             ty::Generator(def_id, ..) | ty::Closure(def_id, ..) => {
-                Some(closure_saved_names_of_captured_variables(cx.tcx, def_id))
+                Some(closure_saved_names_of_captured_variables(cx.tcx, def_id).into_iter())
             }
             _ => None,
         };
@@ -1326,8 +1326,8 @@ impl<'tcx> TupleMemberDescriptionFactory<'tcx> {
             .enumerate()
             .map(|(i, &component_type)| {
                 let (size, align) = cx.size_and_align_of(component_type);
-                let name = if let Some(names) = capture_names.as_ref() {
-                    names[i].clone()
+                let name = if let Some(names) = capture_names.as_mut() {
+                    names.next().unwrap()
                 } else {
                     format!("__{}", i)
                 };

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -285,7 +285,7 @@ pub type DepNode = rustc_query_system::dep_graph::DepNode<DepKind>;
 // required that their size stay the same, but we don't want to change
 // it inadvertently. This assert just ensures we're aware of any change.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-static_assert_size!(DepNode, 17);
+static_assert_size!(DepNode, 18);
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 static_assert_size!(DepNode, 24);

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -329,6 +329,16 @@ rustc_queries! {
         }
     }
 
+    query symbols_for_closure_captures(
+        key: (LocalDefId, DefId)
+    ) -> Vec<rustc_span::Symbol> {
+        desc {
+            |tcx| "symbols for captures of closure `{}` in `{}`",
+            tcx.def_path_str(key.1),
+            tcx.def_path_str(key.0.to_def_id())
+        }
+    }
+
     /// MIR after our optimization passes have run. This is MIR that is ready
     /// for codegen. This is also the only query that can fetch non-local MIR, at present.
     query optimized_mir(key: DefId) -> &'tcx mir::Body<'tcx> {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -16,7 +16,6 @@ pub use self::IntVarValue::*;
 pub use self::Variance::*;
 pub use adt::*;
 pub use assoc::*;
-pub use closure::*;
 pub use generics::*;
 pub use vtable::*;
 
@@ -55,6 +54,12 @@ pub use rustc_type_ir::*;
 
 pub use self::binding::BindingMode;
 pub use self::binding::BindingMode::*;
+pub use self::closure::{
+    is_ancestor_or_same_capture, place_to_string_for_capture, BorrowKind, CaptureInfo,
+    CapturedPlace, ClosureKind, MinCaptureInformationMap, MinCaptureList,
+    RootVariableMinCaptureList, UpvarBorrow, UpvarCapture, UpvarCaptureMap, UpvarId, UpvarListMap,
+    UpvarPath, CAPTURE_STRUCT_LOCAL,
+};
 pub use self::consts::{Const, ConstInt, ConstKind, InferConst, ScalarInt, Unevaluated, ValTree};
 pub use self::context::{
     tls, CanonicalUserType, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations,
@@ -1979,6 +1984,7 @@ pub fn ast_uint_ty(uty: UintTy) -> ast::UintTy {
 }
 
 pub fn provide(providers: &mut ty::query::Providers) {
+    closure::provide(providers);
     context::provide(providers);
     erase_regions::provide(providers);
     layout::provide(providers);

--- a/compiler/rustc_mir_build/src/build/mod.rs
+++ b/compiler/rustc_mir_build/src/build/mod.rs
@@ -16,7 +16,7 @@ use rustc_middle::mir::*;
 use rustc_middle::thir::{BindingMode, Expr, ExprId, LintLevel, PatKind, Thir};
 use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeFoldable, TypeckResults};
-use rustc_span::symbol::{kw, sym};
+use rustc_span::symbol::sym;
 use rustc_span::Span;
 use rustc_target::spec::abi::Abi;
 use rustc_target::spec::PanicStrategy;
@@ -974,13 +974,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     let mutability = captured_place.mutability;
 
-                    // FIXME(project-rfc-2229#8): Store more precise information
-                    let mut name = kw::Empty;
-                    if let Some(Node::Binding(pat)) = tcx_hir.find(var_id) {
-                        if let hir::PatKind::Binding(_, _, ident, _) = pat.kind {
-                            name = ident.name;
-                        }
-                    }
+                    let name = captured_place.to_symbol(tcx);
 
                     let mut projs = closure_env_projs.clone();
                     projs.push(ProjectionElem::Field(Field::new(i), ty));

--- a/src/test/debuginfo/captured-fields-1.rs
+++ b/src/test/debuginfo/captured-fields-1.rs
@@ -4,38 +4,44 @@
 
 // gdb-command:run
 // gdb-command:print test
-// gdbr-check:$1 = captured_fields::main::{closure#0} {_captured_ref__my_ref__my_field1: 0x[...]}
+// gdbr-check:$1 = captured_fields_1::main::{closure#0} {_ref__my_ref__my_field1: 0x[...]}
 // gdb-command:continue
 // gdb-command:print test
-// gdbr-check:$2 = captured_fields::main::{closure#1} {_captured_ref__my_ref__my_field2: 0x[...]}
+// gdbr-check:$2 = captured_fields_1::main::{closure#1} {_ref__my_ref__my_field2: 0x[...]}
 // gdb-command:continue
 // gdb-command:print test
-// gdbr-check:$3 = captured_fields::main::{closure#2} {_captured_ref__my_ref: 0x[...]}
+// gdbr-check:$3 = captured_fields_1::main::{closure#2} {_ref__my_ref: 0x[...]}
 // gdb-command:continue
 // gdb-command:print test
-// gdbr-check:$4 = captured_fields::main::{closure#3} {_captured_val__my_ref: 0x[...]}
+// gdbr-check:$4 = captured_fields_1::main::{closure#3} {my_ref: 0x[...]}
 // gdb-command:continue
 // gdb-command:print test
-// gdbr-check:$5 = captured_fields::main::{closure#4} {_captured_val__my_var: captured_fields::MyStruct {my_field1: 11, my_field2: 22}}
+// gdbr-check:$5 = captured_fields_1::main::{closure#4} {my_var__my_field2: 22}
+// gdb-command:continue
+// gdb-command:print test
+// gdbr-check:$6 = captured_fields_1::main::{closure#5} {my_var: captured_fields_1::MyStruct {my_field1: 11, my_field2: 22}}
 // gdb-command:continue
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
 // lldb-command:print test
-// lldbg-check:(captured_fields::main::{closure#0}) $0 = { _captured_ref__my_ref__my_field1 = 0x[...] }
+// lldbg-check:(captured_fields_1::main::{closure#0}) $0 = { _ref__my_ref__my_field1 = 0x[...] }
 // lldb-command:continue
 // lldb-command:print test
-// lldbg-check:(captured_fields::main::{closure#1}) $1 = { _captured_ref__my_ref__my_field2 = 0x[...] }
+// lldbg-check:(captured_fields_1::main::{closure#1}) $1 = { _ref__my_ref__my_field2 = 0x[...] }
 // lldb-command:continue
 // lldb-command:print test
-// lldbg-check:(captured_fields::main::{closure#2}) $2 = { _captured_ref__my_ref = 0x[...] }
+// lldbg-check:(captured_fields_1::main::{closure#2}) $2 = { _ref__my_ref = 0x[...] }
 // lldb-command:continue
 // lldb-command:print test
-// lldbg-check:(captured_fields::main::{closure#3}) $3 = { _captured_val__my_ref = 0x[...] }
+// lldbg-check:(captured_fields_1::main::{closure#3}) $3 = { my_ref = 0x[...] }
 // lldb-command:continue
 // lldb-command:print test
-// lldbg-check:(captured_fields::main::{closure#4}) $4 = { _captured_val__my_var = { my_field1 = 11 my_field2 = 22 } }
+// lldbg-check:(captured_fields_1::main::{closure#4}) $4 = { my_var__my_field2 = 22 }
+// lldb-command:continue
+// lldb-command:print test
+// lldbg-check:(captured_fields_1::main::{closure#5}) $5 = { my_var = { my_field1 = 11 my_field2 = 22 } }
 // lldb-command:continue
 
 #![feature(capture_disjoint_fields)]
@@ -73,6 +79,12 @@ fn main() {
 
     let test = || {
         let a = my_ref;
+    };
+
+    _zzz(); // #break
+
+    let test = move || {
+        let a = my_var.my_field2;
     };
 
     _zzz(); // #break

--- a/src/test/debuginfo/captured-fields-2.rs
+++ b/src/test/debuginfo/captured-fields-2.rs
@@ -1,0 +1,55 @@
+// compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:print my_ref__my_field1
+// gdbr-check:$1 = 11
+// gdb-command:continue
+// gdb-command:print my_var__my_field2
+// gdbr-check:$2 = 22
+// gdb-command:continue
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+// lldb-command:print my_ref__my_field1
+// lldbg-check:(unsigned int) $0 = 11
+// lldb-command:continue
+// lldb-command:print my_var__my_field2
+// lldbg-check:(unsigned int) $1 = 22
+// lldb-command:continue
+
+#![feature(capture_disjoint_fields)]
+#![allow(unused)]
+
+struct MyStruct {
+    my_field1: u32,
+    my_field2: u32,
+}
+
+fn main() {
+    let mut my_var = MyStruct {
+        my_field1: 11,
+        my_field2: 22,
+    };
+    let my_ref = &mut my_var;
+
+    let test = || {
+        let a = my_ref.my_field1;
+
+        _zzz(); // #break
+    };
+
+    test();
+
+    let test = move || {
+        let a = my_var.my_field2;
+
+        _zzz(); // #break
+    };
+
+    test();
+}
+
+fn _zzz() {}

--- a/src/test/debuginfo/captured-fields.rs
+++ b/src/test/debuginfo/captured-fields.rs
@@ -1,0 +1,87 @@
+// compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:print test
+// gdbr-check:$1 = captured_fields::main::{closure#0} {_captured_ref__my_ref__my_field1: 0x[...]}
+// gdb-command:continue
+// gdb-command:print test
+// gdbr-check:$2 = captured_fields::main::{closure#1} {_captured_ref__my_ref__my_field2: 0x[...]}
+// gdb-command:continue
+// gdb-command:print test
+// gdbr-check:$3 = captured_fields::main::{closure#2} {_captured_ref__my_ref: 0x[...]}
+// gdb-command:continue
+// gdb-command:print test
+// gdbr-check:$4 = captured_fields::main::{closure#3} {_captured_val__my_ref: 0x[...]}
+// gdb-command:continue
+// gdb-command:print test
+// gdbr-check:$5 = captured_fields::main::{closure#4} {_captured_val__my_var: captured_fields::MyStruct {my_field1: 11, my_field2: 22}}
+// gdb-command:continue
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+// lldb-command:print test
+// lldbg-check:(captured_fields::main::{closure#0}) $0 = { _captured_ref__my_ref__my_field1 = 0x[...] }
+// lldb-command:continue
+// lldb-command:print test
+// lldbg-check:(captured_fields::main::{closure#1}) $1 = { _captured_ref__my_ref__my_field2 = 0x[...] }
+// lldb-command:continue
+// lldb-command:print test
+// lldbg-check:(captured_fields::main::{closure#2}) $2 = { _captured_ref__my_ref = 0x[...] }
+// lldb-command:continue
+// lldb-command:print test
+// lldbg-check:(captured_fields::main::{closure#3}) $3 = { _captured_val__my_ref = 0x[...] }
+// lldb-command:continue
+// lldb-command:print test
+// lldbg-check:(captured_fields::main::{closure#4}) $4 = { _captured_val__my_var = { my_field1 = 11 my_field2 = 22 } }
+// lldb-command:continue
+
+#![feature(capture_disjoint_fields)]
+#![allow(unused)]
+
+struct MyStruct {
+    my_field1: u32,
+    my_field2: u32,
+}
+
+fn main() {
+    let mut my_var = MyStruct {
+        my_field1: 11,
+        my_field2: 22,
+    };
+    let my_ref = &mut my_var;
+
+    let test = || {
+        let a = &mut my_ref.my_field1;
+    };
+
+    _zzz(); // #break
+
+    let test = || {
+        let a = &my_ref.my_field2;
+    };
+
+    _zzz(); // #break
+
+    let test = || {
+        let a = &my_ref;
+    };
+
+    _zzz(); // #break
+
+    let test = || {
+        let a = my_ref;
+    };
+
+    _zzz(); // #break
+
+    let test = || {
+        let a = my_var;
+    };
+
+    _zzz(); // #break
+}
+
+fn _zzz() {}

--- a/src/test/debuginfo/generator-objects.rs
+++ b/src/test/debuginfo/generator-objects.rs
@@ -11,16 +11,16 @@
 
 // gdb-command:run
 // gdb-command:print b
-// gdb-check:$1 = generator_objects::main::{generator#0}::Unresumed{_captured_ref__a: 0x[...]}
+// gdb-check:$1 = generator_objects::main::{generator#0}::Unresumed{_ref__a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$2 = generator_objects::main::{generator#0}::Suspend0{c: 6, d: 7, _captured_ref__a: 0x[...]}
+// gdb-check:$2 = generator_objects::main::{generator#0}::Suspend0{c: 6, d: 7, _ref__a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$3 = generator_objects::main::{generator#0}::Suspend1{c: 7, d: 8, _captured_ref__a: 0x[...]}
+// gdb-check:$3 = generator_objects::main::{generator#0}::Suspend1{c: 7, d: 8, _ref__a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$4 = generator_objects::main::{generator#0}::Returned{_captured_ref__a: 0x[...]}
+// gdb-check:$4 = generator_objects::main::{generator#0}::Returned{_ref__a: 0x[...]}
 
 // === LLDB TESTS ==================================================================================
 

--- a/src/test/debuginfo/generator-objects.rs
+++ b/src/test/debuginfo/generator-objects.rs
@@ -11,16 +11,16 @@
 
 // gdb-command:run
 // gdb-command:print b
-// gdb-check:$1 = generator_objects::main::{generator#0}::Unresumed(0x[...])
+// gdb-check:$1 = generator_objects::main::{generator#0}::Unresumed{_captured_ref__a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$2 = generator_objects::main::{generator#0}::Suspend0{c: 6, d: 7, __0: 0x[...]}
+// gdb-check:$2 = generator_objects::main::{generator#0}::Suspend0{c: 6, d: 7, _captured_ref__a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$3 = generator_objects::main::{generator#0}::Suspend1{c: 7, d: 8, __0: 0x[...]}
+// gdb-check:$3 = generator_objects::main::{generator#0}::Suspend1{c: 7, d: 8, _captured_ref__a: 0x[...]}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$4 = generator_objects::main::{generator#0}::Returned(0x[...])
+// gdb-check:$4 = generator_objects::main::{generator#0}::Returned{_captured_ref__a: 0x[...]}
 
 // === LLDB TESTS ==================================================================================
 

--- a/src/test/debuginfo/issue-57822.rs
+++ b/src/test/debuginfo/issue-57822.rs
@@ -11,17 +11,17 @@
 // gdb-command:run
 
 // gdb-command:print g
-// gdb-check:$1 = issue_57822::main::{closure#1} (issue_57822::main::{closure#0} (1))
+// gdb-check:$1 = issue_57822::main::{closure#1} {_captured_val__f: issue_57822::main::{closure#0} {_captured_val__x: 1}}
 
 // gdb-command:print b
-// gdb-check:$2 = issue_57822::main::{generator#3}::Unresumed(issue_57822::main::{generator#2}::Unresumed(2))
+// gdb-check:$2 = issue_57822::main::{generator#3}::Unresumed{_captured_val__a: issue_57822::main::{generator#2}::Unresumed{_captured_val__y: 2}}
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
 
 // lldb-command:print g
-// lldbg-check:(issue_57822::main::{closure#1}) $0 = { 0 = { 0 = 1 } }
+// lldbg-check:(issue_57822::main::{closure#1}) $0 = { _captured_val__f = { _captured_val__x = 1 } }
 
 // lldb-command:print b
 // lldbg-check:(issue_57822::main::{generator#3}) $1 =

--- a/src/test/debuginfo/issue-57822.rs
+++ b/src/test/debuginfo/issue-57822.rs
@@ -11,17 +11,17 @@
 // gdb-command:run
 
 // gdb-command:print g
-// gdb-check:$1 = issue_57822::main::{closure#1} {_captured_val__f: issue_57822::main::{closure#0} {_captured_val__x: 1}}
+// gdb-check:$1 = issue_57822::main::{closure#1} {f: issue_57822::main::{closure#0} {x: 1}}
 
 // gdb-command:print b
-// gdb-check:$2 = issue_57822::main::{generator#3}::Unresumed{_captured_val__a: issue_57822::main::{generator#2}::Unresumed{_captured_val__y: 2}}
+// gdb-check:$2 = issue_57822::main::{generator#3}::Unresumed{a: issue_57822::main::{generator#2}::Unresumed{y: 2}}
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
 
 // lldb-command:print g
-// lldbg-check:(issue_57822::main::{closure#1}) $0 = { _captured_val__f = { _captured_val__x = 1 } }
+// lldbg-check:(issue_57822::main::{closure#1}) $0 = { f = { x = 1 } }
 
 // lldb-command:print b
 // lldbg-check:(issue_57822::main::{generator#3}) $1 =


### PR DESCRIPTION
Previously, debuggers print closures as something like
```
y::main::closure-0 (0x7fffffffdd34)
```
The pointer actually references to an upvar. It is not very obvious, especially for beginners.

It's because upvars don't have names before, as they are packed into a tuple. This PR names the upvars, so we can expect to see something like
```
y::main::closure-0 {_captured_ref__b: 0x[...]}
```

r? @tmandry 
Discussed at https://github.com/rust-lang/rust/pull/84752#issuecomment-831639489 .