### PR TITLE
Avoid predecessors having Drop impls

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -461,7 +461,7 @@ impl<'tcx> Body<'tcx> {
     }
 
     #[inline]
-    pub fn predecessors(&self) -> impl std::ops::Deref<Target = Predecessors> + '_ {
+    pub fn predecessors(&self) -> &Predecessors {
         self.predecessor_cache.compute(&self.basic_blocks)
     }
 
@@ -2815,13 +2815,13 @@ impl<'a, 'b> graph::GraphSuccessors<'b> for Body<'a> {
 
 impl graph::GraphPredecessors<'graph> for Body<'tcx> {
     type Item = BasicBlock;
-    type Iter = smallvec::IntoIter<[BasicBlock; 4]>;
+    type Iter = std::iter::Copied<std::slice::Iter<'graph, BasicBlock>>;
 }
 
 impl graph::WithPredecessors for Body<'tcx> {
     #[inline]
     fn predecessors(&self, node: Self::Node) -> <Self as graph::GraphPredecessors<'_>>::Iter {
-        self.predecessors()[node].clone().into_iter()
+        self.predecessors()[node].iter().copied()
     }
 }
 

--- a/compiler/rustc_mir/src/transform/coverage/graph.rs
+++ b/compiler/rustc_mir/src/transform/coverage/graph.rs
@@ -269,13 +269,13 @@ impl graph::WithSuccessors for CoverageGraph {
 
 impl graph::GraphPredecessors<'graph> for CoverageGraph {
     type Item = BasicCoverageBlock;
-    type Iter = std::vec::IntoIter<BasicCoverageBlock>;
+    type Iter = std::iter::Copied<std::slice::Iter<'graph, BasicCoverageBlock>>;
 }
 
 impl graph::WithPredecessors for CoverageGraph {
     #[inline]
     fn predecessors(&self, node: Self::Node) -> <Self as graph::GraphPredecessors<'_>>::Iter {
-        self.predecessors[node].clone().into_iter()
+        self.predecessors[node].iter().copied()
     }
 }
 


### PR DESCRIPTION
Should be a simple win - but let's make sure with perf.