### PR TITLE
Return `EvaluatedToOk` when type in outlives predicate is global

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -492,7 +492,15 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     None => Ok(EvaluatedToAmbig),
                 },
 
-                ty::PredicateKind::TypeOutlives(..) | ty::PredicateKind::RegionOutlives(..) => {
+                ty::PredicateKind::TypeOutlives(pred) => {
+                    if pred.0.is_global() {
+                        Ok(EvaluatedToOk)
+                    } else {
+                        Ok(EvaluatedToOkModuloRegions)
+                    }
+                }
+
+                ty::PredicateKind::RegionOutlives(..) => {
                     // We do not consider region relationships when evaluating trait matches.
                     Ok(EvaluatedToOkModuloRegions)
                 }

--- a/src/test/ui/traits/issue-83538-tainted-cache-after-cycle.rs
+++ b/src/test/ui/traits/issue-83538-tainted-cache-after-cycle.rs
@@ -17,8 +17,8 @@ pub struct Second {
     d: Vec<First>,
 }
 
-struct Third<f> {
-    g: Vec<f>,
+struct Third<'a, f> {
+    g: Vec<(f, &'a f)>,
 }
 
 enum Ty {
@@ -38,29 +38,29 @@ struct Sixth {
 }
 
 #[rustc_evaluate_where_clauses]
-fn forward()
+fn forward<'a>()
 where
     Vec<First>: Unpin,
-    Third<Ty>: Unpin,
+    Third<'a, Ty>: Unpin,
 {
 }
 
 #[rustc_evaluate_where_clauses]
-fn reverse()
+fn reverse<'a>()
 where
-    Third<Ty>: Unpin,
+    Third<'a, Ty>: Unpin,
     Vec<First>: Unpin,
 {
 }
 
 fn main() {
-    // Key is that Vec<First> is "ok" and Third<Ty> is "ok modulo regions":
+    // Key is that Vec<First> is "ok" and Third<'_, Ty> is "ok modulo regions":
 
     forward();
     //~^ ERROR evaluate(Binder(TraitPredicate(<std::vec::Vec<First> as std::marker::Unpin>), [])) = Ok(EvaluatedToOk)
-    //~| ERROR evaluate(Binder(TraitPredicate(<Third<Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
+    //~| ERROR evaluate(Binder(TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
 
     reverse();
     //~^ ERROR evaluate(Binder(TraitPredicate(<std::vec::Vec<First> as std::marker::Unpin>), [])) = Ok(EvaluatedToOk)
-    //~| ERROR evaluate(Binder(TraitPredicate(<Third<Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
+    //~| ERROR evaluate(Binder(TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
 }

--- a/src/test/ui/traits/issue-83538-tainted-cache-after-cycle.stderr
+++ b/src/test/ui/traits/issue-83538-tainted-cache-after-cycle.stderr
@@ -7,20 +7,20 @@ LL |     Vec<First>: Unpin,
 LL |     forward();
    |     ^^^^^^^
 
-error: evaluate(Binder(TraitPredicate(<Third<Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
+error: evaluate(Binder(TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
   --> $DIR/issue-83538-tainted-cache-after-cycle.rs:59:5
    |
-LL |     Third<Ty>: Unpin,
-   |                ----- predicate
+LL |     Third<'a, Ty>: Unpin,
+   |                    ----- predicate
 ...
 LL |     forward();
    |     ^^^^^^^
 
-error: evaluate(Binder(TraitPredicate(<Third<Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
+error: evaluate(Binder(TraitPredicate(<Third<'_, Ty> as std::marker::Unpin>), [])) = Ok(EvaluatedToOkModuloRegions)
   --> $DIR/issue-83538-tainted-cache-after-cycle.rs:63:5
    |
-LL |     Third<Ty>: Unpin,
-   |                ----- predicate
+LL |     Third<'a, Ty>: Unpin,
+   |                    ----- predicate
 ...
 LL |     reverse();
    |     ^^^^^^^


### PR DESCRIPTION
A global type doesn't reference any local regions or types, so it's
guaranteed to outlive any region.