### PR TITLE
rustdoc: remove explicit boolean comparisons.

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -448,14 +448,14 @@ function hideThemeButtonState() {
     }
 
     function getHelpElement(build) {
-        if (build !== false) {
+        if (build) {
             buildHelperPopup();
         }
         return document.getElementById("help");
     }
 
     function displayHelp(display, ev, help) {
-        if (display === true) {
+        if (display) {
             help = help ? help : getHelpElement(true);
             if (hasClass(help, "hidden")) {
                 ev.preventDefault();
@@ -466,7 +466,7 @@ function hideThemeButtonState() {
             // No need to build the help popup if we want to hide it in case it hasn't been
             // built yet...
             help = help ? help : getHelpElement(false);
-            if (help && hasClass(help, "hidden") === false) {
+            if (help && !hasClass(help, "hidden")) {
                 ev.preventDefault();
                 addClass(help, "hidden");
                 removeClass(document.body, "blur");
@@ -477,9 +477,9 @@ function hideThemeButtonState() {
     function handleEscape(ev) {
         var help = getHelpElement(false);
         var search = searchState.outputElement();
-        if (hasClass(help, "hidden") === false) {
+        if (!hasClass(help, "hidden")) {
             displayHelp(false, ev, help);
-        } else if (hasClass(search, "hidden") === false) {
+        } else if (!hasClass(search, "hidden")) {
             searchState.clearInputTimeout();
             ev.preventDefault();
             searchState.hideResults(search);
@@ -491,7 +491,7 @@ function hideThemeButtonState() {
     var disableShortcuts = getSettingValue("disable-shortcuts") === "true";
     function handleShortcut(ev) {
         // Don't interfere with browser shortcuts
-        if (ev.ctrlKey || ev.altKey || ev.metaKey || disableShortcuts === true) {
+        if (ev.ctrlKey || ev.altKey || ev.metaKey || disableShortcuts) {
             return;
         }
 
@@ -908,11 +908,11 @@ function hideThemeButtonState() {
         function implHider(addOrRemove, fullHide) {
             return function(n) {
                 var shouldHide =
-                    fullHide === true ||
-                    hasClass(n, "method") === true ||
-                    hasClass(n, "associatedconstant") === true;
-                if (shouldHide === true || hasClass(n, "type") === true) {
-                    if (shouldHide === true) {
+                    fullHide ||
+                    hasClass(n, "method") ||
+                    hasClass(n, "associatedconstant");
+                if (shouldHide || hasClass(n, "type")) {
+                    if (shouldHide) {
                         if (addOrRemove) {
                             addClass(n, "hidden-by-impl-hider");
                         } else {
@@ -934,7 +934,7 @@ function hideThemeButtonState() {
 
         var relatedDoc;
         var action = mode;
-        if (hasClass(toggle.parentNode, "impl") === false) {
+        if (!hasClass(toggle.parentNode, "impl")) {
             relatedDoc = toggle.parentNode.nextElementSibling;
             if (hasClass(relatedDoc, "item-info")) {
                 relatedDoc = relatedDoc.nextElementSibling;
@@ -964,11 +964,11 @@ function hideThemeButtonState() {
             relatedDoc = parentElem;
             var docblock = relatedDoc.nextElementSibling;
 
-            while (hasClass(relatedDoc, "impl-items") === false) {
+            while (!hasClass(relatedDoc, "impl-items")) {
                 relatedDoc = relatedDoc.nextElementSibling;
             }
 
-            if (!relatedDoc && hasClass(docblock, "docblock") === false) {
+            if (!relatedDoc && !hasClass(docblock, "docblock")) {
                 return;
             }
 
@@ -987,7 +987,7 @@ function hideThemeButtonState() {
             if (action === "show") {
                 removeClass(relatedDoc, "fns-now-collapsed");
                 // Stability/deprecation/portability information is never hidden.
-                if (hasClass(docblock, "item-info") === false) {
+                if (!hasClass(docblock, "item-info")) {
                     removeClass(docblock, "hidden-by-usual-hider");
                 }
                 onEachLazy(toggle.childNodes, adjustToggle(false, dontApplyBlockRule));
@@ -996,7 +996,7 @@ function hideThemeButtonState() {
                 addClass(relatedDoc, "fns-now-collapsed");
                 // Stability/deprecation/portability information should be shown even when detailed
                 // info is hidden.
-                if (hasClass(docblock, "item-info") === false) {
+                if (!hasClass(docblock, "item-info")) {
                     addClass(docblock, "hidden-by-usual-hider");
                 }
                 onEachLazy(toggle.childNodes, adjustToggle(true, dontApplyBlockRule));
@@ -1045,7 +1045,7 @@ function hideThemeButtonState() {
             });
         }
 
-        if (hideMethodDocs === true) {
+        if (hideMethodDocs) {
             onEachLazy(document.getElementsByClassName("method"), function(e) {
                 var toggle = e.parentNode;
                 if (toggle) {
@@ -1132,7 +1132,7 @@ function hideThemeButtonState() {
     if (sidebar_menu) {
         sidebar_menu.onclick = function() {
             var sidebar = document.getElementsByClassName("sidebar")[0];
-            if (hasClass(sidebar, "mobile") === true) {
+            if (hasClass(sidebar, "mobile")) {
                 hideSidebar();
             } else {
                 showSidebar();

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -146,23 +146,21 @@ window.initSearch = function(rawSearchIndex) {
 
         removeEmptyStringsFromArray(split);
 
-        function transformResults(results, isType) {
+        function transformResults(results) {
             var out = [];
             for (var i = 0, len = results.length; i < len; ++i) {
                 if (results[i].id > -1) {
                     var obj = searchIndex[results[i].id];
                     obj.lev = results[i].lev;
-                    if (isType !== true || obj.type) {
-                        var res = buildHrefAndPath(obj);
-                        obj.displayPath = pathSplitter(res[0]);
-                        obj.fullPath = obj.displayPath + obj.name;
-                        // To be sure than it some items aren't considered as duplicate.
-                        obj.fullPath += "|" + obj.ty;
-                        obj.href = res[1];
-                        out.push(obj);
-                        if (out.length >= MAX_RESULTS) {
-                            break;
-                        }
+                    var res = buildHrefAndPath(obj);
+                    obj.displayPath = pathSplitter(res[0]);
+                    obj.fullPath = obj.displayPath + obj.name;
+                    // To be sure than it some items aren't considered as duplicate.
+                    obj.fullPath += "|" + obj.ty;
+                    obj.href = res[1];
+                    out.push(obj);
+                    if (out.length >= MAX_RESULTS) {
+                        break;
                     }
                 }
             }
@@ -266,9 +264,7 @@ window.initSearch = function(rawSearchIndex) {
                     path = result.item.path.toLowerCase(),
                     parent = result.item.parent;
 
-                if (isType !== true &&
-                    validateResult(name, path, split, parent) === false)
-                {
+                if (!isType && !validateResult(name, path, split, parent)) {
                     result.id = -1;
                 }
             }
@@ -352,7 +348,7 @@ window.initSearch = function(rawSearchIndex) {
             var lev_distance = MAX_LEV_DISTANCE + 1;
             var len, x, firstGeneric;
             if (obj[NAME] === val.name) {
-                if (literalSearch === true) {
+                if (literalSearch) {
                     if (val.generics && val.generics.length !== 0) {
                         if (obj.length > GENERICS_DATA &&
                               obj[GENERICS_DATA].length >= val.generics.length) {
@@ -373,7 +369,7 @@ window.initSearch = function(rawSearchIndex) {
                                     break;
                                 }
                             }
-                            if (allFound === true) {
+                            if (allFound) {
                                 return true;
                             }
                         } else {
@@ -394,7 +390,7 @@ window.initSearch = function(rawSearchIndex) {
                 }
             }
             // Names didn't match so let's check if one of the generic types could.
-            if (literalSearch === true) {
+            if (literalSearch) {
                  if (obj.length > GENERICS_DATA && obj[GENERICS_DATA].length > 0) {
                     return obj[GENERICS_DATA].some(
                         function(name) {
@@ -429,12 +425,12 @@ window.initSearch = function(rawSearchIndex) {
                 var length = obj.type[INPUTS_DATA].length;
                 for (var i = 0; i < length; i++) {
                     var tmp = obj.type[INPUTS_DATA][i];
-                    if (typePassesFilter(typeFilter, tmp[1]) === false) {
+                    if (!typePassesFilter(typeFilter, tmp[1])) {
                         continue;
                     }
                     tmp = checkType(tmp, val, literalSearch);
-                    if (literalSearch === true) {
-                        if (tmp === true) {
+                    if (literalSearch) {
+                        if (tmp) {
                             return true;
                         }
                         continue;
@@ -445,7 +441,7 @@ window.initSearch = function(rawSearchIndex) {
                     }
                 }
             }
-            return literalSearch === true ? false : lev_distance;
+            return literalSearch ? false : lev_distance;
         }
 
         function checkReturned(obj, val, literalSearch, typeFilter) {
@@ -458,12 +454,12 @@ window.initSearch = function(rawSearchIndex) {
                 }
                 for (var x = 0, len = ret.length; x < len; ++x) {
                     var tmp = ret[x];
-                    if (typePassesFilter(typeFilter, tmp[1]) === false) {
+                    if (!typePassesFilter(typeFilter, tmp[1])) {
                         continue;
                     }
                     tmp = checkType(tmp, val, literalSearch);
-                    if (literalSearch === true) {
-                        if (tmp === true) {
+                    if (literalSearch) {
+                        if (tmp) {
                             return true;
                         }
                         continue;
@@ -474,7 +470,7 @@ window.initSearch = function(rawSearchIndex) {
                     }
                 }
             }
-            return literalSearch === true ? false : lev_distance;
+            return literalSearch ? false : lev_distance;
         }
 
         function checkPath(contains, lastElem, ty) {
@@ -507,7 +503,7 @@ window.initSearch = function(rawSearchIndex) {
                     }
                     lev_total += lev;
                 }
-                if (aborted === false) {
+                if (!aborted) {
                     ret_lev = Math.min(ret_lev, Math.round(lev_total / clength));
                 }
             }
@@ -634,14 +630,14 @@ window.initSearch = function(rawSearchIndex) {
                         dontValidate: true,
                     };
                 }
-                if (in_args === true && results_in_args[fullId] === undefined) {
+                if (in_args && results_in_args[fullId] === undefined) {
                     results_in_args[fullId] = {
                         id: i,
                         index: -1,
                         dontValidate: true,
                     };
                 }
-                if (returned === true && results_returned[fullId] === undefined) {
+                if (returned && results_returned[fullId] === undefined) {
                     results_returned[fullId] = {
                         id: i,
                         index: -1,
@@ -676,7 +672,7 @@ window.initSearch = function(rawSearchIndex) {
                 fullId = ty.id;
 
                 returned = checkReturned(ty, output, true, NO_TYPE_FILTER);
-                if (output.name === "*" || returned === true) {
+                if (output.name === "*" || returned) {
                     in_args = false;
                     var is_module = false;
 
@@ -684,26 +680,26 @@ window.initSearch = function(rawSearchIndex) {
                         is_module = true;
                     } else {
                         var allFound = true;
-                        for (it = 0, len = inputs.length; allFound === true && it < len; it++) {
+                        for (it = 0, len = inputs.length; allFound && it < len; it++) {
                             allFound = checkType(type, inputs[it], true);
                         }
                         in_args = allFound;
                     }
-                    if (in_args === true) {
+                    if (in_args) {
                         results_in_args[fullId] = {
                             id: i,
                             index: -1,
                             dontValidate: true,
                         };
                     }
-                    if (returned === true) {
+                    if (returned) {
                         results_returned[fullId] = {
                             id: i,
                             index: -1,
                             dontValidate: true,
                         };
                     }
-                    if (is_module === true) {
+                    if (is_module) {
                         results[fullId] = {
                             id: i,
                             index: -1,
@@ -763,10 +759,10 @@ window.initSearch = function(rawSearchIndex) {
                     }
                 }
                 if ((lev = levenshtein(searchWords[j], val)) <= MAX_LEV_DISTANCE) {
-                    if (typePassesFilter(typeFilter, ty.ty) === false) {
-                        lev = MAX_LEV_DISTANCE + 1;
-                    } else {
+                    if (typePassesFilter(typeFilter, ty.ty)) {
                         lev += 1;
+                    } else {
+                        lev = MAX_LEV_DISTANCE + 1;
                     }
                 }
                 in_args = findArg(ty, valGenerics, false, typeFilter);
@@ -821,7 +817,7 @@ window.initSearch = function(rawSearchIndex) {
         var ret = {
             "in_args": sortResults(results_in_args, true),
             "returned": sortResults(results_returned, true),
-            "others": sortResults(results),
+            "others": sortResults(results, false),
         };
         handleAliases(ret, query, filterCrates);
         return ret;
@@ -1263,7 +1259,7 @@ window.initSearch = function(rawSearchIndex) {
         if (query.query.length === 0) {
             return;
         }
-        if (forced !== true && query.id === currentResults) {
+        if (!forced && query.id === currentResults) {
             if (query.query.length > 0) {
                 searchState.putBackSearch(searchState.input);
             }

--- a/src/librustdoc/html/static/source-script.js
+++ b/src/librustdoc/html/static/source-script.js
@@ -44,7 +44,7 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
     if (elem.dirs) {
         for (i = 0, len = elem.dirs.length; i < len; ++i) {
             if (createDirEntry(elem.dirs[i], folders, fullPath, currentFile,
-                               hasFoundFile) === true) {
+                               hasFoundFile)) {
                 addClass(name, "expand");
                 hasFoundFile = true;
             }
@@ -59,8 +59,7 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
             var file = document.createElement("a");
             file.innerText = elem.files[i];
             file.href = window.rootPath + "src/" + fullPath + elem.files[i] + ".html";
-            if (hasFoundFile === false &&
-                    currentFile === fullPath + elem.files[i]) {
+            if (!hasFoundFile && currentFile === fullPath + elem.files[i]) {
                 file.className = "selected";
                 addClass(name, "expand");
                 hasFoundFile = true;
@@ -72,7 +71,7 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
     children.appendChild(files);
     parent.appendChild(name);
     parent.appendChild(children);
-    return hasFoundFile === true && currentFile.startsWith(fullPath);
+    return hasFoundFile && currentFile.startsWith(fullPath);
 }
 
 function toggleSidebar() {
@@ -116,7 +115,7 @@ function createSidebarToggle() {
 // This function is called from "source-files.js", generated in `html/render/mod.rs`.
 // eslint-disable-next-line no-unused-vars
 function createSourceSidebar() {
-    if (window.rootPath.endsWith("/") === false) {
+    if (!window.rootPath.endsWith("/")) {
         window.rootPath += "/";
     }
     var main = document.getElementById("main");

--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -59,15 +59,15 @@ function onEach(arr, func, reversed) {
     if (arr && arr.length > 0 && func) {
         var length = arr.length;
         var i;
-        if (reversed !== true) {
-            for (i = 0; i < length; ++i) {
-                if (func(arr[i]) === true) {
+        if (reversed) {
+            for (i = length - 1; i >= 0; --i) {
+                if (func(arr[i])) {
                     return true;
                 }
             }
         } else {
-            for (i = length - 1; i >= 0; --i) {
-                if (func(arr[i]) === true) {
+            for (i = 0; i < length; ++i) {
+                if (func(arr[i])) {
                     return true;
                 }
             }
@@ -111,7 +111,7 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
 
     // If this new value comes from a system setting or from the previously
     // saved theme, no need to save it.
-    if (saveTheme === true) {
+    if (saveTheme) {
         updateLocalStorage("rustdoc-theme", newTheme);
     }
 
@@ -131,7 +131,7 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
             return true;
         }
     });
-    if (found === true) {
+    if (found) {
         styleElem.href = newHref;
     }
 }


### PR DESCRIPTION
For boolean variables it's shorter and more readable to check the value directly, or negate it with `!`.

In a couple of cases I reordered an if/else pair because it made the initial `if` statement simpler.

An example of a style guide recommending this: https://airbnb.io/javascript/#comparison--shortcuts

r? @GuillaumeGomez 