### PR TITLE
Update documentation for SharedContext::maybe_collapsed_doc_value

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -135,8 +135,8 @@ impl SharedContext<'_> {
         Ok(())
     }
 
-    /// Based on whether the `collapse-docs` pass was run, return either the `doc_value` or the
-    /// `collapsed_doc_value` of the given item.
+    /// Returns the `collapsed_doc_value` of the given item if this is the main crate, otherwise
+    /// returns the `doc_value`.
     crate fn maybe_collapsed_doc_value<'a>(&self, item: &'a clean::Item) -> Option<String> {
         if self.collapsed { item.collapsed_doc_value() } else { item.doc_value() }
     }


### PR DESCRIPTION
Fixes #85120.

The `doc-collapse` was removed, however, the main crate is always "collapsed", meaning that this function is still needed. I updated the documentation instead to avoid misleading readers.

r? @jsha 