### PR TITLE
Free the TLS slots allocated to avoid leaks when running in a Windows DLL

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -848,6 +848,7 @@ extern "system" {
         args: *const c_void,
     ) -> DWORD;
     pub fn TlsAlloc() -> DWORD;
+    pub fn TlsFree(dwTlsIndex: DWORD) -> DWORD;
     pub fn TlsGetValue(dwTlsIndex: DWORD) -> LPVOID;
     pub fn TlsSetValue(dwTlsIndex: DWORD, lpTlsvalue: LPVOID) -> BOOL;
     pub fn GetLastError() -> DWORD;

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -848,7 +848,7 @@ extern "system" {
         args: *const c_void,
     ) -> DWORD;
     pub fn TlsAlloc() -> DWORD;
-    pub fn TlsFree(dwTlsIndex: DWORD) -> DWORD;
+    pub fn TlsFree(dwTlsIndex: DWORD) -> BOOL;
     pub fn TlsGetValue(dwTlsIndex: DWORD) -> LPVOID;
     pub fn TlsSetValue(dwTlsIndex: DWORD, lpTlsvalue: LPVOID) -> BOOL;
     pub fn GetLastError() -> DWORD;

--- a/library/std/src/sys/windows/thread_local_key.rs
+++ b/library/std/src/sys/windows/thread_local_key.rs
@@ -197,6 +197,9 @@ unsafe extern "system" fn on_tls_callback(h: c::LPVOID, dwReason: c::DWORD, pv: 
     if dwReason == c::DLL_THREAD_DETACH || dwReason == c::DLL_PROCESS_DETACH {
         run_dtors();
     }
+    if dwReason == c::DLL_PROCESS_DETACH {
+        free_tls_slots();
+    }
 
     // See comments above for what this is doing. Note that we don't need this
     // trickery on GNU windows, just on MSVC.
@@ -225,12 +228,21 @@ unsafe fn run_dtors() {
             let ptr = c::TlsGetValue((*cur).key);
 
             if !ptr.is_null() {
-                c::TlsFree((*cur).key);
+                c::TlsSetValue((*cur).key, ptr::null_mut());
                 ((*cur).dtor)(ptr as *mut _);
                 any_run = true;
             }
 
             cur = (*cur).next;
         }
+    }
+}
+
+#[allow(dead_code)] // actually called above
+unsafe fn free_tls_slots() {
+    let mut cur = DTORS.load(SeqCst);
+    while !cur.is_null() {
+        c::TlsFree((*cur).key);
+        cur = (*cur).next;
     }
 }

--- a/library/std/src/sys/windows/thread_local_key.rs
+++ b/library/std/src/sys/windows/thread_local_key.rs
@@ -225,7 +225,7 @@ unsafe fn run_dtors() {
             let ptr = c::TlsGetValue((*cur).key);
 
             if !ptr.is_null() {
-                c::TlsSetValue((*cur).key, ptr::null_mut());
+                c::TlsFree((*cur).key);
                 ((*cur).dtor)(ptr as *mut _);
                 any_run = true;
             }


### PR DESCRIPTION
Fixes #84981
