### PR TITLE
Fix source code line number display and make it clickable again

### DIFF
--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -24,6 +24,7 @@ crate fn render_with_highlighting(
     playground_button: Option<&str>,
     tooltip: Option<(Option<Edition>, &str)>,
     edition: Edition,
+    extra_content: Option<Buffer>,
 ) {
     debug!("highlighting: ================\n{}\n==============", src);
     if let Some((edition_info, class)) = tooltip {
@@ -39,13 +40,21 @@ crate fn render_with_highlighting(
         );
     }
 
-    write_header(out, class);
+    write_header(out, class, extra_content);
     write_code(out, &src, edition);
     write_footer(out, playground_button);
 }
 
-fn write_header(out: &mut Buffer, class: Option<&str>) {
-    writeln!(out, "<div class=\"example-wrap\"><pre class=\"rust {}\">", class.unwrap_or_default());
+fn write_header(out: &mut Buffer, class: Option<&str>, extra_content: Option<Buffer>) {
+    write!(out, "<div class=\"example-wrap\">");
+    if let Some(extra) = extra_content {
+        out.push_buffer(extra);
+    }
+    if let Some(class) = class {
+        writeln!(out, "<pre class=\"rust {}\">", class);
+    } else {
+        writeln!(out, "<pre class=\"rust\">");
+    }
 }
 
 fn write_code(out: &mut Buffer, src: &str, edition: Edition) {

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -315,6 +315,7 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
             playground_button.as_deref(),
             tooltip,
             edition,
+            None,
         );
         Some(Event::Html(s.into_inner().into()))
     }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1016,6 +1016,7 @@ fn item_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Mac
             None,
             None,
             it.span(cx.tcx()).inner().edition(),
+            None,
         );
     });
     document(w, cx, it, None)

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -169,16 +169,17 @@ where
 /// adding line numbers to the left-hand side.
 fn print_src(buf: &mut Buffer, s: &str, edition: Edition) {
     let lines = s.lines().count();
+    let mut line_numbers = Buffer::empty_from(buf);
     let mut cols = 0;
     let mut tmp = lines;
     while tmp > 0 {
         cols += 1;
         tmp /= 10;
     }
-    buf.write_str("<pre class=\"line-numbers\">");
+    line_numbers.write_str("<pre class=\"line-numbers\">");
     for i in 1..=lines {
-        writeln!(buf, "<span id=\"{0}\">{0:1$}</span>", i, cols);
+        writeln!(line_numbers, "<span id=\"{0}\">{0:1$}</span>", i, cols);
     }
-    buf.write_str("</pre>");
-    highlight::render_with_highlighting(s, buf, None, None, None, edition);
+    line_numbers.write_str("</pre>");
+    highlight::render_with_highlighting(s, buf, None, None, None, edition, Some(line_numbers));
 }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -206,7 +206,6 @@ li {
 	max-width: none;
 	overflow: visible;
 	margin-left: 0px;
-	min-width: 70em;
 }
 
 nav.sub {
@@ -357,7 +356,7 @@ nav.sub {
 	padding-left: 0;
 }
 
-.rustdoc:not(.source) .example-wrap {
+.rustdoc .example-wrap {
 	display: inline-flex;
 	margin-bottom: 10px;
 }
@@ -370,8 +369,6 @@ nav.sub {
 .example-wrap > pre.line-number {
 	overflow: initial;
 	border: 1px solid;
-	border-top-left-radius: 5px;
-	border-bottom-left-radius: 5px;
 	padding: 13px 8px;
 	text-align: right;
 }
@@ -381,7 +378,7 @@ nav.sub {
 	overflow-x: auto;
 }
 
-.rustdoc:not(.source) .example-wrap > pre {
+.rustdoc .example-wrap > pre {
 	margin: 0;
 }
 
@@ -395,15 +392,14 @@ nav.sub {
 	table-layout: fixed;
 }
 
-.content pre.line-numbers {
-	float: left;
-	border: none;
+.content > .example-wrap pre.line-numbers {
 	position: relative;
-
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+	border-top-left-radius: 5px;
+	border-bottom-left-radius: 5px;
 }
 .line-numbers span {
 	cursor: pointer;

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -53,7 +53,7 @@ span code {
 .docblock code, .docblock-short code {
 	background-color: #191f26;
 }
-pre {
+pre, .rustdoc.source .example-wrap {
 	color: #e6e1cf;
 	background-color: #191f26;
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -26,7 +26,7 @@ h4:not(.method):not(.type):not(.tymethod) {
 .docblock code, .docblock-short code {
 	background-color: #2A2A2A;
 }
-pre {
+pre, .rustdoc.source .example-wrap {
 	background-color: #2A2A2A;
 }
 

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -28,7 +28,7 @@ h4:not(.method):not(.type):not(.tymethod) {
 .docblock code, .docblock-short code {
 	background-color: #F5F5F5;
 }
-pre {
+pre, .rustdoc.source .example-wrap {
 	background-color: #F5F5F5;
 }
 

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -1,0 +1,13 @@
+goto: file://|DOC_PATH|/../src/test_docs/lib.rs.html
+// Check that we can click on the line number.
+click: (40, 224) // This is the position of the span for line 4.
+// Unfortunately, "#4" isn't a valid query selector, so we have to go around that limitation
+// by instead getting the nth span.
+assert: (".line-numbers > span:nth-child(4)", "class", "line-highlighted")
+// We now check that the good spans are highlighted
+goto: file://|DOC_PATH|/../src/test_docs/lib.rs.html#4-6
+assert-false: (".line-numbers > span:nth-child(3)", "class", "line-highlighted")
+assert: (".line-numbers > span:nth-child(4)", "class", "line-highlighted")
+assert: (".line-numbers > span:nth-child(5)", "class", "line-highlighted")
+assert: (".line-numbers > span:nth-child(6)", "class", "line-highlighted")
+assert-false: (".line-numbers > span:nth-child(7)", "class", "line-highlighted")


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/85119.

I used the same logic we're using for other codeblocks: putting the line number `<span>`s into the `example-wrap` directly and then add `display: inline-flex` on `example-wrap`.

r? @jsha  