### PR TITLE
Fix typo in variable name

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -621,9 +621,9 @@ mod parse {
         true
     }
 
-    crate fn parse_linker_flavor(slote: &mut Option<LinkerFlavor>, v: Option<&str>) -> bool {
+    crate fn parse_linker_flavor(slot: &mut Option<LinkerFlavor>, v: Option<&str>) -> bool {
         match v.and_then(LinkerFlavor::from_str) {
-            Some(lf) => *slote = Some(lf),
+            Some(lf) => *slot = Some(lf),
             _ => return false,
         }
         true


### PR DESCRIPTION
All other sibling functions call this variable "slot", so "slote" was most likely a typo.