### PR TITLE
Make rustc_graphviz build on stable

### DIFF
--- a/compiler/rustc_graphviz/src/lib.rs
+++ b/compiler/rustc_graphviz/src/lib.rs
@@ -275,7 +275,6 @@
     html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
     test(attr(allow(unused_variables), deny(warnings)))
 )]
-#![feature(nll)]
 
 use LabelText::*;
 


### PR DESCRIPTION
This crate is pretty useful, and there's not really a reason it can't build on stable.