### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -58,7 +58,7 @@ The following previously stable APIs are now `const`.
 Rustdoc
 -------
 - [Rustdoc lints are now treated as a tool lint, meaning that
-  lints are now prefixed with `rustdoc::` (e.g. `#[warn(rustdoc::non_autolinks)]`).][80527]
+  lints are now prefixed with `rustdoc::` (e.g. `#[warn(rustdoc::broken_intra_doc_links)]`).][80527]
   Using the old style is still allowed, and will become a warning in
   a future release.
 - [Rustdoc now supports argument files.][82261]

--- a/compiler/rustc_middle/src/ty/query/mod.rs
+++ b/compiler/rustc_middle/src/ty/query/mod.rs
@@ -233,6 +233,7 @@ macro_rules! define_callbacks {
         }
 
         pub trait QueryEngine<'tcx>: rustc_data_structures::sync::Sync {
+            #[cfg(parallel_compiler)]
             unsafe fn deadlock(&'tcx self, tcx: TyCtxt<'tcx>, registry: &rustc_rayon_core::Registry);
 
             fn encode_query_results(

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -550,12 +550,10 @@ macro_rules! define_queries_struct {
         }
 
         impl QueryEngine<'tcx> for Queries<'tcx> {
-            unsafe fn deadlock(&'tcx self, _tcx: TyCtxt<'tcx>, _registry: &rustc_rayon_core::Registry) {
-                #[cfg(parallel_compiler)]
-                {
-                    let tcx = QueryCtxt { tcx: _tcx, queries: self };
-                    rustc_query_system::query::deadlock(tcx, _registry)
-                }
+            #[cfg(parallel_compiler)]
+            unsafe fn deadlock(&'tcx self, tcx: TyCtxt<'tcx>, registry: &rustc_rayon_core::Registry) {
+                let tcx = QueryCtxt { tcx, queries: self };
+                rustc_query_system::query::deadlock(tcx, registry)
             }
 
             fn encode_query_results(

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -605,13 +605,19 @@ fn incremental_verify_ich<CTX, K, V: Debug>(
 
     let old_hash = tcx.dep_graph().prev_fingerprint_of(dep_node);
 
-    assert_eq!(
-        Some(new_hash),
-        old_hash,
-        "found unstable fingerprints for {:?}: {:?}",
-        dep_node,
-        result
-    );
+    if Some(new_hash) != old_hash {
+        let run_cmd = if let Some(crate_name) = &tcx.sess().opts.crate_name {
+            format!("`cargo clean -p {}` or `cargo clean`", crate_name)
+        } else {
+            "`cargo clean`".to_string()
+        };
+        tcx.sess().struct_err(&format!("internal compiler error: encountered incremental compilation error with {:?}", dep_node))
+            .help(&format!("This is a known issue with the compiler. Run {} to allow your project to compile", run_cmd))
+            .note(&format!("Please follow the instructions below to create a bug report with the provided information"))
+            .note(&format!("See <https://github.com/rust-lang/rust/issues/84970> for more information"))
+            .emit();
+        panic!("Found unstable fingerprints for {:?}: {:?}", dep_node, result);
+    }
 }
 
 fn force_query_with_job<C, CTX>(

--- a/config.toml.example
+++ b/config.toml.example
@@ -372,8 +372,6 @@ changelog-seen = 2
 # This is mostly useful for tools; if you have changes to `compiler/` they will be ignored.
 #
 # You can set this to "if-unchanged" to only download if `compiler/` has not been modified.
-#
-# FIXME(#82739): currently, this also uses the downloaded compiler for stage0, but that causes unnecessary rebuilds.
 #download-rustc = false
 
 # Number of codegen units to use for each compiler invocation. A value of 0

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1733,6 +1733,19 @@ impl<T: ?Sized> fmt::Pointer for Rc<T> {
 
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
 impl<T> From<T> for Rc<T> {
+    /// Converts a generic type `T` into a `Rc<T>`
+    ///
+    /// The conversion allocates on the heap and moves `t`
+    /// from the stack into it.
+    ///
+    /// # Example
+    /// ```rust
+    /// # use std::rc::Rc;
+    /// let x = 5;
+    /// let rc = Rc::new(5);
+    ///
+    /// assert_eq!(Rc::from(x), rc);
+    /// ```
     fn from(t: T) -> Self {
         Rc::new(t)
     }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -377,6 +377,8 @@ impl<'a> Builder<'a> {
                 check::Rustdoc,
                 check::CodegenBackend,
                 check::Clippy,
+                check::Miri,
+                check::Rls,
                 check::Bootstrap
             ),
             Kind::Test => describe!(

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -289,7 +289,8 @@ macro_rules! tool_check_step {
         impl Step for $name {
             type Output = ();
             const ONLY_HOSTS: bool = true;
-            const DEFAULT: bool = true $( && $default )?;
+            // don't ever check out-of-tree tools by default, they'll fail when toolstate is broken
+            const DEFAULT: bool = matches!($source_type, SourceType::InTree) $( && $default )?;
 
             fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
                 run.paths(&[ $path, $($alias),* ])
@@ -367,6 +368,8 @@ tool_check_step!(Rustdoc, "src/tools/rustdoc", "src/librustdoc", SourceType::InT
 // behavior, treat it as in-tree so that any new warnings in clippy will be
 // rejected.
 tool_check_step!(Clippy, "src/tools/clippy", SourceType::InTree);
+tool_check_step!(Miri, "src/tools/miri", SourceType::Submodule);
+tool_check_step!(Rls, "src/tools/rls", SourceType::Submodule);
 
 tool_check_step!(Bootstrap, "src/bootstrap", SourceType::InTree, false);
 

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -648,6 +648,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
     }
     if builder.config.rustc_parallel {
         cargo.rustflag("--cfg=parallel_compiler");
+        cargo.rustdocflag("--cfg=parallel_compiler");
     }
     if builder.config.rust_verify_llvm_ir {
         cargo.env("RUSTC_VERIFY_LLVM_IR", "1");

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -91,6 +91,7 @@ pub enum Subcommand {
         paths: Vec<PathBuf>,
     },
     Format {
+        paths: Vec<PathBuf>,
         check: bool,
     },
     Doc {
@@ -578,7 +579,7 @@ Arguments:
 
                 Subcommand::Clean { all: matches.opt_present("all") }
             }
-            "fmt" => Subcommand::Format { check: matches.opt_present("check") },
+            "fmt" => Subcommand::Format { check: matches.opt_present("check"), paths },
             "dist" => Subcommand::Dist { paths },
             "install" => Subcommand::Install { paths },
             "run" | "r" => {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -478,8 +478,8 @@ impl Build {
             job::setup(self);
         }
 
-        if let Subcommand::Format { check } = self.config.cmd {
-            return format::format(self, check);
+        if let Subcommand::Format { check, paths } = &self.config.cmd {
+            return format::format(self, *check, &paths);
         }
 
         if let Subcommand::Clean { all } = self.config.cmd {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -897,7 +897,7 @@ help: to skip test's attempt to check tidiness, pass `--exclude src/tools/tidy` 
                 );
                 std::process::exit(1);
             }
-            crate::format::format(&builder.build, !builder.config.cmd.bless());
+            crate::format::format(&builder.build, !builder.config.cmd.bless(), &[]);
         }
     }
 


### PR DESCRIPTION
Successful merges:

 - #84777 (Apply `--cfg parallel_compiler` when documenting)
 - #84783 (Allow formatting specific subdirectories)
 - #84998 (Show nicer error when an 'unstable fingerprints' error occurs)
 - #85002 (RELEASES.md: Use broken_intra_doc_links as an example, not nightly lint)
 - #85051 (Allow checking miri and RLS with `x.py check src/tools/{miri,rls}`)
 - #85114 (Remove outdated FIXME for download-rustc)
 - #85143 (Document Rc::from)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=84777,84783,84998,85002,85051,85114,85143)
<!-- homu-ignore:end -->