### PR TITLE
Fix border radius for doc code blocks in rustdoc

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -371,6 +371,8 @@ nav.sub {
 	border: 1px solid;
 	padding: 13px 8px;
 	text-align: right;
+	border-top-left-radius: 5px;
+	border-bottom-left-radius: 5px;
 }
 
 .rustdoc:not(.source) .example-wrap > pre.rust {
@@ -398,8 +400,6 @@ nav.sub {
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
-	border-top-left-radius: 5px;
-	border-bottom-left-radius: 5px;
 }
 .line-numbers span {
 	cursor: pointer;


### PR DESCRIPTION
In #85148, I made an invalid change on the border radius of the doc code blocks (look in the top left and bottom left corners of the code blocks). 

Before this fix:

![Screenshot from 2021-05-11 11-14-59](https://user-images.githubusercontent.com/3050060/117791459-a4f86b80-b24a-11eb-8ac3-facc719c799a.png)

After this fix:

![Screenshot from 2021-05-11 11-05-29](https://user-images.githubusercontent.com/3050060/117791482-a9bd1f80-b24a-11eb-8c38-a01989595f5c.png)

r? @jsha 