### PR TITLE
Rustdoc cleanup

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -573,10 +573,6 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         )
     }
 
-    fn write_loading_content(w: &mut Buffer, extra_content: &str) {
-        write!(w, "{}<span class=\"loading-content\">Loading content...</span>", extra_content)
-    }
-
     fn trait_item(w: &mut Buffer, cx: &Context<'_>, m: &clean::Item, t: &clean::Item) {
         let name = m.name.as_ref().unwrap();
         info!("Documenting {} on {:?}", name, t.name);
@@ -601,7 +597,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         for t in types {
             trait_item(w, cx, t, it);
         }
-        write_loading_content(w, "</div>");
+        w.write_str("</div>");
     }
 
     if !consts.is_empty() {
@@ -614,7 +610,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         for t in consts {
             trait_item(w, cx, t, it);
         }
-        write_loading_content(w, "</div>");
+        w.write_str("</div>");
     }
 
     // Output the documentation for each function individually
@@ -628,7 +624,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         for m in required {
             trait_item(w, cx, m, it);
         }
-        write_loading_content(w, "</div>");
+        w.write_str("</div>");
     }
     if !provided.is_empty() {
         write_small_section_header(
@@ -640,7 +636,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         for m in provided {
             trait_item(w, cx, m, it);
         }
-        write_loading_content(w, "</div>");
+        w.write_str("</div>");
     }
 
     // If there are methods directly on this trait object, render them here.
@@ -703,7 +699,6 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
                     &[],
                 );
             }
-            write_loading_content(w, "");
         }
 
         write_small_section_header(
@@ -715,7 +710,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         for implementor in concrete {
             render_implementor(cx, implementor, it, w, &implementor_dups, &[]);
         }
-        write_loading_content(w, "</div>");
+        w.write_str("</div>");
 
         if t.is_auto {
             write_small_section_header(
@@ -734,7 +729,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
                     &collect_paths_for_type(implementor.inner_impl().for_.clone(), &cx.cache),
                 );
             }
-            write_loading_content(w, "</div>");
+            w.write_str("</div>");
         }
     } else {
         // even without any implementations to write in, we still want the heading and list, so the
@@ -743,18 +738,16 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
             w,
             "implementors",
             "Implementors",
-            "<div class=\"item-list\" id=\"implementors-list\">",
+            "<div class=\"item-list\" id=\"implementors-list\"></div>",
         );
-        write_loading_content(w, "</div>");
 
         if t.is_auto {
             write_small_section_header(
                 w,
                 "synthetic-implementors",
                 "Auto implementors",
-                "<div class=\"item-list\" id=\"synthetic-implementors-list\">",
+                "<div class=\"item-list\" id=\"synthetic-implementors-list\"></div>",
             );
-            write_loading_content(w, "</div>");
         }
     }
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -156,152 +156,154 @@ function hideThemeButtonState() {
     "use strict";
 
     window.searchState = {
-      loadingText: "Loading search results...",
-      input: document.getElementsByClassName("search-input")[0],
-      outputElement: function() {
-        return document.getElementById("search");
-      },
-      title: null,
-      titleBeforeSearch: document.title,
-      timeout: null,
-      // On the search screen, so you remain on the last tab you opened.
-      //
-      // 0 for "In Names"
-      // 1 for "In Parameters"
-      // 2 for "In Return Types"
-      currentTab: 0,
-      mouseMovedAfterSearch: true,
-      clearInputTimeout: function() {
-        if (searchState.timeout !== null) {
-            clearTimeout(searchState.timeout);
-            searchState.timeout = null;
-        }
-      },
-      // Sets the focus on the search bar at the top of the page
-      focus: function() {
-          searchState.input.focus();
-      },
-      // Removes the focus from the search bar.
-      defocus: function() {
-          searchState.input.blur();
-      },
-      showResults: function(search) {
-        if (search === null || typeof search === 'undefined') {
-            search = searchState.outputElement();
-        }
-        addClass(main, "hidden");
-        removeClass(search, "hidden");
-        searchState.mouseMovedAfterSearch = false;
-        document.title = searchState.title;
-      },
-      hideResults: function(search) {
-        if (search === null || typeof search === 'undefined') {
-            search = searchState.outputElement();
-        }
-        addClass(search, "hidden");
-        removeClass(main, "hidden");
-        document.title = searchState.titleBeforeSearch;
-        // We also remove the query parameter from the URL.
-        if (searchState.browserSupportsHistoryApi()) {
-            history.replaceState("", window.currentCrate + " - Rust",
-                getNakedUrl() + window.location.hash);
-        }
-      },
-      getQueryStringParams: function() {
-        var params = {};
-        window.location.search.substring(1).split("&").
-            map(function(s) {
-                var pair = s.split("=");
-                params[decodeURIComponent(pair[0])] =
-                    typeof pair[1] === "undefined" ? null : decodeURIComponent(pair[1]);
-            });
-        return params;
-      },
-      putBackSearch: function(search_input) {
-        var search = searchState.outputElement();
-        if (search_input.value !== "" && hasClass(search, "hidden")) {
-            searchState.showResults(search);
-            if (searchState.browserSupportsHistoryApi()) {
-                var extra = "?search=" + encodeURIComponent(search_input.value);
-                history.replaceState(search_input.value, "",
-                    getNakedUrl() + extra + window.location.hash);
+        loadingText: "Loading search results...",
+        input: document.getElementsByClassName("search-input")[0],
+        outputElement: function() {
+            return document.getElementById("search");
+        },
+        title: null,
+        titleBeforeSearch: document.title,
+        timeout: null,
+        // On the search screen, so you remain on the last tab you opened.
+        //
+        // 0 for "In Names"
+        // 1 for "In Parameters"
+        // 2 for "In Return Types"
+        currentTab: 0,
+        mouseMovedAfterSearch: true,
+        clearInputTimeout: function() {
+            if (searchState.timeout !== null) {
+                clearTimeout(searchState.timeout);
+                searchState.timeout = null;
             }
+        },
+        // Sets the focus on the search bar at the top of the page
+        focus: function() {
+            searchState.input.focus();
+        },
+        // Removes the focus from the search bar.
+        defocus: function() {
+            searchState.input.blur();
+        },
+        showResults: function(search) {
+            if (search === null || typeof search === 'undefined') {
+                search = searchState.outputElement();
+            }
+            addClass(main, "hidden");
+            removeClass(search, "hidden");
+            searchState.mouseMovedAfterSearch = false;
             document.title = searchState.title;
-        }
-      },
-      browserSupportsHistoryApi: function() {
-          return window.history && typeof window.history.pushState === "function";
-      },
-      setup: function() {
-        var search_input = searchState.input;
-        if (!searchState.input) {
-            return;
-        }
-        function loadScript(url) {
-            var script = document.createElement('script');
-            script.src = url;
-            document.head.append(script);
-        }
-
-        var searchLoaded = false;
-        function loadSearch() {
-            if (!searchLoaded) {
-                searchLoaded = true;
-                loadScript(window.searchJS);
-                loadScript(window.searchIndexJS);
+        },
+        hideResults: function(search) {
+            if (search === null || typeof search === 'undefined') {
+                search = searchState.outputElement();
             }
-        }
-
-        search_input.addEventListener("focus", function() {
-            searchState.putBackSearch(this);
-            search_input.origPlaceholder = searchState.input.placeholder;
-            search_input.placeholder = "Type your search here.";
-            loadSearch();
-        });
-        search_input.addEventListener("blur", function() {
-            search_input.placeholder = searchState.input.origPlaceholder;
-        });
-
-        document.addEventListener("mousemove", function() {
-          searchState.mouseMovedAfterSearch = true;
-        });
-
-        search_input.removeAttribute('disabled');
-
-        // `crates{version}.js` should always be loaded before this script, so we can use it safely.
-        searchState.addCrateDropdown(window.ALL_CRATES);
-        var params = searchState.getQueryStringParams();
-        if (params.search !== undefined) {
+            addClass(search, "hidden");
+            removeClass(main, "hidden");
+            document.title = searchState.titleBeforeSearch;
+            // We also remove the query parameter from the URL.
+            if (searchState.browserSupportsHistoryApi()) {
+                history.replaceState("", window.currentCrate + " - Rust",
+                    getNakedUrl() + window.location.hash);
+            }
+        },
+        getQueryStringParams: function() {
+            var params = {};
+            window.location.search.substring(1).split("&").
+                map(function(s) {
+                    var pair = s.split("=");
+                    params[decodeURIComponent(pair[0])] =
+                        typeof pair[1] === "undefined" ? null : decodeURIComponent(pair[1]);
+                });
+            return params;
+        },
+        putBackSearch: function(search_input) {
             var search = searchState.outputElement();
-            search.innerHTML = "<h3 style=\"text-align: center;\">" +
-               searchState.loadingText + "</h3>";
-            searchState.showResults(search);
-            loadSearch();
-        }
-      },
-      addCrateDropdown: function(crates) {
-        var elem = document.getElementById("crate-search");
-
-        if (!elem) {
-            return;
-        }
-        var savedCrate = getSettingValue("saved-filter-crate");
-        for (var i = 0, len = crates.length; i < len; ++i) {
-            var option = document.createElement("option");
-            option.value = crates[i];
-            option.innerText = crates[i];
-            elem.appendChild(option);
-            // Set the crate filter from saved storage, if the current page has the saved crate
-            // filter.
-            //
-            // If not, ignore the crate filter -- we want to support filtering for crates on sites
-            // like doc.rust-lang.org where the crates may differ from page to page while on the
-            // same domain.
-            if (crates[i] === savedCrate) {
-                elem.value = savedCrate;
+            if (search_input.value !== "" && hasClass(search, "hidden")) {
+                searchState.showResults(search);
+                if (searchState.browserSupportsHistoryApi()) {
+                    var extra = "?search=" + encodeURIComponent(search_input.value);
+                    history.replaceState(search_input.value, "",
+                        getNakedUrl() + extra + window.location.hash);
+                }
+                document.title = searchState.title;
             }
-        }
-      },
+        },
+        browserSupportsHistoryApi: function() {
+            return window.history && typeof window.history.pushState === "function";
+        },
+        setup: function() {
+            var search_input = searchState.input;
+            if (!searchState.input) {
+                return;
+            }
+            function loadScript(url) {
+                var script = document.createElement('script');
+                script.src = url;
+                document.head.append(script);
+            }
+
+            var searchLoaded = false;
+            function loadSearch() {
+                if (!searchLoaded) {
+                    searchLoaded = true;
+                    loadScript(window.searchJS);
+                    loadScript(window.searchIndexJS);
+                }
+            }
+
+            search_input.addEventListener("focus", function() {
+                searchState.putBackSearch(this);
+                search_input.origPlaceholder = searchState.input.placeholder;
+                search_input.placeholder = "Type your search here.";
+                loadSearch();
+            });
+            search_input.addEventListener("blur", function() {
+                search_input.placeholder = searchState.input.origPlaceholder;
+            });
+
+            document.addEventListener("mousemove", function() {
+                searchState.mouseMovedAfterSearch = true;
+            });
+
+            search_input.removeAttribute('disabled');
+
+            // `crates{version}.js` should always be loaded before this script, so we can use it
+            // safely.
+            searchState.addCrateDropdown(window.ALL_CRATES);
+            var params = searchState.getQueryStringParams();
+            if (params.search !== undefined) {
+                var search = searchState.outputElement();
+                search.innerHTML = "<h3 style=\"text-align: center;\">" +
+                   searchState.loadingText + "</h3>";
+                searchState.showResults(search);
+                loadSearch();
+            }
+        },
+        addCrateDropdown: function(crates) {
+            var elem = document.getElementById("crate-search");
+
+            if (!elem) {
+                return;
+            }
+            var savedCrate = getSettingValue("saved-filter-crate");
+            for (var i = 0, len = crates.length; i < len; ++i) {
+                var option = document.createElement("option");
+                option.value = crates[i];
+                option.innerText = crates[i];
+                elem.appendChild(option);
+                // Set the crate filter from saved storage, if the current page has the saved crate
+                // filter.
+                //
+                // If not, ignore the crate filter -- we want to support filtering for crates on
+                // sites like doc.rust-lang.org where the crates may differ from page to page while
+                // on the
+                // same domain.
+                if (crates[i] === savedCrate) {
+                    elem.value = savedCrate;
+                }
+            }
+        },
     };
 
     function getPageId() {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -1140,26 +1140,6 @@ function hideThemeButtonState() {
         };
     }
 
-    if (main) {
-        onEachLazy(main.getElementsByClassName("loading-content"), function(e) {
-            e.remove();
-        });
-        onEachLazy(main.childNodes, function(e) {
-            // Unhide the actual content once loading is complete. Headers get
-            // flex treatment for their horizontal layout, divs get block treatment
-            // for vertical layout (column-oriented flex layout for divs caused
-            // errors in mobile browsers).
-            if (e.tagName === "H2" || e.tagName === "H3") {
-                var nextTagName = e.nextElementSibling.tagName;
-                if (nextTagName === "H2" || nextTagName === "H3") {
-                    e.nextElementSibling.style.display = "flex";
-                } else if (nextTagName !== "DETAILS") {
-                    e.nextElementSibling.style.display = "block";
-                }
-            }
-        });
-    }
-
     function buildHelperPopup() {
         var popup = document.createElement("aside");
         addClass(popup, "hidden");

--- a/src/librustdoc/html/static/noscript.css
+++ b/src/librustdoc/html/static/noscript.css
@@ -4,31 +4,6 @@ of content is hidden by default (depending on the settings too), we have to over
 rules.
 */
 
-#main > h2 + div, #main > h2 + h3, #main > h3 + div {
-	display: block;
-}
-
-.loading-content {
-	display: none;
-}
-
-#main > h2 + div, #main > h3 + div {
-	display: block;
-}
-
-#main > h2 + h3 {
-	display: flex;
-}
-
-#main .impl-items .hidden {
-	display: block !important;
-}
-
-#main .impl-items h4.hidden {
-	/* Without this rule, the version and the "[src]" span aren't on the same line as the header. */
-	display: flex !important;
-}
-
 #main .attributes {
 	/* Since there is no toggle (the "[-]") when JS is disabled, no need for this margin either. */
 	margin-left: 0 !important;

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -431,11 +431,6 @@ nav.sub {
 #main > .docblock h2 { font-size: 1.15em; }
 #main > .docblock h3, #main > .docblock h4, #main > .docblock h5 { font-size: 1em; }
 
-#main > h2 + div, #main > h2 + h3, #main > h3 + div {
-	display: none; /* Changed to flex or block via js once the page is loaded */
-	flex-wrap: wrap;
-}
-
 .docblock h1 { font-size: 1em; }
 .docblock h2 { font-size: 0.95em; }
 .docblock h3, .docblock h4, .docblock h5 { font-size: 0.9em; }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -145,7 +145,7 @@ h4.type.trait-impl, h4.associatedconstant.trait-impl, h4.associatedtype.trait-im
 
 h1, h2, h3, h4,
 .sidebar, a.source, .search-input, .content table td:first-child > a,
-.collapse-toggle, div.item-list .out-of-band,
+div.item-list .out-of-band,
 #source-sidebar, #sidebar-toggle,
 details.rustdoc-toggle > summary::before,
 details.undocumented > summary::before,
@@ -560,9 +560,6 @@ h4 > code, h3 > code, .invisible > code {
 .content .docblock >.impl-items table td {
 	padding: 0;
 }
-.toggle-wrapper.marg-left > .collapse-toggle {
-	left: -24px;
-}
 .content .docblock > .impl-items .table-display, .impl-items table td {
 	border: none;
 }
@@ -969,45 +966,6 @@ a.test-arrow:hover{
 	font-weight: 300;
 }
 
-.collapse-toggle {
-	font-weight: 300;
-	position: absolute;
-	left: -23px;
-	top: 0;
-}
-
-h3 > .collapse-toggle, h4 > .collapse-toggle {
-	font-size: 0.8em;
-	top: 5px;
-}
-
-.toggle-wrapper > .collapse-toggle {
-	left: -24px;
-	margin-top: 0px;
-}
-
-.toggle-wrapper {
-	position: relative;
-	margin-top: 0;
-}
-
-.toggle-wrapper.collapsed {
-	height: 25px;
-	transition: height .2s;
-	margin-bottom: .6em;
-}
-
-.collapse-toggle > .inner {
-	display: inline-block;
-	width: 1.2ch;
-	text-align: center;
-}
-
-.collapse-toggle.hidden-default {
-	position: relative;
-	margin-left: 20px;
-}
-
 .since + .srclink {
 	display: table-cell;
 	padding-left: 10px;
@@ -1022,14 +980,6 @@ h3 > .collapse-toggle, h4 > .collapse-toggle {
 	position: initial;
 	font-size: 20px;
 	margin-right: 5px;
-}
-
-.toggle-wrapper > .collapse-toggle {
-	left: 0;
-}
-
-.variant + .toggle-wrapper + .docblock > p {
-	margin-top: 5px;
 }
 
 .sub-variant, .sub-variant > h3 {
@@ -1452,14 +1402,6 @@ h4 > .notable-traits {
 		position: inherit;
 	}
 
-	.toggle-wrapper > .collapse-toggle {
-		left: 0px;
-	}
-
-	.toggle-wrapper {
-		height: 1.5em;
-	}
-
 	#search {
 		margin-left: 0;
 	}
@@ -1550,14 +1492,6 @@ h4 > .notable-traits {
 		border-bottom: 1px solid;
 	}
 
-	.collapse-toggle {
-		left: -20px;
-	}
-
-	.impl > .collapse-toggle {
-		left: -10px;
-	}
-
 	.item-list > details.rustdoc-toggle > summary:not(.hideme)::before {
 		left: -10px;
 	}
@@ -1597,7 +1531,7 @@ h4 > .notable-traits {
 }
 
 @media print {
-	nav.sub, .content .out-of-band, .collapse-toggle {
+	nav.sub, .content .out-of-band {
 		display: none;
 	}
 }

--- a/src/librustdoc/html/static/search.js
+++ b/src/librustdoc/html/static/search.js
@@ -1505,7 +1505,7 @@ window.initSearch = function(rawSearchIndex) {
 };
 
 if (window.searchIndex !== undefined) {
-  initSearch(window.searchIndex);
+    initSearch(window.searchIndex);
 }
 
 })();

--- a/src/librustdoc/html/static/themes/ayu.css
+++ b/src/librustdoc/html/static/themes/ayu.css
@@ -224,7 +224,6 @@ a {
 	color: #39AFD7;
 }
 
-.collapse-toggle,
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,
 details.undocumented > summary::before {

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -186,7 +186,6 @@ a.test-arrow {
 	color: #dedede;
 }
 
-.collapse-toggle,
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,
 details.undocumented > summary::before {

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -184,7 +184,6 @@ a.test-arrow {
 	color: #f5f5f5;
 }
 
-.collapse-toggle,
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,
 details.undocumented > summary::before {


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/83332. The goal of this PR is to remove a few unused things:

 * The "loading content" things are now unneeded.
 * Some toggle CSS rules were still there.
 * Some parts of the JS had a different indent, fixed it.

r? @jsha 