### PR TITLE
Use .name_str() to format primitive types in error messages

### DIFF
--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -159,10 +159,23 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
                 )
             }),
             IntMismatch(ref values) => {
-                write!(f, "expected `{:?}`, found `{:?}`", values.expected, values.found)
+                let expected = match values.expected {
+                    ty::IntVarValue::IntType(ty) => ty.name_str(),
+                    ty::IntVarValue::UintType(ty) => ty.name_str(),
+                };
+                let found = match values.found {
+                    ty::IntVarValue::IntType(ty) => ty.name_str(),
+                    ty::IntVarValue::UintType(ty) => ty.name_str(),
+                };
+                write!(f, "expected `{}`, found `{}`", expected, found)
             }
             FloatMismatch(ref values) => {
-                write!(f, "expected `{:?}`, found `{:?}`", values.expected, values.found)
+                write!(
+                    f,
+                    "expected `{}`, found `{}`",
+                    values.expected.name_str(),
+                    values.found.name_str()
+                )
             }
             VariadicMismatch(ref values) => write!(
                 f,

--- a/src/test/ui/mismatched_types/issue-84976.rs
+++ b/src/test/ui/mismatched_types/issue-84976.rs
@@ -1,3 +1,7 @@
+/* Checks whether primitive type names are formatted correctly in the
+ * error messages about mismatched types (#84976).
+ */
+
 fn foo(length: &u32) -> i32 {
     0
 }

--- a/src/test/ui/mismatched_types/issue-84976.rs
+++ b/src/test/ui/mismatched_types/issue-84976.rs
@@ -1,0 +1,21 @@
+fn foo(length: &u32) -> i32 {
+    0
+}
+
+fn bar(length: &f32) -> f64 {
+    0.0
+}
+
+fn main() {
+    let mut length = 0;
+    length = { foo(&length) };
+    //~^ ERROR mismatched types [E0308]
+    length = foo(&length);
+    //~^ ERROR mismatched types [E0308]
+
+    let mut float_length = 0.0;
+    float_length = { bar(&float_length) };
+    //~^ ERROR mismatched types [E0308]
+    float_length = bar(&float_length);
+    //~^ ERROR mismatched types [E0308]
+}

--- a/src/test/ui/mismatched_types/issue-84976.stderr
+++ b/src/test/ui/mismatched_types/issue-84976.stderr
@@ -1,23 +1,23 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-84976.rs:11:16
+  --> $DIR/issue-84976.rs:15:16
    |
 LL |     length = { foo(&length) };
    |                ^^^^^^^^^^^^ expected `u32`, found `i32`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-84976.rs:13:14
+  --> $DIR/issue-84976.rs:17:14
    |
 LL |     length = foo(&length);
    |              ^^^^^^^^^^^^ expected `u32`, found `i32`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-84976.rs:17:22
+  --> $DIR/issue-84976.rs:21:22
    |
 LL |     float_length = { bar(&float_length) };
    |                      ^^^^^^^^^^^^^^^^^^ expected `f32`, found `f64`
 
 error[E0308]: mismatched types
-  --> $DIR/issue-84976.rs:19:20
+  --> $DIR/issue-84976.rs:23:20
    |
 LL |     float_length = bar(&float_length);
    |                    ^^^^^^^^^^^^^^^^^^ expected `f32`, found `f64`

--- a/src/test/ui/mismatched_types/issue-84976.stderr
+++ b/src/test/ui/mismatched_types/issue-84976.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-84976.rs:11:16
+   |
+LL |     length = { foo(&length) };
+   |                ^^^^^^^^^^^^ expected `u32`, found `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-84976.rs:13:14
+   |
+LL |     length = foo(&length);
+   |              ^^^^^^^^^^^^ expected `u32`, found `i32`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-84976.rs:17:22
+   |
+LL |     float_length = { bar(&float_length) };
+   |                      ^^^^^^^^^^^^^^^^^^ expected `f32`, found `f64`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-84976.rs:19:20
+   |
+LL |     float_length = bar(&float_length);
+   |                    ^^^^^^^^^^^^^^^^^^ expected `f32`, found `f64`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This pull request fixes #84976. The problem described there is caused by this code
https://github.com/rust-lang/rust/blob/506e75cbf8cb5305e49a41326307004ca3976029/compiler/rustc_middle/src/ty/error.rs#L161-L166
using `Debug` formatting (`{:?}`), while the proper solution is to call `name_str()` of `ty::IntTy`, `ty::UintTy` and `ty::FloatTy`, respectively.
