### PR TITLE
Re-add support for parsing (and pretty-printing) inner-attributes in match body

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -366,6 +366,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
         self.print_either_attributes(attrs, ast::AttrStyle::Inner, false, true)
     }
 
+    fn print_inner_attributes_no_trailing_hardbreak(&mut self, attrs: &[ast::Attribute]) {
+        self.print_either_attributes(attrs, ast::AttrStyle::Inner, false, false)
+    }
+
     fn print_outer_attributes(&mut self, attrs: &[ast::Attribute]) {
         self.print_either_attributes(attrs, ast::AttrStyle::Outer, false, true)
     }
@@ -1940,6 +1944,7 @@ impl<'a> State<'a> {
                 self.print_expr_as_cond(expr);
                 self.s.space();
                 self.bopen();
+                self.print_inner_attributes_no_trailing_hardbreak(attrs);
                 for arm in arms {
                     self.print_arm(arm);
                 }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1947,7 +1947,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses a `match ... { ... }` expression (`match` token already eaten).
-    fn parse_match_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
+    fn parse_match_expr(&mut self, mut attrs: AttrVec) -> PResult<'a, P<Expr>> {
         let match_span = self.prev_token.span;
         let lo = self.prev_token.span;
         let scrutinee = self.parse_expr_res(Restrictions::NO_STRUCT_LITERAL, None)?;
@@ -1962,6 +1962,7 @@ impl<'a> Parser<'a> {
             }
             return Err(e);
         }
+        attrs.extend(self.parse_inner_attributes()?);
 
         let mut arms: Vec<Arm> = Vec::new();
         while self.token != token::CloseDelim(token::Brace) {

--- a/src/test/pretty/ast-stmt-expr-attr.rs
+++ b/src/test/pretty/ast-stmt-expr-attr.rs
@@ -43,10 +43,10 @@ fn syntax() {
                     #![attr]
                 };
     let _ =
-        #[attr] match true
-                    {
-                     #[attr]
-                     _ => false,
+        #[attr] match true {
+                    #![attr]
+                            #[attr]
+                            _ => false,
                 };
     let _ = #[attr] || #[attr] foo;
     let _ = #[attr] move || #[attr] foo;

--- a/src/test/pretty/stmt_expr_attributes.rs
+++ b/src/test/pretty/stmt_expr_attributes.rs
@@ -41,9 +41,16 @@ fn _3() {
 fn _4() {
 
     #[rustc_dummy]
-    match () { _ => (), }
+    match () {
+        #![rustc_dummy]
+        _ => (),
+    }
 
-    let _ = #[rustc_dummy] match () { () => (), };
+    let _ =
+        #[rustc_dummy] match () {
+                           #![rustc_dummy]
+                           () => (),
+                       };
 }
 
 fn _5() {
@@ -164,7 +171,11 @@ fn _11() {
         #[rustc_dummy] loop  {
                            #![rustc_dummy]
                        };
-    let _ = #[rustc_dummy] match false { _ => (), };
+    let _ =
+        #[rustc_dummy] match false {
+                           #![rustc_dummy]
+                           _ => (),
+                       };
     let _ = #[rustc_dummy] || #[rustc_dummy] ();
     let _ = #[rustc_dummy] move || #[rustc_dummy] ();
     let _ =

--- a/src/test/ui/parser/stmt_expr_attrs_placement.rs
+++ b/src/test/ui/parser/stmt_expr_attrs_placement.rs
@@ -30,7 +30,7 @@ fn main() {
     //~^ ERROR an inner attribute is not permitted in this context
 
     let g = match true { #![allow(warnings)] _ => {} };
-    //~^ ERROR an inner attribute is not permitted in this context
+
 
     struct MyStruct { field: u8 }
     let h = MyStruct { #![allow(warnings)] field: 0 };

--- a/src/test/ui/parser/stmt_expr_attrs_placement.stderr
+++ b/src/test/ui/parser/stmt_expr_attrs_placement.stderr
@@ -47,14 +47,6 @@ LL |     let f = [#![allow(warnings)] 1; 0];
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
 
 error: an inner attribute is not permitted in this context
-  --> $DIR/stmt_expr_attrs_placement.rs:32:26
-   |
-LL |     let g = match true { #![allow(warnings)] _ => {} };
-   |                          ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
-
-error: an inner attribute is not permitted in this context
   --> $DIR/stmt_expr_attrs_placement.rs:36:24
    |
 LL |     let h = MyStruct { #![allow(warnings)] field: 0 };
@@ -62,5 +54,5 @@ LL |     let h = MyStruct { #![allow(warnings)] field: 0 };
    |
    = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files. Outer attributes, like `#[test]`, annotate the item following them.
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Re-add support for parsing (and pretty-printing) inner-attributes within body of a `match`.

In other words, we can do `match EXPR { #![inner_attr] ARM_1 ARM_2 ... }` again.

I believe this unbreaks the only four crates that crater flagged as broken by PR #83312.

(I am putting this up so that the lang-team can check it out and decide whether it changes their mind about what to do regarding PR #83312.)