### PR TITLE
#[inline(always)] on forwarding slice/vec methods

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -775,7 +775,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// let vec: Vec<i32> = Vec::with_capacity(10);
     /// assert_eq!(vec.capacity(), 10);
     /// ```
-    #[inline]
+    #[inline(always)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn capacity(&self) -> usize {
         self.buf.capacity()
@@ -1078,7 +1078,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// let buffer = vec![1, 2, 3, 5, 8];
     /// io::sink().write(buffer.as_slice()).unwrap();
     /// ```
-    #[inline]
+    #[inline(always)]
     #[stable(feature = "vec_as_slice", since = "1.7.0")]
     pub fn as_slice(&self) -> &[T] {
         self
@@ -1095,7 +1095,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// let mut buffer = vec![0; 3];
     /// io::repeat(0b101).read_exact(buffer.as_mut_slice()).unwrap();
     /// ```
-    #[inline]
+    #[inline(always)]
     #[stable(feature = "vec_as_slice", since = "1.7.0")]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self
@@ -1820,7 +1820,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(a.len(), 3);
     /// ```
     #[doc(alias = "length")]
-    #[inline]
+    #[inline(always)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn len(&self) -> usize {
         self.len
@@ -2422,7 +2422,7 @@ impl<T: Hash, A: Allocator> Hash for Vec<T, A> {
 impl<T, I: SliceIndex<[T]>, A: Allocator> Index<I> for Vec<T, A> {
     type Output = I::Output;
 
-    #[inline]
+    #[inline(always)]
     fn index(&self, index: I) -> &Self::Output {
         Index::index(&**self, index)
     }
@@ -2434,7 +2434,7 @@ impl<T, I: SliceIndex<[T]>, A: Allocator> Index<I> for Vec<T, A> {
     label = "vector indices are of type `usize` or ranges of `usize`"
 )]
 impl<T, I: SliceIndex<[T]>, A: Allocator> IndexMut<I> for Vec<T, A> {
-    #[inline]
+    #[inline(always)]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         IndexMut::index_mut(&mut **self, index)
     }
@@ -2496,6 +2496,7 @@ impl<'a, T, A: Allocator> IntoIterator for &'a Vec<T, A> {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;
 
+    #[inline(always)]
     fn into_iter(self) -> slice::Iter<'a, T> {
         self.iter()
     }
@@ -2506,6 +2507,7 @@ impl<'a, T, A: Allocator> IntoIterator for &'a mut Vec<T, A> {
     type Item = &'a mut T;
     type IntoIter = slice::IterMut<'a, T>;
 
+    #[inline(always)]
     fn into_iter(self) -> slice::IterMut<'a, T> {
         self.iter_mut()
     }

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -107,6 +107,7 @@ pub unsafe trait Step: Clone + PartialOrd + Sized {
     ///
     /// * `Step::forward_unchecked(a, n)` is equivalent to `Step::forward(a, n)`
     #[unstable(feature = "step_trait_ext", reason = "recently added", issue = "42168")]
+    #[inline(always)]
     unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
         Step::forward(start, count)
     }
@@ -179,6 +180,7 @@ pub unsafe trait Step: Clone + PartialOrd + Sized {
     ///
     /// * `Step::backward_unchecked(a, n)` is equivalent to `Step::backward(a, n)`
     #[unstable(feature = "step_trait_ext", reason = "recently added", issue = "42168")]
+    #[inline(always)]
     unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
         Step::backward(start, count)
     }
@@ -187,13 +189,13 @@ pub unsafe trait Step: Clone + PartialOrd + Sized {
 // These are still macro-generated because the integer literals resolve to different types.
 macro_rules! step_identical_methods {
     () => {
-        #[inline]
+        #[inline(always)]
         unsafe fn forward_unchecked(start: Self, n: usize) -> Self {
             // SAFETY: the caller has to guarantee that `start + n` doesn't overflow.
             unsafe { start.unchecked_add(n as Self) }
         }
 
-        #[inline]
+        #[inline(always)]
         unsafe fn backward_unchecked(start: Self, n: usize) -> Self {
             // SAFETY: the caller has to guarantee that `start - n` doesn't overflow.
             unsafe { start.unchecked_sub(n as Self) }
@@ -345,12 +347,12 @@ macro_rules! step_integer_impls {
                     }
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn forward_checked(start: Self, n: usize) -> Option<Self> {
                     start.checked_add(n as Self)
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn backward_checked(start: Self, n: usize) -> Option<Self> {
                     start.checked_sub(n as Self)
                 }
@@ -375,12 +377,12 @@ macro_rules! step_integer_impls {
                     }
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn forward_checked(start: Self, n: usize) -> Option<Self> {
                     start.checked_add(n as Self)
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn backward_checked(start: Self, n: usize) -> Option<Self> {
                     start.checked_sub(n as Self)
                 }
@@ -551,17 +553,17 @@ impl<A: Step> Iterator for ops::Range<A> {
         None
     }
 
-    #[inline]
+    #[inline(always)]
     fn last(mut self) -> Option<A> {
         self.next_back()
     }
 
-    #[inline]
+    #[inline(always)]
     fn min(mut self) -> Option<A> {
         self.next()
     }
 
-    #[inline]
+    #[inline(always)]
     fn max(mut self) -> Option<A> {
         self.next_back()
     }
@@ -671,7 +673,7 @@ impl<A: Step> Iterator for ops::RangeFrom<A> {
         Some(mem::replace(&mut self.start, n))
     }
 
-    #[inline]
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (usize::MAX, None)
     }
@@ -793,17 +795,17 @@ impl<A: Step> Iterator for ops::RangeInclusive<A> {
         self.try_fold(init, ok(f)).unwrap()
     }
 
-    #[inline]
+    #[inline(always)]
     fn last(mut self) -> Option<A> {
         self.next_back()
     }
 
-    #[inline]
+    #[inline(always)]
     fn min(mut self) -> Option<A> {
         self.next()
     }
 
-    #[inline]
+    #[inline(always)]
     fn max(mut self) -> Option<A> {
         self.next_back()
     }

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -42,7 +42,7 @@ impl<T: ?Sized> *mut T {
     /// Casts to a pointer of another type.
     #[stable(feature = "ptr_cast", since = "1.38.0")]
     #[rustc_const_stable(feature = "const_ptr_cast", since = "1.38.0")]
-    #[inline]
+    #[inline(always)]
     pub const fn cast<U>(self) -> *mut U {
         self as _
     }
@@ -551,7 +551,7 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[stable(feature = "ptr_offset_from", since = "1.47.0")]
     #[rustc_const_unstable(feature = "const_ptr_offset_from", issue = "41079")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn offset_from(self, origin: *const T) -> isize
     where
         T: Sized,
@@ -859,7 +859,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::read`]: crate::ptr::read()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[rustc_const_unstable(feature = "const_ptr_read", issue = "80377")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn read(self) -> T
     where
         T: Sized,
@@ -879,7 +879,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::read_volatile`]: crate::ptr::read_volatile()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn read_volatile(self) -> T
     where
         T: Sized,
@@ -898,7 +898,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::read_unaligned`]: crate::ptr::read_unaligned()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[rustc_const_unstable(feature = "const_ptr_read", issue = "80377")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn read_unaligned(self) -> T
     where
         T: Sized,
@@ -917,7 +917,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::copy`]: crate::ptr::copy()
     #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn copy_to(self, dest: *mut T, count: usize)
     where
         T: Sized,
@@ -936,7 +936,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::copy_nonoverlapping`]: crate::ptr::copy_nonoverlapping()
     #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn copy_to_nonoverlapping(self, dest: *mut T, count: usize)
     where
         T: Sized,
@@ -955,7 +955,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::copy`]: crate::ptr::copy()
     #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn copy_from(self, src: *const T, count: usize)
     where
         T: Sized,
@@ -974,7 +974,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::copy_nonoverlapping`]: crate::ptr::copy_nonoverlapping()
     #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn copy_from_nonoverlapping(self, src: *const T, count: usize)
     where
         T: Sized,
@@ -989,7 +989,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::drop_in_place`]: crate::ptr::drop_in_place()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn drop_in_place(self) {
         // SAFETY: the caller must uphold the safety contract for `drop_in_place`.
         unsafe { drop_in_place(self) }
@@ -1003,7 +1003,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::write`]: crate::ptr::write()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn write(self, val: T)
     where
         T: Sized,
@@ -1019,7 +1019,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::write_bytes`]: crate::ptr::write_bytes()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn write_bytes(self, val: u8, count: usize)
     where
         T: Sized,
@@ -1039,7 +1039,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::write_volatile`]: crate::ptr::write_volatile()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn write_volatile(self, val: T)
     where
         T: Sized,
@@ -1058,7 +1058,7 @@ impl<T: ?Sized> *mut T {
     /// [`ptr::write_unaligned`]: crate::ptr::write_unaligned()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[rustc_const_unstable(feature = "const_ptr_write", issue = "none")]
-    #[inline]
+    #[inline(always)]
     pub const unsafe fn write_unaligned(self, val: T)
     where
         T: Sized,
@@ -1074,7 +1074,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::replace`]: crate::ptr::replace()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn replace(self, src: T) -> T
     where
         T: Sized,
@@ -1091,7 +1091,7 @@ impl<T: ?Sized> *mut T {
     ///
     /// [`ptr::swap`]: crate::ptr::swap()
     #[stable(feature = "pointer_methods", since = "1.26.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn swap(self, with: *mut T)
     where
         T: Sized,
@@ -1170,7 +1170,7 @@ impl<T> *mut [T] {
     /// let slice: *mut [i8] = ptr::slice_from_raw_parts_mut(ptr::null_mut(), 3);
     /// assert_eq!(slice.len(), 3);
     /// ```
-    #[inline]
+    #[inline(always)]
     #[unstable(feature = "slice_ptr_len", issue = "71146")]
     #[rustc_const_unstable(feature = "const_slice_ptr_len", issue = "71146")]
     pub const fn len(self) -> usize {
@@ -1190,7 +1190,7 @@ impl<T> *mut [T] {
     /// let slice: *mut [i8] = ptr::slice_from_raw_parts_mut(ptr::null_mut(), 3);
     /// assert_eq!(slice.as_mut_ptr(), 0 as *mut i8);
     /// ```
-    #[inline]
+    #[inline(always)]
     #[unstable(feature = "slice_ptr_get", issue = "74265")]
     #[rustc_const_unstable(feature = "slice_ptr_get", issue = "74265")]
     pub const fn as_mut_ptr(self) -> *mut T {
@@ -1217,7 +1217,7 @@ impl<T> *mut [T] {
     /// }
     /// ```
     #[unstable(feature = "slice_ptr_get", issue = "74265")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn get_unchecked_mut<I>(self, index: I) -> *mut I::Output
     where
         I: SliceIndex<[T]>,
@@ -1332,7 +1332,7 @@ impl<T> *mut [T] {
 // Equality for pointers
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> PartialEq for *mut T {
-    #[inline]
+    #[inline(always)]
     fn eq(&self, other: &*mut T) -> bool {
         *self == *other
     }
@@ -1357,27 +1357,27 @@ impl<T: ?Sized> Ord for *mut T {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> PartialOrd for *mut T {
-    #[inline]
+    #[inline(always)]
     fn partial_cmp(&self, other: &*mut T) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 
-    #[inline]
+    #[inline(always)]
     fn lt(&self, other: &*mut T) -> bool {
         *self < *other
     }
 
-    #[inline]
+    #[inline(always)]
     fn le(&self, other: &*mut T) -> bool {
         *self <= *other
     }
 
-    #[inline]
+    #[inline(always)]
     fn gt(&self, other: &*mut T) -> bool {
         *self > *other
     }
 
-    #[inline]
+    #[inline(always)]
     fn ge(&self, other: &*mut T) -> bool {
         *self >= *other
     }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -21,6 +21,7 @@ impl<'a, T> IntoIterator for &'a [T] {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
+    #[inline(always)]
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
     }
@@ -31,6 +32,7 @@ impl<'a, T> IntoIterator for &'a mut [T] {
     type Item = &'a mut T;
     type IntoIter = IterMut<'a, T>;
 
+    #[inline(always)]
     fn into_iter(self) -> IterMut<'a, T> {
         self.iter_mut()
     }

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -299,7 +299,7 @@ impl<T> [T] {
     /// assert_eq!(None, v.get(0..4));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
+    #[inline(always)]
     pub fn get<I>(&self, index: I) -> Option<&I::Output>
     where
         I: SliceIndex<Self>,
@@ -323,7 +323,7 @@ impl<T> [T] {
     /// assert_eq!(x, &[0, 42, 2]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
+    #[inline(always)]
     pub fn get_mut<I>(&mut self, index: I) -> Option<&mut I::Output>
     where
         I: SliceIndex<Self>,
@@ -354,7 +354,7 @@ impl<T> [T] {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn get_unchecked<I>(&self, index: I) -> &I::Output
     where
         I: SliceIndex<Self>,
@@ -390,7 +390,7 @@ impl<T> [T] {
     /// assert_eq!(x, &[1, 13, 4]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
+    #[inline(always)]
     pub unsafe fn get_unchecked_mut<I>(&mut self, index: I) -> &mut I::Output
     where
         I: SliceIndex<Self>,
@@ -429,7 +429,7 @@ impl<T> [T] {
     /// [`as_mut_ptr`]: slice::as_mut_ptr
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_slice_as_ptr", since = "1.32.0")]
-    #[inline]
+    #[inline(always)]
     pub const fn as_ptr(&self) -> *const T {
         self as *const [T] as *const T
     }
@@ -457,7 +457,7 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_ptr_offset", issue = "71499")]
-    #[inline]
+    #[inline(always)]
     pub const fn as_mut_ptr(&mut self) -> *mut T {
         self as *mut [T] as *mut T
     }
@@ -702,7 +702,7 @@ impl<T> [T] {
     /// assert_eq!(iterator.next(), None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
+    #[inline(always)]
     pub fn iter(&self) -> Iter<'_, T> {
         Iter::new(self)
     }
@@ -719,7 +719,7 @@ impl<T> [T] {
     /// assert_eq!(x, &[3, 4, 6]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
+    #[inline(always)]
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         IterMut::new(self)
     }
@@ -3544,7 +3544,7 @@ pub trait SlicePattern {
 impl<T> SlicePattern for [T] {
     type Item = T;
 
-    #[inline]
+    #[inline(always)]
     fn as_slice(&self) -> &[Self::Item] {
         self
     }
@@ -3554,7 +3554,7 @@ impl<T> SlicePattern for [T] {
 impl<T, const N: usize> SlicePattern for [T; N] {
     type Item = T;
 
-    #[inline]
+    #[inline(always)]
     fn as_slice(&self) -> &[Self::Item] {
         self
     }


### PR DESCRIPTION
Similar to #85218 