### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
  "markup5ever_rcdom",
  "matches",
  "tendril",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ dependencies = [
  "toml",
  "unicode-width",
  "unicode-xid",
- "url 2.1.1",
+ "url 2.2.2",
  "walkdir",
  "winapi 0.3.9",
 ]
@@ -378,7 +378,7 @@ dependencies = [
  "serde_json",
  "tar",
  "toml",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -600,7 +600,7 @@ dependencies = [
  "serde_json",
  "toml",
  "unicode-normalization",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -750,7 +750,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde",
  "serde_json",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -1188,6 +1188,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "fortanix-sgx-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,7 +1451,7 @@ dependencies = [
  "log",
  "openssl-probe",
  "openssl-sys",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -1453,7 +1463,7 @@ dependencies = [
  "curl",
  "git2",
  "log",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -2003,7 +2013,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "url 2.1.1",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -3114,7 +3124,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
- "url 2.1.1",
+ "url 2.2.2",
  "walkdir",
 ]
 
@@ -3546,7 +3556,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "syn",
- "url 2.1.1",
+ "url 2.2.2",
  "winapi 0.3.9",
 ]
 
@@ -5533,10 +5543,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",


### PR DESCRIPTION
8 commits in e51522ab3db23b0d8f1de54eb1f0113924896331..070e459c2d8b79c5b2ac5218064e7603329c92ae
2021-05-07 21:29:52 +0000 to 2021-05-11 18:12:23 +0000
- Fix rustdoc warnings (rust-lang/cargo#9468)
- Improve performance of git status check in `cargo package`. (rust-lang/cargo#9478)
- Link to the new rustc tests chapter. (rust-lang/cargo#9477)
- Bump index cache version to deal with semver metadata version mismatch. (rust-lang/cargo#9476)
- Fix Url::into_string deprecation warning (rust-lang/cargo#9475)
- Fix rust-lang/cargo#4482 and rust-lang/cargo#9449: set Fossil ignore and clean settings locally (rust-lang/cargo#9469)
- Improve two error messages (rust-lang/cargo#9472)
- Fix `cargo install` with a semver metadata version. (rust-lang/cargo#9467)