### PR TITLE
Constant::eq skips spans

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -230,7 +230,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
 
     fn visit_terminator(&mut self, terminator: &mir::Terminator<'tcx>, location: Location) {
         let check = match terminator.kind {
-            mir::TerminatorKind::Call { func: mir::Operand::Constant(ref c), ref args, .. } => {
+            mir::TerminatorKind::Call { func: mir::Operand::Constant(box(_, ref c)), ref args, .. } => {
                 match *c.ty().kind() {
                     ty::FnDef(did, _) => Some((did, args)),
                     _ => None,

--- a/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/debuginfo.rs
@@ -420,7 +420,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             None => continue,
                         };
 
-                        if let Ok(operand) = self.eval_mir_constant_to_operand(bx, &c) {
+                        if let Ok(operand) = self.eval_mir_constant_to_operand(bx, var.source_info.span, &c) {
                             let base = Self::spill_operand_to_stack(
                                 &operand,
                                 Some(var.name.to_string()),

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -188,14 +188,14 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
     // Evaluate all required consts; codegen later assumes that CTFE will never fail.
     let mut all_consts_ok = true;
-    for const_ in &mir.required_consts {
-        if let Err(err) = fx.eval_mir_constant(const_) {
+    for (span, const_) in &mir.required_consts {
+        if let Err(err) = fx.eval_mir_constant(*span, const_) {
             all_consts_ok = false;
             match err {
                 // errored or at least linted
                 ErrorHandled::Reported(ErrorReported) | ErrorHandled::Linted => {}
                 ErrorHandled::TooGeneric => {
-                    span_bug!(const_.span, "codgen encountered polymorphic constant: {:?}", err)
+                    span_bug!(*span, "codgen encountered polymorphic constant: {:?}", err)
                 }
             }
         }

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -437,10 +437,10 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 self.codegen_consume(bx, place.as_ref())
             }
 
-            mir::Operand::Constant(ref constant) => {
+            mir::Operand::Constant(box(span, ref constant)) => {
                 // This cannot fail because we checked all required_consts in advance.
-                self.eval_mir_constant_to_operand(bx, constant).unwrap_or_else(|_err| {
-                    span_bug!(constant.span, "erroneous constant not captured by required_consts")
+                self.eval_mir_constant_to_operand(bx, span, constant).unwrap_or_else(|_err| {
+                    span_bug!(span, "erroneous constant not captured by required_consts")
                 })
             }
         }

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -227,7 +227,7 @@ impl<'tcx> Operand<'tcx> {
     {
         match self {
             &Operand::Copy(ref l) | &Operand::Move(ref l) => l.ty(local_decls, tcx).ty,
-            &Operand::Constant(ref c) => c.literal.ty(),
+            &Operand::Constant(box (_, ref c)) => c.literal.ty(),
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -527,7 +527,8 @@ impl<'tcx> TerminatorKind<'tcx> {
                         InlineAsmOperand::InOut { reg, late, in_value, out_place: None } => {
                             write!(fmt, "in{}out({}) {:?} => _", print_late(late), reg, in_value)?;
                         }
-                        InlineAsmOperand::Const { value } => {
+                        InlineAsmOperand::Const { value, .. } => {
+                            // FIXME consider span?
                             write!(fmt, "const {:?}", value)?;
                         }
                         InlineAsmOperand::SymFn { value } => {

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -527,8 +527,8 @@ impl<'tcx> TerminatorKind<'tcx> {
                         InlineAsmOperand::InOut { reg, late, in_value, out_place: None } => {
                             write!(fmt, "in{}out({}) {:?} => _", print_late(late), reg, in_value)?;
                         }
-                        InlineAsmOperand::Const { value, .. } => {
-                            // FIXME consider span?
+                        InlineAsmOperand::Const { span, value } => {
+                            write!(fmt, "span {:?}", span)?;
                             write!(fmt, "const {:?}", value)?;
                         }
                         InlineAsmOperand::SymFn { value } => {

--- a/compiler/rustc_middle/src/mir/type_foldable.rs
+++ b/compiler/rustc_middle/src/mir/type_foldable.rs
@@ -336,7 +336,6 @@ impl<'tcx, R: Idx, C: Idx> TypeFoldable<'tcx> for BitMatrix<R, C> {
 impl<'tcx> TypeFoldable<'tcx> for Constant<'tcx> {
     fn super_fold_with<F: TypeFolder<'tcx>>(self, folder: &mut F) -> Self {
         Constant {
-            span: self.span,
             user_ty: self.user_ty.fold_with(folder),
             literal: self.literal.fold_with(folder),
         }

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/explain_borrow.rs
@@ -565,7 +565,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     {
                         // Just point to the function, to reduce the chance of overlapping spans.
                         let function_span = match func {
-                            Operand::Constant(c) => c.span,
+                            Operand::Constant(box (span, _)) => *span,
                             Operand::Copy(place) | Operand::Move(place) => {
                                 if let Some(l) = place.as_local() {
                                     let local_decl = &self.body.local_decls[l];

--- a/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/diagnostics/mod.rs
@@ -81,7 +81,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let terminator = self.body[location.block].terminator();
         debug!("add_moved_or_invoked_closure_note: terminator={:?}", terminator);
         if let TerminatorKind::Call {
-            func: Operand::Constant(box Constant { literal, .. }),
+            func: Operand::Constant(box (_, Constant { literal, .. })),
             args,
             ..
         } = &terminator.kind

--- a/compiler/rustc_mir/src/borrow_check/invalidation.rs
+++ b/compiler/rustc_mir/src/borrow_check/invalidation.rs
@@ -218,7 +218,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
                                 self.mutate_place(location, out_place, Shallow(None), JustWrite);
                             }
                         }
-                        InlineAsmOperand::Const { value: _ }
+                        InlineAsmOperand::Const { span: _, value: _ }
                         | InlineAsmOperand::SymFn { value: _ }
                         | InlineAsmOperand::SymStatic { def_id: _ } => {}
                     }

--- a/compiler/rustc_mir/src/borrow_check/mod.rs
+++ b/compiler/rustc_mir/src/borrow_check/mod.rs
@@ -756,7 +756,7 @@ impl<'cx, 'tcx> dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtxt<'cx, 'tc
                                 );
                             }
                         }
-                        InlineAsmOperand::Const { value: _ }
+                        InlineAsmOperand::Const { span: _, value: _ }
                         | InlineAsmOperand::SymFn { value: _ }
                         | InlineAsmOperand::SymStatic { def_id: _ } => {}
                     }

--- a/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
+++ b/compiler/rustc_mir/src/dataflow/move_paths/builder.rs
@@ -441,7 +441,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                                 self.gather_init(out_place.as_ref(), InitKind::Deep);
                             }
                         }
-                        InlineAsmOperand::Const { value: _ }
+                        InlineAsmOperand::Const { span: _, value: _ }
                         | InlineAsmOperand::SymFn { value: _ }
                         | InlineAsmOperand::SymStatic { def_id: _ } => {}
                     }

--- a/compiler/rustc_mir/src/interpret/eval_context.rs
+++ b/compiler/rustc_mir/src/interpret/eval_context.rs
@@ -683,14 +683,13 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         self.stack_mut().push(frame);
 
         // Make sure all the constants required by this frame evaluate successfully (post-monomorphization check).
-        for const_ in &body.required_consts {
-            let span = const_.span;
+        for (span, const_) in &body.required_consts {
             let const_ =
                 self.subst_from_current_frame_and_normalize_erasing_regions(const_.literal);
             self.mir_const_to_op(&const_, None).map_err(|err| {
                 // If there was an error, set the span of the current frame to this constant.
                 // Avoiding doing this when evaluation succeeds.
-                self.frame_mut().loc = Err(span);
+                self.frame_mut().loc = Err(*span);
                 err
             })?;
         }

--- a/compiler/rustc_mir/src/interpret/operand.rs
+++ b/compiler/rustc_mir/src/interpret/operand.rs
@@ -517,7 +517,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // FIXME: do some more logic on `move` to invalidate the old location
             Copy(place) | Move(place) => self.eval_place_to_op(place, layout)?,
 
-            Constant(ref constant) => {
+            Constant(box (_, ref constant)) => {
                 let val =
                     self.subst_from_current_frame_and_normalize_erasing_regions(constant.literal);
                 // This can still fail:

--- a/compiler/rustc_mir/src/shim.rs
+++ b/compiler/rustc_mir/src/shim.rs
@@ -418,11 +418,10 @@ impl CloneShimBuilder<'tcx> {
 
         // `func == Clone::clone(&ty) -> ty`
         let func_ty = tcx.mk_fn_def(self.def_id, substs);
-        let func = Operand::Constant(box Constant {
-            span: self.span,
+        let func = Operand::Constant(box (self.span, Constant {
             user_ty: None,
             literal: ty::Const::zero_sized(tcx, func_ty).into(),
-        });
+        }));
 
         let ref_loc = self.make_place(
             Mutability::Not,
@@ -474,12 +473,11 @@ impl CloneShimBuilder<'tcx> {
         );
     }
 
-    fn make_usize(&self, value: u64) -> Box<Constant<'tcx>> {
-        box Constant {
-            span: self.span,
+    fn make_usize(&self, value: u64) -> Box<(Span, Constant<'tcx>)> {
+        box (self.span, Constant {
             user_ty: None,
             literal: ty::Const::from_usize(self.tcx, value).into(),
-        }
+        })
     }
 
     fn array_shim(
@@ -506,11 +504,10 @@ impl CloneShimBuilder<'tcx> {
             ))),
             self.make_statement(StatementKind::Assign(box (
                 end,
-                Rvalue::Use(Operand::Constant(box Constant {
-                    span: self.span,
+                Rvalue::Use(Operand::Constant(box (self.span, Constant {
                     user_ty: None,
                     literal: len.into(),
-                })),
+                }))),
             ))),
         ];
         self.block(inits, TerminatorKind::Goto { target: BasicBlock::new(1) }, false);
@@ -765,11 +762,10 @@ fn build_call_shim<'tcx>(
         CallKind::Direct(def_id) => {
             let ty = tcx.type_of(def_id);
             (
-                Operand::Constant(box Constant {
-                    span,
+                Operand::Constant(box (span, Constant {
                     user_ty: None,
                     literal: ty::Const::zero_sized(tcx, ty).into(),
-                }),
+                })),
                 rcvr.into_iter().collect::<Vec<_>>(),
             )
         }

--- a/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/qualifs.rs
@@ -237,7 +237,7 @@ where
     Q: Qualif,
     F: FnMut(Local) -> bool,
 {
-    let constant = match operand {
+    let box (span, constant) = match operand {
         Operand::Copy(place) | Operand::Move(place) => {
             return in_place::<Q, _>(cx, in_local, place.as_ref());
         }
@@ -252,9 +252,9 @@ where
             // Don't peek inside trait associated constants.
             if cx.tcx.trait_of_item(def.did).is_none() {
                 let qualifs = if let Some((did, param_did)) = def.as_const_arg() {
-                    cx.tcx.at(constant.span).mir_const_qualif_const_arg((did, param_did))
+                    cx.tcx.at(*span).mir_const_qualif_const_arg((did, param_did))
                 } else {
-                    cx.tcx.at(constant.span).mir_const_qualif(def.did)
+                    cx.tcx.at(*span).mir_const_qualif(def.did)
                 };
 
                 if !Q::in_qualifs(&qualifs) {

--- a/compiler/rustc_mir/src/transform/check_consts/validation.rs
+++ b/compiler/rustc_mir/src/transform/check_consts/validation.rs
@@ -709,7 +709,7 @@ impl Visitor<'tcx> for Validator<'mir, 'tcx> {
 
     fn visit_operand(&mut self, op: &Operand<'tcx>, location: Location) {
         self.super_operand(op, location);
-        if let Operand::Constant(c) = op {
+        if let Operand::Constant(box (_, c)) = op {
             if let Some(def_id) = c.check_static_ptr(self.tcx) {
                 self.check_static(def_id, self.span);
             }

--- a/compiler/rustc_mir/src/transform/const_debuginfo.rs
+++ b/compiler/rustc_mir/src/transform/const_debuginfo.rs
@@ -76,7 +76,7 @@ fn find_optimization_oportunities<'tcx>(body: &Body<'tcx>) -> Vec<(Local, Consta
                 continue;
             }
 
-            if let StatementKind::Assign(box (p, Rvalue::Use(Operand::Constant(box c)))) =
+            if let StatementKind::Assign(box (p, Rvalue::Use(Operand::Constant(box (_, c))))) =
                 &bb.statements[location.statement_index].kind
             {
                 if let Some(local) = p.as_local() {

--- a/compiler/rustc_mir/src/transform/const_goto.rs
+++ b/compiler/rustc_mir/src/transform/const_goto.rs
@@ -60,7 +60,7 @@ impl<'a, 'tcx> Visitor<'tcx> for ConstGotoOptimizationFinder<'a, 'tcx> {
             // We only apply this optimization if the last statement is a const assignment
             let last_statement = self.body.basic_blocks()[location.block].statements.last()?;
 
-            if let (place, Rvalue::Use(Operand::Constant(_const))) =
+            if let (place, Rvalue::Use(Operand::Constant(box (_, _const)))) =
                 last_statement.kind.as_assign()?
             {
                 // We found a constant being assigned to `place`.

--- a/compiler/rustc_mir/src/transform/coverage/spans.rs
+++ b/compiler/rustc_mir/src/transform/coverage/spans.rs
@@ -865,9 +865,9 @@ pub(super) fn filtered_terminator_span(
         // Call `func` operand can have a more specific span when part of a chain of calls
         | TerminatorKind::Call { ref func, .. } => {
             let mut span = terminator.source_info.span;
-            if let mir::Operand::Constant(box constant) = func {
-                if constant.span.lo() > span.lo() {
-                    span = span.with_lo(constant.span.lo());
+            if let mir::Operand::Constant(box (c_span, _)) = func {
+                if c_span.lo() > span.lo() {
+                    span = span.with_lo(c_span.lo());
                 }
             }
             Some(function_source_span(span, body_span))

--- a/compiler/rustc_mir/src/transform/deduplicate_blocks.rs
+++ b/compiler/rustc_mir/src/transform/deduplicate_blocks.rs
@@ -150,7 +150,7 @@ fn rvalue_hash<H: Hasher>(hasher: &mut H, rvalue: &Rvalue<'tcx>) {
 
 fn operand_hash<H: Hasher>(hasher: &mut H, operand: &Operand<'tcx>) {
     match operand {
-        Operand::Constant(box Constant { user_ty: _, literal, span: _ }) => literal.hash(hasher),
+        Operand::Constant(box (_, Constant { user_ty: _, literal })) => literal.hash(hasher),
         x => x.hash(hasher),
     };
 }
@@ -179,8 +179,8 @@ fn rvalue_eq(lhs: &Rvalue<'tcx>, rhs: &Rvalue<'tcx>) -> bool {
 fn operand_eq(lhs: &Operand<'tcx>, rhs: &Operand<'tcx>) -> bool {
     let res = match (lhs, rhs) {
         (
-            Operand::Constant(box Constant { user_ty: _, literal, span: _ }),
-            Operand::Constant(box Constant { user_ty: _, literal: literal2, span: _ }),
+            Operand::Constant(box (_, Constant { user_ty: _, literal })),
+            Operand::Constant(box (_, Constant { user_ty: _, literal: literal2 })),
         ) => literal == literal2,
         (x, y) => x == y,
     };

--- a/compiler/rustc_mir/src/transform/dest_prop.rs
+++ b/compiler/rustc_mir/src/transform/dest_prop.rs
@@ -714,7 +714,7 @@ impl Conflicts<'a> {
                                         }
                                     }
                                     InlineAsmOperand::Out { reg: _, late: _, place: None }
-                                    | InlineAsmOperand::Const { value: _ }
+                                    | InlineAsmOperand::Const { span: _, value: _ }
                                     | InlineAsmOperand::SymFn { value: _ }
                                     | InlineAsmOperand::SymStatic { def_id: _ } => {}
                                 }
@@ -728,7 +728,7 @@ impl Conflicts<'a> {
                         }
                         | InlineAsmOperand::In { reg: _, value: _ }
                         | InlineAsmOperand::Out { reg: _, late: _, place: None }
-                        | InlineAsmOperand::Const { value: _ }
+                        | InlineAsmOperand::Const { span: _, value: _ }
                         | InlineAsmOperand::SymFn { value: _ }
                         | InlineAsmOperand::SymStatic { def_id: _ } => {}
                     }

--- a/compiler/rustc_mir/src/transform/elaborate_drops.rs
+++ b/compiler/rustc_mir/src/transform/elaborate_drops.rs
@@ -468,11 +468,10 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
     }
 
     fn constant_bool(&self, span: Span, val: bool) -> Rvalue<'tcx> {
-        Rvalue::Use(Operand::Constant(Box::new(Constant {
-            span,
+        Rvalue::Use(Operand::Constant(Box::new((span, Constant {
             user_ty: None,
             literal: ty::Const::from_bool(self.tcx, val).into(),
-        })))
+        }))))
     }
 
     fn set_drop_flag(&mut self, loc: Location, path: MovePathIndex, val: DropFlagState) {

--- a/compiler/rustc_mir/src/transform/function_item_references.rs
+++ b/compiler/rustc_mir/src/transform/function_item_references.rs
@@ -167,7 +167,7 @@ impl<'a, 'tcx> FunctionItemRefChecker<'a, 'tcx> {
             Operand::Copy(place) | Operand::Move(place) => {
                 self.body.local_decls[place.local].source_info.span
             }
-            Operand::Constant(constant) => constant.span,
+            Operand::Constant(box (span, _)) => *span,
         }
     }
 

--- a/compiler/rustc_mir/src/transform/generator.rs
+++ b/compiler/rustc_mir/src/transform/generator.rs
@@ -987,11 +987,10 @@ fn insert_panic_block<'tcx>(
 ) -> BasicBlock {
     let assert_block = BasicBlock::new(body.basic_blocks().len());
     let term = TerminatorKind::Assert {
-        cond: Operand::Constant(box Constant {
-            span: body.span,
+        cond: Operand::Constant(box (body.span, Constant {
             user_ty: None,
             literal: ty::Const::from_bool(tcx, false).into(),
-        }),
+        })),
         expected: true,
         msg: message,
         target: assert_block,

--- a/compiler/rustc_mir/src/transform/inline.rs
+++ b/compiler/rustc_mir/src/transform/inline.rs
@@ -405,7 +405,7 @@ impl Inliner<'tcx> {
                     threshold = 0;
                 }
 
-                TerminatorKind::Call { func: Operand::Constant(ref f), cleanup, .. } => {
+                TerminatorKind::Call { func: Operand::Constant(box (_, ref f)), cleanup, .. } => {
                     if let ty::FnDef(def_id, substs) =
                         *callsite.callee.subst_mir(self.tcx, &f.literal.ty()).kind()
                     {
@@ -628,7 +628,7 @@ impl Inliner<'tcx> {
                 // `required_consts`, here we may not only have `ConstKind::Unevaluated`
                 // because we are calling `subst_and_normalize_erasing_regions`.
                 caller_body.required_consts.extend(
-                    callee_body.required_consts.iter().copied().filter(|&ct| {
+                    callee_body.required_consts.iter().copied().filter(|(_, ct)| {
                         match ct.literal.const_for_ty() {
                             Some(ct) => matches!(ct.val, ConstKind::Unevaluated(_)),
                             None => true,

--- a/compiler/rustc_mir/src/transform/instcombine.rs
+++ b/compiler/rustc_mir/src/transform/instcombine.rs
@@ -78,7 +78,7 @@ impl<'tcx, 'a> InstCombineContext<'tcx, 'a> {
     }
 
     fn try_eval_bool(&self, a: &Operand<'_>) -> Option<bool> {
-        let a = a.constant()?;
+        let (_, a) = a.constant()?;
         if a.literal.ty().is_bool() { a.literal.try_to_bool() } else { None }
     }
 
@@ -116,8 +116,8 @@ impl<'tcx, 'a> InstCombineContext<'tcx, 'a> {
                 }
 
                 let constant =
-                    Constant { span: source_info.span, literal: len.into(), user_ty: None };
-                *rvalue = Rvalue::Use(Operand::Constant(box constant));
+                    Constant { literal: len.into(), user_ty: None };
+                *rvalue = Rvalue::Use(Operand::Constant(box (source_info.span, constant)));
             }
         }
     }

--- a/compiler/rustc_mir/src/transform/lower_intrinsics.rs
+++ b/compiler/rustc_mir/src/transform/lower_intrinsics.rs
@@ -30,11 +30,10 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                                 source_info: terminator.source_info,
                                 kind: StatementKind::Assign(box (
                                     destination,
-                                    Rvalue::Use(Operand::Constant(box Constant {
-                                        span: terminator.source_info.span,
+                                    Rvalue::Use(Operand::Constant(box (terminator.source_info.span, Constant {
                                         user_ty: None,
                                         literal: ty::Const::zero_sized(tcx, tcx.types.unit).into(),
-                                    })),
+                                    }))),
                                 )),
                             });
                             terminator.kind = TerminatorKind::Goto { target };

--- a/compiler/rustc_mir/src/transform/match_branches.rs
+++ b/compiler/rustc_mir/src/transform/match_branches.rs
@@ -91,8 +91,8 @@ impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
 
                     // If two statements are const bool assignments to the same place, we can optimize.
                     (
-                        StatementKind::Assign(box (lhs_f, Rvalue::Use(Operand::Constant(f_c)))),
-                        StatementKind::Assign(box (lhs_s, Rvalue::Use(Operand::Constant(s_c)))),
+                        StatementKind::Assign(box (lhs_f, Rvalue::Use(Operand::Constant(box (_, f_c))))),
+                        StatementKind::Assign(box (lhs_s, Rvalue::Use(Operand::Constant(box (_, s_c))))),
                     ) if lhs_f == lhs_s
                         && f_c.literal.ty().is_bool()
                         && s_c.literal.ty().is_bool()
@@ -119,8 +119,8 @@ impl<'tcx> MirPass<'tcx> for MatchBranchSimplification {
                     (f_s, s_s) if f_s == s_s => (*f).clone(),
 
                     (
-                        StatementKind::Assign(box (lhs, Rvalue::Use(Operand::Constant(f_c)))),
-                        StatementKind::Assign(box (_, Rvalue::Use(Operand::Constant(s_c)))),
+                        StatementKind::Assign(box (lhs, Rvalue::Use(Operand::Constant(box (_, f_c))))),
+                        StatementKind::Assign(box (_, Rvalue::Use(Operand::Constant(box (_, s_c))))),
                     ) => {
                         // From earlier loop we know that we are dealing with bool constants only:
                         let f_b = f_c.literal.try_eval_bool(tcx, param_env).unwrap();

--- a/compiler/rustc_mir/src/transform/required_consts.rs
+++ b/compiler/rustc_mir/src/transform/required_consts.rs
@@ -1,22 +1,27 @@
 use rustc_middle::mir::visit::Visitor;
-use rustc_middle::mir::{Constant, Location};
+use rustc_middle::mir::{Constant, Location, Operand};
 use rustc_middle::ty::ConstKind;
+use rustc_span::Span;
 
 pub struct RequiredConstsVisitor<'a, 'tcx> {
-    required_consts: &'a mut Vec<Constant<'tcx>>,
+    required_consts: &'a mut Vec<(Span, Constant<'tcx>)>,
 }
 
 impl<'a, 'tcx> RequiredConstsVisitor<'a, 'tcx> {
-    pub fn new(required_consts: &'a mut Vec<Constant<'tcx>>) -> Self {
+    pub fn new(required_consts: &'a mut Vec<(Span, Constant<'tcx>)>) -> Self {
         RequiredConstsVisitor { required_consts }
     }
 }
 
 impl<'a, 'tcx> Visitor<'tcx> for RequiredConstsVisitor<'a, 'tcx> {
-    fn visit_constant(&mut self, constant: &Constant<'tcx>, _: Location) {
-        if let Some(ct) = constant.literal.const_for_ty() {
-            if let ConstKind::Unevaluated(_) = ct.val {
-                self.required_consts.push(*constant);
+    fn visit_operand(&mut self,
+        operand: &Operand<'tcx>,
+        _: Location) {
+        if let Operand::Constant(box(span, constant)) = operand {
+            if let Some(ct) = constant.literal.const_for_ty() {
+                if let ConstKind::Unevaluated(_) = ct.val {
+                    self.required_consts.push((*span, *constant));
+                }
             }
         }
     }

--- a/compiler/rustc_mir/src/transform/rustc_peek.rs
+++ b/compiler/rustc_mir/src/transform/rustc_peek.rs
@@ -202,7 +202,7 @@ impl PeekCall {
         use mir::Operand;
 
         let span = terminator.source_info.span;
-        if let mir::TerminatorKind::Call { func: Operand::Constant(func), args, .. } =
+        if let mir::TerminatorKind::Call { func: Operand::Constant(box (_, func)), args, .. } =
             &terminator.kind
         {
             if let ty::FnDef(def_id, substs) = *func.literal.ty().kind() {

--- a/compiler/rustc_mir/src/transform/simplify_branches.rs
+++ b/compiler/rustc_mir/src/transform/simplify_branches.rs
@@ -27,7 +27,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyBranches {
             let terminator = block.terminator_mut();
             terminator.kind = match terminator.kind {
                 TerminatorKind::SwitchInt {
-                    discr: Operand::Constant(ref c),
+                    discr: Operand::Constant(box (_, ref c)),
                     switch_ty,
                     ref targets,
                     ..
@@ -48,7 +48,7 @@ impl<'tcx> MirPass<'tcx> for SimplifyBranches {
                     }
                 }
                 TerminatorKind::Assert {
-                    target, cond: Operand::Constant(ref c), expected, ..
+                    target, cond: Operand::Constant(box (_, ref c)), expected, ..
                 } => match c.literal.try_eval_bool(tcx, param_env) {
                     Some(v) if v == expected => TerminatorKind::Goto { target },
                     _ => continue,

--- a/compiler/rustc_mir/src/transform/simplify_comparison_integral.rs
+++ b/compiler/rustc_mir/src/transform/simplify_comparison_integral.rs
@@ -203,8 +203,8 @@ fn find_branch_value_info<'tcx>(
     // if any are, we can use the other to switch on, and the constant as a value in a switch
     use Operand::*;
     match (left, right) {
-        (Constant(branch_value), Copy(to_switch_on) | Move(to_switch_on))
-        | (Copy(to_switch_on) | Move(to_switch_on), Constant(branch_value)) => {
+        (Constant(box (_, branch_value)), Copy(to_switch_on) | Move(to_switch_on))
+        | (Copy(to_switch_on) | Move(to_switch_on), Constant(box (_, branch_value))) => {
             let branch_value_ty = branch_value.literal.ty();
             // we only want to apply this optimization if we are matching on integrals (and chars), as it is not possible to switch on floats
             if !branch_value_ty.is_integral() && !branch_value_ty.is_char() {

--- a/compiler/rustc_mir/src/util/elaborate_drops.rs
+++ b/compiler/rustc_mir/src/util/elaborate_drops.rs
@@ -1032,11 +1032,10 @@ where
     }
 
     fn constant_usize(&self, val: u16) -> Operand<'tcx> {
-        Operand::Constant(box Constant {
-            span: self.source_info.span,
+        Operand::Constant(box (self.source_info.span, Constant {
             user_ty: None,
             literal: ty::Const::from_usize(self.tcx(), val.into()).into(),
-        })
+        }))
     }
 
     fn assign(&self, lhs: Place<'tcx>, rhs: Rvalue<'tcx>) -> Statement<'tcx> {

--- a/compiler/rustc_mir/src/util/find_self_call.rs
+++ b/compiler/rustc_mir/src/util/find_self_call.rs
@@ -17,7 +17,7 @@ pub fn find_self_call<'tcx>(
         &body[block].terminator
     {
         debug!("find_self_call: func={:?}", func);
-        if let Operand::Constant(box Constant { literal, .. }) = func {
+        if let Operand::Constant(box (_, Constant { literal, .. })) = func {
             if let ty::FnDef(def_id, substs) = *literal.ty().kind() {
                 if let Some(ty::AssocItem { fn_has_self_parameter: true, .. }) =
                     tcx.opt_associated_item(def_id)

--- a/compiler/rustc_mir/src/util/pretty.rs
+++ b/compiler/rustc_mir/src/util/pretty.rs
@@ -438,14 +438,16 @@ fn use_verbose(ty: &&TyS<'tcx>) -> bool {
 impl Visitor<'tcx> for ExtraComments<'tcx> {
     fn visit_constant(&mut self, constant: &Constant<'tcx>, location: Location) {
         self.super_constant(constant, location);
-        let Constant { span, user_ty, literal } = constant;
+        let Constant { user_ty, literal } = constant;
         match literal.ty().kind() {
             ty::Int(_) | ty::Uint(_) | ty::Bool | ty::Char => {}
             // Unit type
             ty::Tuple(tys) if tys.is_empty() => {}
             _ => {
                 self.push("mir::Constant");
-                self.push(&format!("+ span: {}", self.tcx.sess.source_map().span_to_string(*span)));
+                // FIXME implement visit_operand to take care of visit_span and visit_constant
+                // altogether
+                //self.push(&format!("+ span: {}", self.tcx.sess.source_map().span_to_string(*span)));
                 if let Some(user_ty) = user_ty {
                     self.push(&format!("+ user_ty: {:?}", user_ty));
                 }

--- a/compiler/rustc_mir_build/src/build/cfg.rs
+++ b/compiler/rustc_mir_build/src/build/cfg.rs
@@ -3,6 +3,7 @@
 use crate::build::CFG;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::Span;
 
 impl<'tcx> CFG<'tcx> {
     crate fn block_data(&self, blk: BasicBlock) -> &BasicBlockData<'tcx> {
@@ -49,9 +50,10 @@ impl<'tcx> CFG<'tcx> {
         block: BasicBlock,
         source_info: SourceInfo,
         temp: Place<'tcx>,
+        span: Span,
         constant: Constant<'tcx>,
     ) {
-        self.push_assign(block, source_info, temp, Rvalue::Use(Operand::Constant(box constant)));
+        self.push_assign(block, source_info, temp, Rvalue::Use(Operand::Constant(box (span, constant))));
     }
 
     crate fn push_assign_unit(
@@ -65,11 +67,10 @@ impl<'tcx> CFG<'tcx> {
             block,
             source_info,
             place,
-            Rvalue::Use(Operand::Constant(box Constant {
-                span: source_info.span,
+            Rvalue::Use(Operand::Constant(box(source_info.span, Constant {
                 user_ty: None,
                 literal: ty::Const::zero_sized(tcx, tcx.types.unit).into(),
-            })),
+            }))),
         );
     }
 

--- a/compiler/rustc_mir_build/src/build/expr/as_operand.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_operand.rs
@@ -109,8 +109,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         debug!("as_operand: category={:?} for={:?}", category, expr.kind);
         match category {
             Category::Constant => {
-                let constant = this.as_constant(expr);
-                block.and(Operand::Constant(box constant))
+                let span_and_constant = this.as_constant(expr);
+                block.and(Operand::Constant(box span_and_constant))
             }
             Category::Place | Category::Rvalue(..) => {
                 let operand = unpack!(block = this.as_temp(block, scope, expr, Mutability::Mut));

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -248,11 +248,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
             ExprKind::Assign { .. } | ExprKind::AssignOp { .. } => {
                 block = unpack!(this.stmt_expr(block, expr, None));
-                block.and(Rvalue::Use(Operand::Constant(box Constant {
-                    span: expr_span,
+                block.and(Rvalue::Use(Operand::Constant(box(expr_span, Constant {
                     user_ty: None,
                     literal: ty::Const::zero_sized(this.tcx, this.tcx.types.unit).into(),
-                })))
+                }))))
             }
             ExprKind::Yield { .. }
             | ExprKind::Literal { .. }

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -139,8 +139,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     shortcircuit_block,
                     source_info,
                     destination,
+                    expr_span,
                     Constant {
-                        span: expr_span,
                         user_ty: None,
                         literal: match op {
                             LogicalOp::And => ty::Const::from_bool(this.tcx, false).into(),
@@ -357,11 +357,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         }
                         thir::InlineAsmOperand::Const { value, span } => {
                             mir::InlineAsmOperand::Const {
-                                value: box Constant { span, user_ty: None, literal: value.into() },
+                                span,
+                                value: box Constant { user_ty: None, literal: value.into() },
                             }
                         }
                         thir::InlineAsmOperand::SymFn { expr } => {
-                            mir::InlineAsmOperand::SymFn { value: box this.as_constant(expr) }
+                            let (_, constant) = this.as_constant(expr);
+                            mir::InlineAsmOperand::SymFn { value: box constant }
                         }
                         thir::InlineAsmOperand::SymStatic { def_id } => {
                             mir::InlineAsmOperand::SymStatic { def_id }

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -429,9 +429,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             block,
             source_info,
             TerminatorKind::Call {
-                func: Operand::Constant(box Constant {
-                    span: source_info.span,
-
+                func: Operand::Constant(box (source_info.span, Constant {
                     // FIXME(#54571): This constant comes from user input (a
                     // constant in a pattern).  Are there forms where users can add
                     // type annotations here?  For example, an associated constant?
@@ -439,7 +437,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     user_ty: None,
 
                     literal: method.into(),
-                }),
+                })),
                 args: vec![val, expect],
                 destination: Some((eq_result, eq_block)),
                 cleanup: None,

--- a/compiler/rustc_mir_build/src/build/misc.rs
+++ b/compiler/rustc_mir_build/src/build/misc.rs
@@ -31,7 +31,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         literal: &'tcx ty::Const<'tcx>,
     ) -> Operand<'tcx> {
         let literal = literal.into();
-        let constant = box Constant { span, user_ty: None, literal };
+        let constant = box (span, Constant { user_ty: None, literal });
         Operand::Constant(constant)
     }
 
@@ -55,8 +55,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             block,
             source_info,
             temp,
+            source_info.span,
             Constant {
-                span: source_info.span,
                 user_ty: None,
                 literal: ty::Const::from_usize(self.tcx, value).into(),
             },

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -347,9 +347,9 @@ impl<'a, 'tcx> AbstractConstBuilder<'a, 'tcx> {
                 let local = self.place_to_local(span, p)?;
                 Ok(self.locals[local])
             }
-            mir::Operand::Constant(ct) => match ct.literal {
-                mir::ConstantKind::Ty(ct) => Ok(self.add_node(Node::Leaf(ct), span)),
-                mir::ConstantKind::Val(..) => self.error(Some(span), "unsupported constant")?,
+            mir::Operand::Constant(box(span, ct)) => match ct.literal {
+                mir::ConstantKind::Ty(ct) => Ok(self.add_node(Node::Leaf(ct), *span)),
+                mir::ConstantKind::Val(..) => self.error(Some(*span), "unsupported constant")?,
             },
         }
     }

--- a/src/test/ui/consts/const-err.stderr
+++ b/src/test/ui/consts/const-err.stderr
@@ -15,16 +15,16 @@ LL | #![warn(const_err)]
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error[E0080]: erroneous constant used
-  --> $DIR/const-err.rs:16:16
+  --> $DIR/const-err.rs:16:15
    |
 LL |     black_box((FOO, FOO));
-   |                ^^^ referenced constant has errors
+   |               ^^^^^^^^^^ referenced constant has errors
 
 error[E0080]: erroneous constant used
-  --> $DIR/const-err.rs:16:21
+  --> $DIR/const-err.rs:16:15
    |
 LL |     black_box((FOO, FOO));
-   |                     ^^^ referenced constant has errors
+   |               ^^^^^^^^^^ referenced constant has errors
 
 error: aborting due to 2 previous errors; 1 warning emitted
 


### PR DESCRIPTION
Opening this to start discussion and see what CI says about different approaches we can try for #77608.
For now I've just skipped span on `eq` implementation.

r? @oli-obk 

From what I've seen locally it passes all tests, which surprises me given the comments made on #77608. Although I'm not really sure how well this plays with incremental compilation, but my guess is that it doesn't play well.

Closes #77608