### PR TITLE
[WIP] Optimize Token Cursor

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -292,7 +292,11 @@ fn parse_args<'a>(
 ///
 /// This function must be called immediately after the option token is parsed.
 /// Otherwise, the suggestion will be incorrect.
-fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
+fn err_duplicate_option<'a, const DSDC: bool>(
+    p: &mut Parser<'a, DSDC>,
+    symbol: Symbol,
+    span: Span,
+) {
     let mut err = p
         .sess
         .span_diagnostic
@@ -319,8 +323,8 @@ fn err_duplicate_option<'a>(p: &mut Parser<'a>, symbol: Symbol, span: Span) {
 ///
 /// This function must be called immediately after the option token is parsed.
 /// Otherwise, the error will not point to the correct spot.
-fn try_set_option<'a>(
-    p: &mut Parser<'a>,
+fn try_set_option<'a, const DSDC: bool>(
+    p: &mut Parser<'a, DSDC>,
     args: &mut AsmArgs,
     symbol: Symbol,
     option: ast::InlineAsmOptions,
@@ -332,8 +336,8 @@ fn try_set_option<'a>(
     }
 }
 
-fn parse_options<'a>(
-    p: &mut Parser<'a>,
+fn parse_options<'a, const DSDC: bool>(
+    p: &mut Parser<'a, DSDC>,
     args: &mut AsmArgs,
     is_global_asm: bool,
 ) -> Result<(), DiagnosticBuilder<'a>> {
@@ -373,8 +377,8 @@ fn parse_options<'a>(
     Ok(())
 }
 
-fn parse_reg<'a>(
-    p: &mut Parser<'a>,
+fn parse_reg<'a, const DSDC: bool>(
+    p: &mut Parser<'a, DSDC>,
     explicit_reg: &mut bool,
 ) -> Result<ast::InlineAsmRegOrRegClass, DiagnosticBuilder<'a>> {
     p.expect(&token::OpenDelim(token::DelimToken::Paren))?;

--- a/compiler/rustc_builtin_macros/src/assert.rs
+++ b/compiler/rustc_builtin_macros/src/assert.rs
@@ -150,7 +150,7 @@ fn parse_assert<'a>(
     Ok(Assert { cond_expr, custom_message })
 }
 
-fn parse_custom_message(parser: &mut Parser<'_>) -> Option<TokenStream> {
+fn parse_custom_message<const DSDC: bool>(parser: &mut Parser<'_, DSDC>) -> Option<TokenStream> {
     let ts = parser.parse_tokens();
     if !ts.is_empty() { Some(ts) } else { None }
 }

--- a/compiler/rustc_builtin_macros/src/llvm_asm.rs
+++ b/compiler/rustc_builtin_macros/src/llvm_asm.rs
@@ -66,7 +66,7 @@ pub fn expand_llvm_asm<'cx>(
     }))
 }
 
-fn parse_asm_str<'a>(p: &mut Parser<'a>) -> PResult<'a, Symbol> {
+fn parse_asm_str<'a, const DSDC: bool>(p: &mut Parser<'a, DSDC>) -> PResult<'a, Symbol> {
     match p.parse_str_lit() {
         Ok(str_lit) => Ok(str_lit.symbol_unescaped),
         Err(opt_lit) => {

--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -120,12 +120,12 @@ pub fn expand_include<'cx>(
     cx.current_expansion.module = Rc::new(cx.current_expansion.module.with_dir_path(dir_path));
     cx.current_expansion.dir_ownership = DirOwnership::Owned { relative: None };
 
-    struct ExpandResult<'a> {
-        p: Parser<'a>,
+    struct ExpandResult<'a, const DSDC: bool> {
+        p: Parser<'a, DSDC>,
         node_id: ast::NodeId,
     }
-    impl<'a> base::MacResult for ExpandResult<'a> {
-        fn make_expr(mut self: Box<ExpandResult<'a>>) -> Option<P<ast::Expr>> {
+    impl<'a, const DSDC: bool> base::MacResult for ExpandResult<'a, DSDC> {
+        fn make_expr(mut self: Box<Self>) -> Option<P<ast::Expr>> {
             let r = base::parse_expr(&mut self.p)?;
             if self.p.token != token::Eof {
                 self.p.sess.buffer_lint(
@@ -138,7 +138,7 @@ pub fn expand_include<'cx>(
             Some(r)
         }
 
-        fn make_items(mut self: Box<ExpandResult<'a>>) -> Option<SmallVec<[P<ast::Item>; 1]>> {
+        fn make_items(mut self: Box<Self>) -> Option<SmallVec<[P<ast::Item>; 1]>> {
             let mut ret = SmallVec::new();
             while self.p.token != token::Eof {
                 match self.p.parse_item(ForceCollect::No) {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -977,7 +977,7 @@ impl<'a> ExtCtxt<'a> {
     pub fn monotonic_expander<'b>(&'b mut self) -> expand::MacroExpander<'b, 'a> {
         expand::MacroExpander::new(self, true)
     }
-    pub fn new_parser_from_tts(&self, stream: TokenStream) -> parser::Parser<'a> {
+    pub fn new_parser_from_tts(&self, stream: TokenStream) -> parser::Parser<'a, false> {
         rustc_parse::stream_to_parser(&self.sess.parse_sess, stream, MACRO_ARGUMENTS)
     }
     pub fn source_map(&self) -> &'a SourceMap {
@@ -1158,7 +1158,7 @@ pub fn check_zero_tts(cx: &ExtCtxt<'_>, sp: Span, tts: TokenStream, name: &str) 
 }
 
 /// Parse an expression. On error, emit it, advancing to `Eof`, and return `None`.
-pub fn parse_expr(p: &mut parser::Parser<'_>) -> Option<P<ast::Expr>> {
+pub fn parse_expr<const DSDC: bool>(p: &mut parser::Parser<'_, DSDC>) -> Option<P<ast::Expr>> {
     match p.parse_expr() {
         Ok(e) => return Some(e),
         Err(mut err) => err.emit(),

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -137,8 +137,9 @@ macro_rules! ast_fragments {
             }
         }
 
-        impl<'a> MacResult for crate::mbe::macro_rules::ParserAnyMacro<'a> {
-            $(fn $make_ast(self: Box<crate::mbe::macro_rules::ParserAnyMacro<'a>>)
+        impl<'a, const DSDC: bool> MacResult for crate::mbe::macro_rules::ParserAnyMacro<'a,
+        DSDC > {
+            $(fn $make_ast(self: Box<crate::mbe::macro_rules::ParserAnyMacro<'a, DSDC>>)
                            -> Option<$AstTy> {
                 Some(self.make(AstFragmentKind::$Kind).$make_ast())
             })*
@@ -905,8 +906,8 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
     }
 }
 
-pub fn parse_ast_fragment<'a>(
-    this: &mut Parser<'a>,
+pub fn parse_ast_fragment<'a, const DSDC: bool>(
+    this: &mut Parser<'a, DSDC>,
     kind: AstFragmentKind,
 ) -> PResult<'a, AstFragment> {
     Ok(match kind {
@@ -970,8 +971,8 @@ pub fn parse_ast_fragment<'a>(
     })
 }
 
-pub fn ensure_complete_parse<'a>(
-    this: &mut Parser<'a>,
+pub fn ensure_complete_parse<'a, const DSDC: bool>(
+    this: &mut Parser<'a, DSDC>,
     macro_path: &Path,
     kind_name: &str,
     span: Span,

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -572,7 +572,7 @@ fn inner_parse_loop<'root, 'tt>(
                     //
                     // We use the span of the metavariable declaration to determine any
                     // edition-specific matching behavior for non-terminals.
-                    if Parser::nonterminal_may_begin_with(kind, token) {
+                    if Parser::<true>::nonterminal_may_begin_with(kind, token) {
                         bb_items.push(item);
                     }
                 }
@@ -615,7 +615,10 @@ fn inner_parse_loop<'root, 'tt>(
 
 /// Use the given sequence of token trees (`ms`) as a matcher. Match the token
 /// stream from the given `parser` against it and return the match.
-pub(super) fn parse_tt(parser: &mut Cow<'_, Parser<'_>>, ms: &[TokenTree]) -> NamedParseResult {
+pub(super) fn parse_tt(
+    parser: &mut Cow<'_, Parser<'_, true>>,
+    ms: &[TokenTree],
+) -> NamedParseResult {
     // A queue of possible matcher positions. We initialize it with the matcher position in which
     // the "dot" is before the first token of the first token tree in `ms`. `inner_parse_loop` then
     // processes all of these possible matcher positions and produces possible next positions into

--- a/compiler/rustc_expand/src/tests.rs
+++ b/compiler/rustc_expand/src/tests.rs
@@ -18,13 +18,13 @@ use std::str;
 use std::sync::{Arc, Mutex};
 
 /// Map string to parser (via tts).
-fn string_to_parser(ps: &ParseSess, source_str: String) -> Parser<'_> {
+fn string_to_parser(ps: &ParseSess, source_str: String) -> Parser<'_, false> {
     new_parser_from_source_str(ps, PathBuf::from("bogofile").into(), source_str)
 }
 
 crate fn with_error_checking_parse<'a, T, F>(s: String, ps: &'a ParseSess, f: F) -> T
 where
-    F: FnOnce(&mut Parser<'a>) -> PResult<'a, T>,
+    F: FnOnce(&mut Parser<'a, false>) -> PResult<'a, T>,
 {
     let mut p = string_to_parser(&ps, s);
     let x = f(&mut p).unwrap();

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -30,7 +30,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     pub(super) fn parse_outer_attributes(&mut self) -> PResult<'a, AttrWrapper> {
         let mut attrs: Vec<ast::Attribute> = Vec::new();
         let mut just_parsed_doc_comment = false;
-        let start_pos = self.token_cursor.nncablt.num_next_calls();
+        let start_pos = self.token_cursor.num_next_calls;
         loop {
             debug!("parse_outer_attributes: self.token={:?}", self.token);
             let attr = if self.check(&token::Pound) {
@@ -179,7 +179,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     crate fn parse_inner_attributes(&mut self) -> PResult<'a, Vec<ast::Attribute>> {
         let mut attrs: Vec<ast::Attribute> = vec![];
         loop {
-            let start_pos: u32 = self.token_cursor.nncablt.num_next_calls().try_into().unwrap();
+            let start_pos: u32 = self.token_cursor.num_next_calls.try_into().unwrap();
             // Only try to parse if it is an inner attribute (has `!`).
             let attr = if self.check(&token::Pound) && self.look_ahead(1, |t| t == &token::Not) {
                 Some(self.parse_attribute(InnerAttrPolicy::Permitted)?)
@@ -194,7 +194,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
                 None
             };
             if let Some(attr) = attr {
-                let end_pos: u32 = self.token_cursor.nncablt.num_next_calls().try_into().unwrap();
+                let end_pos: u32 = self.token_cursor.num_next_calls.try_into().unwrap();
                 // If we are currently capturing tokens, mark the location of this inner attribute.
                 // If capturing ends up creating a `LazyTokenStream`, we will include
                 // this replace range with it, removing the inner attribute from the final

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -30,7 +30,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     pub(super) fn parse_outer_attributes(&mut self) -> PResult<'a, AttrWrapper> {
         let mut attrs: Vec<ast::Attribute> = Vec::new();
         let mut just_parsed_doc_comment = false;
-        let start_pos = self.token_cursor.num_next_calls;
+        let start_pos = self.token_cursor.nncablt.num_next_calls();
         loop {
             debug!("parse_outer_attributes: self.token={:?}", self.token);
             let attr = if self.check(&token::Pound) {
@@ -179,7 +179,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     crate fn parse_inner_attributes(&mut self) -> PResult<'a, Vec<ast::Attribute>> {
         let mut attrs: Vec<ast::Attribute> = vec![];
         loop {
-            let start_pos: u32 = self.token_cursor.num_next_calls.try_into().unwrap();
+            let start_pos: u32 = self.token_cursor.nncablt.num_next_calls().try_into().unwrap();
             // Only try to parse if it is an inner attribute (has `!`).
             let attr = if self.check(&token::Pound) && self.look_ahead(1, |t| t == &token::Not) {
                 Some(self.parse_attribute(InnerAttrPolicy::Permitted)?)
@@ -194,7 +194,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
                 None
             };
             if let Some(attr) = attr {
-                let end_pos: u32 = self.token_cursor.num_next_calls.try_into().unwrap();
+                let end_pos: u32 = self.token_cursor.nncablt.num_next_calls().try_into().unwrap();
                 // If we are currently capturing tokens, mark the location of this inner attribute.
                 // If capturing ends up creating a `LazyTokenStream`, we will include
                 // this replace range with it, removing the inner attribute from the final

--- a/compiler/rustc_parse/src/parser/attr.rs
+++ b/compiler/rustc_parse/src/parser/attr.rs
@@ -25,7 +25,7 @@ pub(super) const DEFAULT_INNER_ATTR_FORBIDDEN: InnerAttrPolicy<'_> = InnerAttrPo
     prev_attr_sp: None,
 };
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses attributes that appear before an item.
     pub(super) fn parse_outer_attributes(&mut self) -> PResult<'a, AttrWrapper> {
         let mut attrs: Vec<ast::Attribute> = Vec::new();

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -95,8 +95,10 @@ struct LazyTokenStreamImpl {
     replace_ranges: Box<[ReplaceRange]>,
 }
 
+/*
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 rustc_data_structures::static_assert_size!(LazyTokenStreamImpl, 144);
+*/
 
 impl CreateTokenStream for LazyTokenStreamImpl {
     fn create_token_stream(&self) -> AttrAnnotatedTokenStream {

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -96,7 +96,7 @@ struct LazyTokenStreamImpl<const DESUGAR_DOC_COMMENTS: bool> {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(LazyTokenStreamImpl<true>, 136);
+rustc_data_structures::static_assert_size!(LazyTokenStreamImpl<true>, 144);
 
 impl<const DSDC: bool> CreateTokenStream for LazyTokenStreamImpl<DSDC> {
     fn create_token_stream(&self) -> AttrAnnotatedTokenStream {
@@ -281,8 +281,8 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
 
         let replace_ranges_end = self.capture_state.replace_ranges.len();
 
-        let cursor_snapshot_next_calls = cursor_snapshot.nncablt.num_next_calls();
-        let mut end_pos = self.token_cursor.nncablt.num_next_calls();
+        let cursor_snapshot_next_calls = cursor_snapshot.num_next_calls;
+        let mut end_pos = self.token_cursor.num_next_calls;
 
         // Capture a trailing token if requested by the callback 'f'
         match trailing {
@@ -302,7 +302,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
         // then extend the range of captured tokens to include it, since the parser
         // was not actually bumped past it. When the `LazyTokenStream` gets converted
         // into a `AttrAnnotatedTokenStream`, we will create the proper token.
-        if self.token_cursor.nncablt.break_last_token() {
+        if self.token_cursor.break_last_token {
             assert_eq!(
                 trailing,
                 TrailingToken::None,
@@ -336,7 +336,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
             start_token,
             num_calls,
             cursor_snapshot,
-            break_last_token: self.token_cursor.nncablt.break_last_token(),
+            break_last_token: self.token_cursor.break_last_token,
             replace_ranges,
         });
 
@@ -375,7 +375,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
             let new_tokens = vec![(FlatToken::AttrTarget(attr_data), Spacing::Alone)];
 
             assert!(
-                !self.token_cursor.nncablt.break_last_token(),
+                !self.token_cursor.break_last_token,
                 "Should not have unglued last token with cfg attr"
             );
             let range: Range<u32> = (start_pos.try_into().unwrap())..(end_pos.try_into().unwrap());

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -96,7 +96,7 @@ struct LazyTokenStreamImpl<const DESUGAR_DOC_COMMENTS: bool> {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(LazyTokenStreamImpl<true>, 144);
+rustc_data_structures::static_assert_size!(LazyTokenStreamImpl<true>, 136);
 
 impl<const DSDC: bool> CreateTokenStream for LazyTokenStreamImpl<DSDC> {
     fn create_token_stream(&self) -> AttrAnnotatedTokenStream {
@@ -281,8 +281,8 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
 
         let replace_ranges_end = self.capture_state.replace_ranges.len();
 
-        let cursor_snapshot_next_calls = cursor_snapshot.num_next_calls;
-        let mut end_pos = self.token_cursor.num_next_calls;
+        let cursor_snapshot_next_calls = cursor_snapshot.nncablt.num_next_calls();
+        let mut end_pos = self.token_cursor.nncablt.num_next_calls();
 
         // Capture a trailing token if requested by the callback 'f'
         match trailing {
@@ -302,7 +302,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
         // then extend the range of captured tokens to include it, since the parser
         // was not actually bumped past it. When the `LazyTokenStream` gets converted
         // into a `AttrAnnotatedTokenStream`, we will create the proper token.
-        if self.token_cursor.break_last_token {
+        if self.token_cursor.nncablt.break_last_token() {
             assert_eq!(
                 trailing,
                 TrailingToken::None,
@@ -336,7 +336,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
             start_token,
             num_calls,
             cursor_snapshot,
-            break_last_token: self.token_cursor.break_last_token,
+            break_last_token: self.token_cursor.nncablt.break_last_token(),
             replace_ranges,
         });
 
@@ -375,7 +375,7 @@ impl<'a, const DSDC: bool> Parser<'a, DSDC> {
             let new_tokens = vec![(FlatToken::AttrTarget(attr_data), Spacing::Alone)];
 
             assert!(
-                !self.token_cursor.break_last_token,
+                !self.token_cursor.nncablt.break_last_token(),
                 "Should not have unglued last token with cfg attr"
             );
             let range: Range<u32> = (start_pos.try_into().unwrap())..(end_pos.try_into().unwrap());

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -143,7 +143,7 @@ impl AttemptLocalParseRecovery {
     }
 }
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     pub(super) fn span_err<S: Into<MultiSpan>>(&self, sp: S, err: Error) -> DiagnosticBuilder<'a> {
         err.span_err(sp, self.diagnostic())
     }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -85,7 +85,7 @@ impl From<P<Expr>> for LhsExpr {
     }
 }
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses an expression.
     #[inline]
     pub fn parse_expr(&mut self) -> PResult<'a, P<Expr>> {
@@ -1998,7 +1998,7 @@ impl<'a> Parser<'a> {
         self.bump(); // `;`
         let mut stmts =
             vec![self.mk_stmt(first_expr.span, ast::StmtKind::Expr(first_expr.clone()))];
-        let err = |this: &mut Parser<'_>, stmts: Vec<ast::Stmt>| {
+        let err = |this: &mut Self, stmts: Vec<ast::Stmt>| {
             let span = stmts[0].span.to(stmts[stmts.len() - 1].span);
             let mut err = this.struct_span_err(span, "`match` arm body without braces");
             let (these, s, are) =

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -7,7 +7,7 @@ use rustc_ast::{
 use rustc_errors::PResult;
 use rustc_span::symbol::{kw, sym};
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses bounds of a lifetime parameter `BOUND + BOUND + BOUND`, possibly with trailing `+`.
     ///
     /// ```text

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -22,7 +22,7 @@ use std::convert::TryFrom;
 use std::mem;
 use tracing::debug;
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses a source module as a crate. This is the main entry point for the parser.
     pub fn parse_crate_mod(&mut self) -> PResult<'a, ast::Crate> {
         let (attrs, items, span) = self.parse_mod(&token::Eof)?;
@@ -77,7 +77,7 @@ impl<'a> Parser<'a> {
 
 pub(super) type ItemInfo = (Ident, ItemKind);
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     pub fn parse_item(&mut self, force_collect: ForceCollect) -> PResult<'a, Option<P<Item>>> {
         self.parse_item_(|_| true, force_collect).map(|i| i.map(P))
     }
@@ -580,7 +580,7 @@ impl<'a> Parser<'a> {
     fn parse_item_list<T>(
         &mut self,
         attrs: &mut Vec<Attribute>,
-        mut parse_item: impl FnMut(&mut Parser<'a>) -> PResult<'a, Option<Option<T>>>,
+        mut parse_item: impl FnMut(&mut Self) -> PResult<'a, Option<Option<T>>>,
     ) -> PResult<'a, Vec<T>> {
         let open_brace_span = self.token.span;
         self.expect(&token::OpenDelim(token::Brace))?;
@@ -1647,7 +1647,7 @@ impl<'a> Parser<'a> {
 type ReqName = fn(Edition) -> bool;
 
 /// Parsing of functions and methods.
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parse a function starting from the front matter (`const ...`) to the body `{ ... }` or `;`.
     fn parse_fn(
         &mut self,

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -185,7 +185,7 @@ impl<'a, const DSDC: bool> Drop for Parser<'a, DSDC> {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Default)]
 pub(crate) struct NumNextCallsAndBreakLastToken(usize);
 
 impl NumNextCallsAndBreakLastToken {
@@ -201,19 +201,19 @@ impl NumNextCallsAndBreakLastToken {
 
     #[inline]
     fn set_break_last_token(&mut self) {
-        self.0 = !(Self::MASK_NUM_NEXT_CALLS) | self.0;
+        self.0 |= !(Self::MASK_NUM_NEXT_CALLS);
     }
     #[inline]
     fn unset_break_last_token(&mut self) {
-        self.0 = self.0 & Self::MASK_NUM_NEXT_CALLS;
+        self.0 &= Self::MASK_NUM_NEXT_CALLS;
     }
     #[inline]
     fn num_next_calls(self) -> usize {
         self.0 & Self::MASK_NUM_NEXT_CALLS
     }
     #[inline]
-    fn set_num_next_calls(&mut self, calls: usize) {
-        self.0 = self.0 | (calls & Self::MASK_NUM_NEXT_CALLS)
+    fn inc_num_next_calls(&mut self) {
+        self.0 = self.0.checked_add(1).unwrap();
     }
 }
 
@@ -486,9 +486,7 @@ impl<'a, const DESUGAR_DOC_COMMENTS: bool> Parser<'a, DESUGAR_DOC_COMMENTS> {
             } else {
                 self.token_cursor.next()
             };
-            self.token_cursor
-                .nncablt
-                .set_num_next_calls(self.token_cursor.nncablt.num_next_calls() + 1);
+            self.token_cursor.nncablt.inc_num_next_calls();
             // We've retrieved an token from the underlying
             // cursor, so we no longer need to worry about
             // an unglued token. See `break_and_eat` for more details

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -7,7 +7,7 @@ use rustc_span::symbol::{kw, Ident};
 use crate::parser::pat::RecoverComma;
 use crate::parser::{FollowedByType, ForceCollect, Parser, PathStyle};
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Checks whether a non-terminal may begin with a particular token.
     ///
     /// Returning `false` is a *stability guarantee* that such a matcher will *never* begin with that

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -36,7 +36,7 @@ enum EatOrResult {
     None,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses a pattern.
     ///
     /// Corresponds to `pat<no_top_alt>` in RFC 2535 and does not admit or-patterns

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -37,7 +37,7 @@ pub enum PathStyle {
     Mod,
 }
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses a qualified path.
     /// Assumes that the leading `<` has been parsed already.
     ///

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -21,7 +21,7 @@ use rustc_span::symbol::{kw, sym};
 
 use std::mem;
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses a statement. This stops just before trailing semicolons on everything but items.
     /// e.g., a `StmtKind::Semi` parses to a `StmtKind::Expr`, leaving the trailing `;` unconsumed.
     // Public for rustfmt usage.

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -90,7 +90,7 @@ fn can_continue_type_after_non_fn_ident(t: &Token) -> bool {
     t == &token::ModSep || t == &token::Lt || t == &token::BinOp(token::Shl)
 }
 
-impl<'a> Parser<'a> {
+impl<'a, const DSDC: bool> Parser<'a, DSDC> {
     /// Parses a type.
     pub fn parse_ty(&mut self) -> PResult<'a, P<Ty>> {
         self.parse_ty_common(

--- a/compiler/rustc_parse/src/tests.rs
+++ b/compiler/rustc_parse/src/tests.rs
@@ -1,0 +1,41 @@
+extern crate test;
+use crate::parser::{TokenCursor, TokenCursorFrame};
+use crate::tokenstream::DelimSpan;
+use rustc_ast::token::DelimToken;
+use rustc_span::DUMMY_SP;
+use std::hint::black_box;
+use test::Bencher;
+
+fn mk_dummy_token_cursor_frame() -> TokenCursorFrame {
+    TokenCursorFrame::new(DelimSpan::from_single(DUMMY_SP), DelimToken::Paren, Default::default())
+}
+
+fn mk_token_cursor(n: usize) -> TokenCursor<true> {
+    TokenCursor {
+        frame: mk_dummy_token_cursor_frame(),
+        stack: vec![mk_dummy_token_cursor_frame(); n],
+        num_next_calls: 0,
+        break_last_token: true,
+    }
+}
+macro_rules! bench_for_n {
+    ($name: ident, $n: expr) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            let tc = black_box(mk_token_cursor($n));
+            b.iter(|| {
+                let _ = tc.clone();
+            });
+        }
+    };
+}
+
+bench_for_n!(token_cursor_clone_1, 1);
+bench_for_n!(token_cursor_clone_2, 2);
+bench_for_n!(token_cursor_clone_4, 4);
+bench_for_n!(token_cursor_clone_8, 8);
+bench_for_n!(token_cursor_clone_16, 16);
+bench_for_n!(token_cursor_clone_32, 32);
+bench_for_n!(token_cursor_clone_64, 64);
+bench_for_n!(token_cursor_clone_128, 128);
+bench_for_n!(token_cursor_clone_256, 256);

--- a/compiler/rustc_parse/src/tests.rs
+++ b/compiler/rustc_parse/src/tests.rs
@@ -14,8 +14,7 @@ fn mk_token_cursor(n: usize) -> TokenCursor<true> {
     TokenCursor {
         frame: mk_dummy_token_cursor_frame(),
         stack: vec![mk_dummy_token_cursor_frame(); n],
-        num_next_calls: 0,
-        break_last_token: true,
+        nncablt: Default::default(),
     }
 }
 macro_rules! bench_for_n {

--- a/compiler/rustc_parse/src/tests.rs
+++ b/compiler/rustc_parse/src/tests.rs
@@ -14,7 +14,8 @@ fn mk_token_cursor(n: usize) -> TokenCursor<true> {
     TokenCursor {
         frame: mk_dummy_token_cursor_frame(),
         stack: vec![mk_dummy_token_cursor_frame(); n],
-        nncablt: Default::default(),
+        num_next_calls: 0,
+        break_last_token: true,
     }
 }
 macro_rules! bench_for_n {

--- a/src/tools/clippy/clippy_lints/src/write.rs
+++ b/src/tools/clippy/clippy_lints/src/write.rs
@@ -489,7 +489,7 @@ impl Write {
     /// ```
     #[allow(clippy::too_many_lines)]
     fn check_tts<'a>(&self, cx: &EarlyContext<'a>, tts: TokenStream, is_write: bool) -> (Option<StrLit>, Option<Expr>) {
-        let mut parser = parser::Parser::new(&cx.sess.parse_sess, tts, false, None);
+        let mut parser = parser::Parser::<false>::new(&cx.sess.parse_sess, tts, None);
         let expr = if is_write {
             match parser
                 .parse_expr()

--- a/src/tools/rustfmt/src/syntux/parser.rs
+++ b/src/tools/rustfmt/src/syntux/parser.rs
@@ -26,7 +26,7 @@ pub(crate) struct Directory {
 
 /// A parser for Rust source code.
 pub(crate) struct Parser<'a> {
-    parser: RawParser<'a>,
+    parser: RawParser<'a, false>,
 }
 
 /// A builder for the `Parser`.
@@ -68,7 +68,7 @@ impl<'a> ParserBuilder<'a> {
     fn parser(
         sess: &'a rustc_session::parse::ParseSess,
         input: Input,
-    ) -> Result<rustc_parse::parser::Parser<'a>, Option<Vec<Diagnostic>>> {
+    ) -> Result<rustc_parse::parser::Parser<'a, false>, Option<Vec<Diagnostic>>> {
         match input {
             Input::File(ref file) => catch_unwind(AssertUnwindSafe(move || {
                 new_parser_from_file(sess, file, None)


### PR DESCRIPTION
Attempting to lower the [cost of cloning a token cursor](https://github.com/rust-lang/rust/issues/84143) by shrinking the vector, although it backfired since now 4 vectors need to be maintained. For now just experimenting.

r? @ghost