### PR TITLE
dbg macro: Discuss use in tests, and slightly clarify

### DIFF
--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -185,9 +185,10 @@ macro_rules! eprintln {
 /// builds or when debugging in release mode is significantly faster.
 ///
 /// Note that the macro is intended as a debugging tool and therefore you
-/// should avoid having uses of it in version control for long periods.
-/// Use cases involving debug output that should be added to version control
-/// are better served by macros such as [`debug!`] from the [`log`] crate.
+/// should avoid having uses of it in version control for long periods
+/// (other than in tests etc.)
+/// Debug output from production code is better done with other facilities
+/// such as the [`debug!`] macro from the [`log`] crate.
 ///
 /// # Stability
 ///

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -186,7 +186,7 @@ macro_rules! eprintln {
 ///
 /// Note that the macro is intended as a debugging tool and therefore you
 /// should avoid having uses of it in version control for long periods
-/// (other than in tests etc.)
+/// (other than in tests and similar).
 /// Debug output from production code is better done with other facilities
 /// such as the [`debug!`] macro from the [`log`] crate.
 ///


### PR DESCRIPTION
As discussed in a tangent in #82778.

I chose to use [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/) in the source text but I don't mind reformatting it.