### PR TITLE
Improve error message for non-exhaustive matches on non-exhaustive enums

### DIFF
--- a/src/test/ui/match/auxiliary/match_non_exhaustive_lib.rs
+++ b/src/test/ui/match/auxiliary/match_non_exhaustive_lib.rs
@@ -1,0 +1,5 @@
+#[non_exhaustive]
+pub enum E1 {}
+
+#[non_exhaustive]
+pub enum E2 { A, B }

--- a/src/test/ui/match/match_non_exhaustive.rs
+++ b/src/test/ui/match/match_non_exhaustive.rs
@@ -1,0 +1,32 @@
+// aux-build:match_non_exhaustive_lib.rs
+
+/* The error message for non-exhaustive matches on non-local enums
+ * marked as non-exhaustive should mention the fact that the enum
+ * is marked as non-exhaustive (issue #85227).
+ */
+
+// Ignore non_exhaustive in the same crate
+#[non_exhaustive]
+enum L { A, B }
+
+extern crate match_non_exhaustive_lib;
+use match_non_exhaustive_lib::{E1, E2};
+
+fn foo() -> L {todo!()}
+fn bar() -> (E1, E2) {todo!()}
+
+fn main() {
+    let l = foo();
+    // No error for enums defined in this crate
+    match l { L::A => (), L::B => () };
+    // (except if the match is already non-exhaustive)
+    match l { L::A => () };
+    //~^ ERROR: non-exhaustive patterns: `B` not covered [E0004]
+
+    // E1 is not visibly uninhabited from here
+    let (e1, e2) = bar();
+    match e1 {};
+    //~^ ERROR: non-exhaustive patterns: type `E1` is non-empty [E0004]
+    match e2 { E2::A => (), E2::B => () };
+    //~^ ERROR: non-exhaustive patterns: `_` not covered [E0004]
+}

--- a/src/test/ui/match/match_non_exhaustive.stderr
+++ b/src/test/ui/match/match_non_exhaustive.stderr
@@ -1,0 +1,36 @@
+error[E0004]: non-exhaustive patterns: `B` not covered
+  --> $DIR/match_non_exhaustive.rs:23:11
+   |
+LL | enum L { A, B }
+   | ---------------
+   | |           |
+   | |           not covered
+   | `L` defined here
+...
+LL |     match l { L::A => () };
+   |           ^ pattern `B` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `L`
+
+error[E0004]: non-exhaustive patterns: type `E1` is non-empty
+  --> $DIR/match_non_exhaustive.rs:28:11
+   |
+LL |     match e1 {};
+   |           ^^
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `E1`, which is marked as non-exhaustive
+
+error[E0004]: non-exhaustive patterns: `_` not covered
+  --> $DIR/match_non_exhaustive.rs:30:11
+   |
+LL |     match e2 { E2::A => (), E2::B => () };
+   |           ^^ pattern `_` not covered
+   |
+   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
+   = note: the matched value is of type `E2`, which is marked as non-exhaustive
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/rfc-2008-non-exhaustive/enum.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/enum.stderr
@@ -5,7 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `EmptyNonExhaustiveEnum`
+   = note: the matched value is of type `EmptyNonExhaustiveEnum`, which is marked as non-exhaustive
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/enum.rs:16:11
@@ -14,7 +14,7 @@ LL |     match enum_unit {
    |           ^^^^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `NonExhaustiveEnum`
+   = note: the matched value is of type `NonExhaustiveEnum`, which is marked as non-exhaustive
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/enum.rs:23:11
@@ -23,7 +23,7 @@ LL |     match enum_unit {};
    |           ^^^^^^^^^ pattern `_` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `NonExhaustiveEnum`
+   = note: the matched value is of type `NonExhaustiveEnum`, which is marked as non-exhaustive
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match.stderr
@@ -5,7 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `UninhabitedEnum`
+   = note: the matched value is of type `UninhabitedEnum`, which is marked as non-exhaustive
 
 error[E0004]: non-exhaustive patterns: type `UninhabitedStruct` is non-empty
   --> $DIR/match.rs:23:11

--- a/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/uninhabited/match_with_exhaustive_patterns.stderr
@@ -5,7 +5,7 @@ LL |     match x {}
    |           ^
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
-   = note: the matched value is of type `UninhabitedEnum`
+   = note: the matched value is of type `UninhabitedEnum`, which is marked as non-exhaustive
 
 error[E0004]: non-exhaustive patterns: type `UninhabitedStruct` is non-empty
   --> $DIR/match_with_exhaustive_patterns.rs:26:11


### PR DESCRIPTION
This pull request fixes #85227. For an enum marked with `#[non_exhaustive]` and not defined in the current crate, the error message for non-exhaustive matches now mentions the fact that the enum is marked as non-exhaustive:
```
error[E0004]: non-exhaustive patterns: `_` not covered
  --> main.rs:12:11
   |
12 |     match e {
   |           ^ pattern `_` not covered
   |
   = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
   = note: the matched value is of type `E`, which is marked as non-exhaustive
```
