### PR TITLE
Bring back `x86_64-sun-solaris` target to rustup

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -72,7 +72,7 @@ COPY host-x86_64/dist-various-2/build-fuchsia-toolchain.sh /tmp/
 RUN /tmp/build-fuchsia-toolchain.sh
 COPY host-x86_64/dist-various-2/build-solaris-toolchain.sh /tmp/
 RUN /tmp/build-solaris-toolchain.sh x86_64  amd64   solaris-i386  pc
-# Build now deprecated Solaris target as well
+# Build deprecated target 'x86_64-sun-solaris2.10' until removed
 RUN /tmp/build-solaris-toolchain.sh x86_64  amd64   solaris-i386  sun
 RUN /tmp/build-solaris-toolchain.sh sparcv9 sparcv9 solaris-sparc sun
 COPY host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh /tmp/

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -42,6 +42,9 @@ ENV \
     AR_x86_64_pc_solaris=x86_64-pc-solaris2.10-ar \
     CC_x86_64_pc_solaris=x86_64-pc-solaris2.10-gcc \
     CXX_x86_64_pc_solaris=x86_64-pc-solaris2.10-g++ \
+    AR_x86_64_sun_solaris=x86_64-sun-solaris2.10-ar \
+    CC_x86_64_sun_solaris=x86_64-sun-solaris2.10-gcc \
+    CXX_x86_64_sun_solaris=x86_64-sun-solaris2.10-g++ \
     CC_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-gcc-8 \
     CXX_armv7_unknown_linux_gnueabi=arm-linux-gnueabi-g++-8 \
     AR_x86_64_fortanix_unknown_sgx=ar \
@@ -68,8 +71,10 @@ COPY host-x86_64/dist-various-2/shared.sh /tmp/
 COPY host-x86_64/dist-various-2/build-fuchsia-toolchain.sh /tmp/
 RUN /tmp/build-fuchsia-toolchain.sh
 COPY host-x86_64/dist-various-2/build-solaris-toolchain.sh /tmp/
-RUN /tmp/build-solaris-toolchain.sh x86_64  amd64   solaris-i386
-RUN /tmp/build-solaris-toolchain.sh sparcv9 sparcv9 solaris-sparc
+RUN /tmp/build-solaris-toolchain.sh x86_64  amd64   solaris-i386  pc
+# Build now deprecated Solaris target as well
+RUN /tmp/build-solaris-toolchain.sh x86_64  amd64   solaris-i386  sun
+RUN /tmp/build-solaris-toolchain.sh sparcv9 sparcv9 solaris-sparc sun
 COPY host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh /tmp/
 RUN /tmp/build-x86_64-fortanix-unknown-sgx-toolchain.sh
 
@@ -99,6 +104,7 @@ ENV TARGETS=$TARGETS,wasm32-unknown-unknown
 ENV TARGETS=$TARGETS,wasm32-wasi
 ENV TARGETS=$TARGETS,sparcv9-sun-solaris
 ENV TARGETS=$TARGETS,x86_64-pc-solaris
+ENV TARGETS=$TARGETS,x86_64-sun-solaris
 ENV TARGETS=$TARGETS,x86_64-unknown-linux-gnux32
 ENV TARGETS=$TARGETS,x86_64-fortanix-unknown-sgx
 ENV TARGETS=$TARGETS,nvptx64-nvidia-cuda

--- a/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
@@ -6,21 +6,11 @@ source shared.sh
 ARCH=$1
 LIB_ARCH=$2
 APT_ARCH=$3
+MANUFACTURER=$4
 BINUTILS=2.28.1
 GCC=6.5.0
 
-# Choose correct target based on the $ARCH
-case "$ARCH" in
-x86_64)
-  TARGET=x86_64-pc-solaris2.10
-  ;;
-sparcv9)
-  TARGET=sparcv9-sun-solaris2.10
-  ;;
-*)
-  printf 'ERROR: unknown architecture: %s\n' "$ARCH"
-  exit 1
-esac
+TARGET=${ARCH}-${MANUFACTURER}-solaris2.10
 
 # First up, build binutils
 mkdir binutils


### PR DESCRIPTION
Change #82216 removed now deprecated target `x86_64-sun-solaris` from CI, thus making it no longer possible to use `$ rustup target add x86_64-sun-solaris` to install given target (see #85098 for details). Since there should be a period of time between the deprecation and removal, this PR brings it back (while keeping the new one as well).

Please, correct me if I am wrong; my assumption that these Docker scripts are being used to build artifacts later used by `rustup` might be incorrect.

Closes #85098.
