### PR TITLE
swap function order for better read flow

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0277.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0277.md
@@ -29,14 +29,14 @@ trait Foo {
     fn bar(&self);
 }
 
-fn some_func<T: Foo>(foo: T) {
-    foo.bar(); // we can now use this method since i32 implements the
-               // Foo trait
-}
-
 // we implement the trait on the i32 type
 impl Foo for i32 {
     fn bar(&self) {}
+}
+
+fn some_func<T: Foo>(foo: T) {
+    foo.bar(); // we can now use this method since i32 implements the
+               // Foo trait
 }
 
 fn main() {


### PR DESCRIPTION
I was reading this error message for the first time.

I was a little bit confused when reading that part:
```
foo.bar(); // we can now use this method since i32 implements the Foo trait
```

At the time I was reading `// we can now use this method` I wasn't sure why. It only made sense when reading on. So swapping these parts results in a better read flow.

