### PR TITLE
Fix display for "implementors" section

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -547,7 +547,7 @@ h4 > code, h3 > code, .invisible > code {
 	font-size: 0.8em;
 }
 
-.content .methods > div:not(.notable-traits) {
+.content .methods > div:not(.notable-traits):not(.methods) {
 	margin-left: 40px;
 	margin-bottom: 15px;
 }


### PR DESCRIPTION
Just saw this problem when going through docs:

![Screenshot from 2021-05-13 15-20-52](https://user-images.githubusercontent.com/3050060/118131978-766fc180-b3ff-11eb-86a8-7f6d22afa675.png)

This fix puts it back to normal:

![Screenshot from 2021-05-13 15-23-29](https://user-images.githubusercontent.com/3050060/118132006-7e2f6600-b3ff-11eb-9985-025a7b7c5216.png)

You can see it on the `TryFrom` page for example.

r? @Nemo157 