### PR TITLE
Check for inline assembly in THIR unsafeck

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -153,6 +153,9 @@ impl<'thir, 'tcx> Visitor<'thir, 'tcx> for UnsafetyVisitor<'tcx> {
                     self.requires_unsafe(expr.span, CallToUnsafeFunction);
                 }
             }
+            ExprKind::InlineAsm { .. } | ExprKind::LlvmInlineAsm { .. } => {
+                self.requires_unsafe(expr.span, UseOfInlineAssembly);
+            }
             _ => {}
         }
 
@@ -194,7 +197,6 @@ impl BodyUnsafety {
 #[derive(Clone, Copy, PartialEq)]
 enum UnsafeOpKind {
     CallToUnsafeFunction,
-    #[allow(dead_code)] // FIXME
     UseOfInlineAssembly,
     #[allow(dead_code)] // FIXME
     InitializingTypeWith,

--- a/src/test/ui/asm/bad-arch.mirunsafeck.stderr
+++ b/src/test/ui/asm/bad-arch.mirunsafeck.stderr
@@ -1,11 +1,11 @@
 error[E0472]: inline assembly is unsupported on this target
-  --> $DIR/bad-arch.rs:20:9
+  --> $DIR/bad-arch.rs:22:9
    |
 LL |         asm!("");
    |         ^^^^^^^^^
 
 error[E0472]: inline assembly is unsupported on this target
-  --> $DIR/bad-arch.rs:25:1
+  --> $DIR/bad-arch.rs:27:1
    |
 LL | global_asm!("");
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/asm/bad-arch.rs
+++ b/src/test/ui/asm/bad-arch.rs
@@ -1,5 +1,7 @@
 // compile-flags: --target sparc-unknown-linux-gnu
 // needs-llvm-components: sparc
+// revisions: mirunsafeck thirunsafeck
+// [thirunsafeck]compile-flags: -Z thir-unsafeck
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![no_core]

--- a/src/test/ui/asm/bad-arch.thirunsafeck.stderr
+++ b/src/test/ui/asm/bad-arch.thirunsafeck.stderr
@@ -1,0 +1,16 @@
+error[E0472]: inline assembly is unsupported on this target
+  --> $DIR/bad-arch.rs:22:9
+   |
+LL |         asm!("");
+   |         ^^^^^^^^^
+
+error[E0472]: inline assembly is unsupported on this target
+  --> $DIR/bad-arch.rs:27:1
+   |
+LL | global_asm!("");
+   | ^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `global_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/asm/bad-template.mirunsafeck.stderr
+++ b/src/test/ui/asm/bad-template.mirunsafeck.stderr
@@ -1,5 +1,5 @@
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:8:15
+  --> $DIR/bad-template.rs:10:15
    |
 LL |         asm!("{}");
    |               ^^ from here
@@ -7,7 +7,7 @@ LL |         asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:10:15
+  --> $DIR/bad-template.rs:12:15
    |
 LL |         asm!("{1}", in(reg) foo);
    |               ^^^ from here
@@ -15,7 +15,7 @@ LL |         asm!("{1}", in(reg) foo);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:10:21
+  --> $DIR/bad-template.rs:12:21
    |
 LL |         asm!("{1}", in(reg) foo);
    |                     ^^^^^^^^^^^ argument never used
@@ -23,13 +23,13 @@ LL |         asm!("{1}", in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:13:15
+  --> $DIR/bad-template.rs:15:15
    |
 LL |         asm!("{a}");
    |               ^^^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:15:15
+  --> $DIR/bad-template.rs:17:15
    |
 LL |         asm!("{}", a = in(reg) foo);
    |               ^^   --------------- named argument
@@ -38,13 +38,13 @@ LL |         asm!("{}", a = in(reg) foo);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:15:20
+  --> $DIR/bad-template.rs:17:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:15:20
+  --> $DIR/bad-template.rs:17:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^ named argument never used
@@ -52,7 +52,7 @@ LL |         asm!("{}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:18:15
+  --> $DIR/bad-template.rs:20:15
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
@@ -60,7 +60,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:18:21
+  --> $DIR/bad-template.rs:20:21
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |                     ^^^^^^^^^^^^^^^ named argument never used
@@ -68,7 +68,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:21:15
+  --> $DIR/bad-template.rs:23:15
    |
 LL |         asm!("{}", in("eax") foo);
    |               ^^   ------------- explicit register argument
@@ -77,19 +77,19 @@ LL |         asm!("{}", in("eax") foo);
    |
    = note: no positional arguments were given
 note: explicit register arguments cannot be used in the asm template
-  --> $DIR/bad-template.rs:21:20
+  --> $DIR/bad-template.rs:23:20
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:23:17
+  --> $DIR/bad-template.rs:25:17
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:25:18
+  --> $DIR/bad-template.rs:27:18
    |
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -99,7 +99,7 @@ LL |         asm!("", in(reg) 0, in(reg) 1);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:31:14
+  --> $DIR/bad-template.rs:33:14
    |
 LL | global_asm!("{}");
    |              ^^ from here
@@ -107,7 +107,7 @@ LL | global_asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:33:14
+  --> $DIR/bad-template.rs:35:14
    |
 LL | global_asm!("{1}", const FOO);
    |              ^^^ from here
@@ -115,7 +115,7 @@ LL | global_asm!("{1}", const FOO);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:33:20
+  --> $DIR/bad-template.rs:35:20
    |
 LL | global_asm!("{1}", const FOO);
    |                    ^^^^^^^^^ argument never used
@@ -123,13 +123,13 @@ LL | global_asm!("{1}", const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:36:14
+  --> $DIR/bad-template.rs:38:14
    |
 LL | global_asm!("{a}");
    |              ^^^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:38:14
+  --> $DIR/bad-template.rs:40:14
    |
 LL | global_asm!("{}", a = const FOO);
    |              ^^   ------------- named argument
@@ -138,13 +138,13 @@ LL | global_asm!("{}", a = const FOO);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:38:19
+  --> $DIR/bad-template.rs:40:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:38:19
+  --> $DIR/bad-template.rs:40:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^ named argument never used
@@ -152,7 +152,7 @@ LL | global_asm!("{}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:41:14
+  --> $DIR/bad-template.rs:43:14
    |
 LL | global_asm!("{1}", a = const FOO);
    |              ^^^ from here
@@ -160,7 +160,7 @@ LL | global_asm!("{1}", a = const FOO);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:41:20
+  --> $DIR/bad-template.rs:43:20
    |
 LL | global_asm!("{1}", a = const FOO);
    |                    ^^^^^^^^^^^^^ named argument never used
@@ -168,13 +168,13 @@ LL | global_asm!("{1}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:44:16
+  --> $DIR/bad-template.rs:46:16
    |
 LL | global_asm!("{:foo}", const FOO);
    |                ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:46:17
+  --> $DIR/bad-template.rs:48:17
    |
 LL | global_asm!("", const FOO, const FOO);
    |                 ^^^^^^^^^  ^^^^^^^^^ argument never used

--- a/src/test/ui/asm/bad-template.rs
+++ b/src/test/ui/asm/bad-template.rs
@@ -1,4 +1,6 @@
 // only-x86_64
+// revisions: mirunsafeck thirunsafeck
+// [thirunsafeck]compile-flags: -Z thir-unsafeck
 
 #![feature(asm, global_asm)]
 

--- a/src/test/ui/asm/bad-template.thirunsafeck.stderr
+++ b/src/test/ui/asm/bad-template.thirunsafeck.stderr
@@ -1,0 +1,187 @@
+error: invalid reference to argument at index 0
+  --> $DIR/bad-template.rs:10:15
+   |
+LL |         asm!("{}");
+   |               ^^ from here
+   |
+   = note: no arguments were given
+
+error: invalid reference to argument at index 1
+  --> $DIR/bad-template.rs:12:15
+   |
+LL |         asm!("{1}", in(reg) foo);
+   |               ^^^ from here
+   |
+   = note: there is 1 argument
+
+error: argument never used
+  --> $DIR/bad-template.rs:12:21
+   |
+LL |         asm!("{1}", in(reg) foo);
+   |                     ^^^^^^^^^^^ argument never used
+   |
+   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
+
+error: there is no argument named `a`
+  --> $DIR/bad-template.rs:15:15
+   |
+LL |         asm!("{a}");
+   |               ^^^
+
+error: invalid reference to argument at index 0
+  --> $DIR/bad-template.rs:17:15
+   |
+LL |         asm!("{}", a = in(reg) foo);
+   |               ^^   --------------- named argument
+   |               |
+   |               from here
+   |
+   = note: no positional arguments were given
+note: named arguments cannot be referenced by position
+  --> $DIR/bad-template.rs:17:20
+   |
+LL |         asm!("{}", a = in(reg) foo);
+   |                    ^^^^^^^^^^^^^^^
+
+error: named argument never used
+  --> $DIR/bad-template.rs:17:20
+   |
+LL |         asm!("{}", a = in(reg) foo);
+   |                    ^^^^^^^^^^^^^^^ named argument never used
+   |
+   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
+
+error: invalid reference to argument at index 1
+  --> $DIR/bad-template.rs:20:15
+   |
+LL |         asm!("{1}", a = in(reg) foo);
+   |               ^^^ from here
+   |
+   = note: no positional arguments were given
+
+error: named argument never used
+  --> $DIR/bad-template.rs:20:21
+   |
+LL |         asm!("{1}", a = in(reg) foo);
+   |                     ^^^^^^^^^^^^^^^ named argument never used
+   |
+   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
+
+error: invalid reference to argument at index 0
+  --> $DIR/bad-template.rs:23:15
+   |
+LL |         asm!("{}", in("eax") foo);
+   |               ^^   ------------- explicit register argument
+   |               |
+   |               from here
+   |
+   = note: no positional arguments were given
+note: explicit register arguments cannot be used in the asm template
+  --> $DIR/bad-template.rs:23:20
+   |
+LL |         asm!("{}", in("eax") foo);
+   |                    ^^^^^^^^^^^^^
+
+error: asm template modifier must be a single character
+  --> $DIR/bad-template.rs:25:17
+   |
+LL |         asm!("{:foo}", in(reg) foo);
+   |                 ^^^
+
+error: multiple unused asm arguments
+  --> $DIR/bad-template.rs:27:18
+   |
+LL |         asm!("", in(reg) 0, in(reg) 1);
+   |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
+   |                  |
+   |                  argument never used
+   |
+   = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
+
+error: invalid reference to argument at index 0
+  --> $DIR/bad-template.rs:33:14
+   |
+LL | global_asm!("{}");
+   |              ^^ from here
+   |
+   = note: no arguments were given
+
+error: invalid reference to argument at index 1
+  --> $DIR/bad-template.rs:35:14
+   |
+LL | global_asm!("{1}", const FOO);
+   |              ^^^ from here
+   |
+   = note: there is 1 argument
+
+error: argument never used
+  --> $DIR/bad-template.rs:35:20
+   |
+LL | global_asm!("{1}", const FOO);
+   |                    ^^^^^^^^^ argument never used
+   |
+   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
+
+error: there is no argument named `a`
+  --> $DIR/bad-template.rs:38:14
+   |
+LL | global_asm!("{a}");
+   |              ^^^
+
+error: invalid reference to argument at index 0
+  --> $DIR/bad-template.rs:40:14
+   |
+LL | global_asm!("{}", a = const FOO);
+   |              ^^   ------------- named argument
+   |              |
+   |              from here
+   |
+   = note: no positional arguments were given
+note: named arguments cannot be referenced by position
+  --> $DIR/bad-template.rs:40:19
+   |
+LL | global_asm!("{}", a = const FOO);
+   |                   ^^^^^^^^^^^^^
+
+error: named argument never used
+  --> $DIR/bad-template.rs:40:19
+   |
+LL | global_asm!("{}", a = const FOO);
+   |                   ^^^^^^^^^^^^^ named argument never used
+   |
+   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
+
+error: invalid reference to argument at index 1
+  --> $DIR/bad-template.rs:43:14
+   |
+LL | global_asm!("{1}", a = const FOO);
+   |              ^^^ from here
+   |
+   = note: no positional arguments were given
+
+error: named argument never used
+  --> $DIR/bad-template.rs:43:20
+   |
+LL | global_asm!("{1}", a = const FOO);
+   |                    ^^^^^^^^^^^^^ named argument never used
+   |
+   = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
+
+error: asm template modifier must be a single character
+  --> $DIR/bad-template.rs:46:16
+   |
+LL | global_asm!("{:foo}", const FOO);
+   |                ^^^
+
+error: multiple unused asm arguments
+  --> $DIR/bad-template.rs:48:17
+   |
+LL | global_asm!("", const FOO, const FOO);
+   |                 ^^^^^^^^^  ^^^^^^^^^ argument never used
+   |                 |
+   |                 argument never used
+   |
+   = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
+
+error: aborting due to 21 previous errors
+

--- a/src/test/ui/asm/const.rs
+++ b/src/test/ui/asm/const.rs
@@ -1,6 +1,8 @@
 // min-llvm-version: 10.0.1
 // only-x86_64
 // run-pass
+// revisions: mirunsafeck thirunsafeck
+// [thirunsafeck]compile-flags: -Z thir-unsafeck
 
 #![feature(asm, global_asm)]
 

--- a/src/test/ui/unsafe/inline_asm.mir.stderr
+++ b/src/test/ui/unsafe/inline_asm.mir.stderr
@@ -1,0 +1,20 @@
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/inline_asm.rs:8:5
+   |
+LL |     asm!("nop");
+   |     ^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
+
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/inline_asm.rs:9:5
+   |
+LL |     llvm_asm!("nop");
+   |     ^^^^^^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/inline_asm.rs
+++ b/src/test/ui/unsafe/inline_asm.rs
@@ -1,0 +1,10 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
+#![feature(llvm_asm)]
+#![feature(asm)]
+
+fn main() {
+    asm!("nop"); //~ ERROR use of inline assembly is unsafe and requires unsafe function or block
+    llvm_asm!("nop"); //~ ERROR use of inline assembly is unsafe and requires unsafe function or block
+}

--- a/src/test/ui/unsafe/inline_asm.thir.stderr
+++ b/src/test/ui/unsafe/inline_asm.thir.stderr
@@ -1,0 +1,20 @@
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/inline_asm.rs:8:5
+   |
+LL |     asm!("nop");
+   |     ^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
+
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/inline_asm.rs:9:5
+   |
+LL |     llvm_asm!("nop");
+   |     ^^^^^^^^^^^^^^^^^ use of inline assembly
+   |
+   = note: inline assembly is entirely unchecked and can cause undefined behavior
+   = note: this error originates in the macro `llvm_asm` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
#83129 was merged recently and added a THIR unsafe checker. This adds a check for inline assembly. (and this is 2x simpler than the MIR version, which has to check for `asm` and `llvm_asm` in two separate spots!)

 see also rust-lang/project-thir-unsafeck#7