### PR TITLE
Fix indentation in move keyword documentation

### DIFF
--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1008,9 +1008,9 @@ mod mod_keyword {}
 ///     move || println!("This is a: {}", text)
 /// }
 ///
-///     let fn_plain = create_fn();
+/// let fn_plain = create_fn();
 ///
-///     fn_plain();
+/// fn_plain();
 /// ```
 ///
 /// `move` is often used when [threads] are involved.


### PR DESCRIPTION
See (at the time of writing) the second example code block with `create_fn()` at https://doc.rust-lang.org/std/keyword.move.html 