### PR TITLE
Toggle-wrap items differently than top-doc.

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -509,7 +509,11 @@ fn document(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, parent: Option
         info!("Documenting {}", name);
     }
     document_item_info(w, cx, item, parent);
-    document_full_collapsible(w, item, cx);
+    if parent.is_none() {
+        document_full_collapsible(w, item, cx);
+    } else {
+        document_full(w, item, cx);
+    }
 }
 
 /// Render md_text as markdown.

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -578,12 +578,13 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         info!("Documenting {} on {:?}", name, t.name);
         let item_type = m.type_();
         let id = cx.derive_id(format!("{}.{}", item_type, name));
+        write!(w, "<details class=\"rustdoc-toggle\" open><summary>");
         write!(w, "<h3 id=\"{id}\" class=\"method\"><code>", id = id,);
         render_assoc_item(w, m, AssocItemLink::Anchor(Some(&id)), ItemType::Impl, cx);
         w.write_str("</code>");
         render_stability_since(w, m, t, cx.tcx());
         write_srclink(cx, m, w);
-        w.write_str("</h3>");
+        w.write_str("</h3></summary>");
         document(w, cx, m, Some(t));
     }
 

--- a/src/test/rustdoc/toggle-trait-fn.rs
+++ b/src/test/rustdoc/toggle-trait-fn.rs
@@ -1,0 +1,7 @@
+#![crate_name = "foo"]
+
+// @has foo/trait.Foo.html
+// @has - '//details[@class="rustdoc-toggle"]//code' 'bar'
+pub trait Foo {
+    fn bar() -> ();
+}


### PR DESCRIPTION
This makes sure things like trait methods get wrapped at the
`<h3><code>` level rather than at the `.docblock` level. Also it ensures
that only the actual top documentation gets the `.top-doc` class.

Fixes #85167

Before:

![image](https://user-images.githubusercontent.com/220205/117743384-98790200-b1bb-11eb-8804-588530842514.png)

https://doc.rust-lang.org/nightly/std/io/trait.Read.html#tymethod.read

After:

![image](https://user-images.githubusercontent.com/220205/118410882-98a75080-b646-11eb-949d-ca688bab6923.png)
