### PR TITLE
Improve debugging experience for enums on windows-msvc

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1537,7 +1537,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                     // For MSVC, we generate a union of structs for each variant with an explicit
                     // discriminant field roughly equivalent to the following C:
                     // ```c
-                    // union _enum<{name}> {
+                    // union enum$<{name}> {
                     //   struct {variant 0 name} {
                     //     tag$ variant$;
                     //     <variant 0 fields>
@@ -1628,7 +1628,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                 // make the discriminant field that type. We then use natvis to render the enum type correctly in Windbg/VS.
                 // This will generate debuginfo roughly equivalent to the following C:
                 // ```c
-                // union _enum<{name}, {min niche}, {max niche}, {dataful variant name} {
+                // union enum$<{name}, {min niche}, {max niche}, {dataful variant name} {
                 //   struct dataful_variant {
                 //     <fields in dataful variant>
                 //   },
@@ -1639,7 +1639,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                 //   }
                 // }
                 // ```
-                // The natvis in `intrinsic.natvis` matches on the type name `_enum<*, *, *, *>`
+                // The natvis in `intrinsic.natvis` matches on the type name `enum$<*, *, *, *>`
                 // and evaluates `this.discriminant$.discriminant`. If the value is between
                 // the min niche and max niche, then the enum is in the dataful variant and
                 // `this.dataful_variant` is rendered. Otherwise, the enum is in one of the

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1687,7 +1687,13 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                         source_info: None,
                     }];
 
-                    set_members_of_composite_type(cx, self.enum_type, variant_metadata, members, None);
+                    set_members_of_composite_type(
+                        cx,
+                        self.enum_type,
+                        variant_metadata,
+                        members,
+                        None,
+                    );
 
                     let variant_info = variant_info_for(dataful_variant);
                     let (variant_type_metadata, member_desc_factory) = describe_enum_variant(
@@ -1932,9 +1938,9 @@ fn describe_enum_variant(
                 // We have the layout of an enum variant, we need the layout of the outer enum
                 let enum_layout = cx.layout_of(layout.ty);
                 let offset = enum_layout.fields.offset(tag_field.as_usize());
-                let tag_name = if cx.tcx.sess.target.is_like_msvc { "variant$" } else { "RUST$ENUM$DISR" };
-                let args =
-                    (tag_name.to_owned(), enum_layout.field(cx, tag_field.as_usize()).ty);
+                let tag_name =
+                    if cx.tcx.sess.target.is_like_msvc { "variant$" } else { "RUST$ENUM$DISR" };
+                let args = (tag_name.to_owned(), enum_layout.field(cx, tag_field.as_usize()).ty);
                 (Some(offset), Some(args))
             }
             _ => (None, None),

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1457,7 +1457,6 @@ struct EnumMemberDescriptionFactory<'ll, 'tcx> {
     enum_type: Ty<'tcx>,
     layout: TyAndLayout<'tcx>,
     tag_type_metadata: Option<&'ll DIType>,
-    containing_scope: &'ll DIScope,
     common_members: Vec<Option<&'ll DIType>>,
     span: Span,
 }
@@ -1488,11 +1487,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
 
         // This will always find the metadata in the type map.
         let fallback = use_enum_fallback(cx);
-        let self_metadata = if fallback {
-            self.containing_scope
-        } else {
-            type_metadata(cx, self.enum_type, self.span)
-        };
+        let self_metadata = type_metadata(cx, self.enum_type, self.span);
 
         match self.layout.variants {
             Variants::Single { index } => {
@@ -1607,7 +1602,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                         variant,
                         variant_info_for(dataful_variant),
                         Some(NicheTag),
-                        self.containing_scope,
+                        self_metadata,
                         self.span,
                     );
 
@@ -2085,7 +2080,6 @@ fn prepare_enum_metadata(
                 enum_type,
                 layout,
                 tag_type_metadata: discriminant_type_metadata,
-                containing_scope,
                 common_members: vec![],
                 span,
             }),
@@ -2238,7 +2232,6 @@ fn prepare_enum_metadata(
             enum_type,
             layout,
             tag_type_metadata: None,
-            containing_scope,
             common_members: outer_fields,
             span,
         }),

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2038,7 +2038,7 @@ extern "C" {
 
     pub fn LLVMRustDIBuilderCreateUnionType(
         Builder: &DIBuilder<'a>,
-        Scope: &'a DIScope,
+        Scope: Option<&'a DIScope>,
         Name: *const c_char,
         NameLen: size_t,
         File: &'a DIFile,

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -238,6 +238,10 @@ pub fn push_debuginfo_type_name<'tcx>(
         }
     }
 
+    /// MSVC names enums differently than other platforms so that the debugging visualization
+    // format (natvis) is able to understand enums and render the active variant correctly in the
+    // debugger. For more information, look in `src/etc/natvis/intrinsic.natvis` and
+    // `EnumMemberDescriptionFactor::create_member_descriptions`.
     fn msvc_enum_fallback(
         tcx: TyCtxt<'tcx>,
         ty: Ty<'tcx>,

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -267,7 +267,7 @@ pub fn push_debuginfo_type_name<'tcx>(
             let max = dataful_discriminant_range.end();
             let max = tag.value.size(&tcx).truncate(*max);
 
-            output.push_str("_enum<");
+            output.push_str("enum$<");
             push_item_name(tcx, def.did, true, output);
             push_type_params(tcx, substs, output, visited);
 
@@ -275,7 +275,7 @@ pub fn push_debuginfo_type_name<'tcx>(
 
             output.push_str(&format!(", {}, {}, {}>", min, max, dataful_variant_name));
         } else {
-            output.push_str("_enum<");
+            output.push_str("enum$<");
             push_item_name(tcx, def.did, true, output);
             push_type_params(tcx, substs, output, visited);
             output.push('>');

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -45,8 +45,16 @@ pub fn push_debuginfo_type_name<'tcx>(
         ty::Float(float_ty) => output.push_str(float_ty.name_str()),
         ty::Foreign(def_id) => push_item_name(tcx, def_id, qualified, output),
         ty::Adt(def, substs) => {
+            if def.is_enum() && cpp_like_names {
+                output.push_str("_enum<");
+            }
+
             push_item_name(tcx, def.did, qualified, output);
             push_type_params(tcx, substs, output, visited);
+
+            if def.is_enum() && cpp_like_names {
+                output.push('>');
+            }
         }
         ty::Tuple(component_types) => {
             if cpp_like_names {

--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -149,4 +149,42 @@
       <Synthetic Name="[...]"><DisplayString>...</DisplayString></Synthetic>
     </Expand>
   </Type>
+  <Type Name="_enum&lt;*&gt;">
+    <Intrinsic Name="tag" Expression="Variant0.variant$" />
+    <DisplayString Condition="tag() == 0">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 1" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 2" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 3" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 4" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 5" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 6" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 7" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 8" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 9" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 10" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 11" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 12" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 13" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 14" Optional="true">{tag(),en}</DisplayString>
+    <DisplayString Condition="tag() == 15" Optional="true">{tag(),en}</DisplayString>
+
+    <Expand>
+      <ExpandedItem Condition="tag() == 0">Variant0</ExpandedItem>
+      <ExpandedItem Condition="tag() == 1" Optional="true">Variant1</ExpandedItem>
+      <ExpandedItem Condition="tag() == 2" Optional="true">Variant2</ExpandedItem>
+      <ExpandedItem Condition="tag() == 3" Optional="true">Variant3</ExpandedItem>
+      <ExpandedItem Condition="tag() == 4" Optional="true">Variant4</ExpandedItem>
+      <ExpandedItem Condition="tag() == 5" Optional="true">Variant5</ExpandedItem>
+      <ExpandedItem Condition="tag() == 6" Optional="true">Variant6</ExpandedItem>
+      <ExpandedItem Condition="tag() == 7" Optional="true">Variant7</ExpandedItem>
+      <ExpandedItem Condition="tag() == 8" Optional="true">Variant8</ExpandedItem>
+      <ExpandedItem Condition="tag() == 9" Optional="true">Variant9</ExpandedItem>
+      <ExpandedItem Condition="tag() == 10" Optional="true">Variant10</ExpandedItem>
+      <ExpandedItem Condition="tag() == 11" Optional="true">Variant11</ExpandedItem>
+      <ExpandedItem Condition="tag() == 12" Optional="true">Variant12</ExpandedItem>
+      <ExpandedItem Condition="tag() == 13" Optional="true">Variant13</ExpandedItem>
+      <ExpandedItem Condition="tag() == 14" Optional="true">Variant14</ExpandedItem>
+      <ExpandedItem Condition="tag() == 15" Optional="true">Variant15</ExpandedItem>
+    </Expand>
+  </Type>
 </AutoVisualizer>

--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -187,4 +187,18 @@
       <ExpandedItem Condition="tag() == 15" Optional="true">Variant15</ExpandedItem>
     </Expand>
   </Type>
+
+  <!-- $T1 is the name of the enum, $T2 is the low value of the dataful variant tag, $T3 is the high value of the dataful variant tag, $T4 is the name of the dataful variant -->
+  <Type Name="_enum&lt;*, *, *, *&gt;">
+    <Intrinsic Name="tag" Expression="discriminant$.discriminant" />
+    <Intrinsic Name="is_dataful" Expression="tag() &gt;= $T2 &amp;&amp; tag() &lt;= $T3" />
+    <DisplayString Condition="is_dataful()">{"$T4",sb}({dataful_variant})</DisplayString>
+    <DisplayString Condition="!is_dataful()">{discriminant$.discriminant,en}</DisplayString>
+    <Expand>
+      <ExpandedItem Condition="is_dataful()">dataful_variant</ExpandedItem>
+      <Synthetic Condition="is_dataful()" Name="[variant]">
+        <DisplayString>{"$T4",sb}</DisplayString>
+      </Synthetic>
+    </Expand>
+  </Type>
 </AutoVisualizer>

--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -149,7 +149,7 @@
       <Synthetic Name="[...]"><DisplayString>...</DisplayString></Synthetic>
     </Expand>
   </Type>
-  <Type Name="_enum&lt;*&gt;">
+  <Type Name="enum$&lt;*&gt;">
     <Intrinsic Name="tag" Expression="Variant0.variant$" />
     <DisplayString Condition="tag() == 0">{tag(),en}</DisplayString>
     <DisplayString Condition="tag() == 1" Optional="true">{tag(),en}</DisplayString>
@@ -189,7 +189,7 @@
   </Type>
 
   <!-- $T1 is the name of the enum, $T2 is the low value of the dataful variant tag, $T3 is the high value of the dataful variant tag, $T4 is the name of the dataful variant -->
-  <Type Name="_enum&lt;*, *, *, *&gt;">
+  <Type Name="enum$&lt;*, *, *, *&gt;">
     <Intrinsic Name="tag" Expression="discriminant$.discriminant" />
     <Intrinsic Name="is_dataful" Expression="tag() &gt;= $T2 &amp;&amp; tag() &lt;= $T3" />
     <DisplayString Condition="is_dataful()">{"$T4",sb}({dataful_variant})</DisplayString>

--- a/src/etc/natvis/intrinsic.natvis
+++ b/src/etc/natvis/intrinsic.natvis
@@ -150,7 +150,7 @@
     </Expand>
   </Type>
   <Type Name="enum$&lt;*&gt;">
-    <Intrinsic Name="tag" Expression="Variant0.variant$" />
+    <Intrinsic Name="tag" Expression="variant0.variant$" />
     <DisplayString Condition="tag() == 0">{tag(),en}</DisplayString>
     <DisplayString Condition="tag() == 1" Optional="true">{tag(),en}</DisplayString>
     <DisplayString Condition="tag() == 2" Optional="true">{tag(),en}</DisplayString>
@@ -169,31 +169,32 @@
     <DisplayString Condition="tag() == 15" Optional="true">{tag(),en}</DisplayString>
 
     <Expand>
-      <ExpandedItem Condition="tag() == 0">Variant0</ExpandedItem>
-      <ExpandedItem Condition="tag() == 1" Optional="true">Variant1</ExpandedItem>
-      <ExpandedItem Condition="tag() == 2" Optional="true">Variant2</ExpandedItem>
-      <ExpandedItem Condition="tag() == 3" Optional="true">Variant3</ExpandedItem>
-      <ExpandedItem Condition="tag() == 4" Optional="true">Variant4</ExpandedItem>
-      <ExpandedItem Condition="tag() == 5" Optional="true">Variant5</ExpandedItem>
-      <ExpandedItem Condition="tag() == 6" Optional="true">Variant6</ExpandedItem>
-      <ExpandedItem Condition="tag() == 7" Optional="true">Variant7</ExpandedItem>
-      <ExpandedItem Condition="tag() == 8" Optional="true">Variant8</ExpandedItem>
-      <ExpandedItem Condition="tag() == 9" Optional="true">Variant9</ExpandedItem>
-      <ExpandedItem Condition="tag() == 10" Optional="true">Variant10</ExpandedItem>
-      <ExpandedItem Condition="tag() == 11" Optional="true">Variant11</ExpandedItem>
-      <ExpandedItem Condition="tag() == 12" Optional="true">Variant12</ExpandedItem>
-      <ExpandedItem Condition="tag() == 13" Optional="true">Variant13</ExpandedItem>
-      <ExpandedItem Condition="tag() == 14" Optional="true">Variant14</ExpandedItem>
-      <ExpandedItem Condition="tag() == 15" Optional="true">Variant15</ExpandedItem>
+      <ExpandedItem Condition="tag() == 0">variant0</ExpandedItem>
+      <ExpandedItem Condition="tag() == 1" Optional="true">variant1</ExpandedItem>
+      <ExpandedItem Condition="tag() == 2" Optional="true">variant2</ExpandedItem>
+      <ExpandedItem Condition="tag() == 3" Optional="true">variant3</ExpandedItem>
+      <ExpandedItem Condition="tag() == 4" Optional="true">variant4</ExpandedItem>
+      <ExpandedItem Condition="tag() == 5" Optional="true">variant5</ExpandedItem>
+      <ExpandedItem Condition="tag() == 6" Optional="true">variant6</ExpandedItem>
+      <ExpandedItem Condition="tag() == 7" Optional="true">variant7</ExpandedItem>
+      <ExpandedItem Condition="tag() == 8" Optional="true">variant8</ExpandedItem>
+      <ExpandedItem Condition="tag() == 9" Optional="true">variant9</ExpandedItem>
+      <ExpandedItem Condition="tag() == 10" Optional="true">variant10</ExpandedItem>
+      <ExpandedItem Condition="tag() == 11" Optional="true">variant11</ExpandedItem>
+      <ExpandedItem Condition="tag() == 12" Optional="true">variant12</ExpandedItem>
+      <ExpandedItem Condition="tag() == 13" Optional="true">variant13</ExpandedItem>
+      <ExpandedItem Condition="tag() == 14" Optional="true">variant14</ExpandedItem>
+      <ExpandedItem Condition="tag() == 15" Optional="true">variant15</ExpandedItem>
     </Expand>
   </Type>
 
-  <!-- $T1 is the name of the enum, $T2 is the low value of the dataful variant tag, $T3 is the high value of the dataful variant tag, $T4 is the name of the dataful variant -->
+  <!-- $T1 is the name of the enum, $T2 is the low value of the dataful variant tag,
+       $T3 is the high value of the dataful variant tag, $T4 is the name of the dataful variant -->
   <Type Name="enum$&lt;*, *, *, *&gt;">
-    <Intrinsic Name="tag" Expression="discriminant$.discriminant" />
+    <Intrinsic Name="tag" Expression="discriminant" />
     <Intrinsic Name="is_dataful" Expression="tag() &gt;= $T2 &amp;&amp; tag() &lt;= $T3" />
     <DisplayString Condition="is_dataful()">{"$T4",sb}({dataful_variant})</DisplayString>
-    <DisplayString Condition="!is_dataful()">{discriminant$.discriminant,en}</DisplayString>
+    <DisplayString Condition="!is_dataful()">{discriminant,en}</DisplayString>
     <Expand>
       <ExpandedItem Condition="is_dataful()">dataful_variant</ExpandedItem>
       <Synthetic Condition="is_dataful()" Name="[variant]">

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -14,28 +14,11 @@
     </Expand>
   </Type>
 
-  <Type Name="core::option::Option&lt;*&gt;">
-    <DisplayString Condition="RUST$ENUM$DISR == 0x0">None</DisplayString>
-    <DisplayString Condition="RUST$ENUM$DISR == 0x1">Some({__0})</DisplayString>
-    <Expand>
-      <Item Name="[value]" ExcludeView="simple" Condition="RUST$ENUM$DISR == 1">__0</Item>
-    </Expand>
-  </Type>
-
   <Type Name="core::option::Option&lt;*&gt;" Priority="MediumLow">
     <DisplayString Condition="*(void**)this == nullptr">None</DisplayString>
     <DisplayString>Some({($T1 *)this})</DisplayString>
     <Expand>
       <Item Name="Some" ExcludeView="simple" Condition="*(void**)this != nullptr">($T1 *)this</Item>
-    </Expand>
-  </Type>
-
-  <Type Name="core::result::Result&lt;*&gt;">
-    <DisplayString Condition="RUST$ENUM$DISR == 0x0">Ok({__0})</DisplayString>
-    <DisplayString Condition="RUST$ENUM$DISR == 0x1">Err({(*($T2*) &amp;__0)})</DisplayString>
-    <Expand>
-      <Item Name="[value]" Condition="RUST$ENUM$DISR == 0x0">__0</Item>
-      <Item Name="[value]" Condition="RUST$ENUM$DISR == 0x1">(*($T2*) &amp;__0)</Item>
     </Expand>
   </Type>
 

--- a/src/test/codegen/async-fn-debug-msvc.rs
+++ b/src/test/codegen/async-fn-debug-msvc.rs
@@ -17,33 +17,33 @@ async fn async_fn_test() {
 // FIXME: No way to reliably check the filename.
 
 // CHECK-DAG:  [[ASYNC_FN:!.*]] = !DINamespace(name: "async_fn_test"
-// CHECK-DAG:  [[GEN:!.*]] = !DICompositeType(tag: DW_TAG_union_type, name: "generator-0", scope: [[ASYNC_FN]]
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK-DAG:  [[GEN:!.*]] = !DICompositeType(tag: DW_TAG_union_type, name: "generator-0"
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant0", scope: [[GEN]],
 // For brevity, we only check the struct name and members of the last variant.
 // CHECK-SAME: file: [[FILE:![0-9]*]], line: 11,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant1", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 15,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant2", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 15,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant3", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 12,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant4", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 14,
 // CHECK-SAME: baseType: [[VARIANT:![0-9]*]]
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      [[S1:!.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Suspend1", scope: [[ASYNC_FN]],
+// CHECK:      [[S1:!.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Suspend1", scope: [[GEN]],
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "RUST$ENUM$DISR", scope: [[S1]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant$", scope: [[S1]],
 // CHECK-SAME: flags: DIFlagArtificial
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: [[S1]]
 // CHECK-NOT:  flags: DIFlagArtificial

--- a/src/test/codegen/generator-debug-msvc.rs
+++ b/src/test/codegen/generator-debug-msvc.rs
@@ -21,33 +21,33 @@ fn generator_test() -> impl Generator<Yield = i32, Return = ()> {
 // FIXME: No way to reliably check the filename.
 
 // CHECK-DAG:  [[GEN_FN:!.*]] = !DINamespace(name: "generator_test"
-// CHECK-DAG:  [[GEN:!.*]] = !DICompositeType(tag: DW_TAG_union_type, name: "generator-0", scope: [[GEN_FN]]
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK-DAG:  [[GEN:!.*]] = !DICompositeType(tag: DW_TAG_union_type, name: "generator-0"
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant0", scope: [[GEN]],
 // For brevity, we only check the struct name and members of the last variant.
 // CHECK-SAME: file: [[FILE:![0-9]*]], line: 14,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant1", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 18,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant2", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 18,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant3", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 15,
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, scope: [[GEN]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant4", scope: [[GEN]],
 // CHECK-SAME: file: [[FILE]], line: 17,
 // CHECK-SAME: baseType: [[VARIANT:![0-9]*]]
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      [[S1:!.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Suspend1", scope: [[GEN_FN]],
+// CHECK:      [[S1:!.*]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Suspend1", scope: [[GEN]],
 // CHECK-NOT:  flags: DIFlagArtificial
 // CHECK-SAME: )
-// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "RUST$ENUM$DISR", scope: [[S1]],
+// CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "variant$", scope: [[S1]],
 // CHECK-SAME: flags: DIFlagArtificial
 // CHECK:      {{!.*}} = !DIDerivedType(tag: DW_TAG_member, name: "s", scope: [[S1]]
 // CHECK-NOT:  flags: DIFlagArtificial

--- a/src/test/debuginfo/msvc-pretty-enums.rs
+++ b/src/test/debuginfo/msvc-pretty-enums.rs
@@ -1,0 +1,104 @@
+// only-cdb
+// compile-flags:-g
+
+// cdb-command: g
+
+// Note: The natvis used to visualize niche-layout enums don't work correctly in cdb
+//       so the best we can do is to make sure we are generating the right debuginfo
+
+// cdb-command: dx -r2 a,!
+// cdb-check:a,!              [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
+// cdb-check:        [+0x000] __0              : Low (0x2) [Type: msvc_pretty_enums::CStyleEnum]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x2 [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
+
+// cdb-command: dx -r2 b,!
+// cdb-check:b,!              [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
+// cdb-check:        [+0x000] __0              : 0x11 [Type: msvc_pretty_enums::CStyleEnum]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : None (0x11) [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
+
+// cdb-command: dx -r2 c,!
+// cdb-check:c,!              [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
+// cdb-check:        [+0x000] my_data          : 0x11 [Type: msvc_pretty_enums::CStyleEnum]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : Tag1 (0x11) [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+
+// cdb-command: dx -r2 d,!
+// cdb-check:d,!              [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
+// cdb-check:        [+0x000] my_data          : High (0x10) [Type: msvc_pretty_enums::CStyleEnum]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x10 [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+
+// cdb-command: dx -r2 e,!
+// cdb-check:e,!              [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
+// cdb-check:        [+0x000] my_data          : 0x13 [Type: msvc_pretty_enums::CStyleEnum]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : Tag2 (0x13) [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+
+// cdb-command: dx -r2 f,!
+// cdb-check:f,!              [Type: _enum<core::option::Option<u32*>, 1, [...], Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::Some]
+// cdb-check:        [+0x000] __0              : 0x[...] : 0x1 [Type: unsigned int *]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::tag$]
+
+// cdb-command: dx -r2 g,!
+// cdb-check:g,!              [Type: _enum<core::option::Option<u32*>, 1, [...], Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::Some]
+// cdb-check:        [+0x000] __0              : 0x0 [Type: unsigned int *]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : None (0x0) [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::tag$]
+
+// cdb-command: dx h
+// cdb-check:h                : Some [Type: _enum<core::option::Option<u32>>]
+// cdb-check:    [+0x000] variant$         : Some (0x1) [Type: core::option::Option]
+// cdb-check:    [+0x004] __0              : 0xc [Type: unsigned int]
+
+// cdb-command: dx i
+// cdb-check:i                : None [Type: _enum<core::option::Option<u32>>]
+// cdb-check:    [+0x000] variant$         : None (0x0) [Type: core::option::Option]
+
+// cdb-command: dx j
+// cdb-check:j                : High (0x10) [Type: msvc_pretty_enums::CStyleEnum]
+
+// cdb-command: dx -r2 k,!
+// cdb-check:k,!              [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>::Some]
+// cdb-check:        [+0x000] __0              [Type: alloc::string::String]
+// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>::tag$]
+
+pub enum CStyleEnum {
+    Low = 2,
+    High = 16,
+}
+
+pub enum NicheLayoutEnum {
+    Tag1,
+    Data { my_data: CStyleEnum },
+    Tag2,
+}
+
+fn main() {
+    let a = Some(CStyleEnum::Low);
+    let b = Option::<CStyleEnum>::None;
+    let c = NicheLayoutEnum::Tag1;
+    let d = NicheLayoutEnum::Data { my_data: CStyleEnum::High };
+    let e = NicheLayoutEnum::Tag2;
+    let f = Some(&1u32);
+    let g = Option::<&'static u32>::None;
+    let h = Some(12u32);
+    let i = Option::<u32>::None;
+    let j = CStyleEnum::High;
+    let k = Some("IAMA optional string!".to_string());
+
+    zzz(); // #break
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/msvc-pretty-enums.rs
+++ b/src/test/debuginfo/msvc-pretty-enums.rs
@@ -11,50 +11,43 @@
 // cdb-check:a,!              [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
 // cdb-check:        [+0x000] __0              : Low (0x2) [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x2 [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
+// cdb-check:    [+0x000] discriminant     : 0x2 [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Discriminant$]
 
 // cdb-command: dx -r2 b,!
 // cdb-check:b,!              [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
 // cdb-check:        [+0x000] __0              : 0x11 [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : None (0x11) [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
+// cdb-check:    [+0x000] discriminant     : None (0x11) [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Discriminant$]
 
 // cdb-command: dx -r2 c,!
 // cdb-check:c,!              [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
 // cdb-check:        [+0x000] my_data          : 0x11 [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : Tag1 (0x11) [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+// cdb-check:    [+0x000] discriminant     : Tag1 (0x11) [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Discriminant$]
 
 // cdb-command: dx -r2 d,!
 // cdb-check:d,!              [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
 // cdb-check:        [+0x000] my_data          : High (0x10) [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x10 [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+// cdb-check:    [+0x000] discriminant     : 0x10 [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Discriminant$]
 
 // cdb-command: dx -r2 e,!
 // cdb-check:e,!              [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
 // cdb-check:        [+0x000] my_data          : 0x13 [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : Tag2 (0x13) [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+// cdb-check:    [+0x000] discriminant     : Tag2 (0x13) [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Discriminant$]
 
 // cdb-command: dx -r2 f,!
 // cdb-check:f,!              [Type: enum$<core::option::Option<u32*>, 1, [...], Some>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::Some]
 // cdb-check:        [+0x000] __0              : 0x[...] : 0x1 [Type: unsigned int *]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::tag$]
+// cdb-check:    [+0x000] discriminant     : 0x[...] [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::Discriminant$]
 
 // cdb-command: dx -r2 g,!
 // cdb-check:g,!              [Type: enum$<core::option::Option<u32*>, 1, [...], Some>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::Some]
 // cdb-check:        [+0x000] __0              : 0x0 [Type: unsigned int *]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : None (0x0) [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::tag$]
+// cdb-check:    [+0x000] discriminant     : None (0x0) [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::Discriminant$]
 
 // cdb-command: dx h
 // cdb-check:h                : Some [Type: enum$<core::option::Option<u32>>]
@@ -72,8 +65,7 @@
 // cdb-check:k,!              [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>]
 // cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>::Some]
 // cdb-check:        [+0x000] __0              [Type: alloc::string::String]
-// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>::tag$]
+// cdb-check:    [+0x000] discriminant     : 0x[...] [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>::Discriminant$]
 
 pub enum CStyleEnum {
     Low = 2,

--- a/src/test/debuginfo/msvc-pretty-enums.rs
+++ b/src/test/debuginfo/msvc-pretty-enums.rs
@@ -8,72 +8,72 @@
 //       so the best we can do is to make sure we are generating the right debuginfo
 
 // cdb-command: dx -r2 a,!
-// cdb-check:a,!              [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
+// cdb-check:a,!              [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
 // cdb-check:        [+0x000] __0              : Low (0x2) [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x2 [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x2 [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
 
 // cdb-command: dx -r2 b,!
-// cdb-check:b,!              [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
+// cdb-check:b,!              [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::Some]
 // cdb-check:        [+0x000] __0              : 0x11 [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : None (0x11) [Type: _enum<core::option::Option<_enum<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : None (0x11) [Type: enum$<core::option::Option<enum$<msvc_pretty_enums::CStyleEnum>>, 2, 16, Some>::tag$]
 
 // cdb-command: dx -r2 c,!
-// cdb-check:c,!              [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
+// cdb-check:c,!              [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
 // cdb-check:        [+0x000] my_data          : 0x11 [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : Tag1 (0x11) [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : Tag1 (0x11) [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
 
 // cdb-command: dx -r2 d,!
-// cdb-check:d,!              [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
+// cdb-check:d,!              [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
 // cdb-check:        [+0x000] my_data          : High (0x10) [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x10 [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x10 [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
 
 // cdb-command: dx -r2 e,!
-// cdb-check:e,!              [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
+// cdb-check:e,!              [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::Data]
 // cdb-check:        [+0x000] my_data          : 0x13 [Type: msvc_pretty_enums::CStyleEnum]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : Tag2 (0x13) [Type: _enum<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : Tag2 (0x13) [Type: enum$<msvc_pretty_enums::NicheLayoutEnum, 2, 16, Data>::tag$]
 
 // cdb-command: dx -r2 f,!
-// cdb-check:f,!              [Type: _enum<core::option::Option<u32*>, 1, [...], Some>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::Some]
+// cdb-check:f,!              [Type: enum$<core::option::Option<u32*>, 1, [...], Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::Some]
 // cdb-check:        [+0x000] __0              : 0x[...] : 0x1 [Type: unsigned int *]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::tag$]
 
 // cdb-command: dx -r2 g,!
-// cdb-check:g,!              [Type: _enum<core::option::Option<u32*>, 1, [...], Some>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::Some]
+// cdb-check:g,!              [Type: enum$<core::option::Option<u32*>, 1, [...], Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::Some]
 // cdb-check:        [+0x000] __0              : 0x0 [Type: unsigned int *]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : None (0x0) [Type: _enum<core::option::Option<u32*>, 1, [...], Some>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : None (0x0) [Type: enum$<core::option::Option<u32*>, 1, [...], Some>::tag$]
 
 // cdb-command: dx h
-// cdb-check:h                : Some [Type: _enum<core::option::Option<u32>>]
+// cdb-check:h                : Some [Type: enum$<core::option::Option<u32>>]
 // cdb-check:    [+0x000] variant$         : Some (0x1) [Type: core::option::Option]
 // cdb-check:    [+0x004] __0              : 0xc [Type: unsigned int]
 
 // cdb-command: dx i
-// cdb-check:i                : None [Type: _enum<core::option::Option<u32>>]
+// cdb-check:i                : None [Type: enum$<core::option::Option<u32>>]
 // cdb-check:    [+0x000] variant$         : None (0x0) [Type: core::option::Option]
 
 // cdb-command: dx j
 // cdb-check:j                : High (0x10) [Type: msvc_pretty_enums::CStyleEnum]
 
 // cdb-command: dx -r2 k,!
-// cdb-check:k,!              [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>]
-// cdb-check:    [+0x000] dataful_variant  [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>::Some]
+// cdb-check:k,!              [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>]
+// cdb-check:    [+0x000] dataful_variant  [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>::Some]
 // cdb-check:        [+0x000] __0              [Type: alloc::string::String]
-// cdb-check:    [+0x000] discriminant$    [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>::discriminant$]
-// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>::tag$]
+// cdb-check:    [+0x000] discriminant$    [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>::discriminant$]
+// cdb-check:        [+0x000] discriminant     : 0x[...] [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>::tag$]
 
 pub enum CStyleEnum {
     Low = 2,

--- a/src/test/debuginfo/msvc-pretty-enums.rs
+++ b/src/test/debuginfo/msvc-pretty-enums.rs
@@ -1,4 +1,5 @@
 // only-cdb
+// ignore-tidy-linelength
 // compile-flags:-g
 
 // cdb-command: g

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -1,6 +1,7 @@
 // ignore-freebsd: gdb package too new
 // only-cdb // "Temporarily" ignored on GDB/LLDB due to debuginfo tests being disabled, see PR 47155
 // ignore-android: FIXME(#10381)
+// ignore-tidy-linelength
 // compile-flags:-g
 // min-gdb-version: 7.7
 // min-lldb-version: 310
@@ -115,7 +116,7 @@
 // cdb-command: dx none
 // cdb-check:none             : None [Type: _enum<core::option::Option<i64>>]
 // cdb-command: dx some_string
-// cdb-check:some_string      [Type: _enum<core::option::Option<alloc::string::String>, 1, 18446744073709551615, Some>]
+// cdb-check:some_string      [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>]
 
 #![allow(unused_variables)]
 use std::ffi::OsString;

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -111,11 +111,11 @@
 // NOTE: OsString doesn't have a .natvis entry yet.
 
 // cdb-command: dx some
-// cdb-check:some             : Some(8) [Type: [...]::Option<i16>]
+// cdb-check:some             : Some [Type: _enum<core::option::Option<i16>>]
 // cdb-command: dx none
-// cdb-check:none             : None [Type: [...]::Option<i64>]
+// cdb-check:none             : None [Type: _enum<core::option::Option<i64>>]
 // cdb-command: dx some_string
-// cdb-check:some_string      : Some("IAMA optional string!") [[...]::Option<[...]::String>]
+// cdb-check:some_string      [Type: _enum<core::option::Option<alloc::string::String>, 1, 18446744073709551615, Some>]
 
 #![allow(unused_variables)]
 use std::ffi::OsString;

--- a/src/test/debuginfo/pretty-std.rs
+++ b/src/test/debuginfo/pretty-std.rs
@@ -112,11 +112,11 @@
 // NOTE: OsString doesn't have a .natvis entry yet.
 
 // cdb-command: dx some
-// cdb-check:some             : Some [Type: _enum<core::option::Option<i16>>]
+// cdb-check:some             : Some [Type: enum$<core::option::Option<i16>>]
 // cdb-command: dx none
-// cdb-check:none             : None [Type: _enum<core::option::Option<i64>>]
+// cdb-check:none             : None [Type: enum$<core::option::Option<i64>>]
 // cdb-command: dx some_string
-// cdb-check:some_string      [Type: _enum<core::option::Option<alloc::string::String>, 1, [...], Some>]
+// cdb-check:some_string      [Type: enum$<core::option::Option<alloc::string::String>, 1, [...], Some>]
 
 #![allow(unused_variables)]
 use std::ffi::OsString;


### PR DESCRIPTION
This PR makes significant improvements over the status quo of debugging enums on the windows-msvc platform with either WinDbg or Visual Studio in three ways:

1. Improves the debugger experience for directly tagged enums.
2. Fixes a bug which caused the debugger to sometimes show the wrong debug info for niche layout enums. For example, `Option<&u32>` could sometimes use the debug info for `Option<&f64>` instead leading to nonsensical variable values in the debugger.
3. Significantly improves the debugger experience for niche-layout enums.

Let's look at a few examples:

```rust
pub enum CStyleEnum {
    Base = 2,
    Exponent = 16,
}

pub enum NicheLayoutEnum {
    Tag1,
    Data { my_data: CStyleEnum },
    Tag2,
    Tag3,
    Tag4,
}

pub enum OtherEnum<T> {
    Case1(T),
    Case2(T),
}

fn main() {
    let a = Some(CStyleEnum::Base);
    let b = Option::<CStyleEnum>::None;
    let c = NicheLayoutEnum::Tag1;
    let d = NicheLayoutEnum::Data { my_data: CStyleEnum::Exponent };
    let e = NicheLayoutEnum::Tag2;
    let f = Some(&1u32);
    let g = Option::<&'static u32>::None;
    let h = Some(&2u64);
    let i = Option::<&'static u64>::None;
    let j = Some(12u32);
    let k = Option::<u32>::None;
    let l = Some(12.34f64);
    let m = Option::<f64>::None;
    let n = CStyleEnum::Base;
    let o = CStyleEnum::Exponent;
    let p = Some("IAMA optional string!".to_string());
    let q = OtherEnum::Case1(42u32);
}
```

This is what WinDbg Preview shows using the latest rustc nightly:

![image](https://user-images.githubusercontent.com/831192/118285353-57c10780-b49f-11eb-97aa-db3abfc09508.png)

Most of the variables don't show a meaningful value expect for a few cases that we have targeted natvis definitions covering. Even worse, drilling into many of these variables shows information that can be difficult to interpret without an understanding of the layout of Rust types:

![image](https://user-images.githubusercontent.com/831192/118285609-a1a9ed80-b49f-11eb-9c29-b14576984647.png)

With the changes in this PR, we're able to write two natvis definitions that cover all enum cases generally. After building with these changes, WinDbg now shows this instead:

![image](https://user-images.githubusercontent.com/831192/118287730-be472500-b4a1-11eb-8cad-8f6a91c7516b.png)

Drilling into the same variables, we can see much more useful information:

![image](https://user-images.githubusercontent.com/831192/118287888-e20a6b00-b4a1-11eb-927f-32cf33a31c16.png)

Fixes #84670
Fixes #84671