### PR TITLE
Fix how allow/warn/deny/forbid `warnings` is handled

### DIFF
--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -88,7 +88,7 @@ impl<'s> LintLevelsBuilder<'s> {
         self.sets.lint_cap = sess.opts.lint_cap.unwrap_or(Level::Forbid);
 
         for (position, &(ref lint_name, level)) in (0u32..).zip(sess.opts.lint_opts.iter()) {
-            store.check_lint_name_cmdline(sess, &lint_name, level);
+            store.check_lint_name_cmdline(sess, &lint_name, Some(level));
             let orig_level = level;
 
             // If the cap is less than this specified level, e.g., if we've got
@@ -129,8 +129,6 @@ impl<'s> LintLevelsBuilder<'s> {
                 self.sets.force_warns.extend(&lints);
             }
         }
-
-        self.sets.list.push(LintSet::CommandLine { specs });
     }
 
     fn get_current_depth(&self) -> u32 {

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1169,16 +1169,8 @@ pub fn get_cmd_lint_options(
     let mut lint_opts_with_position = vec![];
     let mut describe_lints = false;
 
-    for level in [lint::Allow, lint::Warn, lint::Deny, lint::Forbid] {
-        for (passed_arg_pos, lint_name) in matches.opt_strs_pos(level.as_str()) {
-            let arg_pos = if let lint::Forbid = level {
-                // HACK: forbid is always specified last, so it can't be overridden.
-                // FIXME: remove this once <https://github.com/rust-lang/rust/issues/70819> is
-                // fixed and `forbid` works as expected.
-                usize::MAX
-            } else {
-                passed_arg_pos
-            };
+    for &level in &[lint::Allow, lint::Warn, lint::Deny, lint::Forbid] {
+        for (arg_pos, lint_name) in matches.opt_strs_pos(level.as_str()) {
             if lint_name == "help" {
                 describe_lints = true;
             } else {

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1266,8 +1266,11 @@ pub fn build_session(
         .lint_opts
         .iter()
         .filter(|&&(ref key, _)| *key == "warnings")
-        .map(|&(_, ref level)| *level == lint::Allow)
+        // We are only interested in the last one, because there might be a chain
+        // of `-A warnings -D warnings -W warnings ...`, and only the last one
+        // should have an effect
         .last()
+        .map(|&(_, ref level)| *level == lint::Allow)
         .unwrap_or(false);
     let cap_lints_allow = sopts.lint_cap.map_or(false, |cap| cap == lint::Allow);
     let can_emit_warnings = !(warnings_allow || cap_lints_allow);

--- a/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.rs
+++ b/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.rs
@@ -1,7 +1,10 @@
 // aux-build:lint-group-plugin-test.rs
-// compile-flags: -F unused -A unused
+// compile-flags: -F unused -D forbidden_lint_groups -A unused -Z deduplicate-diagnostics=yes
+//~^^ ERROR: allow(unused) incompatible
+//~| WARNING: this was previously accepted
+//~| ERROR: allow(unused) incompatible
+//~| WARNING: this was previously accepted
 
 fn main() {
     let x = 1;
-    //~^ ERROR unused variable: `x`
 }

--- a/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.stderr
+++ b/src/test/ui-fulldeps/lint-group-forbid-always-trumps-cli.stderr
@@ -1,10 +1,15 @@
-error: unused variable: `x`
-  --> $DIR/lint-group-forbid-always-trumps-cli.rs:5:9
+error: allow(unused) incompatible with previous forbid
    |
-LL |     let x = 1;
-   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
-   |
-   = note: `-F unused-variables` implied by `-F unused`
+   = note: requested on the command line with `-D forbidden-lint-groups`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: `forbid` lint level was set on command line
 
-error: aborting due to previous error
+error: allow(unused) incompatible with previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: `forbid` lint level was set on command line
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/lint/issue-41941.rs
+++ b/src/test/ui/lint/issue-41941.rs
@@ -1,0 +1,10 @@
+// Checks whether exceptions can be added to #![deny(warnings)].
+// check-pass
+
+#![deny(warnings)]
+#![warn(unused_variables)]
+
+fn main() {
+    let a = 5;
+    //~^ WARNING: unused
+}

--- a/src/test/ui/lint/issue-41941.stderr
+++ b/src/test/ui/lint/issue-41941.stderr
@@ -1,0 +1,14 @@
+warning: unused variable: `a`
+  --> $DIR/issue-41941.rs:8:9
+   |
+LL |     let a = 5;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
+   |
+note: the lint level is defined here
+  --> $DIR/issue-41941.rs:5:9
+   |
+LL | #![warn(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/src/test/ui/lint/issue-70819-command-line-F.rs
+++ b/src/test/ui/lint/issue-70819-command-line-F.rs
@@ -1,0 +1,7 @@
+// compile-flags: -Z deduplicate-diagnostics=yes -F unused -D forbidden_lint_groups -A unused
+//~^ ERROR: allow(unused) incompatible
+//~| WARNING: this was previously accepted
+//~| ERROR: allow(unused) incompatible
+//~| WARNING: this was previously accepted
+
+fn main() {}

--- a/src/test/ui/lint/issue-70819-command-line-F.stderr
+++ b/src/test/ui/lint/issue-70819-command-line-F.stderr
@@ -1,0 +1,15 @@
+error: allow(unused) incompatible with previous forbid
+   |
+   = note: requested on the command line with `-D forbidden-lint-groups`
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: `forbid` lint level was set on command line
+
+error: allow(unused) incompatible with previous forbid
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
+   = note: `forbid` lint level was set on command line
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lint/issue-75668.rs
+++ b/src/test/ui/lint/issue-75668.rs
@@ -1,0 +1,10 @@
+// Checks that `-A warnings` on the command line can be overridden.
+// compile-flags: -A warnings
+// check-pass
+
+#![warn(unused)]
+
+fn main() {
+    let a = 5;
+    //~^ WARNING: unused
+}

--- a/src/test/ui/lint/issue-75668.stderr
+++ b/src/test/ui/lint/issue-75668.stderr
@@ -1,0 +1,13 @@
+warning: unused variable: `a`
+  --> $DIR/issue-75668.rs:8:9
+   |
+LL |     let a = 5;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
+   |
+note: the lint level is defined here
+  --> $DIR/issue-75668.rs:5:9
+   |
+LL | #![warn(unused)]
+   |         ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+

--- a/src/test/ui/lint/override-command-line-D.rs
+++ b/src/test/ui/lint/override-command-line-D.rs
@@ -1,0 +1,8 @@
+// compile-flags: -D warnings
+// check-pass
+
+fn main() {
+    #[warn(unused)]
+    let a = 5;
+    //~^ WARNING: unused
+}

--- a/src/test/ui/lint/override-command-line-D.stderr
+++ b/src/test/ui/lint/override-command-line-D.stderr
@@ -1,0 +1,15 @@
+warning: unused variable: `a`
+  --> $DIR/override-command-line-D.rs:6:9
+   |
+LL |     let a = 5;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_a`
+   |
+note: the lint level is defined here
+  --> $DIR/override-command-line-D.rs:5:12
+   |
+LL |     #[warn(unused)]
+   |            ^^^^^^
+   = note: `#[warn(unused_variables)]` implied by `#[warn(unused)]`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This pull request attempts to fix #41941, fix #70819 (the command line part, which is why the issue was reopened), and fix #75668. The current implementation of `warnings` (as in `-D warnings` or `#[allow(warnings)]`) is "lazy" in that `warnings` is not considered by the linter until it is about to emit a warning, in which case it checks whether an allow/deny/forbid of `warnings` is in scope and up-/downgrades the warning accordingly.

The problem with this approach is that one can never get an (e.g.) `#![allow(warnings)]` _out of scope_ again except by shadowing it with another `#[warn/deny/forbid(warnings)]`; ideally, though, one would also want more fine-grained control, such as
```rust
#![allow(warnings)]

fn main() {
    #[warn(unused)]
    let a = 5;
}
```
which compiles without warnings and errors on current nightly but causes a warning with my changes (as one would expect, I would argue).

My solution basically consists of adding a "depth" and "position" to `LintLevelSource`. This way, whenever a warning is about to be issued, we can check the source of the warning _and_ the source of the `warnings` pseudo-lint (if any), and see whether the latter can override the former. For instance, the following causes an error on nightly and a warning with my changes:
```rust
#[warn(unused)]
#[deny(warnings)] // Same depth, greater position (in the attributes list), overrides `warn(unused)`
fn main() {
    #[warn(unused_variables)] // Greater depth, overrides `deny(warnings)`
    let a = 5;
}
```

I've also worked on the command line arguments: Calling `rustc` with `-F warnings -A unused` works without errors or warnings on current nightly; with my changes, I get
```
warning: allow(unused) incompatible with previous forbid
  |
  = note: `#[warn(forbidden_lint_groups)]` on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #81670 <https://github.com/rust-lang/rust/issues/81670>
  = note: `forbid` lint level was set on command line
```
