### PR TITLE
Add DerefOfRawPointer and CallToFunctionWith to THIR unsafeck

### DIFF
--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -153,6 +153,11 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             ExprKind::InlineAsm { .. } | ExprKind::LlvmInlineAsm { .. } => {
                 self.requires_unsafe(expr.span, UseOfInlineAssembly);
             }
+            ExprKind::Deref { arg } => {
+                if self.thir[arg].ty.is_unsafe_ptr() {
+                    self.requires_unsafe(expr.span, DerefOfRawPointer);
+                }
+            }
             _ => {}
         }
 
@@ -203,7 +208,6 @@ enum UnsafeOpKind {
     UseOfMutableStatic,
     #[allow(dead_code)] // FIXME
     UseOfExternStatic,
-    #[allow(dead_code)] // FIXME
     DerefOfRawPointer,
     #[allow(dead_code)] // FIXME
     AssignToDroppingUnionField,

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.mir.stderr
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-45729-unsafe-in-generator.rs:5:9
+  --> $DIR/issue-45729-unsafe-in-generator.rs:8:9
    |
 LL |         *(1 as *mut u32) = 42;
    |         ^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.rs
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![feature(generators)]
 
 fn main() {

--- a/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
+++ b/src/test/ui/generator/issue-45729-unsafe-in-generator.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-45729-unsafe-in-generator.rs:8:9
+   |
+LL |         *(1 as *mut u32) = 42;
+   |         ^^^^^^^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/issues/issue-47412.mir.stderr
+++ b/src/test/ui/issues/issue-47412.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: access to union field is unsafe and requires unsafe function or block
-  --> $DIR/issue-47412.rs:11:11
+  --> $DIR/issue-47412.rs:14:11
    |
 LL |     match u.void {}
    |           ^^^^^^ access to union field
@@ -7,7 +7,7 @@ LL |     match u.void {}
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-47412.rs:17:11
+  --> $DIR/issue-47412.rs:21:11
    |
 LL |     match *ptr {}
    |           ^^^^ dereference of raw pointer

--- a/src/test/ui/issues/issue-47412.rs
+++ b/src/test/ui/issues/issue-47412.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #[derive(Copy, Clone)]
 enum Void {}
 
@@ -9,7 +12,8 @@ fn union_field() {
     union Union { unit: (), void: Void }
     let u = Union { unit: () };
     match u.void {}
-    //~^ ERROR access to union field is unsafe
+    //[mir]~^ ERROR access to union field is unsafe
+    // FIXME(thir-unsafeck): AccessToUnionField unimplemented
 }
 
 fn raw_ptr_deref() {

--- a/src/test/ui/issues/issue-47412.thir.stderr
+++ b/src/test/ui/issues/issue-47412.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-47412.rs:21:11
+   |
+LL |     match *ptr {}
+   |           ^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/check-pass.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/check-pass.rs
@@ -8,6 +8,8 @@
 
 // check-pass
 // only-x86_64
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 
 #![feature(target_feature_11)]
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/closures-inherit-target_feature.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/closures-inherit-target_feature.rs
@@ -1,6 +1,8 @@
 // Tests #73631: closures inherit `#[target_feature]` annotations
 
 // check-pass
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.mir.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/fn-ptr.rs:9:21
+  --> $DIR/fn-ptr.rs:11:21
    |
 LL | #[target_feature(enable = "sse2")]
    | ---------------------------------- `#[target_feature]` added here

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.rs
@@ -1,3 +1,5 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.thir.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> $DIR/fn-ptr.rs:11:21
+   |
+LL | #[target_feature(enable = "sse2")]
+   | ---------------------------------- `#[target_feature]` added here
+...
+LL |     let foo: fn() = foo;
+   |              ----   ^^^ cannot coerce functions with `#[target_feature]` to safe function pointers
+   |              |
+   |              expected due to this
+   |
+   = note: expected fn pointer `fn()`
+                 found fn item `fn() {foo}`
+   = note: functions with `#[target_feature]` can only be coerced to `unsafe` function pointers
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
@@ -1,69 +1,69 @@
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:21:5
-   |
-LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:22:5
-   |
-LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:23:5
    |
-LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:28:5
-   |
-LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:29:5
-   |
-LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:34:5
-   |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:35:5
+  --> $DIR/safe-calls.rs:24:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:25:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:30:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:31:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:36:5
    |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:37:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:38:5
+   |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:42:5
+  --> $DIR/safe-calls.rs:44:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -71,7 +71,7 @@ LL |     sse2();
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:45:18
+  --> $DIR/safe-calls.rs:47:18
    |
 LL | const name: () = sse2();
    |                  ^^^^^^ call to function with `#[target_feature]`

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
@@ -1,3 +1,5 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
@@ -1,0 +1,83 @@
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:23:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:24:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:25:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:30:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:31:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:36:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:37:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:38:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:44:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:47:18
+   |
+LL | const name: () = sse2();
+   |                  ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/traits/safety-fn-body.mir.stderr
+++ b/src/test/ui/traits/safety-fn-body.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/safety-fn-body.rs:14:9
+   |
+LL |         *self += 1;
+   |         ^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/traits/safety-fn-body.rs
+++ b/src/test/ui/traits/safety-fn-body.rs
@@ -1,6 +1,9 @@
 // Check that an unsafe impl does not imply that unsafe actions are
 // legal in the methods.
 
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 unsafe trait UnsafeTrait : Sized {
     fn foo(self) { }
 }

--- a/src/test/ui/traits/safety-fn-body.thir.stderr
+++ b/src/test/ui/traits/safety-fn-body.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/safety-fn-body.rs:14:9
+   |
+LL |         *self += 1;
+   |         ^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.mir.stderr
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/safety-fn-body.rs:11:9
+  --> $DIR/issue-45087-unreachable-unsafe.rs:6:5
    |
-LL |         *self += 1;
-   |         ^^^^^^^^^^ dereference of raw pointer
+LL |     *(1 as *mut u32) = 42;
+   |     ^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
    |
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.rs
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 fn main() {
     return;
     *(1 as *mut u32) = 42;

--- a/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
+++ b/src/test/ui/unsafe/issue-45087-unreachable-unsafe.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/issue-45087-unreachable-unsafe.rs:6:5
+   |
+LL |     *(1 as *mut u32) = 42;
+   |     ^^^^^^^^^^^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.mir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-fn-assign-deref-ptr.rs:5:5
+   |
+LL |     *p = 0;
+   |     ^^^^^^ dereference of raw pointer
+   |
+   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.rs
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 fn f(p: *mut u8) {
     *p = 0; //~ ERROR dereference of raw pointer is unsafe
     return;

--- a/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-assign-deref-ptr.thir.stderr
@@ -1,10 +1,10 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-unstable-const-fn.rs:8:5
+  --> $DIR/unsafe-fn-assign-deref-ptr.rs:5:5
    |
-LL |     *a == b
+LL |     *p = 0;
    |     ^^ dereference of raw pointer
    |
-   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-fn-assign-deref-ptr.rs:2:5
+  --> $DIR/unsafe-fn-deref-ptr.rs:5:12
    |
-LL |     *p = 0;
-   |     ^^^^^^ dereference of raw pointer
+LL |     return *p;
+   |            ^^ dereference of raw pointer
    |
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.rs
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 fn f(p: *const u8) -> u8 {
     return *p; //~ ERROR dereference of raw pointer is unsafe
 }

--- a/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-deref-ptr.thir.stderr
@@ -1,10 +1,10 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-fn-deref-ptr.rs:2:12
+  --> $DIR/unsafe-fn-deref-ptr.rs:5:12
    |
 LL |     return *p;
    |            ^^ dereference of raw pointer
    |
-   = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.mir.stderr
@@ -1,8 +1,8 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-45087-unreachable-unsafe.rs:3:5
+  --> $DIR/unsafe-unstable-const-fn.rs:11:5
    |
-LL |     *(1 as *mut u32) = 42;
-   |     ^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
+LL |     *a == b
+   |     ^^ dereference of raw pointer
    |
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.rs
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.rs
@@ -1,3 +1,6 @@
+// revisions: mir thir
+// [thir]compile-flags: -Z thir-unsafeck
+
 #![stable(feature = "foo", since = "1.33.0")]
 #![feature(staged_api)]
 #![feature(const_raw_ptr_deref)]

--- a/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-unstable-const-fn.thir.stderr
@@ -1,0 +1,11 @@
+error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
+  --> $DIR/unsafe-unstable-const-fn.rs:11:5
+   |
+LL |     *a == b
+   |     ^^ dereference of raw pointer
+   |
+   = note: raw pointers may be NULL, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
Extends THIR unsafeck to check for two more cases of unsafe operations: dereferences of raw pointers and calls to functions with `#[target_feature]` (RFC 2396). The check for the latter is pretty much copy-pasted from the existing MIR equivalent.

This will clash with #83842 and #85273 which are arguably more important, let's maybe focus on getting those merged first, this can wait.
r? @nikomatsakis
cc rust-lang/project-thir-unsafeck#7