### PR TITLE
Box `Impl.blanket_impl` to reduce size

### DIFF
--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -119,7 +119,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             .clean(self.cx),
                         negative_polarity: false,
                         synthetic: false,
-                        blanket_impl: Some(trait_ref.self_ty().clean(self.cx)),
+                        blanket_impl: Some(box trait_ref.self_ty().clean(self.cx)),
                     }),
                     cfg: None,
                 });

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -2235,7 +2235,7 @@ crate struct Impl {
     crate items: Vec<Item>,
     crate negative_polarity: bool,
     crate synthetic: bool,
-    crate blanket_impl: Option<Type>,
+    crate blanket_impl: Option<Box<Type>>,
 }
 
 impl Impl {

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -482,7 +482,7 @@ impl FromWithTcx<clean::Impl> for Impl {
             items: ids(items),
             negative: negative_polarity,
             synthetic,
-            blanket_impl: blanket_impl.map(|x| x.into_tcx(tcx)),
+            blanket_impl: blanket_impl.map(|x| (*x).into_tcx(tcx)),
         }
     }
 }


### PR DESCRIPTION
Blanket impls are probably not super common, and `Type` is a fairly
large type, so this should reduce `Impl`'s size by a lot: `Option<Type>`
is around 96 bytes, and `Option<Box<Type>>` is 8 bytes, so it's a big
difference!
