### PR TITLE
Warn about unused `pub` fields in non-`pub` structs

### DIFF
--- a/src/test/ui/cast/issue-84213.fixed
+++ b/src/test/ui/cast/issue-84213.fixed
@@ -6,6 +6,7 @@ struct Something {
 
 fn main() {
     let mut something = Something { field: 1337 };
+    let _ = something.field;
 
     let _pointer_to_something = &something as *const Something;
     //~^ ERROR: non-primitive cast

--- a/src/test/ui/cast/issue-84213.rs
+++ b/src/test/ui/cast/issue-84213.rs
@@ -6,6 +6,7 @@ struct Something {
 
 fn main() {
     let mut something = Something { field: 1337 };
+    let _ = something.field;
 
     let _pointer_to_something = something as *const Something;
     //~^ ERROR: non-primitive cast

--- a/src/test/ui/cast/issue-84213.stderr
+++ b/src/test/ui/cast/issue-84213.stderr
@@ -1,5 +1,5 @@
 error[E0605]: non-primitive cast: `Something` as `*const Something`
-  --> $DIR/issue-84213.rs:10:33
+  --> $DIR/issue-84213.rs:11:33
    |
 LL |     let _pointer_to_something = something as *const Something;
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid cast
@@ -10,7 +10,7 @@ LL |     let _pointer_to_something = &something as *const Something;
    |                                 ^
 
 error[E0605]: non-primitive cast: `Something` as `*mut Something`
-  --> $DIR/issue-84213.rs:13:37
+  --> $DIR/issue-84213.rs:14:37
    |
 LL |     let _mut_pointer_to_something = something as *mut Something;
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid cast

--- a/src/test/ui/lint/dead-code/issue-85255.rs
+++ b/src/test/ui/lint/dead-code/issue-85255.rs
@@ -1,0 +1,22 @@
+// Unused `pub` fields in non-`pub` structs should also trigger dead code warnings.
+// check-pass
+
+#![warn(dead_code)]
+
+struct Foo {
+    a: i32, //~ WARNING: field is never read
+    pub b: i32, //~ WARNING: field is never read
+}
+
+struct Bar;
+
+impl Bar {
+    fn a(&self) -> i32 { 5 } //~ WARNING: associated function is never used
+    pub fn b(&self) -> i32 { 6 } //~ WARNING: associated function is never used
+}
+
+
+fn main() {
+    let _ = Foo { a: 1, b: 2 };
+    let _ = Bar;
+}

--- a/src/test/ui/lint/dead-code/issue-85255.stderr
+++ b/src/test/ui/lint/dead-code/issue-85255.stderr
@@ -1,0 +1,32 @@
+warning: field is never read: `a`
+  --> $DIR/issue-85255.rs:7:5
+   |
+LL |     a: i32,
+   |     ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-85255.rs:4:9
+   |
+LL | #![warn(dead_code)]
+   |         ^^^^^^^^^
+
+warning: field is never read: `b`
+  --> $DIR/issue-85255.rs:8:5
+   |
+LL |     pub b: i32,
+   |     ^^^^^^^^^^
+
+warning: associated function is never used: `a`
+  --> $DIR/issue-85255.rs:14:8
+   |
+LL |     fn a(&self) -> i32 { 5 }
+   |        ^
+
+warning: associated function is never used: `b`
+  --> $DIR/issue-85255.rs:15:12
+   |
+LL |     pub fn b(&self) -> i32 { 6 }
+   |            ^
+
+warning: 4 warnings emitted
+


### PR DESCRIPTION
This pull request fixes #85255. The current implementation of dead code analysis is too prudent because it marks all `pub` fields of structs as live, even though they cannot be accessed from outside of the current crate if the struct itself only has restricted or private visibility.

I have changed this behavior to take the containing struct's visibility into account when looking at field visibility and liveness. This also makes dead code warnings more consistent; consider the example given in #85255:
```rust
struct Foo {
    a: i32,
    pub b: i32,
}

struct Bar;

impl Bar {
    fn a(&self) -> i32 { 5 }
    pub fn b(&self) -> i32 { 6 }
}


fn main() {
    let _ = Foo { a: 1, b: 2 };
    let _ = Bar;
}
```
Current nightly already warns about `Bar::b()`, even though it is `pub` (but `Bar` is not). It should therefore also warn about `Foo::b`, which it does with the changes in this PR.
