### PR TITLE
fix version_str comment

### DIFF
--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -922,7 +922,7 @@ impl<'a> MutVisitor for ReplaceBodyWithLoop<'a, '_> {
     }
 }
 
-/// Returns a version string such as "rustc 1.46.0 (04488afe3 2020-08-24)"
+/// Returns a version string such as "1.46.0 (04488afe3 2020-08-24)"
 pub fn version_str() -> Option<&'static str> {
     option_env!("CFG_VERSION")
 }


### PR DESCRIPTION
This version string is ultimately generated here
https://github.com/rust-lang/rust/blob/87423fbc6af5aae2b5f6d0a11f2a0c60c7c22e98/src/bootstrap/channel.rs#L72
and I don't think it includes the `rustc` prefix. That also matches its use here
https://github.com/rust-lang/rust/blob/ac923d94f86a6f7c881ecbedcd0a68d7986a35bd/compiler/rustc_driver/src/lib.rs#L758