### PR TITLE
CTFE validation: handle pointers in str

### DIFF
--- a/compiler/rustc_mir/src/interpret/validity.rs
+++ b/compiler/rustc_mir/src/interpret/validity.rs
@@ -833,6 +833,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValueVisitor<'mir, 'tcx, M>
                     self.ecx.memory.read_bytes(mplace.ptr, Size::from_bytes(len)),
                     self.path,
                     err_ub!(InvalidUninitBytes(..)) => { "uninitialized data in `str`" },
+                    err_unsup!(ReadPointerAsBytes) => { "a pointer in `str`" },
                 );
             }
             ty::Array(tys, ..) | ty::Slice(tys)

--- a/src/test/ui/consts/const-eval/dangling.rs
+++ b/src/test/ui/consts/const-eval/dangling.rs
@@ -3,13 +3,11 @@
 use std::mem;
 
 // Make sure we error with the right kind of error on a too large slice.
-const TEST: () = { unsafe { //~ NOTE
+const TEST: () = { unsafe {
     let slice: *const [u8] = mem::transmute((1usize, usize::MAX));
     let _val = &*slice; //~ ERROR: any use of this value will cause an error
-    //~| NOTE: slice is bigger than largest supported object
-    //~| on by default
+    //~| slice is bigger than largest supported object
     //~| WARN this was previously accepted by the compiler but is being phased out
-    //~| NOTE
 } };
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/dangling.stderr
+++ b/src/test/ui/consts/const-eval/dangling.stderr
@@ -6,7 +6,6 @@ LL | |     let slice: *const [u8] = mem::transmute((1usize, usize::MAX));
 LL | |     let _val = &*slice;
    | |                ^^^^^^^ invalid metadata in wide pointer: slice is bigger than largest supported object
 LL | |
-...  |
 LL | |
 LL | | } };
    | |____-

--- a/src/test/ui/consts/const-points-to-static.rs
+++ b/src/test/ui/consts/const-points-to-static.rs
@@ -5,9 +5,7 @@
 
 const TEST: &u8 = &MY_STATIC;
 //~^ ERROR it is undefined behavior to use this value
-//~| NOTE  encountered a reference pointing to a static variable
-//~| NOTE undefined behavior
-//~| NOTE the raw bytes of the constant
+//~| encountered a reference pointing to a static variable
 
 static MY_STATIC: u8 = 4;
 

--- a/src/test/ui/consts/issue-83182.32bit.stderr
+++ b/src/test/ui/consts/issue-83182.32bit.stderr
@@ -1,12 +1,12 @@
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-83182.rs:3:1
+  --> $DIR/issue-83182.rs:5:1
    |
 LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer in `str` at .<deref>.0
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────alloc3────────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾─alloc3──╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error: aborting due to previous error

--- a/src/test/ui/consts/issue-83182.64bit.stderr
+++ b/src/test/ui/consts/issue-83182.64bit.stderr
@@ -1,0 +1,14 @@
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/issue-83182.rs:5:1
+   |
+LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer in `str` at .<deref>.0
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾───────alloc3────────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/issue-83182.rs
+++ b/src/test/ui/consts/issue-83182.rs
@@ -1,0 +1,6 @@
+use std::mem;
+struct MyStr(str);
+const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
+//~^ ERROR: it is undefined behavior to use this value
+//~| type validation failed: encountered a pointer in `str`
+fn main() {}

--- a/src/test/ui/consts/issue-83182.rs
+++ b/src/test/ui/consts/issue-83182.rs
@@ -1,3 +1,5 @@
+// stderr-per-bitwidth
+
 use std::mem;
 struct MyStr(str);
 const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };

--- a/src/test/ui/consts/issue-83182.stderr
+++ b/src/test/ui/consts/issue-83182.stderr
@@ -1,0 +1,14 @@
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/issue-83182.rs:3:1
+   |
+LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[&()]) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer in `str` at .<deref>.0
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾───────alloc3────────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.32bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.32bit.stderr
@@ -3,8 +3,6 @@ error[E0080]: it is undefined behavior to use this value
    |
 LL | / const REF_INTERIOR_MUT: &usize = {
 LL | |
-LL | |
-LL | |
 LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
 LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
 LL | | };
@@ -16,11 +14,9 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:20:1
+  --> $DIR/const_refers_to_static2.rs:18:1
    |
 LL | / const READ_IMMUT: &usize = {
-LL | |
-LL | |
 LL | |
 LL | |     static FOO: usize = 0;
 LL | |     &FOO
@@ -35,17 +31,17 @@ LL | | };
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static2.rs:16:18
+  --> $DIR/const_refers_to_static2.rs:14:18
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }
    |                  ^^^
 help: skipping check for `const_raw_ptr_deref` feature
-  --> $DIR/const_refers_to_static2.rs:16:14
+  --> $DIR/const_refers_to_static2.rs:14:14
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static2.rs:25:6
+  --> $DIR/const_refers_to_static2.rs:21:6
    |
 LL |     &FOO
    |      ^^^

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.64bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.64bit.stderr
@@ -3,8 +3,6 @@ error[E0080]: it is undefined behavior to use this value
    |
 LL | / const REF_INTERIOR_MUT: &usize = {
 LL | |
-LL | |
-LL | |
 LL | |     static FOO: AtomicUsize = AtomicUsize::new(0);
 LL | |     unsafe { &*(&FOO as *const _ as *const usize) }
 LL | | };
@@ -16,11 +14,9 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static2.rs:20:1
+  --> $DIR/const_refers_to_static2.rs:18:1
    |
 LL | / const READ_IMMUT: &usize = {
-LL | |
-LL | |
 LL | |
 LL | |     static FOO: usize = 0;
 LL | |     &FOO
@@ -35,17 +31,17 @@ LL | | };
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static2.rs:16:18
+  --> $DIR/const_refers_to_static2.rs:14:18
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }
    |                  ^^^
 help: skipping check for `const_raw_ptr_deref` feature
-  --> $DIR/const_refers_to_static2.rs:16:14
+  --> $DIR/const_refers_to_static2.rs:14:14
    |
 LL |     unsafe { &*(&FOO as *const _ as *const usize) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static2.rs:25:6
+  --> $DIR/const_refers_to_static2.rs:21:6
    |
 LL |     &FOO
    |      ^^^

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static2.rs
@@ -9,18 +9,14 @@ use std::sync::atomic::Ordering;
 // so they cause an immediate error when *defining* the const.
 
 const REF_INTERIOR_MUT: &usize = { //~ ERROR undefined behavior to use this value
-//~| NOTE encountered a reference pointing to a static variable
-//~| NOTE undefined behavior
-//~| NOTE the raw bytes of the constant
+//~| encountered a reference pointing to a static variable
     static FOO: AtomicUsize = AtomicUsize::new(0);
     unsafe { &*(&FOO as *const _ as *const usize) }
 };
 
 // ok some day perhaps
 const READ_IMMUT: &usize = { //~ ERROR it is undefined behavior to use this value
-//~| NOTE encountered a reference pointing to a static variable
-//~| NOTE undefined behavior
-//~| NOTE the raw bytes of the constant
+//~| encountered a reference pointing to a static variable
     static FOO: usize = 0;
     &FOO
 };

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.32bit.stderr
@@ -3,8 +3,6 @@ error[E0080]: it is undefined behavior to use this value
    |
 LL | / const SLICE_MUT: &[u8; 1] = {
 LL | |
-LL | |
-LL | |
 LL | |     unsafe { &static_cross_crate::ZERO }
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
@@ -15,17 +13,15 @@ LL | | };
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:47:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:19:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:17:1
    |
 LL | / const U8_MUT: &u8 = {
-LL | |
-LL | |
 LL | |
 LL | |     unsafe { &static_cross_crate::ZERO[0] }
 LL | | };
@@ -37,13 +33,13 @@ LL | | };
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:56:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:29:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:15
    |
 LL | / const U8_MUT2: &u8 = {
 LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
@@ -51,12 +47,11 @@ LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
 LL | |
 LL | |
 LL | |
-LL | |
 LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:23:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
@@ -64,26 +59,25 @@ LL | #[warn(const_err)]
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:67:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:51
    |
 LL | / const U8_MUT3: &u8 = {
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    | |                                                   ^^^^^^^^^^^ constant accesses static
 LL | |
 LL | |
-...  |
 LL | |
 LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:35:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:30:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
@@ -91,31 +85,31 @@ LL | #[warn(const_err)]
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:75:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:47:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:56:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:67:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:75:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
@@ -123,57 +117,57 @@ LL |         U8_MUT3 => true,
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:16:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:16:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:23:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:23:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:23:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:29:17
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:17
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_panic` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:77
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:77
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                                                                             ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.64bit.stderr
@@ -3,8 +3,6 @@ error[E0080]: it is undefined behavior to use this value
    |
 LL | / const SLICE_MUT: &[u8; 1] = {
 LL | |
-LL | |
-LL | |
 LL | |     unsafe { &static_cross_crate::ZERO }
 LL | | };
    | |__^ type validation failed: encountered a reference pointing to a static variable
@@ -15,17 +13,15 @@ LL | | };
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:47:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const_refers_to_static_cross_crate.rs:19:1
+  --> $DIR/const_refers_to_static_cross_crate.rs:17:1
    |
 LL | / const U8_MUT: &u8 = {
-LL | |
-LL | |
 LL | |
 LL | |     unsafe { &static_cross_crate::ZERO[0] }
 LL | | };
@@ -37,13 +33,13 @@ LL | | };
            }
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:56:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:29:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:15
    |
 LL | / const U8_MUT2: &u8 = {
 LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
@@ -51,12 +47,11 @@ LL | |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
 LL | |
 LL | |
 LL | |
-LL | |
 LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:27:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:23:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
@@ -64,26 +59,25 @@ LL | #[warn(const_err)]
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:67:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 warning: any use of this value will cause an error
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:51
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:51
    |
 LL | / const U8_MUT3: &u8 = {
 LL | |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    | |                                                   ^^^^^^^^^^^ constant accesses static
 LL | |
 LL | |
-...  |
 LL | |
 LL | | };
    | |__-
    |
 note: the lint level is defined here
-  --> $DIR/const_refers_to_static_cross_crate.rs:35:8
+  --> $DIR/const_refers_to_static_cross_crate.rs:30:8
    |
 LL | #[warn(const_err)]
    |        ^^^^^^^^^
@@ -91,31 +85,31 @@ LL | #[warn(const_err)]
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:75:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:47:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:40:9
    |
 LL |         SLICE_MUT => true,
    |         ^^^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:56:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:49:9
    |
 LL |         U8_MUT => true,
    |         ^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:67:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:60:9
    |
 LL |         U8_MUT2 => true,
    |         ^^^^^^^
 
 error: could not evaluate constant pattern
-  --> $DIR/const_refers_to_static_cross_crate.rs:75:9
+  --> $DIR/const_refers_to_static_cross_crate.rs:68:9
    |
 LL |         U8_MUT3 => true,
    |         ^^^^^^^
@@ -123,57 +117,57 @@ LL |         U8_MUT3 => true,
 warning: skipping const checks
    |
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:16:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:16:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:14:15
    |
 LL |     unsafe { &static_cross_crate::ZERO }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:23:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:23:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:23:15
+  --> $DIR/const_refers_to_static_cross_crate.rs:19:15
    |
 LL |     unsafe { &static_cross_crate::ZERO[0] }
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:29:17
+  --> $DIR/const_refers_to_static_cross_crate.rs:25:17
    |
 LL |     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: skipping check for `const_panic` feature
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:77
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:77
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                                                                             ^^^^^^^^
 help: skipping check that does not even have a feature gate
-  --> $DIR/const_refers_to_static_cross_crate.rs:37:20
+  --> $DIR/const_refers_to_static_cross_crate.rs:32:20
    |
 LL |     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
+++ b/src/test/ui/consts/miri_unleashed/const_refers_to_static_cross_crate.rs
@@ -10,36 +10,29 @@ extern crate static_cross_crate;
 // Sneaky: reference to a mutable static.
 // Allowing this would be a disaster for pattern matching, we could violate exhaustiveness checking!
 const SLICE_MUT: &[u8; 1] = { //~ ERROR undefined behavior to use this value
-//~| NOTE encountered a reference pointing to a static variable
-//~| NOTE undefined behavior
-//~| NOTE the raw bytes of the constant
+//~| encountered a reference pointing to a static variable
     unsafe { &static_cross_crate::ZERO }
 };
 
 const U8_MUT: &u8 = { //~ ERROR undefined behavior to use this value
-//~| NOTE encountered a reference pointing to a static variable
-//~| NOTE undefined behavior
-//~| NOTE the raw bytes of the constant
+//~| encountered a reference pointing to a static variable
     unsafe { &static_cross_crate::ZERO[0] }
 };
 
 // Also test indirection that reads from other static. This causes a const_err.
-#[warn(const_err)] //~ NOTE
-const U8_MUT2: &u8 = { //~ NOTE
+#[warn(const_err)]
+const U8_MUT2: &u8 = {
     unsafe { &(*static_cross_crate::ZERO_REF)[0] }
     //~^ WARN [const_err]
-    //~| NOTE constant accesses static
+    //~| constant accesses static
     //~| WARN this was previously accepted by the compiler but is being phased out
-    //~| NOTE
 };
-#[warn(const_err)] //~ NOTE
-const U8_MUT3: &u8 = { //~ NOTE
+#[warn(const_err)]
+const U8_MUT3: &u8 = {
     unsafe { match static_cross_crate::OPT_ZERO { Some(ref u) => u, None => panic!() } }
     //~^ WARN [const_err]
-    //~| NOTE constant accesses static
-    //~| NOTE in this expansion of panic!
+    //~| constant accesses static
     //~| WARN this was previously accepted by the compiler but is being phased out
-    //~| NOTE
 };
 
 pub fn test(x: &[u8; 1]) -> bool {

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -59,26 +59,18 @@ check!(!eq, unsafe { (FOO as *const usize as *const u8).offset(3) }, 0);
 // at runtime it would be zero and at compile-time it would not be zero.
 
 const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
-//~^ NOTE
 
 const _: *const u8 =
-//~^ NOTE
     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
 //~^ ERROR any use of this value will cause an error
-//~| NOTE
 //~| WARN this was previously accepted by the compiler but is being phased out
-//~| NOTE
 
 const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
 //~^ ERROR any use of this value will cause an error
-//~| NOTE cannot cast pointer to integer
-//~| NOTE
+//~| cannot cast pointer to integer
 //~| WARN this was previously accepted by the compiler but is being phased out
-//~| NOTE
 
 const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
 //~^ ERROR any use of this value will cause an error
-//~| NOTE cannot cast pointer to integer
-//~| NOTE
+//~| cannot cast pointer to integer
 //~| WARN this was previously accepted by the compiler but is being phased out
-//~| NOTE

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -18,10 +18,9 @@ LL | const _: *const usize = unsafe { (FOO as *const usize).offset(2) };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:66:33
+  --> $DIR/ptr_comparisons.rs:64:33
    |
 LL | / const _: *const u8 =
-LL | |
 LL | |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
    | |_________________________________^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^___-
    |                                   |
@@ -31,7 +30,7 @@ LL | |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 100
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:72:27
+  --> $DIR/ptr_comparisons.rs:68:27
    |
 LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -42,7 +41,7 @@ LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) +
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:79:27
+  --> $DIR/ptr_comparisons.rs:73:27
    |
 LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
    | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---


### PR DESCRIPTION
I also finally learned how I can match *some* NOTEs in a ui test without matching all of them, and applied that to some const tests in the 2nd commit where I added NOTE because I did not know what I was doing. I can separate this into its own PR if you prefer.

Fixes https://github.com/rust-lang/rust/issues/83182
r? @oli-obk 