### PR TITLE
Correctly handle remapping from path containing the current directory with trailing paths

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -497,11 +497,22 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                                 let working_dir = &self.tcx.sess.working_dir;
                                 match working_dir {
                                     RealFileName::LocalPath(absolute) => {
-                                        // If working_dir has not been remapped, then we emit a
-                                        // LocalPath variant as it's likely to be a valid path
-                                        RealFileName::LocalPath(
-                                            Path::new(absolute).join(path_to_file),
-                                        )
+                                        // Although neither working_dir or the file name were subject
+                                        // to path remapping, the concatenation between the two may
+                                        // be. Hence we need to do a remapping here.
+                                        let joined = Path::new(absolute).join(path_to_file);
+                                        let (joined, remapped) =
+                                            source_map.path_mapping().map_prefix(joined);
+                                        if remapped {
+                                            RealFileName::Remapped {
+                                                local_path: None,
+                                                virtual_name: joined,
+                                            }
+                                        } else {
+                                            RealFileName::LocalPath(
+                                                Path::new(absolute).join(path_to_file),
+                                            )
+                                        }
                                     }
                                     RealFileName::Remapped { local_path: _, virtual_name } => {
                                         // If working_dir has been remapped, then we emit

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -509,9 +509,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                                                 virtual_name: joined,
                                             }
                                         } else {
-                                            RealFileName::LocalPath(
-                                                Path::new(absolute).join(path_to_file),
-                                            )
+                                            RealFileName::LocalPath(joined)
                                         }
                                     }
                                     RealFileName::Remapped { local_path: _, virtual_name } => {

--- a/src/test/run-make-fulldeps/remap-path-prefix/Makefile
+++ b/src/test/run-make-fulldeps/remap-path-prefix/Makefile
@@ -1,0 +1,6 @@
+-include ../tools.mk
+
+# Checks if remapping works if the remap-from string contains path to the working directory plus more
+all:
+	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux --crate-type=lib --emit=metadata auxiliary/lib.rs
+	! grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1

--- a/src/test/run-make-fulldeps/remap-path-prefix/Makefile
+++ b/src/test/run-make-fulldeps/remap-path-prefix/Makefile
@@ -1,5 +1,7 @@
 -include ../tools.mk
 
+# ignore-windows
+
 # Checks if remapping works if the remap-from string contains path to the working directory plus more
 all:
 	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux --crate-type=lib --emit=metadata auxiliary/lib.rs

--- a/src/test/run-make-fulldeps/remap-path-prefix/Makefile
+++ b/src/test/run-make-fulldeps/remap-path-prefix/Makefile
@@ -3,4 +3,5 @@
 # Checks if remapping works if the remap-from string contains path to the working directory plus more
 all:
 	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux --crate-type=lib --emit=metadata auxiliary/lib.rs
+	grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
 	! grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1

--- a/src/test/run-make-fulldeps/remap-path-prefix/auxiliary/lib.rs
+++ b/src/test/run-make-fulldeps/remap-path-prefix/auxiliary/lib.rs
@@ -1,0 +1,3 @@
+fn lib() {
+    panic!("calm");
+}

--- a/src/test/run-make-fulldeps/remap-path-prefix/auxiliary/lib.rs
+++ b/src/test/run-make-fulldeps/remap-path-prefix/auxiliary/lib.rs
@@ -1,3 +1,3 @@
-fn lib() {
+pub fn lib() {
     panic!("calm");
 }


### PR DESCRIPTION
If we have a `auxiliary/lib.rs`, and we generate the metadata with `--remap-path-prefix $PWD/auxiliary=xyz`, the path to `$PWD/auxiliary/lib.rs` won't be correctly remapped in the metadata. This is because internally, path to the working directory itself and relative paths to files under the working directory are remapped separately (hence neither are affected since neither has `$PWD/auxiliary` as prefix), but the concatenation between the working directory and the relative path is not remapped. This PR fixes that.