### PR TITLE
Account for incorrect `impl Foo<const N: ty> {}` syntax

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -405,6 +405,21 @@ pub struct GenericParam {
     pub kind: GenericParamKind,
 }
 
+impl GenericParam {
+    pub fn span(&self) -> Span {
+        match &self.kind {
+            GenericParamKind::Lifetime | GenericParamKind::Type { default: None } => {
+                self.ident.span
+            }
+            GenericParamKind::Type { default: Some(ty) } => self.ident.span.to(ty.span),
+            GenericParamKind::Const { kw_span, default: Some(default), .. } => {
+                kw_span.to(default.value.span)
+            }
+            GenericParamKind::Const { kw_span, default: None, ty } => kw_span.to(ty.span),
+        }
+    }
+}
+
 /// Represents lifetime, type and const parameters attached to a declaration of
 /// a function, enum, trait, etc.
 #[derive(Clone, Encodable, Decodable, Debug)]

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -6,9 +6,11 @@ use rustc_ast as ast;
 use rustc_ast::ptr::P;
 use rustc_ast::token::{self, Lit, LitKind, TokenKind};
 use rustc_ast::util::parser::AssocOp;
-use rustc_ast::{AngleBracketedArg, AngleBracketedArgs, AnonConst, AttrVec};
-use rustc_ast::{BinOpKind, BindingMode, Block, BlockCheckMode, Expr, ExprKind, GenericArg, Item};
-use rustc_ast::{ItemKind, Mutability, Param, Pat, PatKind, Path, PathSegment, QSelf, Ty, TyKind};
+use rustc_ast::{
+    AngleBracketedArg, AngleBracketedArgs, AnonConst, AttrVec, BinOpKind, BindingMode, Block,
+    BlockCheckMode, Expr, ExprKind, GenericArg, Generics, Item, ItemKind, Mutability, Param, Pat,
+    PatKind, Path, PathSegment, QSelf, Ty, TyKind,
+};
 use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{pluralize, struct_span_err};
@@ -662,7 +664,7 @@ impl<'a> Parser<'a> {
             let snapshot = self.clone();
             self.bump();
             let lo = self.token.span;
-            match self.parse_angle_args() {
+            match self.parse_angle_args(None) {
                 Ok(args) => {
                     let span = lo.to(self.prev_token.span);
                     // Detect trailing `>` like in `x.collect::Vec<_>>()`.
@@ -719,7 +721,7 @@ impl<'a> Parser<'a> {
                     let x = self.parse_seq_to_before_end(
                         &token::Gt,
                         SeqSep::trailing_allowed(token::Comma),
-                        |p| p.parse_generic_arg(),
+                        |p| p.parse_generic_arg(None),
                     );
                     match x {
                         Ok((_, _, false)) => {
@@ -1103,7 +1105,7 @@ impl<'a> Parser<'a> {
         self.expect(&token::ModSep)?;
 
         let mut path = ast::Path { segments: Vec::new(), span: DUMMY_SP, tokens: None };
-        self.parse_path_segments(&mut path.segments, T::PATH_STYLE)?;
+        self.parse_path_segments(&mut path.segments, T::PATH_STYLE, None)?;
         path.span = ty_span.to(self.prev_token.span);
 
         let ty_str = self.span_to_snippet(ty_span).unwrap_or_else(|_| pprust::ty_to_string(&ty));
@@ -1907,6 +1909,74 @@ impl<'a> Parser<'a> {
             .emit();
         }
         Ok(expr)
+    }
+
+    fn recover_const_param_decl(
+        &mut self,
+        ty_generics: Option<&Generics>,
+    ) -> PResult<'a, Option<GenericArg>> {
+        let snapshot = self.clone();
+        let param = match self.parse_const_param(vec![]) {
+            Ok(param) => param,
+            Err(mut err) => {
+                err.cancel();
+                *self = snapshot;
+                return Err(err);
+            }
+        };
+        let mut err =
+            self.struct_span_err(param.ident.span, "unexpected `const` parameter declaration");
+        err.span_label(
+            param.ident.span,
+            "expected a `const` expression, not a parameter declaration",
+        );
+        if let (Some(generics), Ok(snippet)) =
+            (ty_generics, self.sess.source_map().span_to_snippet(param.span()))
+        {
+            let (span, sugg) = match &generics.params[..] {
+                [] => (generics.span, format!("<{}>", snippet)),
+                [.., generic] => (generic.span().shrink_to_hi(), format!(", {}", snippet)),
+            };
+            err.multipart_suggestion(
+                "`const` parameters must be declared for the `impl`",
+                vec![(span, sugg), (param.span(), param.ident.to_string())],
+                Applicability::MachineApplicable,
+            );
+        }
+        let value = self.mk_expr_err(param.span());
+        err.emit();
+        return Ok(Some(GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value })));
+    }
+
+    pub fn recover_const_param_declaration(
+        &mut self,
+        ty_generics: Option<&Generics>,
+    ) -> PResult<'a, Option<GenericArg>> {
+        // We have to check for a few different cases.
+        if let Ok(arg) = self.recover_const_param_decl(ty_generics) {
+            return Ok(arg);
+        }
+
+        // We haven't consumed `const` yet.
+        let start = self.token.span;
+        self.bump(); // `const`
+
+        // Detect and recover from the old, pre-RFC2000 syntax for const generics.
+        let mut err = self
+            .struct_span_err(start, "expected lifetime, type, or constant, found keyword `const`");
+        if self.check_const_arg() {
+            err.span_suggestion_verbose(
+                start.until(self.token.span),
+                "the `const` keyword is only needed in the definition of the type",
+                String::new(),
+                Applicability::MaybeIncorrect,
+            );
+            err.emit();
+            Ok(Some(GenericArg::Const(self.parse_const_arg()?)))
+        } else {
+            let after_kw_const = self.token.span;
+            self.recover_const_arg(after_kw_const, err).map(Some)
+        }
     }
 
     /// Try to recover from possible generic const argument without `{` and `}`.

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1925,11 +1925,8 @@ impl<'a> Parser<'a> {
             }
         };
         let mut err =
-            self.struct_span_err(param.ident.span, "unexpected `const` parameter declaration");
-        err.span_label(
-            param.ident.span,
-            "expected a `const` expression, not a parameter declaration",
-        );
+            self.struct_span_err(param.span(), "unexpected `const` parameter declaration");
+        err.span_label(param.span(), "expected a `const` expression, not a parameter declaration");
         if let (Some(generics), Ok(snippet)) =
             (ty_generics, self.sess.source_map().span_to_snippet(param.span()))
         {

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1150,7 +1150,7 @@ impl<'a> Parser<'a> {
         }
 
         let fn_span_lo = self.token.span;
-        let mut segment = self.parse_path_segment(PathStyle::Expr)?;
+        let mut segment = self.parse_path_segment(PathStyle::Expr, None)?;
         self.check_trailing_angle_brackets(&segment, &[&token::OpenDelim(token::Paren)]);
         self.check_turbofish_missing_angle_brackets(&mut segment);
 

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -48,7 +48,10 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_const_param(&mut self, preceding_attrs: Vec<Attribute>) -> PResult<'a, GenericParam> {
+    crate fn parse_const_param(
+        &mut self,
+        preceding_attrs: Vec<Attribute>,
+    ) -> PResult<'a, GenericParam> {
         let const_span = self.token.span;
 
         self.expect_keyword(kw::Const)?;

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -514,7 +514,7 @@ impl<'a> Parser<'a> {
                 tokens: None,
             })
         } else {
-            self.parse_ty()?
+            self.parse_ty_with_generics_recovery(&generics)?
         };
 
         // If `for` is missing we try to recover.

--- a/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.rs
+++ b/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.rs
@@ -1,0 +1,6 @@
+struct NInts<const N: usize>([u8; N]);
+impl NInts<const N: usize> {} //~ ERROR unexpected `const` parameter declaration
+
+fn main() {
+    let _: () = 42; //~ ERROR mismatched types
+}

--- a/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.rs
+++ b/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.rs
@@ -4,3 +4,12 @@ impl NInts<const N: usize> {} //~ ERROR unexpected `const` parameter declaration
 fn main() {
     let _: () = 42; //~ ERROR mismatched types
 }
+
+fn banana(a: <T<const N: usize>>::BAR) {}
+//~^ ERROR unexpected `const` parameter declaration
+//~| ERROR cannot find type `T` in this scope
+fn chaenomeles() {
+    path::path::Struct::<const N: usize>()
+    //~^ ERROR unexpected `const` parameter declaration
+    //~| ERROR failed to resolve: use of undeclared crate or module `path`
+}

--- a/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
+++ b/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
@@ -1,0 +1,22 @@
+error: unexpected `const` parameter declaration
+  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:2:18
+   |
+LL | impl NInts<const N: usize> {}
+   |                  ^ expected a `const` expression, not a parameter declaration
+   |
+help: `const` parameters must be declared for the `impl`
+   |
+LL | impl<const N: usize> NInts<N> {}
+   |     ++++++++++++++++       ~
+
+error[E0308]: mismatched types
+  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:5:17
+   |
+LL |     let _: () = 42;
+   |            --   ^^ expected `()`, found integer
+   |            |
+   |            expected due to this
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
+++ b/src/test/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
@@ -1,13 +1,37 @@
 error: unexpected `const` parameter declaration
-  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:2:18
+  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:2:12
    |
 LL | impl NInts<const N: usize> {}
-   |                  ^ expected a `const` expression, not a parameter declaration
+   |            ^^^^^^^^^^^^^^ expected a `const` expression, not a parameter declaration
    |
 help: `const` parameters must be declared for the `impl`
    |
 LL | impl<const N: usize> NInts<N> {}
    |     ++++++++++++++++       ~
+
+error: unexpected `const` parameter declaration
+  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:8:17
+   |
+LL | fn banana(a: <T<const N: usize>>::BAR) {}
+   |                 ^^^^^^^^^^^^^^ expected a `const` expression, not a parameter declaration
+
+error: unexpected `const` parameter declaration
+  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:12:26
+   |
+LL |     path::path::Struct::<const N: usize>()
+   |                          ^^^^^^^^^^^^^^ expected a `const` expression, not a parameter declaration
+
+error[E0433]: failed to resolve: use of undeclared crate or module `path`
+  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:12:5
+   |
+LL |     path::path::Struct::<const N: usize>()
+   |     ^^^^ use of undeclared crate or module `path`
+
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/const-param-decl-on-type-instead-of-impl.rs:8:15
+   |
+LL | fn banana(a: <T<const N: usize>>::BAR) {}
+   |               ^ not found in this scope
 
 error[E0308]: mismatched types
   --> $DIR/const-param-decl-on-type-instead-of-impl.rs:5:17
@@ -17,6 +41,7 @@ LL |     let _: () = 42;
    |            |
    |            expected due to this
 
-error: aborting due to 2 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0412, E0433.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -2236,18 +2236,10 @@ fn rewrite_fn_base(
         result.push_str(&param_indent.to_string_with_newline(context.config));
     }
 
-    // Skip `pub(crate)`.
-    let lo_after_visibility = get_bytepos_after_visibility(fn_sig.visibility, span);
-    // A conservative estimation, the goal is to be over all parens in generics
-    let params_start = fn_sig
-        .generics
-        .params
-        .last()
-        .map_or(lo_after_visibility, |param| param.span().hi());
     let params_end = if fd.inputs.is_empty() {
         context
             .snippet_provider
-            .span_after(mk_sp(params_start, span.hi()), ")")
+            .span_after(mk_sp(fn_sig.generics.span.hi(), span.hi()), ")")
     } else {
         let last_span = mk_sp(fd.inputs[fd.inputs.len() - 1].span().hi(), span.hi());
         context.snippet_provider.span_after(last_span, ")")
@@ -2255,7 +2247,7 @@ fn rewrite_fn_base(
     let params_span = mk_sp(
         context
             .snippet_provider
-            .span_after(mk_sp(params_start, span.hi()), "("),
+            .span_after(mk_sp(fn_sig.generics.span.hi(), span.hi()), "("),
         params_end,
     );
     let param_str = rewrite_params(


### PR DESCRIPTION
Fix #84946