### PR TITLE
Allow `async {}` expressions in const contexts

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -650,6 +650,9 @@ declare_features! (
     /// Allows unsizing coercions in `const fn`.
     (active, const_fn_unsize, "1.53.0", Some(64992), None),
 
+    /// Allows `async {}` expressions in const contexts.
+    (active, const_async_blocks, "1.53.0", None, None),
+
     /// Allows using imported `main` function
     (active, imported_main, "1.53.0", Some(28937), None),
 

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -651,7 +651,7 @@ declare_features! (
     (active, const_fn_unsize, "1.53.0", Some(64992), None),
 
     /// Allows `async {}` expressions in const contexts.
-    (active, const_async_blocks, "1.53.0", None, None),
+    (active, const_async_blocks, "1.53.0", Some(85368), None),
 
     /// Allows using imported `main` function
     (active, imported_main, "1.53.0", Some(28937), None),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -374,6 +374,7 @@ symbols! {
         conservative_impl_trait,
         console,
         const_allocate,
+        const_async_blocks,
         const_compare_raw_pointers,
         const_constructor,
         const_eval_limit,

--- a/src/test/ui/consts/async-block.rs
+++ b/src/test/ui/consts/async-block.rs
@@ -1,8 +1,19 @@
-// From <https://github.com/rust-lang/rust/issues/77361>
+// gate-test-const_async_blocks
 
 // edition:2018
+// revisions: with_feature without_feature
 
+#![feature(rustc_attrs)]
+#![cfg_attr(with_feature, feature(const_async_blocks))]
+
+use std::future::Future;
+
+// From <https://github.com/rust-lang/rust/issues/77361>
 const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
-//~^ `async` block
+//[without_feature]~^ `async` block
 
-fn main() {}
+static _FUT: &(dyn Future<Output = ()> + Sync) = &async {};
+//[without_feature]~^ `async` block
+
+#[rustc_error]
+fn main() {} //[with_feature]~ fatal error triggered by #[rustc_error]

--- a/src/test/ui/consts/async-block.stderr
+++ b/src/test/ui/consts/async-block.stderr
@@ -1,8 +1,0 @@
-error: `async` blocks are not allowed in constants
-  --> $DIR/async-block.rs:5:47
-   |
-LL | const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
-   |                                               ^^^^^^^^^^^
-
-error: aborting due to previous error
-

--- a/src/test/ui/consts/async-block.with_feature.stderr
+++ b/src/test/ui/consts/async-block.with_feature.stderr
@@ -1,0 +1,8 @@
+error: fatal error triggered by #[rustc_error]
+  --> $DIR/async-block.rs:19:1
+   |
+LL | fn main() {}
+   | ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/async-block.without_feature.stderr
+++ b/src/test/ui/consts/async-block.without_feature.stderr
@@ -4,6 +4,7 @@ error[E0658]: `async` blocks are not allowed in constants
 LL | const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
    |                                               ^^^^^^^^^^^
    |
+   = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error[E0658]: `async` blocks are not allowed in statics
@@ -12,6 +13,7 @@ error[E0658]: `async` blocks are not allowed in statics
 LL | static _FUT: &(dyn Future<Output = ()> + Sync) = &async {};
    |                                                   ^^^^^^^^
    |
+   = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/async-block.without_feature.stderr
+++ b/src/test/ui/consts/async-block.without_feature.stderr
@@ -1,0 +1,19 @@
+error[E0658]: `async` blocks are not allowed in constants
+  --> $DIR/async-block.rs:12:47
+   |
+LL | const _: i32 = { core::mem::ManuallyDrop::new(async { 0 }); 4 };
+   |                                               ^^^^^^^^^^^
+   |
+   = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
+
+error[E0658]: `async` blocks are not allowed in statics
+  --> $DIR/async-block.rs:15:51
+   |
+LL | static _FUT: &(dyn Future<Output = ()> + Sync) = &async {};
+   |                                                   ^^^^^^^^
+   |
+   = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/impl-trait/issues/issue-78721.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78721.stderr
@@ -13,6 +13,7 @@ error[E0658]: `async` blocks are not allowed in constants
 LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
    |                                                         ^^^^^^^^^^^
    |
+   = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time

--- a/src/test/ui/impl-trait/issues/issue-78721.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78721.stderr
@@ -7,11 +7,13 @@ LL | #![feature(impl_trait_in_bindings)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
-error: `async` blocks are not allowed in constants
+error[E0658]: `async` blocks are not allowed in constants
   --> $DIR/issue-78721.rs:8:57
    |
 LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
    |                                                         ^^^^^^^^^^^
+   |
+   = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/issue-78721.rs:8:13
@@ -24,4 +26,5 @@ LL |     }],
 
 error: aborting due to 2 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0493, E0658.
+For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/impl-trait/issues/issue-78722.full_tait.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.full_tait.stderr
@@ -15,11 +15,13 @@ LL | #![feature(impl_trait_in_bindings)]
    |
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
-error: `async` blocks are not allowed in constants
+error[E0658]: `async` blocks are not allowed in constants
   --> $DIR/issue-78722.rs:17:20
    |
 LL |         let f: F = async { 1 };
    |                    ^^^^^^^^^^^
+   |
+   = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/issue-78722.rs:17:13
@@ -32,4 +34,5 @@ LL |     }],
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0493, E0658.
+For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/impl-trait/issues/issue-78722.full_tait.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.full_tait.stderr
@@ -21,6 +21,7 @@ error[E0658]: `async` blocks are not allowed in constants
 LL |         let f: F = async { 1 };
    |                    ^^^^^^^^^^^
    |
+   = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time

--- a/src/test/ui/impl-trait/issues/issue-78722.min_tait.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.min_tait.stderr
@@ -7,11 +7,13 @@ LL | #![feature(impl_trait_in_bindings)]
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #63065 <https://github.com/rust-lang/rust/issues/63065> for more information
 
-error: `async` blocks are not allowed in constants
+error[E0658]: `async` blocks are not allowed in constants
   --> $DIR/issue-78722.rs:17:20
    |
 LL |         let f: F = async { 1 };
    |                    ^^^^^^^^^^^
+   |
+   = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/issue-78722.rs:17:13
@@ -24,4 +26,5 @@ LL |     }],
 
 error: aborting due to 2 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0493, E0658.
+For more information about an error, try `rustc --explain E0493`.

--- a/src/test/ui/impl-trait/issues/issue-78722.min_tait.stderr
+++ b/src/test/ui/impl-trait/issues/issue-78722.min_tait.stderr
@@ -13,6 +13,7 @@ error[E0658]: `async` blocks are not allowed in constants
 LL |         let f: F = async { 1 };
    |                    ^^^^^^^^^^^
    |
+   = note: see issue #85368 <https://github.com/rust-lang/rust/issues/85368> for more information
    = help: add `#![feature(const_async_blocks)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time


### PR DESCRIPTION
Gated behind a new `const_async_blocks` feature.