### PR TITLE
Reserve prefixed identifiers and literals (RFC 3101)

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -66,7 +66,12 @@ pub enum TokenKind {
     Ident,
     /// "r#ident"
     RawIdent,
-    /// `foo#`, `foo'`, `foo"`. Note the tailer is not included.
+    /// An unknown prefix like `foo#`, `foo'`, `foo"`. Note that only the
+    /// prefix (`foo`) is included in the token, not the separator (which is
+    /// lexed as its own distinct token). In Rust 2021 and later, reserved
+    /// prefixes are reported as errors; in earlier editions, they result in a
+    /// (allowed by default) lint, and are treated as regular identifier
+    /// tokens.
     BadPrefix,
     /// "12_u8", "1.0e-40", "b"123"". See `LiteralKind` for more details.
     Literal { kind: LiteralKind, suffix_start: usize },
@@ -493,7 +498,7 @@ impl Cursor<'_> {
         debug_assert!(is_id_start(self.prev()));
         // Start is already eaten, eat the rest of identifier.
         self.eat_while(is_id_continue);
-        // Good prefixes must have been handled eariler. So if
+        // Good prefixes must have been handled earlier. So if
         // we see a prefix here, it is definitely a bad prefix.
         match self.first() {
             '#' | '"' | '\'' => BadPrefix,

--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -72,7 +72,7 @@ pub enum TokenKind {
     /// prefixes are reported as errors; in earlier editions, they result in a
     /// (allowed by default) lint, and are treated as regular identifier
     /// tokens.
-    BadPrefix,
+    UnknownPrefix,
     /// "12_u8", "1.0e-40", "b"123"". See `LiteralKind` for more details.
     Literal { kind: LiteralKind, suffix_start: usize },
     /// "'a"
@@ -330,7 +330,7 @@ impl Cursor<'_> {
                     let kind = RawStr { n_hashes, err };
                     Literal { kind, suffix_start }
                 }
-                _ => self.ident_or_bad_prefix(),
+                _ => self.ident_or_unknown_prefix(),
             },
 
             // Byte literal, byte string literal, raw byte string literal or identifier.
@@ -365,12 +365,12 @@ impl Cursor<'_> {
                     let kind = RawByteStr { n_hashes, err };
                     Literal { kind, suffix_start }
                 }
-                _ => self.ident_or_bad_prefix(),
+                _ => self.ident_or_unknown_prefix(),
             },
 
             // Identifier (this should be checked after other variant that can
             // start as identifier).
-            c if is_id_start(c) => self.ident_or_bad_prefix(),
+            c if is_id_start(c) => self.ident_or_unknown_prefix(),
 
             // Numeric literal.
             c @ '0'..='9' => {
@@ -494,14 +494,14 @@ impl Cursor<'_> {
         RawIdent
     }
 
-    fn ident_or_bad_prefix(&mut self) -> TokenKind {
+    fn ident_or_unknown_prefix(&mut self) -> TokenKind {
         debug_assert!(is_id_start(self.prev()));
         // Start is already eaten, eat the rest of identifier.
         self.eat_while(is_id_continue);
-        // Good prefixes must have been handled earlier. So if
-        // we see a prefix here, it is definitely a bad prefix.
+        // Known prefixes must have been handled earlier. So if
+        // we see a prefix here, it is definitely a unknown prefix.
         match self.first() {
-            '#' | '"' | '\'' => BadPrefix,
+            '#' | '"' | '\'' => UnknownPrefix,
             _ => Ident,
         }
     }

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -723,6 +723,15 @@ pub trait LintContext: Sized {
                 BuiltinLintDiagnostics::OrPatternsBackCompat(span,suggestion) => {
                     db.span_suggestion(span, "use pat_param to preserve semantics", suggestion, Applicability::MachineApplicable);
                 }
+                BuiltinLintDiagnostics::ReservedPrefix(span) => {
+                    db.span_label(span, "unknown prefix");
+                    db.span_suggestion_verbose(
+                        span.shrink_to_hi(),
+                        "insert whitespace here to avoid this being parsed as a prefix in Rust 2021",
+                        " ".into(),
+                        Applicability::MachineApplicable,
+                    );
+                }
             }
             // Rewrap `db`, and pass control to the user.
             decorate(LintDiagnosticBuilder::new(db));

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2973,6 +2973,7 @@ declare_lint_pass! {
         OR_PATTERNS_BACK_COMPAT,
         LARGE_ASSIGNMENTS,
         FUTURE_PRELUDE_COLLISION,
+        RESERVED_PREFIX,
     ]
 }
 
@@ -3262,4 +3263,40 @@ declare_lint! {
         reference: "issue #85684 <https://github.com/rust-lang/rust/issues/85684>",
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
     };
+}
+
+declare_lint! {
+    /// The `reserved_prefix` lint detects identifiers that will be parsed as a
+    /// prefix instead in Rust 2021.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(reserved_prefix)]
+    ///
+    /// macro_rules! m {
+    ///     (z $x:expr) => ();
+    /// }
+    ///
+    /// m!(z"hey");
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// In Rust 2015 and 2018, `z"hey"` is two tokens: the identifier `z`
+    /// followed by the string literal `"hey"`. In Rust 2021, the `z` is
+    /// considered a prefix for `"hey"`.
+    ///
+    /// This lint suggests to add whitespace between the `z` and `"hey"` tokens
+    /// to keep them separated in Rust 2021.
+    pub RESERVED_PREFIX,
+    Allow,
+    "identifiers that will be parsed as a prefix in Rust 2021",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #84978 <https://github.com/rust-lang/rust/issues/84978>",
+        edition: Some(Edition::Edition2021),
+    };
+    crate_level_only
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3296,7 +3296,7 @@ declare_lint! {
     "identifiers that will be parsed as a prefix in Rust 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #84978 <https://github.com/rust-lang/rust/issues/84978>",
-        edition: Some(Edition::Edition2021),
+        reason: FutureIncompatibilityReason::EditionError(Edition::Edition2021),
     };
     crate_level_only
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -300,6 +300,7 @@ pub enum BuiltinLintDiagnostics {
     ExternDepSpec(String, ExternDepSpec),
     ProcMacroBackCompat(String),
     OrPatternsBackCompat(Span, String),
+    ReservedPrefix(Span),
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -170,15 +170,15 @@ impl<'a> StringReader<'a> {
             rustc_lexer::TokenKind::Whitespace => return None,
             rustc_lexer::TokenKind::Ident
             | rustc_lexer::TokenKind::RawIdent
-            | rustc_lexer::TokenKind::BadPrefix => {
+            | rustc_lexer::TokenKind::UnknownPrefix => {
                 let is_raw_ident = token == rustc_lexer::TokenKind::RawIdent;
-                let is_bad_prefix = token == rustc_lexer::TokenKind::BadPrefix;
+                let is_unknown_prefix = token == rustc_lexer::TokenKind::UnknownPrefix;
                 let mut ident_start = start;
                 if is_raw_ident {
                     ident_start = ident_start + BytePos(2);
                 }
-                if is_bad_prefix {
-                    self.report_reserved_prefix(start);
+                if is_unknown_prefix {
+                    self.report_unknown_prefix(start);
                 }
                 let sym = nfc_normalize(self.str_from(ident_start));
                 let span = self.mk_sp(start, self.pos);
@@ -503,7 +503,7 @@ impl<'a> StringReader<'a> {
     // using a (unknown) prefix is an error. In earlier editions, however, they
     // only result in a (allowed by default) lint, and are treated as regular
     // identifier tokens.
-    fn report_reserved_prefix(&self, start: BytePos) {
+    fn report_unknown_prefix(&self, start: BytePos) {
         let prefix_span = self.mk_sp(start, self.pos);
         let msg = format!("prefix `{}` is unknown", self.str_from_to(start, self.pos));
 

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -509,12 +509,11 @@ impl<'a> StringReader<'a> {
             &format!("prefix `{}` is unknown", self.str_from_to(start, self.pos)),
         );
         err.span_label(self.mk_sp(start, self.pos), "unknown prefix");
-        err.span_label(
+        err.span_suggestion_verbose(
             self.mk_sp(self.pos, self.pos),
-            &format!(
-                "help: consider inserting a whitespace before this `{}`",
-                self.str_from_to(self.pos, self.pos + BytePos(1)),
-            ),
+            "consider inserting whitespace here",
+            " ".into(),
+            Applicability::MachineApplicable,
         );
         err.note("prefixed identifiers and string literals are reserved since Rust 2021");
 

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -500,7 +500,10 @@ impl<'a> StringReader<'a> {
         FatalError.raise()
     }
 
-    // See RFC 3101.
+    // RFC 3101 introduced the idea of (reserved) prefixes. As of Rust 2021,
+    // using a (unknown) prefix is an error. In earlier editions, however, they
+    // only result in a (allowed by default) lint, and are treated as regular
+    // identifier tokens.
     fn report_reserved_prefix(&self, start: BytePos) {
         let prefix_span = self.mk_sp(start, self.pos);
         let msg = format!("prefix `{}` is unknown", self.str_from_to(start, self.pos));

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -515,7 +515,7 @@ impl<'a> StringReader<'a> {
             " ".into(),
             Applicability::MachineApplicable,
         );
-        err.note("prefixed identifiers and string literals are reserved since Rust 2021");
+        err.note("prefixed identifiers and literals are reserved since Rust 2021");
 
         err.emit();
     }

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -413,7 +413,7 @@ impl<'a> Classifier<'a> {
                 },
                 c => c,
             },
-            TokenKind::RawIdent => Class::Ident,
+            TokenKind::RawIdent | TokenKind::BadPrefix => Class::Ident,
             TokenKind::Lifetime { .. } => Class::Lifetime,
         };
         // Anything that didn't return above is the simple case where we the

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -413,7 +413,7 @@ impl<'a> Classifier<'a> {
                 },
                 c => c,
             },
-            TokenKind::RawIdent | TokenKind::BadPrefix => Class::Ident,
+            TokenKind::RawIdent | TokenKind::UnknownPrefix => Class::Ident,
             TokenKind::Lifetime { .. } => Class::Lifetime,
         };
         // Anything that didn't return above is the simple case where we the

--- a/src/test/ui/rust-2021/auxiliary/reserved-prefixes-macro-2018.rs
+++ b/src/test/ui/rust-2021/auxiliary/reserved-prefixes-macro-2018.rs
@@ -1,0 +1,25 @@
+// force-host
+// edition:2018
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use std::str::FromStr;
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_prefixed_integer_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("hey#123").unwrap().into_iter().count().to_string().parse().unwrap()
+}
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_prefixed_char_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("hey#'a'").unwrap().into_iter().count().to_string().parse().unwrap()
+}
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_prefixed_string_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("hey#\"abc\"").unwrap().into_iter().count().to_string().parse().unwrap()
+}

--- a/src/test/ui/rust-2021/auxiliary/reserved-prefixes-macro-2021.rs
+++ b/src/test/ui/rust-2021/auxiliary/reserved-prefixes-macro-2021.rs
@@ -1,0 +1,25 @@
+// force-host
+// edition:2021
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use std::str::FromStr;
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_prefixed_integer_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("hey#123").unwrap().into_iter().count().to_string().parse().unwrap()
+}
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_prefixed_char_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("hey#'a'").unwrap().into_iter().count().to_string().parse().unwrap()
+}
+
+#[proc_macro]
+pub fn number_of_tokens_in_a_prefixed_string_literal(_: TokenStream) -> TokenStream {
+    TokenStream::from_str("hey#\"abc\"").unwrap().into_iter().count().to_string().parse().unwrap()
+}

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
@@ -1,0 +1,28 @@
+// check-pass
+// run-rustfix
+// compile-flags: -Z unstable-options --edition 2018
+
+#![warn(reserved_prefix)]
+
+macro_rules! m2 {
+    ($a:tt $b:tt) => {};
+}
+
+macro_rules! m3 {
+    ($a:tt $b:tt $c:tt) => {};
+}
+
+fn main() {
+    m2!(z "hey");
+    //~^ WARNING prefix `z` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+    m2!(prefix "hey");
+    //~^ WARNING prefix `prefix` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+    m3!(hey #123);
+    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+    m3!(hey #hey);
+    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+}

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
@@ -15,16 +15,16 @@ macro_rules! m3 {
 fn main() {
     m2!(z "hey");
     //~^ WARNING prefix `z` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
     m2!(prefix "hey");
     //~^ WARNING prefix `prefix` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
     m3!(hey #123);
     //~^ WARNING prefix `hey` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
     m3!(hey #hey);
     //~^ WARNING prefix `hey` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
 }
 
 macro_rules! quote {
@@ -34,5 +34,5 @@ macro_rules! quote {
 quote! {
     #name = #kind #value
     //~^ WARNING prefix `kind` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.fixed
@@ -26,3 +26,13 @@ fn main() {
     //~^ WARNING prefix `hey` is unknown [reserved_prefix]
     //~| WARNING become a hard error
 }
+
+macro_rules! quote {
+    (# name = # kind # value) => {};
+}
+
+quote! {
+    #name = #kind #value
+    //~^ WARNING prefix `kind` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+}

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.rs
@@ -1,0 +1,28 @@
+// check-pass
+// run-rustfix
+// compile-flags: -Z unstable-options --edition 2018
+
+#![warn(reserved_prefix)]
+
+macro_rules! m2 {
+    ($a:tt $b:tt) => {};
+}
+
+macro_rules! m3 {
+    ($a:tt $b:tt $c:tt) => {};
+}
+
+fn main() {
+    m2!(z"hey");
+    //~^ WARNING prefix `z` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+    m2!(prefix"hey");
+    //~^ WARNING prefix `prefix` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+    m3!(hey#123);
+    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+    m3!(hey#hey);
+    //~^ WARNING prefix `hey` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+}

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.rs
@@ -26,3 +26,13 @@ fn main() {
     //~^ WARNING prefix `hey` is unknown [reserved_prefix]
     //~| WARNING become a hard error
 }
+
+macro_rules! quote {
+    (# name = # kind # value) => {};
+}
+
+quote! {
+    #name = #kind#value
+    //~^ WARNING prefix `kind` is unknown [reserved_prefix]
+    //~| WARNING become a hard error
+}

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.rs
@@ -15,16 +15,16 @@ macro_rules! m3 {
 fn main() {
     m2!(z"hey");
     //~^ WARNING prefix `z` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
     m2!(prefix"hey");
     //~^ WARNING prefix `prefix` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
     m3!(hey#123);
     //~^ WARNING prefix `hey` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
     m3!(hey#hey);
     //~^ WARNING prefix `hey` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
 }
 
 macro_rules! quote {
@@ -34,5 +34,5 @@ macro_rules! quote {
 quote! {
     #name = #kind#value
     //~^ WARNING prefix `kind` is unknown [reserved_prefix]
-    //~| WARNING become a hard error
+    //~| WARNING hard error in Rust 2021
 }

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![warn(reserved_prefix)]
    |         ^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
@@ -22,7 +22,7 @@ warning: prefix `prefix` is unknown
 LL |     m2!(prefix"hey");
    |         ^^^^^^ unknown prefix
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
@@ -35,7 +35,7 @@ warning: prefix `hey` is unknown
 LL |     m3!(hey#123);
    |         ^^^ unknown prefix
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
@@ -48,7 +48,7 @@ warning: prefix `hey` is unknown
 LL |     m3!(hey#hey);
    |         ^^^ unknown prefix
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
@@ -61,7 +61,7 @@ warning: prefix `kind` is unknown
 LL |     #name = #kind#value
    |              ^^^^ unknown prefix
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
 help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -1,0 +1,59 @@
+warning: prefix `z` is unknown
+  --> $DIR/reserved-prefixes-migration.rs:16:9
+   |
+LL |     m2!(z"hey");
+   |         ^ unknown prefix
+   |
+note: the lint level is defined here
+  --> $DIR/reserved-prefixes-migration.rs:5:9
+   |
+LL | #![warn(reserved_prefix)]
+   |         ^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
+   |
+LL |     m2!(z "hey");
+   |          --
+
+warning: prefix `prefix` is unknown
+  --> $DIR/reserved-prefixes-migration.rs:19:9
+   |
+LL |     m2!(prefix"hey");
+   |         ^^^^^^ unknown prefix
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
+   |
+LL |     m2!(prefix "hey");
+   |               --
+
+warning: prefix `hey` is unknown
+  --> $DIR/reserved-prefixes-migration.rs:22:9
+   |
+LL |     m3!(hey#123);
+   |         ^^^ unknown prefix
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
+   |
+LL |     m3!(hey #123);
+   |            --
+
+warning: prefix `hey` is unknown
+  --> $DIR/reserved-prefixes-migration.rs:25:9
+   |
+LL |     m3!(hey#hey);
+   |         ^^^ unknown prefix
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
+   |
+LL |     m3!(hey #hey);
+   |            --
+
+warning: 4 warnings emitted
+

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -55,5 +55,18 @@ help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
 LL |     m3!(hey #hey);
    |            --
 
-warning: 4 warnings emitted
+warning: prefix `kind` is unknown
+  --> $DIR/reserved-prefixes-migration.rs:35:14
+   |
+LL |     #name = #kind#value
+   |              ^^^^ unknown prefix
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
+   = note: for more information, see issue #84978 <https://github.com/rust-lang/rust/issues/84978>
+help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
+   |
+LL |     #name = #kind #value
+   |                  --
+
+warning: 5 warnings emitted
 

--- a/src/test/ui/rust-2021/reserved-prefixes-via-macro-2.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-via-macro-2.rs
@@ -1,0 +1,21 @@
+// edition:2018
+// aux-build:reserved-prefixes-macro-2018.rs
+// aux-build:reserved-prefixes-macro-2021.rs
+
+extern crate reserved_prefixes_macro_2018 as m2018;
+extern crate reserved_prefixes_macro_2021 as m2021;
+
+fn main() {
+    // Ok:
+    m2018::number_of_tokens_in_a_prefixed_integer_literal!();
+    m2018::number_of_tokens_in_a_prefixed_char_literal!();
+    m2018::number_of_tokens_in_a_prefixed_string_literal!();
+
+    // Error, even though *this* crate is 2018:
+    m2021::number_of_tokens_in_a_prefixed_integer_literal!();
+    //~^ ERROR prefix `hey` is unknown
+    m2021::number_of_tokens_in_a_prefixed_char_literal!();
+    //~^ ERROR prefix `hey` is unknown
+    m2021::number_of_tokens_in_a_prefixed_string_literal!();
+    //~^ ERROR prefix `hey` is unknown
+}

--- a/src/test/ui/rust-2021/reserved-prefixes-via-macro-2.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-via-macro-2.stderr
@@ -1,0 +1,29 @@
+error: prefix `hey` is unknown
+  --> $DIR/reserved-prefixes-via-macro-2.rs:15:5
+   |
+LL |     m2021::number_of_tokens_in_a_prefixed_integer_literal!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+   = note: this error originates in the macro `m2021::number_of_tokens_in_a_prefixed_integer_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: prefix `hey` is unknown
+  --> $DIR/reserved-prefixes-via-macro-2.rs:17:5
+   |
+LL |     m2021::number_of_tokens_in_a_prefixed_char_literal!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+   = note: this error originates in the macro `m2021::number_of_tokens_in_a_prefixed_char_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: prefix `hey` is unknown
+  --> $DIR/reserved-prefixes-via-macro-2.rs:19:5
+   |
+LL |     m2021::number_of_tokens_in_a_prefixed_string_literal!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown prefix
+   |
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+   = note: this error originates in the macro `m2021::number_of_tokens_in_a_prefixed_string_literal` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/rust-2021/reserved-prefixes-via-macro.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes-via-macro.rs
@@ -1,0 +1,12 @@
+// run-pass
+// edition:2021
+// aux-build:reserved-prefixes-macro-2018.rs
+
+extern crate reserved_prefixes_macro_2018 as m2018;
+
+fn main() {
+    // Ok, even though *this* crate is 2021:
+    assert_eq!(m2018::number_of_tokens_in_a_prefixed_integer_literal!(), 3);
+    assert_eq!(m2018::number_of_tokens_in_a_prefixed_char_literal!(), 3);
+    assert_eq!(m2018::number_of_tokens_in_a_prefixed_string_literal!(), 3);
+}

--- a/src/test/ui/rust-2021/reserved-prefixes.rs
+++ b/src/test/ui/rust-2021/reserved-prefixes.rs
@@ -1,0 +1,36 @@
+// compile-flags: -Z unstable-options --edition 2021
+
+macro_rules! demo2 {
+    ( $a:tt $b:tt ) => { println!("two tokens") };
+}
+
+macro_rules! demo3 {
+    ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
+}
+
+macro_rules! demo4 {
+    ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
+}
+
+fn main() {
+    demo3!(foo#bar);   //~ ERROR prefix `foo` is unknown
+    demo2!(foo"bar");  //~ ERROR prefix `foo` is unknown
+    demo2!(foo'b');    //~ ERROR prefix `foo` is unknown
+
+    demo2!(foo'b);     //~ ERROR prefix `foo` is unknown
+    demo3!(foo# bar);  //~ ERROR prefix `foo` is unknown
+    demo4!(foo#! bar); //~ ERROR prefix `foo` is unknown
+    demo4!(foo## bar); //~ ERROR prefix `foo` is unknown
+
+    demo4!(foo#bar#);
+    //~^ ERROR prefix `foo` is unknown
+    //~| ERROR prefix `bar` is unknown
+
+    demo3!(foo # bar);
+    demo3!(foo #bar);
+    demo4!(foo!#bar);
+    demo4!(foo ##bar);
+
+    demo3!(r"foo"#bar);
+    demo3!(r#foo#bar);
+}

--- a/src/test/ui/rust-2021/reserved-prefixes.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes.stderr
@@ -1,0 +1,92 @@
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:16:12
+   |
+LL |     demo3!(foo#bar);
+   |            ^^^- help: consider inserting a whitespace before this `#`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:17:12
+   |
+LL |     demo2!(foo"bar");
+   |            ^^^- help: consider inserting a whitespace before this `"`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:18:12
+   |
+LL |     demo2!(foo'b');
+   |            ^^^- help: consider inserting a whitespace before this `'`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:20:12
+   |
+LL |     demo2!(foo'b);
+   |            ^^^- help: consider inserting a whitespace before this `'`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:21:12
+   |
+LL |     demo3!(foo# bar);
+   |            ^^^- help: consider inserting a whitespace before this `#`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:22:12
+   |
+LL |     demo4!(foo#! bar);
+   |            ^^^- help: consider inserting a whitespace before this `#`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:23:12
+   |
+LL |     demo4!(foo## bar);
+   |            ^^^- help: consider inserting a whitespace before this `#`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `foo` is unknown
+  --> $DIR/reserved-prefixes.rs:25:12
+   |
+LL |     demo4!(foo#bar#);
+   |            ^^^- help: consider inserting a whitespace before this `#`
+   |            |
+   |            unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: prefix `bar` is unknown
+  --> $DIR/reserved-prefixes.rs:25:16
+   |
+LL |     demo4!(foo#bar#);
+   |                ^^^- help: consider inserting a whitespace before this `#`
+   |                |
+   |                unknown prefix
+   |
+   = note: prefixed identifiers and string literals are reserved since Rust 2021
+
+error: aborting due to 9 previous errors
+

--- a/src/test/ui/rust-2021/reserved-prefixes.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes.stderr
@@ -2,91 +2,109 @@ error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:16:12
    |
 LL |     demo3!(foo#bar);
-   |            ^^^- help: consider inserting a whitespace before this `#`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo3!(foo #bar);
+   |               --
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:17:12
    |
 LL |     demo2!(foo"bar");
-   |            ^^^- help: consider inserting a whitespace before this `"`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(foo "bar");
+   |               --
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:18:12
    |
 LL |     demo2!(foo'b');
-   |            ^^^- help: consider inserting a whitespace before this `'`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(foo 'b');
+   |               --
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:20:12
    |
 LL |     demo2!(foo'b);
-   |            ^^^- help: consider inserting a whitespace before this `'`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo2!(foo 'b);
+   |               --
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:21:12
    |
 LL |     demo3!(foo# bar);
-   |            ^^^- help: consider inserting a whitespace before this `#`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo3!(foo # bar);
+   |               --
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:22:12
    |
 LL |     demo4!(foo#! bar);
-   |            ^^^- help: consider inserting a whitespace before this `#`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo4!(foo #! bar);
+   |               --
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:23:12
    |
 LL |     demo4!(foo## bar);
-   |            ^^^- help: consider inserting a whitespace before this `#`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo4!(foo ## bar);
+   |               --
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:25:12
    |
 LL |     demo4!(foo#bar#);
-   |            ^^^- help: consider inserting a whitespace before this `#`
-   |            |
-   |            unknown prefix
+   |            ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo4!(foo #bar#);
+   |               --
 
 error: prefix `bar` is unknown
   --> $DIR/reserved-prefixes.rs:25:16
    |
 LL |     demo4!(foo#bar#);
-   |                ^^^- help: consider inserting a whitespace before this `#`
-   |                |
-   |                unknown prefix
+   |                ^^^ unknown prefix
    |
-   = note: prefixed identifiers and string literals are reserved since Rust 2021
+   = note: prefixed identifiers and literals are reserved since Rust 2021
+help: consider inserting whitespace here
+   |
+LL |     demo4!(foo#bar #);
+   |                   --
 
 error: aborting due to 9 previous errors
 


### PR DESCRIPTION
This PR denies any identifiers immediately followed by one of three tokens `"`, `'` or `#`, which is stricter than the requirements of RFC 3101 but may be necessary according to the discussion at [Zulip].

[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/268952-edition-2021/topic/reserved.20prefixes/near/238470099

The tracking issue #84599 says we'll add a feature gate named `reserved_prefixes`, but I don't think I can do this because it is impossible for the lexer to know whether a feature is enabled or not. I guess determining the behavior by the edition information should be enough.

Fixes #84599